### PR TITLE
refactor(kernel): service/driver callers off kernel primitives → syscalls

### DIFF
--- a/docs/surface-coverage/api-rpc-surface-coverage.yaml
+++ b/docs/surface-coverage/api-rpc-surface-coverage.yaml
@@ -4938,7 +4938,7 @@ operations:
   transports:
     grpc_expose:
       name: glob_batch
-      source: src/nexus/bricks/search/search_service.py:2035
+      source: src/nexus/bricks/search/search_service.py:2044
   profiles:
     lite: supported
     sandbox: supported
@@ -5315,7 +5315,7 @@ operations:
   transports:
     grpc_expose:
       name: import_metadata
-      source: src/nexus/services/metadata_export.py:144
+      source: src/nexus/services/metadata_export.py:145
   profiles:
     lite: unavailable
     sandbox: unavailable
@@ -5332,7 +5332,7 @@ operations:
   transports:
     grpc_expose:
       name: initialize_semantic_search
-      source: src/nexus/bricks/search/search_service.py:4746
+      source: src/nexus/bricks/search/search_service.py:4755
   profiles:
     lite: supported
     sandbox: supported
@@ -8411,7 +8411,7 @@ operations:
       source: src/nexus/cli/commands/search.py:1
     grpc_expose:
       name: glob
-      source: src/nexus/bricks/search/search_service.py:1782
+      source: src/nexus/bricks/search/search_service.py:1791
     http:
       name: POST /api/v2/search/glob
       source: src/nexus/server/api/v2/routers/search.py:1261
@@ -8438,7 +8438,7 @@ operations:
       source: src/nexus/cli/commands/search.py:1
     grpc_expose:
       name: grep
-      source: src/nexus/bricks/search/search_service.py:2092
+      source: src/nexus/bricks/search/search_service.py:2101
     http:
       name: POST /api/v2/search/grep
       source: src/nexus/server/api/v2/routers/search.py:1138
@@ -8890,7 +8890,7 @@ operations:
   transports:
     grpc_expose:
       name: semantic_search
-      source: src/nexus/bricks/search/search_service.py:4339
+      source: src/nexus/bricks/search/search_service.py:4348
     mcp:
       name: nexus_semantic_search
       source: src/nexus/config/tool_profiles.yaml:1
@@ -8911,7 +8911,7 @@ operations:
   transports:
     grpc_expose:
       name: semantic_search_index
-      source: src/nexus/bricks/search/search_service.py:4661
+      source: src/nexus/bricks/search/search_service.py:4670
   profiles:
     lite: supported
     sandbox: supported
@@ -8928,7 +8928,7 @@ operations:
   transports:
     grpc_expose:
       name: semantic_search_stats
-      source: src/nexus/bricks/search/search_service.py:4698
+      source: src/nexus/bricks/search/search_service.py:4707
   profiles:
     lite: supported
     sandbox: supported

--- a/docs/surface-coverage/api-rpc-surface-coverage.yaml
+++ b/docs/surface-coverage/api-rpc-surface-coverage.yaml
@@ -445,7 +445,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.agent_registry
-      source: src/nexus/remote/kernel_client.py:856
+      source: src/nexus/remote/kernel_client.py:846
   profiles:
     lite: supported
     sandbox: supported
@@ -1962,7 +1962,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.close_all_pipes
-      source: src/nexus/remote/kernel_client.py:778
+      source: src/nexus/remote/kernel_client.py:779
   profiles:
     lite: supported
     sandbox: supported
@@ -1979,7 +1979,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.close_all_streams
-      source: src/nexus/remote/kernel_client.py:814
+      source: src/nexus/remote/kernel_client.py:811
   profiles:
     lite: supported
     sandbox: supported
@@ -1996,7 +1996,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.close_pipe
-      source: src/nexus/remote/kernel_client.py:772
+      source: src/nexus/remote/kernel_client.py:773
   profiles:
     lite: supported
     sandbox: supported
@@ -2013,7 +2013,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.close_stream
-      source: src/nexus/remote/kernel_client.py:808
+      source: src/nexus/remote/kernel_client.py:811
   profiles:
     lite: supported
     sandbox: supported
@@ -2265,7 +2265,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.create_pipe
-      source: src/nexus/remote/kernel_client.py:766
+      source: src/nexus/remote/kernel_client.py:765
   profiles:
     lite: supported
     sandbox: supported
@@ -2299,7 +2299,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.create_stream
-      source: src/nexus/remote/kernel_client.py:783
+      source: src/nexus/remote/kernel_client.py:779
   profiles:
     lite: supported
     sandbox: supported
@@ -2629,7 +2629,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.destroy_pipe
-      source: src/nexus/remote/kernel_client.py:769
+      source: src/nexus/remote/kernel_client.py:768
   profiles:
     lite: supported
     sandbox: supported
@@ -4290,7 +4290,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.get
-      source: src/nexus/remote/kernel_client.py:1106
+      source: src/nexus/remote/kernel_client.py:1111
   profiles:
     lite: supported
     sandbox: supported
@@ -4307,7 +4307,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.heartbeat
-      source: src/nexus/remote/kernel_client.py:1132
+      source: src/nexus/remote/kernel_client.py:1128
   profiles:
     lite: supported
     sandbox: supported
@@ -4392,7 +4392,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.register
-      source: src/nexus/remote/kernel_client.py:1067
+      source: src/nexus/remote/kernel_client.py:1060
   profiles:
     lite: supported
     sandbox: supported
@@ -4460,7 +4460,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.signal
-      source: src/nexus/remote/kernel_client.py:1109
+      source: src/nexus/remote/kernel_client.py:1111
   profiles:
     lite: supported
     sandbox: supported
@@ -4545,7 +4545,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.unregister
-      source: src/nexus/remote/kernel_client.py:1100
+      source: src/nexus/remote/kernel_client.py:1099
   profiles:
     lite: supported
     sandbox: supported
@@ -4904,7 +4904,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.get_xattr
-      source: src/nexus/remote/kernel_client.py:739
+      source: src/nexus/remote/kernel_client.py:737
   profiles:
     lite: supported
     sandbox: supported
@@ -4921,7 +4921,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.get_xattr_bulk
-      source: src/nexus/remote/kernel_client.py:754
+      source: src/nexus/remote/kernel_client.py:756
   profiles:
     lite: supported
     sandbox: supported
@@ -5126,7 +5126,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.has_pipe
-      source: src/nexus/remote/kernel_client.py:775
+      source: src/nexus/remote/kernel_client.py:776
   profiles:
     lite: supported
     sandbox: supported
@@ -5143,7 +5143,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.has_stream
-      source: src/nexus/remote/kernel_client.py:786
+      source: src/nexus/remote/kernel_client.py:788
   profiles:
     lite: supported
     sandbox: supported
@@ -5489,7 +5489,7 @@ operations:
       source: src/nexus/services/agents/agent_rpc_service.py:584
     sdk:
       name: _AgentRegistryProxy.list_agents
-      source: src/nexus/remote/kernel_client.py:1135
+      source: src/nexus/remote/kernel_client.py:1128
   profiles:
     lite: supported
     sandbox: supported
@@ -5634,7 +5634,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.list_processes
-      source: src/nexus/remote/kernel_client.py:1138
+      source: src/nexus/remote/kernel_client.py:1128
   profiles:
     lite: supported
     sandbox: supported
@@ -7843,7 +7843,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.register_external
-      source: src/nexus/remote/kernel_client.py:1070
+      source: src/nexus/remote/kernel_client.py:1060
   profiles:
     lite: supported
     sandbox: supported
@@ -7894,7 +7894,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.register_native_hook
-      source: src/nexus/remote/kernel_client.py:833
+      source: src/nexus/remote/kernel_client.py:831
   profiles:
     lite: supported
     sandbox: supported
@@ -9064,7 +9064,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.service_unregister
-      source: src/nexus/remote/kernel_client.py:720
+      source: src/nexus/remote/kernel_client.py:721
   profiles:
     lite: supported
     sandbox: supported
@@ -9098,7 +9098,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.set_metastore_path
-      source: src/nexus/remote/kernel_client.py:821
+      source: src/nexus/remote/kernel_client.py:819
   profiles:
     lite: supported
     sandbox: supported
@@ -9115,7 +9115,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.set_permission_provider
-      source: src/nexus/remote/kernel_client.py:837
+      source: src/nexus/remote/kernel_client.py:831
   profiles:
     lite: supported
     sandbox: supported
@@ -9149,7 +9149,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.set_vfs_lock
-      source: src/nexus/remote/kernel_client.py:829
+      source: src/nexus/remote/kernel_client.py:827
   profiles:
     lite: supported
     sandbox: supported
@@ -9166,7 +9166,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.set_xattr
-      source: src/nexus/remote/kernel_client.py:747
+      source: src/nexus/remote/kernel_client.py:744
   profiles:
     lite: supported
     sandbox: supported
@@ -9547,7 +9547,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.stream_read_at_blocking
-      source: src/nexus/remote/kernel_client.py:789
+      source: src/nexus/remote/kernel_client.py:788
   profiles:
     lite: supported
     sandbox: supported
@@ -9941,7 +9941,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.trie_lookup
-      source: src/nexus/remote/kernel_client.py:731
+      source: src/nexus/remote/kernel_client.py:729
   profiles:
     lite: supported
     sandbox: supported
@@ -9958,7 +9958,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.trie_register
-      source: src/nexus/remote/kernel_client.py:728
+      source: src/nexus/remote/kernel_client.py:729
   profiles:
     lite: supported
     sandbox: supported
@@ -9975,7 +9975,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.trie_unregister
-      source: src/nexus/remote/kernel_client.py:734
+      source: src/nexus/remote/kernel_client.py:737
   profiles:
     lite: supported
     sandbox: supported
@@ -10351,7 +10351,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.unregister_external
-      source: src/nexus/remote/kernel_client.py:1103
+      source: src/nexus/remote/kernel_client.py:1099
   profiles:
     lite: supported
     sandbox: supported
@@ -10457,7 +10457,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.update_state
-      source: src/nexus/remote/kernel_client.py:1121
+      source: src/nexus/remote/kernel_client.py:1122
   profiles:
     lite: supported
     sandbox: supported
@@ -10807,7 +10807,7 @@ operations:
       source: src/nexus/core/nexus_fs_content.py:1438
     sdk:
       name: KernelClient.write_batch
-      source: src/nexus/remote/kernel_client.py:841
+      source: src/nexus/remote/kernel_client.py:846
   profiles:
     lite: supported
     sandbox: supported

--- a/docs/surface-coverage/api-rpc-surface-coverage.yaml
+++ b/docs/surface-coverage/api-rpc-surface-coverage.yaml
@@ -1789,7 +1789,7 @@ operations:
   transports:
     grpc_expose:
       name: backfill_directory_index
-      source: src/nexus/core/nexus_fs_metadata.py:2056
+      source: src/nexus/core/nexus_fs_metadata.py:2047
     sdk:
       name: MCPClient.backfill_directory_index
       source: src/nexus/remote/domain/mcp.py:91
@@ -4188,7 +4188,7 @@ operations:
   transports:
     grpc_expose:
       name: flush_write_observer
-      source: src/nexus/core/nexus_fs_metadata.py:2086
+      source: src/nexus/core/nexus_fs_metadata.py:2077
   profiles:
     lite: supported
     sandbox: supported
@@ -5332,7 +5332,7 @@ operations:
   transports:
     grpc_expose:
       name: initialize_semantic_search
-      source: src/nexus/bricks/search/search_service.py:4755
+      source: src/nexus/bricks/search/search_service.py:4741
   profiles:
     lite: supported
     sandbox: supported
