### PR TITLE
[codex] Fix sandbox federation E2E paths

### DIFF
--- a/.github/workflows/cluster-binary-build.yml
+++ b/.github/workflows/cluster-binary-build.yml
@@ -33,9 +33,9 @@ jobs:
             artifact_name: nexusd-cluster-linux-x86_64
             binary: nexusd-cluster
             # Real measured size after kernel + slim backends + VFS Call
-            # file API surface: ~12.02 MiB. Keep a tight 128 KiB headroom
-            # rather than masking large regressions.
-            max_size_bytes: 12713984  # 12.125 MiB
+            # file API surface + remote-zone backend support: ~12.64 MiB.
+            # Keep ~128 KiB headroom rather than masking large regressions.
+            max_size_bytes: 13369344  # 12.75 MiB
           - os: macos-14
             artifact_name: nexusd-cluster-macos-arm64
             binary: nexusd-cluster

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -61,7 +61,7 @@ RUN for d in services backends; do \
         printf '[package]\nname = "%s"\nversion = "0.1.0"\nedition = "2021"\n' "$d" > rust/$d/Cargo.toml && \
         echo '' > rust/$d/src/lib.rs; \
     done && \
-    printf '\n[features]\ndefault = []\ndriver-path-local = []\n' >> rust/backends/Cargo.toml && \
+    printf '\n[features]\ndefault = []\ndriver-path-local = []\ndriver-remote = []\n' >> rust/backends/Cargo.toml && \
     mkdir -p rust/profiles/cluster/src && \
     printf '[package]\nname = "nexus-cluster"\nversion = "0.1.0"\nedition = "2021"\n\n[[bin]]\nname = "nexusd-cluster"\npath = "src/main.rs"\n' > rust/profiles/cluster/Cargo.toml && \
     echo 'fn main() {}' > rust/profiles/cluster/src/main.rs

--- a/docs/architecture/api-rpc-surface-coverage.html
+++ b/docs/architecture/api-rpc-surface-coverage.html
@@ -168,7 +168,7 @@
     <a href="#m-portability">portability<span class="count">3</span></a>
 
     <h2>Deployment topology</h2>
-    <a href="#m-hub">hub<span class="count">2</span></a>
+    <a href="#m-hub">hub<span class="count">3</span></a>
     <a href="#m-federation">federation<span class="count">13</span></a>
     <a href="#m-zone">zone<span class="count">14</span></a>
     <a href="#m-daemon">daemon<span class="count">4</span></a>
@@ -184,8 +184,8 @@
       <div class="stat"><div class="stat-value">6</div><div class="stat-label">layers</div></div>
       <div class="stat"><div class="stat-value">28</div><div class="stat-label">bricks</div></div>
       <div class="stat"><div class="stat-value">6</div><div class="stat-label">transports</div></div>
-      <div class="stat"><div class="stat-value">692</div><div class="stat-label">operations</div></div>
-      <div class="stat"><div class="stat-value">14</div><div class="stat-label">missing</div></div>
+      <div class="stat"><div class="stat-value">693</div><div class="stat-label">operations</div></div>
+      <div class="stat"><div class="stat-value">13</div><div class="stat-label">missing</div></div>
     </div>
 
     <input id="search" placeholder="Search by op-id, brick, transport name, or summary..." />
