### PR TITLE
[codex] add real E2E coverage for issue 4136

### DIFF
--- a/docs/architecture/api-rpc-surface-coverage.html
+++ b/docs/architecture/api-rpc-surface-coverage.html
@@ -1196,10 +1196,10 @@ graph TB
     <span>gap: &mdash;</span>
   </div>
 </div>
-<div class="op" data-op-id="auth.oauth" data-op-text="auth.oauth  nexus oauth ">
+<div class="op" data-op-id="auth.oauth" data-op-text="auth.oauth CLI command group for OAuth credential discovery, setup, validation, and revocation. nexus oauth ">
   <div class="op-header">
     <span class="op-id">auth.oauth</span>
-    <span class="op-summary">&mdash; (no summary yet)</span>
+    <span class="op-summary">&mdash; CLI command group for OAuth credential discovery, setup, validation, and revocation.</span>
   </div>
   <div class="transports">
     <span class="transport-pill" data-t="cli"><span class="label">CLI</span> <span>nexus oauth</span></span>
@@ -1210,10 +1210,10 @@ graph TB
 <span class="profile-badge profile-supported">sandbox</span>
 <span class="profile-badge profile-supported">full</span>
     </span>
-    <span>usage: <span class="todo">TODO</span></span>
-    <span>test: <span class="todo">TODO</span></span>
-    <span>perf: <span class="todo">TODO</span></span>
-    <span>owner: &mdash;</span>
+    <span>usage: <code>CLI: nexus oauth list; nexus oauth setup-gdrive --user-email alice@example.com; RPC: oauth_list_credentials/oauth_get_auth_url/oauth_exchange_code provide the same lifecycle.</code></span>
+    <span>test: <a href="../../tests/unit/cli/test_auth_cli.py; tests/unit/services/test_oauth_service.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py">tests/unit/cli/test_auth_cli.py; tests/unit/services/test_oauth_service.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py</a></span>
+    <span>perf: control</span>
+    <span>owner: <a href="https://github.com/nexi-lab/nexus/issues/4136">#4136</a></span>
     <span>gap: &mdash;</span>
   </div>
 </div>
@@ -1721,10 +1721,10 @@ graph TB
     <span>gap: &mdash;</span>
   </div>
 </div>
-<div class="op" data-op-id="connectors.auth_init" data-op-text="connectors.auth_init  POST /api/v2/connectors/auth/init ">
+<div class="op" data-op-id="connectors.auth_init" data-op-text="connectors.auth_init Start connector authentication flow and return the next OAuth or secret-collection step. POST /api/v2/connectors/auth/init ">
   <div class="op-header">
     <span class="op-id">connectors.auth_init</span>
-    <span class="op-summary">&mdash; (no summary yet)</span>
+    <span class="op-summary">&mdash; Start connector authentication flow and return the next OAuth or secret-collection step.</span>
   </div>
   <div class="transports">
     <span class="transport-pill" data-t="http"><span class="label">HTTP</span> <span>POST /api/v2/connectors/auth/init</span></span>
@@ -1735,17 +1735,17 @@ graph TB
 <span class="profile-badge profile-supported">sandbox</span>
 <span class="profile-badge profile-supported">full</span>
     </span>
-    <span>usage: <span class="todo">TODO</span></span>
-    <span>test: <span class="todo">TODO</span></span>
-    <span>perf: <span class="todo">TODO</span></span>
-    <span>owner: &mdash;</span>
+    <span>usage: <code>CLI: nexus oauth setup-gdrive --user-email alice@example.com; RPC: POST /api/v2/connectors/auth/init starts connector auth for UI clients.</code></span>
+    <span>test: <a href="../../tests/integration/services/test_connectors_auth.py; tests/unit/services/test_oauth_service.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py">tests/integration/services/test_connectors_auth.py; tests/unit/services/test_oauth_service.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py</a></span>
+    <span>perf: control</span>
+    <span>owner: <a href="https://github.com/nexi-lab/nexus/issues/4136">#4136</a></span>
     <span>gap: &mdash;</span>
   </div>
 </div>
-<div class="op" data-op-id="connectors.auth_status" data-op-text="connectors.auth_status  GET /api/v2/connectors/auth/status ">
+<div class="op" data-op-id="connectors.auth_status" data-op-text="connectors.auth_status Report whether a connector has usable stored, native, or missing credentials for the caller. GET /api/v2/connectors/auth/status ">
   <div class="op-header">
     <span class="op-id">connectors.auth_status</span>
-    <span class="op-summary">&mdash; (no summary yet)</span>
+    <span class="op-summary">&mdash; Report whether a connector has usable stored, native, or missing credentials for the caller.</span>
   </div>
   <div class="transports">
     <span class="transport-pill" data-t="http"><span class="label">HTTP</span> <span>GET /api/v2/connectors/auth/status</span></span>
@@ -1756,10 +1756,10 @@ graph TB
 <span class="profile-badge profile-supported">sandbox</span>
 <span class="profile-badge profile-supported">full</span>
     </span>
-    <span>usage: <span class="todo">TODO</span></span>
-    <span>test: <span class="todo">TODO</span></span>
-    <span>perf: <span class="todo">TODO</span></span>
-    <span>owner: &mdash;</span>
+    <span>usage: <code>CLI: nexus oauth test google alice@example.com; RPC: GET /api/v2/connectors/auth/status reports authed, expired, missing, or unavailable states.</code></span>
+    <span>test: <a href="../../tests/integration/services/test_connectors_auth.py; tests/unit/auth/test_unified_service.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py">tests/integration/services/test_connectors_auth.py; tests/unit/auth/test_unified_service.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py</a></span>
+    <span>perf: control</span>
+    <span>owner: <a href="https://github.com/nexi-lab/nexus/issues/4136">#4136</a></span>
     <span>gap: &mdash;</span>
   </div>
 </div>
@@ -2225,10 +2225,10 @@ graph TB
     <span>gap: &mdash;</span>
   </div>
 </div>
-<div class="op" data-op-id="oauth.exchange_code" data-op-text="oauth.exchange_code  oauth_exchange_code ">
+<div class="op" data-op-id="oauth.exchange_code" data-op-text="oauth.exchange_code Exchange an OAuth authorization code for encrypted stored credentials scoped to user and zone. oauth_exchange_code ">
   <div class="op-header">
     <span class="op-id">oauth.exchange_code</span>
-    <span class="op-summary">&mdash; (no summary yet)</span>
+    <span class="op-summary">&mdash; Exchange an OAuth authorization code for encrypted stored credentials scoped to user and zone.</span>
   </div>
   <div class="transports">
     <span class="transport-pill" data-t="expose"><span class="label">expose</span> <span>oauth_exchange_code</span></span>
@@ -2239,17 +2239,17 @@ graph TB
 <span class="profile-badge profile-supported">sandbox</span>
 <span class="profile-badge profile-supported">full</span>
     </span>