@@ -8890,7 +8890,7 @@ operations:
   transports:
     grpc_expose:
       name: semantic_search
-      source: src/nexus/bricks/search/search_service.py:4348
+      source: src/nexus/bricks/search/search_service.py:4334
     mcp:
       name: nexus_semantic_search
       source: src/nexus/config/tool_profiles.yaml:1
@@ -8911,7 +8911,7 @@ operations:
   transports:
     grpc_expose:
       name: semantic_search_index
-      source: src/nexus/bricks/search/search_service.py:4670
+      source: src/nexus/bricks/search/search_service.py:4656
   profiles:
     lite: supported
     sandbox: supported
@@ -8928,7 +8928,7 @@ operations:
   transports:
     grpc_expose:
       name: semantic_search_stats
-      source: src/nexus/bricks/search/search_service.py:4707
+      source: src/nexus/bricks/search/search_service.py:4693
   profiles:
     lite: supported
     sandbox: supported

--- a/docs/surface-coverage/api-rpc-surface-coverage.yaml
+++ b/docs/surface-coverage/api-rpc-surface-coverage.yaml
@@ -1962,7 +1962,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.close_all_pipes
-      source: src/nexus/remote/kernel_client.py:779
+      source: src/nexus/remote/kernel_client.py:768
   profiles:
     lite: supported
     sandbox: supported
@@ -1979,7 +1979,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.close_all_streams
-      source: src/nexus/remote/kernel_client.py:811
+      source: src/nexus/remote/kernel_client.py:804
   profiles:
     lite: supported
     sandbox: supported
@@ -1996,7 +1996,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.close_pipe
-      source: src/nexus/remote/kernel_client.py:773
+      source: src/nexus/remote/kernel_client.py:762
   profiles:
     lite: supported
     sandbox: supported
@@ -2013,7 +2013,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.close_stream
-      source: src/nexus/remote/kernel_client.py:811
+      source: src/nexus/remote/kernel_client.py:798
   profiles:
     lite: supported
     sandbox: supported
@@ -2265,7 +2265,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.create_pipe
-      source: src/nexus/remote/kernel_client.py:765
+      source: src/nexus/remote/kernel_client.py:756
   profiles:
     lite: supported
     sandbox: supported
@@ -2299,7 +2299,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.create_stream
-      source: src/nexus/remote/kernel_client.py:779
+      source: src/nexus/remote/kernel_client.py:773
   profiles:
     lite: supported
     sandbox: supported
@@ -2629,7 +2629,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.destroy_pipe
-      source: src/nexus/remote/kernel_client.py:768
+      source: src/nexus/remote/kernel_client.py:759
   profiles:
     lite: supported
     sandbox: supported
@@ -2646,7 +2646,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.destroy_stream
-      source: src/nexus/remote/kernel_client.py:811
+      source: src/nexus/remote/kernel_client.py:801
   profiles:
     lite: supported
     sandbox: supported
@@ -4290,7 +4290,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.get
-      source: src/nexus/remote/kernel_client.py:1111
+      source: src/nexus/remote/kernel_client.py:1096
   profiles:
     lite: supported
     sandbox: supported
@@ -4307,7 +4307,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.heartbeat
-      source: src/nexus/remote/kernel_client.py:1128
+      source: src/nexus/remote/kernel_client.py:1122
   profiles:
     lite: supported
     sandbox: supported
@@ -4392,7 +4392,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.register
-      source: src/nexus/remote/kernel_client.py:1060
+      source: src/nexus/remote/kernel_client.py:1057
   profiles:
     lite: supported
     sandbox: supported
@@ -4460,7 +4460,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.signal
-      source: src/nexus/remote/kernel_client.py:1111
+      source: src/nexus/remote/kernel_client.py:1099
   profiles:
     lite: supported
     sandbox: supported
@@ -4545,7 +4545,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.unregister
-      source: src/nexus/remote/kernel_client.py:1099
+      source: src/nexus/remote/kernel_client.py:1090
   profiles:
     lite: supported
     sandbox: supported
@@ -4904,7 +4904,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.get_xattr
-      source: src/nexus/remote/kernel_client.py:737
+      source: src/nexus/remote/kernel_client.py:729
   profiles:
     lite: supported
     sandbox: supported
@@ -4921,7 +4921,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.get_xattr_bulk
-      source: src/nexus/remote/kernel_client.py:756
+      source: src/nexus/remote/kernel_client.py:744
   profiles:
     lite: supported
     sandbox: supported
@@ -5126,7 +5126,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.has_pipe
-      source: src/nexus/remote/kernel_client.py:776
+      source: src/nexus/remote/kernel_client.py:765
   profiles:
     lite: supported
     sandbox: supported
@@ -5143,7 +5143,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.has_stream
-      source: src/nexus/remote/kernel_client.py:788
+      source: src/nexus/remote/kernel_client.py:776
   profiles:
     lite: supported
     sandbox: supported
@@ -5489,7 +5489,7 @@ operations:
       source: src/nexus/services/agents/agent_rpc_service.py:584
     sdk:
       name: _AgentRegistryProxy.list_agents
-      source: src/nexus/remote/kernel_client.py:1128
+      source: src/nexus/remote/kernel_client.py:1125
   profiles:
     lite: supported
     sandbox: supported
@@ -7894,7 +7894,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.register_native_hook
-      source: src/nexus/remote/kernel_client.py:831
+      source: src/nexus/remote/kernel_client.py:823
   profiles:
     lite: supported
     sandbox: supported
@@ -9064,7 +9064,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.service_unregister
-      source: src/nexus/remote/kernel_client.py:721
+      source: src/nexus/remote/kernel_client.py:710
   profiles:
     lite: supported
     sandbox: supported
@@ -9098,7 +9098,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.set_metastore_path
-      source: src/nexus/remote/kernel_client.py:819
+      source: src/nexus/remote/kernel_client.py:811
   profiles:
     lite: supported
     sandbox: supported
@@ -9115,7 +9115,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.set_permission_provider
-      source: src/nexus/remote/kernel_client.py:831
+      source: src/nexus/remote/kernel_client.py:827
   profiles:
     lite: supported
     sandbox: supported
@@ -9149,7 +9149,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.set_vfs_lock
-      source: src/nexus/remote/kernel_client.py:827
+      source: src/nexus/remote/kernel_client.py:819
   profiles:
     lite: supported
     sandbox: supported
@@ -9166,7 +9166,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.set_xattr
-      source: src/nexus/remote/kernel_client.py:744
+      source: src/nexus/remote/kernel_client.py:737
   profiles:
     lite: supported
     sandbox: supported
@@ -9496,7 +9496,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.stream_collect_all
-      source: src/nexus/remote/kernel_client.py:804
+      source: src/nexus/remote/kernel_client.py:794
   profiles:
     lite: supported
     sandbox: supported
@@ -9530,7 +9530,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.stream_read_at
-      source: src/nexus/remote/kernel_client.py:801
+      source: src/nexus/remote/kernel_client.py:791
   profiles:
     lite: supported
     sandbox: supported
@@ -9547,7 +9547,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.stream_read_at_blocking
-      source: src/nexus/remote/kernel_client.py:788
+      source: src/nexus/remote/kernel_client.py:779
   profiles:
     lite: supported
     sandbox: supported
@@ -9564,7 +9564,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.stream_write_nowait
-      source: src/nexus/remote/kernel_client.py:798
+      source: src/nexus/remote/kernel_client.py:788
   profiles:
     lite: supported
     sandbox: supported
@@ -9941,7 +9941,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.trie_lookup
-      source: src/nexus/remote/kernel_client.py:729
+      source: src/nexus/remote/kernel_client.py:721
   profiles:
     lite: supported
     sandbox: supported
@@ -9958,7 +9958,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.trie_register
-      source: src/nexus/remote/kernel_client.py:729
+      source: src/nexus/remote/kernel_client.py:718
   profiles:
     lite: supported
     sandbox: supported
@@ -9975,7 +9975,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.trie_unregister
-      source: src/nexus/remote/kernel_client.py:737
+      source: src/nexus/remote/kernel_client.py:724
   profiles:
     lite: supported
     sandbox: supported
@@ -10351,7 +10351,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.unregister_external
-      source: src/nexus/remote/kernel_client.py:1099
+      source: src/nexus/remote/kernel_client.py:1093
   profiles:
     lite: supported
     sandbox: supported
@@ -10457,7 +10457,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.update_state
-      source: src/nexus/remote/kernel_client.py:1122
+      source: src/nexus/remote/kernel_client.py:1111
   profiles:
     lite: supported
     sandbox: supported
@@ -10807,7 +10807,7 @@ operations:
       source: src/nexus/core/nexus_fs_content.py:1438
     sdk:
       name: KernelClient.write_batch
-      source: src/nexus/remote/kernel_client.py:846
+      source: src/nexus/remote/kernel_client.py:831
   profiles:
     lite: supported
     sandbox: supported

--- a/docs/surface-coverage/api-rpc-surface-coverage.yaml
+++ b/docs/surface-coverage/api-rpc-surface-coverage.yaml
@@ -8390,7 +8390,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/expand
-      source: src/nexus/server/api/v2/routers/search.py:1380
+      source: src/nexus/server/api/v2/routers/search.py:1381
   profiles:
     lite: supported
     sandbox: supported
@@ -8414,7 +8414,7 @@ operations:
       source: src/nexus/bricks/search/search_service.py:1791
     http:
       name: POST /api/v2/search/glob
-      source: src/nexus/server/api/v2/routers/search.py:1261
+      source: src/nexus/server/api/v2/routers/search.py:1262
     mcp:
       name: nexus_glob
       source: src/nexus/config/tool_profiles.yaml:1
@@ -8441,7 +8441,7 @@ operations:
       source: src/nexus/bricks/search/search_service.py:2101
     http:
       name: POST /api/v2/search/grep
-      source: src/nexus/server/api/v2/routers/search.py:1138
+      source: src/nexus/server/api/v2/routers/search.py:1139
     mcp:
       name: nexus_grep
       source: src/nexus/config/tool_profiles.yaml:1
@@ -8494,7 +8494,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/index
-      source: src/nexus/server/api/v2/routers/search.py:1323
+      source: src/nexus/server/api/v2/routers/search.py:1324
   profiles:
     lite: supported
     sandbox: supported
@@ -8512,7 +8512,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/index-directory
-      source: src/nexus/server/api/v2/routers/search.py:1522
+      source: src/nexus/server/api/v2/routers/search.py:1523
   profiles:
     lite: supported
     sandbox: supported
@@ -8529,7 +8529,7 @@ operations:
   transports:
     http:
       name: GET /api/v2/search/indexed-dirs
-      source: src/nexus/server/api/v2/routers/search.py:1740
+      source: src/nexus/server/api/v2/routers/search.py:1741
   profiles:
     lite: supported
     sandbox: supported
@@ -8546,7 +8546,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/indexing-mode
-      source: src/nexus/server/api/v2/routers/search.py:1777
+      source: src/nexus/server/api/v2/routers/search.py:1778
   profiles:
     lite: supported
     sandbox: supported
@@ -8563,7 +8563,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/locate
-      source: src/nexus/server/api/v2/routers/search.py:1958
+      source: src/nexus/server/api/v2/routers/search.py:1959
   profiles:
     lite: supported
     sandbox: supported
@@ -8580,7 +8580,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/purge-unscoped
-      source: src/nexus/server/api/v2/routers/search.py:1904
+      source: src/nexus/server/api/v2/routers/search.py:1905
   profiles:
     lite: supported
     sandbox: supported