@@ -8989,7 +8989,7 @@ graph TB
 <span class="profile-badge profile-supported">full</span>
     </span>
     <span>usage: <code>MCP: nexus_semantic_search(query=&#34;auth flow&#34;, search_mode=&#34;hybrid&#34;, limit=5)</code></span>
-    <span>test: <a href="../../tests/unit/bricks/mcp/test_mcp_server_tools.py::TestSemanticSearchTool; tests/integration/services/test_search_semantic.py::TestSemanticSearch">tests/unit/bricks/mcp/test_mcp_server_tools.py::TestSemanticSearchTool; tests/integration/services/test_search_semantic.py::TestSemanticSearch</a></span>
+    <span>test: <a href="../../tests/unit/bricks/mcp/test_mcp_server_tools.py::TestSemanticSearchTool; tests/integration/services/test_search_semantic.py::TestSemanticSearch; tests/integration/bricks/search/test_federated_search.py::TestRemoteZoneSearch; tests/unit/bricks/search/test_federated_degraded.py::TestSearchServiceSandboxFallback">tests/unit/bricks/mcp/test_mcp_server_tools.py::TestSemanticSearchTool; tests/integration/services/test_search_semantic.py::TestSemanticSearch; tests/integration/bricks/search/test_federated_search.py::TestRemoteZoneSearch; tests/unit/bricks/search/test_federated_degraded.py::TestSearchServiceSandboxFallback</a></span>
     <span>perf: hot</span>
     <span>owner: <a href="https://github.com/nexi-lab/nexus/issues/4129">#4129</a></span>
     <span>gap: &mdash;</span>
@@ -12476,7 +12476,7 @@ graph TB
           <span class="mod-name">hub</span>
           <span class="mod-desc">&mdash; Shared Nexus instance that other nodes connect to. Manages multi-tenant zones + admin RPCs.</span>
           <span class="mod-meta">
-            <span>2 ops</span>
+            <span>3 ops</span>
           </span>
         </summary>
         <div class="module-body">
@@ -12519,6 +12519,28 @@ graph TB
     <span>test: <span class="todo">TODO</span></span>
     <span>perf: <span class="todo">TODO</span></span>
     <span>owner: &mdash;</span>
+    <span>gap: &mdash;</span>
+  </div>
+</div>
+<div class="op" data-op-id="hub.status" data-op-text="hub.status Hub health and zone/token status surface. Local `--detail` includes zones, tokens, rate limits, and search; `--remote` calls the hub MCP admin tool. nexus hub status nexus_hub_status ">
+  <div class="op-header">
+    <span class="op-id">hub.status</span>
+    <span class="op-summary">&mdash; Hub health and zone/token status surface. Local `--detail` includes zones, tokens, rate limits, and search; `--remote` calls the hub MCP admin tool.</span>
+  </div>
+  <div class="transports">
+    <span class="transport-pill" data-t="cli"><span class="label">CLI</span> <span>nexus hub status</span></span>
+    <span class="transport-pill" data-t="mcp"><span class="label">MCP</span> <span>nexus_hub_status</span></span>
+  </div>
+  <div class="meta-row">
+    <span class="profiles">
+<span class="profile-badge profile-unavailable">lite</span>
+<span class="profile-badge profile-supported">sandbox</span>
+<span class="profile-badge profile-supported">full</span>
+    </span>
+    <span>usage: <code>CLI: nexus hub status --detail --json; remote hub: nexus hub status --remote https://hub.example.com/mcp --admin-token &#34;$NEXUS_HUB_ADMIN_TOKEN&#34; --json</code></span>
+    <span>test: <a href="../../tests/unit/cli/test_hub.py::test_hub_status_detail_json_includes_token_last_seen_and_zones; tests/unit/cli/test_hub_remote.py::test_remote_status_calls_mcp_tool_and_renders_json; tests/e2e/self_contained/cli/test_hub_flow.py::test_hub_end_to_end_token_lifecycle">tests/unit/cli/test_hub.py::test_hub_status_detail_json_includes_token_last_seen_and_zones; tests/unit/cli/test_hub_remote.py::test_remote_status_calls_mcp_tool_and_renders_json; tests/e2e/self_contained/cli/test_hub_flow.py::test_hub_end_to_end_token_lifecycle</a></span>
+    <span>perf: control</span>
+    <span>owner: <a href="https://github.com/nexi-lab/nexus/issues/4130">#4130</a></span>
     <span>gap: &mdash;</span>
   </div>
 </div>
@@ -12569,16 +12591,16 @@ graph TB
 <span class="profile-badge profile-supported">full</span>
     </span>
     <span>usage: <code>RPC: federation_client_whoami({}) with the sandbox hub token returns zones like [{&#34;zone_id&#34;:&#34;company&#34;,&#34;permission&#34;:&#34;r&#34;},{&#34;zone_id&#34;:&#34;shared&#34;,&#34;permission&#34;:&#34;rw&#34;}].</code></span>
-    <span>test: <a href="../../tests/e2e/self_contained/cli/test_sandbox_federation_e2e.py::TestSandboxFederationBoot::test_federation_whoami_returns_both_zones">tests/e2e/self_contained/cli/test_sandbox_federation_e2e.py::TestSandboxFederationBoot::test_federation_whoami_returns_both_zones</a></span>
+    <span>test: <a href="../../tests/unit/grpc/test_federation_whoami_rpc.py::TestFederationClientWhoami; tests/unit/remote/test_federation_handshake.py; tests/e2e/self_contained/cli/test_sandbox_federation_e2e.py::TestSandboxFederationBoot::test_federation_whoami_returns_both_zones">tests/unit/grpc/test_federation_whoami_rpc.py::TestFederationClientWhoami; tests/unit/remote/test_federation_handshake.py; tests/e2e/self_contained/cli/test_sandbox_federation_e2e.py::TestSandboxFederationBoot::test_federation_whoami_returns_both_zones</a></span>
     <span>perf: control</span>
-    <span>owner: <a href="https://github.com/nexi-lab/nexus/issues/4128">#4128</a></span>
+    <span>owner: <a href="https://github.com/nexi-lab/nexus/issues/4130">#4130</a></span>
     <span>gap: &mdash;</span>
   </div>
 </div>
-<div class="op" data-op-id="federation.cluster_info" data-op-text="federation.cluster_info  federation_cluster_info ">
+<div class="op" data-op-id="federation.cluster_info" data-op-text="federation.cluster_info Federation zone topology/status RPC used by `nexus federation info &lt;zone-id&gt;` to show leader and membership state. federation_cluster_info ">
   <div class="op-header">
     <span class="op-id">federation.cluster_info</span>
-    <span class="op-summary">&mdash; (no summary yet)</span>
+    <span class="op-summary">&mdash; Federation zone topology/status RPC used by `nexus federation info &lt;zone-id&gt;` to show leader and membership state.</span>
   </div>
   <div class="transports">
     <span class="transport-pill" data-t="expose"><span class="label">expose</span> <span>federation_cluster_info</span></span>
@@ -12589,10 +12611,10 @@ graph TB
 <span class="profile-badge profile-supported">sandbox</span>
 <span class="profile-badge profile-supported">full</span>
     </span>
-    <span>usage: <span class="todo">TODO</span></span>
-    <span>test: <span class="todo">TODO</span></span>
-    <span>perf: <span class="todo">TODO</span></span>
-    <span>owner: &mdash;</span>
+    <span>usage: <code>RPC: federation_cluster_info({&#34;zone_id&#34;:&#34;corp&#34;}); CLI equivalent: nexus federation info &lt;zone-id&gt;</code></span>
+    <span>test: <a href="../../tests/e2e/docker/test_federation_e2e.py::TestFederationCLIWorkflow::test_status_zones_info_consistent_view">tests/e2e/docker/test_federation_e2e.py::TestFederationCLIWorkflow::test_status_zones_info_consistent_view</a></span>
+    <span>perf: control</span>
+    <span>owner: <a href="https://github.com/nexi-lab/nexus/issues/4130">#4130</a></span>
     <span>gap: &mdash;</span>
   </div>
 </div>
@@ -12680,10 +12702,10 @@ graph TB
     <span>gap: &mdash;</span>
   </div>
 </div>
-<div class="op" data-op-id="federation.list_zones" data-op-text="federation.list_zones  federation_list_zones ">
+<div class="op" data-op-id="federation.list_zones" data-op-text="federation.list_zones Federation zone listing RPC used by `nexus federation zones` and operator status workflows. federation_list_zones ">
   <div class="op-header">
     <span class="op-id">federation.list_zones</span>
-    <span class="op-summary">&mdash; (no summary yet)</span>
+    <span class="op-summary">&mdash; Federation zone listing RPC used by `nexus federation zones` and operator status workflows.</span>
   </div>
   <div class="transports">
     <span class="transport-pill" data-t="expose"><span class="label">expose</span> <span>federation_list_zones</span></span>
@@ -12694,10 +12716,10 @@ graph TB
 <span class="profile-badge profile-supported">sandbox</span>
 <span class="profile-badge profile-supported">full</span>
     </span>
-    <span>usage: <span class="todo">TODO</span></span>
-    <span>test: <span class="todo">TODO</span></span>
-    <span>perf: <span class="todo">TODO</span></span>
-    <span>owner: &mdash;</span>
+    <span>usage: <code>RPC: federation_list_zones({}); CLI equivalent: nexus federation zones</code></span>
+    <span>test: <a href="../../tests/e2e/docker/test_federation_e2e.py::TestFederationCLIWorkflow::test_status_zones_info_consistent_view">tests/e2e/docker/test_federation_e2e.py::TestFederationCLIWorkflow::test_status_zones_info_consistent_view</a></span>
+    <span>perf: control</span>
+    <span>owner: <a href="https://github.com/nexi-lab/nexus/issues/4130">#4130</a></span>
     <span>gap: &mdash;</span>
   </div>
 </div>
@@ -15277,7 +15299,7 @@ graph TB
     </section>
 
     <section>
-      <h2 class="section">&sect;5 Wanted but missing (14)</h2>
+      <h2 class="section">&sect;5 Wanted but missing (13)</h2>
       <p>Capabilities the architecture suggests should exist but currently don't. Subissues should open gap issues for each and link via the row's <code>gap_issue</code> field.</p>
       <details class="module">
         <summary>
@@ -15376,7 +15398,7 @@ graph TB
       <details class="module">
         <summary>
           <span class="mod-name">hub</span>
-          <span class="mod-desc">&mdash; 2 missing surface(s)</span>
+          <span class="mod-desc">&mdash; 1 missing surface(s)</span>
         </summary>
         <div class="module-body">
           <div class="op">
@@ -15391,20 +15413,6 @@ graph TB
                 <span class="profile-badge profile-other">full: missing_needed</span>
               </span>
 <span><em>WANTED: Lowers adoption barrier for hub-mode users.</em></span>              <span>gap: <span class="todo">open one</span></span>
-            </div>
-          </div>
-          <div class="op">
-            <div class="op-header">
-              <span class="op-id">hub.status</span>
-              <span class="op-summary">&mdash; `nexus hub status`: show connected nodes, zones served, federation peers.</span>
-            </div>
-            <div class="meta-row">
-              <span class="profiles">
-                <span class="profile-badge profile-other">lite: missing_needed</span>
-                <span class="profile-badge profile-other">sandbox: missing_needed</span>
-                <span class="profile-badge profile-other">full: missing_needed</span>
-              </span>
-<span><em>WANTED: Hub-mode operators currently have no top-level health view.</em></span>              <span>gap: <span class="todo">open one</span></span>
             </div>
           </div>
         </div>

--- a/docs/architecture/api-rpc-surface-coverage.yaml
+++ b/docs/architecture/api-rpc-surface-coverage.yaml
@@ -3944,14 +3944,16 @@ operations:
     sandbox: supported
     full: supported
   usage_example: 'RPC: federation_client_whoami({}) with the sandbox hub token returns zones like [{"zone_id":"company","permission":"r"},{"zone_id":"shared","permission":"rw"}].'
-  correctness_test: tests/e2e/self_contained/cli/test_sandbox_federation_e2e.py::TestSandboxFederationBoot::test_federation_whoami_returns_both_zones
+  correctness_test: tests/unit/grpc/test_federation_whoami_rpc.py::TestFederationClientWhoami; tests/unit/remote/test_federation_handshake.py;
+    tests/e2e/self_contained/cli/test_sandbox_federation_e2e.py::TestSandboxFederationBoot::test_federation_whoami_returns_both_zones
   perf_class: control
-  perf_link: control-plane startup/discovery path; not on the per-file read/write hot path
+  perf_link: tests/benchmarks/bench_sandbox_federation_latency.py::TestSandboxFederationHandshakeLatency; control-plane startup/discovery
+    path, not on the per-file read/write hot path
   gap_issue: null
-  owning_issue: 4128
+  owning_issue: 4130
 - id: federation.cluster_info
   module: federation
-  summary: ''
+  summary: Federation zone topology/status RPC used by `nexus federation info <zone-id>` to show leader and membership state.
   transports:
     grpc_expose:
       name: federation_cluster_info
@@ -3960,12 +3962,12 @@ operations:
     lite: supported
     sandbox: supported
     full: supported
-  usage_example: null
-  correctness_test: null
-  perf_class: null
-  perf_link: null
+  usage_example: 'RPC: federation_cluster_info({"zone_id":"corp"}); CLI equivalent: nexus federation info <zone-id>'
+  correctness_test: tests/e2e/docker/test_federation_e2e.py::TestFederationCLIWorkflow::test_status_zones_info_consistent_view
+  perf_class: control
+  perf_link: federation status/inspection path; no per-file or search hot-path budget
   gap_issue: null
-  owning_issue: null
+  owning_issue: 4130
 - id: federation.create_zone
   module: federation
   summary: ''
@@ -4036,7 +4038,7 @@ operations:
   owning_issue: null
 - id: federation.list_zones
   module: federation
-  summary: ''
+  summary: Federation zone listing RPC used by `nexus federation zones` and operator status workflows.
   transports:
     grpc_expose:
       name: federation_list_zones
@@ -4045,12 +4047,12 @@ operations:
     lite: supported
     sandbox: supported
     full: supported
-  usage_example: null
-  correctness_test: null
-  perf_class: null
-  perf_link: null
+  usage_example: 'RPC: federation_list_zones({}); CLI equivalent: nexus federation zones'
+  correctness_test: tests/e2e/docker/test_federation_e2e.py::TestFederationCLIWorkflow::test_status_zones_info_consistent_view
+  perf_class: control
+  perf_link: federation status/inspection path; no per-file or search hot-path budget
   gap_issue: null
-  owning_issue: null
+  owning_issue: 4130
 - id: federation.mount
   module: federation
   summary: ''
@@ -4189,7 +4191,7 @@ operations:
   correctness_test: tests/unit/cli/test_fs_parity.py; tests/e2e/self_contained/cli/test_sandbox_federation_e2e.py::TestSandboxZonePermissions::test_write_to_local_zone_stays_on_disk;
     tests/architecture/test_issue_4127_sandbox_filesystem_surface.py
   perf_class: hot
-  perf_link: tests/benchmarks/bench_read_write_overhead.py::TestTypedVsGenericRead and ::TestReadBulkOverhead
+  perf_link: tests/benchmarks/bench_read_write_overhead.py::TestTypedVsGenericRead and ::TestReadBulkOverhead; tests/benchmarks/bench_sandbox_federation_latency.py::TestSandboxFederationReadLatency
   gap_issue: null
   owning_issue: 4127
 - id: filesystem.close
@@ -4514,7 +4516,7 @@ operations:
   correctness_test: tests/unit/cli/test_fs_parity.py; tests/e2e/self_contained/cli/test_sandbox_federation_e2e.py::TestSandboxZonePermissions::test_write_to_local_zone_stays_on_disk;
     tests/architecture/test_issue_4127_sandbox_filesystem_surface.py
   perf_class: hot
-  perf_link: tests/benchmarks/bench_read_write_overhead.py::TestTypedVsGenericRead and ::TestReadBulkOverhead
+  perf_link: tests/benchmarks/bench_read_write_overhead.py::TestTypedVsGenericRead and ::TestReadBulkOverhead; tests/benchmarks/bench_sandbox_federation_latency.py::TestSandboxFederationReadLatency
   gap_issue: null
   owning_issue: 4127
 - id: filesystem.read_bulk
@@ -5887,18 +5889,27 @@ operations:
   owning_issue: null
 - id: hub.status
   module: hub
-  summary: '`nexus hub status`: show connected nodes, zones served, federation peers.'
-  transports: {}
+  summary: Hub health and zone/token status surface. Local `--detail` includes zones, tokens, rate limits, and search; `--remote`
+    calls the hub MCP admin tool.
+  transports:
+    cli:
+      name: nexus hub status
+      source: src/nexus/cli/commands/hub.py:425
+    mcp:
+      name: nexus_hub_status
+      source: src/nexus/bricks/mcp/server.py:509
   profiles:
-    lite: missing_needed
-    sandbox: missing_needed
-    full: missing_needed
-  usage_example: 'WANTED: Hub-mode operators currently have no top-level health view.'
-  correctness_test: null
-  perf_class: null
-  perf_link: null
+    lite: unavailable
+    sandbox: supported
+    full: supported
+  usage_example: 'CLI: nexus hub status --detail --json; remote hub: nexus hub status --remote https://hub.example.com/mcp --admin-token
+    "$NEXUS_HUB_ADMIN_TOKEN" --json'
+  correctness_test: tests/unit/cli/test_hub.py::test_hub_status_detail_json_includes_token_last_seen_and_zones; tests/unit/cli/test_hub_remote.py::test_remote_status_calls_mcp_tool_and_renders_json;
+    tests/e2e/self_contained/cli/test_hub_flow.py::test_hub_end_to_end_token_lifecycle
+  perf_class: control
+  perf_link: hub status is a control-plane inspection path; not a hot data path
   gap_issue: null
-  owning_issue: null
+  owning_issue: 4130
 - id: identity.agent_id_identity
   module: identity
   summary: ''
@@ -7150,7 +7161,7 @@ operations:
   correctness_test: tests/unit/cli/test_fs_parity.py; tests/e2e/self_contained/cli/test_sandbox_federation_e2e.py::TestSandboxZonePermissions::test_write_to_local_zone_stays_on_disk;
     tests/architecture/test_issue_4127_sandbox_filesystem_surface.py
   perf_class: hot
-  perf_link: tests/benchmarks/bench_read_write_overhead.py::TestTypedVsGenericRead and ::TestReadBulkOverhead
+  perf_link: tests/benchmarks/bench_read_write_overhead.py::TestTypedVsGenericRead and ::TestReadBulkOverhead; tests/benchmarks/bench_sandbox_federation_latency.py::TestSandboxFederationReadLatency
   gap_issue: null
   owning_issue: 4127
 - id: nexus_fs.sys_readdir
@@ -9904,9 +9915,10 @@ operations:
     sandbox: supported
     full: supported
   usage_example: 'MCP: nexus_semantic_search(query="auth flow", search_mode="hybrid", limit=5)'
-  correctness_test: tests/unit/bricks/mcp/test_mcp_server_tools.py::TestSemanticSearchTool; tests/integration/services/test_search_semantic.py::TestSemanticSearch
+  correctness_test: tests/unit/bricks/mcp/test_mcp_server_tools.py::TestSemanticSearchTool; tests/integration/services/test_search_semantic.py::TestSemanticSearch;
+    tests/integration/bricks/search/test_federated_search.py::TestRemoteZoneSearch; tests/unit/bricks/search/test_federated_degraded.py::TestSearchServiceSandboxFallback
   perf_class: hot
-  perf_link: tests/benchmarks/test_search_protocol_benchmark.py; docs/benchmarks/2026-04-18-sandbox-vs-gbrain.md
+  perf_link: tests/benchmarks/test_search_protocol_benchmark.py; docs/benchmarks/2026-04-18-sandbox-vs-gbrain.md; tests/benchmarks/bench_sandbox_federation_latency.py::TestFederatedSearchFanoutLatency
   gap_issue: null
   owning_issue: 4129
 - id: semantic.search_index

--- a/docs/architecture/api-rpc-surface-gaps.yaml
+++ b/docs/architecture/api-rpc-surface-gaps.yaml
@@ -23,11 +23,6 @@ missing_operations:
     summary: "Add a node to the raft cluster."
     wanted_why: "HA cluster expansion has no external surface yet."
 
-  - id: hub.status
-    module: hub
-    summary: "`nexus hub status`: show connected nodes, zones served, federation peers."
-    wanted_why: "Hub-mode operators currently have no top-level health view."
-
   - id: hub.deploy
     module: hub
     summary: "Bootstrap a hub deployment from CLI (currently helm/manual)."

--- a/docs/guides/user-guide.md
+++ b/docs/guides/user-guide.md
@@ -527,6 +527,112 @@ and source evidence is JSON output (`--json`), where `semantic_degraded`,
 Human-mode source/degraded formatting is a UX enhancement, not a blocker for
 the documented agent workflow.
 
+### Sandbox local + company hub federation workflow
+
+**Goal:** give an agent one searchable context plane that includes the local
+checkout plus hub-served company knowledge, while keeping writes scoped to the
+local workspace or to hub zones whose token grants `rw`.
+
+Start the sandbox with a local workspace and a hub token:
+
+```bash
+export NEXUS_HUB_TOKEN="nk_live_agent_scoped"
+nexus up --profile sandbox --workspace ~/app --hub-url grpc://hub.example.com:2028 --hub-token "$NEXUS_HUB_TOKEN"
+nexus ready --timeout 60
+```
+
+Hub and zone status are operator surfaces, not sandbox data-path calls. From a
+machine that can administer the hub, use either the local hub CLI or the remote
+MCP admin tool:
+
+```bash
+nexus hub status --detail --json
+nexus hub status --remote https://hub.example.com/mcp --admin-token "$NEXUS_HUB_ADMIN_TOKEN" --json
+nexus hub zone list --json
+nexus federation status
+nexus federation zones
+nexus federation info <zone-id>
+```
+
+Equivalent RPC / SDK shape:
+
+```python
+from nexus.contracts.exceptions import ZoneReadOnlyError
+
+
+async def use_local_and_hub_context(nx):
+    # The sandbox startup handshake calls this RPC with the hub token.
+    grants = nx.call_rpc("federation_client_whoami", {})
+    assert {"zone_id": "company", "permission": "r"} in grants["zones"]
+    assert {"zone_id": "shared", "permission": "rw"} in grants["zones"]
+
+    nx.write("/zone/local/notes/plan.md", b"local draft")
+    assert nx.read("/zone/local/notes/plan.md") == b"local draft"
+
+    company_policy = nx.read("/zone/company/policies/rate-limit.md")
+
+    try:
+        nx.write("/zone/company/policies/rate-limit.md", b"blocked")
+    except ZoneReadOnlyError:
+        pass
+
+    nx.write("/zone/shared/runbooks/new-runbook.md", b"shared edit")
+
+    search = nx.service("search")
+    hits = await search.semantic_search(
+        query="rate limit",
+        path="/",
+        search_mode="hybrid",
+        limit=5,
+    )
+    assert all(hit.get("zone_id") or hit.get("zone_qualified_path") for hit in hits)
+    return company_policy, hits
+```
+
+**Expected behavior:**
+
+- **Success:** the handshake returns the token's hub grants, the daemon mounts
+  the local workspace at `/zone/local`, read-only company knowledge at
+  `/zone/company`, and read-write shared knowledge at `/zone/shared`. Search
+  results carry `zone_id` and cross-zone dedup/source labels such as
+  `zone_qualified_path` so callers can tell which zone produced the hit.
+- **Denied:** writes to a read-only hub zone fail before a transport mutation
+  is attempted. Writes to `/zone/local` stay on local disk, and writes to an
+  `rw` hub zone go through the hub transport.
+- **Unavailable:** a bad token or unreachable hub does not prevent local work.
+  The handshake is logged as failed, remote zones are not mounted, and the
+  sandbox continues in local-only mode. Search may return local BM25S fallback
+  hits with `semantic_degraded=true` when all semantic peers are unavailable.
+
+**Correctness assertions:** `federation_client_whoami` must return exactly the
+remote zone IDs and `r` / `rw` grants used by the mount table; a write through
+`/zone/company` must be denied; a write through `/zone/shared` must be readable
+from the hub; and hub-down startup must keep `/zone/local` usable. These are
+covered by
+`tests/e2e/self_contained/cli/test_sandbox_federation_e2e.py`,
+`tests/unit/remote/test_federation_handshake.py`,
+`tests/unit/backends/test_remote_zone.py`, and
+`tests/integration/bricks/search/test_federated_search.py::TestRemoteZoneSearch`.
+
+**Performance classification:** handshake and hub status are control-plane
+paths. Local workspace read/write/list remain the hot file paths benchmarked in
+`tests/benchmarks/bench_read_write_overhead.py`. Remote hub reads and
+federated search fanout are hot once the agent is running; synthetic guardrails
+live in `tests/benchmarks/bench_sandbox_federation_latency.py`
+(`TestSandboxFederationHandshakeLatency`, `TestSandboxFederationReadLatency`,
+`TestFederatedSearchFanoutLatency`, and
+`TestSandboxHubDownDegradedLatency`). The benchmark budgets are for local
+dispatch overhead only; live hub latency depends on the network and the hub's
+storage/search backend.
+
+**Missing-surface gate verdict:** no new build issue is required for #4130.
+The zone-status concern is covered by `nexus hub status --detail --json`,
+`nexus hub status --remote ... --json`, `nexus hub zone list`, and the
+cluster federation views `nexus federation status`, `nexus federation zones`,
+and `nexus federation info <zone-id>`. The remaining `hub.deploy` gap is a
+separate hub rollout convenience, not a blocker for the sandbox federation
+workflow.
+
 ### Sandbox ReBAC, hub-zone, and MCP tool boundaries
 
 **Goal:** let an agent platform owner prove what a sandboxed agent may read,

--- a/rust/backends/src/storage/remote.rs
+++ b/rust/backends/src/storage/remote.rs
@@ -98,6 +98,17 @@ fn parse_write_result(path: &str, result: &serde_json::Value) -> Result<WriteRes
     })
 }
 
+fn parse_stat_size_from_response(
+    path: &str,
+    response: &serde_json::Value,
+) -> Result<u64, StorageError> {
+    let result = response.get("result").unwrap_or(response);
+    result
+        .get("size")
+        .and_then(|v| v.as_u64())
+        .ok_or_else(|| StorageError::NotFound(path.to_string()))
+}
+
 impl ObjectStore for RemoteBackend {
     fn name(&self) -> &str {
         "remote"
@@ -308,10 +319,7 @@ impl ObjectStore for RemoteBackend {
         }
         let value: serde_json::Value = serde_json::from_slice(&resp)
             .map_err(|e| StorageError::IOError(std::io::Error::other(e.to_string())))?;
-        value
-            .get("size")
-            .and_then(|v| v.as_u64())
-            .ok_or_else(|| StorageError::NotFound(content_id.to_string()))
+        parse_stat_size_from_response(content_id, &value)
     }
 
     fn mkdir(&self, path: &str, parents: bool, exist_ok: bool) -> Result<(), StorageError> {
@@ -429,5 +437,20 @@ mod tests {
         assert_eq!(parsed.content_id, "zone/shared/readback.txt");
         assert_eq!(parsed.version, "zone/shared/readback.txt");
         assert_eq!(parsed.size, 18);
+    }
+
+    #[test]
+    fn parse_stat_size_accepts_call_result_envelope() {
+        let response = serde_json::json!({
+            "result": {
+                "path": "/zone/shared/existing.txt",
+                "size": 42
+            }
+        });
+
+        assert_eq!(
+            parse_stat_size_from_response("/zone/shared/existing.txt", &response).unwrap(),
+            42
+        );
     }
 }

--- a/rust/backends/src/storage/remote.rs
+++ b/rust/backends/src/storage/remote.rs
@@ -22,7 +22,7 @@ use kernel::rpc_transport::RpcTransport;
 /// expects the original absolute path, so `to_server_path` re-prepends
 /// the mount point.  For REMOTE-profile root mounts (`zone_path="/"`)
 /// the backend_path is already the full path — no prefix is added.
-pub(crate) struct RemoteBackend {
+pub struct RemoteBackend {
     transport: Arc<RpcTransport>,
     /// Mount point of this backend (e.g. "/zone/shared" or "/").
     /// Used to reconstruct the absolute path sent to the hub.
@@ -36,6 +36,13 @@ impl RemoteBackend {
         Self {
             transport,
             zone_path: String::new(),
+        }
+    }
+
+    pub fn with_zone_path(transport: Arc<RpcTransport>, zone_path: impl Into<String>) -> Self {
+        Self {
+            transport,
+            zone_path: zone_path.into(),
         }
     }
 }
@@ -56,9 +63,39 @@ fn to_server_path(zone_path: &str, backend_path: &str) -> String {
     };
     if zone_path.is_empty() || zone_path == "/" {
         bp
+    } else if bp
+        .trim_start_matches('/')
+        .starts_with(zone_path.trim_start_matches('/'))
+    {
+        bp
     } else {
         format!("{zone_path}{bp}")
     }
+}
+
+fn parse_write_result(path: &str, result: &serde_json::Value) -> Result<WriteResult, StorageError> {
+    let content_id = result
+        .get("content_id")
+        .or_else(|| result.get("etag"))
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .unwrap_or(path)
+        .to_string();
+    let size = result
+        .get("size")
+        .or_else(|| result.get("bytes_written"))
+        .and_then(|v| v.as_u64())
+        .ok_or_else(|| {
+            StorageError::IOError(std::io::Error::other(format!(
+                "sys_write({path}): response missing size"
+            )))
+        })?;
+
+    Ok(WriteResult {
+        content_id: content_id.clone(),
+        version: content_id,
+        size,
+    })
 }
 
 impl ObjectStore for RemoteBackend {
@@ -228,7 +265,7 @@ impl ObjectStore for RemoteBackend {
             ))));
         }
 
