### PR TITLE
fix(factory): replace kernel type-name check with capability attribute

### DIFF
--- a/src/nexus/factory/_wired.py
+++ b/src/nexus/factory/_wired.py
@@ -127,7 +127,7 @@ def _boot_post_kernel_services(
     # so this late binding is safe.
     rebac_manager = services.get("rebac_manager")
     if rebac_manager is not None:
-        if type(getattr(nx, "_kernel", None)).__name__ == "KernelClient":
+        if getattr(getattr(nx, "_kernel", None), "requires_python_hooks", False):
             logger.debug(
                 "[BOOT:WIRED] ReBAC namespace + version stores left SQL-backed "
                 "(subprocess kernel VFS misses are too expensive)"


### PR DESCRIPTION
## Summary (kernel team review of PR #4184)

**Commit 1**: Replace `type(nx._kernel).__name__ == "KernelClient"` in `_wired.py` with `requires_python_hooks` capability attribute — factory should not check kernel class names (boundary violation).

**Commit 2**: Move `_local_services` shadow registry from NexusFS to KernelClient — SSOT fix. In subprocess mode, KernelClient IS the kernel boundary; service storage belongs there. Updated `service_enlist/service_lookup/service_swap` on KernelClient to maintain local store. Removed 3 `getattr(self, "_local_services", ...)` patches from NexusFS + nexus_fs_metadata.py.

## Test plan
- [x] Pre-commit hooks pass (ruff, ruff-format, mypy, boundary checks)
- [x] Same runtime behavior — KernelClient now stores services it previously dropped