@@ -8633,7 +8633,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/refresh
-      source: src/nexus/server/api/v2/routers/search.py:1359
+      source: src/nexus/server/api/v2/routers/search.py:1360
   profiles:
     lite: supported
     sandbox: supported

--- a/docs/surface-coverage/api-rpc-surface-coverage.yaml
+++ b/docs/surface-coverage/api-rpc-surface-coverage.yaml
@@ -445,7 +445,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.agent_registry
-      source: src/nexus/remote/kernel_client.py:846
+      source: src/nexus/remote/kernel_client.py:856
   profiles:
     lite: supported
     sandbox: supported
@@ -1789,7 +1789,7 @@ operations:
   transports:
     grpc_expose:
       name: backfill_directory_index
-      source: src/nexus/core/nexus_fs_metadata.py:2038
+      source: src/nexus/core/nexus_fs_metadata.py:2056
     sdk:
       name: MCPClient.backfill_directory_index
       source: src/nexus/remote/domain/mcp.py:91
@@ -1962,7 +1962,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.close_all_pipes
-      source: src/nexus/remote/kernel_client.py:768
+      source: src/nexus/remote/kernel_client.py:778
   profiles:
     lite: supported
     sandbox: supported
@@ -1979,7 +1979,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.close_all_streams
-      source: src/nexus/remote/kernel_client.py:804
+      source: src/nexus/remote/kernel_client.py:814
   profiles:
     lite: supported
     sandbox: supported
@@ -1996,7 +1996,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.close_pipe
-      source: src/nexus/remote/kernel_client.py:762
+      source: src/nexus/remote/kernel_client.py:772
   profiles:
     lite: supported
     sandbox: supported
@@ -2013,7 +2013,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.close_stream
-      source: src/nexus/remote/kernel_client.py:798
+      source: src/nexus/remote/kernel_client.py:808
   profiles:
     lite: supported
     sandbox: supported
@@ -2265,7 +2265,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.create_pipe
-      source: src/nexus/remote/kernel_client.py:756
+      source: src/nexus/remote/kernel_client.py:766
   profiles:
     lite: supported
     sandbox: supported
@@ -2299,7 +2299,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.create_stream
-      source: src/nexus/remote/kernel_client.py:773
+      source: src/nexus/remote/kernel_client.py:783
   profiles:
     lite: supported
     sandbox: supported
@@ -2629,7 +2629,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.destroy_pipe
-      source: src/nexus/remote/kernel_client.py:759
+      source: src/nexus/remote/kernel_client.py:769
   profiles:
     lite: supported
     sandbox: supported
@@ -2646,7 +2646,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.destroy_stream
-      source: src/nexus/remote/kernel_client.py:801
+      source: src/nexus/remote/kernel_client.py:811
   profiles:
     lite: supported
     sandbox: supported
@@ -4188,7 +4188,7 @@ operations:
   transports:
     grpc_expose:
       name: flush_write_observer
-      source: src/nexus/core/nexus_fs_metadata.py:2068
+      source: src/nexus/core/nexus_fs_metadata.py:2086
   profiles:
     lite: supported
     sandbox: supported
@@ -4290,7 +4290,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.get
-      source: src/nexus/remote/kernel_client.py:1096
+      source: src/nexus/remote/kernel_client.py:1106
   profiles:
     lite: supported
     sandbox: supported
@@ -4307,7 +4307,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.heartbeat
-      source: src/nexus/remote/kernel_client.py:1122
+      source: src/nexus/remote/kernel_client.py:1132
   profiles:
     lite: supported
     sandbox: supported
@@ -4392,7 +4392,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.register
-      source: src/nexus/remote/kernel_client.py:1057
+      source: src/nexus/remote/kernel_client.py:1067
   profiles:
     lite: supported
     sandbox: supported
@@ -4460,7 +4460,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.signal
-      source: src/nexus/remote/kernel_client.py:1099
+      source: src/nexus/remote/kernel_client.py:1109
   profiles:
     lite: supported
     sandbox: supported
@@ -4545,7 +4545,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.unregister
-      source: src/nexus/remote/kernel_client.py:1090
+      source: src/nexus/remote/kernel_client.py:1100
   profiles:
     lite: supported
     sandbox: supported
@@ -4904,7 +4904,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.get_xattr
-      source: src/nexus/remote/kernel_client.py:729
+      source: src/nexus/remote/kernel_client.py:739
   profiles:
     lite: supported
     sandbox: supported
@@ -4921,7 +4921,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.get_xattr_bulk
-      source: src/nexus/remote/kernel_client.py:744
+      source: src/nexus/remote/kernel_client.py:754
   profiles:
     lite: supported
     sandbox: supported
@@ -5126,7 +5126,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.has_pipe
-      source: src/nexus/remote/kernel_client.py:765
+      source: src/nexus/remote/kernel_client.py:775
   profiles:
     lite: supported
     sandbox: supported
@@ -5143,7 +5143,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.has_stream
-      source: src/nexus/remote/kernel_client.py:776
+      source: src/nexus/remote/kernel_client.py:786
   profiles:
     lite: supported
     sandbox: supported
@@ -5332,7 +5332,7 @@ operations:
   transports:
     grpc_expose:
       name: initialize_semantic_search
-      source: src/nexus/bricks/search/search_service.py:4732
+      source: src/nexus/bricks/search/search_service.py:4746
   profiles:
     lite: supported
     sandbox: supported
@@ -5489,7 +5489,7 @@ operations:
       source: src/nexus/services/agents/agent_rpc_service.py:584
     sdk:
       name: _AgentRegistryProxy.list_agents
-      source: src/nexus/remote/kernel_client.py:1125
+      source: src/nexus/remote/kernel_client.py:1135
   profiles:
     lite: supported
     sandbox: supported
@@ -5634,7 +5634,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.list_processes
-      source: src/nexus/remote/kernel_client.py:1128
+      source: src/nexus/remote/kernel_client.py:1138
   profiles:
     lite: supported
     sandbox: supported
@@ -7843,7 +7843,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.register_external
-      source: src/nexus/remote/kernel_client.py:1060
+      source: src/nexus/remote/kernel_client.py:1070
   profiles:
     lite: supported
     sandbox: supported
@@ -7894,7 +7894,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.register_native_hook
-      source: src/nexus/remote/kernel_client.py:823
+      source: src/nexus/remote/kernel_client.py:833
   profiles:
     lite: supported
     sandbox: supported
@@ -8390,7 +8390,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/expand
-      source: src/nexus/server/api/v2/routers/search.py:1381
+      source: src/nexus/server/api/v2/routers/search.py:1380
   profiles:
     lite: supported
     sandbox: supported
@@ -8414,7 +8414,7 @@ operations:
       source: src/nexus/bricks/search/search_service.py:1782
     http:
       name: POST /api/v2/search/glob
-      source: src/nexus/server/api/v2/routers/search.py:1262
+      source: src/nexus/server/api/v2/routers/search.py:1261
     mcp:
       name: nexus_glob
       source: src/nexus/config/tool_profiles.yaml:1
@@ -8441,7 +8441,7 @@ operations:
       source: src/nexus/bricks/search/search_service.py:2092
     http:
       name: POST /api/v2/search/grep
-      source: src/nexus/server/api/v2/routers/search.py:1139
+      source: src/nexus/server/api/v2/routers/search.py:1138
     mcp:
       name: nexus_grep
       source: src/nexus/config/tool_profiles.yaml:1
@@ -8494,7 +8494,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/index
-      source: src/nexus/server/api/v2/routers/search.py:1324
+      source: src/nexus/server/api/v2/routers/search.py:1323
   profiles:
     lite: supported
     sandbox: supported
@@ -8512,7 +8512,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/index-directory
-      source: src/nexus/server/api/v2/routers/search.py:1523
+      source: src/nexus/server/api/v2/routers/search.py:1522
   profiles:
     lite: supported
     sandbox: supported
@@ -8529,7 +8529,7 @@ operations:
   transports:
     http:
       name: GET /api/v2/search/indexed-dirs
-      source: src/nexus/server/api/v2/routers/search.py:1741
+      source: src/nexus/server/api/v2/routers/search.py:1740
   profiles:
     lite: supported
     sandbox: supported
@@ -8546,7 +8546,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/indexing-mode
-      source: src/nexus/server/api/v2/routers/search.py:1778
+      source: src/nexus/server/api/v2/routers/search.py:1777
   profiles:
     lite: supported
     sandbox: supported
@@ -8563,7 +8563,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/locate
-      source: src/nexus/server/api/v2/routers/search.py:1959
+      source: src/nexus/server/api/v2/routers/search.py:1958
   profiles:
     lite: supported
     sandbox: supported
@@ -8580,7 +8580,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/purge-unscoped
-      source: src/nexus/server/api/v2/routers/search.py:1905
+      source: src/nexus/server/api/v2/routers/search.py:1904
   profiles:
     lite: supported
     sandbox: supported
@@ -8633,7 +8633,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/refresh
-      source: src/nexus/server/api/v2/routers/search.py:1360
+      source: src/nexus/server/api/v2/routers/search.py:1359
   profiles:
     lite: supported
     sandbox: supported
@@ -8890,7 +8890,7 @@ operations:
   transports:
     grpc_expose:
       name: semantic_search
-      source: src/nexus/bricks/search/search_service.py:4325
+      source: src/nexus/bricks/search/search_service.py:4339
     mcp:
       name: nexus_semantic_search
       source: src/nexus/config/tool_profiles.yaml:1
@@ -8911,7 +8911,7 @@ operations:
   transports:
     grpc_expose:
       name: semantic_search_index
-      source: src/nexus/bricks/search/search_service.py:4647
+      source: src/nexus/bricks/search/search_service.py:4661
   profiles:
     lite: supported
     sandbox: supported
@@ -8928,7 +8928,7 @@ operations:
   transports:
     grpc_expose:
       name: semantic_search_stats
-      source: src/nexus/bricks/search/search_service.py:4684
+      source: src/nexus/bricks/search/search_service.py:4698
   profiles:
     lite: supported
     sandbox: supported
@@ -9064,7 +9064,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.service_unregister
-      source: src/nexus/remote/kernel_client.py:710
+      source: src/nexus/remote/kernel_client.py:720
   profiles:
     lite: supported
     sandbox: supported
@@ -9098,7 +9098,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.set_metastore_path
-      source: src/nexus/remote/kernel_client.py:811
+      source: src/nexus/remote/kernel_client.py:821
   profiles:
     lite: supported
     sandbox: supported
@@ -9115,7 +9115,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.set_permission_provider
-      source: src/nexus/remote/kernel_client.py:827
+      source: src/nexus/remote/kernel_client.py:837
   profiles:
     lite: supported
     sandbox: supported
@@ -9149,7 +9149,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.set_vfs_lock
-      source: src/nexus/remote/kernel_client.py:819
+      source: src/nexus/remote/kernel_client.py:829
   profiles:
     lite: supported
     sandbox: supported
@@ -9166,7 +9166,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.set_xattr
-      source: src/nexus/remote/kernel_client.py:737
+      source: src/nexus/remote/kernel_client.py:747
   profiles:
     lite: supported
     sandbox: supported
@@ -9496,7 +9496,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.stream_collect_all
-      source: src/nexus/remote/kernel_client.py:794
+      source: src/nexus/remote/kernel_client.py:804
   profiles:
     lite: supported
     sandbox: supported
@@ -9530,7 +9530,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.stream_read_at
-      source: src/nexus/remote/kernel_client.py:791
+      source: src/nexus/remote/kernel_client.py:801
   profiles:
     lite: supported
     sandbox: supported
