### PR TITLE
[codex] Fix sandbox ReBAC MCP coverage

### DIFF
--- a/docs/architecture/api-rpc-surface-coverage.html
+++ b/docs/architecture/api-rpc-surface-coverage.html
@@ -153,7 +153,7 @@
     <a href="#m-catalog">catalog<span class="count">23</span></a>
     <a href="#m-context_manifest">context_manifest<span class="count">1</span></a>
     <h2 style="font-size:0.65rem; opacity:0.7; margin-top:0.6rem;">Agent runtime</h2>
-    <a href="#m-mcp">mcp<span class="count">11</span></a>
+    <a href="#m-mcp">mcp<span class="count">12</span></a>
     <a href="#m-sandbox">sandbox<span class="count">5</span></a>
     <a href="#m-agent_log">agent_log<span class="count">35</span></a>
     <h2 style="font-size:0.65rem; opacity:0.7; margin-top:0.6rem;">Process &amp; policy</h2>
@@ -184,7 +184,7 @@
       <div class="stat"><div class="stat-value">6</div><div class="stat-label">layers</div></div>
       <div class="stat"><div class="stat-value">28</div><div class="stat-label">bricks</div></div>
       <div class="stat"><div class="stat-value">6</div><div class="stat-label">transports</div></div>
-      <div class="stat"><div class="stat-value">691</div><div class="stat-label">operations</div></div>
+      <div class="stat"><div class="stat-value">692</div><div class="stat-label">operations</div></div>
       <div class="stat"><div class="stat-value">14</div><div class="stat-label">missing</div></div>
     </div>
 
@@ -5223,7 +5223,7 @@ graph TB
 <span class="profile-badge profile-supported">full</span>
     </span>
     <span>usage: <code>CLI: nexus write /workspace/a.txt &#34;hello&#34;; sandbox kernel/RPC: Call(write, {&#34;path&#34;:&#34;/zone/local/a.txt&#34;,&#34;buf&#34;:&#34;hello&#34;})</code></span>
-    <span>test: <a href="../../tests/unit/cli/test_fs_parity.py; tests/e2e/self_contained/cli/test_sandbox_federation_e2e.py::TestSandboxZonePermissions::test_write_to_local_zone_stays_on_disk; tests/architecture/test_issue_4127_sandbox_filesystem_surface.py">tests/unit/cli/test_fs_parity.py; tests/e2e/self_contained/cli/test_sandbox_federation_e2e.py::TestSandboxZonePermissions::test_write_to_local_zone_stays_on_disk; tests/architecture/test_issue_4127_sandbox_filesystem_surface.py</a></span>
+    <span>test: <a href="../../tests/unit/cli/test_fs_parity.py; tests/unit/backends/test_remote_zone.py::TestRemoteZoneBackendReadOnly::test_all_write_mutations_fail_before_remote_transport_call; tests/e2e/self_contained/cli/test_sandbox_federation_e2e.py::TestSandboxZonePermissions::test_write_to_local_zone_stays_on_disk; tests/e2e/self_contained/cli/test_sandbox_federation_e2e.py::TestSandboxZonePermissions::test_write_to_readonly_company_zone_rejected; tests/architecture/test_issue_4127_sandbox_filesystem_surface.py">tests/unit/cli/test_fs_parity.py; tests/unit/backends/test_remote_zone.py::TestRemoteZoneBackendReadOnly::test_all_write_mutations_fail_before_remote_transport_call; tests/e2e/self_contained/cli/test_sandbox_federation_e2e.py::TestSandboxZonePermissions::test_write_to_local_zone_stays_on_disk; tests/e2e/self_contained/cli/test_sandbox_federation_e2e.py::TestSandboxZonePermissions::test_write_to_readonly_company_zone_rejected; tests/architecture/test_issue_4127_sandbox_filesystem_surface.py</a></span>
     <span>perf: hot</span>
     <span>owner: <a href="https://github.com/nexi-lab/nexus/issues/4127">#4127</a></span>
     <span>gap: &mdash;</span>
@@ -9046,10 +9046,10 @@ graph TB
           </span>
         </summary>
         <div class="module-body">
-<div class="op" data-op-id="discovery.get_tool_details" data-op-text="discovery.get_tool_details  nexus_discovery_get_tool_details ">
+<div class="op" data-op-id="discovery.get_tool_details" data-op-text="discovery.get_tool_details MCP discovery tool details are filtered through the caller&#39;s ReBAC-derived tool namespace; invisible tools return not found. nexus_discovery_get_tool_details ">
   <div class="op-header">
     <span class="op-id">discovery.get_tool_details</span>
-    <span class="op-summary">&mdash; (no summary yet)</span>
+    <span class="op-summary">&mdash; MCP discovery tool details are filtered through the caller&#39;s ReBAC-derived tool namespace; invisible tools return not found.</span>
   </div>
   <div class="transports">
     <span class="transport-pill" data-t="mcp"><span class="label">MCP</span> <span>nexus_discovery_get_tool_details</span></span>
@@ -9060,17 +9060,17 @@ graph TB
 <span class="profile-badge profile-supported">sandbox</span>
 <span class="profile-badge profile-supported">full</span>
     </span>
