### PR TITLE
Fix search ReBAC inheritance and delete propagation

### DIFF
--- a/src/nexus/bricks/mcp/server.py
+++ b/src/nexus/bricks/mcp/server.py
@@ -1013,6 +1013,7 @@ async def create_mcp_server(
             auth_result,
             zone_id,
             path_extractor=lambda p: p,
+            operation_context=op_context,
         )
         post_filter_count = len(filtered_paths)
         total = post_filter_count
@@ -1196,6 +1197,7 @@ async def create_mcp_server(
             auth_result,
             zone_id,
             path_extractor=lambda r: r.get("file", ""),
+            operation_context=op_context,
         )
         post_filter_count = len(filtered_results)
 

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -2550,6 +2550,14 @@ class SearchDaemon:
         if change_type == "delete":
             self._pending_delete_paths.add(path)
             self._pending_refresh_paths.discard(path)
+            try:
+                await self._delete_indexes_for_paths([path])
+            except Exception:
+                logger.warning(
+                    "Immediate search delete propagation failed for %s; queued for retry",
+                    path,
+                    exc_info=True,
+                )
         else:
             self._pending_refresh_paths.add(path)
             self._pending_delete_paths.discard(path)

--- a/src/nexus/core/nexus_fs_metadata.py
+++ b/src/nexus/core/nexus_fs_metadata.py
@@ -793,36 +793,35 @@ class MetadataMixin:
 
         if _unlink_result.hit:
             # Rust handled the full operation (§12e: DT_DIR handled via internal sys_rmdir).
-            if _unlink_result.post_hook_needed:
-                et = _unlink_result.entry_type
-                if et == DT_DIR:
-                    from nexus.contracts.vfs_hooks import RmdirHookContext
+            et = _unlink_result.entry_type
+            if et == DT_DIR:
+                from nexus.contracts.vfs_hooks import RmdirHookContext
 
-                    ctx = self._resolve_cred(context)
-                    self._kernel.dispatch_post_hooks(
-                        "rmdir",
-                        RmdirHookContext(
-                            path=path,
-                            context=ctx,
-                            zone_id=zone_id,
-                            agent_id=agent_id,
-                            recursive=recursive,
-                            metadata=_pre_delete_meta,
-                        ),
-                    )
-                else:
-                    from nexus.contracts.vfs_hooks import DeleteHookContext
+                ctx = self._resolve_cred(context)
+                self._kernel.dispatch_post_hooks(
+                    "rmdir",
+                    RmdirHookContext(
+                        path=path,
+                        context=ctx,
+                        zone_id=zone_id,
+                        agent_id=agent_id,
+                        recursive=recursive,
+                        metadata=_pre_delete_meta,
+                    ),
+                )
+            else:
+                from nexus.contracts.vfs_hooks import DeleteHookContext
 