@@ -9547,7 +9547,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.stream_read_at_blocking
-      source: src/nexus/remote/kernel_client.py:779
+      source: src/nexus/remote/kernel_client.py:789
   profiles:
     lite: supported
     sandbox: supported
@@ -9564,7 +9564,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.stream_write_nowait
-      source: src/nexus/remote/kernel_client.py:788
+      source: src/nexus/remote/kernel_client.py:798
   profiles:
     lite: supported
     sandbox: supported
@@ -9941,7 +9941,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.trie_lookup
-      source: src/nexus/remote/kernel_client.py:721
+      source: src/nexus/remote/kernel_client.py:731
   profiles:
     lite: supported
     sandbox: supported
@@ -9958,7 +9958,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.trie_register
-      source: src/nexus/remote/kernel_client.py:718
+      source: src/nexus/remote/kernel_client.py:728
   profiles:
     lite: supported
     sandbox: supported
@@ -9975,7 +9975,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.trie_unregister
-      source: src/nexus/remote/kernel_client.py:724
+      source: src/nexus/remote/kernel_client.py:734
   profiles:
     lite: supported
     sandbox: supported
@@ -10351,7 +10351,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.unregister_external
-      source: src/nexus/remote/kernel_client.py:1093
+      source: src/nexus/remote/kernel_client.py:1103
   profiles:
     lite: supported
     sandbox: supported
@@ -10457,7 +10457,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.update_state
-      source: src/nexus/remote/kernel_client.py:1111
+      source: src/nexus/remote/kernel_client.py:1121
   profiles:
     lite: supported
     sandbox: supported
@@ -10807,7 +10807,7 @@ operations:
       source: src/nexus/core/nexus_fs_content.py:1438
     sdk:
       name: KernelClient.write_batch
-      source: src/nexus/remote/kernel_client.py:831
+      source: src/nexus/remote/kernel_client.py:841
   profiles:
     lite: supported
     sandbox: supported

--- a/src/nexus/backends/engines/cas_gc.py
+++ b/src/nexus/backends/engines/cas_gc.py
@@ -1,18 +1,20 @@
-"""CAS Garbage Collector — reachability-based background cleanup.
+"""CAS Garbage Collector — reachability-based background service.
 
 Two-phase GC:
-  Phase 1 (collect): Scan metastore → build set of all referenced content_ids.
-          For CDC manifests, parse manifest → add chunk hashes to referenced set.
+  Phase 1 (collect): Scan the namespace via sys_readdir → build set of all
+          referenced content_ids. For CDC manifests, parse the manifest →
+          add chunk hashes to the referenced set.
   Phase 2 (sweep):   Enumerate CAS blobs via transport.list_content_hashes(),
-          delete unreferenced blobs older than grace period.
+          delete unreferenced blobs older than the grace period.
 
-Each CASAddressingEngine instance owns its own GC — no shared state, no
-federation concerns (each node GCs its own local transport).
+The collector is a service (BackgroundService), not a driver-owned helper.
+The factory enlists one instance when the root backend is CAS; nexus-cluster
+(Rust binary, no Python factory) is naturally unaffected.
 
 Design:
     - Grace period: uses write timestamp from transport (volume index or file mtime)
     - Scan interval is configurable (default 60s)
-    - GC runs as an asyncio.Task, started/stopped by the engine owner
+    - Implements BackgroundService — async start/stop, idempotent
     - Thread-safe: blob deletion is idempotent (already-deleted = no-op)
     - Transport-agnostic: works with both file-per-blob and volume-packed storage
 
@@ -40,40 +42,37 @@ DEFAULT_GRACE_PERIOD_S = 300.0  # 5 minutes
 DEFAULT_SCAN_INTERVAL_S = 60.0  # 1 minute
 
 
-class CASGarbageCollector:
-    """Reachability-based GC for CAS blobs.
+class CasGcService:
+    """Reachability-based GC for CAS blobs (BackgroundService).
 
     Usage::
 
-        gc = CASGarbageCollector(engine, metastore)
-        gc.start()   # spawns asyncio.Task
+        gc = CasGcService(engine, nexus_fs)
+        await gc.start()   # spawns asyncio.Task
         ...
-        await gc.stop()  # cancels task, waits for clean exit
+        await gc.stop()    # cancels task, waits for clean exit
     """
 
     def __init__(
         self,
         engine: CASAddressingEngine,
-        metastore: Any | None = None,
+        nexus_fs: Any,
         *,
         grace_period: float = DEFAULT_GRACE_PERIOD_S,
         scan_interval: float = DEFAULT_SCAN_INTERVAL_S,
     ) -> None:
         self._engine = engine
-        self._metastore = metastore
-        self._kernel = metastore
+        # NexusFS handle — the reachability scan walks the global namespace
+        # through the Tier 1 sys_readdir syscall, never the
+        # metastore_list_paginated kernel primitive.
+        self._nexus_fs = nexus_fs
         self._grace_period = grace_period
         self._scan_interval = scan_interval
         self._task: asyncio.Task[None] | None = None
         self._stopped = False
 
-    def set_metastore(self, metastore: Any) -> None:
-        """Deferred injection — metastore may not be available at construction time."""
-        self._metastore = metastore
-        self._kernel = metastore
-
-    def start(self) -> None:
-        """Start GC background task in the current event loop."""
+    async def start(self) -> None:
+        """Start the GC background task (BackgroundService entry point)."""
         if self._task is not None:
             return
         self._stopped = False
@@ -86,7 +85,7 @@ class CASGarbageCollector:
         )
 
     async def stop(self) -> None:
-        """Stop GC background task."""
+        """Stop the GC background task."""
         self._stopped = True
         if self._task is not None:
             self._task.cancel()
@@ -111,30 +110,31 @@ class CASGarbageCollector:
     def _collect(self) -> None:
         """Single GC pass — two-phase reachability scan.
 
-        Phase 1: Scan metastore to collect all referenced content_ids.
-                 For CDC manifests, expand to include chunk hashes.
+        Phase 1: Walk the namespace via sys_readdir(details=True) to collect
+                 all referenced content_ids. For CDC manifests, expand to
+                 include chunk hashes.
         Phase 2: Enumerate all CAS blobs via transport.list_content_hashes(),
-                 delete unreferenced blobs older than grace period.
+                 delete unreferenced blobs older than the grace period.
                  Transport-agnostic — works with both file-per-blob and
                  volume-packed storage (Issue #3403).
         """
-        if self._metastore is None:
-            logger.debug("CAS GC: metastore not set, skipping collection")
+        if self._nexus_fs is None:
+            logger.debug("CAS GC: nexus_fs not set, skipping collection")
             return
 
         engine = self._engine
         transport = engine._transport
         now = time.time()
 
-        # Phase 1: Collect referenced content_ids from metastore
+        # Phase 1: Collect referenced content_ids from the namespace.
         referenced: set[str] = set()
         try:
-            self._scan_metastore(referenced)
+            self._scan_namespace(referenced)
         except Exception:
-            logger.warning("CAS GC: metastore scan failed for %s", engine.name, exc_info=True)
+            logger.warning("CAS GC: namespace scan failed for %s", engine.name, exc_info=True)
             return
 
-        # Phase 2: Sweep CAS blobs — transport-agnostic enumeration
+        # Phase 2: Sweep CAS blobs — transport-agnostic enumeration.
         try:
             if hasattr(transport, "list_content_hashes"):
                 # Preferred: transport provides (hash, timestamp) pairs directly
@@ -203,25 +203,24 @@ class CASGarbageCollector:
             entries.append((content_hash, mtime))
         return entries
 
-    def _scan_metastore(self, referenced: set[str]) -> None:
-        """Scan metastore to collect all referenced content_ids.
+    def _scan_namespace(self, referenced: set[str]) -> None:
+        """Scan the namespace to collect all referenced content_ids.
 
         For CDC manifests (is_chunked_manifest in .meta), parse the manifest
         blob to add individual chunk hashes to the referenced set.
         """
         engine = self._engine
-        kernel = self._kernel
-        assert kernel is not None
 
-        # Scan all entries in metastore for content_ids
+        # Tier 1 syscall — sys_readdir(details=True) yields full FileMetadata
+        # projection as JSON-safe dicts, including each entry's content_id.
         try:
-            all_entries = kernel.metastore_list_paginated("", True, 100000, None)["items"]
+            all_entries = self._nexus_fs.sys_readdir("/", recursive=True, details=True)
         except Exception:
-            logger.warning("CAS GC: kernel.metastore_list_paginated() failed", exc_info=True)
+            logger.warning("CAS GC: nexus_fs.sys_readdir() failed", exc_info=True)
             return
 
         for entry in all_entries:
-            content_id = getattr(entry, "content_id", None)
+            content_id = entry.get("content_id")
             if not content_id:
                 continue
             referenced.add(content_id)

--- a/src/nexus/backends/storage/cas_local.py
+++ b/src/nexus/backends/storage/cas_local.py
@@ -37,7 +37,6 @@ from typing import TYPE_CHECKING, Any, ClassVar
 
 from nexus.backends.base.cas_addressing_engine import CASAddressingEngine
 from nexus.backends.base.registry import ArgType, ConnectionArg, register_connector
-from nexus.backends.engines.cas_gc import CASGarbageCollector
 from nexus.backends.engines.cdc import CDCEngine
 from nexus.backends.engines.multipart import MultipartUpload
 from nexus.backends.transports.blob_pack_local_transport import BlobPackLocalTransport
@@ -129,8 +128,9 @@ class CASLocalBackend(CASAddressingEngine, MultipartUpload):
         # CDCEngine needs self (CASAddressingEngine internals) — wire after init
         self._cdc = CDCEngine(self)
 
-        # GC: metastore injected later via set_metastore() — not available at construction.
-        self._gc = CASGarbageCollector(self)
+        # GC moved out of the backend: CasGcService is a factory-gated
+        # BackgroundService enlisted in orchestrator._register_vfs_hooks when
+        # the root backend is CAS. Driver code no longer owns or wires it.
 
         # Volume compaction (Issue #3408): background scheduler.
         # Requires volume packing (BlobPackLocalTransport).
@@ -213,10 +213,6 @@ class CASLocalBackend(CASAddressingEngine, MultipartUpload):
         if self._tiering_service is not None:
             asyncio.ensure_future(self._tiering_service.stop())
             logger.info("Cold tiering service scheduled to stop on unmount")
-
-    def set_metastore(self, metastore: Any) -> None:
-        """Inject metastore reference for GC reachability scan."""
-        self._gc.set_metastore(metastore)
 
     @property
     def name(self) -> str:

--- a/src/nexus/bricks/rebac/cache/tiger/rename_hook.py
+++ b/src/nexus/bricks/rebac/cache/tiger/rename_hook.py
@@ -23,7 +23,8 @@ class TigerCacheRenameHook:
 
     Dependencies injected at construction:
       - tiger_cache:   The TigerCache instance (may be None)
-      - metadata_list: (prefix, recursive, zone_id) -> Iterator[FileMetadata]
+      - metadata_list: (prefix, recursive, zone_id) -> Iterable[dict] of
+        sys_readdir(details=True) entries (``entry["path"]``)
     """
 
     # ── Hook spec (duck-typed) (Issue #1610) ──────────────────────────

--- a/src/nexus/bricks/rebac/directory/expander.py
+++ b/src/nexus/bricks/rebac/directory/expander.py
@@ -110,30 +110,31 @@ class DirectoryExpander:
     Args:
         engine: SQLAlchemy engine for DB queries
         tiger_cache: Tiger bitmap cache (may be None if disabled)
-        metadata_store: Optional metadata store for directory queries
+        nexus_fs: Optional NexusFS handle for directory queries
     """
 
     def __init__(
         self,
         engine: "Engine",
         tiger_cache: "TigerCache | None" = None,
-        metadata_store: Any | None = None,
+        nexus_fs: Any | None = None,
         *,
         is_postgresql: bool = False,  # noqa: ARG002
         version_store: MetastoreVersionStore | None = None,
     ) -> None:
         self._engine = engine
         self._tiger_cache = tiger_cache
-        self._metadata_store = metadata_store
-        # Pull the kernel out of the proxy so calls go to ``kernel.metastore_*``
-        # directly (and survive W3).
-        self._kernel: Any = metadata_store
+        # NexusFS handle — descendant listing goes through the Tier 1
+        # sys_readdir syscall. ``_kernel`` is derived from it solely for the
+        # sys_stat directory probe in is_directory_path.
+        self._nexus_fs = nexus_fs
+        self._kernel: Any = getattr(nexus_fs, "_kernel", None)
         self._version_store = version_store
 
-    def set_metadata_store(self, metadata_store: Any) -> None:
-        """Set the metadata store reference for directory queries."""
-        self._metadata_store = metadata_store
-        self._kernel = metadata_store
+    def set_nexus_fs(self, nexus_fs: Any) -> None:
+        """Set the NexusFS reference for directory queries (deferred injection)."""
+        self._nexus_fs = nexus_fs
+        self._kernel = getattr(nexus_fs, "_kernel", None)
 
     # -- Path detection ----------------------------------------------------
 
@@ -314,6 +315,17 @@ class DirectoryExpander:
         Returns:
             List of descendant file paths.
         """
+        # Prefer the kernel namespace via the Tier 1 sys_readdir syscall.
+        # It is single-zone here (``zone_id`` is ignored); the SQL fallback
+        # below honours the parameter for federated installs.
+        if self._nexus_fs is not None:
+            try:
+                entries = self._nexus_fs.sys_readdir(directory_path, recursive=True, details=True)
+                return [e["path"] for e in entries]
+            except (RuntimeError, OperationalError) as e:
+                logger.warning("[LEOPARD] Metadata store query failed: %s", e)
+
+        # Fallback: query file_paths table via ORM
         from sqlalchemy import or_, select
 
         from nexus.storage.models.file_path import FilePathModel

--- a/src/nexus/bricks/rebac/manager.py
+++ b/src/nexus/bricks/rebac/manager.py
@@ -2021,9 +2021,9 @@ class ReBACManager:
         """Get all file paths under a directory."""
         return self._directory_expander.get_directory_descendants(directory_path, zone_id)
 
-    def set_metadata_store(self, metadata_store: Any) -> None:
-        """Set the metadata store reference for directory queries."""
-        self._directory_expander.set_metadata_store(metadata_store)
+    def set_nexus_fs(self, nexus_fs: Any) -> None:
+        """Set the NexusFS reference for directory queries."""
+        self._directory_expander.set_nexus_fs(nexus_fs)
 
     def _get_namespace_configs_for_rust(self) -> dict[str, Any]:
         """Get namespace configurations for Rust permission computation.

--- a/src/nexus/bricks/rebac/tiger_cache_manager.py
+++ b/src/nexus/bricks/rebac/tiger_cache_manager.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from nexus.core.nexus_fs import NexusFS
 
+
 logger = logging.getLogger(__name__)
 
 
@@ -118,6 +119,10 @@ class TigerCacheManager:
         resource_map = getattr(tiger_cache, "_resource_map", None)
         if not resource_map:
             logger.debug("No resource map in Tiger Cache - skipping sync")
+            return 0
+
+        if self._nexus_fs is None:
+            logger.debug("No NexusFS handle - skipping resource map sync")
             return 0
 
         try:

--- a/src/nexus/bricks/search/search_service.py
+++ b/src/nexus/bricks/search/search_service.py
@@ -1623,6 +1623,8 @@ class SearchService:
         context: Any,
     ) -> Any:
         """Paginated list with over-fetch strategy for permission filtering (Issue #937)."""
