### PR TITLE
[codex] fix develop CI publishing failures

### DIFF
--- a/.github/workflows/demo-memory.yml
+++ b/.github/workflows/demo-memory.yml
@@ -29,6 +29,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  PYO3_USE_ABI3_FORWARD_COMPATIBILITY: "1"
+
 jobs:
   demo-memory:
     name: nexusd demo idle RSS <= 450 MB
@@ -61,7 +64,7 @@ jobs:
           build-args: |
             NEXUS_PROFILE_EXTRAS=all,performance,monitoring,docker,event-streaming,sentry,pay
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-to: type=gha,mode=max,ignore-error=true
 
       - name: Run demo memory regression
         run: uv run pytest -m demo_memory tests/integration/test_demo_memory.py -v -s

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -69,7 +69,7 @@ jobs:
           platforms: ${{ matrix.platform }}
           outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true,oci-mediatypes=true
           cache-from: type=gha,scope=${{ github.ref_name }}-${{ steps.pair.outputs.value }}
-          cache-to: type=gha,mode=max,scope=${{ github.ref_name }}-${{ steps.pair.outputs.value }}
+          cache-to: type=gha,mode=max,scope=${{ github.ref_name }}-${{ steps.pair.outputs.value }},ignore-error=true
 
       - name: Export digest
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,6 +10,9 @@ permissions:
   pages: write
   id-token: write
 
+env:
+  PYO3_USE_ABI3_FORWARD_COMPATIBILITY: "1"
+
 concurrency:
   group: "pages"
   cancel-in-progress: false

--- a/tests/unit/ci/test_workflow_guards.py
+++ b/tests/unit/ci/test_workflow_guards.py
@@ -50,6 +50,35 @@ def _step_by_name(job: dict[str, Any], name: str) -> dict[str, Any]:
     raise AssertionError(f"step {name!r} not found; have: {names}")
 
 
+def _workflow_env(workflow: dict[str, Any]) -> dict[str, Any]:
+    env = workflow.get("env") or {}
+    assert isinstance(env, dict), f"workflow env must be a mapping, got: {env!r}"
+    return env
+
+
+def _assert_pyo3_forward_compat_enabled(workflow_name: str) -> None:
+    workflow = _load_workflow(workflow_name)
+    env = _workflow_env(workflow)
+    assert env.get("PYO3_USE_ABI3_FORWARD_COMPATIBILITY") == "1", (
+        f"{workflow_name} installs the project under Python 3.14. "
+        "pdf-inspector may build its PyO3 sdist there, so the workflow "
+        "must export PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1."
+    )
+
+
+def _assert_gha_cache_export_non_blocking(workflow_name: str, job_id: str, step_name: str) -> None:
+    workflow = _load_workflow(workflow_name)
+    step = _step_by_name(_job(workflow, job_id), step_name)
+    with_block = step.get("with") or {}
+    cache_to = with_block.get("cache-to", "")
+    assert "type=gha" in cache_to, f"{workflow_name}:{step_name} should export a GHA build cache"
+    assert "ignore-error=true" in cache_to, (
+        f"{workflow_name}:{step_name} must set ignore-error=true on cache-to. "
+        "The image build/push is the required artifact; a transient GitHub "
+        "Actions cache export failure must not fail the job after the image is built."
+    )
+
+
 # ---------------------------------------------------------------------------
 # cluster-binary-build.yml
 # ---------------------------------------------------------------------------
@@ -89,6 +118,14 @@ def test_cluster_binary_uses_single_rust_cache_layer() -> None:
 # ---------------------------------------------------------------------------
 
 
+def test_docker_publish_gha_cache_export_is_non_blocking() -> None:
+    _assert_gha_cache_export_non_blocking(
+        "docker-publish.yml",
+        "build-platform",
+        "Build and push by digest",
+    )
+
+
 _VFS_GRPC_GATE = "steps.vfs_grpc.outputs.available == 'true'"
 
 
@@ -125,3 +162,29 @@ def test_docker_edge_smoke_skips_grpc_dependent_steps_without_vfs_grpc() -> None
             f"otherwise it will fail against an edge image without VFS gRPC. "
             f"Got: if={condition!r}"
         )
+
+
+# ---------------------------------------------------------------------------
+# docs.yml
+# ---------------------------------------------------------------------------
+
+
+def test_docs_workflow_exports_pyo3_forward_compatibility() -> None:
+    _assert_pyo3_forward_compat_enabled("docs.yml")
+
+
+# ---------------------------------------------------------------------------
+# demo-memory.yml
+# ---------------------------------------------------------------------------
+
+
+def test_demo_memory_workflow_exports_pyo3_forward_compatibility() -> None:
+    _assert_pyo3_forward_compat_enabled("demo-memory.yml")
+
+
+def test_demo_memory_gha_cache_export_is_non_blocking() -> None:
+    _assert_gha_cache_export_non_blocking(
+        "demo-memory.yml",
+        "demo-memory",
+        "Build nexus image",
+    )


### PR DESCRIPTION
## Summary

- Export `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1` in the Documentation and Demo Memory Regression workflows so `pdf-inspector` can build its PyO3 sdist under Python 3.14.
- Make GitHub Actions BuildKit cache exports non-blocking for Docker Publish and Demo Memory image builds with `ignore-error=true`.
- Add workflow guard tests for these CI invariants.

## Root Cause

The latest `develop` push failed before docs and demo memory could run because `pdf-inspector` built from sdist under Python 3.14 and PyO3 rejected that interpreter without ABI3 forward compatibility enabled. The Docker arm64 publish built and pushed the platform image, then failed during GitHub Actions cache export.

## Validation

- `uv run pytest tests/unit/ci/test_workflow_guards.py -q` -> 6 passed
- `git diff --check` -> exit 0
- Commit hook checks passed during `git commit`
- Earlier local docs smoke: `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 uv run python scripts/build_docs_site.py` -> exit 0, with existing docs warnings