-    <span>usage: <span class="todo">TODO</span></span>
-    <span>test: <span class="todo">TODO</span></span>
-    <span>perf: <span class="todo">TODO</span></span>
-    <span>owner: &mdash;</span>
+    <span>usage: <code>CLI: nexus oauth setup-gdrive --user-email alice@example.com completes code exchange; RPC: oauth_exchange_code(provider=&#34;google-drive&#34;, code=&#34;4/...&#34;, user_email=&#34;alice@example.com&#34;) stores the credential.</code></span>
+    <span>test: <a href="../../tests/unit/services/test_oauth_service.py; tests/e2e/server/test_extracted_services_e2e.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py">tests/unit/services/test_oauth_service.py; tests/e2e/server/test_extracted_services_e2e.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py</a></span>
+    <span>perf: control</span>
+    <span>owner: <a href="https://github.com/nexi-lab/nexus/issues/4136">#4136</a></span>
     <span>gap: &mdash;</span>
   </div>
 </div>
-<div class="op" data-op-id="oauth.get_auth_url" data-op-text="oauth.get_auth_url  oauth_get_auth_url ">
+<div class="op" data-op-id="oauth.get_auth_url" data-op-text="oauth.get_auth_url Create an OAuth authorization URL and PKCE state for a provider. oauth_get_auth_url ">
   <div class="op-header">
     <span class="op-id">oauth.get_auth_url</span>
-    <span class="op-summary">&mdash; (no summary yet)</span>
+    <span class="op-summary">&mdash; Create an OAuth authorization URL and PKCE state for a provider.</span>
   </div>
   <div class="transports">
     <span class="transport-pill" data-t="expose"><span class="label">expose</span> <span>oauth_get_auth_url</span></span>
@@ -2260,17 +2260,17 @@ graph TB
 <span class="profile-badge profile-supported">sandbox</span>
 <span class="profile-badge profile-supported">full</span>
     </span>
-    <span>usage: <span class="todo">TODO</span></span>
-    <span>test: <span class="todo">TODO</span></span>
-    <span>perf: <span class="todo">TODO</span></span>
-    <span>owner: &mdash;</span>
+    <span>usage: <code>CLI: nexus oauth setup-gdrive --user-email alice@example.com opens the provider flow; RPC: oauth_get_auth_url(provider=&#34;google-drive&#34;, redirect_uri=&#34;http://localhost:2026/oauth/callback&#34;) returns auth_url and state.</code></span>
+    <span>test: <a href="../../tests/unit/services/test_oauth_service.py; tests/e2e/server/test_extracted_services_e2e.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py">tests/unit/services/test_oauth_service.py; tests/e2e/server/test_extracted_services_e2e.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py</a></span>
+    <span>perf: control</span>
+    <span>owner: <a href="https://github.com/nexi-lab/nexus/issues/4136">#4136</a></span>
     <span>gap: &mdash;</span>
   </div>
 </div>
-<div class="op" data-op-id="oauth.list_credentials" data-op-text="oauth.list_credentials  oauth_list_credentials ">
+<div class="op" data-op-id="oauth.list_credentials" data-op-text="oauth.list_credentials List non-revoked OAuth credentials visible to the caller, with admin/user filtering. oauth_list_credentials ">
   <div class="op-header">
     <span class="op-id">oauth.list_credentials</span>
-    <span class="op-summary">&mdash; (no summary yet)</span>
+    <span class="op-summary">&mdash; List non-revoked OAuth credentials visible to the caller, with admin/user filtering.</span>
   </div>
   <div class="transports">
     <span class="transport-pill" data-t="expose"><span class="label">expose</span> <span>oauth_list_credentials</span></span>
@@ -2281,17 +2281,17 @@ graph TB
 <span class="profile-badge profile-supported">sandbox</span>
 <span class="profile-badge profile-supported">full</span>
     </span>
-    <span>usage: <span class="todo">TODO</span></span>
-    <span>test: <span class="todo">TODO</span></span>
-    <span>perf: <span class="todo">TODO</span></span>
-    <span>owner: &mdash;</span>
+    <span>usage: <code>CLI: nexus oauth list --zone-id org_acme; RPC: oauth_list_credentials(provider=&#34;google-drive&#34;) returns stored credential metadata without tokens.</code></span>
+    <span>test: <a href="../../tests/unit/services/test_oauth_service.py; tests/e2e/server/test_extracted_services_e2e.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py">tests/unit/services/test_oauth_service.py; tests/e2e/server/test_extracted_services_e2e.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py</a></span>
+    <span>perf: control</span>
+    <span>owner: <a href="https://github.com/nexi-lab/nexus/issues/4136">#4136</a></span>
     <span>gap: &mdash;</span>
   </div>
 </div>
-<div class="op" data-op-id="oauth.list_providers" data-op-text="oauth.list_providers  oauth_list_providers ">
+<div class="op" data-op-id="oauth.list_providers" data-op-text="oauth.list_providers List configured OAuth providers, scopes, PKCE requirements, and display metadata. oauth_list_providers ">
   <div class="op-header">
     <span class="op-id">oauth.list_providers</span>
-    <span class="op-summary">&mdash; (no summary yet)</span>
+    <span class="op-summary">&mdash; List configured OAuth providers, scopes, PKCE requirements, and display metadata.</span>
   </div>
   <div class="transports">
     <span class="transport-pill" data-t="expose"><span class="label">expose</span> <span>oauth_list_providers</span></span>
@@ -2302,17 +2302,17 @@ graph TB
 <span class="profile-badge profile-supported">sandbox</span>
 <span class="profile-badge profile-supported">full</span>
     </span>
-    <span>usage: <span class="todo">TODO</span></span>
-    <span>test: <span class="todo">TODO</span></span>
-    <span>perf: <span class="todo">TODO</span></span>
-    <span>owner: &mdash;</span>
+    <span>usage: <code>CLI: nexus oauth list shows stored credentials; RPC: oauth_list_providers() returns available OAuth provider definitions for setup UI.</code></span>
+    <span>test: <a href="../../tests/unit/services/test_oauth_service.py; tests/e2e/server/test_extracted_services_e2e.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py">tests/unit/services/test_oauth_service.py; tests/e2e/server/test_extracted_services_e2e.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py</a></span>
+    <span>perf: control</span>
+    <span>owner: <a href="https://github.com/nexi-lab/nexus/issues/4136">#4136</a></span>
     <span>gap: &mdash;</span>
   </div>
 </div>
-<div class="op" data-op-id="oauth.revoke_credential" data-op-text="oauth.revoke_credential  oauth_revoke_credential ">
+<div class="op" data-op-id="oauth.revoke_credential" data-op-text="oauth.revoke_credential Revoke a stored OAuth credential after ownership checks. oauth_revoke_credential ">
   <div class="op-header">
     <span class="op-id">oauth.revoke_credential</span>
-    <span class="op-summary">&mdash; (no summary yet)</span>
+    <span class="op-summary">&mdash; Revoke a stored OAuth credential after ownership checks.</span>
   </div>
   <div class="transports">
     <span class="transport-pill" data-t="expose"><span class="label">expose</span> <span>oauth_revoke_credential</span></span>
@@ -2323,17 +2323,17 @@ graph TB
 <span class="profile-badge profile-supported">sandbox</span>
 <span class="profile-badge profile-supported">full</span>
     </span>
-    <span>usage: <span class="todo">TODO</span></span>
-    <span>test: <span class="todo">TODO</span></span>
-    <span>perf: <span class="todo">TODO</span></span>
-    <span>owner: &mdash;</span>
+    <span>usage: <code>CLI: nexus oauth revoke google alice@example.com; RPC: oauth_revoke_credential(provider=&#34;google&#34;, user_email=&#34;alice@example.com&#34;) returns success=true.</code></span>
+    <span>test: <a href="../../tests/unit/services/test_oauth_service.py; tests/e2e/server/test_extracted_services_e2e.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py">tests/unit/services/test_oauth_service.py; tests/e2e/server/test_extracted_services_e2e.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py</a></span>
+    <span>perf: control</span>
+    <span>owner: <a href="https://github.com/nexi-lab/nexus/issues/4136">#4136</a></span>
     <span>gap: &mdash;</span>
   </div>
 </div>
-<div class="op" data-op-id="oauth.test_credential" data-op-text="oauth.test_credential  oauth_test_credential ">
+<div class="op" data-op-id="oauth.test_credential" data-op-text="oauth.test_credential Validate an OAuth credential and report whether it can be used or refreshed. oauth_test_credential ">
   <div class="op-header">
     <span class="op-id">oauth.test_credential</span>
-    <span class="op-summary">&mdash; (no summary yet)</span>
+    <span class="op-summary">&mdash; Validate an OAuth credential and report whether it can be used or refreshed.</span>
   </div>
   <div class="transports">
     <span class="transport-pill" data-t="expose"><span class="label">expose</span> <span>oauth_test_credential</span></span>
@@ -2344,10 +2344,10 @@ graph TB
 <span class="profile-badge profile-supported">sandbox</span>
 <span class="profile-badge profile-supported">full</span>
     </span>
-    <span>usage: <span class="todo">TODO</span></span>
-    <span>test: <span class="todo">TODO</span></span>
-    <span>perf: <span class="todo">TODO</span></span>
-    <span>owner: &mdash;</span>
+    <span>usage: <code>CLI: nexus oauth test google alice@example.com; RPC: oauth_test_credential(provider=&#34;google&#34;, user_email=&#34;alice@example.com&#34;) returns valid/error metadata.</code></span>
+    <span>test: <a href="../../tests/unit/services/test_oauth_service.py; tests/e2e/server/test_extracted_services_e2e.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py">tests/unit/services/test_oauth_service.py; tests/e2e/server/test_extracted_services_e2e.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py</a></span>
+    <span>perf: control</span>
+    <span>owner: <a href="https://github.com/nexi-lab/nexus/issues/4136">#4136</a></span>
     <span>gap: &mdash;</span>
   </div>
 </div>
@@ -6545,10 +6545,10 @@ graph TB
           </span>
         </summary>
         <div class="module-body">
-<div class="op" data-op-id="add.mount" data-op-text="add.mount  add_mount ">
+<div class="op" data-op-id="add.mount" data-op-text="add.mount Activate a backend connector under a Nexus virtual path and grant the creator owner permissions. add_mount ">
   <div class="op-header">
     <span class="op-id">add.mount</span>
-    <span class="op-summary">&mdash; (no summary yet)</span>
+    <span class="op-summary">&mdash; Activate a backend connector under a Nexus virtual path and grant the creator owner permissions.</span>
   </div>
   <div class="transports">
     <span class="transport-pill" data-t="expose"><span class="label">expose</span> <span>add_mount</span></span>
@@ -6559,17 +6559,17 @@ graph TB
 <span class="profile-badge profile-supported">sandbox</span>
 <span class="profile-badge profile-supported">full</span>
     </span>
-    <span>usage: <span class="todo">TODO</span></span>
-    <span>test: <span class="todo">TODO</span></span>
-    <span>perf: <span class="todo">TODO</span></span>
-    <span>owner: &mdash;</span>
+    <span>usage: <code>CLI: nexus mounts add /sources/hn hn &#39;{}&#39;; RPC: add_mount(mount_point=&#39;/sources/hn&#39;, backend_type=&#39;hn&#39;, backend_config={}) returns &#39;/sources/hn&#39;.</code></span>
+    <span>test: <a href="../../tests/unit/services/test_mount_service.py; tests/integration/services/test_connectors_router.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py">tests/unit/services/test_mount_service.py; tests/integration/services/test_connectors_router.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py</a></span>
+    <span>perf: control</span>
+    <span>owner: <a href="https://github.com/nexi-lab/nexus/issues/4136">#4136</a></span>
     <span>gap: &mdash;</span>
   </div>
 </div>
-<div class="op" data-op-id="connectors.api_v2" data-op-text="connectors.api_v2  GET /api/v2/connectors ">
+<div class="op" data-op-id="connectors.api_v2" data-op-text="connectors.api_v2 HTTP endpoint listing registered connector types and capabilities for mount selection. GET /api/v2/connectors ">
   <div class="op-header">
     <span class="op-id">connectors.api_v2</span>
-    <span class="op-summary">&mdash; (no summary yet)</span>
+    <span class="op-summary">&mdash; HTTP endpoint listing registered connector types and capabilities for mount selection.</span>
   </div>
   <div class="transports">
     <span class="transport-pill" data-t="http"><span class="label">HTTP</span> <span>GET /api/v2/connectors</span></span>
@@ -6580,17 +6580,17 @@ graph TB
 <span class="profile-badge profile-supported">sandbox</span>
 <span class="profile-badge profile-supported">full</span>
     </span>
-    <span>usage: <span class="todo">TODO</span></span>
-    <span>test: <span class="todo">TODO</span></span>
-    <span>perf: <span class="todo">TODO</span></span>
-    <span>owner: &mdash;</span>
+    <span>usage: <code>CLI: nexus connectors list --json; RPC: GET /api/v2/connectors returns connectors used by list_connectors(category).</code></span>
+    <span>test: <a href="../../tests/integration/services/test_connectors_router.py; tests/integration/services/test_connectors_auth.py; tests/unit/cli/test_json_contract.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py">tests/integration/services/test_connectors_router.py; tests/integration/services/test_connectors_auth.py; tests/unit/cli/test_json_contract.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py</a></span>
+    <span>perf: control</span>
+    <span>owner: <a href="https://github.com/nexi-lab/nexus/issues/4136">#4136</a></span>
     <span>gap: &mdash;</span>
   </div>
 </div>
-<div class="op" data-op-id="connectors.available" data-op-text="connectors.available  GET /api/v2/connectors/available ">
+<div class="op" data-op-id="connectors.available" data-op-text="connectors.available HTTP endpoint listing connectors with current auth status for the caller. GET /api/v2/connectors/available ">
   <div class="op-header">
     <span class="op-id">connectors.available</span>
-    <span class="op-summary">&mdash; (no summary yet)</span>
+    <span class="op-summary">&mdash; HTTP endpoint listing connectors with current auth status for the caller.</span>
   </div>
   <div class="transports">
     <span class="transport-pill" data-t="http"><span class="label">HTTP</span> <span>GET /api/v2/connectors/available</span></span>
@@ -6601,10 +6601,10 @@ graph TB
 <span class="profile-badge profile-supported">sandbox</span>
 <span class="profile-badge profile-supported">full</span>
     </span>
-    <span>usage: <span class="todo">TODO</span></span>
-    <span>test: <span class="todo">TODO</span></span>
-    <span>perf: <span class="todo">TODO</span></span>
-    <span>owner: &mdash;</span>
+    <span>usage: <code>CLI: nexus connectors list shows available types; RPC: GET /api/v2/connectors/available includes auth_status/auth_source for connector setup UI.</code></span>
+    <span>test: <a href="../../tests/integration/services/test_connectors_router.py; tests/integration/services/test_connectors_auth.py; tests/unit/cli/test_json_contract.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py">tests/integration/services/test_connectors_router.py; tests/integration/services/test_connectors_auth.py; tests/unit/cli/test_json_contract.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py</a></span>
+    <span>perf: control</span>
+    <span>owner: <a href="https://github.com/nexi-lab/nexus/issues/4136">#4136</a></span>
     <span>gap: &mdash;</span>
   </div>
 </div>
@@ -6629,10 +6629,10 @@ graph TB
     <span>gap: &mdash;</span>
   </div>
 </div>
-<div class="op" data-op-id="connectors.mount" data-op-text="connectors.mount  POST /api/v2/connectors/mount ">
+<div class="op" data-op-id="connectors.mount" data-op-text="connectors.mount HTTP connector mount endpoint used by the mounts CLI to attach an external backend path. POST /api/v2/connectors/mount ">
   <div class="op-header">
     <span class="op-id">connectors.mount</span>
-    <span class="op-summary">&mdash; (no summary yet)</span>
+    <span class="op-summary">&mdash; HTTP connector mount endpoint used by the mounts CLI to attach an external backend path.</span>
   </div>
   <div class="transports">
     <span class="transport-pill" data-t="http"><span class="label">HTTP</span> <span>POST /api/v2/connectors/mount</span></span>
@@ -6643,17 +6643,17 @@ graph TB
 <span class="profile-badge profile-supported">sandbox</span>
 <span class="profile-badge profile-supported">full</span>
     </span>
-    <span>usage: <span class="todo">TODO</span></span>
-    <span>test: <span class="todo">TODO</span></span>
-    <span>perf: <span class="todo">TODO</span></span>
-    <span>owner: &mdash;</span>
+    <span>usage: <code>CLI: nexus mounts add /sources/hn hn &#39;{}&#39;; RPC: POST /api/v2/connectors/mount with connector_type, mount_point, and config returns mounted=true.</code></span>
+    <span>test: <a href="../../tests/integration/services/test_connectors_router.py; tests/integration/services/test_connectors_auth.py; tests/unit/cli/test_json_contract.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py">tests/integration/services/test_connectors_router.py; tests/integration/services/test_connectors_auth.py; tests/unit/cli/test_json_contract.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py</a></span>
+    <span>perf: control</span>
+    <span>owner: <a href="https://github.com/nexi-lab/nexus/issues/4136">#4136</a></span>
     <span>gap: &mdash;</span>
   </div>
 </div>
-<div class="op" data-op-id="connectors.mounts" data-op-text="connectors.mounts  GET /api/v2/connectors/mounts ">
+<div class="op" data-op-id="connectors.mounts" data-op-text="connectors.mounts HTTP endpoint listing mounted connectors for remote CLI and UI clients. GET /api/v2/connectors/mounts ">
   <div class="op-header">
     <span class="op-id">connectors.mounts</span>
-    <span class="op-summary">&mdash; (no summary yet)</span>
+    <span class="op-summary">&mdash; HTTP endpoint listing mounted connectors for remote CLI and UI clients.</span>
   </div>
   <div class="transports">
     <span class="transport-pill" data-t="http"><span class="label">HTTP</span> <span>GET /api/v2/connectors/mounts</span></span>
@@ -6664,10 +6664,10 @@ graph TB
 <span class="profile-badge profile-supported">sandbox</span>
 <span class="profile-badge profile-supported">full</span>
     </span>
-    <span>usage: <span class="todo">TODO</span></span>
-    <span>test: <span class="todo">TODO</span></span>
-    <span>perf: <span class="todo">TODO</span></span>
-    <span>owner: &mdash;</span>
+    <span>usage: <code>CLI: nexus mounts list --json; RPC: GET /api/v2/connectors/mounts returns mounted connector records.</code></span>
+    <span>test: <a href="../../tests/integration/services/test_connectors_router.py; tests/integration/services/test_connectors_auth.py; tests/unit/cli/test_json_contract.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py">tests/integration/services/test_connectors_router.py; tests/integration/services/test_connectors_auth.py; tests/unit/cli/test_json_contract.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py</a></span>
+    <span>perf: control</span>
+    <span>owner: <a href="https://github.com/nexi-lab/nexus/issues/4136">#4136</a></span>
     <span>gap: &mdash;</span>
   </div>
 </div>
@@ -6776,10 +6776,10 @@ graph TB
     <span>gap: &mdash;</span>
   </div>
 </div>
-<div class="op" data-op-id="connectors.unmount" data-op-text="connectors.unmount  POST /api/v2/connectors/unmount ">
+<div class="op" data-op-id="connectors.unmount" data-op-text="connectors.unmount HTTP endpoint used by the mounts CLI to remove an active connector mount. POST /api/v2/connectors/unmount ">
   <div class="op-header">
     <span class="op-id">connectors.unmount</span>
-    <span class="op-summary">&mdash; (no summary yet)</span>
+    <span class="op-summary">&mdash; HTTP endpoint used by the mounts CLI to remove an active connector mount.</span>
   </div>
   <div class="transports">
     <span class="transport-pill" data-t="http"><span class="label">HTTP</span> <span>POST /api/v2/connectors/unmount</span></span>
@@ -6790,10 +6790,10 @@ graph TB
 <span class="profile-badge profile-supported">sandbox</span>
 <span class="profile-badge profile-supported">full</span>
     </span>
-    <span>usage: <span class="todo">TODO</span></span>
-    <span>test: <span class="todo">TODO</span></span>
-    <span>perf: <span class="todo">TODO</span></span>
-    <span>owner: &mdash;</span>
+    <span>usage: <code>CLI: nexus mounts remove /sources/hn; RPC: POST /api/v2/connectors/unmount removes the mount_point.</code></span>
+    <span>test: <a href="../../tests/integration/services/test_connectors_router.py; tests/integration/services/test_connectors_auth.py; tests/unit/cli/test_json_contract.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py">tests/integration/services/test_connectors_router.py; tests/integration/services/test_connectors_auth.py; tests/unit/cli/test_json_contract.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py</a></span>
+    <span>perf: control</span>
+    <span>owner: <a href="https://github.com/nexi-lab/nexus/issues/4136">#4136</a></span>
     <span>gap: &mdash;</span>
   </div>
 </div>
@@ -6881,10 +6881,10 @@ graph TB
     <span>gap: &mdash;</span>
   </div>
 </div>
-<div class="op" data-op-id="delete.saved_mount" data-op-text="delete.saved_mount  delete_saved_mount ">
+<div class="op" data-op-id="delete.saved_mount" data-op-text="delete.saved_mount Delete persisted mount configuration without necessarily deactivating an active runtime mount. delete_saved_mount ">
   <div class="op-header">
     <span class="op-id">delete.saved_mount</span>
-    <span class="op-summary">&mdash; (no summary yet)</span>
+    <span class="op-summary">&mdash; Delete persisted mount configuration without necessarily deactivating an active runtime mount.</span>
   </div>
   <div class="transports">
     <span class="transport-pill" data-t="expose"><span class="label">expose</span> <span>delete_saved_mount</span></span>
@@ -6895,10 +6895,10 @@ graph TB
 <span class="profile-badge profile-supported">sandbox</span>
 <span class="profile-badge profile-supported">full</span>
     </span>
-    <span>usage: <span class="todo">TODO</span></span>
-    <span>test: <span class="todo">TODO</span></span>
-    <span>perf: <span class="todo">TODO</span></span>
-    <span>owner: &mdash;</span>
+    <span>usage: <code>CLI: no dedicated saved-delete command yet, use nexus mounts remove for runtime cleanup; RPC: delete_saved_mount(mount_point=&#34;/sources/hn&#34;) removes stored config.</code></span>
+    <span>test: <a href="../../tests/unit/services/test_mount_service.py; tests/integration/services/test_connectors_router.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py">tests/unit/services/test_mount_service.py; tests/integration/services/test_connectors_router.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py</a></span>
+    <span>perf: control</span>
+    <span>owner: <a href="https://github.com/nexi-lab/nexus/issues/4136">#4136</a></span>
     <span>gap: &mdash;</span>
   </div>
 </div>
@@ -7029,10 +7029,10 @@ graph TB
     <span>gap: &mdash;</span>
   </div>
 </div>
-<div class="op" data-op-id="list.connectors" data-op-text="list.connectors  list_connectors ">
+<div class="op" data-op-id="list.connectors" data-op-text="list.connectors List connector backend types available for dynamic mounts, optionally filtered by category. list_connectors ">
   <div class="op-header">
     <span class="op-id">list.connectors</span>
-    <span class="op-summary">&mdash; (no summary yet)</span>
+    <span class="op-summary">&mdash; List connector backend types available for dynamic mounts, optionally filtered by category.</span>
   </div>
   <div class="transports">
     <span class="transport-pill" data-t="expose"><span class="label">expose</span> <span>list_connectors</span></span>
@@ -7043,17 +7043,17 @@ graph TB
 <span class="profile-badge profile-supported">sandbox</span>
 <span class="profile-badge profile-supported">full</span>
     </span>
-    <span>usage: <span class="todo">TODO</span></span>
-    <span>test: <span class="todo">TODO</span></span>
-    <span>perf: <span class="todo">TODO</span></span>
-    <span>owner: &mdash;</span>
+    <span>usage: <code>CLI: nexus connectors list --category api --json; RPC: list_connectors(category=&#34;api&#34;) returns connector metadata and user_scoped flags.</code></span>
+    <span>test: <a href="../../tests/integration/services/test_connectors_router.py; tests/integration/services/test_connectors_auth.py; tests/unit/cli/test_json_contract.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py">tests/integration/services/test_connectors_router.py; tests/integration/services/test_connectors_auth.py; tests/unit/cli/test_json_contract.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py</a></span>
+    <span>perf: control</span>
+    <span>owner: <a href="https://github.com/nexi-lab/nexus/issues/4136">#4136</a></span>
     <span>gap: &mdash;</span>
   </div>
 </div>
-<div class="op" data-op-id="list.mounts" data-op-text="list.mounts  list_mounts MCPClient.list_mounts ">
+<div class="op" data-op-id="list.mounts" data-op-text="list.mounts List active backend mounts visible to the caller after permission filtering. list_mounts MCPClient.list_mounts ">
   <div class="op-header">
     <span class="op-id">list.mounts</span>
-    <span class="op-summary">&mdash; (no summary yet)</span>
+    <span class="op-summary">&mdash; List active backend mounts visible to the caller after permission filtering.</span>
   </div>
   <div class="transports">
     <span class="transport-pill" data-t="expose"><span class="label">expose</span> <span>list_mounts</span></span>
@@ -7065,10 +7065,10 @@ graph TB
 <span class="profile-badge profile-supported">sandbox</span>
 <span class="profile-badge profile-supported">full</span>
     </span>
-    <span>usage: <span class="todo">TODO</span></span>
-    <span>test: <span class="todo">TODO</span></span>
-    <span>perf: <span class="todo">TODO</span></span>
-    <span>owner: &mdash;</span>
+    <span>usage: <code>CLI: nexus mounts list --json; RPC: list_mounts() returns [{&#34;mount_point&#34;: &#34;/sources/hn&#34;}] for visible mounts.</code></span>
+    <span>test: <a href="../../tests/unit/services/test_mount_service.py; tests/integration/services/test_connectors_router.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py">tests/unit/services/test_mount_service.py; tests/integration/services/test_connectors_router.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py</a></span>
+    <span>perf: control</span>
+    <span>owner: <a href="https://github.com/nexi-lab/nexus/issues/4136">#4136</a></span>
     <span>gap: &mdash;</span>
   </div>
 </div>
@@ -7093,10 +7093,10 @@ graph TB
     <span>gap: &mdash;</span>
   </div>
 </div>
-<div class="op" data-op-id="load.mount" data-op-text="load.mount  load_mount ">
+<div class="op" data-op-id="load.mount" data-op-text="load.mount Load a saved mount configuration and activate it through the normal add_mount path. load_mount ">
   <div class="op-header">
     <span class="op-id">load.mount</span>
-    <span class="op-summary">&mdash; (no summary yet)</span>
+    <span class="op-summary">&mdash; Load a saved mount configuration and activate it through the normal add_mount path.</span>
   </div>
   <div class="transports">
     <span class="transport-pill" data-t="expose"><span class="label">expose</span> <span>load_mount</span></span>
@@ -7107,17 +7107,17 @@ graph TB
 <span class="profile-badge profile-supported">sandbox</span>
 <span class="profile-badge profile-supported">full</span>
     </span>
-    <span>usage: <span class="todo">TODO</span></span>
-    <span>test: <span class="todo">TODO</span></span>
-    <span>perf: <span class="todo">TODO</span></span>
-    <span>owner: &mdash;</span>
+    <span>usage: <code>CLI: no dedicated saved-load command yet, use nexus mounts add for normal UX; RPC: load_mount(mount_point=&#34;/sources/hn&#34;) activates stored config.</code></span>
+    <span>test: <a href="../../tests/unit/services/test_mount_service.py; tests/integration/services/test_connectors_router.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py">tests/unit/services/test_mount_service.py; tests/integration/services/test_connectors_router.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py</a></span>
+    <span>perf: control</span>
+    <span>owner: <a href="https://github.com/nexi-lab/nexus/issues/4136">#4136</a></span>
     <span>gap: &mdash;</span>
   </div>
 </div>
-<div class="op" data-op-id="mount.connectors" data-op-text="mount.connectors  nexus connectors ">
+<div class="op" data-op-id="mount.connectors" data-op-text="mount.connectors CLI command group for discovering connector types before mounting external sources. nexus connectors ">
   <div class="op-header">
     <span class="op-id">mount.connectors</span>
-    <span class="op-summary">&mdash; (no summary yet)</span>
+    <span class="op-summary">&mdash; CLI command group for discovering connector types before mounting external sources.</span>
   </div>
   <div class="transports">
     <span class="transport-pill" data-t="cli"><span class="label">CLI</span> <span>nexus connectors</span></span>
@@ -7128,10 +7128,10 @@ graph TB
 <span class="profile-badge profile-supported">sandbox</span>
 <span class="profile-badge profile-supported">full</span>
     </span>
-    <span>usage: <span class="todo">TODO</span></span>
-    <span>test: <span class="todo">TODO</span></span>
-    <span>perf: <span class="todo">TODO</span></span>
-    <span>owner: &mdash;</span>
+    <span>usage: <code>CLI: nexus connectors list --category api; RPC: list_connectors(category=&#34;api&#34;) returns the same connector inventory shape.</code></span>
+    <span>test: <a href="../../tests/integration/services/test_connectors_router.py; tests/integration/services/test_connectors_auth.py; tests/unit/cli/test_json_contract.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py">tests/integration/services/test_connectors_router.py; tests/integration/services/test_connectors_auth.py; tests/unit/cli/test_json_contract.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py</a></span>
+    <span>perf: control</span>
+    <span>owner: <a href="https://github.com/nexi-lab/nexus/issues/4136">#4136</a></span>
     <span>gap: &mdash;</span>
   </div>
 </div>
@@ -7156,10 +7156,10 @@ graph TB
     <span>gap: &mdash;</span>
   </div>
 </div>
-<div class="op" data-op-id="mount.mounts" data-op-text="mount.mounts  nexus mounts ">
+<div class="op" data-op-id="mount.mounts" data-op-text="mount.mounts CLI command group for connector mount lifecycle: add, list, info, remove, update, and reauth. nexus mounts ">
   <div class="op-header">
     <span class="op-id">mount.mounts</span>
-    <span class="op-summary">&mdash; (no summary yet)</span>
+    <span class="op-summary">&mdash; CLI command group for connector mount lifecycle: add, list, info, remove, update, and reauth.</span>
   </div>
   <div class="transports">
     <span class="transport-pill" data-t="cli"><span class="label">CLI</span> <span>nexus mounts</span></span>
@@ -7170,10 +7170,10 @@ graph TB
 <span class="profile-badge profile-supported">sandbox</span>
 <span class="profile-badge profile-supported">full</span>
     </span>
-    <span>usage: <span class="todo">TODO</span></span>
-    <span>test: <span class="todo">TODO</span></span>
-    <span>perf: <span class="todo">TODO</span></span>
-    <span>owner: &mdash;</span>
+    <span>usage: <code>CLI: nexus mounts add /sources/hn hn &#39;{}&#39; &amp;&amp; nexus mounts list --json; RPC: add_mount/list_mounts/remove_mount provide the equivalent lifecycle.</code></span>
+    <span>test: <a href="../../tests/unit/services/test_mount_service.py; tests/integration/services/test_connectors_router.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py">tests/unit/services/test_mount_service.py; tests/integration/services/test_connectors_router.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py</a></span>
+    <span>perf: control</span>
+    <span>owner: <a href="https://github.com/nexi-lab/nexus/issues/4136">#4136</a></span>
     <span>gap: &mdash;</span>
   </div>
 </div>
@@ -7261,10 +7261,10 @@ graph TB
     <span>gap: &mdash;</span>
   </div>
 </div>
-<div class="op" data-op-id="reauth.mount" data-op-text="reauth.mount  reauth_mount ">
+<div class="op" data-op-id="reauth.mount" data-op-text="reauth.mount Refresh or rotate OAuth credentials for a mounted connector when a runtime backend supports token refresh. reauth_mount ">
   <div class="op-header">
     <span class="op-id">reauth.mount</span>
-    <span class="op-summary">&mdash; (no summary yet)</span>
+    <span class="op-summary">&mdash; Refresh or rotate OAuth credentials for a mounted connector when a runtime backend supports token refresh.</span>
   </div>
   <div class="transports">
     <span class="transport-pill" data-t="expose"><span class="label">expose</span> <span>reauth_mount</span></span>
@@ -7275,17 +7275,17 @@ graph TB
 <span class="profile-badge profile-supported">sandbox</span>
 <span class="profile-badge profile-supported">full</span>
     </span>
-    <span>usage: <span class="todo">TODO</span></span>
-    <span>test: <span class="todo">TODO</span></span>
-    <span>perf: <span class="todo">TODO</span></span>
-    <span>owner: &mdash;</span>
+    <span>usage: <code>CLI: nexus mounts reauth /sources/drive --provider google --email alice@example.com; RPC: reauth_mount(mount_point=&#34;/sources/drive&#34;, provider=&#34;google&#34;, user_email=&#34;alice@example.com&#34;) refreshes or returns a stable unavailable error.</code></span>
+    <span>test: <a href="../../tests/unit/services/test_mount_service.py; tests/integration/services/test_connectors_router.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py">tests/unit/services/test_mount_service.py; tests/integration/services/test_connectors_router.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py</a></span>
+    <span>perf: control</span>
+    <span>owner: <a href="https://github.com/nexi-lab/nexus/issues/4136">#4136</a></span>
     <span>gap: &mdash;</span>
   </div>
 </div>
-<div class="op" data-op-id="remove.mount" data-op-text="remove.mount  remove_mount ">
+<div class="op" data-op-id="remove.mount" data-op-text="remove.mount Deactivate a backend mount and clean up routing, metadata, and permission tuples. remove_mount ">
   <div class="op-header">
     <span class="op-id">remove.mount</span>
-    <span class="op-summary">&mdash; (no summary yet)</span>
+    <span class="op-summary">&mdash; Deactivate a backend mount and clean up routing, metadata, and permission tuples.</span>
   </div>
   <div class="transports">
     <span class="transport-pill" data-t="expose"><span class="label">expose</span> <span>remove_mount</span></span>
@@ -7296,17 +7296,17 @@ graph TB
 <span class="profile-badge profile-supported">sandbox</span>
 <span class="profile-badge profile-supported">full</span>
     </span>
-    <span>usage: <span class="todo">TODO</span></span>
-    <span>test: <span class="todo">TODO</span></span>
-    <span>perf: <span class="todo">TODO</span></span>
-    <span>owner: &mdash;</span>
+    <span>usage: <code>CLI: nexus mounts remove /sources/hn; RPC: remove_mount(mount_point=&#39;/sources/hn&#39;) returns removal details with removed=true.</code></span>
+    <span>test: <a href="../../tests/unit/services/test_mount_service.py; tests/integration/services/test_connectors_router.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py">tests/unit/services/test_mount_service.py; tests/integration/services/test_connectors_router.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py</a></span>
+    <span>perf: control</span>
+    <span>owner: <a href="https://github.com/nexi-lab/nexus/issues/4136">#4136</a></span>
     <span>gap: &mdash;</span>
   </div>
 </div>
-<div class="op" data-op-id="save.mount" data-op-text="save.mount  save_mount ">
+<div class="op" data-op-id="save.mount" data-op-text="save.mount Persist a mount configuration so it can be loaded on demand or restored after restart. save_mount ">
   <div class="op-header">
     <span class="op-id">save.mount</span>
-    <span class="op-summary">&mdash; (no summary yet)</span>
+    <span class="op-summary">&mdash; Persist a mount configuration so it can be loaded on demand or restored after restart.</span>
   </div>
   <div class="transports">
     <span class="transport-pill" data-t="expose"><span class="label">expose</span> <span>save_mount</span></span>
@@ -7317,17 +7317,17 @@ graph TB
 <span class="profile-badge profile-supported">sandbox</span>
 <span class="profile-badge profile-supported">full</span>
     </span>
-    <span>usage: <span class="todo">TODO</span></span>
-    <span>test: <span class="todo">TODO</span></span>
-    <span>perf: <span class="todo">TODO</span></span>
-    <span>owner: &mdash;</span>
+    <span>usage: <code>CLI: nexus mounts add /sources/hn hn &#39;{}&#39; persists through the connector HTTP path; RPC: save_mount(&#39;/sources/hn&#39;, &#39;hn&#39;, {}) stores reusable config.</code></span>
+    <span>test: <a href="../../tests/unit/services/test_mount_service.py; tests/integration/services/test_connectors_router.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py">tests/unit/services/test_mount_service.py; tests/integration/services/test_connectors_router.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py</a></span>
+    <span>perf: control</span>
+    <span>owner: <a href="https://github.com/nexi-lab/nexus/issues/4136">#4136</a></span>
     <span>gap: &mdash;</span>
   </div>
 </div>
-<div class="op" data-op-id="update.mount" data-op-text="update.mount  update_mount ">
+<div class="op" data-op-id="update.mount" data-op-text="update.mount Attempt to update runtime mount backend configuration while preserving mount metadata and permissions. update_mount ">
   <div class="op-header">
     <span class="op-id">update.mount</span>
-    <span class="op-summary">&mdash; (no summary yet)</span>
+    <span class="op-summary">&mdash; Attempt to update runtime mount backend configuration while preserving mount metadata and permissions.</span>
   </div>
   <div class="transports">
     <span class="transport-pill" data-t="expose"><span class="label">expose</span> <span>update_mount</span></span>
@@ -7338,10 +7338,10 @@ graph TB
 <span class="profile-badge profile-supported">sandbox</span>
 <span class="profile-badge profile-supported">full</span>
     </span>
-    <span>usage: <span class="todo">TODO</span></span>
-    <span>test: <span class="todo">TODO</span></span>
-    <span>perf: <span class="todo">TODO</span></span>
-    <span>owner: &mdash;</span>
+    <span>usage: <code>CLI: nexus mounts update /sources/crm &#39;{&#34;api_url&#34;:&#34;https://crm-v2.internal&#34;}&#39;; RPC: update_mount(&#39;/sources/crm&#39;, {&#39;api_url&#39;: &#39;https://crm-v2.internal&#39;}) returns changed_keys or a stable no-change result.</code></span>
+    <span>test: <a href="../../tests/unit/services/test_mount_service.py; tests/integration/services/test_connectors_router.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py">tests/unit/services/test_mount_service.py; tests/integration/services/test_connectors_router.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py</a></span>
+    <span>perf: control</span>
+    <span>owner: <a href="https://github.com/nexi-lab/nexus/issues/4136">#4136</a></span>
     <span>gap: &mdash;</span>
   </div>
 </div>
@@ -9691,64 +9691,64 @@ graph TB
     <span>gap: &mdash;</span>
   </div>
 </div>
-<div class="op" data-op-id="mcp.connect" data-op-text="mcp.connect  mcp_connect ">
+<div class="op" data-op-id="mcp.connect" data-op-text="mcp.connect Create a hosted MCP provider connection, reusing stored OAuth credentials when possible. mcp_connect ">
   <div class="op-header">
     <span class="op-id">mcp.connect</span>
-    <span class="op-summary">&mdash; (no summary yet)</span>
+    <span class="op-summary">&mdash; Create a hosted MCP provider connection, reusing stored OAuth credentials when possible.</span>
   </div>
   <div class="transports">
     <span class="transport-pill" data-t="expose"><span class="label">expose</span> <span>mcp_connect</span></span>
   </div>
   <div class="meta-row">
     <span class="profiles">
-<span class="profile-badge profile-supported">lite</span>
+<span class="profile-badge profile-unavailable">lite</span>
 <span class="profile-badge profile-supported">sandbox</span>
 <span class="profile-badge profile-supported">full</span>
     </span>
-    <span>usage: <span class="todo">TODO</span></span>
-    <span>test: <span class="todo">TODO</span></span>
-    <span>perf: <span class="todo">TODO</span></span>
-    <span>owner: &mdash;</span>
+    <span>usage: <code>CLI: nexus mcp serve --transport http exposes the MCP frontend; RPC: mcp_connect(provider=&#34;google_drive&#34;, redirect_url=&#34;http://localhost:2026/oauth/callback&#34;) returns strata_url or oauth_url.</code></span>
+    <span>test: <a href="../../tests/unit/services/test_smoke.py; tests/unit/bricks/mcp/test_oauth_mappings.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py">tests/unit/services/test_smoke.py; tests/unit/bricks/mcp/test_oauth_mappings.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py</a></span>
+    <span>perf: setup</span>
+    <span>owner: <a href="https://github.com/nexi-lab/nexus/issues/4136">#4136</a></span>
     <span>gap: &mdash;</span>
   </div>
 </div>
-<div class="op" data-op-id="mcp.list_mounts" data-op-text="mcp.list_mounts  mcp_list_mounts ">
+<div class="op" data-op-id="mcp.list_mounts" data-op-text="mcp.list_mounts List configured MCP server mounts, optionally filtered by user/zone/system tier. mcp_list_mounts ">
   <div class="op-header">
     <span class="op-id">mcp.list_mounts</span>
-    <span class="op-summary">&mdash; (no summary yet)</span>
+    <span class="op-summary">&mdash; List configured MCP server mounts, optionally filtered by user/zone/system tier.</span>
   </div>
   <div class="transports">
     <span class="transport-pill" data-t="expose"><span class="label">expose</span> <span>mcp_list_mounts</span></span>
   </div>
   <div class="meta-row">
     <span class="profiles">
-<span class="profile-badge profile-supported">lite</span>
+<span class="profile-badge profile-unavailable">lite</span>
 <span class="profile-badge profile-supported">sandbox</span>
 <span class="profile-badge profile-supported">full</span>
     </span>
-    <span>usage: <span class="todo">TODO</span></span>
-    <span>test: <span class="todo">TODO</span></span>
-    <span>perf: <span class="todo">TODO</span></span>
-    <span>owner: &mdash;</span>
+    <span>usage: <code>CLI: nexus mcp serve --transport http then MCP clients can inspect mounted tools; RPC: mcp_list_mounts(include_unmounted=true, tier=&#34;system&#34;) returns mount metadata.</code></span>
+    <span>test: <a href="../../tests/unit/server/api/v2/test_mcp_router.py; tests/e2e/server/test_extracted_services_e2e.py; tests/e2e/self_contained/mcp/test_mcp_http_audit.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py">tests/unit/server/api/v2/test_mcp_router.py; tests/e2e/server/test_extracted_services_e2e.py; tests/e2e/self_contained/mcp/test_mcp_http_audit.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py</a></span>
+    <span>perf: control</span>
+    <span>owner: <a href="https://github.com/nexi-lab/nexus/issues/4136">#4136</a></span>
     <span>gap: &mdash;</span>
   </div>
 </div>
-<div class="op" data-op-id="mcp.list_tools" data-op-text="mcp.list_tools List mounted MCP tools; the sandbox tool namespace middleware filters the visible set by ReBAC /tools/... grants. mcp_list_tools ">
+<div class="op" data-op-id="mcp.list_tools" data-op-text="mcp.list_tools List mounted MCP tools; the tool namespace middleware filters the visible set by ReBAC /tools/... grants. mcp_list_tools ">
   <div class="op-header">
     <span class="op-id">mcp.list_tools</span>
-    <span class="op-summary">&mdash; List mounted MCP tools; the sandbox tool namespace middleware filters the visible set by ReBAC /tools/... grants.</span>
+    <span class="op-summary">&mdash; List mounted MCP tools; the tool namespace middleware filters the visible set by ReBAC /tools/... grants.</span>
   </div>
   <div class="transports">
     <span class="transport-pill" data-t="expose"><span class="label">expose</span> <span>mcp_list_tools</span></span>
   </div>
   <div class="meta-row">
     <span class="profiles">
-<span class="profile-badge profile-supported">lite</span>
+<span class="profile-badge profile-unavailable">lite</span>
 <span class="profile-badge profile-supported">sandbox</span>
 <span class="profile-badge profile-supported">full</span>
     </span>
-    <span>usage: <code>RPC/MCP: mcp_list_tools(&#34;github&#34;) or MCP tools/list returns only tools visible to the current subject after profile grants are materialized.</code></span>
-    <span>test: <a href="../../tests/unit/bricks/mcp/test_tool_namespace_middleware.py::TestProfileGrantIntegration::test_profile_grants_drive_list_filtering_and_call_denial">tests/unit/bricks/mcp/test_tool_namespace_middleware.py::TestProfileGrantIntegration::test_profile_grants_drive_list_filtering_and_call_denial</a></span>
+    <span>usage: <code>CLI: nexus mcp serve --transport http exposes tools/list to MCP clients; RPC: mcp_list_tools(&#34;github&#34;) returns only tools visible to the current subject after profile grants are materialized.</code></span>
+    <span>test: <a href="../../tests/unit/bricks/mcp/test_tool_namespace_middleware.py::TestProfileGrantIntegration::test_profile_grants_drive_list_filtering_and_call_denial; tests/e2e/self_contained/mcp/test_mcp_http_audit.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py">tests/unit/bricks/mcp/test_tool_namespace_middleware.py::TestProfileGrantIntegration::test_profile_grants_drive_list_filtering_and_call_denial; tests/e2e/self_contained/mcp/test_mcp_http_audit.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py</a></span>
     <span>perf: hot</span>
     <span>owner: <a href="https://github.com/nexi-lab/nexus/issues/4128">#4128</a></span>
     <span>gap: &mdash;</span>
@@ -9775,45 +9775,45 @@ graph TB
     <span>gap: &mdash;</span>
   </div>
 </div>
-<div class="op" data-op-id="mcp.mount" data-op-text="mcp.mount  mcp_mount ">
+<div class="op" data-op-id="mcp.mount" data-op-text="mcp.mount Mount an external MCP server over stdio, SSE, HTTP, or Klavis and discover its tools. mcp_mount ">
   <div class="op-header">
     <span class="op-id">mcp.mount</span>
-    <span class="op-summary">&mdash; (no summary yet)</span>
+    <span class="op-summary">&mdash; Mount an external MCP server over stdio, SSE, HTTP, or Klavis and discover its tools.</span>
   </div>
   <div class="transports">
     <span class="transport-pill" data-t="expose"><span class="label">expose</span> <span>mcp_mount</span></span>
   </div>
   <div class="meta-row">
     <span class="profiles">
-<span class="profile-badge profile-supported">lite</span>
+<span class="profile-badge profile-unavailable">lite</span>
 <span class="profile-badge profile-supported">sandbox</span>
 <span class="profile-badge profile-supported">full</span>
     </span>
-    <span>usage: <span class="todo">TODO</span></span>
-    <span>test: <span class="todo">TODO</span></span>
-    <span>perf: <span class="todo">TODO</span></span>
-    <span>owner: &mdash;</span>
+    <span>usage: <code>CLI: nexus mcp serve exposes the frontend while MCP mount administration is RPC/HTTP; RPC: mcp_mount(name=&#34;github&#34;, url=&#34;https://mcp.example.com/sse&#34;, transport=&#34;sse&#34;) returns mounted=true and tool_count.</code></span>
+    <span>test: <a href="../../tests/unit/server/api/v2/test_mcp_router.py; tests/e2e/server/test_extracted_services_e2e.py; tests/e2e/self_contained/mcp/test_mcp_http_audit.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py">tests/unit/server/api/v2/test_mcp_router.py; tests/e2e/server/test_extracted_services_e2e.py; tests/e2e/self_contained/mcp/test_mcp_http_audit.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py</a></span>
+    <span>perf: setup</span>
+    <span>owner: <a href="https://github.com/nexi-lab/nexus/issues/4136">#4136</a></span>
     <span>gap: &mdash;</span>
   </div>
 </div>
-<div class="op" data-op-id="mcp.mounts" data-op-text="mcp.mounts  POST /api/v2/mcp/mounts ">
+<div class="op" data-op-id="mcp.mounts" data-op-text="mcp.mounts HTTP admin endpoint for creating MCP mounts with bearer/admin checks and SSRF validation delegated to MCPService. POST /api/v2/mcp/mounts ">
   <div class="op-header">
     <span class="op-id">mcp.mounts</span>
-    <span class="op-summary">&mdash; (no summary yet)</span>
+    <span class="op-summary">&mdash; HTTP admin endpoint for creating MCP mounts with bearer/admin checks and SSRF validation delegated to MCPService.</span>
   </div>
   <div class="transports">
     <span class="transport-pill" data-t="http"><span class="label">HTTP</span> <span>POST /api/v2/mcp/mounts</span></span>
   </div>
   <div class="meta-row">
     <span class="profiles">
-<span class="profile-badge profile-supported">lite</span>
+<span class="profile-badge profile-unavailable">lite</span>
 <span class="profile-badge profile-supported">sandbox</span>
 <span class="profile-badge profile-supported">full</span>
     </span>
-    <span>usage: <span class="todo">TODO</span></span>
-    <span>test: <span class="todo">TODO</span></span>
-    <span>perf: <span class="todo">TODO</span></span>
-    <span>owner: &mdash;</span>
+    <span>usage: <code>CLI: nexus mcp serve --transport http runs the frontend; RPC: POST /api/v2/mcp/mounts calls mcp_mount for admin users and rejects missing/non-admin bearers.</code></span>
+    <span>test: <a href="../../tests/unit/server/api/v2/test_mcp_router.py; tests/integration/mcp/test_ssrf_wiring.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py">tests/unit/server/api/v2/test_mcp_router.py; tests/integration/mcp/test_ssrf_wiring.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py</a></span>
+    <span>perf: setup</span>
+    <span>owner: <a href="https://github.com/nexi-lab/nexus/issues/4136">#4136</a></span>
     <span>gap: &mdash;</span>
   </div>
 </div>
@@ -9859,24 +9859,24 @@ graph TB
     <span>gap: &mdash;</span>
   </div>
 </div>
-<div class="op" data-op-id="mcp.sync" data-op-text="mcp.sync  mcp_sync ">
+<div class="op" data-op-id="mcp.sync" data-op-text="mcp.sync Refresh tool definitions from a mounted MCP server after its advertised tools change. mcp_sync ">
   <div class="op-header">
     <span class="op-id">mcp.sync</span>
-    <span class="op-summary">&mdash; (no summary yet)</span>
+    <span class="op-summary">&mdash; Refresh tool definitions from a mounted MCP server after its advertised tools change.</span>
   </div>
   <div class="transports">
     <span class="transport-pill" data-t="expose"><span class="label">expose</span> <span>mcp_sync</span></span>
   </div>
   <div class="meta-row">
     <span class="profiles">
-<span class="profile-badge profile-supported">lite</span>
+<span class="profile-badge profile-unavailable">lite</span>
 <span class="profile-badge profile-supported">sandbox</span>
 <span class="profile-badge profile-supported">full</span>
     </span>
-    <span>usage: <span class="todo">TODO</span></span>
-    <span>test: <span class="todo">TODO</span></span>
-    <span>perf: <span class="todo">TODO</span></span>
-    <span>owner: &mdash;</span>
+    <span>usage: <code>CLI: restart or keep nexus mcp serve running for clients; RPC: mcp_sync(name=&#34;github&#34;) refreshes tool files and returns tool_count.</code></span>
+    <span>test: <a href="../../tests/unit/server/api/v2/test_mcp_router.py; tests/e2e/server/test_extracted_services_e2e.py; tests/e2e/self_contained/mcp/test_mcp_http_audit.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py">tests/unit/server/api/v2/test_mcp_router.py; tests/e2e/server/test_extracted_services_e2e.py; tests/e2e/self_contained/mcp/test_mcp_http_audit.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py</a></span>
+    <span>perf: control</span>
+    <span>owner: <a href="https://github.com/nexi-lab/nexus/issues/4136">#4136</a></span>
     <span>gap: &mdash;</span>
   </div>
 </div>
@@ -9901,24 +9901,24 @@ graph TB
     <span>gap: &mdash;</span>
   </div>
 </div>
-<div class="op" data-op-id="mcp.unmount" data-op-text="mcp.unmount  mcp_unmount ">
+<div class="op" data-op-id="mcp.unmount" data-op-text="mcp.unmount Unmount an MCP server and close its active client/subprocess connection. mcp_unmount ">
   <div class="op-header">
     <span class="op-id">mcp.unmount</span>
-    <span class="op-summary">&mdash; (no summary yet)</span>
+    <span class="op-summary">&mdash; Unmount an MCP server and close its active client/subprocess connection.</span>
   </div>
   <div class="transports">
     <span class="transport-pill" data-t="expose"><span class="label">expose</span> <span>mcp_unmount</span></span>
   </div>
   <div class="meta-row">
     <span class="profiles">
-<span class="profile-badge profile-supported">lite</span>
+<span class="profile-badge profile-unavailable">lite</span>
 <span class="profile-badge profile-supported">sandbox</span>
 <span class="profile-badge profile-supported">full</span>
     </span>
-    <span>usage: <span class="todo">TODO</span></span>
-    <span>test: <span class="todo">TODO</span></span>
-    <span>perf: <span class="todo">TODO</span></span>
-    <span>owner: &mdash;</span>
+    <span>usage: <code>CLI: stop nexus mcp serve to remove the frontend process; RPC: mcp_unmount(name=&#34;github&#34;) returns success=true for an existing mount.</code></span>
+    <span>test: <a href="../../tests/unit/server/api/v2/test_mcp_router.py; tests/e2e/server/test_extracted_services_e2e.py; tests/e2e/self_contained/mcp/test_mcp_http_audit.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py">tests/unit/server/api/v2/test_mcp_router.py; tests/e2e/server/test_extracted_services_e2e.py; tests/e2e/self_contained/mcp/test_mcp_http_audit.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py</a></span>
+    <span>perf: control</span>
+    <span>owner: <a href="https://github.com/nexi-lab/nexus/issues/4136">#4136</a></span>
     <span>gap: &mdash;</span>
   </div>
 </div>

--- a/docs/architecture/api-rpc-surface-coverage.yaml
+++ b/docs/architecture/api-rpc-surface-coverage.yaml
@@ -439,7 +439,7 @@ operations:
   owning_issue: null
 - id: add.mount
   module: mount
-  summary: ''
+  summary: Activate a backend connector under a Nexus virtual path and grant the creator owner permissions.
   transports:
     grpc_expose:
       name: add_mount
@@ -448,12 +448,14 @@ operations:
     lite: supported
     sandbox: supported
     full: supported
-  usage_example: null
-  correctness_test: null
-  perf_class: null
-  perf_link: null
+  usage_example: 'CLI: nexus mounts add /sources/hn hn ''{}''; RPC: add_mount(mount_point=''/sources/hn'', backend_type=''hn'',
+    backend_config={}) returns ''/sources/hn''.'
+  correctness_test: tests/unit/services/test_mount_service.py; tests/integration/services/test_connectors_router.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py
+  perf_class: control
+  perf_link: control/setup path; mount add/list are not per-request hot paths, connector read/list latency is backend-specific
+    and covered by connector/search benchmarks when enabled.
   gap_issue: null
-  owning_issue: null
+  owning_issue: 4136
 - id: admin.reindex
   module: search
   summary: ''
@@ -528,7 +530,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.agent_registry
-      source: src/nexus/remote/kernel_client.py:738
+      source: src/nexus/remote/kernel_client.py:794
   profiles:
     lite: supported
     sandbox: supported
@@ -1671,7 +1673,7 @@ operations:
   owning_issue: null
 - id: auth.oauth
   module: auth
-  summary: ''
+  summary: CLI command group for OAuth credential discovery, setup, validation, and revocation.
   transports:
     cli:
       name: nexus oauth
@@ -1680,12 +1682,13 @@ operations:
     lite: supported
     sandbox: supported
     full: supported
-  usage_example: null
-  correctness_test: null
-  perf_class: null
-  perf_link: null
+  usage_example: 'CLI: nexus oauth list; nexus oauth setup-gdrive --user-email alice@example.com; RPC: oauth_list_credentials/oauth_get_auth_url/oauth_exchange_code
+    provide the same lifecycle.'
+  correctness_test: tests/unit/cli/test_auth_cli.py; tests/unit/services/test_oauth_service.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py
+  perf_class: control
+  perf_link: control-plane credential flow; OAuth provider round trips dominate and are not Nexus hot paths.
   gap_issue: null
-  owning_issue: null
+  owning_issue: 4136
 - id: auth.tls
   module: auth
   summary: ''
@@ -2100,7 +2103,7 @@ operations:
   transports:
     grpc_expose:
       name: backfill_directory_index
-      source: src/nexus/core/nexus_fs_metadata.py:1912
+      source: src/nexus/core/nexus_fs_metadata.py:2027
     sdk:
       name: MCPClient.backfill_directory_index
       source: src/nexus/remote/domain/mcp.py:91
@@ -2290,7 +2293,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.close_all_pipes
-      source: src/nexus/remote/kernel_client.py:661
+      source: src/nexus/remote/kernel_client.py:717
   profiles:
     lite: supported
     sandbox: supported
@@ -2307,7 +2310,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.close_all_streams
-      source: src/nexus/remote/kernel_client.py:697
+      source: src/nexus/remote/kernel_client.py:753
   profiles:
     lite: supported
     sandbox: supported
@@ -2324,7 +2327,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.close_pipe
-      source: src/nexus/remote/kernel_client.py:655
+      source: src/nexus/remote/kernel_client.py:711
   profiles:
     lite: supported
     sandbox: supported
@@ -2341,7 +2344,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.close_stream
-      source: src/nexus/remote/kernel_client.py:691
+      source: src/nexus/remote/kernel_client.py:747
   profiles:
     lite: supported
     sandbox: supported
@@ -2354,7 +2357,7 @@ operations:
   owning_issue: null
 - id: connectors.api_v2
   module: mount
-  summary: ''
+  summary: HTTP endpoint listing registered connector types and capabilities for mount selection.
   transports:
     http:
       name: GET /api/v2/connectors
@@ -2363,15 +2366,17 @@ operations:
     lite: supported
     sandbox: supported
     full: supported
-  usage_example: null
-  correctness_test: null
-  perf_class: null
-  perf_link: null
+  usage_example: 'CLI: nexus connectors list --json; RPC: GET /api/v2/connectors returns connectors used by list_connectors(category).'
+  correctness_test: tests/integration/services/test_connectors_router.py; tests/integration/services/test_connectors_auth.py;
+    tests/unit/cli/test_json_contract.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py
+  perf_class: control
+  perf_link: control/setup path; mount add/list are not per-request hot paths, connector read/list latency is backend-specific
+    and covered by connector/search benchmarks when enabled.
   gap_issue: null
-  owning_issue: null
+  owning_issue: 4136
 - id: connectors.auth_init
   module: auth
-  summary: ''
+  summary: Start connector authentication flow and return the next OAuth or secret-collection step.
   transports:
     http:
       name: POST /api/v2/connectors/auth/init
@@ -2380,15 +2385,16 @@ operations:
     lite: supported
     sandbox: supported
     full: supported
-  usage_example: null
-  correctness_test: null
-  perf_class: null
-  perf_link: null
+  usage_example: 'CLI: nexus oauth setup-gdrive --user-email alice@example.com; RPC: POST /api/v2/connectors/auth/init starts
+    connector auth for UI clients.'
+  correctness_test: tests/integration/services/test_connectors_auth.py; tests/unit/services/test_oauth_service.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py
+  perf_class: control
+  perf_link: control-plane credential flow; OAuth provider round trips dominate and are not Nexus hot paths.
   gap_issue: null
-  owning_issue: null
+  owning_issue: 4136
 - id: connectors.auth_status
   module: auth
-  summary: ''
+  summary: Report whether a connector has usable stored, native, or missing credentials for the caller.
   transports:
     http:
       name: GET /api/v2/connectors/auth/status
@@ -2397,15 +2403,16 @@ operations:
     lite: supported
     sandbox: supported
     full: supported
-  usage_example: null
-  correctness_test: null
-  perf_class: null
-  perf_link: null
+  usage_example: 'CLI: nexus oauth test google alice@example.com; RPC: GET /api/v2/connectors/auth/status reports authed,
+    expired, missing, or unavailable states.'
+  correctness_test: tests/integration/services/test_connectors_auth.py; tests/unit/auth/test_unified_service.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py
+  perf_class: control
+  perf_link: control-plane credential flow; OAuth provider round trips dominate and are not Nexus hot paths.
   gap_issue: null
-  owning_issue: null
+  owning_issue: 4136
 - id: connectors.available
   module: mount
-  summary: ''
+  summary: HTTP endpoint listing connectors with current auth status for the caller.
   transports:
     http:
       name: GET /api/v2/connectors/available
@@ -2414,12 +2421,15 @@ operations:
     lite: supported
     sandbox: supported
     full: supported
-  usage_example: null
-  correctness_test: null
-  perf_class: null
-  perf_link: null
+  usage_example: 'CLI: nexus connectors list shows available types; RPC: GET /api/v2/connectors/available includes auth_status/auth_source
+    for connector setup UI.'
+  correctness_test: tests/integration/services/test_connectors_router.py; tests/integration/services/test_connectors_auth.py;
+    tests/unit/cli/test_json_contract.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py
+  perf_class: control
+  perf_link: control/setup path; mount add/list are not per-request hot paths, connector read/list latency is backend-specific
+    and covered by connector/search benchmarks when enabled.
   gap_issue: null
-  owning_issue: null
+  owning_issue: 4136
 - id: connectors.get
   module: mount
   summary: ''
@@ -2439,7 +2449,7 @@ operations:
   owning_issue: null
 - id: connectors.mount
   module: mount
-  summary: ''
+  summary: HTTP connector mount endpoint used by the mounts CLI to attach an external backend path.
   transports:
     http:
       name: POST /api/v2/connectors/mount
@@ -2448,15 +2458,18 @@ operations:
     lite: supported
     sandbox: supported
     full: supported
-  usage_example: null
-  correctness_test: null
-  perf_class: null
-  perf_link: null
+  usage_example: 'CLI: nexus mounts add /sources/hn hn ''{}''; RPC: POST /api/v2/connectors/mount with connector_type, mount_point,
+    and config returns mounted=true.'
+  correctness_test: tests/integration/services/test_connectors_router.py; tests/integration/services/test_connectors_auth.py;
+    tests/unit/cli/test_json_contract.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py
+  perf_class: control
+  perf_link: control/setup path; mount add/list are not per-request hot paths, connector read/list latency is backend-specific
+    and covered by connector/search benchmarks when enabled.
   gap_issue: null
-  owning_issue: null
+  owning_issue: 4136
 - id: connectors.mounts
   module: mount
-  summary: ''
+  summary: HTTP endpoint listing mounted connectors for remote CLI and UI clients.
   transports:
     http:
       name: GET /api/v2/connectors/mounts
@@ -2465,12 +2478,14 @@ operations:
     lite: supported
     sandbox: supported
     full: supported
-  usage_example: null
-  correctness_test: null
-  perf_class: null
-  perf_link: null
+  usage_example: 'CLI: nexus mounts list --json; RPC: GET /api/v2/connectors/mounts returns mounted connector records.'
+  correctness_test: tests/integration/services/test_connectors_router.py; tests/integration/services/test_connectors_auth.py;
+    tests/unit/cli/test_json_contract.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py
+  perf_class: control
+  perf_link: control/setup path; mount add/list are not per-request hot paths, connector read/list latency is backend-specific
+    and covered by connector/search benchmarks when enabled.
   gap_issue: null
-  owning_issue: null
+  owning_issue: 4136
 - id: connectors.name_capabilities
   module: mount
   summary: ''
@@ -2558,7 +2573,7 @@ operations:
   owning_issue: null
 - id: connectors.unmount
   module: mount
-  summary: ''
+  summary: HTTP endpoint used by the mounts CLI to remove an active connector mount.
   transports:
     http:
       name: POST /api/v2/connectors/unmount
@@ -2567,12 +2582,14 @@ operations:
     lite: supported
     sandbox: supported
     full: supported
-  usage_example: null
-  correctness_test: null
-  perf_class: null
-  perf_link: null
+  usage_example: 'CLI: nexus mounts remove /sources/hn; RPC: POST /api/v2/connectors/unmount removes the mount_point.'
+  correctness_test: tests/integration/services/test_connectors_router.py; tests/integration/services/test_connectors_auth.py;
+    tests/unit/cli/test_json_contract.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py
+  perf_class: control
+  perf_link: control/setup path; mount add/list are not per-request hot paths, connector read/list latency is backend-specific
+    and covered by connector/search benchmarks when enabled.
   gap_issue: null
-  owning_issue: null
+  owning_issue: 4136
 - id: connectors.write_mount_path:path
   module: mount
   summary: ''
@@ -2664,7 +2681,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.create_pipe
-      source: src/nexus/remote/kernel_client.py:649
+      source: src/nexus/remote/kernel_client.py:705
   profiles:
     lite: supported
     sandbox: supported
@@ -2698,7 +2715,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.create_stream
-      source: src/nexus/remote/kernel_client.py:666
+      source: src/nexus/remote/kernel_client.py:722
   profiles:
     lite: supported
     sandbox: supported
@@ -3039,7 +3056,7 @@ operations:
   transports:
     grpc_expose:
       name: delete_batch
-      source: src/nexus/core/nexus_fs_metadata.py:1434
+      source: src/nexus/core/nexus_fs_metadata.py:1433
   profiles:
     lite: supported
     sandbox: supported
@@ -3088,7 +3105,7 @@ operations:
   owning_issue: null
 - id: delete.saved_mount
   module: mount
-  summary: ''
+  summary: Delete persisted mount configuration without necessarily deactivating an active runtime mount.
   transports:
     grpc_expose:
       name: delete_saved_mount
@@ -3097,12 +3114,14 @@ operations:
     lite: supported
     sandbox: supported
     full: supported
-  usage_example: null
-  correctness_test: null
-  perf_class: null
-  perf_link: null
+  usage_example: 'CLI: no dedicated saved-delete command yet, use nexus mounts remove for runtime cleanup; RPC: delete_saved_mount(mount_point="/sources/hn")
+    removes stored config.'
+  correctness_test: tests/unit/services/test_mount_service.py; tests/integration/services/test_connectors_router.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py
+  perf_class: control
+  perf_link: control/setup path; mount add/list are not per-request hot paths, connector read/list latency is backend-specific
+    and covered by connector/search benchmarks when enabled.
   gap_issue: null
-  owning_issue: null
+  owning_issue: 4136
 - id: deprovision.user
   module: identity
   summary: ''
@@ -3126,7 +3145,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.destroy_pipe
-      source: src/nexus/remote/kernel_client.py:652
+      source: src/nexus/remote/kernel_client.py:708
   profiles:
     lite: supported
     sandbox: supported
@@ -3143,7 +3162,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.destroy_stream
-      source: src/nexus/remote/kernel_client.py:694
+      source: src/nexus/remote/kernel_client.py:750
   profiles:
     lite: supported
     sandbox: supported
@@ -3248,7 +3267,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.dispatch_post_hooks
-      source: src/nexus/remote/kernel_client.py:455
+      source: src/nexus/remote/kernel_client.py:511
   profiles:
     lite: supported
     sandbox: supported
@@ -3265,7 +3284,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.dispatch_pre_hooks
-      source: src/nexus/remote/kernel_client.py:462
+      source: src/nexus/remote/kernel_client.py:518
   profiles:
     lite: supported
     sandbox: supported
@@ -3282,7 +3301,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.dispatch_pre_hooks_batch_stat
-      source: src/nexus/remote/kernel_client.py:490
+      source: src/nexus/remote/kernel_client.py:546
   profiles:
     lite: supported
     sandbox: supported
@@ -3744,10 +3763,10 @@ operations:
   transports:
     grpc_expose:
       name: exists_batch
-      source: src/nexus/core/nexus_fs_metadata.py:1329
+      source: src/nexus/core/nexus_fs_metadata.py:1328
     sdk:
       name: KernelClient.exists_batch
-      source: src/nexus/remote/kernel_client.py:516
+      source: src/nexus/remote/kernel_client.py:572
   profiles:
     lite: supported
     sandbox: supported
@@ -4654,7 +4673,7 @@ operations:
       source: src/nexus/cli/commands/file_ops.py:1
     grpc_expose:
       name: stat
-      source: src/nexus/core/nexus_fs_metadata.py:1109
+      source: src/nexus/core/nexus_fs_metadata.py:1108
   profiles:
     lite: supported
     sandbox: supported
@@ -4803,7 +4822,7 @@ operations:
   transports:
     grpc_expose:
       name: flush_write_observer
-      source: src/nexus/core/nexus_fs_metadata.py:1942
+      source: src/nexus/core/nexus_fs_metadata.py:2057
   profiles:
     lite: supported
     sandbox: supported
@@ -4956,7 +4975,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.open
-      source: src/nexus/remote/kernel_client.py:73
+      source: src/nexus/remote/kernel_client.py:120
   profiles:
     lite: supported
     sandbox: supported
@@ -4990,7 +5009,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.register
-      source: src/nexus/remote/kernel_client.py:915
+      source: src/nexus/remote/kernel_client.py:971
   profiles:
     lite: supported
     sandbox: supported
@@ -5126,7 +5145,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.unregister
-      source: src/nexus/remote/kernel_client.py:918
+      source: src/nexus/remote/kernel_client.py:974
   profiles:
     lite: supported
     sandbox: supported
@@ -5242,7 +5261,7 @@ operations:
       source: src/nexus/core/nexus_fs_metadata.py:627
     sdk:
       name: KernelClient.get_content_id
-      source: src/nexus/remote/kernel_client.py:507
+      source: src/nexus/remote/kernel_client.py:563
   profiles:
     lite: supported
     sandbox: supported
@@ -5310,7 +5329,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.get_mount_points
-      source: src/nexus/remote/kernel_client.py:521
+      source: src/nexus/remote/kernel_client.py:577
   profiles:
     lite: supported
     sandbox: supported
@@ -5432,7 +5451,7 @@ operations:
       source: src/nexus/core/nexus_fs_metadata.py:268
     sdk:
       name: KernelClient.get_top_level_mounts
-      source: src/nexus/remote/kernel_client.py:525
+      source: src/nexus/remote/kernel_client.py:581
   profiles:
     lite: supported
     sandbox: supported
@@ -5483,7 +5502,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.get_xattr
-      source: src/nexus/remote/kernel_client.py:622
+      source: src/nexus/remote/kernel_client.py:678
   profiles:
     lite: supported
     sandbox: supported
@@ -5500,7 +5519,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.get_xattr_bulk
-      source: src/nexus/remote/kernel_client.py:637
+      source: src/nexus/remote/kernel_client.py:693
   profiles:
     lite: supported
     sandbox: supported
@@ -5517,7 +5536,7 @@ operations:
   transports:
     grpc_expose:
       name: glob_batch
-      source: src/nexus/bricks/search/search_service.py:1923
+      source: src/nexus/bricks/search/search_service.py:1882
   profiles:
     lite: supported
     sandbox: supported
@@ -5721,7 +5740,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.has_pipe
-      source: src/nexus/remote/kernel_client.py:658
+      source: src/nexus/remote/kernel_client.py:714
   profiles:
     lite: supported
     sandbox: supported
@@ -5738,7 +5757,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.has_stream
-      source: src/nexus/remote/kernel_client.py:669
+      source: src/nexus/remote/kernel_client.py:725
   profiles:
     lite: supported
     sandbox: supported
@@ -5773,7 +5792,7 @@ operations:
   transports:
     http:
       name: GET /health/detailed
-      source: src/nexus/server/api/core/health.py:65
+      source: src/nexus/server/api/core/health.py:67
   profiles:
     lite: supported
     sandbox: supported
@@ -5790,7 +5809,7 @@ operations:
   transports:
     http:
       name: GET /metrics/pool
-      source: src/nexus/server/api/core/health.py:203
+      source: src/nexus/server/api/core/health.py:205
   profiles:
     lite: supported
     sandbox: supported
@@ -5807,7 +5826,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.hook_count
-      source: src/nexus/remote/kernel_client.py:452
+      source: src/nexus/remote/kernel_client.py:508
   profiles:
     lite: supported
     sandbox: supported
@@ -5971,7 +5990,7 @@ operations:
   transports:
     grpc_expose:
       name: initialize_semantic_search
-      source: src/nexus/bricks/search/search_service.py:4191
+      source: src/nexus/bricks/search/search_service.py:4150
   profiles:
     lite: supported
     sandbox: supported
@@ -5989,7 +6008,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.is_directory
-      source: src/nexus/remote/kernel_client.py:498
+      source: src/nexus/remote/kernel_client.py:554
   profiles:
     lite: supported
     sandbox: supported
@@ -6145,7 +6164,7 @@ operations:
       source: src/nexus/services/agents/agent_rpc_service.py:497
     sdk:
       name: _AgentRegistryProxy.list_agents
-      source: src/nexus/remote/kernel_client.py:921
+      source: src/nexus/remote/kernel_client.py:977
   profiles:
     lite: supported
     sandbox: supported
@@ -6158,7 +6177,7 @@ operations:
   owning_issue: null
 - id: list.connectors
   module: mount
-  summary: ''
+  summary: List connector backend types available for dynamic mounts, optionally filtered by category.
   transports:
     grpc_expose:
       name: list_connectors
@@ -6167,12 +6186,15 @@ operations:
     lite: supported
     sandbox: supported
     full: supported
-  usage_example: null
-  correctness_test: null
-  perf_class: null
-  perf_link: null
+  usage_example: 'CLI: nexus connectors list --category api --json; RPC: list_connectors(category="api") returns connector
+    metadata and user_scoped flags.'
+  correctness_test: tests/integration/services/test_connectors_router.py; tests/integration/services/test_connectors_auth.py;
+    tests/unit/cli/test_json_contract.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py
+  perf_class: control
+  perf_link: control/setup path; mount add/list are not per-request hot paths, connector read/list latency is backend-specific
+    and covered by connector/search benchmarks when enabled.
   gap_issue: null
-  owning_issue: null
+  owning_issue: 4136
 - id: list.credentials
   module: filesystem
   summary: ''
@@ -6243,7 +6265,7 @@ operations:
   owning_issue: null
 - id: list.mounts
   module: mount
-  summary: ''
+  summary: List active backend mounts visible to the caller after permission filtering.
   transports:
     grpc_expose:
       name: list_mounts
@@ -6255,12 +6277,13 @@ operations:
     lite: supported
     sandbox: supported
     full: supported
-  usage_example: null
-  correctness_test: null
-  perf_class: null
-  perf_link: null
+  usage_example: 'CLI: nexus mounts list --json; RPC: list_mounts() returns [{"mount_point": "/sources/hn"}] for visible mounts.'
+  correctness_test: tests/unit/services/test_mount_service.py; tests/integration/services/test_connectors_router.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py
+  perf_class: control
+  perf_link: control/setup path; mount add/list are not per-request hot paths, connector read/list latency is backend-specific
+    and covered by connector/search benchmarks when enabled.
   gap_issue: null
-  owning_issue: null
+  owning_issue: 4136
 - id: list.outgoing_shares
   module: rebac
   summary: List shared-* tuples granted on a resource with immediate revoke visibility.
@@ -6399,7 +6422,7 @@ operations:
   owning_issue: null
 - id: load.mount
   module: mount
-  summary: ''
+  summary: Load a saved mount configuration and activate it through the normal add_mount path.
   transports:
     grpc_expose:
       name: load_mount
@@ -6408,12 +6431,14 @@ operations:
     lite: supported
     sandbox: supported
     full: supported
-  usage_example: null
-  correctness_test: null
-  perf_class: null
-  perf_link: null
+  usage_example: 'CLI: no dedicated saved-load command yet, use nexus mounts add for normal UX; RPC: load_mount(mount_point="/sources/hn")
+    activates stored config.'
+  correctness_test: tests/unit/services/test_mount_service.py; tests/integration/services/test_connectors_router.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py
+  perf_class: control
+  perf_link: control/setup path; mount add/list are not per-request hot paths, connector read/list latency is backend-specific
+    and covered by connector/search benchmarks when enabled.
   gap_issue: null
-  owning_issue: null
+  owning_issue: 4136
 - id: load.workspace_config
   module: workspace
   summary: ''
@@ -6586,52 +6611,58 @@ operations:
   owning_issue: null
 - id: mcp.connect
   module: mcp
-  summary: ''
+  summary: Create a hosted MCP provider connection, reusing stored OAuth credentials when possible.
   transports:
     grpc_expose:
       name: mcp_connect
       source: src/nexus/bricks/mcp/mcp_service.py:528
   profiles:
-    lite: supported
+    lite: unavailable
     sandbox: supported
     full: supported
-  usage_example: null
-  correctness_test: null
-  perf_class: null
-  perf_link: null
+  usage_example: 'CLI: nexus mcp serve --transport http exposes the MCP frontend; RPC: mcp_connect(provider="google_drive",
+    redirect_url="http://localhost:2026/oauth/callback") returns strata_url or oauth_url.'
+  correctness_test: tests/unit/services/test_smoke.py; tests/unit/bricks/mcp/test_oauth_mappings.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py
+  perf_class: setup
+  perf_link: tests/benchmarks/bench_permission_hotpath.py covers MCP tools/list; mount/connect/sync/unmount are setup/control-plane
+    operations.
   gap_issue: null
-  owning_issue: null
+  owning_issue: 4136
 - id: mcp.list_mounts
   module: mcp
-  summary: ''
+  summary: List configured MCP server mounts, optionally filtered by user/zone/system tier.
   transports:
     grpc_expose:
       name: mcp_list_mounts
       source: src/nexus/bricks/mcp/mcp_service.py:139
   profiles:
-    lite: supported
+    lite: unavailable
     sandbox: supported
     full: supported
-  usage_example: null
-  correctness_test: null
-  perf_class: null
-  perf_link: null
+  usage_example: 'CLI: nexus mcp serve --transport http then MCP clients can inspect mounted tools; RPC: mcp_list_mounts(include_unmounted=true,
+    tier="system") returns mount metadata.'
+  correctness_test: tests/unit/server/api/v2/test_mcp_router.py; tests/e2e/server/test_extracted_services_e2e.py; tests/e2e/self_contained/mcp/test_mcp_http_audit.py;
+    tests/e2e/server/test_issue_4136_api_surface_e2e.py
+  perf_class: control
+  perf_link: tests/benchmarks/bench_permission_hotpath.py covers MCP tools/list; mount/connect/sync/unmount are setup/control-plane
+    operations.
   gap_issue: null
-  owning_issue: null
+  owning_issue: 4136
 - id: mcp.list_tools
   module: mcp
-  summary: List mounted MCP tools; the sandbox tool namespace middleware filters the visible set by ReBAC /tools/... grants.
+  summary: List mounted MCP tools; the tool namespace middleware filters the visible set by ReBAC /tools/... grants.
   transports:
     grpc_expose:
       name: mcp_list_tools
       source: src/nexus/bricks/mcp/mcp_service.py:205
   profiles:
-    lite: supported
+    lite: unavailable
     sandbox: supported
     full: supported
-  usage_example: 'RPC/MCP: mcp_list_tools("github") or MCP tools/list returns only tools visible to the current subject after
-    profile grants are materialized.'
-  correctness_test: tests/unit/bricks/mcp/test_tool_namespace_middleware.py::TestProfileGrantIntegration::test_profile_grants_drive_list_filtering_and_call_denial
+  usage_example: 'CLI: nexus mcp serve --transport http exposes tools/list to MCP clients; RPC: mcp_list_tools("github") returns
+    only tools visible to the current subject after profile grants are materialized.'
+  correctness_test: tests/unit/bricks/mcp/test_tool_namespace_middleware.py::TestProfileGrantIntegration::test_profile_grants_drive_list_filtering_and_call_denial;
+    tests/e2e/self_contained/mcp/test_mcp_http_audit.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py
   perf_class: hot
   perf_link: tests/benchmarks/bench_permission_hotpath.py::TestMCPToolNamespaceFiltering::test_cached_tool_list_filtering_latency
   gap_issue: null
@@ -6655,38 +6686,43 @@ operations:
   owning_issue: null
 - id: mcp.mount
   module: mcp
-  summary: ''
+  summary: Mount an external MCP server over stdio, SSE, HTTP, or Klavis and discover its tools.
   transports:
     grpc_expose:
       name: mcp_mount
       source: src/nexus/bricks/mcp/mcp_service.py:297
   profiles:
-    lite: supported
+    lite: unavailable
     sandbox: supported
     full: supported
-  usage_example: null
-  correctness_test: null
-  perf_class: null
-  perf_link: null
+  usage_example: 'CLI: nexus mcp serve exposes the frontend while MCP mount administration is RPC/HTTP; RPC: mcp_mount(name="github",
+    url="https://mcp.example.com/sse", transport="sse") returns mounted=true and tool_count.'
+  correctness_test: tests/unit/server/api/v2/test_mcp_router.py; tests/e2e/server/test_extracted_services_e2e.py; tests/e2e/self_contained/mcp/test_mcp_http_audit.py;
+    tests/e2e/server/test_issue_4136_api_surface_e2e.py
+  perf_class: setup
+  perf_link: tests/benchmarks/bench_permission_hotpath.py covers MCP tools/list; mount/connect/sync/unmount are setup/control-plane
+    operations.
   gap_issue: null
-  owning_issue: null
+  owning_issue: 4136
 - id: mcp.mounts
   module: mcp
-  summary: ''
+  summary: HTTP admin endpoint for creating MCP mounts with bearer/admin checks and SSRF validation delegated to MCPService.
   transports:
     http:
       name: POST /api/v2/mcp/mounts
       source: src/nexus/server/api/v2/routers/mcp.py:105
   profiles:
-    lite: supported
+    lite: unavailable
     sandbox: supported
     full: supported
-  usage_example: null
-  correctness_test: null
-  perf_class: null
-  perf_link: null
+  usage_example: 'CLI: nexus mcp serve --transport http runs the frontend; RPC: POST /api/v2/mcp/mounts calls mcp_mount for
+    admin users and rejects missing/non-admin bearers.'
+  correctness_test: tests/unit/server/api/v2/test_mcp_router.py; tests/integration/mcp/test_ssrf_wiring.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py
+  perf_class: setup
+  perf_link: tests/benchmarks/bench_permission_hotpath.py covers MCP tools/list; mount/connect/sync/unmount are setup/control-plane
+    operations.
   gap_issue: null
-  owning_issue: null
+  owning_issue: 4136
 - id: mcp.mounts_name
   module: mcp
   summary: ''
@@ -6723,26 +6759,29 @@ operations:
   owning_issue: null
 - id: mcp.sync
   module: mcp
-  summary: ''
+  summary: Refresh tool definitions from a mounted MCP server after its advertised tools change.
   transports:
     grpc_expose:
       name: mcp_sync
       source: src/nexus/bricks/mcp/mcp_service.py:469
   profiles:
-    lite: supported
+    lite: unavailable
     sandbox: supported
     full: supported
-  usage_example: null
-  correctness_test: null
-  perf_class: null
-  perf_link: null
+  usage_example: 'CLI: restart or keep nexus mcp serve running for clients; RPC: mcp_sync(name="github") refreshes tool files
+    and returns tool_count.'
+  correctness_test: tests/unit/server/api/v2/test_mcp_router.py; tests/e2e/server/test_extracted_services_e2e.py; tests/e2e/self_contained/mcp/test_mcp_http_audit.py;
+    tests/e2e/server/test_issue_4136_api_surface_e2e.py
+  perf_class: control
+  perf_link: tests/benchmarks/bench_permission_hotpath.py covers MCP tools/list; mount/connect/sync/unmount are setup/control-plane
+    operations.
   gap_issue: null
-  owning_issue: null
+  owning_issue: 4136
 - id: mcp.tool_profile_assign
   module: mcp
   summary: '`nexus mcp profile assign SUBJECT_TYPE SUBJECT_ID PROFILE --zone-id ZONE`: assign a configured MCP tool profile
-    to an agent or user; `nexus mcp profile inspect SUBJECT_TYPE SUBJECT_ID --zone-id ZONE` shows the resulting
-    effective /tools/... ReBAC grants.'
+    to an agent or user; `nexus mcp profile inspect SUBJECT_TYPE SUBJECT_ID --zone-id ZONE` shows the resulting effective
+    /tools/... ReBAC grants.'
   transports:
     cli:
       name: nexus mcp profile assign
@@ -6751,7 +6790,8 @@ operations:
     lite: supported
     sandbox: supported
     full: supported
-  usage_example: 'CLI: nexus mcp profile assign agent alice coding --zone-id sandbox-agent-1; nexus mcp profile inspect agent alice --zone-id sandbox-agent-1 --format json'
+  usage_example: 'CLI: nexus mcp profile assign agent alice coding --zone-id sandbox-agent-1; nexus mcp profile inspect agent
+    alice --zone-id sandbox-agent-1 --format json'
   correctness_test: tests/unit/cli/test_mcp_profile_cli.py; tests/unit/bricks/mcp/test_tool_namespace_middleware.py::TestProfileGrantIntegration::test_profile_grants_drive_list_filtering_and_call_denial
   perf_class: setup
   perf_link: setup/control-plane operation; effective tools/list filtering remains the hot path and is benchmarked in tests/benchmarks/bench_permission_hotpath.py
@@ -6759,21 +6799,24 @@ operations:
   owning_issue: 4128
 - id: mcp.unmount
   module: mcp
-  summary: ''
+  summary: Unmount an MCP server and close its active client/subprocess connection.
   transports:
     grpc_expose:
       name: mcp_unmount
       source: src/nexus/bricks/mcp/mcp_service.py:420
   profiles:
-    lite: supported
+    lite: unavailable
     sandbox: supported
     full: supported
-  usage_example: null
-  correctness_test: null
-  perf_class: null
-  perf_link: null
+  usage_example: 'CLI: stop nexus mcp serve to remove the frontend process; RPC: mcp_unmount(name="github") returns success=true
+    for an existing mount.'
+  correctness_test: tests/unit/server/api/v2/test_mcp_router.py; tests/e2e/server/test_extracted_services_e2e.py; tests/e2e/self_contained/mcp/test_mcp_http_audit.py;
+    tests/e2e/server/test_issue_4136_api_surface_e2e.py
+  perf_class: control
+  perf_link: tests/benchmarks/bench_permission_hotpath.py covers MCP tools/list; mount/connect/sync/unmount are setup/control-plane
+    operations.
   gap_issue: null
-  owning_issue: null
+  owning_issue: 4136
 - id: metadata.batch
   module: filesystem
   summary: Sandbox local workspace filesystem surface. The daemon mounts the operator workspace at /zone/local; CLI parity
@@ -6781,7 +6824,7 @@ operations:
   transports:
     grpc_expose:
       name: metadata_batch
-      source: src/nexus/core/nexus_fs_metadata.py:1339
+      source: src/nexus/core/nexus_fs_metadata.py:1338
   profiles:
     lite: supported
     sandbox: supported
@@ -6799,7 +6842,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.metastore_list_paginated
-      source: src/nexus/remote/kernel_client.py:533
+      source: src/nexus/remote/kernel_client.py:589
   profiles:
     lite: supported
     sandbox: supported
@@ -6880,7 +6923,7 @@ operations:
   owning_issue: null
 - id: mount.connectors
   module: mount
-  summary: ''
+  summary: CLI command group for discovering connector types before mounting external sources.
   transports:
     cli:
       name: nexus connectors
@@ -6889,12 +6932,15 @@ operations:
     lite: supported
     sandbox: supported
     full: supported
-  usage_example: null
-  correctness_test: null
-  perf_class: null
-  perf_link: null
+  usage_example: 'CLI: nexus connectors list --category api; RPC: list_connectors(category="api") returns the same connector
+    inventory shape.'
+  correctness_test: tests/integration/services/test_connectors_router.py; tests/integration/services/test_connectors_auth.py;
+    tests/unit/cli/test_json_contract.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py
+  perf_class: control
+  perf_link: control/setup path; mount add/list are not per-request hot paths, connector read/list latency is backend-specific
+    and covered by connector/search benchmarks when enabled.
   gap_issue: null
-  owning_issue: null
+  owning_issue: 4136
 - id: mount.down
   module: mount
   summary: ''
@@ -6914,7 +6960,7 @@ operations:
   owning_issue: null
 - id: mount.mounts
   module: mount
-  summary: ''
+  summary: 'CLI command group for connector mount lifecycle: add, list, info, remove, update, and reauth.'
   transports:
     cli:
       name: nexus mounts
@@ -6923,12 +6969,14 @@ operations:
     lite: supported
     sandbox: supported
     full: supported
-  usage_example: null
-  correctness_test: null
-  perf_class: null
-  perf_link: null
+  usage_example: 'CLI: nexus mounts add /sources/hn hn ''{}'' && nexus mounts list --json; RPC: add_mount/list_mounts/remove_mount
+    provide the equivalent lifecycle.'
+  correctness_test: tests/unit/services/test_mount_service.py; tests/integration/services/test_connectors_router.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py
+  perf_class: control
+  perf_link: control/setup path; mount add/list are not per-request hot paths, connector read/list latency is backend-specific
+    and covered by connector/search benchmarks when enabled.
   gap_issue: null
-  owning_issue: null
+  owning_issue: 4136
 - id: mount.restart
   module: mount
   summary: ''
@@ -7369,7 +7417,7 @@ operations:
   owning_issue: 4127
 - id: oauth.exchange_code
   module: auth
-  summary: ''
+  summary: Exchange an OAuth authorization code for encrypted stored credentials scoped to user and zone.
   transports:
     grpc_expose:
       name: oauth_exchange_code
@@ -7378,15 +7426,16 @@ operations:
     lite: supported
     sandbox: supported
     full: supported
-  usage_example: null
-  correctness_test: null
-  perf_class: null
-  perf_link: null
+  usage_example: 'CLI: nexus oauth setup-gdrive --user-email alice@example.com completes code exchange; RPC: oauth_exchange_code(provider="google-drive",
+    code="4/...", user_email="alice@example.com") stores the credential.'
+  correctness_test: tests/unit/services/test_oauth_service.py; tests/e2e/server/test_extracted_services_e2e.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py
+  perf_class: control
+  perf_link: control-plane credential flow; OAuth provider round trips dominate and are not Nexus hot paths.
   gap_issue: null
-  owning_issue: null
+  owning_issue: 4136
 - id: oauth.get_auth_url
   module: auth
-  summary: ''
+  summary: Create an OAuth authorization URL and PKCE state for a provider.
   transports:
     grpc_expose:
       name: oauth_get_auth_url
@@ -7395,15 +7444,16 @@ operations:
     lite: supported
     sandbox: supported
     full: supported
-  usage_example: null
-  correctness_test: null
-  perf_class: null
-  perf_link: null
+  usage_example: 'CLI: nexus oauth setup-gdrive --user-email alice@example.com opens the provider flow; RPC: oauth_get_auth_url(provider="google-drive",
+    redirect_uri="http://localhost:2026/oauth/callback") returns auth_url and state.'
+  correctness_test: tests/unit/services/test_oauth_service.py; tests/e2e/server/test_extracted_services_e2e.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py
+  perf_class: control
+  perf_link: control-plane credential flow; OAuth provider round trips dominate and are not Nexus hot paths.
   gap_issue: null
-  owning_issue: null
+  owning_issue: 4136
 - id: oauth.list_credentials
   module: auth
-  summary: ''
+  summary: List non-revoked OAuth credentials visible to the caller, with admin/user filtering.
   transports:
     grpc_expose:
       name: oauth_list_credentials
@@ -7412,15 +7462,16 @@ operations:
     lite: supported
     sandbox: supported
     full: supported
-  usage_example: null
-  correctness_test: null
-  perf_class: null
-  perf_link: null
+  usage_example: 'CLI: nexus oauth list --zone-id org_acme; RPC: oauth_list_credentials(provider="google-drive") returns stored
+    credential metadata without tokens.'
+  correctness_test: tests/unit/services/test_oauth_service.py; tests/e2e/server/test_extracted_services_e2e.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py
+  perf_class: control
+  perf_link: control-plane credential flow; OAuth provider round trips dominate and are not Nexus hot paths.
   gap_issue: null
-  owning_issue: null
+  owning_issue: 4136
 - id: oauth.list_providers
   module: auth
-  summary: ''
+  summary: List configured OAuth providers, scopes, PKCE requirements, and display metadata.
   transports:
     grpc_expose:
       name: oauth_list_providers
@@ -7429,15 +7480,16 @@ operations:
     lite: supported
     sandbox: supported
     full: supported
-  usage_example: null
-  correctness_test: null
-  perf_class: null
-  perf_link: null
+  usage_example: 'CLI: nexus oauth list shows stored credentials; RPC: oauth_list_providers() returns available OAuth provider
+    definitions for setup UI.'
+  correctness_test: tests/unit/services/test_oauth_service.py; tests/e2e/server/test_extracted_services_e2e.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py
+  perf_class: control
+  perf_link: control-plane credential flow; OAuth provider round trips dominate and are not Nexus hot paths.
   gap_issue: null
-  owning_issue: null
+  owning_issue: 4136
 - id: oauth.revoke_credential
   module: auth
-  summary: ''
+  summary: Revoke a stored OAuth credential after ownership checks.
   transports:
     grpc_expose:
       name: oauth_revoke_credential
@@ -7446,15 +7498,16 @@ operations:
     lite: supported
     sandbox: supported
     full: supported
-  usage_example: null
-  correctness_test: null
-  perf_class: null
-  perf_link: null
+  usage_example: 'CLI: nexus oauth revoke google alice@example.com; RPC: oauth_revoke_credential(provider="google", user_email="alice@example.com")
+    returns success=true.'
+  correctness_test: tests/unit/services/test_oauth_service.py; tests/e2e/server/test_extracted_services_e2e.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py
+  perf_class: control
+  perf_link: control-plane credential flow; OAuth provider round trips dominate and are not Nexus hot paths.
   gap_issue: null
-  owning_issue: null
+  owning_issue: 4136
 - id: oauth.test_credential
   module: auth
-  summary: ''
+  summary: Validate an OAuth credential and report whether it can be used or refreshed.
   transports:
     grpc_expose:
       name: oauth_test_credential
@@ -7463,12 +7516,13 @@ operations:
     lite: supported
     sandbox: supported
     full: supported
-  usage_example: null
-  correctness_test: null
-  perf_class: null
-  perf_link: null
+  usage_example: 'CLI: nexus oauth test google alice@example.com; RPC: oauth_test_credential(provider="google", user_email="alice@example.com")
+    returns valid/error metadata.'
+  correctness_test: tests/unit/services/test_oauth_service.py; tests/e2e/server/test_extracted_services_e2e.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py
+  perf_class: control
+  perf_link: control-plane credential flow; OAuth provider round trips dominate and are not Nexus hot paths.
   gap_issue: null
-  owning_issue: null
+  owning_issue: 4136
 - id: operations.agents_agent_id
   module: uncategorized
   summary: ''
@@ -8475,7 +8529,7 @@ operations:
       source: src/nexus/core/nexus_fs_content.py:1600
     sdk:
       name: KernelClient.read_batch
-      source: src/nexus/remote/kernel_client.py:367
+      source: src/nexus/remote/kernel_client.py:423
   profiles:
     lite: supported
     sandbox: supported
@@ -8561,7 +8615,7 @@ operations:
   owning_issue: 4134
 - id: reauth.mount
   module: mount
-  summary: ''
+  summary: Refresh or rotate OAuth credentials for a mounted connector when a runtime backend supports token refresh.
   transports:
     grpc_expose:
       name: reauth_mount
@@ -8570,12 +8624,13 @@ operations:
     lite: supported
     sandbox: supported
     full: supported
-  usage_example: null
-  correctness_test: null
-  perf_class: null
-  perf_link: null
+  usage_example: 'CLI: nexus mounts reauth /sources/drive --provider google --email alice@example.com; RPC: reauth_mount(mount_point="/sources/drive",
+    provider="google", user_email="alice@example.com") refreshes or returns a stable unavailable error.'
+  correctness_test: tests/unit/services/test_mount_service.py; tests/integration/services/test_connectors_router.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py
+  perf_class: control
+  perf_link: control-plane credential flow; OAuth provider round trips dominate and are not Nexus hot paths.
   gap_issue: null
-  owning_issue: null
+  owning_issue: 4136
 - id: rebac.access
   module: rebac
   summary: ''
@@ -8804,7 +8859,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.register_hook
-      source: src/nexus/remote/kernel_client.py:469
+      source: src/nexus/remote/kernel_client.py:525
   profiles:
     lite: supported
     sandbox: supported
@@ -8838,7 +8893,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.register_native_hook
-      source: src/nexus/remote/kernel_client.py:716
+      source: src/nexus/remote/kernel_client.py:772
   profiles:
     lite: supported
     sandbox: supported
@@ -8902,7 +8957,7 @@ operations:
   owning_issue: null
 - id: remove.mount
   module: mount
-  summary: ''
+  summary: Deactivate a backend mount and clean up routing, metadata, and permission tuples.
   transports:
     grpc_expose:
       name: remove_mount
@@ -8911,12 +8966,14 @@ operations:
     lite: supported
     sandbox: supported
     full: supported
-  usage_example: null
-  correctness_test: null
-  perf_class: null
-  perf_link: null
+  usage_example: 'CLI: nexus mounts remove /sources/hn; RPC: remove_mount(mount_point=''/sources/hn'') returns removal details
+    with removed=true.'
+  correctness_test: tests/unit/services/test_mount_service.py; tests/integration/services/test_connectors_router.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py
+  perf_class: control
+  perf_link: control/setup path; mount add/list are not per-request hot paths, connector read/list latency is backend-specific
+    and covered by connector/search benchmarks when enabled.
   gap_issue: null
-  owning_issue: null
+  owning_issue: 4136
 - id: rename.batch
   module: filesystem
   summary: Sandbox local workspace filesystem surface. The daemon mounts the operator workspace at /zone/local; CLI parity
@@ -8924,7 +8981,7 @@ operations:
   transports:
     grpc_expose:
       name: rename_batch
-      source: src/nexus/core/nexus_fs_metadata.py:1573
+      source: src/nexus/core/nexus_fs_metadata.py:1572
   profiles:
     lite: supported
     sandbox: supported
@@ -9162,7 +9219,7 @@ operations:
   owning_issue: null
 - id: save.mount
   module: mount
-  summary: ''
+  summary: Persist a mount configuration so it can be loaded on demand or restored after restart.
   transports:
     grpc_expose:
       name: save_mount
@@ -9171,12 +9228,14 @@ operations:
     lite: supported
     sandbox: supported
     full: supported
-  usage_example: null
-  correctness_test: null
-  perf_class: null
-  perf_link: null
+  usage_example: 'CLI: nexus mounts add /sources/hn hn ''{}'' persists through the connector HTTP path; RPC: save_mount(''/sources/hn'',
+    ''hn'', {}) stores reusable config.'
+  correctness_test: tests/unit/services/test_mount_service.py; tests/integration/services/test_connectors_router.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py
+  perf_class: control
+  perf_link: control/setup path; mount add/list are not per-request hot paths, connector read/list latency is backend-specific
+    and covered by connector/search benchmarks when enabled.
   gap_issue: null
-  owning_issue: null
+  owning_issue: 4136
 - id: scheduler.classify
   module: task_manager
   summary: ''
@@ -9302,7 +9361,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/expand
-      source: src/nexus/server/api/v2/routers/search.py:1322
+      source: src/nexus/server/api/v2/routers/search.py:1340
   profiles:
     lite: supported
     sandbox: supported
@@ -9323,10 +9382,10 @@ operations:
       source: src/nexus/cli/commands/search.py:1
     grpc_expose:
       name: glob
-      source: src/nexus/bricks/search/search_service.py:1738
+      source: src/nexus/bricks/search/search_service.py:1697
     http:
       name: POST /api/v2/search/glob
-      source: src/nexus/server/api/v2/routers/search.py:1203
+      source: src/nexus/server/api/v2/routers/search.py:1221
     mcp:
       name: nexus_glob
       source: src/nexus/config/tool_profiles.yaml:1
@@ -9350,10 +9409,10 @@ operations:
       source: src/nexus/cli/commands/search.py:1
     grpc_expose:
       name: grep
-      source: src/nexus/bricks/search/search_service.py:1980
+      source: src/nexus/bricks/search/search_service.py:1939
     http:
       name: POST /api/v2/search/grep
-      source: src/nexus/server/api/v2/routers/search.py:1082
+      source: src/nexus/server/api/v2/routers/search.py:1100
     mcp:
       name: nexus_grep
       source: src/nexus/config/tool_profiles.yaml:1
@@ -9406,7 +9465,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/index
-      source: src/nexus/server/api/v2/routers/search.py:1265
+      source: src/nexus/server/api/v2/routers/search.py:1283
   profiles:
     lite: supported
     sandbox: supported
@@ -9424,7 +9483,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/index-directory
-      source: src/nexus/server/api/v2/routers/search.py:1464
+      source: src/nexus/server/api/v2/routers/search.py:1482
   profiles:
     lite: supported
     sandbox: supported
@@ -9441,7 +9500,7 @@ operations:
   transports:
     http:
       name: GET /api/v2/search/indexed-dirs
-      source: src/nexus/server/api/v2/routers/search.py:1682
+      source: src/nexus/server/api/v2/routers/search.py:1700
   profiles:
     lite: supported
     sandbox: supported
@@ -9458,7 +9517,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/indexing-mode
-      source: src/nexus/server/api/v2/routers/search.py:1719
+      source: src/nexus/server/api/v2/routers/search.py:1737
   profiles:
     lite: supported
     sandbox: supported
@@ -9475,7 +9534,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/locate
-      source: src/nexus/server/api/v2/routers/search.py:1900
+      source: src/nexus/server/api/v2/routers/search.py:1918
   profiles:
     lite: supported
     sandbox: supported
@@ -9492,7 +9551,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/purge-unscoped
-      source: src/nexus/server/api/v2/routers/search.py:1846
+      source: src/nexus/server/api/v2/routers/search.py:1864
   profiles:
     lite: supported
     sandbox: supported
@@ -9528,7 +9587,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/query/batch
-      source: src/nexus/server/api/v2/routers/search.py:558
+      source: src/nexus/server/api/v2/routers/search.py:569
   profiles:
     lite: supported
     sandbox: supported
@@ -9545,7 +9604,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/refresh
-      source: src/nexus/server/api/v2/routers/search.py:1301
+      source: src/nexus/server/api/v2/routers/search.py:1319
   profiles:
     lite: supported
     sandbox: supported
@@ -9836,7 +9895,7 @@ operations:
   transports:
     grpc_expose:
       name: semantic_search
-      source: src/nexus/bricks/search/search_service.py:3791
+      source: src/nexus/bricks/search/search_service.py:3750
     mcp:
       name: nexus_semantic_search
       source: src/nexus/config/tool_profiles.yaml:1
@@ -9856,7 +9915,7 @@ operations:
   transports:
     grpc_expose:
       name: semantic_search_index
-      source: src/nexus/bricks/search/search_service.py:4106
+      source: src/nexus/bricks/search/search_service.py:4065
   profiles:
     lite: supported
     sandbox: supported
@@ -9873,7 +9932,7 @@ operations:
   transports:
     grpc_expose:
       name: semantic_search_stats
-      source: src/nexus/bricks/search/search_service.py:4143
+      source: src/nexus/bricks/search/search_service.py:4102
   profiles:
     lite: supported
     sandbox: supported
@@ -9890,7 +9949,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.service_close_all
-      source: src/nexus/remote/kernel_client.py:444
+      source: src/nexus/remote/kernel_client.py:500
   profiles:
     lite: supported
     sandbox: supported
@@ -9907,7 +9966,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.service_enlist
-      source: src/nexus/remote/kernel_client.py:431
+      source: src/nexus/remote/kernel_client.py:487
   profiles:
     lite: supported
     sandbox: supported
@@ -9924,7 +9983,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.service_lookup
-      source: src/nexus/remote/kernel_client.py:419
+      source: src/nexus/remote/kernel_client.py:475
   profiles:
     lite: supported
     sandbox: supported
@@ -9941,7 +10000,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.service_mark_bootstrapped
-      source: src/nexus/remote/kernel_client.py:416
+      source: src/nexus/remote/kernel_client.py:472
   profiles:
     lite: supported
     sandbox: supported
@@ -9958,7 +10017,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.service_start_all
-      source: src/nexus/remote/kernel_client.py:413
+      source: src/nexus/remote/kernel_client.py:469
   profiles:
     lite: supported
     sandbox: supported
@@ -9975,7 +10034,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.service_stop_all
-      source: src/nexus/remote/kernel_client.py:441
+      source: src/nexus/remote/kernel_client.py:497
   profiles:
     lite: supported
     sandbox: supported
@@ -9992,7 +10051,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.service_swap
-      source: src/nexus/remote/kernel_client.py:423
+      source: src/nexus/remote/kernel_client.py:479
   profiles:
     lite: supported
     sandbox: supported
@@ -10009,7 +10068,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.service_unregister
-      source: src/nexus/remote/kernel_client.py:603
+      source: src/nexus/remote/kernel_client.py:659
   profiles:
     lite: supported
     sandbox: supported
@@ -10026,7 +10085,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.set_hook_count
-      source: src/nexus/remote/kernel_client.py:486
+      source: src/nexus/remote/kernel_client.py:542
   profiles:
     lite: supported
     sandbox: supported
@@ -10043,7 +10102,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.set_metastore_path
-      source: src/nexus/remote/kernel_client.py:704
+      source: src/nexus/remote/kernel_client.py:760
   profiles:
     lite: supported
     sandbox: supported
@@ -10060,7 +10119,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.set_permission_provider
-      source: src/nexus/remote/kernel_client.py:720
+      source: src/nexus/remote/kernel_client.py:776
   profiles:
     lite: supported
     sandbox: supported
@@ -10094,7 +10153,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.set_vfs_lock
-      source: src/nexus/remote/kernel_client.py:712
+      source: src/nexus/remote/kernel_client.py:768
   profiles:
     lite: supported
     sandbox: supported
@@ -10111,7 +10170,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.set_xattr
-      source: src/nexus/remote/kernel_client.py:630
+      source: src/nexus/remote/kernel_client.py:686
   profiles:
     lite: supported
     sandbox: supported
@@ -10502,7 +10561,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.stat_batch
-      source: src/nexus/remote/kernel_client.py:400
+      source: src/nexus/remote/kernel_client.py:456
   profiles:
     lite: supported
     sandbox: supported
@@ -10519,7 +10578,7 @@ operations:
   transports:
     grpc_expose:
       name: stat_bulk
-      source: src/nexus/core/nexus_fs_metadata.py:1197
+      source: src/nexus/core/nexus_fs_metadata.py:1196
   profiles:
     lite: supported
     sandbox: supported
@@ -10536,7 +10595,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.stream_collect_all
-      source: src/nexus/remote/kernel_client.py:687
+      source: src/nexus/remote/kernel_client.py:743
   profiles:
     lite: supported
     sandbox: supported
@@ -10570,7 +10629,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.stream_read_at
-      source: src/nexus/remote/kernel_client.py:684
+      source: src/nexus/remote/kernel_client.py:740
   profiles:
     lite: supported
     sandbox: supported
@@ -10587,7 +10646,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.stream_read_at_blocking
-      source: src/nexus/remote/kernel_client.py:672
+      source: src/nexus/remote/kernel_client.py:728
   profiles:
     lite: supported
     sandbox: supported
@@ -10604,7 +10663,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.stream_write_nowait
-      source: src/nexus/remote/kernel_client.py:681
+      source: src/nexus/remote/kernel_client.py:737
   profiles:
     lite: supported
     sandbox: supported
@@ -10757,7 +10816,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.sys_copy
-      source: src/nexus/remote/kernel_client.py:305
+      source: src/nexus/remote/kernel_client.py:361
   profiles:
     lite: supported
     sandbox: supported
@@ -10774,7 +10833,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.sys_lock
-      source: src/nexus/remote/kernel_client.py:340
+      source: src/nexus/remote/kernel_client.py:396
   profiles:
     lite: supported
     sandbox: supported
@@ -10791,7 +10850,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.sys_mkdir
-      source: src/nexus/remote/kernel_client.py:284
+      source: src/nexus/remote/kernel_client.py:340
   profiles:
     lite: supported
     sandbox: supported
@@ -10808,7 +10867,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.sys_read
-      source: src/nexus/remote/kernel_client.py:192
+      source: src/nexus/remote/kernel_client.py:248
   profiles:
     lite: supported
     sandbox: supported
@@ -10825,7 +10884,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.sys_readdir
-      source: src/nexus/remote/kernel_client.py:317
+      source: src/nexus/remote/kernel_client.py:373
   profiles:
     lite: supported
     sandbox: supported
@@ -10842,7 +10901,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.sys_rename
-      source: src/nexus/remote/kernel_client.py:293
+      source: src/nexus/remote/kernel_client.py:349
   profiles:
     lite: supported
     sandbox: supported
@@ -10859,7 +10918,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.sys_setattr
-      source: src/nexus/remote/kernel_client.py:270
+      source: src/nexus/remote/kernel_client.py:326
   profiles:
     lite: supported
     sandbox: supported
@@ -10876,7 +10935,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.sys_stat
-      source: src/nexus/remote/kernel_client.py:244
+      source: src/nexus/remote/kernel_client.py:300
   profiles:
     lite: supported
     sandbox: supported
@@ -10893,7 +10952,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.sys_unlink
-      source: src/nexus/remote/kernel_client.py:277
+      source: src/nexus/remote/kernel_client.py:333
   profiles:
     lite: supported
     sandbox: supported
@@ -10910,7 +10969,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.sys_unlock
-      source: src/nexus/remote/kernel_client.py:363
+      source: src/nexus/remote/kernel_client.py:419
   profiles:
     lite: supported
     sandbox: supported
@@ -10930,7 +10989,7 @@ operations:
       source: src/nexus/core/nexus_fs_watch.py:26
     sdk:
       name: KernelClient.sys_watch
-      source: src/nexus/remote/kernel_client.py:407
+      source: src/nexus/remote/kernel_client.py:463
   profiles:
     lite: supported
     sandbox: supported
@@ -10947,7 +11006,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.sys_write
-      source: src/nexus/remote/kernel_client.py:228
+      source: src/nexus/remote/kernel_client.py:284
   profiles:
     lite: supported
     sandbox: supported
@@ -11032,7 +11091,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.trie_lookup
-      source: src/nexus/remote/kernel_client.py:614
+      source: src/nexus/remote/kernel_client.py:670
   profiles:
     lite: supported
     sandbox: supported
@@ -11049,7 +11108,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.trie_register
-      source: src/nexus/remote/kernel_client.py:611
+      source: src/nexus/remote/kernel_client.py:667
   profiles:
     lite: supported
     sandbox: supported
@@ -11066,7 +11125,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.trie_unregister
-      source: src/nexus/remote/kernel_client.py:617
+      source: src/nexus/remote/kernel_client.py:673
   profiles:
     lite: supported
     sandbox: supported
@@ -11442,7 +11501,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.unregister_hook
-      source: src/nexus/remote/kernel_client.py:474
+      source: src/nexus/remote/kernel_client.py:530
   profiles:
     lite: supported
     sandbox: supported
@@ -11506,7 +11565,7 @@ operations:
   owning_issue: null
 - id: update.mount
   module: mount
-  summary: ''
+  summary: Attempt to update runtime mount backend configuration while preserving mount metadata and permissions.
   transports:
     grpc_expose:
       name: update_mount
@@ -11515,12 +11574,14 @@ operations:
     lite: supported
     sandbox: supported
     full: supported
-  usage_example: null
-  correctness_test: null
-  perf_class: null
-  perf_link: null
+  usage_example: 'CLI: nexus mounts update /sources/crm ''{"api_url":"https://crm-v2.internal"}''; RPC: update_mount(''/sources/crm'',
+    {''api_url'': ''https://crm-v2.internal''}) returns changed_keys or a stable no-change result.'
+  correctness_test: tests/unit/services/test_mount_service.py; tests/integration/services/test_connectors_router.py; tests/e2e/server/test_issue_4136_api_surface_e2e.py
+  perf_class: control
+  perf_link: control/setup path; mount add/list are not per-request hot paths, connector read/list latency is backend-specific
+    and covered by connector/search benchmarks when enabled.
   gap_issue: null
-  owning_issue: null
+  owning_issue: 4136
 - id: update.workspace
   module: workspace
   summary: ''
@@ -12020,7 +12081,7 @@ operations:
       source: src/nexus/core/nexus_fs_content.py:1438
     sdk:
       name: KernelClient.write_batch
-      source: src/nexus/remote/kernel_client.py:724
+      source: src/nexus/remote/kernel_client.py:780
   profiles:
     lite: supported
     sandbox: supported
@@ -16226,4 +16287,6 @@ stale_rows:
 - operation_id: zone_routes.post
   reason: present in committed YAML but not detected by extractor
 - operation_id: zone_routes.zone_id
+  reason: present in committed YAML but not detected by extractor
+- operation_id: mcp.tool_profile_assign
   reason: present in committed YAML but not detected by extractor

--- a/docs/guides/user-guide.md
+++ b/docs/guides/user-guide.md
@@ -1684,6 +1684,119 @@ nexus connectors info gcs_connector
 If your build exposes `nexus mounts`, that is the persistent mount management
 group for attaching external backends under virtual paths.
 
+#### Mount External Data Source, List Tools, And Use Them
+
+Goal: in the `full` profile, attach an external source under a Nexus virtual
+path, expose the resulting filesystem/search tools through MCP, and verify that
+auth and SSRF boundaries fail closed.
+
+CLI flow:
+
+```bash
+export NEXUS_PROFILE=full
+export NEXUS_URL="http://localhost:2026"
+export NEXUS_API_KEY="..."
+
+nexus connectors list --category api
+nexus mounts add /sources/hn hn '{}'
+nexus mounts list --json
+nexus mcp serve --transport http --port 8081 --remote-url "$NEXUS_URL"
+```
+
+Use any MCP client against `http://localhost:8081/mcp` with
+`Authorization: Bearer $NEXUS_API_KEY`, call `tools/list`, then call a file or
+search tool such as `nexus_list_files` with `{"path": "/sources/hn"}`. The mount
+is correct when `/sources/hn` appears in `nexus mounts list` and the MCP tool
+call can read or list under that path without leaking sibling zones.
+
+Equivalent RPC/SDK flow:
+
+```python
+import nexus
+from nexus.remote.domain import MCPClient, OAuthClient
+
+nx = nexus.connect(
+    config={"profile": "remote", "url": "http://localhost:2026", "api_key": "..."}
+)
+
+connectors = nx.list_connectors(category="api")
+assert any(c["name"] == "hn" for c in connectors)
+
+mount_id = nx.add_mount(
+    mount_point="/sources/hn",
+    backend_type="hn",
+    backend_config={},
+)
+assert mount_id == "/sources/hn"
+
+mounts = nx.list_mounts()
+assert {"mount_point": "/sources/hn"} in mounts
+```
+
+For an external MCP server, use the MCP service RPCs directly:
+
+```python
+mcp = MCPClient(nx._call_rpc)
+mcp.mount(name="github", url="https://mcp.example.com/sse", transport="sse")
+tools = mcp.list_tools("github")
+mcp.sync("github")
+mcp.unmount("github")
+```
+
+These SDK helpers call the underlying RPC names `mcp_mount`, `mcp_list_tools`,
+`mcp_sync`, and `mcp_unmount`.
+
+OAuth-backed connectors use the OAuth credential RPCs or CLI helpers:
+
+```bash
+nexus oauth list
+nexus oauth setup-gdrive --user-email alice@example.com
+nexus oauth test google alice@example.com
+nexus oauth revoke google alice@example.com
+```
+
+```python
+oauth = OAuthClient(nx._call_rpc)
+auth_url = oauth.get_auth_url(
+    provider="google-drive",
+    redirect_uri="http://localhost:2026/oauth/callback",
+)
+oauth.exchange_code(
+    provider="google-drive",
+    code="4/...",
+    user_email="alice@example.com",
+)
+oauth.list_credentials(provider="google-drive")
+```
+
+The helper methods map to `oauth_get_auth_url`, `oauth_exchange_code`,
+`oauth_list_credentials`, `oauth_revoke_credential`, and `oauth_test_credential`.
+
+Expected behavior:
+
+- Success: `add_mount` returns the mount point, `list_mounts` returns only mounts
+  visible to the caller, and MCP `tools/list`/`tools/call` run with the caller's
+  bearer identity.
+- Denial: a caller without write permission on the parent path cannot add or
+  remove a mount; MCP HTTP with `NEXUS_MCP_REQUIRE_BEARER=true` returns 401
+  without a bearer token and 403 for non-admin mount administration.
+- SSRF: remote MCP `sse`/`http` URLs are validated before connection. Private,
+  loopback, link-local, or operator-denied CIDRs are blocked unless an approval
+  policy explicitly allows the host and re-validation still passes.
+- Unavailable: `reauth_mount` and `update_mount` preserve stable unavailable or
+  no-change results when the runtime has no retained Python backend object for
+  that mount; refresh credentials through `nexus oauth setup-*` or
+  `oauth_exchange_code` before remounting.
+
+Correctness assertion: after mounting, `nexus mounts list --json` contains the
+mount point, `tools/list` shows only tools granted to the subject, and an MCP
+tool call under `/sources/hn` succeeds with the same zone visibility as the
+equivalent RPC read/list operation.
+
+Performance classification: connector and OAuth setup is control-plane work;
+mount add/list is a setup/control-plane path. MCP `tools/list` and `tools/call`
+are request hot paths and use the permission hot-path benchmark coverage.
+
 ### 12.2 OAuth-backed integrations
 
 ```bash

--- a/rust/transport/src/call_dispatch.rs
+++ b/rust/transport/src/call_dispatch.rs
@@ -38,6 +38,7 @@ pub fn dispatch(
         "sys_unlock" => do_sys_unlock(kernel, &params),
         "sys_watch" => do_sys_watch(kernel, &params),
         "stat_batch" => do_stat_batch(kernel, &params, ctx),
+        "get_mount_points" => ok_json(serde_json::json!(kernel.get_mount_points())),
 
         // Service lifecycle — no-ops for subprocess mode (the Rust
         // binary manages its own service lifecycle).

--- a/src/nexus/bricks/auth/oauth/credential_service.py
+++ b/src/nexus/bricks/auth/oauth/credential_service.py
@@ -140,7 +140,6 @@ class OAuthCredentialService:
 
         state = secrets.token_urlsafe(32)
         provider_instance = self._create_provider(provider, redirect_uri, scopes)
-        self._register_provider(provider_instance)
 
         return await self._get_authorization_url_with_pkce_support(
             provider_instance, provider, state
@@ -298,6 +297,8 @@ class OAuthCredentialService:
         from nexus.lib.context_utils import get_zone_id
 
         token_manager = self._get_token_manager()
+        if token_manager is None:
+            raise ValueError("OAuth credential store not configured")
         zone_id = get_zone_id(context)
 
         await self._check_credential_ownership(

--- a/src/nexus/bricks/mcp/mcp_service.py
+++ b/src/nexus/bricks/mcp/mcp_service.py
@@ -111,6 +111,7 @@ class MCPService:
         self._ssrf_config = ssrf_config
         self._policy_gate = policy_gate
         self._zone_id = zone_id
+        self._mcp_mount_manager: Any | None = None
 
         logger.info("[MCPService] Initialized")
 
@@ -122,6 +123,8 @@ class MCPService:
         consults the gate when SSRF blocks an unlisted host (Issue #3790).
         """
         self._policy_gate = gate
+        if self._mcp_mount_manager is not None:
+            self._mcp_mount_manager._policy_gate = gate
 
     def set_zone(self, zone_id: str | None) -> None:
         """Attach (or detach) the daemon zone after construction.
@@ -131,6 +134,8 @@ class MCPService:
         egress is filed against the correct zone (not ROOT_ZONE_ID).
         """
         self._zone_id = zone_id
+        if self._mcp_mount_manager is not None:
+            self._mcp_mount_manager.set_zone(zone_id)
 
     # =========================================================================
     # Public API: MCP Mount Management
@@ -236,7 +241,6 @@ class MCPService:
             tools = service.mcp_list_tools("github", context=context)
             has_issues = any(t['name'] == 'create_issue' for t in tools)
         """
-        import asyncio
         import json
 
         from nexus.contracts.exceptions import ValidationError
@@ -244,8 +248,7 @@ class MCPService:
         # Get MCP mount manager
         manager = self._get_mcp_mount_manager()
 
-        # Get mount info (run in thread to avoid blocking)
-        mount = await asyncio.to_thread(manager.get_mount, name, context=context)
+        mount = await manager.get_mount(name, context=context)
 
         if not mount:
             raise ValidationError(f"MCP mount not found: {name}")
@@ -506,14 +509,11 @@ class MCPService:
             Server must be mounted before syncing. Use mcp_mount() first
             if the server is not yet mounted.
         """
-        import asyncio
-
         from nexus.contracts.exceptions import ValidationError
 
         manager = self._get_mcp_mount_manager()
 
-        # Get mount to verify it exists (run in thread)
-        mount = await asyncio.to_thread(manager.get_mount, name, context=context)
+        mount = await manager.get_mount(name, context=context)
         if not mount:
             raise ValidationError(f"MCP mount not found: {name}")
 
@@ -886,9 +886,12 @@ class MCPService:
         if self._filesystem is None:
             raise RuntimeError("Filesystem not configured for MCPService")
 
-        return MCPMountManager(
-            self._filesystem,
-            ssrf_config=self._ssrf_config,
-            policy_gate=self._policy_gate,
-            zone_id=self._zone_id,
-        )
+        if self._mcp_mount_manager is None:
+            self._mcp_mount_manager = MCPMountManager(
+                self._filesystem,
+                ssrf_config=self._ssrf_config,
+                policy_gate=self._policy_gate,
+                zone_id=self._zone_id,
+            )
+
+        return self._mcp_mount_manager

--- a/src/nexus/remote/kernel_client.py
+++ b/src/nexus/remote/kernel_client.py
@@ -575,7 +575,10 @@ class KernelClient:
         return [self.sys_stat(p, zone_id=zid) is not None for p in paths]
 
     def get_mount_points(self) -> list[str]:
-        """Return empty — mount points are kernel-internal."""
+        """Return zone-canonical mount points from the subprocess kernel."""
+        result = self._call("get_mount_points", {})
+        if isinstance(result, list):
+            return [str(p) for p in result]
         return []
 
     def get_top_level_mounts(self, zone_id: str = "") -> list[str]:

--- a/src/nexus/server/api/v2/routers/connectors.py
+++ b/src/nexus/server/api/v2/routers/connectors.py
@@ -23,7 +23,7 @@ from typing import Any
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, Field
 
-from nexus.server.dependencies import require_auth
+from nexus.server.dependencies import get_operation_context, require_auth
 from nexus.server.zone_execution import run_zone_scoped
 
 logger = logging.getLogger(__name__)
@@ -194,6 +194,11 @@ def _auth_zone(auth_result: dict[str, Any]) -> str | None:
 
     zone_id = auth_result.get("zone_id") or ROOT_ZONE_ID
     return zone_id if zone_id != ROOT_ZONE_ID else None
+
+
+def _operation_context_from_auth(auth_result: dict[str, Any]) -> Any:
+    """Build the OperationContext used for connector mount lifecycle calls."""
+    return get_operation_context(auth_result)
 
 
 # ---------------------------------------------------------------------------
@@ -599,17 +604,8 @@ async def mount_connector(
     Inherits the API key's zone and permissions. Parent directories
     (e.g., /mnt for /mnt/gmail) are auto-created in the same zone.
     """
-    from nexus.contracts.constants import ROOT_ZONE_ID
-    from nexus.contracts.types import OperationContext
-
     # Build context from the authenticated user's identity
-    mount_context = OperationContext(
-        user_id=auth.get("subject_id", "system"),
-        groups=[],
-        is_admin=auth.get("is_admin", True),
-        is_system=True,
-        zone_id=auth.get("zone_id") or ROOT_ZONE_ID,
-    )
+    mount_context = _operation_context_from_auth(auth)
 
     mount_svc = _get_mount_service(request)
     nx = _get_nx(request)
@@ -769,9 +765,10 @@ async def list_mounted_connectors(
 ) -> list[MountInfo]:
     """List all mounted connectors with status."""
     mount_svc = _get_mount_service(request)
+    list_context = _operation_context_from_auth(auth_result)
 
     async def _list_mounts() -> list[MountInfo]:
-        mounts = await mount_svc.list_mounts()
+        mounts = await mount_svc.list_mounts(context=list_context)
 
         result = []
         for m in mounts:
@@ -800,10 +797,11 @@ async def unmount_connector(
 ) -> MountResponse:
     """Unmount a connector."""
     mount_svc = _get_mount_service(request)
+    unmount_context = _operation_context_from_auth(auth_result)
 
     async def _unmount() -> MountResponse:
         try:
-            await mount_svc.remove_mount(mount_point=req.mount_point)
+            await mount_svc.remove_mount(mount_point=req.mount_point, context=unmount_context)
             _mount_types.pop(req.mount_point, None)
 
             # Mirror the dual-write from the mount handler: also drop the

--- a/tests/architecture/test_issue_4136_full_mcp_mount_oauth_surface.py
+++ b/tests/architecture/test_issue_4136_full_mcp_mount_oauth_surface.py
@@ -1,0 +1,101 @@
+"""Coverage contract checks for issue #4136.
+
+The full-profile MCP/mount/OAuth story is complete only when the shared
+surface model points users to real usage examples, correctness coverage,
+and performance classification for the externally visible surfaces.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.surface_coverage.schema import load_yaml
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_COVERAGE_YAML = _REPO_ROOT / "docs/architecture/api-rpc-surface-coverage.yaml"
+_USER_GUIDE = _REPO_ROOT / "docs/guides/user-guide.md"
+_REAL_E2E_TEST = "tests/e2e/server/test_issue_4136_api_surface_e2e.py"
+
+_ISSUE_4136_ROWS = {
+    "add.mount",
+    "auth.oauth",
+    "connectors.api_v2",
+    "connectors.auth_init",
+    "connectors.auth_status",
+    "connectors.available",
+    "connectors.mount",
+    "connectors.mounts",
+    "connectors.unmount",
+    "delete.saved_mount",
+    "list.connectors",
+    "list.mounts",
+    "load.mount",
+    "mcp.connect",
+    "mcp.list_mounts",
+    "mcp.list_tools",
+    "mcp.mount",
+    "mcp.mounts",
+    "mcp.sync",
+    "mcp.unmount",
+    "mount.connectors",
+    "mount.mounts",
+    "oauth.exchange_code",
+    "oauth.get_auth_url",
+    "oauth.list_credentials",
+    "oauth.list_providers",
+    "oauth.revoke_credential",
+    "oauth.test_credential",
+    "reauth.mount",
+    "remove.mount",
+    "save.mount",
+    "update.mount",
+}
+
+
+def _coverage_ops():
+    coverage = load_yaml(_COVERAGE_YAML)
+    return {op.id: op for op in coverage.operations}
+
+
+def _assert_test_links_exist(link_field: str) -> None:
+    for part in link_field.split(";"):
+        target = part.strip()
+        if not target or target.startswith("N/A") or target.startswith("setup/"):
+            continue
+        path_part = target.split("::", 1)[0].strip()
+        assert (_REPO_ROOT / path_part).exists(), f"missing linked test path: {path_part}"
+
+
+def test_issue_4136_rows_have_full_story_contract() -> None:
+    ops = _coverage_ops()
+    missing = sorted(_ISSUE_4136_ROWS - set(ops))
+    assert not missing, f"missing #4136 operation rows: {missing}"
+
+    for op_id in sorted(_ISSUE_4136_ROWS):
+        op = ops[op_id]
+        assert op.profiles["full"] == "supported", op_id
+        assert op.summary.strip(), op_id
+        assert op.usage_example and "CLI:" in op.usage_example and "RPC:" in op.usage_example, op_id
+        assert op.correctness_test, op_id
+        _assert_test_links_exist(op.correctness_test)
+        assert _REAL_E2E_TEST in op.correctness_test, op_id
+        assert op.perf_class is not None, op_id
+        assert op.perf_link and op.perf_link.strip(), op_id
+        assert op.owning_issue in {4128, 4136}, op_id
+
+
+def test_user_guide_documents_mount_to_tool_story() -> None:
+    guide = _USER_GUIDE.read_text(encoding="utf-8")
+
+    required_phrases = [
+        "Mount External Data Source, List Tools, And Use Them",
+        "nexus connectors list",
+        "nexus mounts add /sources/hn hn",
+        "mcp_list_tools",
+        "oauth_get_auth_url",
+        "SSRF",
+        "Correctness assertion:",
+        "Performance classification:",
+    ]
+    for phrase in required_phrases:
+        assert phrase in guide

--- a/tests/e2e/server/test_issue_4136_api_surface_e2e.py
+++ b/tests/e2e/server/test_issue_4136_api_surface_e2e.py
@@ -1,0 +1,456 @@
+"""Issue #4136 real E2E coverage for mounts, connectors, OAuth, and MCP APIs."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import sys
+import textwrap
+import time
+import uuid
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+API_KEY = "test-e2e-api-key-12345"
+E2E_TIMEOUT_SECONDS = 30.0
+
+
+def _resolve_issue_4136_kernel_binary(repo_root: Path) -> str | None:
+    configured = os.environ.get("NEXUS_KERNEL_BINARY")
+    if configured:
+        return configured
+
+    local_binary = repo_root / "target" / "debug" / "nexusd-cluster"
+    if local_binary.exists():
+        return str(local_binary)
+
+    for binary_name in ("nexusd-cluster", "nexus-cluster"):
+        resolved = shutil.which(binary_name)
+        if resolved:
+            return resolved
+
+    return None
+
+
+@pytest.fixture
+def issue_4136_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Configure external-control dependencies before the real server starts."""
+    kernel_binary = _resolve_issue_4136_kernel_binary(Path(__file__).resolve().parents[3])
+    if kernel_binary is None:
+        pytest.skip(
+            "nexusd-cluster binary not found; build it with "
+            "`cargo build --manifest-path rust/profiles/cluster/Cargo.toml "
+            "--bin nexusd-cluster` or put nexusd-cluster/nexus-cluster on PATH"
+        )
+
+    monkeypatch.setenv("NEXUS_PROFILE", "full")
+    monkeypatch.setenv("NEXUS_KERNEL_BINARY", kernel_binary)
+    monkeypatch.setenv("NEXUS_ACTIVITY_ENABLED", "0")
+    monkeypatch.setenv("NEXUS_CACHE_WARMUP_DEPTH", "0")
+    monkeypatch.setenv("NEXUS_CACHE_WARMUP_MAX_FILES", "0")
+    monkeypatch.setenv("NEXUS_DISABLE_VECTOR_SEARCH", "1")
+    monkeypatch.setenv("NEXUS_RATE_LIMIT_ENABLED", "false")
+    monkeypatch.setenv("NEXUS_SEARCH_DAEMON", "false")
+    monkeypatch.setenv("NEXUS_OAUTH_GOOGLE_CLIENT_ID", "issue-4136-client-id")
+    monkeypatch.setenv("NEXUS_OAUTH_GOOGLE_CLIENT_SECRET", "issue-4136-client-secret")
+    monkeypatch.delenv("KLAVIS_API_KEY", raising=False)
+
+
+def test_issue_4136_kernel_binary_prefers_path_when_local_debug_missing(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.delenv("NEXUS_KERNEL_BINARY", raising=False)
+    monkeypatch.setattr(
+        "shutil.which",
+        lambda name: f"/usr/local/bin/{name}" if name == "nexusd-cluster" else None,
+    )
+
+    assert _resolve_issue_4136_kernel_binary(tmp_path) == "/usr/local/bin/nexusd-cluster"
+
+
+@pytest.fixture
+def issue_4136_app(issue_4136_env: None, test_app: httpx.Client) -> httpx.Client:
+    return test_app
+
+
+def _headers() -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {API_KEY}",
+        "X-Nexus-Subject": "user:admin",
+        "X-Nexus-Zone-Id": "root",
+    }
+
+
+def _time_ms(perf: dict[str, float], name: str, fn: Callable[[], Any]) -> Any:
+    start = time.perf_counter()
+    try:
+        return fn()
+    finally:
+        perf[name] = round((time.perf_counter() - start) * 1000, 2)
+
+
+def _rpc(client: httpx.Client, method: str, params: dict[str, Any] | None, perf: dict[str, float]):
+    body = {
+        "jsonrpc": "2.0",
+        "method": method,
+        "params": params or {},
+        "id": 1,
+    }
+
+    def _call() -> httpx.Response:
+        return client.post(
+            f"/api/nfs/{method}",
+            json=body,
+            headers=_headers(),
+            timeout=E2E_TIMEOUT_SECONDS,
+        )
+
+    resp = _time_ms(perf, method, _call)
+    payload = resp.json()
+    return resp.status_code, payload
+
+
+def _rpc_result(
+    client: httpx.Client,
+    method: str,
+    params: dict[str, Any] | None,
+    perf: dict[str, float],
+) -> Any:
+    status, payload = _rpc(client, method, params, perf)
+    assert status == 200, f"{method} returned HTTP {status}: {payload}"
+    assert payload.get("error") in (None, {}), f"{method} returned RPC error: {payload}"
+    return payload.get("result")
+
+
+def _rpc_error(
+    client: httpx.Client,
+    method: str,
+    params: dict[str, Any] | None,
+    perf: dict[str, float],
+) -> dict[str, Any]:
+    status, payload = _rpc(client, method, params, perf)
+    assert status == 200, f"{method} returned HTTP {status}: {payload}"
+    assert payload.get("error"), f"{method} unexpectedly succeeded: {payload}"
+    return payload["error"]
+
+
+def _write_stdio_mcp_server(tmp_path: Path) -> Path:
+    server_path = tmp_path / "issue_4136_mcp_server.py"
+    server_path.write_text(
+        textwrap.dedent(
+            """
+            import json
+            import sys
+
+            TOOL = {
+                "name": "issue_4136_echo",
+                "description": "Echo text",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {"text": {"type": "string"}},
+                    "required": ["text"],
+                },
+            }
+
+
+            def respond(request, result):
+                sys.stdout.write(
+                    json.dumps(
+                        {
+                            "jsonrpc": "2.0",
+                            "id": request.get("id"),
+                            "result": result,
+                        },
+                        separators=(",", ":"),
+                    )
+                    + "\\n"
+                )
+                sys.stdout.flush()
+
+
+            for line in sys.stdin:
+                if not line.strip():
+                    continue
+                request = json.loads(line)
+                method = request.get("method")
+                if method == "initialize":
+                    params = request.get("params") or {}
+                    respond(
+                        request,
+                        {
+                            "protocolVersion": params.get("protocolVersion", "2025-06-18"),
+                            "capabilities": {"tools": {"listChanged": False}},
+                            "serverInfo": {
+                                "name": "issue-4136-e2e",
+                                "version": "1.0.0",
+                            },
+                        },
+                    )
+                elif method == "tools/list":
+                    respond(request, {"tools": [TOOL]})
+                elif method == "tools/call":
+                    text = ((request.get("params") or {}).get("arguments") or {}).get("text", "")
+                    respond(
+                        request,
+                        {
+                            "content": [{"type": "text", "text": text}],
+                            "isError": False,
+                        },
+                    )
+                elif method == "ping":
+                    respond(request, {})
+            """
+        ).strip()
+        + "\n"
+    )
+    return server_path
+
+
+def test_issue_4136_mount_connector_oauth_mcp_real_e2e(
+    issue_4136_app: httpx.Client,
+    tmp_path: Path,
+) -> None:
+    """Drive every #4136 API family through a real server process."""
+    client = issue_4136_app
+    perf: dict[str, float] = {}
+    suffix = uuid.uuid4().hex[:8]
+    connector_mount = f"/issue-4136-http-{suffix}"
+    rpc_mount = f"/issue-4136-rpc-{suffix}"
+    saved_mount = f"/issue-4136-saved-{suffix}"
+    http_mcp_name = f"issue-4136-http-mcp-{suffix}"
+    rpc_mcp_name = f"issue-4136-rpc-mcp-{suffix}"
+    stdio_server = _write_stdio_mcp_server(tmp_path)
+
+    def _http(method: str, path: str, **kwargs: Any) -> httpx.Response:
+        kwargs.setdefault("headers", _headers())
+        kwargs.setdefault("timeout", E2E_TIMEOUT_SECONDS)
+        return _time_ms(
+            perf, f"{method.upper()} {path}", lambda: client.request(method, path, **kwargs)
+        )
+
+    # Connector HTTP APIs.
+    connectors = _http("GET", "/api/v2/connectors")
+    assert connectors.status_code == 200, connectors.text
+    connector_names = {c["name"] for c in connectors.json()["connectors"]}
+    assert "path_local" in connector_names
+
+    available = _http("GET", "/api/v2/connectors/available")
+    assert available.status_code == 200, available.text
+    assert isinstance(available.json(), list)
+
+    auth_init = _http(
+        "POST",
+        "/api/v2/connectors/auth/init",
+        json={"connector_name": "gmail_connector", "provider": "gmail"},
+    )
+    assert auth_init.status_code == 200, auth_init.text
+    state_token = auth_init.json()["state_token"]
+    assert "accounts.google.com" in auth_init.json()["auth_url"]
+
+    auth_status = _http(
+        "GET", "/api/v2/connectors/auth/status", params={"state_token": state_token}
+    )
+    assert auth_status.status_code == 200, auth_status.text
+    assert auth_status.json()["status"] == "pending"
+
+    mount_resp = _http(
+        "POST",
+        "/api/v2/connectors/mount",
+        json={
+            "connector_type": "path_local",
+            "mount_point": connector_mount,
+            "config": {"root_path": str(tmp_path / "connector-store")},
+        },
+    )
+    assert mount_resp.status_code == 200, mount_resp.text
+    assert mount_resp.json()["mounted"] is True
+    mount_payload = mount_resp.json()
+
+    mounts_resp = _http("GET", "/api/v2/connectors/mounts")
+    assert mounts_resp.status_code == 200, mounts_resp.text
+    assert any(m["mount_point"] == connector_mount for m in mounts_resp.json()), {
+        "mount_response": mount_payload,
+        "mounts_response": mounts_resp.json(),
+    }
+
+    unmount_resp = _http(
+        "POST",
+        "/api/v2/connectors/unmount",
+        json={
+            "connector_type": "path_local",
+            "mount_point": connector_mount,
+            "config": {},
+        },
+    )
+    assert unmount_resp.status_code == 200, unmount_resp.text
+    assert unmount_resp.json()["mounted"] is False
+
+    # Mount RPC APIs.
+    storage_connectors = _rpc_result(client, "list_connectors", {"category": "storage"}, perf)
+    assert any(c["name"] == "path_local" for c in storage_connectors)
+
+    added = _rpc_result(
+        client,
+        "add_mount",
+        {
+            "mount_point": rpc_mount,
+            "backend_type": "path_local",
+            "backend_config": {"root_path": str(tmp_path / "rpc-store")},
+        },
+        perf,
+    )
+    assert added == rpc_mount
+
+    listed_mounts = _rpc_result(client, "list_mounts", {}, perf)
+    assert any(m["mount_point"] == rpc_mount for m in listed_mounts)
+
+    update = _rpc_result(
+        client,
+        "update_mount",
+        {"mount_point": rpc_mount, "backend_config": {"fsync": False}},
+        perf,
+    )
+    assert update == {"updated": False, "mount_point": rpc_mount, "changed_keys": []}
+
+    reauth_error = _rpc_error(
+        client,
+        "reauth_mount",
+        {"mount_point": rpc_mount, "provider": "gmail", "user_email": "admin@example.com"},
+        perf,
+    )
+    assert "No Python backend available for reauth" in str(reauth_error)
+
+    removed = _rpc_result(client, "remove_mount", {"mount_point": rpc_mount}, perf)
+    assert removed["removed"] is True
+
+    mount_id = _rpc_result(
+        client,
+        "save_mount",
+        {
+            "mount_point": saved_mount,
+            "backend_type": "path_local",
+            "backend_config": {"root_path": str(tmp_path / "saved-store")},
+            "description": "Issue 4136 saved mount E2E",
+        },
+        perf,
+    )
+    assert mount_id
+
+    loaded = _rpc_result(client, "load_mount", {"mount_point": saved_mount}, perf)
+    assert loaded == saved_mount
+
+    saved_listed = _rpc_result(client, "list_mounts", {}, perf)
+    assert any(m["mount_point"] == saved_mount for m in saved_listed)
+
+    saved_removed = _rpc_result(client, "remove_mount", {"mount_point": saved_mount}, perf)
+    assert saved_removed["removed"] is True
+
+    deleted = _rpc_result(client, "delete_saved_mount", {"mount_point": saved_mount}, perf)
+    assert deleted is True
+
+    # OAuth RPC APIs. Success paths are local-control only; external token exchange is
+    # intentionally verified as a clean error without contacting a real provider.
+    providers = _rpc_result(client, "oauth_list_providers", {}, perf)
+    assert any(p["name"] == "gmail" for p in providers)
+
+    auth_url = _rpc_result(
+        client,
+        "oauth_get_auth_url",
+        {"provider": "gmail", "redirect_uri": "http://localhost:5173/oauth/callback"},
+        perf,
+    )
+    assert "accounts.google.com" in auth_url["url"]
+
+    credentials = _rpc_result(client, "oauth_list_credentials", {}, perf)
+    assert isinstance(credentials, list)
+
+    test_credential = _rpc_result(
+        client,
+        "oauth_test_credential",
+        {"provider": "gmail", "user_email": "missing@example.com"},
+        perf,
+    )
+    assert test_credential["valid"] is False
+
+    revoke_error = _rpc_error(
+        client,
+        "oauth_revoke_credential",
+        {"provider": "gmail", "user_email": "missing@example.com"},
+        perf,
+    )
+    assert "OAuth credential store not configured" in str(revoke_error)
+
+    exchange_error = _rpc_error(
+        client,
+        "oauth_exchange_code",
+        {"provider": "not-a-provider", "code": "dummy-code", "user_email": "admin@example.com"},
+        perf,
+    )
+    assert "not-a-provider" in str(exchange_error)
+
+    # MCP RPC APIs.
+    connect_error = _rpc_error(
+        client,
+        "mcp_connect",
+        {"provider": "gmail", "redirect_url": "http://localhost:5173/oauth/callback"},
+        perf,
+    )
+    assert "KLAVIS_API_KEY" in str(connect_error)
+
+    rpc_mounted = _rpc_result(
+        client,
+        "mcp_mount",
+        {
+            "name": rpc_mcp_name,
+            "transport": "stdio",
+            "command": sys.executable,
+            "args": [str(stdio_server)],
+            "description": "Issue 4136 RPC MCP mount",
+        },
+        perf,
+    )
+    assert rpc_mounted["mounted"] is True
+    assert rpc_mounted["tool_count"] >= 1
+
+    rpc_mcp_mounts = _rpc_result(client, "mcp_list_mounts", {}, perf)
+    assert any(m["name"] == rpc_mcp_name for m in rpc_mcp_mounts)
+
+    rpc_tools = _rpc_result(client, "mcp_list_tools", {"name": rpc_mcp_name}, perf)
+    assert any(t["name"] == "issue_4136_echo" for t in rpc_tools)
+
+    rpc_synced = _rpc_result(client, "mcp_sync", {"name": rpc_mcp_name}, perf)
+    assert rpc_synced["tool_count"] >= 1
+
+    rpc_unmounted = _rpc_result(client, "mcp_unmount", {"name": rpc_mcp_name}, perf)
+    assert rpc_unmounted == {"success": True, "name": rpc_mcp_name}
+
+    # MCP HTTP APIs.
+    http_mounted = _http(
+        "POST",
+        "/api/v2/mcp/mounts",
+        json={
+            "name": http_mcp_name,
+            "transport": "stdio",
+            "command": sys.executable,
+            "args": [str(stdio_server)],
+            "description": "Issue 4136 HTTP MCP mount",
+        },
+    )
+    assert http_mounted.status_code == 201, http_mounted.text
+    assert http_mounted.json()["mounted"] is True
+
+    http_mcp_mounts = _http("GET", "/api/v2/mcp/mounts")
+    assert http_mcp_mounts.status_code == 200, http_mcp_mounts.text
+    assert any(m["name"] == http_mcp_name for m in http_mcp_mounts.json()["mounts"])
+
+    http_unmounted = _http("DELETE", f"/api/v2/mcp/mounts/{http_mcp_name}")
+    assert http_unmounted.status_code == 200, http_unmounted.text
+    assert http_unmounted.json() == {"success": True, "name": http_mcp_name}
+
+    print("ISSUE_4136_E2E_PERF " + json.dumps(perf, sort_keys=True))

--- a/tests/integration/services/test_connectors_router.py
+++ b/tests/integration/services/test_connectors_router.py
@@ -11,7 +11,7 @@ from fastapi.testclient import TestClient
 
 from nexus.backends.base.registry import ConnectorInfo
 from nexus.contracts.backend_features import BackendFeature
-from nexus.server.api.v2.routers.connectors import router
+from nexus.server.api.v2.routers.connectors import _operation_context_from_auth, router
 from nexus.server.dependencies import require_auth
 
 # ---------------------------------------------------------------------------
@@ -45,6 +45,34 @@ def _make_connector_info(
         backend_features=backend_features or frozenset(),
         service_name=name,
     )
+
+
+class TestConnectorAuthContext:
+    """Auth context passed into connector mount lifecycle calls."""
+
+    def test_preserves_authenticated_principal_and_zone_perms(self) -> None:
+        context = _operation_context_from_auth(
+            {
+                "authenticated": True,
+                "subject_type": "agent",
+                "subject_id": "agent-123",
+                "is_admin": False,
+                "zone_id": "zone-a",
+                "zone_perms": [["zone-a", "r"], ["zone-b", "rw"]],
+                "agent_generation": 7,
+            }
+        )
+
+        assert context.user_id == "agent-123"
+        assert context.subject_type == "agent"
+        assert context.subject_id == "agent-123"
+        assert context.agent_id == "agent-123"
+        assert context.is_admin is False
+        assert context.is_system is False
+        assert context.zone_id == "root"
+        assert context.zone_perms == (("zone-a", "r"), ("zone-b", "rw"))
+        assert context.zone_set == ("zone-a", "zone-b")
+        assert context.agent_generation == 7
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/bricks/mcp/test_policy_gate_threading.py
+++ b/tests/unit/bricks/mcp/test_policy_gate_threading.py
@@ -7,7 +7,11 @@ production. Without this wiring the hook in ``mount.py`` is dead code.
 
 from __future__ import annotations
 
+import json
+from types import SimpleNamespace
 from unittest.mock import MagicMock
+
+import pytest
 
 from nexus.bricks.approvals.policy_gate import PolicyGate
 from nexus.bricks.mcp.connection_manager import MCPConnectionManager
@@ -73,7 +77,7 @@ def test_mcp_service_set_policy_gate_updates_internal_state() -> None:
 
 
 def test_mcp_service_get_mount_manager_forwards_policy_gate() -> None:
-    """_get_mcp_mount_manager() must forward the gate to every MCPMountManager it builds."""
+    """_get_mcp_mount_manager() must forward the gate to its MCPMountManager."""
     gate = MagicMock(spec=PolicyGate)
     fake_fs = MagicMock()
     svc = MCPService(filesystem=fake_fs, policy_gate=gate)
@@ -81,9 +85,10 @@ def test_mcp_service_get_mount_manager_forwards_policy_gate() -> None:
     manager = svc._get_mcp_mount_manager()
     assert manager._policy_gate is gate
 
-    # Detach via setter — newly constructed managers reflect the new state.
+    # Detach via setter — the cached manager reflects the new state.
     svc.set_policy_gate(None)
     manager2 = svc._get_mcp_mount_manager()
+    assert manager2 is manager
     assert manager2._policy_gate is None
 
 
@@ -142,4 +147,68 @@ def test_mcp_service_get_mount_manager_forwards_zone_id() -> None:
 
     svc.set_zone(None)
     mgr2 = svc._get_mcp_mount_manager()
+    assert mgr2 is mgr
     assert mgr2._zone_id is None
+
+
+def test_mcp_service_reuses_mount_manager_state_between_calls() -> None:
+    """RPC calls must share one manager so mounted MCP clients stay visible."""
+    fake_fs = MagicMock()
+    svc = MCPService(filesystem=fake_fs)
+
+    mgr = svc._get_mcp_mount_manager()
+    mgr._mounts["existing"] = object()
+
+    assert svc._get_mcp_mount_manager() is mgr
+    assert "existing" in svc._get_mcp_mount_manager()._mounts
+
+
+@pytest.mark.asyncio
+async def test_mcp_service_list_tools_awaits_manager_get_mount() -> None:
+    """mcp_list_tools must await MCPMountManager.get_mount directly."""
+
+    class _FakeManager:
+        async def get_mount(self, name: str, context=None):  # noqa: ANN001, ARG002
+            return SimpleNamespace(tools_path="/skills/system/mcp-tools/demo/")
+
+    fake_fs = MagicMock()
+    fake_fs.sys_readdir.return_value = [
+        "/skills/system/mcp-tools/demo/echo.json",
+        "/skills/system/mcp-tools/demo/mount.json",
+    ]
+    fake_fs.sys_read.return_value = json.dumps(
+        {
+            "name": "echo",
+            "description": "Echo text",
+            "input_schema": {"type": "object"},
+        }
+    )
+
+    svc = MCPService(filesystem=fake_fs)
+    svc._mcp_mount_manager = _FakeManager()
+
+    assert await svc.mcp_list_tools("demo") == [
+        {
+            "name": "echo",
+            "description": "Echo text",
+            "input_schema": {"type": "object"},
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_mcp_service_sync_awaits_manager_get_mount() -> None:
+    """mcp_sync uses the async mount lookup before refreshing tools."""
+
+    class _FakeManager:
+        async def get_mount(self, name: str, context=None):  # noqa: ANN001, ARG002
+            return SimpleNamespace(name=name)
+
+        async def sync_tools(self, name: str) -> int:
+            assert name == "demo"
+            return 3
+
+    svc = MCPService(filesystem=MagicMock())
+    svc._mcp_mount_manager = _FakeManager()
+
+    assert await svc.mcp_sync("demo") == {"name": "demo", "tool_count": 3}

--- a/tests/unit/services/test_mount_service.py
+++ b/tests/unit/services/test_mount_service.py
@@ -6,6 +6,7 @@ pytest-asyncio dependency.
 """
 
 import asyncio
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -387,6 +388,69 @@ class TestSavedMounts:
 
         with pytest.raises(RuntimeError, match="Mount manager not available"):
             asyncio.run(service.delete_saved_mount("/mnt/test"))
+
+    def test_load_mount_activates_saved_config(self, mount_service, mock_mount_manager):
+        """load_mount reads stored config and activates it through add_mount."""
+        mock_mount_manager.get_mount.return_value = {
+            "mount_point": "/mnt/saved",
+            "backend_type": "path_local",
+            "backend_config": {"root_path": "/tmp/saved"},
+        }
+        mount_service.add_mount = MagicMock(
+            side_effect=lambda **kwargs: asyncio.sleep(0, result=kwargs["mount_point"])
+        )
+
+        result = asyncio.run(mount_service.load_mount("/mnt/saved"))
+
+        assert result == "/mnt/saved"
+        mount_service.add_mount.assert_called_once_with(
+            mount_point="/mnt/saved",
+            backend_type="path_local",
+            backend_config={"root_path": "/tmp/saved"},
+        )
+
+
+class TestConnectorDiscovery:
+    """Tests for connector discovery RPC surface."""
+
+    def test_list_connectors_filters_by_category(self, mount_service):
+        """list_connectors delegates category filtering to ConnectorRegistry."""
+        with patch("nexus.backends.base.registry.ConnectorRegistry") as mock_registry:
+            mock_registry.list_by_category.return_value = [
+                SimpleNamespace(
+                    name="hn",
+                    description="Hacker News",
+                    category="api",
+                    runtime_deps=[],
+                    user_scoped=False,
+                ),
+            ]
+
+            result = asyncio.run(mount_service.list_connectors(category="api"))
+
+        assert [item["name"] for item in result] == ["hn"]
+        mock_registry.list_by_category.assert_called_once_with("api")
+
+
+class TestMountUpdateAndReauth:
+    """Stable behavior for update/reauth RPC surfaces."""
+
+    def test_update_mount_reports_no_change_without_runtime_backend(self, mount_service):
+        """update_mount preserves a stable no-op result when DLC has no Python backend."""
+        mount_service._check_permission = MagicMock(return_value=True)
+        mount_service._dlc._kernel.sys_stat.return_value = {"entry_type": 2}
+
+        result = asyncio.run(mount_service.update_mount("/mnt/saved", {"api_url": "v2"}))
+
+        assert result == {"updated": False, "mount_point": "/mnt/saved", "changed_keys": []}
+
+    def test_reauth_mount_reports_unavailable_without_runtime_backend(self, mount_service):
+        """reauth_mount has a stable unavailable error when no Python backend is retained."""
+        mount_service._check_permission = MagicMock(return_value=True)
+        mount_service._dlc._kernel.sys_stat.return_value = {"entry_type": 2}
+
+        with pytest.raises(ValueError, match="No Python backend available"):
+            asyncio.run(mount_service.reauth_mount("/mnt/saved", provider="google"))
 
 
 # =============================================================================

--- a/tests/unit/services/test_oauth_service.py
+++ b/tests/unit/services/test_oauth_service.py
@@ -208,8 +208,32 @@ class TestListProviders:
 
 
 # ===========================================================================
-# OAuthCredentialService — OAuth Flow (exchange_code)
+# OAuthCredentialService — OAuth Flow (get_auth_url / exchange_code)
 # ===========================================================================
+
+
+class TestGetAuthUrl:
+    """Tests for get_auth_url."""
+
+    @pytest.mark.asyncio
+    async def test_get_auth_url_does_not_require_token_manager(self) -> None:
+        factory = MagicMock()
+        factory.get_provider_config.return_value = FakeProviderConfig(
+            name="google-drive",
+            requires_pkce=False,
+        )
+        factory.create_provider.return_value = FakeOAuthProvider("google-drive")
+        service = OAuthCredentialService(oauth_factory=factory, token_manager=None)
+
+        with patch.object(
+            service,
+            "_get_token_manager",
+            side_effect=AssertionError("get_auth_url must not require token storage"),
+        ):
+            result = await service.get_auth_url(provider="google-drive")
+
+        assert result["url"].startswith("https://accounts.google.com")
+        assert result["state"]
 
 
 class TestExchangeCode:
@@ -425,6 +449,21 @@ class TestRevokeCredential:
         with (
             patch("nexus.lib.context_utils.get_zone_id", return_value="zone1"),
             pytest.raises(ValueError, match="Credential not found"),
+        ):
+            await service.revoke_credential(
+                provider="google-drive",
+                user_email="unknown@example.com",
+                context=ctx,
+            )
+
+    @pytest.mark.asyncio
+    async def test_revoke_without_token_manager_reports_unconfigured_store(self) -> None:
+        service = OAuthCredentialService(token_manager=None, database_url=None)
+        ctx = MagicMock(user_id="user-alice", is_admin=True)
+
+        with (
+            patch("nexus.lib.context_utils.get_zone_id", return_value="zone1"),
+            pytest.raises(ValueError, match="OAuth credential store not configured"),
         ):
             await service.revoke_credential(
                 provider="google-drive",


### PR DESCRIPTION
Refs #4136

## Summary

- Add a real daemon E2E for the full-profile MCP, mount, connector, and OAuth control surfaces required by #4136.
- Update the user guide and API/RPC coverage matrix so each #4136 row points to correctness coverage, performance classification, and the real E2E.
- Fix bugs discovered by the real E2E: connector mount lifecycle auth context, subprocess mount-point discovery, OAuth auth-url/revoke behavior without token storage, and MCP service state/async mount lookups.
- Address review feedback by preserving the canonical authenticated `OperationContext` for connector lifecycle calls and avoiding a hard-coded local debug Rust binary path in the E2E.

## Root Cause / Fix Notes

- Connector HTTP list/unmount paths did not pass the authenticated `OperationContext` into `MountService`, so mounted connectors could disappear under permission filtering.
- The connector auth context helper initially synthesized a partial system context; it now reuses `get_operation_context(auth_result)` so principal identity, zone permissions, agent metadata, and admin flags are preserved.
- Subprocess `KernelClient.get_mount_points()` returned an empty list, which broke real Rust-kernel mount discovery.
- `OAuthCredentialService.get_auth_url()` initialized token storage even though generating an auth URL does not need persisted credentials.
- `oauth_revoke_credential` raised an incidental `NoneType` error when the OAuth credential store was not configured.
- `MCPService` created a new `MCPMountManager` per call, losing mounted stdio MCP state across RPC/HTTP requests.
- `mcp_list_tools` and `mcp_sync` treated async `get_mount()` as a blocking function.

## Validation

- `uv run pytest tests/architecture/test_issue_4136_full_mcp_mount_oauth_surface.py tests/unit/bricks/mcp/test_policy_gate_threading.py tests/unit/services/test_mount_service.py tests/unit/services/test_oauth_service.py tests/unit/server/api/v2/test_mcp_router.py tests/integration/services/test_connectors_router.py tests/integration/services/test_connectors_auth.py tests/e2e/server/test_issue_4136_api_surface_e2e.py -q -s --tb=short -p no:xdist -o addopts=''`
  - `109 passed in 21.49s`
- `uv run pytest tests/integration/services/test_connectors_router.py tests/e2e/server/test_issue_4136_api_surface_e2e.py -q -s --tb=short -p no:xdist -o addopts=''`
  - `10 passed in 31.86s`
- `uv run pytest tests/benchmarks/bench_permission_hotpath.py::TestMCPToolNamespaceFiltering::test_cached_tool_list_filtering_latency -q -s -p no:xdist -o addopts=''`
  - `113,063 ops/s | p50=7.4us | p99=34.5us`
- `cargo build --manifest-path rust/profiles/cluster/Cargo.toml --bin nexusd-cluster`
  - passed
- commit hooks on `cdcb6881d`
  - `ruff`, `ruff format`, `mypy`, repo boundary checks passed
- `git diff --check`
  - passed

## Notes

Live external Google/Klavis credential-success flows are intentionally not required for this PR scope per reviewer direction; the E2E covers local control behavior and expected unavailable/error behavior for missing credentials/API keys.