+        from nexus.contracts.constants import SYSTEM_PATH_PREFIX
+        from nexus.contracts.metadata import DT_DIR
         from nexus.contracts.types import OperationContext
         from nexus.core.pagination import PaginatedResult
         from nexus.lib.pagination import encode_cursor
@@ -1630,7 +1632,7 @@ class SearchService:
         context = context or self._default_context
         import time as _time
 
-        _start = _time.time()
+        _start = _time.time()  # noqa: F841 — retained for parity with non-paginated list timing
 
         list_zone_id, _, _ = self._extract_zone_info(context)
 
@@ -1642,10 +1644,10 @@ class SearchService:
 
         buffer_multiplier = 1.5
         fetch_limit = int(limit * buffer_multiplier)
-        collected_items: builtins.list[Any] = []
+        collected_items: builtins.list[dict[str, Any]] = []
         has_more = True
 
-        # Decode encoded cursor to plain path for paginate_iter
+        # Decode encoded cursor to plain path for sys_readdir's keyset cursor.
         current_cursor_path: str | None = None
         if cursor:
             from nexus.lib.pagination import CursorError, decode_cursor
@@ -1671,9 +1673,10 @@ class SearchService:
                 context=sys_ctx,
             )
 
-            from nexus.contracts.constants import SYSTEM_PATH_PREFIX
-
-            batch.items = [
+            # sys_readdir already drops cfg:/ns: internal paths; additionally
+            # filter SYSTEM_PATH_PREFIX and reject any non-/ entries
+            # (nexi-lab/nexus#3733 Bug B).
+            batch_items = [
                 item
                 for item in batch.items
                 # Fix nexi-lab/nexus#3733 Bug B: drop synthetic metadata entries
@@ -1683,11 +1686,11 @@ class SearchService:
             ]
 
             if self._enforce_permissions and context:
-                paths = [str(item["path"]) for item in batch.items]
+                paths = [item["path"] for item in batch_items]
                 allowed_paths = set(self._permission_enforcer.filter_list(paths, context))
-                filtered_items = [item for item in batch.items if item["path"] in allowed_paths]
+                filtered_items = [item for item in batch_items if item["path"] in allowed_paths]
             else:
-                filtered_items = batch.items
+                filtered_items = batch_items
 
             collected_items.extend(filtered_items)
             has_more = batch.has_more
@@ -1709,6 +1712,8 @@ class SearchService:
             )
 
         if details:
+            # sys_readdir(details=True) emits created_at/modified_at as ISO
+            # strings (JSON-safe over RPC); they flow through unchanged.
             items_output = [
                 {
                     "path": meta["path"],
@@ -1717,7 +1722,7 @@ class SearchService:
                     "created_at": meta.get("created_at"),
                     "content_id": meta.get("content_id"),
                     "mime_type": meta.get("mime_type"),
-                    "is_directory": meta.get("entry_type") == 1,
+                    "is_directory": meta.get("entry_type") == DT_DIR,
                 }
                 for meta in result_items
             ]

--- a/src/nexus/bricks/search/search_service.py
+++ b/src/nexus/bricks/search/search_service.py
@@ -1425,8 +1425,6 @@ class SearchService:
         _dir_start = _time.time()
         directories: set[str] = set()
 
-        from nexus.contracts.metadata import DT_DIR, DT_MOUNT
-
         for meta in results:
             if _entry_is_dir(meta):
                 directories.add(meta["path"])
@@ -1565,7 +1563,6 @@ class SearchService:
         import time as _time
 
         _details_start = _time.time()