-        // Response envelope: {"result": {"bytes_written": N, "etag": "...", "size": N, ...}}
+        // Response envelope: {"result": {"bytes_written": N, "content_id": "...", "size": N, ...}}
         let value: serde_json::Value = serde_json::from_slice(&resp)
             .map_err(|e| StorageError::IOError(std::io::Error::other(e.to_string())))?;
         let result = value.get("result").ok_or_else(|| {
@@ -237,27 +274,15 @@ impl ObjectStore for RemoteBackend {
             )))
         })?;
 
-        let etag = result
-            .get("etag")
-            .and_then(|v| v.as_str())
-            .unwrap_or_default()
-            .to_string();
-        let size = result
-            .get("size")
-            .and_then(|v| v.as_u64())
-            .unwrap_or(content.len() as u64);
+        let write_result = parse_write_result(&path, result)?;
 
         tracing::debug!(
             path = %path,
-            etag = %etag,
-            size = size,
+            content_id = %write_result.content_id,
+            size = write_result.size,
             "RemoteBackend::write_content ok"
         );
-        Ok(WriteResult {
-            content_id: etag.clone(),
-            version: etag,
-            size,
-        })
+        Ok(write_result)
     }
 
     fn delete_content(&self, _content_id: &str) -> Result<(), StorageError> {
@@ -385,5 +410,24 @@ impl ObjectStore for RemoteBackend {
             ))));
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_write_result_accepts_current_sys_write_content_id_shape() {
+        let result = serde_json::json!({
+            "content_id": "zone/shared/readback.txt",
+            "size": 18
+        });
+
+        let parsed = parse_write_result("/zone/shared/readback.txt", &result).unwrap();
+
+        assert_eq!(parsed.content_id, "zone/shared/readback.txt");
+        assert_eq!(parsed.version, "zone/shared/readback.txt");
+        assert_eq!(parsed.size, 18);
     }
 }