-    <span>usage: <span class="todo">TODO</span></span>
-    <span>test: <span class="todo">TODO</span></span>
-    <span>perf: <span class="todo">TODO</span></span>
-    <span>owner: &mdash;</span>
+    <span>usage: <code>MCP: nexus_discovery_get_tool_details(&#34;nexus_write_file&#34;) returns details only when /tools/nexus_write_file is visible to the subject.</code></span>
+    <span>test: <a href="../../tests/unit/bricks/mcp/test_tool_namespace_middleware.py::TestProfileGrantIntegration::test_profile_grants_drive_list_filtering_and_call_denial">tests/unit/bricks/mcp/test_tool_namespace_middleware.py::TestProfileGrantIntegration::test_profile_grants_drive_list_filtering_and_call_denial</a></span>
+    <span>perf: hot</span>
+    <span>owner: <a href="https://github.com/nexi-lab/nexus/issues/4128">#4128</a></span>
     <span>gap: &mdash;</span>
   </div>
 </div>
-<div class="op" data-op-id="discovery.list_servers" data-op-text="discovery.list_servers  nexus_discovery_list_servers ">
+<div class="op" data-op-id="discovery.list_servers" data-op-text="discovery.list_servers MCP discovery server listing reports tool counts after the caller&#39;s ReBAC-derived tool namespace filter. nexus_discovery_list_servers ">
   <div class="op-header">
     <span class="op-id">discovery.list_servers</span>
-    <span class="op-summary">&mdash; (no summary yet)</span>
+    <span class="op-summary">&mdash; MCP discovery server listing reports tool counts after the caller&#39;s ReBAC-derived tool namespace filter.</span>
   </div>
   <div class="transports">
     <span class="transport-pill" data-t="mcp"><span class="label">MCP</span> <span>nexus_discovery_list_servers</span></span>
@@ -9081,17 +9081,17 @@ graph TB
 <span class="profile-badge profile-supported">sandbox</span>
 <span class="profile-badge profile-supported">full</span>
     </span>
-    <span>usage: <span class="todo">TODO</span></span>
-    <span>test: <span class="todo">TODO</span></span>
-    <span>perf: <span class="todo">TODO</span></span>
-    <span>owner: &mdash;</span>
+    <span>usage: <code>MCP: nexus_discovery_list_servers() reports only tools visible through the caller&#39;s assigned tool profile.</code></span>
+    <span>test: <a href="../../tests/unit/bricks/mcp/test_tool_namespace_middleware.py::TestProfileGrantIntegration::test_profile_grants_drive_list_filtering_and_call_denial">tests/unit/bricks/mcp/test_tool_namespace_middleware.py::TestProfileGrantIntegration::test_profile_grants_drive_list_filtering_and_call_denial</a></span>
+    <span>perf: hot</span>
+    <span>owner: <a href="https://github.com/nexi-lab/nexus/issues/4128">#4128</a></span>
     <span>gap: &mdash;</span>
   </div>
 </div>
-<div class="op" data-op-id="discovery.load_tools" data-op-text="discovery.load_tools  nexus_discovery_load_tools ">
+<div class="op" data-op-id="discovery.load_tools" data-op-text="discovery.load_tools MCP discovery load treats tools outside the caller&#39;s ReBAC-derived namespace as not found before loading. nexus_discovery_load_tools ">
   <div class="op-header">
     <span class="op-id">discovery.load_tools</span>
-    <span class="op-summary">&mdash; (no summary yet)</span>
+    <span class="op-summary">&mdash; MCP discovery load treats tools outside the caller&#39;s ReBAC-derived namespace as not found before loading.</span>
   </div>
   <div class="transports">
     <span class="transport-pill" data-t="mcp"><span class="label">MCP</span> <span>nexus_discovery_load_tools</span></span>
@@ -9102,17 +9102,17 @@ graph TB
 <span class="profile-badge profile-supported">sandbox</span>
 <span class="profile-badge profile-supported">full</span>
     </span>
-    <span>usage: <span class="todo">TODO</span></span>
-    <span>test: <span class="todo">TODO</span></span>
-    <span>perf: <span class="todo">TODO</span></span>
-    <span>owner: &mdash;</span>
+    <span>usage: <code>MCP: nexus_discovery_load_tools([&#34;nexus_write_file&#34;]) loads only if the assigned profile grants /tools/nexus_write_file.</code></span>
+    <span>test: <a href="../../tests/unit/bricks/mcp/test_tool_namespace_middleware.py::TestProfileGrantIntegration::test_profile_grants_drive_list_filtering_and_call_denial">tests/unit/bricks/mcp/test_tool_namespace_middleware.py::TestProfileGrantIntegration::test_profile_grants_drive_list_filtering_and_call_denial</a></span>
+    <span>perf: hot</span>
+    <span>owner: <a href="https://github.com/nexi-lab/nexus/issues/4128">#4128</a></span>
     <span>gap: &mdash;</span>
   </div>
 </div>
-<div class="op" data-op-id="discovery.search_tools" data-op-text="discovery.search_tools  nexus_discovery_search_tools ">
+<div class="op" data-op-id="discovery.search_tools" data-op-text="discovery.search_tools MCP discovery search over-fetches then filters results through the caller&#39;s ReBAC-derived tool namespace. nexus_discovery_search_tools ">
   <div class="op-header">
     <span class="op-id">discovery.search_tools</span>
-    <span class="op-summary">&mdash; (no summary yet)</span>
+    <span class="op-summary">&mdash; MCP discovery search over-fetches then filters results through the caller&#39;s ReBAC-derived tool namespace.</span>
   </div>
   <div class="transports">
     <span class="transport-pill" data-t="mcp"><span class="label">MCP</span> <span>nexus_discovery_search_tools</span></span>
@@ -9123,10 +9123,10 @@ graph TB
 <span class="profile-badge profile-supported">sandbox</span>
 <span class="profile-badge profile-supported">full</span>
     </span>
-    <span>usage: <span class="todo">TODO</span></span>
-    <span>test: <span class="todo">TODO</span></span>
-    <span>perf: <span class="todo">TODO</span></span>
-    <span>owner: &mdash;</span>
+    <span>usage: <code>MCP: nexus_discovery_search_tools(&#34;write file&#34;) returns nexus_write_file only after the subject has a profile grant for /tools/nexus_write_file.</code></span>
+    <span>test: <a href="../../tests/unit/bricks/mcp/test_tool_namespace_middleware.py::TestProfileGrantIntegration::test_profile_grants_drive_list_filtering_and_call_denial">tests/unit/bricks/mcp/test_tool_namespace_middleware.py::TestProfileGrantIntegration::test_profile_grants_drive_list_filtering_and_call_denial</a></span>
+    <span>perf: hot</span>
+    <span>owner: <a href="https://github.com/nexi-lab/nexus/issues/4128">#4128</a></span>
     <span>gap: &mdash;</span>
   </div>
 </div>
@@ -9664,7 +9664,7 @@ graph TB
           <span class="mod-name">mcp</span>
           <span class="mod-desc">&mdash; Model Context Protocol tools and provider registry.</span>
           <span class="mod-meta">
-<span class="tier-badge tier-dependent">dependent</span>            <span>11 ops</span>
+<span class="tier-badge tier-dependent">dependent</span>            <span>12 ops</span>
           </span>
         </summary>
         <div class="module-body">
@@ -9731,10 +9731,10 @@ graph TB
     <span>gap: &mdash;</span>
   </div>
 </div>
-<div class="op" data-op-id="mcp.list_tools" data-op-text="mcp.list_tools  mcp_list_tools ">
+<div class="op" data-op-id="mcp.list_tools" data-op-text="mcp.list_tools List mounted MCP tools; the sandbox tool namespace middleware filters the visible set by ReBAC /tools/... grants. mcp_list_tools ">
   <div class="op-header">
     <span class="op-id">mcp.list_tools</span>
-    <span class="op-summary">&mdash; (no summary yet)</span>
+    <span class="op-summary">&mdash; List mounted MCP tools; the sandbox tool namespace middleware filters the visible set by ReBAC /tools/... grants.</span>
   </div>
   <div class="transports">
     <span class="transport-pill" data-t="expose"><span class="label">expose</span> <span>mcp_list_tools</span></span>
@@ -9745,10 +9745,10 @@ graph TB
 <span class="profile-badge profile-supported">sandbox</span>
 <span class="profile-badge profile-supported">full</span>
     </span>
-    <span>usage: <span class="todo">TODO</span></span>
-    <span>test: <span class="todo">TODO</span></span>
-    <span>perf: <span class="todo">TODO</span></span>
-    <span>owner: &mdash;</span>
+    <span>usage: <code>RPC/MCP: mcp_list_tools(&#34;github&#34;) or MCP tools/list returns only tools visible to the current subject after profile grants are materialized.</code></span>
+    <span>test: <a href="../../tests/unit/bricks/mcp/test_tool_namespace_middleware.py::TestProfileGrantIntegration::test_profile_grants_drive_list_filtering_and_call_denial">tests/unit/bricks/mcp/test_tool_namespace_middleware.py::TestProfileGrantIntegration::test_profile_grants_drive_list_filtering_and_call_denial</a></span>
+    <span>perf: hot</span>
+    <span>owner: <a href="https://github.com/nexi-lab/nexus/issues/4128">#4128</a></span>
     <span>gap: &mdash;</span>
   </div>
 </div>
@@ -9875,6 +9875,27 @@ graph TB
     <span>test: <span class="todo">TODO</span></span>
     <span>perf: <span class="todo">TODO</span></span>
     <span>owner: &mdash;</span>
+    <span>gap: &mdash;</span>
+  </div>
+</div>
+<div class="op" data-op-id="mcp.tool_profile_assign" data-op-text="mcp.tool_profile_assign `nexus mcp profile assign SUBJECT_TYPE SUBJECT_ID PROFILE --zone-id ZONE`: assign a configured MCP tool profile to an agent or user; `nexus mcp profile inspect SUBJECT_TYPE SUBJECT_ID --zone-id ZONE` shows the resulting effective /tools/... ReBAC grants. nexus mcp profile assign ">
+  <div class="op-header">
+    <span class="op-id">mcp.tool_profile_assign</span>
+    <span class="op-summary">&mdash; `nexus mcp profile assign SUBJECT_TYPE SUBJECT_ID PROFILE --zone-id ZONE`: assign a configured MCP tool profile to an agent or user; `nexus mcp profile inspect SUBJECT_TYPE SUBJECT_ID --zone-id ZONE` shows the resulting effective /tools/... ReBAC grants.</span>
+  </div>
+  <div class="transports">
+    <span class="transport-pill" data-t="cli"><span class="label">CLI</span> <span>nexus mcp profile assign</span></span>
+  </div>
+  <div class="meta-row">
+    <span class="profiles">
+<span class="profile-badge profile-supported">lite</span>
+<span class="profile-badge profile-supported">sandbox</span>
+<span class="profile-badge profile-supported">full</span>
+    </span>
+    <span>usage: <code>CLI: nexus mcp profile assign agent alice coding --zone-id sandbox-agent-1; nexus mcp profile inspect agent alice --zone-id sandbox-agent-1 --format json</code></span>
+    <span>test: <a href="../../tests/unit/cli/test_mcp_profile_cli.py; tests/unit/bricks/mcp/test_tool_namespace_middleware.py::TestProfileGrantIntegration::test_profile_grants_drive_list_filtering_and_call_denial">tests/unit/cli/test_mcp_profile_cli.py; tests/unit/bricks/mcp/test_tool_namespace_middleware.py::TestProfileGrantIntegration::test_profile_grants_drive_list_filtering_and_call_denial</a></span>
+    <span>perf: setup</span>
+    <span>owner: <a href="https://github.com/nexi-lab/nexus/issues/4128">#4128</a></span>
     <span>gap: &mdash;</span>
   </div>
 </div>
@@ -12531,10 +12552,10 @@ graph TB
     <span>gap: &mdash;</span>
   </div>
 </div>
-<div class="op" data-op-id="federation.client_whoami" data-op-text="federation.client_whoami  federation_client_whoami ">
+<div class="op" data-op-id="federation.client_whoami" data-op-text="federation.client_whoami Sandbox hub-token grant discovery; returns the remote zones and r/rw permissions used to mount read-only and read-write hub zones. federation_client_whoami ">
   <div class="op-header">
     <span class="op-id">federation.client_whoami</span>
-    <span class="op-summary">&mdash; (no summary yet)</span>
+    <span class="op-summary">&mdash; Sandbox hub-token grant discovery; returns the remote zones and r/rw permissions used to mount read-only and read-write hub zones.</span>
   </div>
   <div class="transports">
     <span class="transport-pill" data-t="expose"><span class="label">expose</span> <span>federation_client_whoami</span></span>
@@ -12545,10 +12566,10 @@ graph TB
 <span class="profile-badge profile-supported">sandbox</span>
 <span class="profile-badge profile-supported">full</span>
     </span>
-    <span>usage: <span class="todo">TODO</span></span>
-    <span>test: <span class="todo">TODO</span></span>
-    <span>perf: <span class="todo">TODO</span></span>
-    <span>owner: &mdash;</span>
+    <span>usage: <code>RPC: federation_client_whoami({}) with the sandbox hub token returns zones like [{&#34;zone_id&#34;:&#34;company&#34;,&#34;permission&#34;:&#34;r&#34;},{&#34;zone_id&#34;:&#34;shared&#34;,&#34;permission&#34;:&#34;rw&#34;}].</code></span>
+    <span>test: <a href="../../tests/e2e/self_contained/cli/test_sandbox_federation_e2e.py::TestSandboxFederationBoot::test_federation_whoami_returns_both_zones">tests/e2e/self_contained/cli/test_sandbox_federation_e2e.py::TestSandboxFederationBoot::test_federation_whoami_returns_both_zones</a></span>
+    <span>perf: control</span>
+    <span>owner: <a href="https://github.com/nexi-lab/nexus/issues/4128">#4128</a></span>
     <span>gap: &mdash;</span>
   </div>
 </div>

--- a/docs/architecture/api-rpc-surface-coverage.yaml
+++ b/docs/architecture/api-rpc-surface-coverage.yaml
@@ -3173,7 +3173,8 @@ operations:
   owning_issue: null
 - id: discovery.get_tool_details
   module: discovery
-  summary: ''
+  summary: MCP discovery tool details are filtered through the caller's ReBAC-derived tool namespace; invisible tools return
+    not found.
   transports:
     mcp:
       name: nexus_discovery_get_tool_details
@@ -3182,15 +3183,16 @@ operations:
     lite: supported
     sandbox: supported
     full: supported
-  usage_example: null
-  correctness_test: null
-  perf_class: null
-  perf_link: null
+  usage_example: 'MCP: nexus_discovery_get_tool_details("nexus_write_file") returns details only when /tools/nexus_write_file
+    is visible to the subject.'
+  correctness_test: tests/unit/bricks/mcp/test_tool_namespace_middleware.py::TestProfileGrantIntegration::test_profile_grants_drive_list_filtering_and_call_denial
+  perf_class: hot
+  perf_link: tests/benchmarks/bench_permission_hotpath.py::TestMCPToolNamespaceFiltering::test_cached_tool_list_filtering_latency
   gap_issue: null
-  owning_issue: null
+  owning_issue: 4128
 - id: discovery.list_servers
   module: discovery
-  summary: ''
+  summary: MCP discovery server listing reports tool counts after the caller's ReBAC-derived tool namespace filter.
   transports:
     mcp:
       name: nexus_discovery_list_servers
@@ -3199,15 +3201,15 @@ operations:
     lite: supported
     sandbox: supported
     full: supported
-  usage_example: null
-  correctness_test: null
-  perf_class: null
-  perf_link: null
+  usage_example: 'MCP: nexus_discovery_list_servers() reports only tools visible through the caller''s assigned tool profile.'
+  correctness_test: tests/unit/bricks/mcp/test_tool_namespace_middleware.py::TestProfileGrantIntegration::test_profile_grants_drive_list_filtering_and_call_denial
+  perf_class: hot
+  perf_link: tests/benchmarks/bench_permission_hotpath.py::TestMCPToolNamespaceFiltering::test_cached_tool_list_filtering_latency
   gap_issue: null
-  owning_issue: null
+  owning_issue: 4128
 - id: discovery.load_tools
   module: discovery
-  summary: ''
+  summary: MCP discovery load treats tools outside the caller's ReBAC-derived namespace as not found before loading.
   transports:
     mcp:
       name: nexus_discovery_load_tools
@@ -3216,15 +3218,15 @@ operations:
     lite: supported
     sandbox: supported
     full: supported
-  usage_example: null
-  correctness_test: null
-  perf_class: null
-  perf_link: null
+  usage_example: 'MCP: nexus_discovery_load_tools(["nexus_write_file"]) loads only if the assigned profile grants /tools/nexus_write_file.'
+  correctness_test: tests/unit/bricks/mcp/test_tool_namespace_middleware.py::TestProfileGrantIntegration::test_profile_grants_drive_list_filtering_and_call_denial
+  perf_class: hot
+  perf_link: tests/benchmarks/bench_permission_hotpath.py::TestMCPToolNamespaceFiltering::test_cached_tool_list_filtering_latency
   gap_issue: null
-  owning_issue: null
+  owning_issue: 4128
 - id: discovery.search_tools
   module: discovery
-  summary: ''
+  summary: MCP discovery search over-fetches then filters results through the caller's ReBAC-derived tool namespace.
   transports:
     mcp:
       name: nexus_discovery_search_tools
@@ -3233,12 +3235,13 @@ operations:
     lite: supported
     sandbox: supported
     full: supported
-  usage_example: null
-  correctness_test: null
-  perf_class: null
-  perf_link: null
+  usage_example: 'MCP: nexus_discovery_search_tools("write file") returns nexus_write_file only after the subject has a profile
+    grant for /tools/nexus_write_file.'
+  correctness_test: tests/unit/bricks/mcp/test_tool_namespace_middleware.py::TestProfileGrantIntegration::test_profile_grants_drive_list_filtering_and_call_denial
+  perf_class: hot
+  perf_link: tests/benchmarks/bench_permission_hotpath.py::TestMCPToolNamespaceFiltering::test_cached_tool_list_filtering_latency
   gap_issue: null
-  owning_issue: null
+  owning_issue: 4128
 - id: dispatch.post_hooks
   module: uncategorized
   summary: ''
@@ -3911,7 +3914,8 @@ operations:
   owning_issue: null
 - id: federation.client_whoami
   module: federation
-  summary: ''
+  summary: Sandbox hub-token grant discovery; returns the remote zones and r/rw permissions used to mount read-only and read-write
+    hub zones.
   transports:
     grpc_expose:
       name: federation_client_whoami
@@ -3920,12 +3924,12 @@ operations:
     lite: supported
     sandbox: supported
     full: supported
-  usage_example: null
-  correctness_test: null
-  perf_class: null
-  perf_link: null
+  usage_example: 'RPC: federation_client_whoami({}) with the sandbox hub token returns zones like [{"zone_id":"company","permission":"r"},{"zone_id":"shared","permission":"rw"}].'
+  correctness_test: tests/e2e/self_contained/cli/test_sandbox_federation_e2e.py::TestSandboxFederationBoot::test_federation_whoami_returns_both_zones
+  perf_class: control
+  perf_link: control-plane startup/discovery path; not on the per-file read/write hot path
   gap_issue: null
-  owning_issue: null
+  owning_issue: 4128
 - id: federation.cluster_info
   module: federation
   summary: ''
@@ -4747,10 +4751,12 @@ operations:
     sandbox: supported
     full: supported
   usage_example: 'CLI: nexus write /workspace/a.txt "hello"; sandbox kernel/RPC: Call(write, {"path":"/zone/local/a.txt","buf":"hello"})'
-  correctness_test: tests/unit/cli/test_fs_parity.py; tests/e2e/self_contained/cli/test_sandbox_federation_e2e.py::TestSandboxZonePermissions::test_write_to_local_zone_stays_on_disk;
+  correctness_test: tests/unit/cli/test_fs_parity.py; tests/unit/backends/test_remote_zone.py::TestRemoteZoneBackendReadOnly::test_all_write_mutations_fail_before_remote_transport_call;
+    tests/e2e/self_contained/cli/test_sandbox_federation_e2e.py::TestSandboxZonePermissions::test_write_to_local_zone_stays_on_disk;
+    tests/e2e/self_contained/cli/test_sandbox_federation_e2e.py::TestSandboxZonePermissions::test_write_to_readonly_company_zone_rejected;
     tests/architecture/test_issue_4127_sandbox_filesystem_surface.py
   perf_class: hot
-  perf_link: tests/benchmarks/bench_read_write_overhead.py::TestWriteNewFile and ::TestWriteBatchThroughput
+  perf_link: tests/benchmarks/bench_read_write_overhead.py::TestWriteNewFile and ::TestWriteBatchThroughput; tests/benchmarks/bench_permission_hotpath.py::TestRemoteZoneDeniedWriteFastFail::test_readonly_remote_zone_write_fast_fails_before_transport_call
   gap_issue: null
   owning_issue: 4127
 - id: filesystem.write-batch
@@ -6613,7 +6619,7 @@ operations:
   owning_issue: null
 - id: mcp.list_tools
   module: mcp
-  summary: ''
+  summary: List mounted MCP tools; the sandbox tool namespace middleware filters the visible set by ReBAC /tools/... grants.
   transports:
     grpc_expose:
       name: mcp_list_tools
@@ -6622,12 +6628,13 @@ operations:
     lite: supported
     sandbox: supported
     full: supported
-  usage_example: null
-  correctness_test: null
-  perf_class: null
-  perf_link: null
+  usage_example: 'RPC/MCP: mcp_list_tools("github") or MCP tools/list returns only tools visible to the current subject after
+    profile grants are materialized.'
+  correctness_test: tests/unit/bricks/mcp/test_tool_namespace_middleware.py::TestProfileGrantIntegration::test_profile_grants_drive_list_filtering_and_call_denial
+  perf_class: hot
+  perf_link: tests/benchmarks/bench_permission_hotpath.py::TestMCPToolNamespaceFiltering::test_cached_tool_list_filtering_latency
   gap_issue: null
-  owning_issue: null
+  owning_issue: 4128
 - id: mcp.llm
   module: mcp
   summary: ''
@@ -6730,6 +6737,25 @@ operations:
   perf_link: null
   gap_issue: null
   owning_issue: null
+- id: mcp.tool_profile_assign
+  module: mcp
+  summary: '`nexus mcp profile assign SUBJECT_TYPE SUBJECT_ID PROFILE --zone-id ZONE`: assign a configured MCP tool profile
+    to an agent or user; `nexus mcp profile inspect SUBJECT_TYPE SUBJECT_ID --zone-id ZONE` shows the resulting
+    effective /tools/... ReBAC grants.'
+  transports:
+    cli:
+      name: nexus mcp profile assign
+      source: src/nexus/cli/commands/mcp.py:462
+  profiles:
+    lite: supported
+    sandbox: supported
+    full: supported
+  usage_example: 'CLI: nexus mcp profile assign agent alice coding --zone-id sandbox-agent-1; nexus mcp profile inspect agent alice --zone-id sandbox-agent-1 --format json'
+  correctness_test: tests/unit/cli/test_mcp_profile_cli.py; tests/unit/bricks/mcp/test_tool_namespace_middleware.py::TestProfileGrantIntegration::test_profile_grants_drive_list_filtering_and_call_denial
+  perf_class: setup
+  perf_link: setup/control-plane operation; effective tools/list filtering remains the hot path and is benchmarked in tests/benchmarks/bench_permission_hotpath.py
+  gap_issue: null
+  owning_issue: 4128
 - id: mcp.unmount
   module: mcp
   summary: ''

--- a/docs/guides/user-guide.md
+++ b/docs/guides/user-guide.md
@@ -425,6 +425,115 @@ are hot local edit paths. Guidance benchmarks live in
 `TestSandboxBootIndexerInitialWalk`. Rename/delete/mkdir/rmdir are tested
 behaviorally and treated as non-hot local edit mutations.
 
+### Sandbox ReBAC, hub-zone, and MCP tool boundaries
+
+**Goal:** let an agent platform owner prove what a sandboxed agent may read,
+write, call, and discover across the local workspace, hub-backed zones, and
+MCP tools.
+
+**Why this profile:** the sandbox profile includes `permissions`, `mcp`, and
+`search`, so the same lightweight runtime can enforce local ReBAC tuples,
+mount hub zones with token-scoped `r` or `rw` grants, and filter MCP tools by
+`/tools/...` ReBAC grants. The sandbox-provisioning brick remains disabled;
+this is about the per-agent Nexus runtime's own access boundary.
+
+Current CLI surface for the ReBAC part is the tuple-level `nexus rebac`
+workflow:
+
+```bash
+nexus rebac create agent alice direct_owner file /zone/local/notes/todo.txt \
+  --zone-id sandbox-agent-1
+nexus rebac check agent alice write file /zone/local/notes/todo.txt \
+  --zone-id sandbox-agent-1
+nexus rebac check agent charlie write file /zone/local/notes/todo.txt \
+  --zone-id sandbox-agent-1
+nexus rebac explain agent alice write file /zone/local/notes/todo.txt \
+  --zone-id sandbox-agent-1 --verbose
+```
+
+MCP tool grants use named profiles from `src/nexus/config/tool_profiles.yaml`.
+The profile CLI materializes those profiles into the same `/tools/...` ReBAC
+namespace used by MCP `tools/list` and `tools/call` filtering:
+
+```bash
+nexus mcp profile list
+nexus mcp profile show minimal
+nexus mcp profile assign agent alice minimal \
+  --zone-id sandbox-agent-1
+nexus mcp profile inspect agent alice \
+  --zone-id sandbox-agent-1 --format json
+```
+
+The tuple-level equivalent remains available when you need to inspect or
+debug the raw grants:
+
+```bash
+nexus rebac list --subject-type agent --subject-id alice \
+  --object-type file --zone-id sandbox-agent-1 --format json
+nexus rebac create agent alice direct_viewer file /tools/nexus_read_file \
+  --zone-id sandbox-agent-1
+```
+
+Equivalent RPC / SDK shape:
+
+```python
+rebac = nx.service("rebac")
+
+await rebac.rebac_create(
+    subject=("agent", "alice"),
+    relation="direct_owner",
+    object=("file", "/zone/local/notes/todo.txt"),
+    zone_id="sandbox-agent-1",
+)
+assert await rebac.rebac_check(
+    subject=("agent", "alice"),
+    permission="write",
+    object=("file", "/zone/local/notes/todo.txt"),
+    zone_id="sandbox-agent-1",
+)
+
+# Tool-profile helper used by provisioning code:
+from pathlib import Path
+
+from nexus.bricks.mcp.profiles import grant_tools_for_profile, load_profiles
+
+profile = load_profiles(Path("src/nexus/config/tool_profiles.yaml")).get_profile("minimal")
+grant_tools_for_profile(
+    rebac_manager=nx.service("rebac")._rebac_manager,
+    subject=("agent", "alice"),
+    profile=profile,
+    zone_id="sandbox-agent-1",
+)
+```
+
+Expected behavior:
+
+- **Success:** Alice's local write check is granted after the tuple exists,
+  and MCP `tools/list` or discovery tools show only tools whose
+  `/tools/<name>` paths are visible to Alice.
+- **Denied:** Charlie's write check is false until a tuple grants access.
+  A write to a hub zone mounted with permission `r` fails before a remote
+  transport mutation is attempted; the `rw` hub zone path can write.
+- **Unavailable:** invisible MCP tools return `not found`, not a permission
+  detail, so the agent does not learn restricted tool names.
+
+**Correctness assertions:** the ReBAC tuple/check/list/explain RPC and CLI
+rows are covered by `tests/unit/services/test_rebac_service.py` and the
+ReBAC story gate in `tests/architecture/test_rebac_surface_story.py`.
+Read-only hub-zone fast-fail is covered by
+`tests/unit/backends/test_remote_zone.py::TestRemoteZoneBackendReadOnly::test_all_write_mutations_fail_before_remote_transport_call`
+and the sandbox federation E2E. Tool-profile assignment and grants affecting
+visible and callable tools are covered by `tests/unit/cli/test_mcp_profile_cli.py`
+and
+`tests/unit/bricks/mcp/test_tool_namespace_middleware.py::TestProfileGrantIntegration::test_profile_grants_drive_list_filtering_and_call_denial`.
+
+**Performance classification:** permission checks are hot path and benchmarked
+in `tests/benchmarks/test_rebac_latency.py` and
+`tests/benchmarks/bench_rebac_scale.py`. MCP cached `tools/list` filtering
+and read-only hub-zone write fast-fail are hot-path guardrails in
+`tests/benchmarks/bench_permission_hotpath.py`. Tool-profile assignment is a
+control-plane setup operation and is not performance-sensitive.
+
 ## 2.1 Capability checklist for a serious demo
 
 If you are evaluating Nexus as more than a toy filesystem, the first real

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -422,6 +422,7 @@ build-backend = "setuptools.build_meta"
 where = ["src"]
 
 [tool.setuptools.package-data]
+"nexus" = ["config/*.yaml"]
 "nexus.cli" = ["data/*.yml", "data/*.Dockerfile", "data/*.sql"]
 "nexus.backends.connectors.gws" = ["configs/*.yaml"]
 "nexus.backends.connectors.github" = ["*.yaml"]

--- a/src/nexus/cli/commands/mcp.py
+++ b/src/nexus/cli/commands/mcp.py
@@ -6,9 +6,12 @@ This module contains MCP-related CLI commands for:
 """
 
 import sys
-from typing import TYPE_CHECKING, Any, cast
+from inspect import isawaitable
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, TypedDict, cast
 
 import click
+from rich.table import Table
 from starlette.middleware.base import BaseHTTPMiddleware
 
 from nexus.cli.utils import (
@@ -21,6 +24,15 @@ from nexus.cli.utils import (
 if TYPE_CHECKING:
     from starlette.requests import Request
     from starlette.responses import Response
+
+    from nexus.bricks.mcp.profiles import ToolProfile, ToolProfileConfig
+
+
+class _ProfilePayload(TypedDict):
+    name: str
+    description: str | None
+    extends: str | None
+    tools: list[str]
 
 
 def _add_health_check_route(mcp_server: Any) -> None:
@@ -260,6 +272,375 @@ def mcp() -> None:
         }
     """
     pass
+
+
+def _default_tool_profiles_path() -> Path:
+    return Path(__file__).resolve().parents[2] / "config" / "tool_profiles.yaml"
+
+
+def _load_tool_profile_config(config_path: str | None) -> "ToolProfileConfig":
+    from nexus.bricks.mcp.profiles import load_profiles
+
+    return load_profiles(Path(config_path) if config_path else _default_tool_profiles_path())
+
+
+def _profile_payload(profile: "ToolProfile") -> _ProfilePayload:
+    return {
+        "name": profile.name,
+        "description": profile.description,
+        "extends": profile.extends,
+        "tools": sorted(profile.tools),
+    }
+
+
+def _print_json(payload: Any) -> None:
+    import json
+
+    click.echo(json.dumps(payload, indent=2, default=str))
+
+
+async def _maybe_await(result: Any) -> Any:
+    if isawaitable(result):
+        return await result
+    return result
+
+
+def _extract_tuple_id(result: Any) -> str:
+    if isinstance(result, dict):
+        return str(result.get("tuple_id", ""))
+    return str(getattr(result, "tuple_id", result))
+
+
+def _has_declared_method(obj: Any, name: str) -> bool:
+    return callable(getattr(type(obj), name, None))
+
+
+def _resolve_rebac_surface(nx: Any) -> Any:
+    rebac = None
+    if hasattr(nx, "service"):
+        try:
+            rebac = nx.service("rebac_manager")
+        except Exception:
+            rebac = None
+        if rebac is None:
+            try:
+                rebac_service = nx.service("rebac")
+                rebac = getattr(rebac_service, "_rebac_manager", None) or rebac_service
+            except Exception:
+                rebac = None
+    if rebac is None:
+        rebac = getattr(nx, "_rebac_manager", None)
+    if rebac is None:
+        raise click.ClickException("ReBAC service is not available")
+    return rebac
+
+
+async def _grant_tool_profile(
+    rebac: Any,
+    *,
+    subject: tuple[str, str],
+    profile: "ToolProfile",
+    zone_id: str | None,
+) -> list[str]:
+    tuple_ids: list[str] = []
+    for tool_name in sorted(profile.tools):
+        tool_path = f"/tools/{tool_name}"
+        if _has_declared_method(rebac, "rebac_write"):
+            result = rebac.rebac_write(
+                subject=subject,
+                relation="direct_viewer",
+                object=("file", tool_path),
+                zone_id=zone_id,
+            )
+        elif _has_declared_method(rebac, "rebac_create_sync") or not _has_declared_method(
+            rebac, "rebac_create"
+        ):
+            result = rebac.rebac_create_sync(
+                subject=subject,
+                relation="direct_viewer",
+                object=("file", tool_path),
+                zone_id=zone_id,
+            )
+        elif _has_declared_method(rebac, "rebac_create"):
+            result = rebac.rebac_create(
+                subject=subject,
+                relation="direct_viewer",
+                object=("file", tool_path),
+                zone_id=zone_id,
+            )
+        else:
+            raise click.ClickException("ReBAC surface does not support tuple writes")
+        tuple_ids.append(_extract_tuple_id(await _maybe_await(result)))
+    return tuple_ids
+
+
+async def _list_effective_tool_grants(
+    rebac: Any,
+    *,
+    subject: tuple[str, str],
+    zone_id: str | None,
+) -> list[str]:
+    if _has_declared_method(rebac, "rebac_write"):
+        result = rebac.rebac_list_objects(
+            subject=subject,
+            permission="read",
+            object_type="file",
+            zone_id=zone_id,
+            limit=10000,
+        )
+    else:
+        result = rebac.rebac_list_objects(
+            relation="direct_viewer",
+            subject=subject,
+            zone_id=zone_id,
+        )
+    objects = await _maybe_await(result)
+
+    tools: set[str] = set()
+    for object_type, object_id in objects:
+        if object_type == "file" and str(object_id).startswith("/tools/"):
+            tools.add(str(object_id)[len("/tools/") :])
+    return sorted(tools)
+
+
+def _matching_profiles(config: "ToolProfileConfig", tools: list[str]) -> list[str]:
+    granted = set(tools)
+    return [
+        name
+        for name, profile in sorted(config.profiles.items())
+        if profile.tools and profile.tools.issubset(granted)
+    ]
+
+
+@mcp.group(name="profile")
+def mcp_profile() -> None:
+    """Inspect and assign MCP tool profiles."""
+    pass
+
+
+@mcp_profile.command(name="list")
+@click.option("--config", "config_path", type=click.Path(), default=None)
+@click.option("--format", "output_format", type=click.Choice(["table", "json"]), default="table")
+def mcp_profile_list(config_path: str | None, output_format: str) -> None:
+    """List configured MCP tool profiles."""
+    config = _load_tool_profile_config(config_path)
+    profiles = [_profile_payload(config.profiles[name]) for name in config.profile_names]
+    payload = {
+        "default_profile": config.default_profile,
+        "profiles": profiles,
+    }
+    if output_format == "json":
+        _print_json(payload)
+        return
+
+    table = Table(title="MCP Tool Profiles")
+    table.add_column("Name", style="nexus.value")
+    table.add_column("Extends", style="nexus.muted")
+    table.add_column("Tools")
+    table.add_column("Description")
+    for item in profiles:
+        table.add_row(
+            item["name"],
+            item["extends"] or "",
+            str(len(item["tools"])),
+            item["description"] or "",
+        )
+    console.print(table)
+
+
+@mcp_profile.command(name="show")
+@click.argument("profile_name", type=str)
+@click.option("--config", "config_path", type=click.Path(), default=None)
+@click.option("--format", "output_format", type=click.Choice(["table", "json"]), default="table")
+def mcp_profile_show(profile_name: str, config_path: str | None, output_format: str) -> None:
+    """Show one MCP tool profile."""
+    config = _load_tool_profile_config(config_path)
+    profile = config.get_profile(profile_name)
+    if profile is None:
+        raise click.ClickException(f"Unknown MCP tool profile '{profile_name}'")
+    payload = _profile_payload(profile)
+    if output_format == "json":
+        _print_json(payload)
+        return
+
+    console.print(f"[bold nexus.value]{profile.name}[/bold nexus.value]")
+    if profile.description:
+        console.print(f"  Description: {profile.description}")
+    if profile.extends:
+        console.print(f"  Extends: [nexus.muted]{profile.extends}[/nexus.muted]")
+    console.print("  Tools:")
+    for tool in sorted(profile.tools):
+        console.print(f"    - [nexus.value]{tool}[/nexus.value]")
+
+
+@mcp_profile.command(name="assign")
+@click.argument("subject_type", type=str)
+@click.argument("subject_id", type=str)
+@click.argument("profile_name", type=str)
+@click.option("--zone-id", type=str, default=None, envvar="NEXUS_ZONE_ID")
+@click.option("--config", "config_path", type=click.Path(), default=None)
+@click.option("--format", "output_format", type=click.Choice(["text", "json"]), default="text")
+@add_backend_options
+def mcp_profile_assign(
+    subject_type: str,
+    subject_id: str,
+    profile_name: str,
+    zone_id: str | None,
+    config_path: str | None,
+    output_format: str,
+    remote_url: str | None,
+    remote_api_key: str | None,
+) -> None:
+    """Assign a configured MCP tool profile to a subject."""
+    import asyncio
+
+    asyncio.run(
+        _async_mcp_profile_assign(
+            subject_type,
+            subject_id,
+            profile_name,
+            zone_id,
+            config_path,
+            output_format,
+            remote_url,
+            remote_api_key,
+        )
+    )
+
+
+async def _async_mcp_profile_assign(
+    subject_type: str,
+    subject_id: str,
+    profile_name: str,
+    zone_id: str | None,
+    config_path: str | None,
+    output_format: str,
+    remote_url: str | None,
+    remote_api_key: str | None,
+) -> None:
+    config = _load_tool_profile_config(config_path)
+    profile = config.get_profile(profile_name)
+    if profile is None:
+        raise click.ClickException(f"Unknown MCP tool profile '{profile_name}'")
+
+    nx = None
+    try:
+        nx = await get_filesystem(remote_url, remote_api_key)
+        rebac = _resolve_rebac_surface(nx)
+        subject = (subject_type, subject_id)
+        tuple_ids = await _grant_tool_profile(
+            rebac,
+            subject=subject,
+            profile=profile,
+            zone_id=zone_id,
+        )
+    except click.ClickException:
+        raise
+    except Exception as exc:
+        raise click.ClickException(str(exc)) from exc
+    finally:
+        if nx is not None and hasattr(nx, "close"):
+            nx.close()
+
+    payload = {
+        "profile": profile.name,
+        "subject": [subject_type, subject_id],
+        "zone_id": zone_id,
+        "tools": sorted(profile.tools),
+        "tuple_ids": tuple_ids,
+    }
+    if output_format == "json":
+        _print_json(payload)
+        return
+
+    console.print("[nexus.success]✓[/nexus.success] Assigned MCP tool profile")
+    console.print(f"  Profile: [nexus.value]{profile.name}[/nexus.value]")
+    console.print(f"  Subject: [nexus.warning]{subject_type}:{subject_id}[/nexus.warning]")
+    if zone_id:
+        console.print(f"  Zone: [nexus.reference]{zone_id}[/nexus.reference]")
+    console.print(f"  Tools: {len(profile.tools)}")
+
+
+@mcp_profile.command(name="inspect")
+@click.argument("subject_type", type=str)
+@click.argument("subject_id", type=str)
+@click.option("--zone-id", type=str, default=None, envvar="NEXUS_ZONE_ID")
+@click.option("--config", "config_path", type=click.Path(), default=None)
+@click.option("--format", "output_format", type=click.Choice(["table", "json"]), default="table")
+@add_backend_options
+def mcp_profile_inspect(
+    subject_type: str,
+    subject_id: str,
+    zone_id: str | None,
+    config_path: str | None,
+    output_format: str,
+    remote_url: str | None,
+    remote_api_key: str | None,
+) -> None:
+    """Inspect effective MCP tool grants for a subject."""
+    import asyncio
+
+    asyncio.run(
+        _async_mcp_profile_inspect(
+            subject_type,
+            subject_id,
+            zone_id,
+            config_path,
+            output_format,
+            remote_url,
+            remote_api_key,
+        )
+    )
+
+
+async def _async_mcp_profile_inspect(
+    subject_type: str,
+    subject_id: str,
+    zone_id: str | None,
+    config_path: str | None,
+    output_format: str,
+    remote_url: str | None,
+    remote_api_key: str | None,
+) -> None:
+    config = _load_tool_profile_config(config_path)
+    nx = None
+    try:
+        nx = await get_filesystem(remote_url, remote_api_key)
+        rebac = _resolve_rebac_surface(nx)
+        subject = (subject_type, subject_id)
+        tools = await _list_effective_tool_grants(
+            rebac,
+            subject=subject,
+            zone_id=zone_id,
+        )
+    except click.ClickException:
+        raise
+    except Exception as exc:
+        raise click.ClickException(str(exc)) from exc
+    finally:
+        if nx is not None and hasattr(nx, "close"):
+            nx.close()
+
+    payload = {
+        "subject": [subject_type, subject_id],
+        "zone_id": zone_id,
+        "tools": tools,
+        "matching_profiles": _matching_profiles(config, tools),
+    }
+    if output_format == "json":
+        _print_json(payload)
+        return
+
+    table = Table(title=f"MCP tool grants for {subject_type}:{subject_id}")
+    table.add_column("Tool", style="nexus.value")
+    for tool in tools:
+        table.add_row(tool)
+    console.print(table)
+    if payload["matching_profiles"]:
+        console.print(
+            "Matching profiles: "
+            + ", ".join(f"[nexus.value]{p}[/nexus.value]" for p in payload["matching_profiles"])
+        )
 
 
 @mcp.command(name="serve")

--- a/src/nexus/core/boot_indexer.py
+++ b/src/nexus/core/boot_indexer.py
@@ -104,6 +104,12 @@ class BootIndexer:
             raise FileNotFoundError(
                 f"workspace directory does not exist or is not a directory: {self._workspace}"
             )
+        if self._search_daemon is None or not hasattr(self._search_daemon, "index_file"):
+            logger.info(
+                "[BootIndexer] search daemon unavailable, skipping workspace indexing for %s",
+                self._workspace,
+            )
+            return
 
         indexed = 0
         errors = 0

--- a/src/nexus/remote/federation_handshake.py
+++ b/src/nexus/remote/federation_handshake.py
@@ -10,6 +10,9 @@ from nexus.remote.rpc_transport import RPCTransport
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_HANDSHAKE_TIMEOUT_SECONDS = 5.0
+DEFAULT_HANDSHAKE_CONNECT_TIMEOUT_SECONDS = 2.0
+
 
 @dataclass(frozen=True)
 class HubZoneGrant:
@@ -26,9 +29,18 @@ class HubSession:
 class FederationHandshake:
     """Authenticates to a Nexus hub and discovers the caller's zone grants."""
 
-    def __init__(self, hub_url: str, token: str) -> None:
+    def __init__(
+        self,
+        hub_url: str,
+        token: str,
+        *,
+        timeout: float = DEFAULT_HANDSHAKE_TIMEOUT_SECONDS,
+        connect_timeout: float = DEFAULT_HANDSHAKE_CONNECT_TIMEOUT_SECONDS,
+    ) -> None:
         self._hub_url = hub_url
         self._token = token
+        self._timeout = timeout
+        self._connect_timeout = connect_timeout
 
     def run(self) -> HubSession:
         """Connect to hub, call federation_client_whoami, return HubSession.
@@ -38,11 +50,19 @@ class FederationHandshake:
             HandshakeConnectionError: Hub is unreachable.
         """
         try:
-            transport = RPCTransport(self._hub_url, auth_token=self._token)
+            transport = RPCTransport(
+                self._hub_url,
+                auth_token=self._token,
+                timeout=self._timeout,
+                connect_timeout=self._connect_timeout,
+            )
         except ValueError as exc:
             raise HandshakeConnectionError(str(exc)) from exc
         try:
-            result = transport.call_rpc("federation_client_whoami")
+            result = transport.call_rpc(
+                "federation_client_whoami",
+                read_timeout=self._timeout,
+            )
         except NexusError as exc:
             if getattr(exc, "status_code", None) == 401:
                 raise HandshakeAuthError(str(exc)) from exc

--- a/src/nexus/remote/kernel_client.py
+++ b/src/nexus/remote/kernel_client.py
@@ -17,9 +17,11 @@ from __future__ import annotations
 
 import logging
 import os
+import shutil
 import signal
 import subprocess
 import time
+from pathlib import Path
 from typing import IO, Any
 
 from nexus.contracts.constants import ROOT_ZONE_ID
@@ -29,6 +31,51 @@ logger = logging.getLogger(__name__)
 
 # Default port for local kernel subprocess.
 _DEFAULT_LOCAL_PORT = 2126
+_KERNEL_BINARY_ENV = "NEXUS_KERNEL_BINARY"
+_KERNEL_BINARY_CANDIDATES = ("nexus-cluster", "nexusd-cluster")
+_KERNEL_DATA_DIR_FILE_FALLBACK_SUFFIX = ".kernel"
+
+
+def _resolve_kernel_binary() -> str:
+    """Return the Rust kernel binary to spawn.
+
+    CI and packaged installs often provide the compatibility name
+    ``nexus-cluster``. Local Cargo builds produce the actual bin target
+    ``nexusd-cluster``. Accept both so real local E2E runs do not require a
+    manual symlink.
+    """
+    configured = os.environ.get(_KERNEL_BINARY_ENV)
+    if configured:
+        return configured
+
+    for binary_name in _KERNEL_BINARY_CANDIDATES:
+        resolved = shutil.which(binary_name)
+        if resolved:
+            return resolved
+
+    return _KERNEL_BINARY_CANDIDATES[0]
+
+
+def _resolve_kernel_data_dir(metadata_path: str | None) -> str | None:
+    """Return a directory path suitable for the Rust kernel data dir.
+
+    Older Python-only runs used ``metadata_path`` as a database file. The Rust
+    kernel reads ``NEXUS_DATA_DIR`` as a directory, so passing that legacy file
+    path makes the subprocess panic before it can report a useful startup
+    error. Keep normal directory/nonexistent paths unchanged, but route an
+    existing file to a deterministic sidecar directory.
+    """
+    if not metadata_path:
+        return None
+
+    path = Path(metadata_path).expanduser()
+    try:
+        if path.exists() and path.is_file():
+            return str(path.with_name(f"{path.name}{_KERNEL_DATA_DIR_FILE_FALLBACK_SUFFIX}"))
+    except OSError:
+        return metadata_path
+
+    return metadata_path
 
 
 class KernelClient:
@@ -113,11 +160,19 @@ class KernelClient:
 
     def _spawn_kernel(self) -> None:
         """Spawn nexus-cluster as a subprocess."""
-        cmd = ["nexus-cluster"]
+        kernel_binary = _resolve_kernel_binary()
+        cmd = [kernel_binary]
         env = os.environ.copy()
         # Pass data directory if provided (Rust binary reads NEXUS_DATA_DIR).
-        if self._metadata_path:
-            env["NEXUS_DATA_DIR"] = self._metadata_path
+        kernel_data_dir = _resolve_kernel_data_dir(self._metadata_path)
+        if kernel_data_dir:
+            env["NEXUS_DATA_DIR"] = kernel_data_dir
+            if self._metadata_path and kernel_data_dir != self._metadata_path:
+                logger.warning(
+                    "Kernel metadata path %s is a file; using %s as NEXUS_DATA_DIR",
+                    self._metadata_path,
+                    kernel_data_dir,
+                )
         env["NEXUS_BIND_ADDR"] = self._server_address
         env["NEXUS_NO_TLS"] = "true"  # Loopback, no TLS needed.
         env.setdefault("NEXUS_BOOTSTRAP_MODE", "dynamic")
@@ -137,7 +192,8 @@ class KernelClient:
             stderr=self._stderr_file,
         )
         logger.info(
-            "Spawned nexus-cluster (pid=%d) at %s, log=%s",
+            "Spawned %s (pid=%d) at %s, log=%s",
+            kernel_binary,
             self._process.pid,
             self._server_address,
             self._stderr_path,

--- a/src/nexus/storage/schema_invariants.py
+++ b/src/nexus/storage/schema_invariants.py
@@ -712,21 +712,25 @@ def _ensure_mcl_sequence(conn: Any) -> None:
 
 
 def ensure_postgres_schema_invariants(engine: Engine) -> None:
-    """Repair PostgreSQL invariants that ``Base.metadata.create_all`` cannot express.
+    """Repair storage invariants that ``Base.metadata.create_all`` cannot express.
 
     Alembic is the schema source of truth, but some legacy/fresh-init paths
     created tables from ORM metadata and then stamped migrations as applied.
     Validate those invariants explicitly before the server accepts writes.
     """
-    if engine.dialect.name != "postgresql":
-        return
-
     inspector = inspect(engine)
     table_names = set(inspector.get_table_names())
     columns_by_table = _column_names_by_table(inspector, table_names)
 
     with engine.begin() as conn:
+        # ReBACManager still supports a SQL-backed namespace store when the
+        # kernel is a subprocess. This table must exist for SQLite dev/test
+        # stores as well as PostgreSQL installs.
         _ensure_rebac_namespaces_table(conn, columns_by_table, table_names)
+
+        if engine.dialect.name != "postgresql":
+            return
+
         _ensure_zones_table_shape(conn, columns_by_table)
         _ensure_zone_column(conn, columns_by_table, "file_paths", "VARCHAR(255)")
         _ensure_zone_column(conn, columns_by_table, "rebac_changelog", "VARCHAR(255)")

--- a/tests/architecture/test_issue_4128_sandbox_rebac_mcp_boundaries.py
+++ b/tests/architecture/test_issue_4128_sandbox_rebac_mcp_boundaries.py
@@ -1,0 +1,85 @@
+"""Issue #4128 sandbox ReBAC, hub-zone, and MCP boundary coverage gate."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.surface_coverage.schema import PerfClass, ProfileStatus, load_yaml
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_COVERAGE_YAML = _REPO_ROOT / "docs/architecture/api-rpc-surface-coverage.yaml"
+
+_REBAC_SANDBOX_ROWS = {
+    "rebac.create",
+    "rebac.check",
+    "rebac.list_tuples",
+    "rebac.explain",
+}
+
+_MCP_SECURITY_ROWS = {
+    "discovery.get_tool_details",
+    "discovery.list_servers",
+    "discovery.load_tools",
+    "discovery.search_tools",
+    "mcp.list_tools",
+}
+
+
+def _operations_by_id():
+    return {op.id: op for op in load_yaml(_COVERAGE_YAML).operations}
+
+
+def _assert_supported_sandbox_story_row(op_id: str) -> None:
+    op = _operations_by_id()[op_id]
+    assert op.profiles["sandbox"] == ProfileStatus.SUPPORTED, op_id
+    assert op.summary, op_id
+    assert op.usage_example, op_id
+    assert op.correctness_test, op_id
+    assert op.perf_class is not None, op_id
+    assert op.perf_link, op_id
+
+
+def test_issue_4128_rebac_core_rows_are_available_in_sandbox() -> None:
+    for op_id in sorted(_REBAC_SANDBOX_ROWS):
+        _assert_supported_sandbox_story_row(op_id)
+
+
+def test_issue_4128_mcp_security_rows_are_linked_to_profile_grant_tests() -> None:
+    ops = _operations_by_id()
+
+    for op_id in sorted(_MCP_SECURITY_ROWS):
+        _assert_supported_sandbox_story_row(op_id)
+        op = ops[op_id]
+        assert op.owning_issue == 4128, op_id
+        assert "test_tool_namespace_middleware.py" in op.correctness_test, op_id
+        assert op.perf_class in {PerfClass.HOT, PerfClass.HOT_PATH}, op_id
+        assert "bench_permission_hotpath.py" in op.perf_link, op_id
+
+
+def test_issue_4128_remote_zone_readonly_write_denial_is_linked() -> None:
+    ops = _operations_by_id()
+
+    write = ops["filesystem.write"]
+    assert write.profiles["sandbox"] == ProfileStatus.SUPPORTED
+    assert "test_remote_zone.py" in write.correctness_test
+    assert "test_sandbox_federation_e2e.py" in write.correctness_test
+    assert "bench_permission_hotpath.py" in write.perf_link
+
+    whoami = ops["federation.client_whoami"]
+    assert whoami.profiles["sandbox"] == ProfileStatus.SUPPORTED
+    assert whoami.owning_issue == 4128
+    assert whoami.usage_example
+    assert "test_sandbox_federation_e2e.py" in whoami.correctness_test
+    assert whoami.perf_class == PerfClass.CONTROL
+    assert whoami.perf_link
+
+
+def test_issue_4128_tool_profile_assignment_cli_is_supported() -> None:
+    op = _operations_by_id()["mcp.tool_profile_assign"]
+    assert op.owning_issue == 4128
+    assert op.gap_issue is None
+    assert all(status == ProfileStatus.SUPPORTED for status in op.profiles.values())
+    assert op.transports["cli"].name == "nexus mcp profile assign"
+    assert "tests/unit/cli/test_mcp_profile_cli.py" in op.correctness_test
+    assert op.perf_class == PerfClass.SETUP
+    assert "bench_permission_hotpath.py" in op.perf_link

--- a/tests/architecture/test_issue_4128_sandbox_rebac_mcp_boundaries.py
+++ b/tests/architecture/test_issue_4128_sandbox_rebac_mcp_boundaries.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import tomllib
 from pathlib import Path
 
 from scripts.surface_coverage.schema import PerfClass, ProfileStatus, load_yaml
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _COVERAGE_YAML = _REPO_ROOT / "docs/architecture/api-rpc-surface-coverage.yaml"
+_PYPROJECT = _REPO_ROOT / "pyproject.toml"
 
 _REBAC_SANDBOX_ROWS = {
     "rebac.create",
@@ -83,3 +85,10 @@ def test_issue_4128_tool_profile_assignment_cli_is_supported() -> None:
     assert "tests/unit/cli/test_mcp_profile_cli.py" in op.correctness_test
     assert op.perf_class == PerfClass.SETUP
     assert "bench_permission_hotpath.py" in op.perf_link
+
+
+def test_issue_4128_default_mcp_tool_profiles_are_packaged() -> None:
+    pyproject = tomllib.loads(_PYPROJECT.read_text())
+    package_data = pyproject["tool"]["setuptools"]["package-data"]
+
+    assert "config/*.yaml" in package_data["nexus"]

--- a/tests/benchmarks/bench_permission_hotpath.py
+++ b/tests/benchmarks/bench_permission_hotpath.py
@@ -14,6 +14,7 @@ Run with:
 
 import statistics
 import time
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -528,4 +529,80 @@ class TestTigerCacheWriteThroughput:
 
         assert stats["ops_per_sec"] > 100_000, (
             f"add_to_bitmap throughput too low: {stats['ops_per_sec']:,.0f} ops/s (target >100k)"
+        )
+
+
+# ============================================================================
+# Benchmark 5 — MCP tool namespace filtering cached path
+# ============================================================================
+
+
+class TestMCPToolNamespaceFiltering:
+    """Measure cached MCP tools/list filtering through ReBAC-derived grants."""
+
+    def test_cached_tool_list_filtering_latency(self) -> None:
+        from nexus.bricks.mcp.middleware import ToolNamespaceMiddleware
+
+        visible_tools = {f"tool_{i}" for i in range(32)}
+        all_tools = [SimpleNamespace(name=f"tool_{i}") for i in range(64)]
+        subject = ("agent", "bench_agent")
+
+        rebac = MagicMock()
+        rebac.get_zone_revision.return_value = 0
+        rebac.rebac_list_objects.return_value = [
+            ("file", f"/tools/{name}") for name in sorted(visible_tools)
+        ]
+        middleware = ToolNamespaceMiddleware(rebac_manager=rebac, zone_id=ZONE_ID)
+
+        # Warm the ReBAC-derived visible tool set. The measured path below is
+        # the per-tools/list cache hit plus O(n) membership filtering.
+        assert middleware._get_visible_tools(subject) == frozenset(visible_tools)
+
+        def _filter_once() -> list[Any]:
+            visible = middleware._get_visible_tools(subject)
+            return [tool for tool in all_tools if tool.name in visible]
+
+        for _ in range(WARMUP_ITERATIONS):
+            assert len(_filter_once()) == len(visible_tools)
+
+        stats = _measure_ops(_filter_once, iterations=5_000)
+        _report("MCP tools/list cached filter", stats)
+
+        assert stats["p99_us"] < 1_000.0, (
+            f"MCP tools/list cached filter too slow: p99={stats['p99_us']:.1f}us (target <1000us)"
+        )
+        rebac.rebac_list_objects.assert_called_once()
+
+
+# ============================================================================
+# Benchmark 6 — read-only remote-zone write fast-fail
+# ============================================================================
+
+
+class TestRemoteZoneDeniedWriteFastFail:
+    """Measure read-only hub-zone write denial before transport mutation."""
+
+    def test_readonly_remote_zone_write_fast_fails_before_transport_call(self) -> None:
+        from nexus.backends.storage.remote_zone import RemoteZoneBackend
+        from nexus.contracts.exceptions import ZoneReadOnlyError
+
+        transport = MagicMock()
+        backend = RemoteZoneBackend(zone_id="company", transport=transport, permission="r")
+
+        def _deny_once() -> None:
+            try:
+                backend.write_content(b"blocked")
+            except ZoneReadOnlyError:
+                return
+            raise AssertionError("read-only zone write unexpectedly succeeded")
+
+        for _ in range(WARMUP_ITERATIONS):
+            _deny_once()
+
+        stats = _measure_ops(_deny_once, iterations=5_000)
+        _report("Remote zone read-only write fast-fail", stats)
+
+        assert transport.method_calls == []
+        assert stats["p99_us"] < 1_000.0, (
+            f"read-only remote zone denial too slow: p99={stats['p99_us']:.1f}us (target <1000us)"
         )

--- a/tests/e2e/self_contained/cli/test_sandbox_federation_e2e.py
+++ b/tests/e2e/self_contained/cli/test_sandbox_federation_e2e.py
@@ -263,6 +263,7 @@ def sandbox(
     workspace = tmp_path / "workspace"
     workspace.mkdir()
     (workspace / "hello.txt").write_text("hello from local workspace")
+    data_dir = tmp_path / "data"
 
     port = _SANDBOX_PORT_BASE + (os.getpid() % 1000)
     hub_url = f"grpc://{hub_grpc}"
@@ -278,6 +279,8 @@ def sandbox(
         hub_token,
         "--port",
         str(port),
+        "--data-dir",
+        str(data_dir),
     ]
     cmd = nexusd.split() + base_flags if " " in nexusd else [nexusd] + base_flags
 
@@ -289,12 +292,12 @@ def sandbox(
     )
 
     health_url = f"http://localhost:{port}/health"
-    ready = _poll_health(health_url, timeout=30)
+    ready = _poll_health(health_url, timeout=60)
 
     if not ready:
         _terminate(proc)
         stderr = proc.stderr.read() if proc.stderr else ""
-        pytest.fail(f"Sandbox did not reach healthy within 30s\nstderr: {stderr[:2000]}")
+        pytest.fail(f"Sandbox did not reach healthy within 60s\nstderr: {stderr[:2000]}")
 
     # gRPC port is HTTP port + 2 by nexusd convention (main.py always sets NEXUS_GRPC_PORT=port+2)
     handle = SandboxHandle(
@@ -459,6 +462,7 @@ class TestSandboxLocalOnlyFallback:
         """Sandbox must boot (not crash) when hub is unreachable."""
         workspace = tmp_path / "ws"
         workspace.mkdir()
+        data_dir = tmp_path / "data"
 
         port = _SANDBOX_PORT_BASE + (os.getpid() % 1000) + 100
         nexusd = _nexusd_bin()
@@ -473,6 +477,8 @@ class TestSandboxLocalOnlyFallback:
             "sk-fake-token",
             "--port",
             str(port),
+            "--data-dir",
+            str(data_dir),
         ]
         cmd = nexusd.split() + base_flags if " " in nexusd else [nexusd] + base_flags
 
@@ -486,13 +492,17 @@ class TestSandboxLocalOnlyFallback:
             time.sleep(2)
             if proc.poll() is not None:
                 stderr = proc.stderr.read() if proc.stderr else ""
-                if "nexus_kernel" in stderr or "No module named" in stderr:
+                if (
+                    "nexus-cluster" in stderr
+                    or "nexus_kernel" in stderr
+                    or "No module named" in stderr
+                ):
                     pytest.skip(
                         "nexusd requires nexus-cluster binary — run cargo build --release -p nexus-cluster"
                     )
                 pytest.skip(f"nexusd exited immediately: {stderr[:500]}")
 
-            ready = _poll_health(f"http://localhost:{port}/health", timeout=30)
+            ready = _poll_health(f"http://localhost:{port}/health", timeout=60)
             assert ready, "Sandbox should start in local-only mode even if hub is unreachable"
         finally:
             _terminate(proc)

--- a/tests/e2e/server/test_mcp_tool_namespace_e2e.py
+++ b/tests/e2e/server/test_mcp_tool_namespace_e2e.py
@@ -29,6 +29,7 @@ from nexus.bricks.mcp.profiles import (
     revoke_tools_by_tuple_ids,
 )
 from nexus.bricks.mcp.server import create_mcp_server
+from nexus.bricks.rebac.consistency.metastore_namespace_store import MetastoreNamespaceStore
 from nexus.bricks.rebac.consistency.metastore_version_store import MetastoreVersionStore
 from nexus.bricks.rebac.manager import EnhancedReBACManager
 from nexus.storage.models import Base
@@ -56,6 +57,7 @@ def rebac_manager(rebac_engine):
         engine=rebac_engine,
         cache_ttl_seconds=1,
         version_store=MetastoreVersionStore(InMemoryNexusFS()),
+        namespace_store=MetastoreNamespaceStore(InMemoryNexusFS()),
     )
 
 
@@ -75,6 +77,7 @@ def mock_nx():
     """Minimal mock NexusFS for server creation."""
     nx = Mock()
     nx.read = Mock(return_value=b"hello world")
+    nx.sys_read = Mock(return_value=b"hello world")
     nx.write = Mock()
     nx.delete = Mock()
     nx.list = Mock(return_value=[])
@@ -156,9 +159,10 @@ def _get_tool(server, name):
 class TestToolNamespaceE2E:
     """Full lifecycle: grant → discover → call → revoke → verify gone."""
 
-    def test_full_lifecycle(self, rebac_manager, middleware, mock_nx, profiles):
+    @pytest.mark.asyncio
+    async def test_full_lifecycle(self, rebac_manager, middleware, mock_nx, profiles):
         """Complete grant → discover → use → revoke → verify lifecycle."""
-        server = create_mcp_server(nx=mock_nx, tool_namespace_middleware=middleware)
+        server = await create_mcp_server(nx=mock_nx, tool_namespace_middleware=middleware)
         ctx = _make_ctx("agent", "lifecycle-agent")
 
         # --- Phase 1: No grants → no tools visible ---
@@ -186,7 +190,7 @@ class TestToolNamespaceE2E:
 
         # Use: read_file should work
         read_fn = _get_tool(server, "nexus_read_file")
-        read_result = read_fn.fn(path="/test.txt", ctx=ctx)
+        read_result = await read_fn.fn(path="/test.txt", ctx=ctx)
         assert "hello world" in read_result
 
         # Get details: visible tool returns details, invisible returns not found
@@ -396,7 +400,8 @@ class TestPerformanceE2E:
         assert elapsed_ms < 1, f"Hot lookup took {elapsed_ms:.3f}ms (expected <1ms)"
         logger.info("Hot lookup: %.3fms (cache hit)", elapsed_ms)
 
-    def test_discovery_search_performance(self, rebac_manager, middleware, mock_nx, profiles):
+    @pytest.mark.asyncio
+    async def test_discovery_search_performance(self, rebac_manager, middleware, mock_nx, profiles):
         """Discovery search with namespace filtering under 50ms."""
         reader_profile = profiles.get_profile("reader")
         grant_tools_for_profile(
@@ -406,7 +411,7 @@ class TestPerformanceE2E:
         )
         middleware.invalidate()
 
-        server = create_mcp_server(nx=mock_nx, tool_namespace_middleware=middleware)
+        server = await create_mcp_server(nx=mock_nx, tool_namespace_middleware=middleware)
         search_fn = _get_tool(server, "nexus_discovery_search_tools")
         ctx = _make_ctx("agent", "perf-disco-agent")
 
@@ -432,18 +437,20 @@ class TestPerformanceE2E:
 class TestBackwardCompat:
     """No middleware → all tools visible (backward compat)."""
 
-    def test_no_middleware_returns_all_tools(self, mock_nx):
+    @pytest.mark.asyncio
+    async def test_no_middleware_returns_all_tools(self, mock_nx):
         """Server without middleware returns unfiltered tool results."""
-        server = create_mcp_server(nx=mock_nx)
+        server = await create_mcp_server(nx=mock_nx)
         search_fn = _get_tool(server, "nexus_discovery_search_tools")
 
         result = json.loads(search_fn.fn(query="file", top_k=20, ctx=None))
         assert result["count"] > 3, "Without middleware, all tools should be visible"
         logger.info("PASS: Backward compat — %d tools visible", result["count"])
 
-    def test_no_ctx_returns_all_tools(self, mock_nx, middleware):
+    @pytest.mark.asyncio
+    async def test_no_ctx_returns_all_tools(self, mock_nx, middleware):
         """With middleware but no ctx, all tools visible."""
-        server = create_mcp_server(nx=mock_nx, tool_namespace_middleware=middleware)
+        server = await create_mcp_server(nx=mock_nx, tool_namespace_middleware=middleware)
         search_fn = _get_tool(server, "nexus_discovery_search_tools")
 
         result = json.loads(search_fn.fn(query="file", top_k=20, ctx=None))

--- a/tests/e2e/server/test_rebac_latency_e2e.py
+++ b/tests/e2e/server/test_rebac_latency_e2e.py
@@ -13,6 +13,7 @@ Run with:
     pytest tests/e2e/server/test_rebac_latency_e2e.py -v -s
 """
 
+import base64
 import os
 import shutil
 import signal
@@ -21,8 +22,10 @@ import statistics
 import subprocess
 import sys
 import tempfile
+import threading
 import time
 import uuid
+from collections import deque
 from pathlib import Path
 from typing import Any
 
@@ -32,7 +35,10 @@ import pytest
 pytestmark = pytest.mark.quarantine
 
 PYTHON = sys.executable
-SERVER_STARTUP_TIMEOUT = 30
+# Cold lite-profile startup can cross 30s on developer machines because this
+# fixture starts the Rust kernel and the full FastAPI lifespan before measuring
+# permission-operation latency. Startup time itself is not the benchmark target.
+SERVER_STARTUP_TIMEOUT = 60
 
 # Clear proxy env vars so localhost connections work
 for _key in ("HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy"):
@@ -52,6 +58,10 @@ def _find_free_port() -> int:
 
 def _make_client() -> httpx.Client:
     return httpx.Client(timeout=60)
+
+
+def _rpc_bytes(data: bytes) -> dict[str, str]:
+    return {"__type__": "bytes", "data": base64.b64encode(data).decode("utf-8")}
 
 
 def _wait_for_health(base_url: str, timeout: float = SERVER_STARTUP_TIMEOUT) -> None:
@@ -129,7 +139,7 @@ def server():
             (
                 "from nexus.daemon.main import main; "
                 f"main(['--host', '127.0.0.1', '--port', '{port}', "
-                f"'--data-dir', '{data_dir}'])"
+                f"'--data-dir', '{data_dir}', '--profile', 'lite'])"
             ),
         ],
         env=env,
@@ -138,6 +148,20 @@ def server():
         text=True,
         preexec_fn=os.setsid if sys.platform != "win32" else None,
     )
+    server_output: deque[str] = deque(maxlen=500)
+
+    def _drain_stdout() -> None:
+        if proc.stdout is None:
+            return
+        for line in proc.stdout:
+            server_output.append(line)
+
+    stdout_reader = threading.Thread(
+        target=_drain_stdout,
+        name="nexus-rebac-latency-e2e-stdout",
+        daemon=True,
+    )
+    stdout_reader.start()
 
     try:
         _wait_for_health(base_url)
@@ -160,7 +184,8 @@ def server():
         except subprocess.TimeoutExpired:
             proc.kill()
             proc.wait(timeout=3)
-        stdout = proc.stdout.read() if proc.stdout else ""
+        stdout_reader.join(timeout=1)
+        stdout = "".join(server_output)
         pytest.fail(f"Server failed to start. Output:\n{stdout}")
     finally:
         if proc.poll() is None:
@@ -176,6 +201,7 @@ def server():
             except subprocess.TimeoutExpired:
                 proc.kill()
                 proc.wait(timeout=5)
+        stdout_reader.join(timeout=1)
         shutil.rmtree(data_dir, ignore_errors=True)
 
 
@@ -187,12 +213,19 @@ def client(server: dict) -> httpx.Client:
 
 @pytest.fixture(scope="module")
 def admin_headers() -> dict[str, str]:
-    return {"X-Agent-ID": "admin", "X-Zone-ID": "rebac-latency-e2e"}
+    return {
+        "X-Nexus-Subject": "user:admin",
+        "X-Agent-ID": "admin",
+        "X-Nexus-Zone-ID": "rebac-latency-e2e",
+    }
 
 
 @pytest.fixture(scope="module")
 def alice_headers() -> dict[str, str]:
-    return {"X-Agent-ID": "alice", "X-Zone-ID": "rebac-latency-e2e"}
+    return {
+        "X-Nexus-Subject": "agent:alice",
+        "X-Nexus-Zone-ID": "rebac-latency-e2e",
+    }
 
 
 @pytest.fixture(scope="module")
@@ -205,13 +238,13 @@ def setup_permissions(server, client, admin_headers):
         client,
         base_url,
         "write",
-        {"path": "/latency_test/file.txt", "content_b64": "SGVsbG8gV29ybGQ="},
+        {"path": "/latency_test/file.txt", "content": _rpc_bytes(b"Hello World")},
         headers=admin_headers,
     )
     assert result.get("error") is None, f"Admin write failed: {result}"
 
     # Grant alice viewer on the file
-    _rpc(
+    result = _rpc(
         client,
         base_url,
         "rebac_create",
@@ -223,20 +256,23 @@ def setup_permissions(server, client, admin_headers):
         },
         headers=admin_headers,
     )
+    assert result.get("error") is None, f"Grant alice viewer failed: {result}"
 
     # Write 10 files for batch testing
     for i in range(10):
-        _rpc(
+        result = _rpc(
             client,
             base_url,
             "write",
             {
                 "path": f"/latency_test/batch/file_{i:02d}.txt",
-                "content_b64": "SGVsbG8=",
+                "content": _rpc_bytes(b"Hello"),
             },
             headers=admin_headers,
         )
-        _rpc(
+        assert result.get("error") is None, f"Admin batch write {i} failed: {result}"
+
+        result = _rpc(
             client,
             base_url,
             "rebac_create",
@@ -248,6 +284,7 @@ def setup_permissions(server, client, admin_headers):
             },
             headers=admin_headers,
         )
+        assert result.get("error") is None, f"Grant alice batch viewer {i} failed: {result}"
 
     return True
 
@@ -336,7 +373,7 @@ class TestPermissionCheckedWriteLatency:
                 "write",
                 {
                     "path": f"/latency_test/write_{counter[0]}.txt",
-                    "content_b64": "SGVsbG8=",
+                    "content": _rpc_bytes(b"Hello"),
                 },
                 headers=admin_headers,
             )
@@ -362,8 +399,8 @@ class TestPermissionDenialLatency:
         """Unknown user attempting to read should be denied quickly."""
         base_url = server["base_url"]
         unknown_headers = {
-            "X-Agent-ID": "unknown_intruder",
-            "X-Zone-ID": "rebac-latency-e2e",
+            "X-Nexus-Subject": "agent:unknown_intruder",
+            "X-Nexus-Zone-ID": "rebac-latency-e2e",
         }
 
         denial_times: list[float] = []

--- a/tests/unit/backends/test_remote_zone.py
+++ b/tests/unit/backends/test_remote_zone.py
@@ -68,6 +68,22 @@ class TestRemoteZoneBackendReadOnly:
             readonly_backend.rmdir("/some/path")
         mock_transport.call_rpc.assert_not_called()
 
+    def test_all_write_mutations_fail_before_remote_transport_call(
+        self, readonly_backend: RemoteZoneBackend, mock_transport: MagicMock
+    ) -> None:
+        write_operations = (
+            lambda: readonly_backend.write_content(b"data"),
+            lambda: readonly_backend.delete_content("content-id"),
+            lambda: readonly_backend.mkdir("/some/path"),
+            lambda: readonly_backend.rmdir("/some/path"),
+        )
+
+        for operation in write_operations:
+            with pytest.raises(ZoneReadOnlyError):
+                operation()
+
+        assert mock_transport.method_calls == []
+
     def test_read_content_passes_through(
         self, readonly_backend: RemoteZoneBackend, mock_transport: MagicMock
     ) -> None:

--- a/tests/unit/bricks/mcp/test_tool_namespace_middleware.py
+++ b/tests/unit/bricks/mcp/test_tool_namespace_middleware.py
@@ -11,12 +11,14 @@ Tests cover:
 import time
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Any
+from types import SimpleNamespace
+from typing import Any, cast
 from unittest.mock import MagicMock
 
 import pytest
 
 from nexus.bricks.mcp.middleware import ToolNamespaceMiddleware
+from nexus.bricks.mcp.profiles import grant_tools_for_profile, load_profiles_from_dict
 
 # ---------------------------------------------------------------------------
 # Test helpers
@@ -87,6 +89,45 @@ def make_middleware(
         zone_id=zone_id,
         enabled=enabled,
     )
+
+
+class MemoryToolGrantReBAC:
+    """Small ReBAC test double for profile grant -> namespace filter integration."""
+
+    def __init__(self) -> None:
+        self._objects_by_subject: dict[
+            tuple[tuple[str, str], str | None], set[tuple[str, str]]
+        ] = {}
+        self._revision = 0
+
+    def rebac_write(
+        self,
+        *,
+        subject: tuple[str, str],
+        relation: str,
+        object: tuple[str, str],
+        zone_id: str | None = None,
+    ) -> Any:
+        assert relation == "direct_viewer"
+        self._objects_by_subject.setdefault((subject, zone_id), set()).add(object)
+        self._revision += 1
+        return SimpleNamespace(tuple_id=f"tuple-{self._revision}", revision=self._revision)
+
+    def rebac_list_objects(
+        self,
+        *,
+        subject: tuple[str, str],
+        permission: str,
+        object_type: str,
+        zone_id: str | None = None,
+        limit: int,
+    ) -> list[tuple[str, str]]:
+        assert permission == "read"
+        objects = self._objects_by_subject.get((subject, zone_id), set())
+        return [obj for obj in sorted(objects) if obj[0] == object_type][:limit]
+
+    def get_zone_revision(self, zone_id: str | None) -> int:  # noqa: ARG002
+        return self._revision
 
 
 # ---------------------------------------------------------------------------
@@ -256,6 +297,69 @@ class TestOnCallTool:
 
         result = await mw.on_call_tool(ctx, call_next)  # type: ignore[arg-type]
         assert result is expected_result
+
+
+class TestProfileGrantIntegration:
+    @pytest.mark.asyncio
+    async def test_profile_grants_drive_list_filtering_and_call_denial(self):
+        config = load_profiles_from_dict(
+            {
+                "profiles": {
+                    "minimal": {"tools": ["nexus_read_file"]},
+                    "coding": {
+                        "extends": "minimal",
+                        "tools": ["nexus_write_file"],
+                    },
+                }
+            }
+        )
+        profile = config.get_profile("coding")
+        assert profile is not None
+
+        rebac = MemoryToolGrantReBAC()
+        rebac_manager = cast(Any, rebac)
+        grant_tools_for_profile(
+            rebac_manager=rebac_manager,
+            subject=("agent", "alice"),
+            profile=profile,
+            zone_id="sandbox-agent-1",
+        )
+
+        mw = ToolNamespaceMiddleware(rebac_manager=rebac_manager, zone_id="sandbox-agent-1")
+        ctx = FakeMiddlewareContext(
+            fastmcp_context=FakeContext({"subject_type": "agent", "subject_id": "alice"}),
+        )
+        all_tools = [
+            FakeTool(name="nexus_read_file"),
+            FakeTool(name="nexus_write_file"),
+            FakeTool(name="nexus_python"),
+        ]
+
+        async def list_next(context: Any) -> Sequence[Any]:
+            return all_tools
+
+        listed = await mw.on_list_tools(cast(Any, ctx), cast(Any, list_next))
+        assert [tool.name for tool in listed] == ["nexus_read_file", "nexus_write_file"]
+
+        allowed_result = MagicMock()
+
+        async def call_next(context: Any) -> Any:
+            return allowed_result
+
+        allowed_ctx = FakeMiddlewareContext(
+            message=FakeCallToolParams(name="nexus_write_file"),
+            fastmcp_context=ctx.fastmcp_context,
+        )
+        assert await mw.on_call_tool(cast(Any, allowed_ctx), cast(Any, call_next)) is allowed_result
+
+        denied_ctx = FakeMiddlewareContext(
+            message=FakeCallToolParams(name="nexus_python"),
+            fastmcp_context=ctx.fastmcp_context,
+        )
+        denied = await mw.on_call_tool(cast(Any, denied_ctx), cast(Any, call_next))
+        denied_text = denied.content[0].text
+        assert "not found" in denied_text.lower()
+        assert "permission" not in denied_text.lower()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/cli/test_mcp_profile_cli.py
+++ b/tests/unit/cli/test_mcp_profile_cli.py
@@ -1,0 +1,301 @@
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+from click.testing import CliRunner
+
+from nexus.cli.commands import mcp as mcp_commands
+from nexus.cli.commands.mcp import mcp
+
+PROFILE_YAML = """
+profiles:
+  minimal:
+    description: Read-only access
+    tools:
+      - nexus_read_file
+      - nexus_list_files
+  coding:
+    extends: minimal
+    description: Coding access
+    tools:
+      - nexus_write_file
+      - nexus_grep
+default_profile: minimal
+"""
+
+
+class FakeReBAC:
+    def __init__(self) -> None:
+        self.writes: list[dict[str, Any]] = []
+        self.objects_by_subject: dict[tuple[tuple[str, str], str | None], set[tuple[str, str]]] = {}
+        self.fail_writes = False
+
+    def rebac_write(
+        self,
+        *,
+        subject: tuple[str, str],
+        relation: str,
+        object: tuple[str, str],
+        zone_id: str | None = None,
+    ) -> SimpleNamespace:
+        if self.fail_writes:
+            raise PermissionError("write denied")
+        self.writes.append(
+            {
+                "subject": subject,
+                "relation": relation,
+                "object": object,
+                "zone_id": zone_id,
+            }
+        )
+        self.objects_by_subject.setdefault((subject, zone_id), set()).add(object)
+        return SimpleNamespace(tuple_id=f"tuple-{len(self.writes)}", revision=len(self.writes))
+
+    def rebac_list_objects(
+        self,
+        *,
+        subject: tuple[str, str],
+        permission: str,
+        object_type: str = "file",
+        zone_id: str | None = None,
+        limit: int = 1000,
+    ) -> list[tuple[str, str]]:
+        assert permission == "read"
+        objects = self.objects_by_subject.get((subject, zone_id), set())
+        return [obj for obj in sorted(objects) if obj[0] == object_type][:limit]
+
+
+class FakeNx:
+    def __init__(self, rebac: Any) -> None:
+        self.rebac = rebac
+        self.closed = False
+
+    def service(self, name: str) -> Any:
+        if name == "rebac_manager":
+            return self.rebac
+        return None
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class FakeRemoteReBACProxy:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    def __getattr__(self, name: str) -> Any:
+        if name.startswith("_"):
+            raise AttributeError(name)
+
+        def _call(**kwargs: Any) -> dict[str, Any]:
+            self.calls.append({"method": name, "kwargs": kwargs})
+            return {"tuple_id": f"remote-{len(self.calls)}"}
+
+        return _call
+
+
+def _write_profiles(tmp_path: Path) -> Path:
+    path = tmp_path / "tool_profiles.yaml"
+    path.write_text(PROFILE_YAML)
+    return path
+
+
+def test_mcp_profile_list_outputs_configured_profiles(tmp_path: Path) -> None:
+    config_path = _write_profiles(tmp_path)
+
+    result = CliRunner().invoke(
+        mcp,
+        ["profile", "list", "--config", str(config_path), "--format", "json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["default_profile"] == "minimal"
+    assert [profile["name"] for profile in payload["profiles"]] == ["coding", "minimal"]
+
+
+def test_mcp_profile_show_outputs_resolved_inherited_profile(tmp_path: Path) -> None:
+    config_path = _write_profiles(tmp_path)
+
+    result = CliRunner().invoke(
+        mcp,
+        ["profile", "show", "coding", "--config", str(config_path), "--format", "json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload == {
+        "name": "coding",
+        "description": "Coding access",
+        "extends": "minimal",
+        "tools": [
+            "nexus_grep",
+            "nexus_list_files",
+            "nexus_read_file",
+            "nexus_write_file",
+        ],
+    }
+
+
+def test_mcp_profile_assign_materializes_inherited_tool_grants(
+    monkeypatch: Any,
+    tmp_path: Path,
+) -> None:
+    config_path = _write_profiles(tmp_path)
+    rebac = FakeReBAC()
+    nx = FakeNx(rebac)
+
+    async def fake_get_filesystem(*_args: Any, **_kwargs: Any) -> FakeNx:
+        return nx
+
+    monkeypatch.setattr(mcp_commands, "get_filesystem", fake_get_filesystem)
+
+    result = CliRunner().invoke(
+        mcp,
+        [
+            "profile",
+            "assign",
+            "agent",
+            "alice",
+            "coding",
+            "--zone-id",
+            "org_acme",
+            "--config",
+            str(config_path),
+            "--format",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["profile"] == "coding"
+    assert payload["subject"] == ["agent", "alice"]
+    assert payload["zone_id"] == "org_acme"
+    assert payload["tools"] == [
+        "nexus_grep",
+        "nexus_list_files",
+        "nexus_read_file",
+        "nexus_write_file",
+    ]
+    assert payload["tuple_ids"] == ["tuple-1", "tuple-2", "tuple-3", "tuple-4"]
+    assert [write["object"] for write in rebac.writes] == [
+        ("file", "/tools/nexus_grep"),
+        ("file", "/tools/nexus_list_files"),
+        ("file", "/tools/nexus_read_file"),
+        ("file", "/tools/nexus_write_file"),
+    ]
+    assert nx.closed
+
+
+def test_mcp_profile_inspect_reports_effective_tool_grants(
+    monkeypatch: Any,
+    tmp_path: Path,
+) -> None:
+    config_path = _write_profiles(tmp_path)
+    rebac = FakeReBAC()
+    rebac.objects_by_subject[(("agent", "alice"), "org_acme")] = {
+        ("file", "/tools/nexus_list_files"),
+        ("file", "/tools/nexus_read_file"),
+        ("file", "/tools/nexus_write_file"),
+        ("file", "/workspace/not-a-tool"),
+    }
+    nx = FakeNx(rebac)
+
+    async def fake_get_filesystem(*_args: Any, **_kwargs: Any) -> FakeNx:
+        return nx
+
+    monkeypatch.setattr(mcp_commands, "get_filesystem", fake_get_filesystem)
+
+    result = CliRunner().invoke(
+        mcp,
+        [
+            "profile",
+            "inspect",
+            "agent",
+            "alice",
+            "--zone-id",
+            "org_acme",
+            "--config",
+            str(config_path),
+            "--format",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["subject"] == ["agent", "alice"]
+    assert payload["zone_id"] == "org_acme"
+    assert payload["tools"] == ["nexus_list_files", "nexus_read_file", "nexus_write_file"]
+    assert payload["matching_profiles"] == ["minimal"]
+    assert nx.closed
+
+
+def test_mcp_profile_assign_unknown_profile_fails(tmp_path: Path) -> None:
+    config_path = _write_profiles(tmp_path)
+
+    result = CliRunner().invoke(
+        mcp,
+        ["profile", "assign", "agent", "alice", "missing", "--config", str(config_path)],
+    )
+
+    assert result.exit_code != 0
+    assert "Unknown MCP tool profile 'missing'" in result.output
+
+
+def test_mcp_profile_assign_rebac_write_failure_is_nonzero(
+    monkeypatch: Any,
+    tmp_path: Path,
+) -> None:
+    config_path = _write_profiles(tmp_path)
+    rebac = FakeReBAC()
+    rebac.fail_writes = True
+    nx = FakeNx(rebac)
+
+    async def fake_get_filesystem(*_args: Any, **_kwargs: Any) -> FakeNx:
+        return nx
+
+    monkeypatch.setattr(mcp_commands, "get_filesystem", fake_get_filesystem)
+
+    result = CliRunner().invoke(
+        mcp,
+        ["profile", "assign", "agent", "alice", "minimal", "--config", str(config_path)],
+    )
+
+    assert result.exit_code != 0
+    assert "write denied" in result.output
+    assert nx.closed
+
+
+def test_mcp_profile_assign_uses_rpc_create_for_proxy_surface(
+    monkeypatch: Any,
+    tmp_path: Path,
+) -> None:
+    config_path = _write_profiles(tmp_path)
+    rebac = FakeRemoteReBACProxy()
+    nx = FakeNx(rebac)
+
+    async def fake_get_filesystem(*_args: Any, **_kwargs: Any) -> FakeNx:
+        return nx
+
+    monkeypatch.setattr(mcp_commands, "get_filesystem", fake_get_filesystem)
+
+    result = CliRunner().invoke(
+        mcp,
+        [
+            "profile",
+            "assign",
+            "agent",
+            "alice",
+            "minimal",
+            "--config",
+            str(config_path),
+            "--format",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert {call["method"] for call in rebac.calls} == {"rebac_create_sync"}

--- a/tests/unit/core/test_boot_indexer.py
+++ b/tests/unit/core/test_boot_indexer.py
@@ -99,6 +99,27 @@ class TestBootIndexerSuccessfulWalk:
         assert health_state["status"] == "ready"
         search_daemon.index_file.assert_not_called()
 
+    def test_missing_search_daemon_skips_indexing_without_warning(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A sandbox without a search daemon still becomes ready without per-file errors."""
+        (tmp_path / "file.txt").write_text("content")
+        health_state: dict[str, str] = {"status": "indexing"}
+
+        import logging
+
+        with caplog.at_level(logging.INFO, logger="nexus.core.boot_indexer"):
+            indexer = BootIndexer(tmp_path, None, health_state)
+            indexer.start_async()
+
+            deadline = time.monotonic() + 5.0
+            while health_state["status"] != "ready" and time.monotonic() < deadline:
+                time.sleep(0.01)
+
+        assert health_state["status"] == "ready"
+        assert any("search daemon unavailable" in r.message for r in caplog.records)
+        assert not any("failed to index" in r.message for r in caplog.records)
+
 
 class TestBootIndexerWalkFailure:
     """BootIndexer handles walk errors gracefully — partial index is acceptable."""

--- a/tests/unit/remote/test_federation_handshake.py
+++ b/tests/unit/remote/test_federation_handshake.py
@@ -32,6 +32,34 @@ def test_successful_handshake_returns_hub_session():
     assert session.zones[1] == HubZoneGrant(zone_id="shared", permission="rw")
 
 
+def test_handshake_uses_startup_bounded_timeouts():
+    """Unreachable hubs must not block sandbox local-only boot for transport defaults."""
+    mock_transport = MagicMock()
+    mock_transport.call_rpc.return_value = {"zones": []}
+
+    with patch(
+        "nexus.remote.federation_handshake.RPCTransport", return_value=mock_transport
+    ) as transport_cls:
+        handshake = FederationHandshake(
+            hub_url="grpc://hub.example.com",
+            token="tok-abc",
+            timeout=1.25,
+            connect_timeout=0.5,
+        )
+        handshake.run()
+
+    transport_cls.assert_called_once_with(
+        "grpc://hub.example.com",
+        auth_token="tok-abc",
+        timeout=1.25,
+        connect_timeout=0.5,
+    )
+    mock_transport.call_rpc.assert_called_once_with(
+        "federation_client_whoami",
+        read_timeout=1.25,
+    )
+
+
 def test_handshake_401_raises_auth_error():
     """Hub rejects the token with 401 → HandshakeAuthError."""
     mock_transport = MagicMock()

--- a/tests/unit/remote/test_kernel_client_hooks.py
+++ b/tests/unit/remote/test_kernel_client_hooks.py
@@ -1,8 +1,13 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
+from unittest.mock import patch
 
-from nexus.remote.kernel_client import KernelClient
+from nexus.remote.kernel_client import (
+    KernelClient,
+    _resolve_kernel_binary,
+    _resolve_kernel_data_dir,
+)
 
 
 class RecordingHook:
@@ -32,6 +37,32 @@ def test_kernel_client_keeps_python_hook_registry_for_subprocess_mode() -> None:
     assert hook.post == [ctx]
     assert client.unregister_hook("read", hook) is True
     assert client.hook_count("read") == 0
+
+
+def test_kernel_client_resolves_cargo_binary_name_without_symlink(monkeypatch) -> None:
+    monkeypatch.delenv("NEXUS_KERNEL_BINARY", raising=False)
+
+    def fake_which(binary_name: str) -> str | None:
+        if binary_name == "nexusd-cluster":
+            return "/repo/target/debug/nexusd-cluster"
+        return None
+
+    with patch("nexus.remote.kernel_client.shutil.which", side_effect=fake_which):
+        assert _resolve_kernel_binary() == "/repo/target/debug/nexusd-cluster"
+
+
+def test_kernel_client_routes_legacy_metadata_file_to_sidecar_data_dir(tmp_path) -> None:
+    legacy_db = tmp_path / "nexus.db"
+    legacy_db.write_text("legacy metadata")
+
+    assert _resolve_kernel_data_dir(str(legacy_db)) == str(tmp_path / "nexus.db.kernel")
+
+
+def test_kernel_client_keeps_directory_metadata_path(tmp_path) -> None:
+    metadata_dir = tmp_path / "metastore"
+    metadata_dir.mkdir()
+
+    assert _resolve_kernel_data_dir(str(metadata_dir)) == str(metadata_dir)
 
 
 def test_kernel_client_sys_read_honors_nonblocking_timeout() -> None:

--- a/tests/unit/storage/test_schema_invariants.py
+++ b/tests/unit/storage/test_schema_invariants.py
@@ -2,12 +2,15 @@ from __future__ import annotations
 
 from typing import Any
 
+from sqlalchemy import create_engine, inspect
+
 from nexus.storage.schema_invariants import (
     _ensure_file_paths_search_columns,
     _ensure_rebac_namespaces_table,
     _ensure_version_history_content_columns,
     _ensure_zone_indexes,
     _ensure_zones_table_shape,
+    ensure_postgres_schema_invariants,
 )
 
 
@@ -86,6 +89,14 @@ def test_ensure_rebac_namespaces_table_creates_missing_table() -> None:
     assert "rebac_namespaces" in table_names
     assert "rebac_namespaces" in columns_by_table
     assert "CREATE TABLE IF NOT EXISTS rebac_namespaces" in statements
+
+
+def test_schema_invariants_create_rebac_namespaces_for_sqlite() -> None:
+    engine = create_engine("sqlite:///:memory:")
+
+    ensure_postgres_schema_invariants(engine)
+
+    assert "rebac_namespaces" in inspect(engine).get_table_names()
 
 
 def test_ensure_version_history_content_columns_repairs_legacy_content_hash() -> None:


### PR DESCRIPTION
## Summary

Closes the issue-scoped ReBAC/MCP sandbox boundary gaps for #4128.

- Adds `nexus mcp profile list/show/assign/inspect` so configured MCP tool profiles can be inspected, assigned, and debugged from the CLI.
- Updates the sandbox ReBAC/MCP coverage matrix, guide, and generated coverage HTML so `mcp.tool_profile_assign` is documented as supported instead of missing.
- Hardens the tested sandbox/server paths: kernel binary discovery, sidecar kernel data isolation, bounded hub handshake timeouts, disabled search boot indexing, SQLite ReBAC namespace schema creation, and E2E startup behavior.
- Adds architecture, unit, benchmark, and real E2E coverage for local file boundaries, remote-zone behavior, MCP tool filtering/calling, read-only hub denial, and permission latency.

## Root Cause

The #4128 acceptance surface had docs/tests for most boundaries, but MCP profile assignment/debugging was only tracked as a gap, and several real E2E paths had local-environment startup failures or flakes that prevented reliable validation.

## Validation

- `uv run --extra dev ruff check ...` on touched implementation/tests
- `uv run pytest -p no:xdist -o addopts= tests/unit/cli/test_mcp_profile_cli.py tests/unit/bricks/mcp/test_tool_namespace_middleware.py tests/architecture/test_issue_4128_sandbox_rebac_mcp_boundaries.py tests/benchmarks/bench_permission_hotpath.py -q` -> `50 passed`
- `uv run pytest -p no:xdist -o addopts= tests/e2e/self_contained/test_rebac_full_story_e2e.py tests/e2e/self_contained/mcp/test_tool_namespace_integration.py tests/e2e/server/test_mcp_tool_namespace_e2e.py -q` -> `26 passed`
- `PATH="$PWD/target/debug:$PATH" uv run pytest -p no:xdist -o addopts= --run-quarantine tests/e2e/server/test_rebac_latency_e2e.py -q -s` -> `5 passed`
- `PATH="$PWD/target/debug:$PATH" uv run pytest -p no:xdist -o addopts= tests/e2e/self_contained/cli/test_sandbox_federation_e2e.py -q -rs` -> `1 passed, 6 skipped` because live hub env is not configured (`NEXUS_GRPC_HOST`, `NEXUS_ADMIN_KEY`, `NEXUS_DATABASE_URL`, `psql`)
- Commit hooks passed: trailing whitespace, EOF, YAML, large-file, merge-conflict, debug statements, ruff, ruff format, mypy, type-ignore gate, brick import/boundary checks