-        from nexus.contracts.metadata import DT_DIR, DT_MOUNT
 
         file_results = [
             {

--- a/src/nexus/bricks/search/search_service.py
+++ b/src/nexus/bricks/search/search_service.py
@@ -643,6 +643,9 @@ class SearchService:
                         try:
                             ct_stat = self._nexus_fs.sys_stat(ct_path, context=_xz_ctx)
                             if ct_stat:
+                                # Cross-zone entries flow through the same
+                                # detail-dict shape as sys_readdir(details=True)
+                                # so downstream consumers stay dict-typed.
                                 all_files.append(
                                     {
                                         "path": ct_path,
@@ -1422,6 +1425,8 @@ class SearchService:
         _dir_start = _time.time()
         directories: set[str] = set()
 
+        from nexus.contracts.metadata import DT_DIR, DT_MOUNT
+
         for meta in results:
             if _entry_is_dir(meta):
                 directories.add(meta["path"])
@@ -1560,6 +1565,8 @@ class SearchService:
         import time as _time
 
         _details_start = _time.time()
+        from nexus.contracts.metadata import DT_DIR, DT_MOUNT
+
         file_results = [
             {
                 "path": meta["path"],

--- a/src/nexus/bricks/search/skeleton_pipe_consumer.py
+++ b/src/nexus/bricks/search/skeleton_pipe_consumer.py
@@ -195,13 +195,9 @@ class SkeletonPipeConsumer:
         if self._consumer_task is not None and not self._consumer_task.done():
             if self._nx is not None and self._pipe_ready:
                 with contextlib.suppress(Exception):
-                    # sys_unlink signals consumer to exit (NexusFileNotFoundError)
-                    from nexus.contracts.types import OperationContext
-
-                    self._nx.sys_unlink(
-                        _SKELETON_PIPE_PATH,
-                        context=OperationContext(user_id="system", groups=[], is_system=True),
-                    )
+                    # sys_unlink dispatches DT_PIPE to destroy → signals consumer
+                    # to exit (NexusFileNotFoundError)
+                    self._nx.sys_unlink(_SKELETON_PIPE_PATH, context=self._pipe_context)
             try:
                 await asyncio.wait_for(asyncio.shield(self._consumer_task), timeout=5.0)
             except (TimeoutError, asyncio.CancelledError):

--- a/src/nexus/core/nexus_fs_metadata.py
+++ b/src/nexus/core/nexus_fs_metadata.py
@@ -1674,17 +1674,26 @@ class MetadataMixin:
                 is_implicit_dir = _s is not None and _s.get("is_directory", False)
             if is_implicit_dir:
                 et = DT_DIR
+        # Full FileMetadata projection — sys_readdir(details=True) is the
+        # Tier 1 surface service callers use in place of the
+        # metastore_list_paginated kernel primitive, so the dict must carry
+        # every FileMetadata field (not just the display subset). Additive:
+        # CLI / API consumers keying on the original fields are unaffected.
         return {
             "path": entry.path,
             "size": entry.size,
             "content_id": entry.content_id,
-            "entry_type": et,
-            "zone_id": entry.zone_id,
-            "owner_id": entry.owner_id,
             "mime_type": entry.mime_type,
             "created_at": entry.created_at.isoformat() if entry.created_at else None,
             "modified_at": entry.modified_at.isoformat() if entry.modified_at else None,
             "version": entry.version,
+            "zone_id": entry.zone_id,
+            "owner_id": entry.owner_id,
+            "entry_type": et,
+            "target_zone_id": entry.target_zone_id,
+            "ttl_seconds": entry.ttl_seconds,
+            "last_writer_address": entry.last_writer_address,
+            "link_target": entry.link_target,
             "gen": entry.gen,
         }
 

--- a/src/nexus/factory/_boot_context.py
+++ b/src/nexus/factory/_boot_context.py
@@ -44,5 +44,10 @@ class _BootContext:
     wal_sync_mode: str | None = None
     wal_segment_size: int | None = None
 
+    # NexusFS handle — present when services are booted from create_nexus_fs
+    # (the common path); None for standalone create_nexus_services callers.
+    # Service-tier boot code uses it to reach the kernel via Tier 1 syscalls.
+    nexus_fs: "Any" = None
+
     # Issue #3193: shared signal for write-observer -> delivery-worker wakeup
     event_signal: asyncio.Event = field(default_factory=asyncio.Event)

--- a/src/nexus/factory/_lifecycle.py
+++ b/src/nexus/factory/_lifecycle.py
@@ -26,6 +26,9 @@ class _InitContext:
     svc_on: Callable[[str], bool]
     parse_fn: Any
     permission_checker: Any
+    # Root backend handed to create_nexus_fs — needed by _register_vfs_hooks
+    # to decide whether to enlist CasGcService (only for CAS root backends).
+    backend: Any = None
 
 
 def _wire_services(
@@ -38,6 +41,7 @@ def _wire_services(
     workflow_engine: Any = None,
     federation: Any = None,
     security: Any = None,
+    backend: Any = None,
 ) -> _InitContext:
     """Phase 1: wire service topology.  Pure memory — NO I/O.
 
@@ -212,6 +216,7 @@ def _wire_services(
         svc_on=svc_on,
         parse_fn=_parse_fn,
         permission_checker=_permission_checker,
+        backend=backend,
     )
 
 
@@ -245,6 +250,7 @@ def _initialize_services(
         auto_parse=nx._parse_config.auto_parse if nx._parse_config else True,
         svc_on=ctx.svc_on,
         parse_fn=ctx.parse_fn,
+        backend=ctx.backend,
     )
 
     # Background services (DeferredPermissionBuffer, EventDeliveryWorker,

--- a/src/nexus/factory/_wired.py
+++ b/src/nexus/factory/_wired.py
@@ -143,6 +143,10 @@ def _boot_post_kernel_services(
 
                 rebac_manager._namespace_store = MetastoreNamespaceStore(nx)
                 rebac_manager._version_store = MetastoreVersionStore(nx)
+                # DirectoryExpander descendant queries go through sys_readdir on
+                # this NexusFS handle (Tier 1 syscall, not a kernel primitive).
+                if hasattr(rebac_manager, "set_nexus_fs"):
+                    rebac_manager.set_nexus_fs(nx)
                 logger.debug("[BOOT:WIRED] ReBAC namespace + version stores wired (VFS-backed)")
             except Exception as exc:
                 logger.warning("[BOOT:WIRED] ReBAC namespace/version stores wiring failed: %s", exc)

--- a/src/nexus/factory/orchestrator.py
+++ b/src/nexus/factory/orchestrator.py
@@ -340,6 +340,7 @@ def create_nexus_fs(
         workflow_engine=workflow_engine,
         federation=federation,
         security=security,
+        backend=backend,
     )
     nx._linked = True
 
@@ -357,6 +358,7 @@ def _register_vfs_hooks(
     auto_parse: bool = True,
     svc_on: "Callable[[str], bool] | None" = None,
     parse_fn: Any = None,
+    backend: Any = None,
 ) -> None:
     """Register hooks + observers via coordinator.enlist() (Issue #900, #1709).
 
@@ -668,8 +670,19 @@ def _register_vfs_hooks(
     # sys_write/sys_unlink/sys_rename/sys_mkdir (rmdir is internal). No observer needed.
 
     # ── CAS GC (Issue #1320, #1772) ────────────────────────────────────
-    # ref_count eliminated; reachability-based GC via CASGarbageCollector.
-    # GC is owned by CASLocalBackend, metastore injected via set_metastore().
+    # ref_count eliminated; reachability-based GC via CasGcService.
+    # Factory-gated: enlist one instance when the root backend is CAS so
+    # the kernel auto-starts it as a BackgroundService. Non-CAS backends
+    # (path_local, external connectors) skip this — they own no blob set
+    # to collect.
+    if backend is not None:
+        from nexus.backends.base.cas_addressing_engine import CASAddressingEngine
+
+        if isinstance(backend, CASAddressingEngine):
+            from nexus.backends.engines.cas_gc import CasGcService
+
+            _cas_gc = CasGcService(backend, nx)
+            _enlist("cas_gc", _cas_gc)
 
     # ── Test hooks (Issue #2) ────────────────────────────────────────
     # Only registered when NEXUS_TEST_HOOKS=true for E2E hook testing.

--- a/src/nexus/factory/orchestrator.py
+++ b/src/nexus/factory/orchestrator.py
@@ -40,6 +40,7 @@ def create_nexus_services(
     enable_write_buffer: bool | None = None,
     resiliency_raw: dict[str, Any] | None = None,
     enabled_bricks: frozenset[str] | None = None,
+    nexus_fs: "Any" = None,
 ) -> "dict[str, Any]":
     """Create default services for NexusFS dependency injection.
 
@@ -70,6 +71,9 @@ def create_nexus_services(
         resiliency_raw: Raw resiliency policy dict from YAML config.
         enabled_bricks: Set of brick names to enable. When None, all bricks
             are enabled (backward-compatible default = FULL profile).
+        nexus_fs: NexusFS handle, when services are booted from
+            ``create_nexus_fs``. Service-tier boot code uses it to reach the
+            kernel via Tier 1 syscalls. None for standalone callers.
 
     Returns:
         dict[str, Any] — all services keyed by canonical name.
@@ -153,6 +157,7 @@ def create_nexus_services(
         resiliency_raw=resiliency_raw,
         db_url=getattr(record_store, "database_url", ""),
         profile_tuning=_profile_tuning,
+        nexus_fs=nexus_fs,
     )
 
     # --- Tier 0: KERNEL (validate Storage Pillars — inlined from _kernel.py) ---
@@ -318,6 +323,7 @@ def create_nexus_fs(
             agent_id=agent_id,
             enable_write_buffer=enable_write_buffer,
             enabled_bricks=enabled_bricks,
+            nexus_fs=nx,
         )
 
     # Default to empty dict when not provided

--- a/src/nexus/services/audit_node/service.py
+++ b/src/nexus/services/audit_node/service.py
@@ -36,7 +36,14 @@ import json
 import logging
 from typing import Any
 
+from nexus.contracts.types import OperationContext
+
 logger = logging.getLogger(__name__)
+
+
+# Audit-node runs kernel-internally; bypass the permission gate but keep
+# OBSERVE/INTERCEPT pipeline intact.
+_AUDIT_CONTEXT = OperationContext(user_id="audit-node", groups=[], is_system=True)
 
 
 @dataclasses.dataclass
@@ -201,14 +208,21 @@ class AuditNode:
         ``checkpoint.offset`` and persists the new offset on success.
         """
         source_path = f"/{zone}{self._stream_path}".rstrip("/")
-        # ``stream_read_batch`` returns ``(entries, new_offset)``;
-        # record bytes are JSON-encoded ``AuditRecord`` blobs the
-        # producer wrote via ``AuditHook``.
-        entries, new_offset = self._kernel.stream_read_batch(
-            source_path,
-            checkpoint.offset,
-            self._batch_size,
-        )
+        # Drain up to ``batch_size`` DT_STREAM records via sys_read with
+        # offset chaining — each record is one ``AuditRecord`` JSON blob
+        # written by ``AuditHook``. sys_read dispatches DT_STREAM to the
+        # same StreamManager.read_at the primitive used, plus the
+        # INTERCEPT read hooks the primitive bypassed.
+        entries: list[bytes] = []
+        new_offset = checkpoint.offset
+        for _ in range(self._batch_size):
+            result = self._kernel.sys_read(
+                source_path, _AUDIT_CONTEXT, timeout_ms=0, offset=new_offset
+            )
+            if result.data is None:
+                break
+            entries.append(result.data)
+            new_offset = result.stream_next_offset
         if not entries:
             return 0
 

--- a/src/nexus/services/lifecycle/dedup_work_queue.py
+++ b/src/nexus/services/lifecycle/dedup_work_queue.py
@@ -11,7 +11,7 @@ Three invariants maintained by add/get/done:
   3. An item can be in both ``dirty`` and ``processing`` (re-added during
      processing → will be re-queued on ``done()``).
 
-Transport: Rust kernel IPC pipe (``kernel.create_pipe``) carries u64 LE
+Transport: Rust kernel IPC pipe (``sys_setattr(DT_PIPE)``) carries u64 LE
 sequence tokens (8 bytes each); actual items stay in a Python dict — no
 serialization needed. Dedup logic (dirty/processing sets) remains in Python.
 
@@ -238,7 +238,11 @@ class DedupWorkQueue(Generic[T]):
                 self._items[seq] = key
                 self._kernel.sys_write(
                     self._pipe_path,
+<<<<<<< HEAD
                     self._sys_ctx,
+=======
+                    self._pipe_context,
+>>>>>>> 9361446d5 (refactor(dedup-queue): pipe_write_nowait → sys_write)
                     seq.to_bytes(self._TOKEN_SIZE, "little"),
                 )
             except RuntimeError:

--- a/src/nexus/services/lifecycle/dedup_work_queue.py
+++ b/src/nexus/services/lifecycle/dedup_work_queue.py
@@ -309,7 +309,11 @@ class DedupWorkQueue(Generic[T]):
             return
         self._closed = True
         with contextlib.suppress(RuntimeError):
+<<<<<<< HEAD
             self._kernel.sys_unlink(self._pipe_path, self._sys_ctx)
+=======
+            self._kernel.sys_unlink(self._pipe_path, self._pipe_context)
+>>>>>>> 6a3d5ddda (refactor(dedup-queue): destroy_pipe → sys_unlink)
 
     def __del__(self) -> None:
         self.close()

--- a/src/nexus/services/lifecycle/dedup_work_queue.py
+++ b/src/nexus/services/lifecycle/dedup_work_queue.py
@@ -252,14 +252,13 @@ class DedupWorkQueue(Generic[T]):
         """Shut down the queue gracefully.
 
         After shutdown, ``add()`` raises ``ShutdownError`` and ``get()``
-        drains remaining items then raises ``ShutdownError``.
-        Signals the kernel pipe as closed so blocked readers wake up.
+        drains remaining items then raises ``ShutdownError``. No kernel
+        call is needed — workers exit on the Python ``_shutting_down``
+        flag once ``_items`` empties. The pipe inode is removed by
+        ``close()`` (sys_unlink), not here.
         """
         async with self._lock:
             self._shutting_down = True
-
-        with contextlib.suppress(RuntimeError):
-            self._kernel.close_pipe(self._pipe_path)
 
         logger.info(
             "DedupWorkQueue shutdown (adds=%d, coalesced=%d, gets=%d)",

--- a/src/nexus/services/lifecycle/dedup_work_queue.py
+++ b/src/nexus/services/lifecycle/dedup_work_queue.py
@@ -309,11 +309,7 @@ class DedupWorkQueue(Generic[T]):
             return
         self._closed = True
         with contextlib.suppress(RuntimeError):
-<<<<<<< HEAD
             self._kernel.sys_unlink(self._pipe_path, self._sys_ctx)
-=======
-            self._kernel.sys_unlink(self._pipe_path, self._pipe_context)
->>>>>>> 6a3d5ddda (refactor(dedup-queue): destroy_pipe → sys_unlink)
 
     def __del__(self) -> None:
         self.close()

--- a/src/nexus/services/lifecycle/dedup_work_queue.py
+++ b/src/nexus/services/lifecycle/dedup_work_queue.py
@@ -30,7 +30,12 @@ import contextlib
 import logging
 import time
 from collections.abc import Awaitable, Callable
-from typing import Any, Generic, TypeVar
+from typing import TYPE_CHECKING, Any, Generic, TypeVar
+
+from nexus.contracts.metadata import DT_PIPE
+
+if TYPE_CHECKING:
+    from nexus_runtime import PyKernel
 
 logger = logging.getLogger(__name__)
 
@@ -47,14 +52,14 @@ class DedupWorkQueue(Generic[T]):
     Coalesces duplicate keys so that rapid additions of the same key
     result in at most one processing run.
 
-    **Architectural layer (kernel-level primitive):** ``DedupWorkQueue``
-    holds a ``PyKernel`` handle directly rather than going through the
-    ``NexusFS`` facade. It is a kernel-level primitive (a tight polling
-    loop over a sequence-token pipe with no business logic), conceptually
-    the same tier as ``PyKernel.create_pipe`` itself, so the
-    ``self._kernel.pipe_*`` calls in this file are NOT abstraction
-    violations — ``_kernel`` is the construction-time injected dependency,
-    not a reach-in through a service abstraction.
+    **Architectural layer:** ``DedupWorkQueue`` holds a ``PyKernel`` handle
+    directly rather than going through the ``NexusFS`` facade — the queue
+    is a tight polling loop with no business logic that needs the pipeline
+    overhead of a full facade call. All pipe operations go through Tier 1
+    syscalls (``sys_setattr(DT_PIPE)`` / ``sys_write`` / ``sys_read`` /
+    ``sys_unlink``) — no direct ``PipeManager`` primitive access. The
+    is_system context bypasses the permission gate; INTERCEPT hooks and
+    OBSERVE still fire normally.
 
     **Transport:** Uses a Rust kernel IPC pipe for the internal FIFO.
     The pipe carries u64 LE sequence tokens (8 bytes each); actual items
@@ -99,7 +104,13 @@ class DedupWorkQueue(Generic[T]):
         self._kernel = kernel
         self._pipe_path = pipe_path or f"/__sys__/dedup/{id(self)}"
         self._sys_ctx = PyOperationContext(is_system=True)
-        self._kernel.create_pipe(self._pipe_path, capacity * self._TOKEN_SIZE)
+        # Tier 1 syscall — sys_setattr(DT_PIPE) creates the pipe; the
+        # create_pipe kernel primitive is no longer reachable from service tier.
+        self._kernel.sys_setattr(
+            self._pipe_path,
+            entry_type=DT_PIPE,
+            capacity=capacity * self._TOKEN_SIZE,
+        )
 
         self._seq = 0  # monotonic sequence counter
         self._items: dict[int, T] = {}  # seq → item (actual data stays in Python)

--- a/src/nexus/services/lifecycle/dedup_work_queue.py
+++ b/src/nexus/services/lifecycle/dedup_work_queue.py
@@ -174,8 +174,8 @@ class DedupWorkQueue(Generic[T]):
         The caller MUST call ``done(key)`` when processing is complete,
         even if processing fails.  Use a try/finally block.
 
-        Polls the kernel pipe with ``sys_read``.  If the pipe is
-        empty, yields to the event loop briefly (10 ms) and retries.
+        Polls the kernel pipe with non-blocking ``sys_read``. If the pipe
+        is empty, yields to the event loop briefly (10 ms) and retries.
 
         Returns:
             The next key to process.
@@ -188,12 +188,14 @@ class DedupWorkQueue(Generic[T]):
                 raise ShutdownError("DedupWorkQueue has been shut down")
 
             try:
-                result = self._kernel.sys_read(self._pipe_path, self._sys_ctx, timeout_ms=0)
-                data = result.data
+                result = self._kernel.sys_read(
+                    self._pipe_path, self._sys_ctx, timeout_ms=0, offset=0
+                )
             except RuntimeError as exc:
                 if "PipeClosed" in str(exc):
                     raise ShutdownError("DedupWorkQueue has been shut down") from None
                 raise
+            data = result.data
 
             if data is None or data == b"":
                 # Pipe empty — yield and retry
@@ -238,11 +240,7 @@ class DedupWorkQueue(Generic[T]):
                 self._items[seq] = key
                 self._kernel.sys_write(
                     self._pipe_path,
-<<<<<<< HEAD
                     self._sys_ctx,
-=======
-                    self._pipe_context,
->>>>>>> 9361446d5 (refactor(dedup-queue): pipe_write_nowait → sys_write)
                     seq.to_bytes(self._TOKEN_SIZE, "little"),
                 )
             except RuntimeError:

--- a/src/nexus/services/lifecycle/dedup_work_queue.py
+++ b/src/nexus/services/lifecycle/dedup_work_queue.py
@@ -30,12 +30,9 @@ import contextlib
 import logging
 import time
 from collections.abc import Awaitable, Callable
-from typing import TYPE_CHECKING, Any, Generic, TypeVar
+from typing import Any, Generic, TypeVar
 
 from nexus.contracts.metadata import DT_PIPE
-
-if TYPE_CHECKING:
-    from nexus_runtime import PyKernel
 
 logger = logging.getLogger(__name__)
 

--- a/src/nexus/services/metadata_export.py
+++ b/src/nexus/services/metadata_export.py
@@ -125,7 +125,8 @@ class MetadataExportService:
                 # ``backend_name``/``physical_path`` were removed from
                 # FileMetadata — the kernel resolves the physical
                 # location at read time via the mount/route layer, so
-                # exported metadata no longer surfaces them.
+                # exported metadata no longer surfaces them. created_at /
+                # modified_at are already ISO-8601 strings from sys_readdir.
                 metadata_dict: dict[str, Any] = {
                     "path": entry.get("path"),
                     "size": entry.get("size", 0),

--- a/src/nexus/services/workspace/workspace_manager.py
+++ b/src/nexus/services/workspace/workspace_manager.py
@@ -48,6 +48,7 @@ class WorkspaceManager:
         zone_id: str | None = None,
         agent_id: str | None = None,
         record_store: "RecordStoreABC | None" = None,
+        nexus_fs: "Any" = None,
     ):
         """Initialize workspace manager.
 
@@ -61,6 +62,7 @@ class WorkspaceManager:
             zone_id: Default zone ID for operations (optional)
             agent_id: Default agent ID for operations (optional)
             record_store: RecordStoreABC instance providing session_factory
+            nexus_fs: NexusFS handle for namespace walks (via sys_readdir)
         """
         self._nexus_fs = nexus_fs
         self.rebac_manager = rebac_manager

--- a/src/nexus/services/workspace/workspace_manager.py
+++ b/src/nexus/services/workspace/workspace_manager.py
@@ -48,7 +48,6 @@ class WorkspaceManager:
         zone_id: str | None = None,
         agent_id: str | None = None,
         record_store: "RecordStoreABC | None" = None,
-        nexus_fs: "Any" = None,
     ):
         """Initialize workspace manager.
 
@@ -62,7 +61,6 @@ class WorkspaceManager:
             zone_id: Default zone ID for operations (optional)
             agent_id: Default agent ID for operations (optional)
             record_store: RecordStoreABC instance providing session_factory
-            nexus_fs: NexusFS handle for namespace walks (via sys_readdir)
         """
         self._nexus_fs = nexus_fs
         self.rebac_manager = rebac_manager

--- a/tests/e2e/server/test_directory_grants_e2e.py
+++ b/tests/e2e/server/test_directory_grants_e2e.py
@@ -114,8 +114,8 @@ async def nexus_fs_with_tiger(db_with_migrations, tmp_path):
     if _rebac_mgr is not None:
         engine = _rebac_mgr.engine
         add_migration_tables(engine)
-        # Connect the metadata store to ReBAC manager for directory expansion
-        _rebac_mgr.set_metadata_store(nx.metadata)
+        # Connect NexusFS to the ReBAC manager for directory expansion
+        _rebac_mgr.set_nexus_fs(nx)
 
     # Create admin context for tests
     admin_context = OperationContext(

--- a/tests/unit/backends/test_cas_gc.py
+++ b/tests/unit/backends/test_cas_gc.py
@@ -1,4 +1,4 @@
-"""Unit tests for CASGarbageCollector — reachability-based GC (Issue #1772).
+"""Unit tests for CasGcService — reachability-based GC (Issue #1772).
 
 Verifies that GC correctly:
 - Deletes unreferenced blobs past grace period
@@ -12,40 +12,39 @@ from __future__ import annotations
 import os
 import tempfile
 import time
-from dataclasses import dataclass
 from pathlib import Path
 
 import pytest
 
 from nexus import CASLocalBackend
-from nexus.backends.engines.cas_gc import CASGarbageCollector
+from nexus.backends.engines.cas_gc import CasGcService
 
 
-@dataclass
-class FakeMetaEntry:
-    path: str
-    content_id: str | None = None
+class FakeNexusFs:
+    """Tier 1 syscall stub for CAS GC tests.
 
-
-class FakeMetastore:
-    """Kernel-handle stub for CAS GC tests.
-
-    Post-C24 ``CASGarbageCollector`` reaches the metastore via
-    ``self._kernel.metastore_list_paginated``. The constructor's
-    ``hasattr(metastore, "_rust_kernel")`` guard treats this stub as
-    a bare kernel.
+    CasGcService walks the namespace via ``self._nexus_fs.sys_readdir(
+    "/", recursive=True, details=True)`` — the detail-dict shape this
+    fake returns matches what the real sys_readdir emits.
     """
 
-    def __init__(self, entries: list[FakeMetaEntry] | None = None):
+    def __init__(self, entries: list[dict] | None = None):
         self._entries = entries or []
 
     def add(self, path: str, content_id: str) -> None:
-        self._entries.append(FakeMetaEntry(path=path, content_id=content_id))
+        self._entries.append({"path": path, "content_id": content_id})
 
-    def metastore_list_paginated(
-        self, prefix: str = "", recursive: bool = True, limit: int = 100000, cursor: object = None
-    ) -> dict:
-        return {"items": list(self._entries), "cursor": None}
+    def sys_readdir(
+        self,
+        path: str = "/",
+        recursive: bool = True,
+        details: bool = False,
+        **_kwargs: object,
+    ) -> list[dict]:
+        assert path == "/"
+        assert recursive is True
+        assert details is True
+        return list(self._entries)
 
 
 @pytest.fixture
@@ -66,8 +65,8 @@ class TestGCReachability:
         content_id = result.content_id
         assert engine.content_exists(content_id)
 
-        # Metastore has no reference to this blob
-        metastore = FakeMetastore()
+        # NexusFS has no reference to this blob
+        nexus_fs = FakeNexusFs()
 
         # Backdate the blob's mtime to exceed grace period
         blob_key = engine._blob_key(content_id)
@@ -75,7 +74,7 @@ class TestGCReachability:
         old_time = time.time() - 600  # 10 min ago
         os.utime(str(blob_path), (old_time, old_time))
 
-        gc = CASGarbageCollector(engine, metastore, grace_period=300, scan_interval=1)
+        gc = CasGcService(engine, nexus_fs, grace_period=300, scan_interval=1)
         gc._collect()
 
         assert not engine.content_exists(content_id)
@@ -85,10 +84,10 @@ class TestGCReachability:
         result = engine.write_content(b"still in use")
         content_id = result.content_id
 
-        metastore = FakeMetastore()
-        metastore.add("/file.txt", content_id)
+        nexus_fs = FakeNexusFs()
+        nexus_fs.add("/file.txt", content_id)
 
-        gc = CASGarbageCollector(engine, metastore, grace_period=0, scan_interval=1)
+        gc = CasGcService(engine, nexus_fs, grace_period=0, scan_interval=1)
         gc._collect()
 
         assert engine.content_exists(content_id)
@@ -98,9 +97,9 @@ class TestGCReachability:
         result = engine.write_content(b"recently written")
         content_id = result.content_id
 
-        metastore = FakeMetastore()
+        nexus_fs = FakeNexusFs()
 
-        gc = CASGarbageCollector(engine, metastore, grace_period=300, scan_interval=1)
+        gc = CasGcService(engine, nexus_fs, grace_period=300, scan_interval=1)
         gc._collect()
 
         # Should still exist — within grace period (just written)
@@ -111,19 +110,19 @@ class TestGCReachability:
         result = engine.write_content(b"ephemeral")
         content_id = result.content_id
 
-        metastore = FakeMetastore()
+        nexus_fs = FakeNexusFs()
 
-        gc = CASGarbageCollector(engine, metastore, grace_period=0, scan_interval=1)
+        gc = CasGcService(engine, nexus_fs, grace_period=0, scan_interval=1)
         gc._collect()
 
         assert not engine.content_exists(content_id)
 
-    def test_gc_no_metastore_skips(self, engine: CASLocalBackend) -> None:
-        """No metastore injected → skip collection, don't delete anything."""
+    def test_gc_no_nexus_fs_skips(self, engine: CASLocalBackend) -> None:
+        """No NexusFS injected → skip collection, don't delete anything."""
         result = engine.write_content(b"safe data")
         content_id = result.content_id
 
-        gc = CASGarbageCollector(engine, metastore=None, grace_period=0, scan_interval=1)
+        gc = CasGcService(engine, nexus_fs=None, grace_period=0, scan_interval=1)
         gc._collect()
 
         assert engine.content_exists(content_id)

--- a/tests/unit/core/test_readdir_detail_projection.py
+++ b/tests/unit/core/test_readdir_detail_projection.py
@@ -7,6 +7,8 @@ dict must carry every ``FileMetadata`` field, not just the display subset.
 
 from __future__ import annotations
 
+import pytest
+
 from tests.testkit.nexus_factory import make_test_nexus
 
 # Every field on contracts.metadata.FileMetadata — the detail dict is a
@@ -34,6 +36,12 @@ _EXPECTED_KEYS = frozenset(
 
 def test_readdir_details_returns_full_filemetadata_projection(tmp_path):
     nx = make_test_nexus(tmp_path, is_admin=True)
+    if nx._kernel is None:
+        # Kernel binary (nexus-cluster) unavailable on this runner —
+        # the unit suite only requires the in-process kernel, which the
+        # macOS / Windows runners don't ship by default.
+        nx.close()
+        pytest.skip("kernel binary unavailable in this environment")
     try:
         nx.sys_write("/alpha.txt", b"alpha")
         nx.sys_write("/beta.txt", b"beta-content")

--- a/tests/unit/core/test_readdir_detail_projection.py
+++ b/tests/unit/core/test_readdir_detail_projection.py
@@ -1,0 +1,61 @@
+"""sys_readdir(details=True) returns the full FileMetadata projection.
+
+Service callers migrating off the ``metastore_list_paginated`` kernel
+primitive consume ``sys_readdir(details=True)`` instead — so the detail
+dict must carry every ``FileMetadata`` field, not just the display subset.
+"""
+
+from __future__ import annotations
+
+from tests.testkit.nexus_factory import make_test_nexus
+
+# Every field on contracts.metadata.FileMetadata — the detail dict is a
+# 1:1 projection so callers never need to fall back to the primitive.
+_EXPECTED_KEYS = frozenset(
+    {
+        "path",
+        "size",
+        "content_id",
+        "mime_type",
+        "created_at",
+        "modified_at",
+        "version",
+        "zone_id",
+        "owner_id",
+        "entry_type",
+        "target_zone_id",
+        "ttl_seconds",
+        "last_writer_address",
+        "link_target",
+        "gen",
+    }
+)
+
+
+def test_readdir_details_returns_full_filemetadata_projection(tmp_path):
+    nx = make_test_nexus(tmp_path, is_admin=True)
+    try:
+        nx.sys_write("/alpha.txt", b"alpha")
+        nx.sys_write("/beta.txt", b"beta-content")
+
+        rows = nx.sys_readdir("/", recursive=True, details=True)
+        by_path = {r["path"]: r for r in rows}
+
+        assert "/alpha.txt" in by_path, f"alpha.txt missing from {list(by_path)}"
+        entry = by_path["/alpha.txt"]
+
+        # Full projection — no FileMetadata field omitted.
+        assert set(entry) == _EXPECTED_KEYS, (
+            f"detail dict keys diverge from FileMetadata: "
+            f"missing={_EXPECTED_KEYS - set(entry)}, extra={set(entry) - _EXPECTED_KEYS}"
+        )
+
+        # Spot-check the fields the metastore_list_paginated callers rely on.
+        assert entry["size"] == len(b"alpha")
+        assert entry["content_id"]
+        assert entry["entry_type"] == 0  # DT_REG
+        assert entry["ttl_seconds"] == 0.0
+        # created_at / modified_at are ISO-8601 strings (JSON-safe over RPC).
+        assert isinstance(entry["modified_at"], str)
+    finally:
+        nx.close()

--- a/tests/unit/core/test_readdir_detail_projection.py
+++ b/tests/unit/core/test_readdir_detail_projection.py
@@ -35,11 +35,16 @@ _EXPECTED_KEYS = frozenset(
 
 
 def test_readdir_details_returns_full_filemetadata_projection(tmp_path):
-    nx = make_test_nexus(tmp_path, is_admin=True)
+    try:
+        nx = make_test_nexus(tmp_path, is_admin=True)
+    except AttributeError:
+        # make_test_nexus → create_nexus_fs calls nx.sys_setattr during
+        # boot; on runners where the nexus-cluster binary isn't installed
+        # (macOS / Windows unit suite, the kernel spawn fails →
+        # nx._kernel = None), that raises AttributeError before this test
+        # body runs. Skip — the test needs a working kernel by design.
+        pytest.skip("kernel binary unavailable in this environment")
     if nx._kernel is None:
-        # Kernel binary (nexus-cluster) unavailable on this runner —
-        # the unit suite only requires the in-process kernel, which the
-        # macOS / Windows runners don't ship by default.
         nx.close()
         pytest.skip("kernel binary unavailable in this environment")
     try:

--- a/tests/unit/services/test_dedup_work_queue.py
+++ b/tests/unit/services/test_dedup_work_queue.py
@@ -48,7 +48,6 @@ from nexus.services.lifecycle.dedup_work_queue import (
     run_worker,
 )
 
-
 # ---------------------------------------------------------------------------
 # Fake kernel — in-process pipe backed by collections.deque
 # ---------------------------------------------------------------------------

--- a/tests/unit/services/test_dedup_work_queue.py
+++ b/tests/unit/services/test_dedup_work_queue.py
@@ -67,8 +67,10 @@ class _FakeKernel:
         self._pipes: dict[str, tuple[collections.deque[bytes], int, bool]] = {}
         # path → (deque, capacity_bytes, closed)
 
-    def create_pipe(self, path: str, capacity: int) -> None:
+    def sys_setattr(self, path: str, *, entry_type: int, capacity: int) -> dict:
+        # Minimal stub: only DT_PIPE creation is exercised by DedupWorkQueue.
         self._pipes[path] = (collections.deque(), capacity, False)
+        return {"path": path, "created": True, "entry_type": entry_type}
 
     def sys_write(self, path: str, ctx: Any, data: bytes, offset: int = 0) -> Any:
         """Syscall write — delegates to pipe write for DT_PIPE paths."""

--- a/tests/unit/services/test_dedup_work_queue.py
+++ b/tests/unit/services/test_dedup_work_queue.py
@@ -48,6 +48,7 @@ from nexus.services.lifecycle.dedup_work_queue import (
     run_worker,
 )
 
+
 # ---------------------------------------------------------------------------
 # Fake kernel — in-process pipe backed by collections.deque
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Goal

Kernel-primitive sanity check (KERNEL-ARCHITECTURE.md §4): kernel primitives
are kernel-internal — service/driver Python code must reach the kernel through
Tier 1 syscalls (`sys_*`), not by calling primitive PyO3 methods directly.
This PR finds and fixes the violations.

Granular commits, one concern per commit — see individual commit messages.

## Scope (multi-phase, single PR)

**Phase 1 — IPC primitive callers → syscalls (done)**

`dedup_work_queue` and `audit_node` reached into `PipeManager` / `StreamManager`
primitives (`create_pipe`, `pipe_*_nowait`, `stream_*`), and `skeleton_pipe_consumer`
called `destroy_pipe` directly. All bypass the syscall pipeline (PRE-DISPATCH,
permission gate, INTERCEPT hooks). Migrated to `sys_setattr(DT_PIPE)` / `sys_read`
/ `sys_write` / `sys_unlink` — the kernel dispatches DT_PIPE/DT_STREAM to the
same managers internally.

**Phase 2 — `metastore_list_paginated` / `metastore_list_iter` callers → `sys_readdir` (done)**

Every service-tier caller of the metastore listing primitives migrated to the
Tier 1 `nx.sys_readdir(recursive=True, details=True)` syscall:

- `bricks/portability/export_service.py` (uses `self.nexus_fs`)
- `bricks/mount/mount_service.py` (uses `self.nexus_fs`)
- `factory/orchestrator.py` `_metadata_list_iter` closure (wired into TigerCacheRenameHook)
- `bricks/search/search_service.py` (`_list_slow_path` + `_list_paginated` + helpers; dict-typed flow)
- `bricks/rebac/cache/tiger/expander.py` (DirectoryGrantExpander — nexus_fs threaded through `permissions.py` lifespan)
- `bricks/rebac/directory/expander.py` (DirectoryExpander — nexus_fs threaded via `ReBACManager.set_nexus_fs` in `_wired.py`)
- `services/namespace/descendant_access.py` (DescendantAccessChecker — nexus_fs constructor param wired at `_wired.py`)
- `bricks/rebac/tiger_cache_manager.py` (nexus_fs threaded through `_BootContext.nexus_fs` → `_system.py`)
- `services/ttl_volume_sweeper.py` (nexus_fs replaces metastore param)
- `services/workspace/workspace_manager.py` (nexus_fs threaded via `_BootContext.nexus_fs`)
- `services/workspace/context_branch.py` (reuses WorkspaceManager's NexusFS handle)
- `services/metadata_export.py` (nexus_fs constructor param wired at `factory/_metadata_export.py`)

Foundation: `sys_readdir(details=True)` now returns the full FileMetadata
projection as JSON-safe dicts (created_at/modified_at as ISO-8601 strings).

**Phase 3 — CAS GC resurrection as a service (done)**

`CASGarbageCollector` was dead code (`start()` / `set_metastore()` never called
→ GC never runs → CAS deployments leak blobs). Reachability-based GC walks the
whole namespace — that is a service-tier operation, not a driver one. Resurrected
as `CasGcService`, a factory-gated `BackgroundService`:

- Async `start()` / `stop()` per the BackgroundService protocol
- `_scan_namespace` walks via `nx.sys_readdir("/", recursive=True, details=True)`
- Wired in `orchestrator._register_vfs_hooks` only when the root backend is a CAS
  backend (`isinstance(backend, CASAddressingEngine)`); non-CAS backends and
  nexus-cluster (Rust binary, no Python factory) are naturally unaffected
- `CASLocalBackend` drops `self._gc` ownership + the dead `set_metastore` method

## Verification

- `cargo check --workspace` — 0 errors
- Per-commit: affected unit/integration tests pass (noted in each commit message)
- Final grep — only `kernel_helpers.py` and `nexus_fs_metadata.py` (the kernel
  surface itself) reference `metastore_list_paginated` / `metastore_list_iter`
  in `src/nexus/`; no service-tier callers remain