### PR TITLE
feat(integration): audit auto-wire + state-observer DI + doc alignment

### DIFF
--- a/docs/architecture/nexus-integration-architecture.md
+++ b/docs/architecture/nexus-integration-architecture.md
@@ -1,0 +1,756 @@
+# Nexus Integration Architecture
+
+End-state architecture for the sudowork ↔ nexus ↔ sudo-code surface — agent identity,
+A2A messaging, audit trace, cross-instance transport.
+
+Cross-references:
+
+- `KERNEL-ARCHITECTURE.md` (peer doc): kernel primitives, syscall surface, dispatch model
+- `federation-memo.md` (peer doc): Raft, zone topology, gRPC transport
+- sudowork repo (`sudoprivacy/sudowork`) — `OPEN-ITEMS.md`: items not yet implemented; xfail sentinel keeps the list visible in CI
+
+---
+
+## 1. System Overview
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                         sudowork (Electron)                          │
+│   Renderer (React UI)  ←IPC bridge→  Main process (Node/TS)         │
+│        │                                      │                      │
+│   chat UI, audit viewer,           starts nexusd, manages sessions  │
+│   messenger UI                     via gRPC                          │
+└───────────────────────────────────────┬─────────────────────────────┘
+                                        │ gRPC (localhost:2028)
+                                        ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│              nexusd + sudo-code  (single process, always-on)         │
+│                                                                      │
+│  ┌─────────────────────────────────────────────────────────────┐    │
+│  │  Rust Kernel cdylib  (nexus_runtime)                        │    │
+│  │  VFSRouter · DCache · Metastore(redb) · LockManager         │    │
+│  │  PipeManager(DT_PIPE) · StreamManager(DT_STREAM)            │    │
+│  │  FileWatchRegistry(sys_watch) · KernelDispatch(hooks)       │    │
+│  │  AuditHook · AgentStatusResolver                            │    │
+│  └────────────┬────────────────────────┬────────────────────────┘   │
+│               │                        │                             │
+│  ┌────────────▼─────────┐   ┌──────────▼──────────────────┐         │
+│  │  services rlib       │   │  sudo-code runtime          │         │
+│  │  AgentRegistry (state)  │   │  (linked Rust crate,        │         │
+│  │  mailbox stamping    │   │   spawned by                 │         │
+│  │                      │   │   ManagedAgentService via    │         │
+│  │                      │   │   sudo_code::spawn_task)     │         │
+│  └────────┬─────────────┘   │  one tokio task per pid     │         │
+│           │                 │  cwd = /proc/{pid}/workspace│         │
+│  ┌────────▼─────────────┐   │  direct in-process kernel   │         │
+│  │  Rust service tier   │   │  calls, plain Rust API      │         │
+│  │  ManagedAgentService │   └─────────────────────────────┘         │
+│  │  AcpService          │                                           │
+│  │   (claude/codex/…)   │   FastAPI bricks (mount, rebac, …)        │
+│  │  + AgentRegistry     │   AgentRegistry is a Rust SSOT reachable  │
+│  │    (Rust SSOT;       │   from Python via `kernel.agent_registry`;│
+│  │     PyAgentRegistry) │   ACP / managed_agent reach it directly.  │
+│  └──────────────────────┘                                           │
+│                                                                      │
+│  AcpService spawns external ACP backends as subprocesses with        │
+│  StdioPipeBackend → /proc/{pid}/fd/{0,1,2}; managed-agent runtimes   │
+│  do NOT use that path because they share the process with nexusd.    │
+│                                                                      │
+│  gRPC port 2028: NexusVFSService.Call routes ACP +                  │
+│    ManagedAgent methods through Rust dispatch                        │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+### Constraints
+
+- **One nexusd per sudowork instance.** sudowork starts nexusd at launch and tears it down on quit.
+- **Single Python-facing cdylib.** `nexus_runtime` is the only PyO3 extension module. Service-tier rlibs (`services`, `raft`, `library`, `contracts`) link into it.
+- **State SSOT.** Agent runtime state (`pid → AgentState`, condvar wakeup, signal semantics, parent/child links, transition validation) lives in `kernel::core::agents::registry::AgentRegistry`. Python callers reach it through `kernel.agent_registry` — a thin PyO3 wrapper handing back `nexus_runtime.AgentDescriptor` instances with attribute getters mirroring `contracts/process_types.py`. There is no Python-side state mirror or dual-write step. Profile config lives on disk under `/agents/{name}/`.
+- **gRPC is the integration surface.** sudowork (Node/TS) reaches nexusd through tonic-served gRPC at port 2028; HTTP is reserved for human-facing dashboards.
+- **Cluster profile.** sudowork uses Nexus's cluster profile — bricks: IPC, FEDERATION.
+- **Zone = VFS path mount point.** A zone's visibility boundary is its mount path. ReBAC governs sub-path access within a zone.
+
+---
+
+## 2. Agent Identity & Runtime
+
+Two namespaces, the same Linux distinction between an executable on disk and a running process:
+
+| Namespace | Lifetime | Content | Backing store |
+|-----------|----------|---------|---------------|
+| `/agents/{name}/` | Persistent | Profile config: `config.toml`, `prompts/`, `skills/`, `chat-with-me` | Metastore (DT_FILE / DT_DIR) |
+| `/proc/{pid}/` | Ephemeral | Runtime: `status`, `agent` link, `chat-with-me`, `sessions/`, `tasks/`, `workspace/` | In-memory + WAL while pid alive |
+
+`/agents/{name}/` is the stable identity an outsider addresses (other agents, humans on Element). One agent name can spawn many `pid`s — different worktrees, parallel work — and all of them share the same profile.
+
+### 2.1 Agent-name namespace
+
+```
+/agents/scode-standard/          ← profile (DT_DIR)
+   config.toml                   ← model selection, MCP endpoints, default workspace recipe
+   prompts/                      ← system-prompt overrides, per-skill prompts
+   skills/                       ← which tool sets are loadable
+```
+
+(`/agents/{name}/chat-with-me` exists only for **human** identities —
+e.g. `/agents/human-ethan/chat-with-me` is a real DT_STREAM. For agent
+names like `scode-standard` it is intentionally absent; addressing
+goes through the pid level. See §3.6.)
+
+`chat-with-me` lives at the pid level — `/proc/{pid}/chat-with-me` is
+the canonical address, and `/proc/{pid}/workspace/chat-with-me` is a
+DT_LINK to it (stamped at start_session, followed transparently by
+VFSRouter on read/write — see §2.2). The agent-name level
+(`/agents/{name}/chat-with-me`) reaches the same stream for **human**
+identities (long-lived DT_STREAM owned by the user); for managed-agent
+names like `scode-standard` the agent-name level holds profile config
+only and addressing flows through the pid level. Callers always have a
+pid by the time they need to address a managed agent (sudowork gets it
+from `ManagedAgentService.start_session_v1`; in-process runtimes have
+their own `pid`); requiring the pid keeps the addressing model
+unambiguous and avoids the design questions around multi-instance
+fan-out / fan-in.
+
+Three kinds of recipient still share the same DT_STREAM-backed surface:
+
+- **Local agent pid** (e.g. `/proc/p_42/chat-with-me` for the active
+  scode-standard instance): real DT_STREAM. Writes append; `sys_watch`
+  wakes up readers.
+- **Remote identity** (e.g. `human-bob` on a stock Matrix client like
+  Element): same DT_STREAM under the hood; reach across instances goes
+  through the Matrix C-S adapter (§4) which translates Element's HTTP
+  REST traffic into nexus VFS reads / writes against this stream.
+- **Local persistent identity** (e.g. `/agents/human-ethan/chat-with-me`):
+  a long-lived DT_STREAM owned by the user, not a transient pid. The
+  sudowork UI reads it for inbox display, writes for outgoing messages.
+  This is the one place `/agents/{name}/...` resolves directly to a
+  stream, because the "user" agent has no spawn lifecycle.
+
+### 2.2 Runtime namespace
+
+```
+/proc/{pid}/
+   status                        ← virtual file: AgentStatusResolver renders descriptor JSON
+   agent                         ← DT_LINK → /agents/{name}/   (Linux /proc/{pid}/exe analogue)
+   chat-with-me                  ← DT_STREAM: this pid's conversation
+   sessions/                     ← DT_DIR; sudo-code writes per-session jsonls under here
+   tasks/                        ← DT_DIR; reserved for sudo-code task list persistence
+   workspace/                    ← DT_DIR (agent cwd)
+      chat-with-me               ← DT_LINK → /proc/{pid}/chat-with-me
+      project-x/                 ← DT_LINK → host repo path from desc.repos
+      project-y/                 ← DT_LINK → host repo path from desc.repos
+```
+
+`/proc/{pid}/status` is served by `AgentStatusResolver`, a `PathResolver`
+that renders the live `AgentDescriptor` as JSON on each read — content
+is a function of the current AgentRegistry snapshot. The DT_LINK rows
+under `/proc/{pid}/workspace/` and `/proc/{pid}/agent` are static for
+the pid's lifetime, so they live in the metastore as plain DT_LINK
+entries stamped at start_session; VFSRouter follows them transparently
+on `sys_read` / `sys_write` (single-hop, ELOOP-detected), and the
+existing hooks (mailbox stamping, workspace boundary, audit) match on
+the link path's suffix so they fire correctly whether the caller writes
+to `chat-with-me` directly or through the workspace shortcut. The
+descriptor is the SSOT for state, exit code, agent name, parent pid,
+timestamps, model, and the workspace mount list (`AgentDescriptor.repos`,
+useful PCB metadata for inspection); the metastore's DT_LINK rows are
+the SSOT for routing.
+
+`/proc/{pid}/agent` is a kernel-resolved DT_LINK to the agent-name directory. `readlink` returns `/agents/{name}/`; `stat` follows. This is the single SSOT pointer from a runtime back to its profile — no metadata duplication.
+
+### 2.3 Spawn lifecycle
+
+sudo-code is in-process: a Rust crate linked into nexusd, driven as a tokio
+task per pid. There is no subprocess and no stdio plumbing — that machinery
+exists in `AcpService` only because external ACP agents (claude / codex /
+codebuddy / nanobot) run in separate OS processes and the only protocol
+those binaries support is JSON-RPC over stdio. sudo-code is our own code in
+our own process, so it talks to the kernel through direct Rust syscalls
+(`kernel.sys_read`, `kernel.sys_write`, `kernel.sys_watch`, …) and to the
+dispatch hooks through the same in-process channel every kernel observer
+uses.
+
+```
+sudowork (Electron, TS)
+   │ gRPC: NexusVFSService.Call(method="managed_agent.start_session_v1",
+   │       payload={agent_id:"scode-standard", repos:[…], model, owner_id, zone_id})
+   ▼
+nexusd:
+   tonic Call handler
+      │ resolve_rust_dispatch -> ("managed_agent", "start_session_v1")
+      │ Kernel::dispatch_rust_call -> ManagedAgentService::dispatch
+      │ ManagedAgentService::start_session
+      │   → AgentRegistry.register descriptor (model + repos in PCB)
+      │   → AgentRegistry.update_state(WARMING_UP)
+      │   → register_proc_entry: stamp /proc/{pid}/workspace/ dirent
+      ▼
+   {session_id=pid, workspace_path="/proc/{pid}/workspace/"} → sudowork
+```
+
+The session identifier IS the AgentRegistry pid — there is no second id.
+The descriptor (`AgentDescriptor`) is the per-pid SSOT for spawn-time
+surface info: `agent_id` (static profile name) lands in `desc.name`,
+`model` in `desc.labels["model"]`, workspace mount list in
+`desc.repos`.  ManagedAgentService plants the descriptor, stamps the
+per-pid procfs entries, and hands off to sudo-code:
+
+  - `/proc/{pid}/` (DT_DIR) — process root.
+  - `/proc/{pid}/agent` (DT_LINK → `/agents/{desc.name}/`) — Linux
+    `/proc/{pid}/exe` analogue; readlink returns the static profile dir.
+  - `/proc/{pid}/chat-with-me` (DT_STREAM) — the canonical mailbox; A2A
+    writes append here, sudo-code's loop `sys_watch`es it for prompts.
+  - `/proc/{pid}/sessions/` (DT_DIR) — sudo-code writes per-session jsonl
+    transcripts under this prefix.
+  - `/proc/{pid}/tasks/` (DT_DIR) — reserved for sudo-code task list
+    persistence.
+  - `/proc/{pid}/workspace/` (DT_DIR) — agent cwd; per-repo mounts and
+    the chat-with-me shortcut hang under here.
+  - `/proc/{pid}/workspace/chat-with-me` (DT_LINK → `/proc/{pid}/chat-with-me`)
+    — workspace shortcut so the agent can write `chat-with-me` relative
+    to its cwd.  Resolved by VFSRouter's standard DT_LINK follow.
+  - `/proc/{pid}/workspace/{alias}` (DT_LINK → `desc.repos[alias].mount_path`)
+    — one per `WorkspaceRepo` in the spawn request.
+
+Out-of-band termination (SIGTERM / SIGKILL / orphan reap) flows through
+`AgentRegistry::on_terminate`, which reaps every entry under
+`/proc/{pid}/`.  `cancel(Session)` calls `AgentRegistry::kill(pid, 0)`
+for the same outcome — orphan auto-reap removes the descriptor, the
+observer reaps the procfs subtree.
+
+After the procfs entries are in place, ManagedAgentService hands off
+to the sudo-code crate by calling `sudo_code::spawn_task(pid, ...)` —
+a direct in-process Rust call into a crate linked into the same nexusd
+binary.  The crate spawns a tokio task on the kernel's shared runtime
+(`kernel.runtime()`); the task is the per-pid agent loop.  Tokio is
+the I/O-concurrency model (LLM HTTP round-trips run seconds; many pids
+share a small worker pool); the call surface between
+ManagedAgentService and sudo-code is plain Rust function calls,
+sharing the address space with the kernel.
+
+After spawn, prompts and responses flow through the chat-with-me VFS
+surface — same A2A primitive every other agent uses (§3). sudowork
+writes prompts to `/proc/{pid}/chat-with-me`; the kernel rewrites the
+envelope's `from` field to sudowork's caller identity (§3.3). The
+sudo-code task in nexusd `sys_watch`es its own `/proc/{pid}/chat-with-me`
+for incoming prompts and writes responses to `/agents/{user}/chat-with-me`.
+sudowork's UI `sys_watch`es the user's chat-with-me for those responses.
+
+**ManagedAgentService surface is intentionally narrow** — only spawn /
+cancel / liveness, exposed over `NexusVFSService.Call`:
+
+- `start_session_v1` — payload `{agent_id, repos, model, owner_id, zone_id}` →
+  `{session_id, workspace_path}`. `agent_id` names the static profile
+  (`/agents/{agent_id}/`); `session_id` is the runtime pid.
+- `cancel_v1` — payload `{session_id, mode}` → `{cancelled}`.
+  `mode ∈ {turn, session}` — turn aborts the current generation,
+  session reaps the pid.
+- `get_session_v1` — payload `{session_id}` →
+  `{session_id, agent_id, workspace_path, model, state}`. `agent_id`
+  echoes the static profile; `state` mirrors `AgentDescriptor.state`.
+
+The dotted form (`managed_agent.start_session_v1`) is canonical;
+flat-name fallback (`managed_agent_start_session_v1`) is wired for
+backward compat in the gRPC `Call` handler (KERNEL-ARCHITECTURE §8.1).
+Prompt / event flow uses the existing `NexusVFSService` gRPC
+(`sys_write`, `sys_watch`, `sys_read`) over the chat-with-me paths.
+There is no `SendPrompt` or `SubscribeEvents` gRPC — those would
+duplicate the A2A surface the rest of the system uses.
+
+`AgentState` lifecycle: `REGISTERED → WARMING_UP → READY ↔ BUSY → SUSPENDED → TERMINATED`.
+`kernel.agent_wait(pid, target_state, timeout_ms)` releases the GIL and
+parks on the per-pid condvar — Python supervisors get a blocking wait
+without pinning the interpreter.
+
+ManagedAgentService dispatches to the runtime through a direct
+in-process call — `sudo_code::spawn_task(pid, ...)` — keeping the
+dispatch surface a single named function for the one-runtime
+configuration. The dispatch site is the place a trait lands the day
+a second in-process runtime joins; the existing call slots in as
+the first trait impl with no behavior change.
+
+### 2.4 sudo-code state placement
+
+sudo-code's `runtime` crate already organises persistence around two
+configurable surfaces — `SessionStore` (which builds session jsonl
+paths) and `ConfigLoader` (which discovers config files via env +
+project-local lookup). The integration redirects those surfaces at
+nexus VFS paths and lets `file_ops.rs` workspace-bounded helpers
+(`read_file_in_workspace` / `write_file_in_workspace` / etc.) issue
+kernel syscalls instead of `std::fs`. sudo-code's static prompt
+sections + AGENTS.md scan stay as-is on the read path.
+
+| sudo-code surface | Current on-disk shape | nexus VFS path | Adaptation |
+|---|---|---|---|
+| `SessionStore::from_data_dir(data_dir, workspace_root)` — conversation jsonls | `<data_dir>/sessions/<workspace_hash>/<session_id>.jsonl` (FNV-1a 64-bit hex of canonical workspace path) | `/proc/{pid}/sessions/<workspace_hash>/<session_id>.jsonl` | **READS UNCHANGED** — call `from_data_dir(data_dir="/proc/{pid}/sessions", workspace_root="/proc/{pid}/workspace")`; replace `std::fs` usage in `session.rs` with kernel syscalls |
+| `task_registry` — sub-agent task lifecycle | In-memory only (no disk) today | `/proc/{pid}/tasks/<task_list_name>.json` once persistence lands in sudo-code | **NEEDS PATCH** in upstream sudo-code (forked) — `tasks/` dirent is reserved by nexus; persistence is a sudo-code-side change driven by sudo-code's own roadmap, not by this integration |
+| `prompt.rs` — static prompt sections | Embedded `&'static str` constants returned by `get_simple_*_section()` | n/a (no IO) | **READS UNCHANGED** — embedded strings pass through |
+| `prompt.rs` — project AGENTS.md scan | Walks parent dirs from cwd looking for `AGENTS.md` and `.nexus/sudocode/AGENTS.md` | walks `/proc/{pid}/workspace/{repo}/...AGENTS.md` and `.nexus/sudocode/AGENTS.md` (DT_FILE under the repo's mount) | **READS UNCHANGED** — sudo-code already takes cwd as input; cwd = `/proc/{pid}/workspace/`; replace `std::fs` with kernel syscalls in the scanner |
+| `ConfigLoader` — runtime settings | `$SUDO_CODE_CONFIG_HOME` (default `$HOME/.nexus/sudocode/`) for user-level; `./.scode.json` or `./.nexus/sudocode/settings.json` for project-level | `/agents/{name}/config/` for user-level; `/proc/{pid}/workspace/{repo}/.nexus/sudocode/settings.json` for project-level | **READS UNCHANGED** — set `SUDO_CODE_CONFIG_HOME` to a VFS-mapped path; replace `std::fs` with kernel syscalls in the loader |
+| Agent profile config | (no equivalent on disk today) | `/agents/{name}/config.toml` (DT_FILE) | **NEW** — user-global agent settings written by sudowork's profile UI; sudo-code reads it through ConfigLoader's user-level slot |
+
+`workspace_hash` matches sudo-code's existing FNV-1a 64-bit fingerprint
+of the canonical workspace path (16-char hex), so a single profile
+talking to multiple repos still partitions sessions per-repo on disk.
+
+User-global agent settings live at `/agents/{name}/config.toml` inside
+nexus VFS, sharing the same SSOT as the rest of agent identity.
+
+---
+
+## 3. A2A Communication
+
+A2A, H2A, and A2H share one primitive: write a message to the recipient's `chat-with-me`.
+
+### 3.1 Mailbox
+
+`/agents/{name}/chat-with-me` and `/proc/{pid}/chat-with-me` are append-only message streams. They are normal DT_STREAMs that any caller can write to and the owner can read with `sys_watch`. Federation Raft replicates them across zone members; reach to clients outside the federation (e.g. Element on a stock Matrix server) goes through the Matrix C-S adapter (§4).
+
+### 3.2 The chat-with-me link inside a workspace
+
+Every workspace exposes a sibling `chat-with-me` entry that resolves to the owning pid's chat:
+
+```
+/proc/{pid}/workspace/chat-with-me  →  /proc/{pid}/chat-with-me
+```
+
+So an agent inside another's workspace — say agent A is staged at `/proc/p_other/workspace/projects/nexus/` and wants to talk to whoever owns this nexus repo — writes to `chat-with-me` relative to wherever it stands; resolution follows back to the workspace owner's stream.
+
+The link is a plain DT_LINK row in the metastore, stamped at start_session
+(§2.2). VFSRouter follows it transparently on `sys_read` / `sys_write`
+(single-hop, ELOOP-detected); hooks match on the link path's `/chat-with-me`
+suffix so audit, sender stamping, and boundary checks behave identically
+to a direct write to `/proc/{pid}/chat-with-me`.
+
+### 3.3 Sender identity
+
+Mailbox envelope stamping rewrites the message envelope's `from` field
+to the caller's authenticated `agent_id` before the write reaches the
+backend. The on-disk envelope's `from` always reflects the kernel's
+authenticated identity; the LLM-supplied envelope contributes message
+body and metadata only.
+
+The rewrite is implemented as a registered `NativeInterceptHook`
+(`MailboxStampingHook`) that delegates the actual envelope policy to
+`mailbox_stamping_policy::maybe_stamp_chat_envelope`. Both live under
+`rust/services/src/managed_agent/` — owned by `ManagedAgentService`
+(the chat-with-me mailbox is a managed-agent concern, not a generic
+agent-table concern). The hook struct owns "how to be a hook"
+(dispatch wiring + content-clone bypass); the policy module owns
+"what to rewrite" (envelope schema, identity guarantee). The hook
+trait was widened to
+support content rewriting — `on_pre` returns
+`Result<HookOutcome, String>` where `HookOutcome::Replace(bytes)` is
+the new variant that substitutes write content. Accept/reject hooks
+(audit, permission, workspace boundary) all return `HookOutcome::Pass`.
+
+To keep the hot path allocation-free for the writes that don't need
+rewriting, hooks declare a `mutating_path_suffix` and the dispatcher
+uses it as a double bypass:
+
+- **Layer 1 (no mutating hooks registered)**: empty-Vec check, dispatcher
+  goes straight to `WriteHookCtx::content = vec![]` — identical to the
+  pre-widening cost.
+- **Layer 2 (mutating hook registered, write path doesn't match)**:
+  suffix scan returns false, dispatcher still passes `vec![]`. Only
+  writes whose path ends in a registered suffix (`*/chat-with-me`)
+  pay the content clone.
+
+```
+agent A writes envelope { to: "scode-standard", body: "ping" }
+   │
+   ▼
+sys_write
+   has_mutating_hook_match(path) → true (suffix matches "/chat-with-me")
+   clone content into WriteHookCtx
+   │
+   ▼
+dispatch_native_pre → MailboxStampingHook.on_pre
+   reads ctx.agent_id = "human-ethan"
+   delegates to maybe_stamp_chat_envelope
+   returns HookOutcome::Replace({ from:"human-ethan", to:"scode-standard", … })
+   │
+   ▼
+DT_STREAM append (the per-pid stream — `/proc/{pid}/chat-with-me`,
+                  possibly reached via the workspace DT_LINK shortcut)
+```
+
+### 3.4 Boundary teaching UX
+
+`WorkspaceBoundaryHook` is registered as an `INTERCEPT pre-write` hook scoped to `/proc/{pid}/workspace/{...}`. It compares the caller's `agent_id` to the workspace owner derived from the path (`pid → AgentRegistry.lookup(pid).name`). On mismatch the hook returns `Err(EPERM)` with a structured payload:
+
+```
+EPERM at /proc/p_scode/workspace/projects/nexus/src/main.rs:
+  This workspace is owned by agent 'scode-standard' (pid p_scode).
+  You are 'human-ethan'. To send a message about this workspace, write to:
+     /proc/p_scode/workspace/chat-with-me
+  (DT_LINK to /proc/p_scode/chat-with-me.)
+```
+
+The error is intentionally instructive. LLMs that hit it once learn the convention without memory or system-prompt edits — the path layout itself is the SSOT for permissions.
+
+### 3.5 Same primitive across humans and agents
+
+`/agents/human-ethan/chat-with-me` is the canonical Ethan address —
+"human" identities have no spawn lifecycle so the path resolves
+directly to a long-lived DT_STREAM, no pid indirection needed. From
+sudowork's UI Ethan sends through gRPC writes to other agents'
+`/proc/{pid}/chat-with-me`; he reads his own through `sys_watch` over
+`/agents/human-ethan/chat-with-me`. Other humans (Bob on Element)
+reach the same DT_STREAM through the Matrix C-S adapter (§4); the
+adapter speaks Matrix REST at the edge and nexus VFS underneath, so
+the recipient's transport is invisible to the sender.
+
+### 3.6 Addressing non-human agents
+
+Non-human agent names (`scode-standard`, `claude`, etc.) can map to
+zero, one, or many running pids in parallel — different worktrees,
+sessions, supervisors. The chat-with-me surface for these agents is
+per-pid:
+
+- `/proc/{pid}/chat-with-me` — direct DT_STREAM at the per-pid path.
+- `/proc/{pid}/workspace/chat-with-me` — DT_LINK to the same stream so
+  callers inside the workspace tree can write `chat-with-me` relative
+  to their cwd; VFSRouter follows the link transparently.
+
+Callers reach the pid through the lifecycle surface: sudowork from
+`managed_agent.start_session_v1` (§2.3); in-process runtimes from
+`self.pid`. Per-pid addressing keeps the routing model unambiguous
+for the supervised, parallel-worktree workflows this integration
+runs.
+
+---
+
+## 4. Cross-instance Transport
+
+Two layers compose. **Within** a federation, raft replicates the
+chat-with-me DT_STREAM across every nexus instance voted into the
+zone — recipients on any peer node read through their local kernel
+just like a same-host write. **Outside** the federation, a Matrix
+Client-Server adapter exposes the same DT_STREAMs over Matrix REST so
+unmodified third-party clients (Element, FluffyChat, Cinny) can join
+conversations without nexus needing a bespoke client.
+
+### 4.1 Federation-internal — raft replication
+
+Every chat-with-me DT_STREAM lives inside its zone's raft cluster. The
+write path is `sys_write` → `WalStreamCore` → `Command::AppendStreamEntry`
+→ raft commit → state-machine apply on every voter, including remote
+peers. Cross-instance reach is the same `sys_watch` wake-up that a
+same-host caller sees. Read § 6 for the broader DT_STREAM /
+WalStreamBackend contract — there is no separate transport for the
+in-federation case.
+
+### 4.2 Federation-external — Matrix C-S adapter
+
+The Matrix C-S adapter is a nexus services-tier component
+(`services::matrix_adapter`) that hosts the Matrix Client-Server REST
+surface at the edge and translates each call into nexus kernel
+syscalls underneath. Element opens a TCP socket to the adapter's
+`/_matrix/...` HTTP endpoints; the adapter walks the room state and
+DT_STREAM contents through `sys_read` / `sys_write` / `stream_read_batch`.
+
+```
+Element   ──HTTP REST + JSON──►  services::matrix_adapter  ──in-process──►  nexus kernel
+                                  /_matrix/client/v3/sync                    sys_read /
+                                  /_matrix/client/v3/rooms/.../send          sys_write /
+                                  /_matrix/media/v3/...                      stream_read_batch
+                                                                              on chat-with-me
+                                                                              DT_STREAMs
+```
+
+#### Endpoint scope
+
+The adapter implements the minimal Client-Server v3 surface needed
+for stock chat clients (Element, FluffyChat, Cinny) to participate
+in nexus chat-with-me streams.  Scope is the C-S surface those
+clients use — server-to-server federation, admin API, application
+service, spaces, and end-to-end encryption are layers nexus already
+covers (raft / AuthService / ReBAC) or layers the v1 surface does
+not need.  ~20 endpoints organised in five groups:
+
+| Group | Endpoints | Backed by |
+|-------|-----------|-----------|
+| **Auth** | `POST /_matrix/client/v3/login`, `POST /_matrix/client/v3/logout`, `GET /_matrix/client/v3/account/whoami` | `AuthService`; Matrix access token = AuthService session token, stamped into `OperationContext` per call |
+| **Sync** | `GET /_matrix/client/v3/sync` (long-poll, since-token paging) | `sys_watch` on the user's joined chat-with-me streams; since-token is `(stream_path → offset)` map |
+| **Rooms — read state** | `GET /_matrix/client/v3/rooms/{rid}/state`, `GET /_matrix/client/v3/rooms/{rid}/state/{event_type}/{state_key}`, `GET /_matrix/client/v3/rooms/{rid}/messages` (back-paginate), `GET /_matrix/client/v3/rooms/{rid}/joined_members` | `stream_read_batch` over the chat-with-me DT_STREAM; room state synthesised from ReBAC membership + envelope metadata |
+| **Rooms — write** | `PUT /_matrix/client/v3/rooms/{rid}/send/{event_type}/{txn_id}`, `POST /_matrix/client/v3/rooms/{rid}/leave`, `POST /_matrix/client/v3/rooms/{rid}/join`, `POST /_matrix/client/v3/createRoom` | `sys_write` (envelope assembled from PDU body); join/leave write ReBAC mutations; createRoom binds a new `/agents/{name}/chat-with-me` |
+| **Media** | `GET /_matrix/media/v3/download/{server}/{media_id}`, `POST /_matrix/media/v3/upload`, `GET /_matrix/media/v3/thumbnail/{server}/{media_id}` | DT_FILE under `/media/{media_id}`; CAS storage for content, raft for the metastore entry |
+
+#### Room ↔ chat-with-me mapping
+
+A Matrix room id maps 1:1 to a chat-with-me DT_STREAM path.  Stable
+encoding so cross-restart the same room id resolves to the same
+stream:
+
+```
+!{base32(stream_path)}:nexus.local
+  e.g. /agents/human-bob/chat-with-me
+       ↔ !MFRGS43FORZS6ZTPMVQHIYLUMRZA:nexus.local
+```
+
+The `:nexus.local` suffix is the Matrix server-name; it's a stable
+constant per nexus deployment, configured at adapter boot.
+
+#### PDU envelope ↔ chat envelope
+
+Matrix PDUs (Persistent Data Units) and the nexus chat envelope
+(§3.3) are both JSON; the adapter translates field-by-field on the
+hot path:
+
+| PDU field | Chat envelope field | Notes |
+|-----------|---------------------|-------|
+| `sender` | `from` | Stamped by `MailboxStampingHook` from `OperationContext` — adapter cannot forge |
+| `content.body` | `body` | `m.room.message` text; pass-through |
+| `content.msgtype` | `msgtype` | `m.text`, `m.image`, etc. |
+| `origin_server_ts` | `ts_ms` | Unix ms |
+| `event_id` | derived from DT_STREAM offset | `$offset_{n}:nexus.local` so it's stable |
+| `room_id` | derived from path | See above |
+| `unsigned.age` | computed at send time | Standard Matrix |
+
+Adapter scope is the C-S surface stock chat clients use; nexus raft
+provides cross-instance replication (§4.1), so PDU signing, state DAG
+resolution, and depth/prev_events tracking belong to layers nexus
+already owns — the DT_STREAM linear order is the SSOT for
+ordering.
+
+#### Storage
+
+Adapter is **stateless** — every read/write goes through the kernel.
+The kernel's metastore + WalStreamBackend hold the SSOT; the adapter
+keeps three things in-memory, all rebuilt on restart:
+
+  - Active `/sync` long-poll registrations (channel per pinned client)
+  - Access-token → user-id map (mirrors AuthService; cache miss falls
+    back to AuthService lookup)
+  - Room id → stream path decoding (pure function of room id)
+
+#### Identity & permissions
+
+Matrix `/login` calls AuthService with the same credential schemes
+sudowork uses.  AuthService returns the session token; adapter
+returns it as Matrix `access_token`.  Subsequent calls validate the
+token once per request (cached) and stamp the resolved user id into
+`OperationContext` before issuing kernel syscalls.  ReBAC then
+governs read/write — Matrix room membership IS the ReBAC `read` /
+`write` predicate on the chat-with-me path.  No second permission
+model.
+
+#### Reference reading
+
+The Matrix protocol mechanics (PDU canonical JSON, `/sync` semantics,
+media repo) come from the [Matrix C-S spec v1.10+](https://spec.matrix.org/v1.10/client-server-api/);
+upstream Rust implementations to read for patterns: Tuwunel
+(Conduit fork, Apache-2.0).  The adapter is a fresh Rust crate that
+reuses no upstream storage or S2S code.
+
+### 4.3 Properties retained across both layers
+
+Both layers preserve the kernel-level surfaces that make the
+chat-with-me primitive uniform:
+
+- **Permissions** — ReBAC on the DT_STREAM path governs who may write
+  / read. Matrix room membership is derived from the same ReBAC
+  decision on each `/send` call.
+- **Audit** — Every Matrix-originated write reaches the kernel through
+  `sys_write`, so `AuditHook` captures it like any other VFS write
+  with no Matrix-specific bookkeeping.
+- **Single SSOT** — The DT_STREAM at `/agents/human-bob/chat-with-me`
+  is authoritative. The Matrix room view, the sudowork chat UI, and a
+  federation peer's `sys_watch` all resolve to the same byte sequence;
+  the adapter does not maintain a parallel store.
+
+Native sudowork clients keep talking gRPC directly to nexus; only
+external Matrix clients touch the adapter.
+
+---
+
+## 5. Audit Trace
+
+### 5.1 Surface
+
+| Concern | What | Source |
+|---------|------|--------|
+| VFS operation trace | Every read/write/delete/rename through nexus kernel, including chat-with-me writes | Rust `AuditHook` on kernel dispatch (POST phase) |
+| Exchange audit | Agent economic transactions | Python exchange service |
+
+Both write to **DT_STREAM with WalStreamBackend** — ordered, durable, Raft-replicated.
+
+### 5.2 AuditHook pipeline
+
+```
+Kernel dispatch (Rust)
+      │
+      │  on_post_write / on_post_read / on_post_delete (POST hook)
+      ▼
+AuditHook  (impl NativeInterceptHook — pure Rust)
+      │
+      │  mpsc::SyncSender::try_send()  ← ~10–50ns, non-blocking
+      ▼
+audit-flush  (background Rust thread)
+      │
+      │  serialise AuditRecord → JSON → WalStreamCore::write_nowait
+      ▼
+WalStreamCore  (Command::AppendStreamEntry → zone Raft cluster)
+      │
+      └─► registered with StreamManager at /{zone}/audit/traces/
+```
+
+### 5.3 Auto-wiring on zone create / join
+
+`zone_create(zone_id, audit=true)` and `zone_join(zone_id, as_learner, audit=true)` are kernel syscalls that auto-wire the AuditHook from Rust before any `sys_*` mutation can race in. The legacy Python wire-up (`_init_audit_hook` in `nexus/__init__.py`) handles the boot-time root-zone hook for federation deployments; every other zone gets its hook through the syscall flag.
+
+### 5.4 Central audit zone
+
+Each production node shares a 1:1 zone with the audit-node. `AuditHook` writes formatted `AuditRecord` entries to `/audit/traces/` in that shared zone; the audit-node reads and gathers them locally.
+
+```
+Production nexusd (node A)
+    │  AuditHook → /audit/traces/  (auto-wired by zone_create(audit=true))
+    │
+    └──► Shared zone: zone-A-audit
+              Raft cluster: [node-A voter, audit-node learner]
+
+Production nexusd (node B)
+    │  AuditHook → /audit/traces/
+    │
+    └──► Shared zone: zone-B-audit
+              Raft cluster: [node-B voter, audit-node learner]
+
+Audit nexusd (audit-node)
+    ├── learner of zone-A-audit  ← receives only node-A's audit stream
+    ├── learner of zone-B-audit  ← receives only node-B's audit stream
+    └── local collect/gather: reads all /audit/traces/ streams, aggregates
+```
+
+The 1:1 zone holds `AuditRecord` only — formatted by `AuditHook`, with no production-zone metadata or lock commands. audit-node joins via `zone_join(zone_id, as_learner=true, audit=true)` so the production zone's voter quorum is unaffected; audit loss is preferable to blocking production writes.
+
+### 5.5 AuditRecord schema
+
+```json
+{
+  "v": 1,
+  "ts": "2026-04-26T10:00:00.123Z",
+  "trace_id": "req_a1b2c3d4",
+  "agent_id": "agent:sudo-code",
+  "op": "write",
+  "path": "/proc/p_scode/workspace/projects/nexus/src/main.rs",
+  "zone_id": "root",
+  "size_bytes": 1024,
+  "status": "ok",
+  "duration_us": 42
+}
+```
+
+---
+
+## 6. Data Replication Mechanisms
+
+Replication composes two channels — metadata via raft and content
+via CAS — and dispatches by entry type:
+
+| Entry type | Used for | Metadata channel | Content channel |
+|-----------|----------|------------------|-----------------|
+| **DT_FILE** | sudo-code sessions, profile configs, task lists | Raft (intra-zone, strongly consistent) | Local CAS (`cas_local` backend) + on-miss lazy fetch from a peer voter via `PeerBlobClient` |
+| **DT_STREAM** (via `WalStreamBackend`) | `chat-with-me`, `/audit/traces/` | Raft (intra-zone) | Same raft log — `WalStreamBackend` writes content as `Command::AppendStreamEntry` so total order across voters is the same channel as metadata |
+
+For `DT_FILE`, the file's `FileMetadata` (entry type, content hash,
+size, last-writer address, etc.) commits through raft so every voter
+agrees on the namespace. The bytes themselves stay local-first in the
+zone's CAS engine; a voter that misses the chunk on read pulls it on
+demand through `PeerBlobClient` from the recorded `last_writer_address`.
+
+For `DT_STREAM`, ordering is the load-bearing property — every voter
+applies the same sequence of `AppendStreamEntry` commands, so a
+`stream_read_batch` at offset N returns the same bytes on every node.
+Append throughput is bounded by raft commit latency; `chat-with-me`
+and audit traffic stay within that envelope by design.
+
+The Matrix C-S adapter (§4.2) is an edge surface that calls
+`sys_read` / `sys_write` / `stream_read_batch` against these same
+mechanisms; the adapter is stateless. Stock Matrix clients see the
+chat-with-me DT_STREAM, not a parallel store.
+
+Primitive contracts (`DT_FILE` / `DT_STREAM` / `WalStreamBackend` /
+`PeerBlobClient` / CAS engine) live in `KERNEL-ARCHITECTURE.md` §3
+and §4. This doc captures only how the integration layer uses them.
+
+---
+
+## 7. Messenger Surface
+
+Three clients sit over the same chat-with-me DT_STREAMs:
+
+- **sudowork chat UI** — talks gRPC directly to nexus. Reads each
+  `/agents/{name}/chat-with-me` and `/proc/{pid}/chat-with-me` through
+  `stream_read_batch` + `sys_watch`; writes via `sys_write`.
+- **Stock Matrix clients** (Element, FluffyChat, Cinny) — connect to
+  the Matrix C-S adapter (§4.2) over HTTP. Each Matrix room id maps
+  1:1 to a chat-with-me path; `m.room.message` events serialize into
+  the same envelope schema sudowork's UI emits.
+- **In-process agent runtimes** — read / write `chat-with-me` directly
+  through the kernel like any other VFS surface; no gateway involved.
+
+The chat-with-me DT_STREAM is the SSOT. None of the three clients
+maintain a parallel inbox; identity, ordering, and audit all derive
+from the kernel.
+
+---
+
+## 8. Appendix A: Kernel Dispatch Hook Lifecycle
+
+```
+syscall (sys_write, sys_read, …)
+    │
+    ├─► [CLONE GATE — sys_write only] mutating-suffix bypass
+    │         has_mutating_hook_match(path)
+    │         → false: WriteHookCtx.content = vec![] (no clone)
+    │         → true:  WriteHookCtx.content = clone(content)
+    │
+    ├─► [PRE] NativeInterceptHook chain
+    │         on_pre(ctx) → Result<HookOutcome, String>
+    │         → Err to abort  (PermissionHook, WorkspaceBoundaryHook)
+    │         → HookOutcome::Pass to proceed unchanged
+    │         → HookOutcome::Replace(bytes) to rewrite write content
+    │           (MailboxStampingHook on */chat-with-me)
+    │
+    ├─► [EXECUTE] backend write with replacement.unwrap_or(content)
+    │             (redb / CAS / MemoryStreamBackend / WalStreamBackend / …)
+    │
+    ├─► [POST] NativeInterceptHook chain
+    │         on_post(ctx)  ← AuditHook fires here
+    │         → fire-and-forget, non-blocking (mpsc try_send)
+    │
+    └─► [OBSERVE] MutationObserver::on_mutation(FileEvent)
+              → StreamEventObserver writes to DT_STREAM (sys_watch wakeup)
+              → FileWatcher wakes sys_watch subscribers
+```
+
+The clone gate keeps the hot path allocation-free for writes that
+do not need rewriting. Each hook declares a `mutating_path_suffix`
+at registration; the dispatcher scans the registered suffixes
+against the write path and only clones content into `WriteHookCtx`
+when one matches. `MailboxStampingHook` declares `/chat-with-me`;
+accept/reject hooks (audit, permission, workspace boundary) declare
+`None` and the dispatcher passes them an empty content vec. When
+multiple mutating hooks register, the chain semantics are
+last-write-wins on `HookOutcome::Replace`.
+
+---
+
+## 9. Appendix B: Raft Command Taxonomy
+
+All commands in a zone's Raft cluster share a single `Command` enum (`state_machine.rs`):
+
+```
+Command::SetMetadata           — VFS file/dir metadata (path, size, etag, …)
+Command::DeleteMetadata        — VFS delete
+Command::AcquireLock           — distributed lock
+Command::ReleaseLock           — lock release
+Command::AppendStreamEntry{…}  — WalStreamBackend stream data (chat, audit)
+Command::DeleteStreamEntry     — stream cleanup
+… (others)
+```
+
+In the audit 1:1 zone the only `AppendStreamEntry` traffic comes from `AuditHook` writes to `/audit/traces/`; the audit-node learner applies them in order and exposes the aggregated stream to its local `collect/gather` consumer.
+
+In a chat zone the `AppendStreamEntry` traffic is the conversation itself — every envelope (with its `from` field rewritten by `MailboxStampingHook` on `*/chat-with-me`, see §3.3) replicates to every voter and learner in the zone.

--- a/docs/architecture/nexus-integration-architecture.md
+++ b/docs/architecture/nexus-integration-architecture.md
@@ -631,9 +631,26 @@ WalStreamCore  (Command::AppendStreamEntry → zone Raft cluster)
       └─► registered with StreamManager at /__sys__/audit/traces/
 ```
 
-### 5.3 Auto-wiring on zone create / join
+### 5.3 Auto-wiring on zone mount
 
-`zone_create(zone_id, audit=true)` and `zone_join(zone_id, as_learner, audit=true)` are kernel syscalls that auto-wire the AuditHook from Rust before any `sys_*` mutation can race in. The legacy Python wire-up (`_init_audit_hook` in `nexus/__init__.py`) handles the boot-time root-zone hook for federation deployments; every other zone gets its hook through the syscall flag.
+Zone creation is a raft-layer operation, not a syscall — voters in a
+zone's raft cluster agree on the zone's existence through
+`DistributedCoordinator::create_zone`. The kernel-facing entry point
+for an existing zone showing up on the local kernel is
+`kernel.sys_setattr(mount_path, DT_MOUNT, …, zone_id, …)`, which
+registers the mount with `VFSRouter` and dispatches a
+`FileEvent { event_type: FileEventType::Mount, path, zone_id, … }`
+(`rust/kernel/src/core/dispatch/mod.rs:54` for the enum variant,
+`:288` for the `MutationObserver` trait).
+
+`services::audit::install_root` (called once at boot) installs a
+`MutationObserver` that filters on `FileEventType::Mount.bit()`. Each
+fired event maps to a per-zone `install_for_zone(zone_id)` call,
+guarded by a `Mutex<HashSet<String>>` so a re-mount is a harmless
+no-op. New zones therefore wire their AuditHook + DT_STREAM the
+moment they mount on this kernel, with no zone-creation API
+duplication; the install path is purely syscall-driven. See §8 for
+the dispatch lifecycle the observer hooks into.
 
 ### 5.4 Central audit zone
 
@@ -759,6 +776,8 @@ syscall (sys_write, sys_read, …)
     └─► [OBSERVE] MutationObserver::on_mutation(FileEvent)
               → StreamEventObserver writes to DT_STREAM (sys_watch wakeup)
               → FileWatcher wakes sys_watch subscribers
+              → AuditZoneAutoWire (filter FileEventType::Mount) installs
+                AuditHook for the newly-mounted zone (§5.3)
 ```
 
 The clone gate keeps the hot path allocation-free for writes that

--- a/docs/architecture/nexus-integration-architecture.md
+++ b/docs/architecture/nexus-integration-architecture.md
@@ -628,7 +628,7 @@ audit-flush  (background Rust thread)
       ▼
 WalStreamCore  (Command::AppendStreamEntry → zone Raft cluster)
       │
-      └─► registered with StreamManager at /{zone}/audit/traces/
+      └─► registered with StreamManager at /__sys__/audit/traces/
 ```
 
 ### 5.3 Auto-wiring on zone create / join
@@ -637,17 +637,17 @@ WalStreamCore  (Command::AppendStreamEntry → zone Raft cluster)
 
 ### 5.4 Central audit zone
 
-Each production node shares a 1:1 zone with the audit-node. `AuditHook` writes formatted `AuditRecord` entries to `/audit/traces/` in that shared zone; the audit-node reads and gathers them locally.
+Each production node shares a 1:1 zone with the audit-node. `AuditHook` writes formatted `AuditRecord` entries to `/__sys__/audit/traces/` in that shared zone; the audit-node reads and gathers them locally.
 
 ```
 Production nexusd (node A)
-    │  AuditHook → /audit/traces/  (auto-wired by zone_create(audit=true))
+    │  AuditHook → /__sys__/audit/traces/  (auto-wired by zone_create(audit=true))
     │
     └──► Shared zone: zone-A-audit
               Raft cluster: [node-A voter, audit-node learner]
 
 Production nexusd (node B)
-    │  AuditHook → /audit/traces/
+    │  AuditHook → /__sys__/audit/traces/
     │
     └──► Shared zone: zone-B-audit
               Raft cluster: [node-B voter, audit-node learner]
@@ -655,7 +655,7 @@ Production nexusd (node B)
 Audit nexusd (audit-node)
     ├── learner of zone-A-audit  ← receives only node-A's audit stream
     ├── learner of zone-B-audit  ← receives only node-B's audit stream
-    └── local collect/gather: reads all /audit/traces/ streams, aggregates
+    └── local collect/gather: reads all /__sys__/audit/traces/ streams, aggregates
 ```
 
 The 1:1 zone holds `AuditRecord` only — formatted by `AuditHook`, with no production-zone metadata or lock commands. audit-node joins via `zone_join(zone_id, as_learner=true, audit=true)` so the production zone's voter quorum is unaffected; audit loss is preferable to blocking production writes.
@@ -687,7 +687,7 @@ via CAS — and dispatches by entry type:
 | Entry type | Used for | Metadata channel | Content channel |
 |-----------|----------|------------------|-----------------|
 | **DT_FILE** | sudo-code sessions, profile configs, task lists | Raft (intra-zone, strongly consistent) | Local CAS (`cas_local` backend) + on-miss lazy fetch from a peer voter via `PeerBlobClient` |
-| **DT_STREAM** (via `WalStreamBackend`) | `chat-with-me`, `/audit/traces/` | Raft (intra-zone) | Same raft log — `WalStreamBackend` writes content as `Command::AppendStreamEntry` so total order across voters is the same channel as metadata |
+| **DT_STREAM** (via `WalStreamBackend`) | `chat-with-me`, `/__sys__/audit/traces/` | Raft (intra-zone) | Same raft log — `WalStreamBackend` writes content as `Command::AppendStreamEntry` so total order across voters is the same channel as metadata |
 
 For `DT_FILE`, the file's `FileMetadata` (entry type, content hash,
 size, last-writer address, etc.) commits through raft so every voter
@@ -787,6 +787,6 @@ Command::DeleteStreamEntry     — stream cleanup
 … (others)
 ```
 
-In the audit 1:1 zone the only `AppendStreamEntry` traffic comes from `AuditHook` writes to `/audit/traces/`; the audit-node learner applies them in order and exposes the aggregated stream to its local `collect/gather` consumer.
+In the audit 1:1 zone the only `AppendStreamEntry` traffic comes from `AuditHook` writes to `/__sys__/audit/traces/`; the audit-node learner applies them in order and exposes the aggregated stream to its local `collect/gather` consumer.
 
 In a chat zone the `AppendStreamEntry` traffic is the conversation itself — every envelope (with its `from` field rewritten by `MailboxStampingHook` on `*/chat-with-me`, see §3.3) replicates to every voter and learner in the zone.

--- a/docs/architecture/nexus-integration-architecture.md
+++ b/docs/architecture/nexus-integration-architecture.md
@@ -284,6 +284,26 @@ duplicate the A2A surface the rest of the system uses.
 parks on the per-pid condvar — Python supervisors get a blocking wait
 without pinning the interpreter.
 
+`AgentRegistry` is the SSOT for `AgentState`.
+`AgentRegistry::update_state(&pid, new_state)` at
+`rust/kernel/src/core/agents/registry.rs:579` is the only writer in
+the runtime path — it enforces the FSM via `can_transition_to`
+(`registry.rs:177`), updates `updated_at_ms`, and fires the
+`on_terminate` observers when a session transitions to `TERMINATED`.
+
+The runtime-path callsite is a state-observer closure constructed by
+`ManagedAgentService::start_session`. The closure captures
+`Arc<AgentRegistry>` and the new session's pid, maps the runtime
+crate's `AgentLoopState` (`WarmingUp` / `Ready` / `Busy`) onto
+`AgentState`, and calls `registry.update_state(&pid, target)` — any
+`AgentError::InvalidTransition` is logged so a runtime FSM bug is
+visible without aborting the worker. The `SpawnTask<K>::spawn` DI
+seam takes this observer as a parameter; the binary-edge adapter
+(e.g. `nexus-cdylib`'s `SudoCodeSpawnAdapter`) forwards it through to
+the runtime crate's `state_callback` parameter and never touches
+`AgentRegistry` itself. The adapter is a pure runtime-wrapper; the
+service owns the SSOT writes.
+
 ### 2.4 sudo-code state placement
 
 sudo-code's `runtime` crate already organises persistence around two

--- a/docs/architecture/nexus-integration-architecture.md
+++ b/docs/architecture/nexus-integration-architecture.md
@@ -27,7 +27,7 @@ Cross-references:
 │              nexusd + sudo-code  (single process, always-on)         │
 │                                                                      │
 │  ┌─────────────────────────────────────────────────────────────┐    │
-│  │  Rust Kernel cdylib  (nexus_runtime)                        │    │
+│  │  Rust Kernel  (nexus-cluster binary)                       │    │
 │  │  VFSRouter · DCache · Metastore(redb) · LockManager         │    │
 │  │  PipeManager(DT_PIPE) · StreamManager(DT_STREAM)            │    │
 │  │  FileWatchRegistry(sys_watch) · KernelDispatch(hooks)       │    │
@@ -47,9 +47,9 @@ Cross-references:
 │  │  ManagedAgentService │   └─────────────────────────────┘         │
 │  │  AcpService          │                                           │
 │  │   (claude/codex/…)   │   FastAPI bricks (mount, rebac, …)        │
-│  │  + AgentRegistry     │   AgentRegistry is a Rust SSOT reachable  │
-│  │    (Rust SSOT;       │   from Python via `kernel.agent_registry`;│
-│  │     PyAgentRegistry) │   ACP / managed_agent reach it directly.  │
+│  │  + AgentRegistry     │   AgentRegistry is a Rust SSOT; ACP and   │
+│  │    (Rust SSOT)       │   managed_agent reach it in-process,      │
+│  │                      │   other callers over the gRPC surface.    │
 │  └──────────────────────┘                                           │
 │                                                                      │
 │  AcpService spawns external ACP backends as subprocesses with        │
@@ -64,8 +64,8 @@ Cross-references:
 ### Constraints
 
 - **One nexusd per sudowork instance.** sudowork starts nexusd at launch and tears it down on quit.
-- **Single Python-facing cdylib.** `nexus_runtime` is the only PyO3 extension module. Service-tier rlibs (`services`, `raft`, `library`, `contracts`) link into it.
-- **State SSOT.** Agent runtime state (`pid → AgentState`, condvar wakeup, signal semantics, parent/child links, transition validation) lives in `kernel::core::agents::registry::AgentRegistry`. Python callers reach it through `kernel.agent_registry` — a thin PyO3 wrapper handing back `nexus_runtime.AgentDescriptor` instances with attribute getters mirroring `contracts/process_types.py`. There is no Python-side state mirror or dual-write step. Profile config lives on disk under `/agents/{name}/`.
+- **Pure-Rust kernel.** The kernel and the service-tier crates (`services`, `raft`, `lib`, `contracts`) compile into the `nexus-cluster` binary; out-of-process components reach nexus through gRPC.
+- **State SSOT.** Agent runtime state (`pid → AgentState`, condvar wakeup, signal semantics, parent/child links, transition validation) lives in `kernel::core::agents::registry::AgentRegistry`. In-process Rust callers (ACP, managed_agent) reach it directly; out-of-process callers reach it through the gRPC surface. There is no second state mirror or dual-write step. Profile config lives on disk under `/agents/{name}/`.
 - **gRPC is the integration surface.** sudowork (Node/TS) reaches nexusd through tonic-served gRPC at port 2028; HTTP is reserved for human-facing dashboards.
 - **Cluster profile.** sudowork uses Nexus's cluster profile — bricks: IPC, FEDERATION.
 - **Zone = VFS path mount point.** A zone's visibility boundary is its mount path. ReBAC governs sub-path access within a zone.
@@ -220,7 +220,7 @@ observer reaps the procfs subtree.
 After the procfs entries are in place, ManagedAgentService hands off
 to the runtime crate through the `SpawnTask<K: KernelAbi>` DI seam.
 The seam is one indirect call per session start — the binary edge
-(cluster binary, or `nexus-cdylib` for the Python wheel) constructs
+(the `nexus-cluster` binary) constructs
 a concrete `SpawnTask<Kernel>` adapter wrapping
 `sudocode_runtime::spawn_task` and registers it via
 `install_managed_agent_with_spawn(kernel, Arc::new(adapter))`.
@@ -280,9 +280,9 @@ There is no `SendPrompt` or `SubscribeEvents` gRPC — those would
 duplicate the A2A surface the rest of the system uses.
 
 `AgentState` lifecycle: `REGISTERED → WARMING_UP → READY ↔ BUSY → SUSPENDED → TERMINATED`.
-`kernel.agent_wait(pid, target_state, timeout_ms)` releases the GIL and
-parks on the per-pid condvar — Python supervisors get a blocking wait
-without pinning the interpreter.
+`kernel.agent_wait(pid, target_state, timeout_ms)` parks the calling
+thread on the per-pid condvar — supervisors get an event-driven
+blocking wait instead of polling.
 
 `AgentRegistry` is the SSOT for `AgentState`.
 `AgentRegistry::update_state(&pid, new_state)` at
@@ -299,7 +299,7 @@ crate's `AgentLoopState` (`WarmingUp` / `Ready` / `Busy`) onto
 `AgentError::InvalidTransition` is logged so a runtime FSM bug is
 visible without aborting the worker. The `SpawnTask<K>::spawn` DI
 seam takes this observer as a parameter; the binary-edge adapter
-(e.g. `nexus-cdylib`'s `SudoCodeSpawnAdapter`) forwards it through to
+forwards it through to
 the runtime crate's `state_callback` parameter and never touches
 `AgentRegistry` itself. The adapter is a pure runtime-wrapper; the
 service owns the SSOT writes.

--- a/docs/architecture/nexus-integration-architecture.md
+++ b/docs/architecture/nexus-integration-architecture.md
@@ -218,14 +218,37 @@ for the same outcome — orphan auto-reap removes the descriptor, the
 observer reaps the procfs subtree.
 
 After the procfs entries are in place, ManagedAgentService hands off
-to the sudo-code crate by calling `sudo_code::spawn_task(pid, ...)` —
-a direct in-process Rust call into a crate linked into the same nexusd
-binary.  The crate spawns a tokio task on the kernel's shared runtime
-(`kernel.runtime()`); the task is the per-pid agent loop.  Tokio is
-the I/O-concurrency model (LLM HTTP round-trips run seconds; many pids
-share a small worker pool); the call surface between
-ManagedAgentService and sudo-code is plain Rust function calls,
-sharing the address space with the kernel.
+to the runtime crate through the `SpawnTask<K: KernelAbi>` DI seam.
+The seam is one indirect call per session start — the binary edge
+(cluster binary, or `nexus-cdylib` for the Python wheel) constructs
+a concrete `SpawnTask<Kernel>` adapter wrapping
+`sudocode_runtime::spawn_task` and registers it via
+`install_managed_agent_with_spawn(kernel, Arc::new(adapter))`.
+`start_session` then calls `provider.spawn(kernel, desc, observer)`
+through `Arc<dyn SpawnTask<K>>`: exactly one vtable dispatch per
+session. The returned `Box<dyn SpawnHandle>` lands in the service's
+`spawn_handles` sidecar so the on_terminate observer can abort the
+worker on session reap.
+
+Inside the spawn body the call surface is plain monomorphic Rust.
+`sudocode_runtime::spawn_task::spawn_task::<K: KernelAbi + Send +
+Sync + 'static>` (and its inner `run_loop<K, C, T, F>` at
+`rust/crates/runtime/src/spawn_task.rs` in the
+[sudocode repo](https://github.com/sudoprivacy/sudocode)) is generic
+over `K`; binary-edge
+monomorphisation specialises it against the concrete `Kernel`. Every
+`kernel.sys_read`, `kernel.sys_write`, and `kernel.sys_watch` in the
+mailbox poll loop is an inline direct call — no per-syscall vtable
+cost. Tokio supplies the I/O-concurrency model (LLM HTTP round-trips
+run seconds; many pids share a small worker pool) on the kernel's
+shared runtime.
+
+The services rlib stays runtime-agnostic: it depends on the
+`SpawnTask` trait only, not on `sudocode_runtime` or any other
+concrete runtime crate. Pure-Rust slim builds that ship managed-agent
+without a runtime body call `install_managed_agent` instead of
+`install_managed_agent_with_spawn`; `start_session` then leaves
+`spawn_provider == None` and no per-pid task is launched.
 
 After spawn, prompts and responses flow through the chat-with-me VFS
 surface — same A2A primitive every other agent uses (§3). sudowork
@@ -260,13 +283,6 @@ duplicate the A2A surface the rest of the system uses.
 `kernel.agent_wait(pid, target_state, timeout_ms)` releases the GIL and
 parks on the per-pid condvar — Python supervisors get a blocking wait
 without pinning the interpreter.
-
-ManagedAgentService dispatches to the runtime through a direct
-in-process call — `sudo_code::spawn_task(pid, ...)` — keeping the
-dispatch surface a single named function for the one-runtime
-configuration. The dispatch site is the place a trait lands the day
-a second in-process runtime joins; the existing call slots in as
-the first trait impl with no behavior change.
 
 ### 2.4 sudo-code state placement
 

--- a/rust/kernel/src/core/dispatch/mod.rs
+++ b/rust/kernel/src/core/dispatch/mod.rs
@@ -140,6 +140,14 @@ impl FileEvent {
         &self.path
     }
 
+    /// Kernel namespace partition. Public accessor for the same reason
+    /// as `path()` — peer crates (services-tier MutationObservers like
+    /// `services::audit::ZoneAuditAutoWire`) need to read the zone an
+    /// event belongs to without `crate::` access to the raw field.
+    pub fn zone_id(&self) -> Option<&str> {
+        self.zone_id.as_deref()
+    }
+
     /// Serialize to compact JSON for DT_STREAM / audit trail.
     ///
     /// Uses `serde_json` so arbitrary control characters in path/new_path

--- a/rust/kernel/src/core/dispatch/mod.rs
+++ b/rust/kernel/src/core/dispatch/mod.rs
@@ -148,6 +148,19 @@ impl FileEvent {
         self.zone_id.as_deref()
     }
 
+    /// Construct a `FileEvent` carrying a zone id. Public helper for
+    /// peer-crate observer tests (services-tier MutationObservers
+    /// fire `on_mutation` against a constructed event when exercising
+    /// the observer body without going through the kernel's full
+    /// sys_setattr dispatch path). Production callers go through
+    /// `Kernel::dispatch_mutation` which builds the event from an
+    /// `OperationContext`.
+    pub fn with_zone(event_type: FileEventType, path: impl Into<String>, zone_id: &str) -> Self {
+        let mut event = Self::new(event_type, path);
+        event.zone_id = Some(zone_id.to_string());
+        event
+    }
+
     /// Serialize to compact JSON for DT_STREAM / audit trail.
     ///
     /// Uses `serde_json` so arbitrary control characters in path/new_path

--- a/rust/kernel/src/core/meta_store/mod.rs
+++ b/rust/kernel/src/core/meta_store/mod.rs
@@ -74,7 +74,7 @@ const FILE_METADATA_TABLE: TableDefinition<&str, &[u8]> = TableDefinition::new("
 /// pre-PR global `Kernel.dcache` — there is no longer a separate
 /// metadata cache that callers can consult; cache management is
 /// metastore-internal and transparent to callers.
-pub(crate) struct LocalMetaStore {
+pub struct LocalMetaStore {
     db: Arc<Database>,
     cache: DashMap<String, FileMetadata>,
 }

--- a/rust/kernel/src/kernel/mod.rs
+++ b/rust/kernel/src/kernel/mod.rs
@@ -1655,6 +1655,20 @@ impl Kernel {
                     let canonical_key = format!("/{zone_id}{path}");
                     self.vfs_router.install_metastore(&canonical_key, rms);
                 }
+                // Dispatch FileEventType::Mount to MutationObservers so
+                // services-tier consumers (e.g. services::audit's
+                // ZoneAuditAutoWire — see docs/architecture/
+                // nexus-integration-architecture.md §5.3) can wire
+                // per-zone state before any caller issues a sys_*
+                // mutation against the new mount. Fire AFTER routing +
+                // metastore install so observers see a fully-routable
+                // mount on read-back.
+                let mut event = crate::core::dispatch::FileEvent::new(
+                    crate::core::dispatch::FileEventType::Mount,
+                    path,
+                );
+                event.zone_id = Some(zone_id.to_string());
+                self.dispatch_observers(&event);
                 Ok(SysSetAttrResult {
                     path: path.to_string(),
                     created: true,
@@ -3249,6 +3263,38 @@ mod tests {
         // Idempotent open
         let r2 = setattr(&k, "/test-stream", 4).unwrap();
         assert!(!r2.created);
+    }
+
+    /// `sys_setattr DT_MOUNT` dispatches a `FileEventType::Mount`
+    /// event through `MutationObserver`. Wired for services-tier
+    /// consumers (e.g. `services::audit::ZoneAuditAutoWire`) to
+    /// auto-wire per-zone state on new mounts — see
+    /// docs/architecture/nexus-integration-architecture.md §5.3.
+    #[test]
+    fn sys_setattr_mount_dispatches_mount_event() {
+        let kernel = Kernel::new();
+        let captured = Arc::new(parking_lot::Mutex::new(None));
+        kernel.register_observer(
+            Arc::new(CapturingObserver {
+                captured: Arc::clone(&captured),
+            }),
+            "mount-probe".to_string(),
+            FileEventType::Mount.bit(),
+        );
+
+        let r = setattr(&kernel, "/zone-new", 2).unwrap();
+        assert!(r.created);
+        assert_eq!(r.entry_type, 2);
+
+        let event = captured
+            .lock()
+            .clone()
+            .expect("Mount observer received event");
+        assert_eq!(event.event_type, FileEventType::Mount);
+        assert_eq!(event.path, "/zone-new");
+        // The `setattr` test helper passes zone_id = "root"; observer
+        // sees that zone identity so per-zone wiring has the right key.
+        assert_eq!(event.zone_id(), Some("root"));
     }
 
     #[test]

--- a/rust/services/src/audit/mod.rs
+++ b/rust/services/src/audit/mod.rs
@@ -24,16 +24,18 @@
 //! //    — install-time control plane (LSM-style EXPORT_SYMBOL).
 //! ```
 
+use std::collections::HashSet;
 use std::sync::mpsc;
 use std::sync::Arc;
 
 use chrono::SecondsFormat;
 use contracts::{is_system_path, OperationContext};
+use parking_lot::Mutex;
 use serde::Serialize;
 
 use kernel::abi::KernelAbi;
-use kernel::core::dispatch::{HookContext, NativeInterceptHook};
-use kernel::kernel::KernelError;
+use kernel::core::dispatch::{FileEvent, FileEventType, HookContext, MutationObserver, NativeInterceptHook};
+use kernel::kernel::{Kernel, KernelError};
 
 /// DT_STREAM entry-type discriminant (mirrors `kernel::core::dcache::DT_STREAM`).
 const DT_STREAM: i32 = 4;
@@ -265,6 +267,95 @@ pub fn prepare_stream_only<K: KernelAbi>(
     setup_audit_stream(kernel, zone_id, stream_path)
 }
 
+/// Boot-time install for the root zone + auto-wire for every zone
+/// that mounts later. Companion to [`install`] for deployments that
+/// want audit on every zone, not just the one named at boot.
+///
+/// Steps:
+///   1. Install AuditHook + DT_STREAM for `root_zone_id` (one call
+///      to [`install`]) so the boot-time stream is ready before any
+///      VFS op fires.
+///   2. Register a [`ZoneAuditAutoWire`] [`MutationObserver`] on
+///      `kernel` filtering [`FileEventType::Mount`]. Each Mount
+///      event maps to a per-zone [`install`] call (the same code
+///      path used at boot for `root_zone_id`), guarded by an
+///      internal `HashSet<String>` so a re-mount is a harmless
+///      no-op.
+///
+/// `K = Kernel`-specific (not generic over `K: KernelAbi`) because
+/// `kernel.register_observer` is a kernel-internal accessor — same
+/// reason `ManagedAgentService::install_returning` is gated to
+/// `K = Kernel`. Slim builds that ship a non-Kernel `K` use
+/// [`install`] for the single boot zone and don't get the auto-wire.
+///
+/// See `docs/architecture/nexus-integration-architecture.md` §5.3
+/// for the architectural rationale.
+pub fn install_root(
+    kernel: &Arc<Kernel>,
+    root_zone_id: &str,
+    stream_path: &str,
+) -> Result<(), KernelError> {
+    install(Arc::clone(kernel), root_zone_id, stream_path)?;
+
+    let mut seeded = HashSet::new();
+    seeded.insert(root_zone_id.to_string());
+
+    let auto_wire = Arc::new(ZoneAuditAutoWire {
+        kernel: Arc::clone(kernel),
+        installed: Mutex::new(seeded),
+        stream_path: stream_path.to_string(),
+    });
+    kernel.register_observer(
+        auto_wire,
+        ZoneAuditAutoWire::OBSERVER_NAME.to_string(),
+        FileEventType::Mount as u32,
+    );
+    Ok(())
+}
+
+/// [`MutationObserver`] that auto-installs AuditHook for newly
+/// mounted zones. Registered exactly once by [`install_root`] and
+/// keeps its own `HashSet` of zones it has already installed for so
+/// re-mount events are no-ops.
+struct ZoneAuditAutoWire {
+    kernel: Arc<Kernel>,
+    /// Zones the observer has already wired AuditHook for. The
+    /// root zone is seeded into this set by [`install_root`] before
+    /// the observer is registered, so a re-mount of the root zone
+    /// also no-ops.
+    installed: Mutex<HashSet<String>>,
+    stream_path: String,
+}
+
+impl ZoneAuditAutoWire {
+    pub(crate) const OBSERVER_NAME: &'static str = "audit-zone-auto-wire";
+}
+
+impl MutationObserver for ZoneAuditAutoWire {
+    fn on_mutation(&self, event: &FileEvent) {
+        let zone_id = match event.zone_id() {
+            Some(z) if !z.is_empty() => z.to_string(),
+            _ => return,
+        };
+        // First-writer wins on the HashSet — drop the lock before
+        // calling install() so a re-entrant Mount event (impossible
+        // today, defensive) wouldn't deadlock.
+        {
+            let mut guard = self.installed.lock();
+            if !guard.insert(zone_id.clone()) {
+                return;
+            }
+        }
+        if let Err(e) = install(Arc::clone(&self.kernel), &zone_id, &self.stream_path) {
+            tracing::warn!(
+                zone = %zone_id,
+                error = ?e,
+                "audit auto-wire install_for_zone failed",
+            );
+        }
+    }
+}
+
 fn setup_audit_stream<K: KernelAbi>(
     kernel: &K,
     zone_id: &str,
@@ -294,4 +385,62 @@ fn setup_audit_stream<K: KernelAbi>(
         /* remote_metastore */ None,
     )?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use kernel::kernel::Kernel;
+
+    fn fresh_kernel() -> Arc<Kernel> {
+        Arc::new(Kernel::new())
+    }
+
+    /// `ZoneAuditAutoWire` records each zone in its HashSet exactly
+    /// once and no-ops on a re-mount. Drives the observer directly
+    /// (skipping the `install` call by short-circuiting through the
+    /// HashSet-already-contains check) so the test doesn't depend on
+    /// federation being wired — `install`'s `io_profile="wal"`
+    /// requires `DistributedCoordinator`, which a bare
+    /// `Kernel::new()` doesn't have.
+    #[test]
+    fn zone_audit_auto_wire_dedups_by_zone_id() {
+        let kernel = fresh_kernel();
+        let mut seeded = HashSet::new();
+        // Pre-seed every zone we'll fire events for — the HashSet
+        // check short-circuits before install() runs, so we exercise
+        // only the dedup logic without needing federation.
+        seeded.insert("z1".to_string());
+        seeded.insert("z2".to_string());
+
+        let auto_wire = ZoneAuditAutoWire {
+            kernel,
+            installed: Mutex::new(seeded),
+            stream_path: "/__sys__/audit/traces/".to_string(),
+        };
+
+        // Fire Mount events for already-seeded zones — short-circuits
+        // via HashSet check, install() never runs, no panic on missing
+        // federation.
+        auto_wire.on_mutation(&FileEvent::with_zone(FileEventType::Mount, "/mnt/z1", "z1"));
+        auto_wire.on_mutation(&FileEvent::with_zone(FileEventType::Mount, "/mnt/z1", "z1"));
+        auto_wire.on_mutation(&FileEvent::with_zone(FileEventType::Mount, "/mnt/z2", "z2"));
+
+        // Events with an empty zone_id are ignored (early return);
+        // proves the observer doesn't index `installed` on a blank
+        // key.
+        auto_wire.on_mutation(&FileEvent::with_zone(
+            FileEventType::Mount,
+            "/mnt/no-zone",
+            "",
+        ));
+
+        let installed = auto_wire.installed.lock();
+        assert!(installed.contains("z1"));
+        assert!(installed.contains("z2"));
+        // Still exactly the two we seeded — no spurious inserts from
+        // re-mounts or from zone-less events.
+        assert_eq!(installed.len(), 2);
+    }
 }

--- a/rust/services/src/audit/mod.rs
+++ b/rust/services/src/audit/mod.rs
@@ -397,6 +397,132 @@ mod tests {
         Arc::new(Kernel::new())
     }
 
+    // ── Test federation fixture ──────────────────────────────────────
+    //
+    // `audit::install`'s `io_profile="wal"` codepath requires a
+    // `DistributedCoordinator` so the WAL stream backend can route
+    // through `coordinator.metastore_for_zone(zone)`. A bare
+    // `Kernel::new()` ships with `NoopDistributedCoordinator` which
+    // returns `is_initialized=false` — the stream setattr rejects
+    // with `"io_profile=wal requires federation"`.
+    //
+    // `TestFederationCoordinator` is the minimal stub: reports
+    // `is_initialized=true` and hands back a single tempdir-backed
+    // `LocalMetaStore` from `metastore_for_zone` (same store for
+    // every zone — production multi-zone redb separation is not what
+    // these tests exercise). Mirrors the kernel's own federation_wal_e2e
+    // test fixture (`rust/kernel/src/kernel/mod.rs:3991-4065`); kept
+    // local to audit tests to avoid promoting it to the kernel public
+    // surface for a single peer-crate consumer.
+    mod federation_stub {
+        use std::sync::Arc;
+
+        use kernel::abc::meta_store::MetaStore;
+        use kernel::hal::distributed_coordinator::{
+            ClusterInfo, CoordinatorResult, DistributedCoordinator, ShareInfo,
+        };
+        use kernel::kernel::Kernel;
+        use kernel::meta_store::LocalMetaStore;
+        use tempfile::TempDir;
+
+        pub(super) struct TestFederationCoordinator {
+            metastore: Arc<dyn MetaStore>,
+            _tempdir: TempDir,
+        }
+
+        impl TestFederationCoordinator {
+            pub(super) fn new() -> Self {
+                let tempdir = TempDir::new().expect("tempdir for audit fed-stub");
+                let path = tempdir.path().join("audit-fed-metastore.redb");
+                let metastore: Arc<dyn MetaStore> =
+                    Arc::new(LocalMetaStore::open(&path).expect("open LocalMetaStore"));
+                Self {
+                    metastore,
+                    _tempdir: tempdir,
+                }
+            }
+        }
+
+        impl DistributedCoordinator for TestFederationCoordinator {
+            fn list_zones(&self, _kernel: &Kernel) -> Vec<String> {
+                vec!["root".to_string()]
+            }
+            fn is_initialized(&self, _kernel: &Kernel) -> bool {
+                true
+            }
+            fn cluster_info(&self, _: &Kernel, _: &str) -> CoordinatorResult<ClusterInfo> {
+                Err("test coordinator: cluster_info unused".into())
+            }
+            fn create_zone(&self, _: &Kernel, _: &str) -> CoordinatorResult<()> {
+                Ok(())
+            }
+            fn remove_zone(&self, _: &Kernel, _: &str, _: bool) -> CoordinatorResult<()> {
+                Err("test coordinator: remove_zone unused".into())
+            }
+            fn join_zone(&self, _: &Kernel, _: &str, _: bool) -> CoordinatorResult<()> {
+                Err("test coordinator: join_zone unused".into())
+            }
+            fn wire_mount(&self, _: &Kernel, _: &str, _: &str, _: &str) -> CoordinatorResult<()> {
+                Ok(())
+            }
+            fn unwire_mount(&self, _: &Kernel, _: &str, _: &str) -> CoordinatorResult<()> {
+                Err("test coordinator: unwire_mount unused".into())
+            }
+            fn share_zone(&self, _: &Kernel, _: &str, _: &str) -> CoordinatorResult<ShareInfo> {
+                Err("test coordinator: share_zone unused".into())
+            }
+            fn lookup_share(
+                &self,
+                _: &Kernel,
+                _: &str,
+            ) -> CoordinatorResult<Option<ShareInfo>> {
+                Ok(None)
+            }
+            fn metastore_for_zone(
+                &self,
+                _: &Kernel,
+                _: &str,
+            ) -> CoordinatorResult<Arc<dyn MetaStore>> {
+                Ok(Arc::clone(&self.metastore))
+            }
+            fn locks_for_zone(
+                &self,
+                _: &Kernel,
+                _: &str,
+            ) -> CoordinatorResult<Arc<dyn contracts::lock_state::Locks>> {
+                Err("test coordinator: locks_for_zone unused".into())
+            }
+        }
+    }
+
+    /// Build a `Kernel` with `TestFederationCoordinator` installed
+    /// so `is_federation_initialized()` returns true and the WAL
+    /// stream backend can route through the per-zone metastore.
+    fn fresh_federated_kernel() -> Arc<Kernel> {
+        let kernel = Arc::new(Kernel::new());
+        kernel.set_distributed_coordinator(Arc::new(
+            federation_stub::TestFederationCoordinator::new(),
+        )
+            as Arc<dyn kernel::hal::distributed_coordinator::DistributedCoordinator>);
+        kernel
+    }
+
+    /// Smoke test for the federation stub: `install_root` against a
+    /// federated kernel composes the root-zone audit DT_STREAM
+    /// successfully (and is idempotent on re-install).
+    #[test]
+    fn install_root_against_federated_kernel_composes_root_audit_stream() {
+        let kernel = fresh_federated_kernel();
+        install_root(&kernel, "root", "/__sys__/audit/traces/").expect("install_root");
+
+        // Idempotent: a second install_root call surfaces — install()
+        // re-uses the existing DT_STREAM (sys_setattr DT_STREAM is a
+        // no-op re-open), the auto-wire HashSet has "root" seeded
+        // again (no-op insert), and a second observer registration is
+        // harmless beyond a slight per-dispatch cost.
+        install_root(&kernel, "root", "/__sys__/audit/traces/").expect("install_root idempotent");
+    }
+
     /// `ZoneAuditAutoWire` records each zone in its HashSet exactly
     /// once and no-ops on a re-mount. Drives the observer directly
     /// (skipping the `install` call by short-circuiting through the

--- a/rust/services/src/audit/mod.rs
+++ b/rust/services/src/audit/mod.rs
@@ -15,7 +15,7 @@
 //! ## Boot wiring (Linux LSM analogue)
 //!
 //! ```ignore
-//! services::audit::install(&kernel, "root", "/audit/traces/")?;
+//! services::audit::install(&kernel, "root", "/__sys__/audit/traces/")?;
 //! // 1. kernel.sys_setattr(stream_path, DT_STREAM, …, "wal", zone)
 //! //    — service-side syscall; kernel composes the WAL stream.
 //! // 2. AuditHook::new(kernel, stream_path, zone)

--- a/rust/services/src/audit/mod.rs
+++ b/rust/services/src/audit/mod.rs
@@ -407,14 +407,16 @@ mod tests {
     // with `"io_profile=wal requires federation"`.
     //
     // `TestFederationCoordinator` is the minimal stub: reports
-    // `is_initialized=true` and hands back a single tempdir-backed
-    // `LocalMetaStore` from `metastore_for_zone` (same store for
-    // every zone — production multi-zone redb separation is not what
-    // these tests exercise). Mirrors the kernel's own federation_wal_e2e
-    // test fixture (`rust/kernel/src/kernel/mod.rs:3991-4065`); kept
-    // local to audit tests to avoid promoting it to the kernel public
-    // surface for a single peer-crate consumer.
+    // `is_initialized=true` and hands back a per-zone tempdir-backed
+    // `LocalMetaStore` from `metastore_for_zone` (lazily created and
+    // cached per zone, so cross-zone tests get the production-style
+    // "different zones have different metastores" semantics rather
+    // than sharing one store across zones). Inspired by the kernel's
+    // own federation_wal_e2e fixture (`rust/kernel/src/kernel/mod.rs:
+    // 3991-4065`) but with multi-zone support, kept local to audit
+    // tests to avoid promoting it to the kernel public surface.
     mod federation_stub {
+        use std::collections::HashMap;
         use std::sync::Arc;
 
         use kernel::abc::meta_store::MetaStore;
@@ -423,29 +425,30 @@ mod tests {
         };
         use kernel::kernel::Kernel;
         use kernel::meta_store::LocalMetaStore;
+        use parking_lot::Mutex;
         use tempfile::TempDir;
 
         pub(super) struct TestFederationCoordinator {
-            metastore: Arc<dyn MetaStore>,
-            _tempdir: TempDir,
+            tempdir: TempDir,
+            /// Per-zone metastore cache. Lazily populated on each
+            /// `metastore_for_zone(zone)` call so the test fixture
+            /// matches production's "every zone owns its own
+            /// metastore" semantics.
+            stores: Mutex<HashMap<String, Arc<dyn MetaStore>>>,
         }
 
         impl TestFederationCoordinator {
             pub(super) fn new() -> Self {
-                let tempdir = TempDir::new().expect("tempdir for audit fed-stub");
-                let path = tempdir.path().join("audit-fed-metastore.redb");
-                let metastore: Arc<dyn MetaStore> =
-                    Arc::new(LocalMetaStore::open(&path).expect("open LocalMetaStore"));
                 Self {
-                    metastore,
-                    _tempdir: tempdir,
+                    tempdir: TempDir::new().expect("tempdir for audit fed-stub"),
+                    stores: Mutex::new(HashMap::new()),
                 }
             }
         }
 
         impl DistributedCoordinator for TestFederationCoordinator {
             fn list_zones(&self, _kernel: &Kernel) -> Vec<String> {
-                vec!["root".to_string()]
+                self.stores.lock().keys().cloned().collect()
             }
             fn is_initialized(&self, _kernel: &Kernel) -> bool {
                 true
@@ -481,9 +484,22 @@ mod tests {
             fn metastore_for_zone(
                 &self,
                 _: &Kernel,
-                _: &str,
+                zone_id: &str,
             ) -> CoordinatorResult<Arc<dyn MetaStore>> {
-                Ok(Arc::clone(&self.metastore))
+                let mut stores = self.stores.lock();
+                if let Some(existing) = stores.get(zone_id) {
+                    return Ok(Arc::clone(existing));
+                }
+                let path = self
+                    .tempdir
+                    .path()
+                    .join(format!("zone-{zone_id}.redb"));
+                let store: Arc<dyn MetaStore> = Arc::new(
+                    LocalMetaStore::open(&path)
+                        .map_err(|e| format!("LocalMetaStore::open({path:?}): {e:?}"))?,
+                );
+                stores.insert(zone_id.to_string(), Arc::clone(&store));
+                Ok(store)
             }
             fn locks_for_zone(
                 &self,
@@ -521,6 +537,104 @@ mod tests {
         // again (no-op insert), and a second observer registration is
         // harmless beyond a slight per-dispatch cost.
         install_root(&kernel, "root", "/__sys__/audit/traces/").expect("install_root idempotent");
+    }
+
+    /// Helper that issues `sys_setattr DT_MOUNT` for a new zone with
+    /// the federated-test-friendly default args (empty backend_name,
+    /// `None` for backend / metastore / raft_backend, `"memory"`
+    /// io_profile for the mount itself — the per-zone audit DT_STREAM
+    /// `install()` creates is what uses `"wal"`).
+    fn mount_zone(kernel: &Arc<Kernel>, path: &str, zone_id: &str) {
+        use kernel::meta_store::DT_MOUNT;
+        kernel
+            .sys_setattr(
+                path,
+                DT_MOUNT as i32,
+                /* backend_name */ "",
+                /* backend */ None,
+                /* metastore */ None,
+                /* raft_backend */ None,
+                /* io_profile */ "memory",
+                zone_id,
+                /* is_external */ false,
+                /* capacity */ 0,
+                /* read_fd */ None,
+                /* write_fd */ None,
+                /* mime_type */ None,
+                /* modified_at_ms */ None,
+                /* content_id */ None,
+                /* size */ None,
+                /* version */ None,
+                /* created_at_ms */ None,
+                /* link_target */ None,
+                /* source */ None,
+                /* remote_metastore */ None,
+            )
+            .expect("sys_setattr DT_MOUNT");
+    }
+
+    /// Mount → auto-wire → observer-records-zone integration test.
+    ///
+    /// `install_root` registers a private `ZoneAuditAutoWire`
+    /// instance internally, so the test can't get a handle to that
+    /// one. Instead the test constructs its own `ZoneAuditAutoWire`,
+    /// registers it on the kernel with the same `FileEventType::Mount`
+    /// mask `install_root` would use, and asserts that a real
+    /// `sys_setattr DT_MOUNT` reaches `on_mutation` with the new
+    /// zone's id — proving the kernel's Mount-dispatch wiring (C7) +
+    /// observer dispatch path land at the auto-wire correctly.
+    ///
+    /// Re-mount idempotency is exercised end-to-end too: a second
+    /// `sys_setattr DT_MOUNT` for the same zone fires the observer
+    /// again, but the `installed` HashSet still has exactly one
+    /// entry per zone afterwards.
+    #[test]
+    fn dt_mount_dispatch_reaches_zone_audit_auto_wire_observer() {
+        let kernel = fresh_federated_kernel();
+
+        // Pre-seed the audit DT_STREAM for the root zone via
+        // `install` so the observer's per-zone `install` calls can
+        // succeed against the federated kernel.
+        install(Arc::clone(&kernel), "root", "/__sys__/audit/traces/").expect("install root");
+
+        // Construct + register the auto-wire ourselves so we can
+        // inspect its `installed` HashSet after the dispatch fires.
+        let auto_wire = Arc::new(ZoneAuditAutoWire {
+            kernel: Arc::clone(&kernel),
+            installed: Mutex::new({
+                let mut s = HashSet::new();
+                s.insert("root".to_string());
+                s
+            }),
+            stream_path: "/__sys__/audit/traces/".to_string(),
+        });
+        kernel.register_observer(
+            Arc::clone(&auto_wire) as Arc<dyn MutationObserver>,
+            ZoneAuditAutoWire::OBSERVER_NAME.to_string(),
+            FileEventType::Mount as u32,
+        );
+
+        // Mount audit-z1 through the real syscall path — dispatches
+        // FileEventType::Mount → auto-wire on_mutation fires.
+        mount_zone(&kernel, "/mnt/audit-z1", "audit-z1");
+        assert!(
+            auto_wire.installed.lock().contains("audit-z1"),
+            "auto-wire HashSet should contain audit-z1 after Mount dispatch",
+        );
+
+        // Mount audit-z2 — fires for the new zone too.
+        mount_zone(&kernel, "/mnt/audit-z2", "audit-z2");
+        assert!(auto_wire.installed.lock().contains("audit-z2"));
+
+        // Re-mount audit-z1 — fires again, but HashSet entries don't
+        // multiply: still exactly 3 (root + audit-z1 + audit-z2).
+        mount_zone(&kernel, "/mnt/audit-z1", "audit-z1");
+        let installed = auto_wire.installed.lock();
+        assert_eq!(
+            installed.len(),
+            3,
+            "re-mount of audit-z1 must not duplicate the HashSet entry",
+        );
     }
 
     /// `ZoneAuditAutoWire` records each zone in its HashSet exactly

--- a/rust/services/src/audit/mod.rs
+++ b/rust/services/src/audit/mod.rs
@@ -637,6 +637,105 @@ mod tests {
         );
     }
 
+    /// Write-captured integration test: a `sys_write` to a non-
+    /// system DT_STREAM fires the AuditHook installed by
+    /// `install_root` for the root zone, which serialises the op
+    /// into an `AuditRecord` and (on the background flush thread)
+    /// appends it to `/__sys__/audit/traces/`. A subsequent
+    /// `sys_read` on the audit stream returns the captured record.
+    ///
+    /// Async note: `AuditHook` ships records to its background
+    /// flush thread via `mpsc::SyncSender::try_send`; the actual
+    /// `sys_write` to the audit stream runs off the syscall hot
+    /// path. The test polls `sys_read` for up to ~200 ms (20 × 10
+    /// ms) before giving up — the loop typically terminates on the
+    /// first or second iteration.
+    #[test]
+    fn audit_hook_captures_sys_write_through_to_audit_stream() {
+        let kernel = fresh_federated_kernel();
+
+        // Mount both the test path and /__sys__/ at root zone BEFORE
+        // install_root. Unrouted paths land in stream_manager but
+        // their metastore_get / write_stream_inode bookkeeping
+        // misses, making subsequent sys_write a no-op (`hit=false`)
+        // and sys_read return `FileNotFound`. /__sys__/ matters here
+        // because that's where install_root composes the audit
+        // DT_STREAM; we need to be able to read it back.
+        let router = kernel.vfs_router_arc();
+        router.add_mount("/test-audit", "root", None, false);
+        router.add_mount("/__sys__", "root", None, false);
+
+        install_root(&kernel, "root", "/__sys__/audit/traces/").expect("install_root");
+
+        // Create a non-system DT_STREAM to write into. AuditHook's
+        // is_system_path() short-circuit means writes to /__sys__/...
+        // are excluded from audit (self-write recursion break), so
+        // the target lives outside that prefix.
+        let target = "/test-audit/target";
+        kernel
+            .sys_setattr(
+                target,
+                DT_STREAM,
+                /* backend_name */ "",
+                /* backend */ None,
+                /* metastore */ None,
+                /* raft_backend */ None,
+                /* io_profile */ "wal",
+                /* zone_id */ "root",
+                /* is_external */ false,
+                /* capacity */ 0,
+                None, None, None, None, None, None, None, None, None, None, None,
+            )
+            .expect("setattr DT_STREAM target");
+
+        let writer_ctx = OperationContext::new(
+            /* user_id */ "alice",
+            /* zone_id */ "root",
+            /* is_admin */ false,
+            /* agent_id */ Some("agent-test"),
+            /* is_system */ false,
+        );
+        KernelAbi::sys_write(kernel.as_ref(), target, &writer_ctx, b"payload", 0)
+            .expect("sys_write target payload");
+
+        // Poll the audit stream until the flush thread has drained
+        // the record (or fail after ~200 ms).
+        let reader_ctx = OperationContext::new(
+            /* user_id */ "audit-reader",
+            /* zone_id */ "root",
+            /* is_admin */ true,
+            /* agent_id */ Some("audit-reader"),
+            /* is_system */ true,
+        );
+        let mut captured: Option<Vec<u8>> = None;
+        for _ in 0..20 {
+            std::thread::sleep(std::time::Duration::from_millis(10));
+            if let Ok(read) =
+                KernelAbi::sys_read(kernel.as_ref(), "/__sys__/audit/traces/", &reader_ctx, 0, 0)
+            {
+                if let Some(data) = read.data {
+                    if !data.is_empty() {
+                        captured = Some(data);
+                        break;
+                    }
+                }
+            }
+        }
+        let bytes = captured.expect("AuditHook drained at least one record to the audit stream");
+
+        // First record decodes as JSON with the expected op + path
+        // + agent_id stamped by build_record from the writer ctx.
+        let mut decoder = serde_json::Deserializer::from_slice(&bytes).into_iter::<serde_json::Value>();
+        let record = decoder
+            .next()
+            .expect("at least one JSON record present")
+            .expect("first audit record decodes as JSON");
+        assert_eq!(record["op"], "write");
+        assert_eq!(record["path"], target);
+        assert_eq!(record["agent_id"], "agent-test");
+        assert_eq!(record["zone_id"], "root");
+    }
+
     /// `ZoneAuditAutoWire` records each zone in its HashSet exactly
     /// once and no-ops on a re-mount. Drives the observer directly
     /// (skipping the `install` call by short-circuiting through the

--- a/rust/services/src/managed_agent/mod.rs
+++ b/rust/services/src/managed_agent/mod.rs
@@ -203,6 +203,30 @@ pub trait SpawnHandle: Send + Sync {
     fn abort(&self);
 }
 
+/// Lifecycle-state notifications a [`SpawnTask`] body emits as the
+/// runtime loop progresses. Service-side mirror of the runtime
+/// crate's equivalent enum (today: `sudocode_runtime::spawn_task::
+/// AgentLoopState`); the binary-edge adapter maps the runtime enum
+/// to this one on the way through the [`SpawnTask::spawn`]
+/// `state_observer`.
+///
+/// Services owns this enum (not the runtime crate) because state
+/// transition semantics are a managed-agent concern — keeping the
+/// trait surface runtime-agnostic preserves the services rlib's
+/// no-cross-repo-runtime-dep boundary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AgentLoopState {
+    /// Runtime is initialising (loading prompt, system setup); maps
+    /// to [`AgentState::WarmingUp`].
+    WarmingUp,
+    /// Runtime is parked waiting for input on the mailbox; maps to
+    /// [`AgentState::Ready`].
+    Ready,
+    /// Runtime is mid-turn (LLM streaming, tool execution); maps to
+    /// [`AgentState::Busy`].
+    Busy,
+}
+
 /// Spawn-task provider. `start_session` calls
 /// [`Self::spawn`] after `register_proc_entry` succeeds to kick off
 /// the per-pid runtime body. The concrete impl wraps whatever
@@ -214,7 +238,22 @@ pub trait SpawnTask<K: KernelAbi>: Send + Sync + 'static {
     /// service stores in its `spawn_handles` sidecar; the
     /// on_terminate observer aborts via the handle on session
     /// termination.
-    fn spawn(&self, kernel: Arc<K>, desc: AgentDescriptor) -> Box<dyn SpawnHandle>;
+    ///
+    /// `state_observer` is the SSOT writer for the session's
+    /// [`AgentState`]. The closure is constructed by
+    /// `ManagedAgentService::start_session` — it captures the
+    /// service's `Arc<AgentRegistry>` and the session's pid, maps
+    /// the runtime-side [`AgentLoopState`] onto [`AgentState`], and
+    /// calls `AgentRegistry::update_state`. The spawn body's only
+    /// role w.r.t. state is to invoke the observer on each
+    /// transition; it MUST NOT write to AgentRegistry through any
+    /// other path.
+    fn spawn(
+        &self,
+        kernel: Arc<K>,
+        desc: AgentDescriptor,
+        state_observer: Arc<dyn Fn(AgentLoopState) + Send + Sync>,
+    ) -> Box<dyn SpawnHandle>;
 }
 
 // ── Service ─────────────────────────────────────────────────────────────
@@ -383,7 +422,34 @@ impl<K: KernelAbi> ManagedAgentService<K> {
             // provider (`spawn_provider: None`) skip the spawn and
             // run procfs-only.
             if let Some(provider) = self.spawn_provider.as_ref() {
-                let handle = provider.spawn(Arc::clone(&self.kernel), desc);
+                // Construct the SSOT state observer. AgentRegistry is
+                // the single writer of AgentState in the runtime path
+                // (see kernel::core::agents::registry::update_state +
+                // can_transition_to FSM); the spawn body calls this
+                // closure on each AgentLoopState transition and the
+                // closure forwards the update through update_state.
+                // InvalidTransition is logged rather than panicked so
+                // an FSM bug in the runtime body surfaces as a warning
+                // instead of taking down the worker thread.
+                let registry = Arc::clone(&self.agent_registry);
+                let pid_for_observer = pid.clone();
+                let observer: Arc<dyn Fn(AgentLoopState) + Send + Sync> =
+                    Arc::new(move |loop_state: AgentLoopState| {
+                        let target = match loop_state {
+                            AgentLoopState::WarmingUp => AgentState::WarmingUp,
+                            AgentLoopState::Ready => AgentState::Ready,
+                            AgentLoopState::Busy => AgentState::Busy,
+                        };
+                        if let Err(e) = registry.update_state(&pid_for_observer, target) {
+                            tracing::warn!(
+                                pid = %pid_for_observer,
+                                state = ?target,
+                                error = %e,
+                                "AgentRegistry.update_state rejected runtime-side transition",
+                            );
+                        }
+                    });
+                let handle = provider.spawn(Arc::clone(&self.kernel), desc, observer);
                 self.spawn_handles.insert(pid.clone(), handle);
             }
         }
@@ -663,11 +729,58 @@ mod tests {
         }
     }
 
+    /// Mock [`SpawnTask`] that invokes the injected `state_observer`
+    /// with a scripted WARMING_UP → READY → BUSY transition sequence,
+    /// then returns a no-op handle. Used by the
+    /// `state_observer_drives_agent_registry_through_loop_states`
+    /// test to verify the service-constructed observer closure is the
+    /// SSOT writer of AgentState.
+    struct ScriptedSpawn;
+    struct NoopHandle;
+    impl SpawnHandle for NoopHandle {
+        fn abort(&self) {}
+    }
+    impl SpawnTask<Kernel> for ScriptedSpawn {
+        fn spawn(
+            &self,
+            _kernel: Arc<Kernel>,
+            _desc: AgentDescriptor,
+            state_observer: Arc<dyn Fn(AgentLoopState) + Send + Sync>,
+        ) -> Box<dyn SpawnHandle> {
+            state_observer(AgentLoopState::WarmingUp);
+            state_observer(AgentLoopState::Ready);
+            state_observer(AgentLoopState::Busy);
+            Box::new(NoopHandle)
+        }
+    }
+
     #[test]
     fn service_has_canonical_name() {
         let (_kernel, _table, svc) = fresh_service();
         assert_eq!(svc.name(), "managed_agent");
         assert_eq!(ManagedAgentService::<Kernel>::NAME, "managed_agent");
+    }
+
+    #[test]
+    fn state_observer_drives_agent_registry_through_loop_states() {
+        let kernel = Arc::new(Kernel::new());
+        let registry = Arc::clone(kernel.agent_registry());
+        let svc = ManagedAgentService::<Kernel>::with_spawn(
+            Arc::clone(&kernel),
+            Arc::clone(&registry),
+            Arc::new(ScriptedSpawn),
+        );
+
+        let resp = svc.start_session(req("scode-standard")).unwrap();
+        let desc = registry
+            .get(&resp.session_id)
+            .expect("AgentRegistry record present");
+        // The scripted observer fired WARMING_UP → READY → BUSY; final
+        // state in the SSOT is BUSY. (start_session already moves
+        // REGISTERED → WARMING_UP before spawn, so a re-fired
+        // WARMING_UP from the observer is a no-op via the from==new
+        // shortcut in update_state.)
+        assert_eq!(desc.state, AgentState::Busy);
     }
 
     #[test]
@@ -1134,13 +1247,21 @@ mod tests {
                 zone_perms: vec![],
             };
 
-            kernel
-                .sys_write(&shortcut, &ctx, payload, 0)
+            // Use UFCS through KernelAbi so we get the single-path
+            // trait wrappers (sys_read_single / sys_write_with_link_depth)
+            // — the inherent Kernel::sys_read/sys_write are now batch-shaped
+            // (&[ReadRequest] / &[WriteRequest]).
+            KernelAbi::sys_write(kernel.as_ref(), &shortcut, &ctx, payload, 0)
                 .expect("sys_write through workspace shortcut DT_LINK");
 
-            let read = kernel
-                .sys_read(&canonical, &ctx, /* timeout_ms */ 0, 0)
-                .expect("sys_read on canonical chat-with-me");
+            let read = KernelAbi::sys_read(
+                kernel.as_ref(),
+                &canonical,
+                &ctx,
+                /* timeout_ms */ 0,
+                0,
+            )
+            .expect("sys_read on canonical chat-with-me");
             let bytes = read.data.expect("stream data present after write");
             assert_eq!(bytes.as_slice(), payload);
         }
@@ -1184,12 +1305,10 @@ mod tests {
                 zone_perms: vec![],
             };
 
-            kernel
-                .sys_write(&shortcut, &ctx, &llm_authored, 0)
+            KernelAbi::sys_write(kernel.as_ref(), &shortcut, &ctx, &llm_authored, 0)
                 .expect("sys_write through workspace shortcut DT_LINK");
 
-            let read = kernel
-                .sys_read(&canonical, &ctx, 0, 0)
+            let read = KernelAbi::sys_read(kernel.as_ref(), &canonical, &ctx, 0, 0)
                 .expect("sys_read on canonical chat-with-me");
             let bytes = read.data.expect("stream data present");
             let json: serde_json::Value =


### PR DESCRIPTION
## What this does

Three architecture-independent kernel/services improvements plus the integration architecture doc:

- **`feat(kernel)` — `FileEventType::Mount` is now fired.** The enum variant + `MutationObserver` trait existed but no `sys_*` path dispatched it. Wired into the `DT_MOUNT` branch of `sys_setattr` (mirrors the existing DT_FILE/DT_DIR dispatch sites). `FileEvent::zone_id()` accessor + `FileEvent::with_zone()` constructor added for peer-crate observers.
- **`feat(services::audit)` — audit auto-wires on zone mount.** `install_root` registers a `ZoneAuditAutoWire` `MutationObserver` filtering `Mount` events; each new zone gets its AuditHook + DT_STREAM installed idempotently (HashSet-guarded). No zone-creation API duplication.
- **`feat(services::managed_agent)` — `SpawnTask::spawn` takes a state observer.** AgentRegistry stays the single SSOT writer of `AgentState`; the runtime body reports transitions through an observer closure constructed by `ManagedAgentService::start_session`.
- **`docs(architecture)` — `nexus-integration-architecture.md`** moved in from the sudowork repo (companion PR: sudoprivacy/sudowork — deletes it there + leaves a stub pointer).

## Commits (14, history preserved — see "back-and-forth" below)

```
docs(architecture): add nexus-integration-architecture.md (moved from sudowork-2)
docs(integration): §2.3 spawn handoff — DI seam + direct Rust hot path
docs(integration): §2.3 AgentRegistry is SSOT for AgentState
docs+code: audit stream path = /__sys__/audit/traces/
docs(integration): §5.3 zone audit auto-wire via Mount observer
feat(kernel): fire FileEventType::Mount on sys_setattr DT_MOUNT success
feat(services::managed_agent): SpawnTask::spawn takes state observer
refactor(nexus-cdylib): SudoCodeSpawnAdapter delegates state to observer   [empty — see below]
feat(services::audit): MutationObserver auto-wires audit for new zones
fix(kernel): expose LocalMetaStore pub for peer-crate test fixtures
test(services::audit): TestFederationCoordinator stub + install_root smoke
test(services::audit): Mount dispatch reaches ZoneAuditAutoWire observer
test(services::audit): sys_write captured to audit stream end-to-end
docs(integration): honor nexus-cdylib deletion — gRPC-only architecture
```

## Back-and-forth (intentional, history kept)

This branch was cut before `develop`'s `d3025fc29` (*"refactor(rust): delete nexus-cdylib crate + all PyO3 code"* — the kernel is now pure Rust, Python↔nexus is gRPC-only). The rebase honors that deletion:

- **`refactor(nexus-cdylib): SudoCodeSpawnAdapter…` is an empty commit.** It edited `nexus-cdylib/src/lib.rs`, which `d3025fc29` deleted. The modify/delete conflict was resolved by honoring the deletion; the commit is kept empty to preserve the full history.
- **`docs(integration): honor nexus-cdylib deletion`** (last commit) reconciles the integration doc — §1/§2.3 cdylib/`nexus_runtime`/PyO3/GIL references rewritten to the gRPC-only `nexus-cluster` model.
- **C5's `services/python/mod.rs` hunk dropped** — that file was also deleted by `d3025fc29`; the audit-path doc-comment fix it carried is moot (develop's `audit/mod.rs` already uses `/__sys__/audit/traces/`).

`SpawnTask::spawn`'s state-observer param (C8) is kept as a forward-looking DI-contract improvement — the trait survives in `services`, its unit test uses a mock impl. Its only prior production implementor was the deleted cdylib adapter; the next implementor (cluster binary) picks up the better contract.

## Tests

- `cargo check --workspace`: clean (incl. `nexus-cluster`)
- `cargo test -p kernel --lib`: C7's `sys_setattr_mount_dispatches_mount_event` green
- `cargo test -p services --features service-audit --lib`: 9/9
- `cargo test -p services --features service-managed-agent --lib`: 63/63

**Note:** 4 `core::fdt::tests::*` fail on Windows local — `FileDescriptorTable` has a `#[cfg(not(unix))]` no-op stub but those 4 tests aren't `#[cfg(unix)]`-gated. This is develop's code (`fdt.rs` new in `0e97f999b`, untouched by this PR) and passes on Linux CI. Not in this PR's scope.

## Deferred follow-ups (carried, on hold)

AgentRegistry storage migration · `HookContext::AgentTerminate` variant · Matrix media DT_FILE+CAS · ReBAC-backed room membership · D4 Element smoke test · sudowork TS gRPC client · mid-stream LLM cancellation · post-pivot doc review of the §1 "FastAPI bricks" / §5.1 "Python exchange service" elements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