--- a/rust/kernel/src/core/meta_store/remote.rs
+++ b/rust/kernel/src/core/meta_store/remote.rs
@@ -36,6 +36,10 @@ impl RemoteMetaStore {
     }
 }
 
+fn unwrap_result_envelope(value: &serde_json::Value) -> &serde_json::Value {
+    value.get("result").unwrap_or(value)
+}
+
 impl MetaStore for RemoteMetaStore {
     fn get(&self, path: &str) -> Result<Option<FileMetadata>, MetaStoreError> {
         if let Some(cached) = self.cache.get(path) {
@@ -58,40 +62,38 @@ impl MetaStore for RemoteMetaStore {
         let value: serde_json::Value = serde_json::from_slice(&resp_bytes)
             .map_err(|e| MetaStoreError::IOError(format!("decode sys_stat response: {e}")))?;
 
+        let value = unwrap_result_envelope(&value);
+
         // Server returns None/null for missing paths
         if value.is_null() {
             return Ok(None);
         }
 
-        let meta = parse_metadata_from_json(&value)?;
+        let meta = parse_metadata_from_json(value)?;
         self.cache.insert(path.to_string(), meta.clone());
         Ok(Some(meta))
     }
 
     fn put(&self, path: &str, metadata: FileMetadata) -> Result<(), MetaStoreError> {
-        // Wire format expected by the hub's `handle_set_metadata` (#3786):
-        //     {"path": ..., "metadata": { ...flat fields... }}
-        // The handler reads `params.path` + `params.metadata` (a dict) and
-        // reconstructs the FileMetadata via MetadataMapper.from_json.  Sending
-        // flat fields at the top level fails parse_method_params(SetMetadataParams)
-        // and the SimpleNamespace fallback has no `metadata` attribute.
+        // Use the kernel-syscall wire shape, not the old set_metadata handler
+        // shape. The Python gRPC Call path routes `sys_setattr` through
+        // `_kernel_syscall_dispatch`, which forwards flat kwargs into
+        // NexusFS.sys_setattr.
         let payload = serde_json::json!({
             "path": path,
-            "metadata": {
-                "entry_type": metadata.entry_type,
-                "size": metadata.size,
-                "content_id": metadata.content_id,
-                "gen": metadata.gen,
-                "version": metadata.version,
-                "zone_id": metadata.zone_id,
-                "mime_type": metadata.mime_type,
-                "last_writer_address": metadata.last_writer_address,
-                "created_at_ms": metadata.created_at_ms,
-                "modified_at_ms": metadata.modified_at_ms,
-                "target_zone_id": metadata.target_zone_id,
-                "link_target": metadata.link_target,
-                "owner_id": metadata.owner_id,
-            },
+            "entry_type": metadata.entry_type,
+            "size": metadata.size,
+            "content_id": metadata.content_id,
+            "gen": metadata.gen,
+            "version": metadata.version,
+            "zone_id": metadata.zone_id,
+            "mime_type": metadata.mime_type,
+            "last_writer_address": metadata.last_writer_address,
+            "created_at_ms": metadata.created_at_ms,
+            "modified_at_ms": metadata.modified_at_ms,
+            "target_zone_id": metadata.target_zone_id,
+            "link_target": metadata.link_target,
+            "owner_id": metadata.owner_id,
         });
         let bytes =
             serde_json::to_vec(&payload).map_err(|e| MetaStoreError::IOError(e.to_string()))?;
@@ -148,8 +150,11 @@ impl MetaStore for RemoteMetaStore {
         let value: serde_json::Value = serde_json::from_slice(&resp_bytes)
             .map_err(|e| MetaStoreError::IOError(format!("decode sys_readdir: {e}")))?;
 
+        let value = unwrap_result_envelope(&value);
+        let files = value.get("files").unwrap_or(value);
+
         // Server returns an array of entries (path, entry_type pairs or full metadata)
-        let entries = match value.as_array() {
+        let entries = match files.as_array() {
             Some(arr) => arr
                 .iter()
                 .filter_map(|v| parse_metadata_from_json(v).ok())
@@ -176,6 +181,7 @@ impl MetaStore for RemoteMetaStore {
 
         // Server returns a bool or a JSON object with an "exists" field
         let value: serde_json::Value = serde_json::from_slice(&resp_bytes).unwrap_or_default();
+        let value = unwrap_result_envelope(&value);
         Ok(value.as_bool().unwrap_or_else(|| {
             value
                 .get("exists")
@@ -199,6 +205,7 @@ impl MetaStore for RemoteMetaStore {
         }
 
         let value: serde_json::Value = serde_json::from_slice(&resp_bytes).unwrap_or_default();
+        let value = unwrap_result_envelope(&value);
         Ok(value.as_bool().unwrap_or(false))
     }
 
@@ -231,10 +238,12 @@ impl MetaStore for RemoteMetaStore {
 
         let value: serde_json::Value = serde_json::from_slice(&resp_bytes)
             .map_err(|e| MetaStoreError::IOError(format!("decode paginated readdir: {e}")))?;
+        let value = unwrap_result_envelope(&value);
 
         let items: Vec<FileMetadata> = value
             .get("items")
-            .or(Some(&value))
+            .or_else(|| value.get("files"))
+            .or(Some(value))
             .and_then(|v| v.as_array())
             .map(|arr| {
                 arr.iter()

--- a/rust/kernel/src/rpc_transport.rs
+++ b/rust/kernel/src/rpc_transport.rs
@@ -7,6 +7,7 @@
 //! Issue #1133: Unified gRPC transport.
 //! Issue #1202: gRPC for REMOTE profile.
 
+use std::future::Future;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -72,6 +73,14 @@ impl RpcTransport {
         &self.runtime
     }
 
+    fn block_on<F: Future>(&self, future: F) -> F::Output {
+        if tokio::runtime::Handle::try_current().is_ok() {
+            tokio::task::block_in_place(|| self.runtime.handle().block_on(future))
+        } else {
+            self.runtime.block_on(future)
+        }
+    }
+
     fn build_channel(
         address: &str,
         tls: Option<&TlsConfig>,
@@ -115,7 +124,7 @@ impl RpcTransport {
 
     /// Generic Call RPC — method name + JSON payload.
     pub fn call(&self, method: &str, payload: &[u8]) -> Result<(Vec<u8>, bool), String> {
-        self.runtime.block_on(self.call_async(method, payload))
+        self.block_on(self.call_async(method, payload))
     }
 
     async fn call_async(&self, method: &str, payload: &[u8]) -> Result<(Vec<u8>, bool), String> {
@@ -146,7 +155,7 @@ impl RpcTransport {
 
     /// Typed Read RPC — raw bytes, no base64.
     pub fn read(&self, path: &str, content_id: &str) -> Result<ReadResult, String> {
-        self.runtime.block_on(self.read_async(path, content_id))
+        self.block_on(self.read_async(path, content_id))
     }
 
     async fn read_async(&self, path: &str, content_id: &str) -> Result<ReadResult, String> {
@@ -191,8 +200,7 @@ impl RpcTransport {
         content: &[u8],
         content_id: &str,
     ) -> Result<WriteRpcResult, String> {
-        self.runtime
-            .block_on(self.write_async(path, content, content_id))
+        self.block_on(self.write_async(path, content, content_id))
     }
 
     async fn write_async(
@@ -237,7 +245,7 @@ impl RpcTransport {
 
     /// Typed Delete RPC.
     pub fn delete(&self, path: &str, recursive: bool) -> Result<bool, String> {
-        self.runtime.block_on(self.delete_async(path, recursive))
+        self.block_on(self.delete_async(path, recursive))
     }
 
     async fn delete_async(&self, path: &str, recursive: bool) -> Result<bool, String> {
@@ -262,7 +270,7 @@ impl RpcTransport {
     /// Health check — returns (version, zone_id, uptime_seconds).
     #[allow(dead_code)]
     pub fn ping(&self) -> Result<(String, String, i64), String> {
-        self.runtime.block_on(self.ping_async())
+        self.block_on(self.ping_async())
     }
 
     #[allow(dead_code)]

--- a/rust/profiles/cluster/Cargo.toml
+++ b/rust/profiles/cluster/Cargo.toml
@@ -22,7 +22,7 @@ contracts = { workspace = true }
 # `default-features = false` drops every other driver and the connector
 # HTTP stack so the binary stays at the sudowork target size.
 kernel = { workspace = true }
-backends = { workspace = true, default-features = false, features = ["driver-path-local"] }
+backends = { workspace = true, default-features = false, features = ["driver-path-local", "driver-remote"] }
 # VFS gRPC server — pure Rust content I/O on a separate port.
 # No python feature — cluster binary has zero PyO3.
 transport = { workspace = true }

--- a/rust/transport/Cargo.toml
+++ b/rust/transport/Cargo.toml
@@ -19,7 +19,7 @@ contracts = { workspace = true }
 # (mimalloc allocator, connectors HTTP, py-hook adapters) off in this
 # rlib; the cdylib pulls them via its own kernel dep.
 kernel = { workspace = true }
-backends = { workspace = true, default-features = false, features = ["driver-path-local"] }
+backends = { workspace = true, default-features = false, features = ["driver-path-local", "driver-remote"] }
 # `services::auth::AuthProvider` trait consumed by grpc.rs for auth
 # resolution. No feature flags — auth module is always compiled.
 services = { workspace = true }

--- a/rust/transport/src/call_dispatch.rs
+++ b/rust/transport/src/call_dispatch.rs
@@ -6,11 +6,14 @@
 //! `{"code": N, "message": "..."}` for errors.
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use kernel::abi::KernelAbi;
 use kernel::kernel::convenience::KernelConvenience;
 use kernel::kernel::vfs_proto::CallResponse;
 use kernel::kernel::{Kernel, KernelError, OperationContext, WriteRequest};
+use kernel::meta_store::remote::RemoteMetaStore;
+use kernel::rpc_transport::RpcTransport;
 use tonic::{Response, Status};
 
 use crate::grpc::{encode_rpc_error, RpcErrorCode};
@@ -283,6 +286,80 @@ fn do_sys_setattr(
                 None,
                 None,
                 None,
+            ) {
+                Ok(r) => {
+                    return ok_json(serde_json::json!({
+                        "path": r.path,
+                        "created": r.created,
+                        "entry_type": r.entry_type,
+                        "backend_name": r.backend_name,
+                    }));
+                }
+                Err(e) => return Err(kernel_err_to_payload(e)),
+            }
+        }
+
+        if backend_type == "remote" {
+            if !ctx.is_admin && !ctx.is_system {
+                return Err(call_err(
+                    RpcErrorCode::PermissionError,
+                    "sys_setattr DT_MOUNT remote requires admin or system context",
+                ));
+            }
+            let server_address = s(params, "server_address");
+            if server_address.is_empty() {
+                return Err(call_err(
+                    RpcErrorCode::InternalError,
+                    "sys_setattr DT_MOUNT remote requires server_address",
+                ));
+            }
+            let remote_auth_token = s(params, "remote_auth_token");
+            let remote_timeout = params
+                .get("remote_timeout")
+                .and_then(|v| v.as_f64())
+                .unwrap_or(90.0);
+            let transport = Arc::new(
+                RpcTransport::new(
+                    Arc::clone(kernel.runtime()),
+                    &server_address,
+                    &remote_auth_token,
+                    None,
+                    Duration::from_secs_f64(remote_timeout),
+                )
+                .map_err(|e| {
+                    call_err(
+                        RpcErrorCode::InternalError,
+                        &format!("remote transport init failed for {server_address}: {e}"),
+                    )
+                })?,
+            );
+            let backend = backends::storage::remote::RemoteBackend::with_zone_path(
+                Arc::clone(&transport),
+                path.clone(),
+            );
+            let remote_metastore = RemoteMetaStore::new(transport);
+            match kernel.sys_setattr(
+                &path,
+                entry_type,
+                backend_name,
+                Some(Arc::new(backend)),
+                None,
+                None,
+                "",
+                zone_id,
+                is_external,
+                0,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                Some(Arc::new(remote_metastore)),
             ) {
                 Ok(r) => {
                     return ok_json(serde_json::json!({
@@ -827,6 +904,19 @@ mod tests {
         serde_json::to_vec(&serde_json::json!({ "files": files })).expect("payload")
     }
 
+    fn remote_mount_payload() -> Vec<u8> {
+        serde_json::to_vec(&serde_json::json!({
+            "path": "/zone/company",
+            "entry_type": 2,
+            "backend_type": "remote",
+            "backend_name": "remote_zone:company",
+            "server_address": "127.0.0.1:9",
+            "remote_auth_token": "sk-test",
+            "zone_id": kernel::ROOT_ZONE_ID,
+        }))
+        .expect("payload")
+    }
+
     struct DenyBlockedWriteHook;
 
     impl NativeInterceptHook for DenyBlockedWriteHook {
@@ -876,6 +966,22 @@ mod tests {
             .into_inner();
 
         assert!(response.is_error, "non-admin path_local mount succeeded");
+    }
+
+    #[test]
+    fn sys_setattr_remote_mount_from_json_installs_mount() {
+        let kernel = Arc::new(Kernel::new());
+        let ctx = OperationContext::new("test", kernel::ROOT_ZONE_ID, true, None, true);
+
+        let response = dispatch(&kernel, &ctx, "sys_setattr", &remote_mount_payload())
+            .expect("dispatch")
+            .into_inner();
+
+        assert!(!response.is_error, "remote mount returned error payload");
+        assert!(
+            kernel.has_mount("/zone/company", kernel::ROOT_ZONE_ID),
+            "remote mount call returned success without installing a route"
+        );
     }
 
     #[test]

--- a/rust/transport/src/grpc.rs
+++ b/rust/transport/src/grpc.rs
@@ -98,6 +98,17 @@ impl VfsServiceImpl {
             KernelError::FileNotFound(p) => (RpcErrorCode::FileNotFound, p),
             KernelError::PermissionDenied(m) => (RpcErrorCode::PermissionError, m),
             KernelError::InvalidPath(m) => (RpcErrorCode::InvalidPath, m),
+            KernelError::BackendError(m) => {
+                let lower = m.to_ascii_lowercase();
+                if lower.contains("permission")
+                    || lower.contains("denied")
+                    || lower.contains("read-only")
+                {
+                    (RpcErrorCode::PermissionError, m)
+                } else {
+                    (RpcErrorCode::InternalError, m)
+                }
+            }
             KernelError::PipeClosed(m) | KernelError::StreamClosed(m) => {
                 (RpcErrorCode::InternalError, m)
             }

--- a/src/nexus/bricks/rebac/checker.py
+++ b/src/nexus/bricks/rebac/checker.py
@@ -180,6 +180,8 @@ class PermissionChecker:
                         if _z == _path_zone:
                             if _perm_char in _perms or "x" in _perms:
                                 _allowed = True
+                                if ctx.zone_id == ROOT_ZONE_ID:
+                                    return
                             else:
                                 raise PermissionError(
                                     f"Access denied: zone {_path_zone!r} is "

--- a/src/nexus/lib/rpc_codec.py
+++ b/src/nexus/lib/rpc_codec.py
@@ -23,6 +23,20 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 
+def _slot_items(obj: Any) -> dict[str, Any]:
+    slots = getattr(obj, "__slots__", ())
+    if isinstance(slots, str):
+        slots = (slots,)
+    return {
+        name: getattr(obj, name)
+        for name in slots
+        if isinstance(name, str)
+        and not name.startswith("_")
+        and hasattr(obj, name)
+        and not callable(getattr(obj, name))
+    }
+
+
 class RPCEncoder(json.JSONEncoder):
     """Custom JSON encoder for RPC messages.
 
@@ -54,6 +68,7 @@ class RPCEncoder(json.JSONEncoder):
 
             if is_dataclass(obj):
                 return {f.name: getattr(obj, f.name) for f in fields(obj)}
+            return _slot_items(obj)
         return super().default(obj)
 
 
@@ -114,7 +129,7 @@ def _prepare_for_orjson(obj: Any) -> Any:
 
         if is_dataclass(obj):
             return {f.name: _prepare_for_orjson(getattr(obj, f.name)) for f in fields(obj)}
-        return obj
+        return {k: _prepare_for_orjson(v) for k, v in _slot_items(obj).items()}
     else:
         return obj
 

--- a/src/nexus/server/zone_execution.py
+++ b/src/nexus/server/zone_execution.py
@@ -24,6 +24,12 @@ def context_for_target_zone(context: Any, target_zone: str | None) -> Any:
         return context
     if not context_allows_target_zone(context, target_zone):
         return context
+    zone_perms = tuple(getattr(context, "zone_perms", ()) or ())
+    real_zone_perms = tuple(
+        zp for zp in zone_perms if isinstance(zp, (list, tuple)) and zp and zp[0] != "root"
+    )
+    if len(real_zone_perms) > 1 and getattr(context, "zone_id", None) == "root":
+        return context
     updates: dict[str, Any] = {"zone_id": target_zone}
     if getattr(context, "is_admin", False):
         updates["zone_set"] = (target_zone,)

--- a/tests/architecture/test_issue_4128_sandbox_rebac_mcp_boundaries.py
+++ b/tests/architecture/test_issue_4128_sandbox_rebac_mcp_boundaries.py
@@ -69,7 +69,7 @@ def test_issue_4128_remote_zone_readonly_write_denial_is_linked() -> None:
 
     whoami = ops["federation.client_whoami"]
     assert whoami.profiles["sandbox"] == ProfileStatus.SUPPORTED
-    assert whoami.owning_issue == 4128
+    assert whoami.owning_issue in {4128, 4130}
     assert whoami.usage_example
     assert "test_sandbox_federation_e2e.py" in whoami.correctness_test
     assert whoami.perf_class == PerfClass.CONTROL

--- a/tests/architecture/test_issue_4130_sandbox_federation_surface.py
+++ b/tests/architecture/test_issue_4130_sandbox_federation_surface.py
@@ -1,0 +1,106 @@
+"""Coverage contract tests for the sandbox workspace + hub federation story (#4130)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.surface_coverage.schema import PerfClass, ProfileStatus, load_yaml
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_COVERAGE_YAML = _REPO_ROOT / "docs/architecture/api-rpc-surface-coverage.yaml"
+_GAPS_YAML = _REPO_ROOT / "docs/architecture/api-rpc-surface-gaps.yaml"
+_USER_GUIDE = _REPO_ROOT / "docs/guides/user-guide.md"
+_BENCHMARK = _REPO_ROOT / "tests/benchmarks/bench_sandbox_federation_latency.py"
+
+OWNING_ISSUE = 4130
+
+FEDERATION_CONTROL_ROWS = {
+    "federation.client_whoami",
+    "federation.cluster_info",
+    "federation.list_zones",
+    "hub.status",
+}
+
+
+def _operations_by_id():
+    return {op.id: op for op in load_yaml(_COVERAGE_YAML).operations}
+
+
+def test_issue_4130_control_rows_have_docs_tests_and_perf_classification() -> None:
+    ops = _operations_by_id()
+
+    missing = sorted(FEDERATION_CONTROL_ROWS - set(ops))
+    assert not missing
+
+    for op_id in sorted(FEDERATION_CONTROL_ROWS):
+        op = ops[op_id]
+        assert op.owning_issue == OWNING_ISSUE, op_id
+        assert op.summary, op_id
+        assert op.usage_example, op_id
+        assert op.correctness_test, op_id
+        assert op.perf_class in {PerfClass.CONTROL, PerfClass.SETUP}, op_id
+        assert op.perf_link, op_id
+        assert op.gap_issue is None, op_id
+
+    assert ops["federation.client_whoami"].profiles["sandbox"] == ProfileStatus.SUPPORTED
+    assert ops["federation.cluster_info"].profiles["sandbox"] == ProfileStatus.SUPPORTED
+    assert ops["federation.list_zones"].profiles["sandbox"] == ProfileStatus.SUPPORTED
+
+    hub_status = ops["hub.status"]
+    assert hub_status.transports, "hub.status must point at the implemented CLI/MCP surface"
+    assert hub_status.profiles["full"] == ProfileStatus.SUPPORTED
+    assert hub_status.profiles["sandbox"] != ProfileStatus.MISSING_NEEDED
+
+
+def test_issue_4130_hot_paths_link_remote_read_and_fanout_benchmarks() -> None:
+    ops = _operations_by_id()
+
+    read = ops["nexus_fs.sys_read"]
+    assert read.profiles["sandbox"] == ProfileStatus.SUPPORTED
+    assert "test_sandbox_federation_e2e.py" in read.correctness_test
+    assert "bench_sandbox_federation_latency.py::TestSandboxFederationReadLatency" in (
+        read.perf_link or ""
+    )
+
+    write = ops["filesystem.write"]
+    assert write.profiles["sandbox"] == ProfileStatus.SUPPORTED
+    assert "test_remote_zone.py" in write.correctness_test
+    assert "test_sandbox_federation_e2e.py" in write.correctness_test
+    assert "bench_permission_hotpath.py" in (write.perf_link or "")
+
+    search = ops["semantic.search"]
+    assert search.profiles["sandbox"] == ProfileStatus.SUPPORTED
+    assert "test_federated_search.py::TestRemoteZoneSearch" in search.correctness_test
+    assert "bench_sandbox_federation_latency.py::TestFederatedSearchFanoutLatency" in (
+        search.perf_link or ""
+    )
+
+    assert _BENCHMARK.exists()
+
+
+def test_issue_4130_user_guide_contains_federation_workflow_and_gap_verdict() -> None:
+    text = _USER_GUIDE.read_text(encoding="utf-8")
+
+    for needle in [
+        "Sandbox local + company hub federation workflow",
+        'nexus up --profile sandbox --workspace ~/app --hub-url grpc://hub.example.com:2028 --hub-token "$NEXUS_HUB_TOKEN"',
+        "federation_client_whoami",
+        "/zone/local",
+        "/zone/company",
+        "/zone/shared",
+        "nexus hub status --detail --json",
+        'nexus hub status --remote https://hub.example.com/mcp --admin-token "$NEXUS_HUB_ADMIN_TOKEN" --json',
+        "nexus federation info <zone-id>",
+        "semantic_degraded",
+        "zone_qualified_path",
+        "tests/e2e/self_contained/cli/test_sandbox_federation_e2e.py",
+        "tests/benchmarks/bench_sandbox_federation_latency.py",
+        "Missing-surface gate verdict",
+    ]:
+        assert needle in text
+
+
+def test_issue_4130_hub_status_is_not_listed_as_missing_surface() -> None:
+    text = _GAPS_YAML.read_text(encoding="utf-8")
+
+    assert "id: hub.status" not in text

--- a/tests/benchmarks/bench_sandbox_federation_latency.py
+++ b/tests/benchmarks/bench_sandbox_federation_latency.py
@@ -1,0 +1,220 @@
+"""Synthetic latency guardrails for sandbox workspace + hub federation (#4130).
+
+These benchmarks do not require a live hub. They pin the expected cost class
+for the local control branches that wrap the real network calls:
+handshake parsing/mapping, remote-zone read dispatch, federated search fanout,
+and the local-only degraded branch used when the hub is down.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from nexus.backends.storage.remote_zone import RemoteZoneBackend
+from nexus.bricks.search.federated_search import (
+    FederatedSearchConfig,
+    FederatedSearchDispatcher,
+    FederatedSearchResponse,
+    ZoneFailure,
+)
+from nexus.bricks.search.results import BaseSearchResult
+from nexus.bricks.search.search_service import SearchService
+from nexus.contracts.types import OperationContext
+from nexus.remote import federation_handshake
+
+
+def _p99(values: list[float]) -> float:
+    ordered = sorted(values)
+    return ordered[max(0, int(len(ordered) * 0.99) - 1)]
+
+
+def _measure_us(fn: Any, *, iterations: int = 500, warmup: int = 50) -> dict[str, float]:
+    for _ in range(warmup):
+        fn()
+
+    samples: list[float] = []
+    for _ in range(iterations):
+        start = time.perf_counter()
+        fn()
+        samples.append((time.perf_counter() - start) * 1_000_000)
+
+    return {"p50_us": sorted(samples)[len(samples) // 2], "p99_us": _p99(samples)}
+
+
+async def _measure_async_us(
+    fn: Any, *, iterations: int = 200, warmup: int = 20
+) -> dict[str, float]:
+    for _ in range(warmup):
+        await fn()
+
+    samples: list[float] = []
+    for _ in range(iterations):
+        start = time.perf_counter()
+        await fn()
+        samples.append((time.perf_counter() - start) * 1_000_000)
+
+    return {"p50_us": sorted(samples)[len(samples) // 2], "p99_us": _p99(samples)}
+
+
+class FakeHandshakeTransport:
+    def __init__(self, *_args: Any, **_kwargs: Any) -> None:
+        self.calls: list[str] = []
+
+    def call_rpc(
+        self,
+        method: str,
+        params: dict[str, Any] | None = None,
+        read_timeout: float | None = None,
+    ) -> dict[str, Any]:
+        assert params is None
+        assert read_timeout == 0.1
+        self.calls.append(method)
+        return {
+            "zones": [
+                {"zone_id": "company", "permission": "r"},
+                {"zone_id": "shared", "permission": "rw"},
+            ]
+        }
+
+
+class FakeFileTransport:
+    def __init__(self) -> None:
+        self.read_calls = 0
+
+    def read_file(self, path: str, content_id: str = "") -> bytes:
+        self.read_calls += 1
+        assert path == "/zone/company/policies/rate-limit.md"
+        assert content_id == "cid-policy"
+        return b"company policy"
+
+
+class FakeRebac:
+    async def list_accessible_zones(self, subject: tuple[str, str]) -> list[str]:
+        assert subject == ("agent", "alice")
+        return ["local", "company", "shared"]
+
+
+class FakeSearchDaemon:
+    def get_stats(self) -> dict[str, Any]:
+        return {"bm25_documents": 0, "zoekt_available": False}
+
+    async def search(
+        self,
+        query: str,
+        search_type: str = "hybrid",
+        limit: int = 10,
+        path_filter: str | None = None,
+        alpha: float = 0.5,
+        fusion_method: str = "rrf",
+        zone_id: str | None = None,
+    ) -> list[BaseSearchResult]:
+        assert query == "rate limit"
+        assert search_type == "hybrid"
+        assert path_filter is None
+        assert zone_id is not None
+        return [
+            BaseSearchResult(
+                path=f"/{zone_id}/policies/rate-limit.md",
+                chunk_text=f"{zone_id} result",
+                score=1.0,
+                zone_id=zone_id,
+            )
+        ]
+
+
+class TestSandboxFederationHandshakeLatency:
+    def test_handshake_control_path_maps_zone_grants_under_5ms(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(federation_handshake, "RPCTransport", FakeHandshakeTransport)
+
+        def _run_once() -> None:
+            session = federation_handshake.FederationHandshake(
+                "grpc://hub.example.com:2028",
+                "hub-token",
+                timeout=0.1,
+                connect_timeout=0.1,
+            ).run()
+            assert [z.zone_id for z in session.zones] == ["company", "shared"]
+
+        stats = _measure_us(_run_once, iterations=500)
+        assert stats["p99_us"] < 5_000.0, stats
+
+
+class TestSandboxFederationReadLatency:
+    def test_remote_zone_read_dispatch_under_5ms_synthetic(self) -> None:
+        transport = FakeFileTransport()
+        backend = RemoteZoneBackend(zone_id="company", transport=transport, permission="r")
+        context = OperationContext(
+            user_id="alice",
+            groups=[],
+            zone_id="company",
+            backend_path="policies/rate-limit.md",
+            virtual_path="/zone/company/policies/rate-limit.md",
+        )
+
+        def _run_once() -> None:
+            assert backend.read_content("cid-policy", context=context) == b"company policy"
+
+        stats = _measure_us(_run_once, iterations=1_000)
+        assert stats["p99_us"] < 5_000.0, stats
+        assert transport.read_calls >= 1_000
+
+
+class TestFederatedSearchFanoutLatency:
+    @pytest.mark.asyncio
+    async def test_three_zone_fanout_and_source_labels_under_20ms_synthetic(self) -> None:
+        dispatcher = FederatedSearchDispatcher(
+            daemon=FakeSearchDaemon(),
+            rebac=FakeRebac(),
+            config=FederatedSearchConfig(max_concurrent_zones=3),
+        )
+
+        async def _run_once() -> None:
+            response = await dispatcher.search("rate limit", subject=("agent", "alice"), limit=3)
+            assert set(response.zones_searched) == {"local", "company", "shared"}
+            assert {r["zone_id"] for r in response.results} == {"local", "company", "shared"}
+            assert all("zone_qualified_path" in r for r in response.results)
+
+        stats = await _measure_async_us(_run_once, iterations=200)
+        assert stats["p99_us"] < 20_000.0, stats
+
+
+class TestSandboxHubDownDegradedLatency:
+    @pytest.mark.asyncio
+    async def test_local_only_degraded_branch_under_10ms_synthetic(self) -> None:
+        service = SearchService(
+            metadata_store=MagicMock(),
+            enforce_permissions=False,
+            deployment_profile="sandbox",
+        )
+
+        async def _federation_failed() -> FederatedSearchResponse:
+            return FederatedSearchResponse(
+                results=[],
+                zones_searched=["company", "shared"],
+                zones_failed=[
+                    ZoneFailure(zone_id="company", error="hub unavailable"),
+                    ZoneFailure(zone_id="shared", error="hub unavailable"),
+                ],
+            )
+
+        async def _local_bm25() -> list[BaseSearchResult]:
+            return [
+                BaseSearchResult(path="/zone/local/README.md", chunk_text="fallback", score=0.5)
+            ]
+
+        async def _run_once() -> None:
+            results = await service._semantic_with_sandbox_fallback(
+                _federation_failed,
+                _local_bm25,
+            )
+            assert len(results) == 1
+            assert results[0].semantic_degraded is True
+
+        stats = await _measure_async_us(_run_once, iterations=200)
+        assert stats["p99_us"] < 10_000.0, stats

--- a/tests/e2e/self_contained/cli/test_sandbox_federation_e2e.py
+++ b/tests/e2e/self_contained/cli/test_sandbox_federation_e2e.py
@@ -180,7 +180,7 @@ def _poll_health_until_ready_or_exit(
 
 
 def _kernel_missing_skip_reason(stderr: str) -> str | None:
-    if "nexus-cluster" in stderr or "nexus_kernel" in stderr or "No module named" in stderr:
+    if "nexus-cluster" in stderr or "nexus_kernel" in stderr:
         return "nexusd requires nexus-cluster binary — run cargo build --release -p nexus-cluster"
     return None
 

--- a/tests/e2e/self_contained/cli/test_sandbox_federation_e2e.py
+++ b/tests/e2e/self_contained/cli/test_sandbox_federation_e2e.py
@@ -51,6 +51,14 @@ class SandboxHandle:
     hub_token: str = ""  # bearer token the sandbox was configured with
 
 
+@dataclasses.dataclass
+class HealthPollResult:
+    ready: bool
+    exited: bool = False
+    returncode: int | None = None
+    stderr: str = ""
+
+
 def _nexus_bin() -> str:
     return str(Path(sys.executable).parent / "nexus")
 
@@ -127,6 +135,54 @@ def _poll_health(url: str, timeout: int = 60) -> bool:
             pass
         time.sleep(1)
     return False
+
+
+def _read_process_stderr(proc: object) -> str:
+    stderr = getattr(proc, "stderr", None)
+    if stderr is None:
+        return ""
+    try:
+        return str(stderr.read())
+    except Exception:
+        return ""
+
+
+def _poll_health_until_ready_or_exit(
+    url: str,
+    proc: object,
+    timeout: int = 60,
+) -> HealthPollResult:
+    """Poll /health until ready, timeout, or daemon exit.
+
+    The sandbox daemon can fail after startup begins, for example when the local
+    environment lacks the Rust kernel binary. Detect that during polling so E2E
+    reports the real environment problem instead of timing out as a product
+    readiness failure.
+    """
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        returncode = proc.poll()
+        if returncode is not None:
+            return HealthPollResult(
+                ready=False,
+                exited=True,
+                returncode=returncode,
+                stderr=_read_process_stderr(proc),
+            )
+        try:
+            resp = httpx.get(url, timeout=3)
+            if resp.status_code == 200 and resp.json().get("status") in ("healthy", "ready"):
+                return HealthPollResult(ready=True)
+        except Exception:
+            pass
+        time.sleep(1)
+    return HealthPollResult(ready=False)
+
+
+def _kernel_missing_skip_reason(stderr: str) -> str | None:
+    if "nexus-cluster" in stderr or "nexus_kernel" in stderr or "No module named" in stderr:
+        return "nexusd requires nexus-cluster binary — run cargo build --release -p nexus-cluster"
+    return None
 
 
 def _terminate(proc: subprocess.Popen[str]) -> None:
@@ -292,11 +348,19 @@ def sandbox(
     )
 
     health_url = f"http://localhost:{port}/health"
-    ready = _poll_health(health_url, timeout=60)
+    poll = _poll_health_until_ready_or_exit(health_url, proc, timeout=60)
 
-    if not ready:
+    if not poll.ready:
         _terminate(proc)
-        stderr = proc.stderr.read() if proc.stderr else ""
+        stderr = poll.stderr or (proc.stderr.read() if proc.stderr else "")
+        skip_reason = _kernel_missing_skip_reason(stderr)
+        if skip_reason:
+            pytest.skip(skip_reason)
+        if poll.exited:
+            pytest.fail(
+                "Sandbox daemon exited before reaching healthy "
+                f"(returncode={poll.returncode})\nstderr: {stderr[:2000]}"
+            )
         pytest.fail(f"Sandbox did not reach healthy within 60s\nstderr: {stderr[:2000]}")
 
     # gRPC port is HTTP port + 2 by nexusd convention (main.py always sets NEXUS_GRPC_PORT=port+2)
@@ -502,7 +566,21 @@ class TestSandboxLocalOnlyFallback:
                     )
                 pytest.skip(f"nexusd exited immediately: {stderr[:500]}")
 
-            ready = _poll_health(f"http://localhost:{port}/health", timeout=60)
-            assert ready, "Sandbox should start in local-only mode even if hub is unreachable"
+            poll = _poll_health_until_ready_or_exit(
+                f"http://localhost:{port}/health",
+                proc,
+                timeout=60,
+            )
+            if not poll.ready:
+                stderr = poll.stderr or (proc.stderr.read() if proc.stderr else "")
+                skip_reason = _kernel_missing_skip_reason(stderr)
+                if skip_reason:
+                    pytest.skip(skip_reason)
+                if poll.exited:
+                    pytest.fail(
+                        "Sandbox daemon exited before reaching healthy "
+                        f"(returncode={poll.returncode})\nstderr: {stderr[:2000]}"
+                    )
+            assert poll.ready, "Sandbox should start in local-only mode even if hub is unreachable"
         finally:
             _terminate(proc)

--- a/tests/unit/bricks/rebac/test_permission_checker_zone_perms.py
+++ b/tests/unit/bricks/rebac/test_permission_checker_zone_perms.py
@@ -1,0 +1,51 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from nexus.bricks.rebac.checker import PermissionChecker
+from nexus.contracts.constants import ROOT_ZONE_ID
+from nexus.contracts.types import OperationContext, Permission
+
+
+def test_root_multizone_zone_perms_grant_short_circuits_rebac() -> None:
+    enforcer = MagicMock()
+    enforcer._effective_zone_perms.return_value = (("company", "r"), ("shared", "rw"))
+    enforcer.check_owner.return_value = False
+
+    checker = PermissionChecker(
+        permission_enforcer=enforcer,
+        metadata_store=MagicMock(),
+        default_context=OperationContext(user_id="default", groups=[]),
+        enforce_permissions=True,
+    )
+    ctx = OperationContext(
+        user_id="sandbox-token",
+        groups=[],
+        zone_id=ROOT_ZONE_ID,
+        zone_perms=(("company", "r"), ("shared", "rw")),
+    )
+
+    checker.check("/zone/shared/note.txt", Permission.WRITE, ctx)
+
+    enforcer.check_owner.assert_not_called()
+
+
+def test_root_multizone_zone_perms_deny_readonly_write() -> None:
+    enforcer = MagicMock()
+    enforcer._effective_zone_perms.return_value = (("company", "r"), ("shared", "rw"))
+
+    checker = PermissionChecker(
+        permission_enforcer=enforcer,
+        metadata_store=MagicMock(),
+        default_context=OperationContext(user_id="default", groups=[]),
+        enforce_permissions=True,
+    )
+    ctx = OperationContext(
+        user_id="sandbox-token",
+        groups=[],
+        zone_id=ROOT_ZONE_ID,
+        zone_perms=(("company", "r"), ("shared", "rw")),
+    )
+
+    with pytest.raises(PermissionError, match="read-only"):
+        checker.check("/zone/company/no.txt", Permission.WRITE, ctx)

--- a/tests/unit/e2e/test_sandbox_federation_harness.py
+++ b/tests/unit/e2e/test_sandbox_federation_harness.py
@@ -37,3 +37,11 @@ def test_kernel_missing_skip_reason_matches_late_daemon_exit() -> None:
 
     assert reason
     assert "nexus-cluster" in reason
+
+
+def test_kernel_missing_skip_reason_does_not_mask_unrelated_import_error() -> None:
+    reason = sandbox_e2e._kernel_missing_skip_reason(
+        "ModuleNotFoundError: No module named 'nexus.bricks.some_dependency'"
+    )
+
+    assert reason is None

--- a/tests/unit/e2e/test_sandbox_federation_harness.py
+++ b/tests/unit/e2e/test_sandbox_federation_harness.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import io
+
+from tests.e2e.self_contained.cli import test_sandbox_federation_e2e as sandbox_e2e
+
+
+class _ExitedProcess:
+    returncode = 70
+
+    def __init__(self, stderr: str) -> None:
+        self.stderr = io.StringIO(stderr)
+
+    def poll(self) -> int:
+        return self.returncode
+
+
+def test_health_poll_reports_daemon_exit_before_timeout() -> None:
+    proc = _ExitedProcess("Error: Failed to initialize NexusFS: 'nexus-cluster'")
+
+    result = sandbox_e2e._poll_health_until_ready_or_exit(
+        "http://127.0.0.1:9/health",
+        proc,
+        timeout=60,
+    )
+
+    assert result.ready is False
+    assert result.exited is True
+    assert result.returncode == 70
+    assert "nexus-cluster" in result.stderr
+
+
+def test_kernel_missing_skip_reason_matches_late_daemon_exit() -> None:
+    reason = sandbox_e2e._kernel_missing_skip_reason(
+        "Error: Failed to initialize NexusFS: [Errno 2] No such file or directory: 'nexus-cluster'"
+    )
+
+    assert reason
+    assert "nexus-cluster" in reason

--- a/tests/unit/server/test_vfs_grpc.py
+++ b/tests/unit/server/test_vfs_grpc.py
@@ -6,7 +6,7 @@ from typing import Any
 import pytest
 
 from nexus.grpc.vfs import vfs_pb2
-from nexus.lib.rpc_codec import encode_rpc_message
+from nexus.lib.rpc_codec import decode_rpc_message, encode_rpc_message
 from nexus.server.lifespan import vfs_grpc
 
 
@@ -83,4 +83,46 @@ async def test_write_forwards_content_id_as_if_match(monkeypatch: pytest.MonkeyP
             "if_match": "old-content",
         },
         "token": "sk-test",
+    }
+
+
+@pytest.mark.asyncio
+async def test_call_serializes_slotted_syscall_results(monkeypatch: pytest.MonkeyPatch) -> None:
+    class SlottedSyscallResult:
+        __slots__ = ("created", "entry_type", "path")
+
+        def __init__(self) -> None:
+            self.path = "/zone/shared/note.txt"
+            self.created = True
+            self.entry_type = 1
+
+    app = SimpleNamespace(state=SimpleNamespace())
+    servicer = vfs_grpc.VFSGrpcServicer(app)
+
+    async def _dispatch(
+        _method: str,
+        _params: dict[str, Any],
+        _token: str,
+        **_kwargs: Any,
+    ) -> SlottedSyscallResult:
+        return SlottedSyscallResult()
+
+    monkeypatch.setattr(servicer, "_dispatch", _dispatch)
+
+    response = await servicer.Call(
+        vfs_pb2.CallRequest(
+            method="sys_setattr",
+            payload=encode_rpc_message({"path": "/zone/shared/note.txt"}),
+            auth_token="sk-test",
+        ),
+        _FakeGrpcContext(),
+    )
+
+    assert response.is_error is False
+    assert decode_rpc_message(response.payload) == {
+        "result": {
+            "created": True,
+            "entry_type": 1,
+            "path": "/zone/shared/note.txt",
+        }
     }

--- a/tests/unit/server/test_zone_execution.py
+++ b/tests/unit/server/test_zone_execution.py
@@ -1,9 +1,10 @@
 from collections.abc import Awaitable, Callable
+from types import SimpleNamespace
 from typing import TypeVar
 
 import pytest
 
-from nexus.server.zone_execution import run_zone_scoped
+from nexus.server.zone_execution import context_for_target_zone, run_zone_scoped
 
 T = TypeVar("T")
 
@@ -58,3 +59,18 @@ async def test_run_zone_scoped_runs_inline_without_target_zone() -> None:
 
     assert await run_zone_scoped(registry, None, work) == "global"
     assert registry.requested == []
+
+
+def test_context_for_target_zone_preserves_root_for_multizone_token() -> None:
+    context = SimpleNamespace(
+        zone_id="root",
+        zone_set=("company", "shared"),
+        zone_perms=(("company", "r"), ("shared", "rw")),
+        is_admin=False,
+    )
+
+    result = context_for_target_zone(context, "shared")
+
+    assert result is context
+    assert context.zone_id == "root"
+    assert context.zone_perms == (("company", "r"), ("shared", "rw"))


### PR DESCRIPTION
## Summary

Fixes #4130.

This PR documents and validates the sandbox-local to company-hub federation workflow, then fixes the runtime bugs found while running real E2E coverage for the issue-scoped CLI/RPC paths.

Key changes:

- Adds issue #4130 API/RPC surface coverage docs and generated HTML coverage output.
- Adds real sandbox federation E2E coverage for health, federation identity, remote read/write, read-only denial, local-zone isolation, and hub-down local-only fallback.
- Adds benchmark guardrails for federation handshake, remote-zone dispatch, federated search fanout, and degraded local-only search.
- Fixes remote mount installation, remote RPC nested runtime handling, multi-zone auth context handling, root zone permission short-circuiting, backend permission error mapping, remote metastore JSON envelopes, VFS gRPC slotted result serialization, and remote write result parsing.

## Validation

- Real E2E: `NEXUS_ADMIN_KEY=... NEXUS_GRPC_HOST=localhost:13712 NEXUS_DATABASE_URL=... NEXUS_KERNEL_BINARY=$PWD/target/debug/nexusd-cluster uv run pytest tests/e2e/self_contained/cli/test_sandbox_federation_e2e.py -q -rs --durations=20 -n 0` -> `7 passed`
- Focused Python units: `uv run pytest tests/unit/server/test_vfs_grpc.py tests/unit/bricks/rebac/test_permission_checker_zone_perms.py tests/unit/server/test_zone_execution.py tests/unit/e2e/test_sandbox_federation_harness.py -q -n 0` -> `11 passed`
- Architecture + benchmark: `uv run pytest tests/architecture/test_issue_4130_sandbox_federation_surface.py tests/architecture/test_issue_4128_sandbox_rebac_mcp_boundaries.py tests/architecture/test_issue_4129_sandbox_search_surface.py tests/architecture/test_inventory.py tests/benchmarks/bench_sandbox_federation_latency.py -q -n 0` -> `19 passed`
- Federation/CLI control plane: `uv run pytest tests/unit/remote/test_federation_handshake.py tests/unit/grpc/test_federation_whoami_rpc.py tests/unit/backends/test_remote_zone.py tests/unit/cli/test_hub.py::test_hub_status_detail_json_includes_token_last_seen_and_zones tests/unit/cli/test_hub_remote.py::test_remote_status_calls_mcp_tool_and_renders_json -q -n 0` -> `22 passed`
- Rust: `cargo build -p nexus-cluster`; `cargo check -p nexus-cluster`; focused Rust tests for remote mount and write-result parsing passed
- Pre-commit on commit: whitespace/YAML/TOML/Ruff/Ruff format/mypy/boundary checks/rustfmt/Rust Clippy passed
- `git diff --check` passed

## Notes

Real E2E timings from the final local-hub run included: health `0.01s`, `federation_client_whoami` `0.02s`, read-only remote write rejection `0.16s`, shared-zone remote write `1.31s`, remote readback `0.54s`, local-zone write `0.18s`, and hub-down local-only fallback `19.53s`. These are issue-scoped local E2E timings, not production-scale load-test results.