-                    self._kernel.dispatch_post_hooks(
-                        "delete",
-                        DeleteHookContext(
-                            path=path,
-                            context=context,
-                            zone_id=zone_id,
-                            agent_id=agent_id,
-                            metadata=_pre_delete_meta,
-                        ),
-                    )
+                self._kernel.dispatch_post_hooks(
+                    "delete",
+                    DeleteHookContext(
+                        path=path,
+                        context=context,
+                        zone_id=zone_id,
+                        agent_id=agent_id,
+                        metadata=_pre_delete_meta,
+                    ),
+                )
             if _unlink_result.entry_type == DT_MOUNT:
                 self._forget_mounted_backend_instance(path)
             emit_op_completed(

--- a/src/nexus/lib/rebac_filter.py
+++ b/src/nexus/lib/rebac_filter.py
@@ -37,6 +37,7 @@ def apply_rebac_filter(
     auth_result: dict[str, Any],
     zone_id: str,
     path_extractor: Any | None = None,
+    operation_context: Any | None = None,
 ) -> tuple[list[Any], float]:
     """Apply ReBAC file-level permission filtering to search results.
 
@@ -49,11 +50,16 @@ def apply_rebac_filter(
         zone_id: Zone ID for ReBAC scope.
         path_extractor: Callable ``(result) -> str`` that extracts the file
             path from a result element.  Defaults to ``lambda r: r.path``.
+        operation_context: Optional OperationContext.  When supplied, use the
+            same ``filter_list`` permission chain as filesystem list/read
+            operations so inherited directory grants behave identically.
     """
     if permission_enforcer is None:
         return results, 0.0
 
-    if not hasattr(permission_enforcer, "filter_search_results"):
+    use_filter_list = operation_context is not None and hasattr(permission_enforcer, "filter_list")
+    use_search_filter = hasattr(permission_enforcer, "filter_search_results")
+    if not use_filter_list and not use_search_filter:
         return results, 0.0
 
     if path_extractor is None:
@@ -75,12 +81,32 @@ def apply_rebac_filter(
             unique_abs_paths.append(abs_path)
 
     filter_start = time.perf_counter()
-    permitted_abs = permission_enforcer.filter_search_results(
-        unique_abs_paths,
-        user_id=user_id,
-        zone_id=zone_id,
-        is_admin=is_admin,
-    )
+    if use_filter_list:
+        permitted_abs = permission_enforcer.filter_list(unique_abs_paths, operation_context)
+        check_permission = getattr(permission_enforcer, "check", None)
+        if callable(check_permission):
+            permitted_set = set(permitted_abs)
+            denied_by_fast_path = [p for p in unique_abs_paths if p not in permitted_set]
+            if denied_by_fast_path:
+                from nexus.contracts.types import Permission
+
+                for denied_path in denied_by_fast_path:
+                    try:
+                        if check_permission(denied_path, Permission.READ, operation_context):
+                            permitted_abs.append(denied_path)
+                    except Exception:
+                        logger.debug(
+                            "[SEARCH-REBAC] exact read fallback denied %s",
+                            denied_path,
+                            exc_info=True,
+                        )
+    else:
+        permitted_abs = permission_enforcer.filter_search_results(
+            unique_abs_paths,
+            user_id=user_id,
+            zone_id=zone_id,
+            is_admin=is_admin,
+        )
     filter_ms = (time.perf_counter() - filter_start) * 1000
 
     logger.debug(

--- a/src/nexus/server/api/v2/routers/search.py
+++ b/src/nexus/server/api/v2/routers/search.py
@@ -36,7 +36,7 @@ from nexus.lib.rebac_filter import apply_rebac_filter as _apply_rebac_filter
 from nexus.lib.rebac_filter import compute_rebac_fetch_limit as _compute_rebac_fetch_limit
 from nexus.lib.rebac_filter import rebac_denial_stats as _rebac_denial_stats
 from nexus.runtime.zone_resolution import target_zone_for_context
-from nexus.server.dependencies import require_auth
+from nexus.server.dependencies import get_operation_context, require_auth
 from nexus.server.zone_execution import run_zone_scoped
 
 logger = logging.getLogger(__name__)
@@ -292,6 +292,7 @@ async def _handle_single_zone_search(
     # --- Standard single-zone search path ---
     # ReBAC file-level permission enforcer (Decision #17)
     permission_enforcer = getattr(request.app.state, "permission_enforcer", None)
+    op_context = get_operation_context(auth_result)
 
     routing_info: dict[str, Any] | None = None
     effective_graph_mode = graph_mode
@@ -358,7 +359,11 @@ async def _handle_single_zone_search(
             # ReBAC file-level filtering (Decision #17)
             pre_filter_count = len(results)
             results, filter_ms = _apply_rebac_filter(
-                results, permission_enforcer, auth_result, zone_id
+                results,
+                permission_enforcer,
+                auth_result,
+                zone_id,
+                operation_context=op_context,
             )
             post_filter_count = len(results)
             results = results[:effective_limit]
@@ -399,7 +404,13 @@ async def _handle_single_zone_search(
 
         # ReBAC file-level filtering (Decision #17)
         pre_filter_count = len(results)
-        results, filter_ms = _apply_rebac_filter(results, permission_enforcer, auth_result, zone_id)
+        results, filter_ms = _apply_rebac_filter(
+            results,
+            permission_enforcer,
+            auth_result,
+            zone_id,
+            operation_context=op_context,
+        )
         post_filter_count = len(results)
         results = results[:effective_limit]
 
@@ -595,6 +606,7 @@ async def search_query_batch(
 
     # Same ReBAC hook the single-query endpoint uses.
     permission_enforcer = getattr(request.app.state, "permission_enforcer", None)
+    op_context = get_operation_context(auth_result)
     overfetch_multiplier = 3 if permission_enforcer is not None else 1
 
     # Over-fetch per-query so ReBAC filtering does not strip us below the
@@ -624,7 +636,11 @@ async def search_query_batch(
     for q_spec, results, orig_limit in zip(raw_queries, raw_results, requested_limits, strict=True):
         # File-level ReBAC filtering (Decision #17) — same enforcement as /query.
         filtered, filter_ms = _apply_rebac_filter(
-            results, permission_enforcer, auth_result, zone_id
+            results,
+            permission_enforcer,
+            auth_result,
+            zone_id,
+            operation_context=op_context,
         )
         filter_ms_total += filter_ms
         trimmed = filtered[:orig_limit]
@@ -799,6 +815,7 @@ async def _do_grep_operation(
             auth_result,
             zone_id,
             path_extractor=lambda r: r.get("file", ""),
+            operation_context=op_context,
         )
         post_filter_count = len(filtered_results)
 
@@ -921,6 +938,7 @@ async def _do_glob_operation(
             auth_result,
             zone_id,
             path_extractor=lambda p: p,
+            operation_context=op_context,
         )
         post_filter_count = len(filtered_paths)
 
@@ -1982,6 +2000,7 @@ async def search_locate(
         permission_enforcer,
         auth_result,
         zone_id,
+        operation_context=get_operation_context(auth_result),
     )
 
     # Unpack back to dicts and truncate to effective_limit

--- a/src/nexus/storage/piped_record_store_write_observer.py
+++ b/src/nexus/storage/piped_record_store_write_observer.py
@@ -44,6 +44,27 @@ def _metadata_from_dict(d: dict[str, Any]) -> Any:
     return FileMetadata(**d)
 
 
+def _metadata_content_id(metadata: Any | None) -> str | None:
+    if metadata is None:
+        return None
+    if isinstance(metadata, dict):
+        value = metadata.get("content_id")
+        return value if isinstance(value, str) else None
+    value = getattr(metadata, "content_id", None)
+    return value if isinstance(value, str) else None
+
+
+def _metadata_snapshot(metadata: Any | None) -> dict[str, Any] | None:
+    if metadata is None:
+        return None
+    if isinstance(metadata, dict):
+        return metadata
+    if hasattr(metadata, "to_dict"):
+        snapshot = metadata.to_dict()
+        return snapshot if isinstance(snapshot, dict) else None
+    return None
+
+
 class RecordStoreWriteObserver:
     """OBSERVE-phase observer for RecordStore audit trail + versioning.
 
@@ -180,10 +201,8 @@ class RecordStoreWriteObserver:
                 "path": path,
                 "zone_id": zone_id,
                 "agent_id": agent_id,
-                "snapshot_hash": metadata.content_id if metadata else None,
-                "metadata_snapshot": metadata.to_dict()
-                if metadata and hasattr(metadata, "to_dict")
-                else None,
+                "snapshot_hash": _metadata_content_id(metadata),
+                "metadata_snapshot": _metadata_snapshot(metadata),
             }
         )
 
@@ -204,10 +223,8 @@ class RecordStoreWriteObserver:
                 "new_path": new_path,
                 "zone_id": zone_id,
                 "agent_id": agent_id,
-                "snapshot_hash": metadata.content_id if metadata else None,
-                "metadata_snapshot": metadata.to_dict()
-                if metadata and hasattr(metadata, "to_dict")
-                else None,
+                "snapshot_hash": _metadata_content_id(metadata),
+                "metadata_snapshot": _metadata_snapshot(metadata),
             }
         )
 

--- a/tests/unit/bricks/search/test_daemon_delete_notify.py
+++ b/tests/unit/bricks/search/test_daemon_delete_notify.py
@@ -1,0 +1,33 @@
+"""SearchDaemon delete notification regressions."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_notify_file_change_delete_prunes_indexes_immediately() -> None:
+    """Delete hooks should hide removed files without waiting for debounce."""
+    from nexus.bricks.search.daemon import SearchDaemon
+
+    daemon = SearchDaemon.__new__(SearchDaemon)
+    daemon.config = SimpleNamespace(refresh_enabled=True)
+    daemon._mutation_resolver = None
+    daemon._pending_refresh_paths = {"/workspace/demo/delete-test.md"}
+    daemon._pending_delete_paths = set()
+    daemon._mutation_wakeup = asyncio.Event()
+    daemon._delete_indexes_for_paths = AsyncMock()
+
+    await SearchDaemon.notify_file_change(
+        daemon,
+        "/workspace/demo/delete-test.md",
+        "delete",
+    )
+
+    daemon._delete_indexes_for_paths.assert_awaited_once_with(["/workspace/demo/delete-test.md"])
+    assert "/workspace/demo/delete-test.md" in daemon._pending_delete_paths
+    assert "/workspace/demo/delete-test.md" not in daemon._pending_refresh_paths

--- a/tests/unit/core/test_nexus_fs_unlink_hooks.py
+++ b/tests/unit/core/test_nexus_fs_unlink_hooks.py
@@ -1,0 +1,53 @@
+"""Regression coverage for sys_unlink post-hook dispatch."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+
+def test_sys_unlink_dispatches_delete_post_hooks_even_when_kernel_flag_is_false() -> None:
+    """Python VFS hooks are authoritative for audit/search delete propagation."""
+    from nexus.core.nexus_fs_metadata import MetadataMixin
+
+    class _Kernel:
+        def __init__(self) -> None:
+            self.dispatch_post_hooks = MagicMock()
+
+        def sys_stat(self, path: str, zone_id: str) -> dict[str, object]:
+            return {"path": path, "zone_id": zone_id, "content_id": "cid"}
+
+        def sys_unlink(self, path: str, rust_ctx: object, recursive: bool) -> SimpleNamespace:
+            return SimpleNamespace(
+                hit=True,
+                entry_type=0,
+                post_hook_needed=False,
+                content_id="cid",
+                size=3,
+            )
+
+    class _FS(MetadataMixin):
+        def __init__(self) -> None:
+            self._kernel = _Kernel()
+            self._hook_specs = {}
+
+        def _prepare_rust_ctx(self, _context: object) -> tuple[str, None, bool, object]:
+            return ("root", None, False, object())
+
+        def _resolve_cred(self, context: object) -> object:
+            return context
+
+        def resolve_delete(self, _path: str, *, context: object) -> tuple[bool, object | None]:
+            return (False, None)
+
+        def _forget_mounted_backend_instance(self, _path: str) -> None:
+            return None
+
+    fs = _FS()
+
+    assert fs.sys_unlink("/workspace/demo/delete-test.md") == {}
+
+    fs._kernel.dispatch_post_hooks.assert_called_once()
+    op_name, hook_ctx = fs._kernel.dispatch_post_hooks.call_args.args
+    assert op_name == "delete"
+    assert hook_ctx.path == "/workspace/demo/delete-test.md"

--- a/tests/unit/server/routers/test_search_rebac_filter.py
+++ b/tests/unit/server/routers/test_search_rebac_filter.py
@@ -238,6 +238,71 @@ class TestApplyRebacFilterBehaviour:
         call = enforcer.filter_search_results.call_args
         assert call.args[0] == ["/a.py"]
 
+    def test_operation_context_uses_filter_list_for_inherited_directory_grants(self) -> None:
+        """Search filtering must match list/read inheritance semantics.
+
+        ``filter_search_results`` checks only exact paths; ``filter_list``
+        runs the full strategy chain, including directory inheritance.
+        """
+        results = [
+            _StubResult("/workspace/demo/herb/customers/cust-002.md", marker="inherited"),
+            _StubResult("/workspace/private/secret.md", marker="denied"),
+        ]
+        op_context = object()
+        enforcer = MagicMock()
+        enforcer.filter_list = MagicMock(
+            return_value=["/workspace/demo/herb/customers/cust-002.md"]
+        )
+        enforcer.filter_search_results = MagicMock(return_value=[])
+        enforcer.check = None
+
+        filtered, _ = _apply_rebac_filter(
+            results=results,
+            permission_enforcer=enforcer,
+            auth_result=_auth(),
+            zone_id=ROOT_ZONE_ID,
+            operation_context=op_context,
+        )
+
+        assert [r.marker for r in filtered] == ["inherited"]
+        enforcer.filter_list.assert_called_once_with(
+            [
+                "/workspace/demo/herb/customers/cust-002.md",
+                "/workspace/private/secret.md",
+            ],
+            op_context,
+        )
+        enforcer.filter_search_results.assert_not_called()
+
+    def test_operation_context_falls_back_to_exact_read_check_for_fast_path_denials(self) -> None:
+        """A stale or incomplete list fast path must not hide readable hits."""
+        results = [
+            _StubResult("/workspace/demo/herb/customers/cust-002.md", marker="granted"),
+            _StubResult("/workspace/private/secret.md", marker="denied"),
+        ]
+        op_context = object()
+        enforcer = MagicMock()
+        enforcer.filter_list = MagicMock(return_value=[])
+        enforcer.filter_search_results = MagicMock(return_value=[])
+
+        def exact_check(path: str, _permission: Any, context: Any) -> bool:
+            assert context is op_context
+            return path == "/workspace/demo/herb/customers/cust-002.md"
+
+        enforcer.check = MagicMock(side_effect=exact_check)
+
+        filtered, _ = _apply_rebac_filter(
+            results=results,
+            permission_enforcer=enforcer,
+            auth_result=_auth(),
+            zone_id=ROOT_ZONE_ID,
+            operation_context=op_context,
+        )
+
+        assert [r.marker for r in filtered] == ["granted"]
+        assert enforcer.check.call_count == 2
+        enforcer.filter_search_results.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # _apply_rebac_filter — auth_result extraction

--- a/tests/unit/storage/test_piped_record_store_write_observer.py
+++ b/tests/unit/storage/test_piped_record_store_write_observer.py
@@ -30,3 +30,26 @@ def test_on_write_accepts_dict_old_metadata_contract_shape() -> None:
     finally:
         if observer._timer is not None:
             observer._timer.cancel()
+
+
+def test_on_delete_accepts_dict_metadata_contract_shape() -> None:
+    observer = RecordStoreWriteObserver(FakeRecordStore(), debounce_seconds=60)
+    try:
+        observer.on_delete(
+            path="/workspace/report.csv",
+            metadata={"content_id": "old", "path": "/workspace/report.csv"},
+            zone_id="zone-a",
+            agent_id="agent-a",
+        )
+
+        with observer._lock:
+            event = observer._pending[-1]
+
+        assert event["snapshot_hash"] == "old"
+        assert event["metadata_snapshot"] == {
+            "content_id": "old",
+            "path": "/workspace/report.csv",
+        }
+    finally:
+        if observer._timer is not None:
+            observer._timer.cancel()


### PR DESCRIPTION
## Summary
- Route search, batch search, grep, glob, locate, and MCP search filtering through the filesystem ReBAC operation context so inherited directory grants match real read/list behavior.
- Dispatch delete/rmdir post-hooks for Rust-handled unlinks and prune search indexes immediately on delete notifications while retaining retry queueing.
- Accept dict-shaped delete metadata in the piped record-store observer to avoid crashing the delete hook path.
- Add regressions for inherited search filtering, exact read fallback, delete notification pruning, unlink post-hook dispatch, and dict metadata intake.

## Verification
- `PYTHONPATH=/Users/tafeng/.codex/worktrees/732c/nexus-followup-4135/src /Users/tafeng/.codex/worktrees/732c/nexus/.venv/bin/python -m pytest tests/unit/storage/test_piped_record_store_write_observer.py tests/unit/server/routers/test_search_rebac_filter.py tests/unit/core/test_nexus_fs_unlink_hooks.py tests/unit/bricks/search/test_daemon_delete_notify.py -q` -> 43 passed
- `scripts/test_build_perf_e2e.py` against live demo stack -> 25 passed, 0 failed; HERB 8/8, search p50 1132ms incl CLI, permission RPC p50 5.5ms p95 29.9ms, deleted file removed from search on first propagation check
- `permissions_demo_enhanced.sh` against live demo stack -> passed with script-declared non-blocking BUG #341 rename warnings; overall permission median 4.54ms, p95 75.48ms

## Notes
- PR #4189 is already merged, so this is a clean follow-up branch from current `origin/develop` containing only the new fix commit.
