### PR TITLE
[codex] Close MCP profile RPC coverage gaps

### DIFF
--- a/docs/architecture/api-rpc-surface-coverage.html
+++ b/docs/architecture/api-rpc-surface-coverage.html
@@ -4297,10 +4297,10 @@ graph TB
     <span>gap: &mdash;</span>
   </div>
 </div>
-<div class="op" data-op-id="delete.file" data-op-text="delete.file  nexus_delete_file ">
+<div class="op" data-op-id="delete.file" data-op-text="delete.file Delete a file through MCP; visible from the coding profile and broader profiles. nexus_delete_file ">
   <div class="op-header">
     <span class="op-id">delete.file</span>
-    <span class="op-summary">&mdash; (no summary yet)</span>
+    <span class="op-summary">&mdash; Delete a file through MCP; visible from the coding profile and broader profiles.</span>
   </div>
   <div class="transports">
     <span class="transport-pill" data-t="mcp"><span class="label">MCP</span> <span>nexus_delete_file</span></span>
@@ -4311,10 +4311,10 @@ graph TB
 <span class="profile-badge profile-supported">sandbox</span>
 <span class="profile-badge profile-supported">full</span>
     </span>
-    <span>usage: <span class="todo">TODO</span></span>
-    <span>test: <span class="todo">TODO</span></span>
-    <span>perf: <span class="todo">TODO</span></span>
-    <span>owner: &mdash;</span>
+    <span>usage: <code>CLI: nexus rm /workspace/old.txt; MCP: tools/call nexus_delete_file {&#34;path&#34;:&#34;/workspace/old.txt&#34;}.</code></span>
+    <span>test: <a href="../../tests/unit/bricks/mcp/test_mcp_server_tools.py::TestFileOperationTools::test_delete_file_success; tests/unit/bricks/mcp/test_tool_profiles.py::TestDefaultConfigValidity::test_default_profiles_match_expected_tool_matrix; tests/unit/bricks/mcp/test_tool_namespace_middleware.py::TestDefaultToolProfileEnforcement::test_default_profile_grants_filter_list_and_call; tests/architecture/test_issue_4131_mcp_tool_profile_story.py::test_issue_4131_owned_mcp_rows_have_story_contract; tests/e2e/self_contained/mcp/test_issue_4131_mcp_profile_story_e2e.py::test_issue_4131_mcp_profiles_real_protocol_and_perf">tests/unit/bricks/mcp/test_mcp_server_tools.py::TestFileOperationTools::test_delete_file_success; tests/unit/bricks/mcp/test_tool_profiles.py::TestDefaultConfigValidity::test_default_profiles_match_expected_tool_matrix; tests/unit/bricks/mcp/test_tool_namespace_middleware.py::TestDefaultToolProfileEnforcement::test_default_profile_grants_filter_list_and_call; tests/architecture/test_issue_4131_mcp_tool_profile_story.py::test_issue_4131_owned_mcp_rows_have_story_contract; tests/e2e/self_contained/mcp/test_issue_4131_mcp_profile_story_e2e.py::test_issue_4131_mcp_profiles_real_protocol_and_perf</a></span>
+    <span>perf: hot</span>
+    <span>owner: <a href="https://github.com/nexi-lab/nexus/issues/4131">#4131</a></span>
     <span>gap: &mdash;</span>
   </div>
 </div>
@@ -4360,10 +4360,10 @@ graph TB
     <span>gap: &mdash;</span>
   </div>
 </div>
-<div class="op" data-op-id="edit.file" data-op-text="edit.file  nexus_edit_file ">
+<div class="op" data-op-id="edit.file" data-op-text="edit.file Apply structured file edits through MCP; visible from the coding profile and broader profiles. nexus_edit_file ">
   <div class="op-header">
     <span class="op-id">edit.file</span>
-    <span class="op-summary">&mdash; (no summary yet)</span>
+    <span class="op-summary">&mdash; Apply structured file edits through MCP; visible from the coding profile and broader profiles.</span>
   </div>
   <div class="transports">
     <span class="transport-pill" data-t="mcp"><span class="label">MCP</span> <span>nexus_edit_file</span></span>
@@ -4374,10 +4374,10 @@ graph TB
 <span class="profile-badge profile-supported">sandbox</span>
 <span class="profile-badge profile-supported">full</span>
     </span>
-    <span>usage: <span class="todo">TODO</span></span>
-    <span>test: <span class="todo">TODO</span></span>
-    <span>perf: <span class="todo">TODO</span></span>
-    <span>owner: &mdash;</span>
+    <span>usage: <code>CLI: use nexus write/cat for simple edits; MCP: tools/call nexus_edit_file {&#34;path&#34;:&#34;/workspace/app.py&#34;,&#34;edits&#34;:[...]}.</code></span>
+    <span>test: <a href="../../tests/unit/bricks/mcp/test_mcp_server_tools.py::TestEditFileTool::test_edit_file_success; tests/unit/bricks/mcp/test_tool_profiles.py::TestDefaultConfigValidity::test_default_profiles_match_expected_tool_matrix; tests/unit/bricks/mcp/test_tool_namespace_middleware.py::TestDefaultToolProfileEnforcement::test_default_profile_grants_filter_list_and_call; tests/architecture/test_issue_4131_mcp_tool_profile_story.py::test_issue_4131_owned_mcp_rows_have_story_contract; tests/e2e/self_contained/mcp/test_issue_4131_mcp_profile_story_e2e.py::test_issue_4131_mcp_profiles_real_protocol_and_perf">tests/unit/bricks/mcp/test_mcp_server_tools.py::TestEditFileTool::test_edit_file_success; tests/unit/bricks/mcp/test_tool_profiles.py::TestDefaultConfigValidity::test_default_profiles_match_expected_tool_matrix; tests/unit/bricks/mcp/test_tool_namespace_middleware.py::TestDefaultToolProfileEnforcement::test_default_profile_grants_filter_list_and_call; tests/architecture/test_issue_4131_mcp_tool_profile_story.py::test_issue_4131_owned_mcp_rows_have_story_contract; tests/e2e/self_contained/mcp/test_issue_4131_mcp_profile_story_e2e.py::test_issue_4131_mcp_profiles_real_protocol_and_perf</a></span>
+    <span>perf: hot</span>
+    <span>owner: <a href="https://github.com/nexi-lab/nexus/issues/4131">#4131</a></span>
     <span>gap: &mdash;</span>
   </div>
 </div>
@@ -4466,10 +4466,10 @@ graph TB
     <span>gap: &mdash;</span>
   </div>
 </div>
-<div class="op" data-op-id="file.info" data-op-text="file.info  nexus_file_info ">
+<div class="op" data-op-id="file.info" data-op-text="file.info Inspect file metadata through MCP; visible from the minimal profile. nexus_file_info ">
   <div class="op-header">
     <span class="op-id">file.info</span>
-    <span class="op-summary">&mdash; (no summary yet)</span>
+    <span class="op-summary">&mdash; Inspect file metadata through MCP; visible from the minimal profile.</span>
   </div>
   <div class="transports">
     <span class="transport-pill" data-t="mcp"><span class="label">MCP</span> <span>nexus_file_info</span></span>
@@ -4480,10 +4480,10 @@ graph TB
 <span class="profile-badge profile-supported">sandbox</span>
 <span class="profile-badge profile-supported">full</span>
     </span>
-    <span>usage: <span class="todo">TODO</span></span>
-    <span>test: <span class="todo">TODO</span></span>
-    <span>perf: <span class="todo">TODO</span></span>
-    <span>owner: &mdash;</span>
+    <span>usage: <code>CLI: nexus info /workspace/hello.txt; MCP: tools/call nexus_file_info {&#34;path&#34;:&#34;/workspace/hello.txt&#34;}.</code></span>
+    <span>test: <a href="../../tests/unit/bricks/mcp/test_mcp_server_tools.py::TestFileOperationTools::test_file_info_exists; tests/unit/bricks/mcp/test_tool_profiles.py::TestDefaultConfigValidity::test_default_profiles_match_expected_tool_matrix; tests/unit/bricks/mcp/test_tool_namespace_middleware.py::TestDefaultToolProfileEnforcement::test_default_profile_grants_filter_list_and_call; tests/architecture/test_issue_4131_mcp_tool_profile_story.py::test_issue_4131_owned_mcp_rows_have_story_contract; tests/e2e/self_contained/mcp/test_issue_4131_mcp_profile_story_e2e.py::test_issue_4131_mcp_profiles_real_protocol_and_perf">tests/unit/bricks/mcp/test_mcp_server_tools.py::TestFileOperationTools::test_file_info_exists; tests/unit/bricks/mcp/test_tool_profiles.py::TestDefaultConfigValidity::test_default_profiles_match_expected_tool_matrix; tests/unit/bricks/mcp/test_tool_namespace_middleware.py::TestDefaultToolProfileEnforcement::test_default_profile_grants_filter_list_and_call; tests/architecture/test_issue_4131_mcp_tool_profile_story.py::test_issue_4131_owned_mcp_rows_have_story_contract; tests/e2e/self_contained/mcp/test_issue_4131_mcp_profile_story_e2e.py::test_issue_4131_mcp_profiles_real_protocol_and_perf</a></span>
+    <span>perf: hot</span>
+    <span>owner: <a href="https://github.com/nexi-lab/nexus/issues/4131">#4131</a></span>
     <span>gap: &mdash;</span>
   </div>
 </div>
@@ -4805,7 +4805,7 @@ graph TB
     <span>gap: &mdash;</span>
   </div>
 </div>
-<div class="op" data-op-id="filesystem.mkdir" data-op-text="filesystem.mkdir Sandbox local workspace filesystem surface. The daemon mounts the operator workspace at /zone/local; CLI parity is covered by the local file command harness and kernel/RPC parity is covered through the same syscall dispatcher. nexus mkdir mkdir ">
+<div class="op" data-op-id="filesystem.mkdir" data-op-text="filesystem.mkdir Sandbox local workspace filesystem surface. The daemon mounts the operator workspace at /zone/local; CLI parity is covered by the local file command harness and kernel/RPC parity is covered through the same syscall dispatcher. nexus mkdir mkdir nexus_mkdir ">
   <div class="op-header">
     <span class="op-id">filesystem.mkdir</span>
     <span class="op-summary">&mdash; Sandbox local workspace filesystem surface. The daemon mounts the operator workspace at /zone/local; CLI parity is covered by the local file command harness and kernel/RPC parity is covered through the same syscall dispatcher.</span>
@@ -4813,6 +4813,7 @@ graph TB
   <div class="transports">
     <span class="transport-pill" data-t="cli"><span class="label">CLI</span> <span>nexus mkdir</span></span>
     <span class="transport-pill" data-t="call"><span class="label">Call</span> <span>mkdir</span></span>
+    <span class="transport-pill" data-t="mcp"><span class="label">MCP</span> <span>nexus_mkdir</span></span>
   </div>
   <div class="meta-row">
     <span class="profiles">
@@ -5058,7 +5059,7 @@ graph TB
     <span>gap: &mdash;</span>
   </div>
 </div>
-<div class="op" data-op-id="filesystem.rmdir" data-op-text="filesystem.rmdir Sandbox local workspace filesystem surface. The daemon mounts the operator workspace at /zone/local; CLI parity is covered by the local file command harness and kernel/RPC parity is covered through the same syscall dispatcher. nexus rmdir rmdir ">
+<div class="op" data-op-id="filesystem.rmdir" data-op-text="filesystem.rmdir Sandbox local workspace filesystem surface. The daemon mounts the operator workspace at /zone/local; CLI parity is covered by the local file command harness and kernel/RPC parity is covered through the same syscall dispatcher. nexus rmdir rmdir nexus_rmdir ">
   <div class="op-header">
     <span class="op-id">filesystem.rmdir</span>
     <span class="op-summary">&mdash; Sandbox local workspace filesystem surface. The daemon mounts the operator workspace at /zone/local; CLI parity is covered by the local file command harness and kernel/RPC parity is covered through the same syscall dispatcher.</span>
@@ -5066,6 +5067,7 @@ graph TB
   <div class="transports">
     <span class="transport-pill" data-t="cli"><span class="label">CLI</span> <span>nexus rmdir</span></span>
     <span class="transport-pill" data-t="call"><span class="label">Call</span> <span>rmdir</span></span>
+    <span class="transport-pill" data-t="mcp"><span class="label">MCP</span> <span>nexus_rmdir</span></span>
   </div>
   <div class="meta-row">
     <span class="profiles">
@@ -5818,10 +5820,10 @@ graph TB
     <span>gap: &mdash;</span>
   </div>
 </div>
-<div class="op" data-op-id="list.files" data-op-text="list.files  nexus_list_files ">
+<div class="op" data-op-id="list.files" data-op-text="list.files List directory contents through MCP; visible from the minimal profile for read-only workspace inspection. nexus_list_files ">
   <div class="op-header">
     <span class="op-id">list.files</span>
-    <span class="op-summary">&mdash; (no summary yet)</span>
+    <span class="op-summary">&mdash; List directory contents through MCP; visible from the minimal profile for read-only workspace inspection.</span>
   </div>
   <div class="transports">
     <span class="transport-pill" data-t="mcp"><span class="label">MCP</span> <span>nexus_list_files</span></span>
@@ -5832,10 +5834,10 @@ graph TB
 <span class="profile-badge profile-supported">sandbox</span>
 <span class="profile-badge profile-supported">full</span>
     </span>
-    <span>usage: <span class="todo">TODO</span></span>
-    <span>test: <span class="todo">TODO</span></span>
-    <span>perf: <span class="todo">TODO</span></span>
-    <span>owner: &mdash;</span>
+    <span>usage: <code>CLI: nexus ls /workspace -l; MCP: tools/call nexus_list_files {&#34;path&#34;:&#34;/workspace&#34;,&#34;recursive&#34;:false}.</code></span>
+    <span>test: <a href="../../tests/unit/bricks/mcp/test_mcp_server_tools.py::TestFileOperationTools::test_list_files_basic; tests/unit/bricks/mcp/test_tool_profiles.py::TestDefaultConfigValidity::test_default_profiles_match_expected_tool_matrix; tests/unit/bricks/mcp/test_tool_namespace_middleware.py::TestDefaultToolProfileEnforcement::test_default_profile_grants_filter_list_and_call; tests/architecture/test_issue_4131_mcp_tool_profile_story.py::test_issue_4131_owned_mcp_rows_have_story_contract; tests/e2e/self_contained/mcp/test_issue_4131_mcp_profile_story_e2e.py::test_issue_4131_mcp_profiles_real_protocol_and_perf">tests/unit/bricks/mcp/test_mcp_server_tools.py::TestFileOperationTools::test_list_files_basic; tests/unit/bricks/mcp/test_tool_profiles.py::TestDefaultConfigValidity::test_default_profiles_match_expected_tool_matrix; tests/unit/bricks/mcp/test_tool_namespace_middleware.py::TestDefaultToolProfileEnforcement::test_default_profile_grants_filter_list_and_call; tests/architecture/test_issue_4131_mcp_tool_profile_story.py::test_issue_4131_owned_mcp_rows_have_story_contract; tests/e2e/self_contained/mcp/test_issue_4131_mcp_profile_story_e2e.py::test_issue_4131_mcp_profiles_real_protocol_and_perf</a></span>
+    <span>perf: hot</span>
+    <span>owner: <a href="https://github.com/nexi-lab/nexus/issues/4131">#4131</a></span>
     <span>gap: &mdash;</span>
   </div>
 </div>
@@ -6218,10 +6220,10 @@ graph TB
     <span>gap: &mdash;</span>
   </div>
 </div>
-<div class="op" data-op-id="read.file" data-op-text="read.file  nexus_read_file ">
+<div class="op" data-op-id="read.file" data-op-text="read.file Read file content through MCP; visible from the minimal profile and inherited by every broader profile. nexus_read_file ">
   <div class="op-header">
     <span class="op-id">read.file</span>
-    <span class="op-summary">&mdash; (no summary yet)</span>
+    <span class="op-summary">&mdash; Read file content through MCP; visible from the minimal profile and inherited by every broader profile.</span>
   </div>
   <div class="transports">
     <span class="transport-pill" data-t="mcp"><span class="label">MCP</span> <span>nexus_read_file</span></span>
@@ -6232,10 +6234,10 @@ graph TB
 <span class="profile-badge profile-supported">sandbox</span>
 <span class="profile-badge profile-supported">full</span>
     </span>
-    <span>usage: <span class="todo">TODO</span></span>
-    <span>test: <span class="todo">TODO</span></span>
-    <span>perf: <span class="todo">TODO</span></span>
-    <span>owner: &mdash;</span>
+    <span>usage: <code>CLI: nexus cat /workspace/hello.txt; MCP: tools/call nexus_read_file {&#34;path&#34;:&#34;/workspace/hello.txt&#34;}.</code></span>
+    <span>test: <a href="../../tests/unit/bricks/mcp/test_mcp_server_tools.py::TestFileOperationTools::test_read_file_success; tests/unit/bricks/mcp/test_tool_profiles.py::TestDefaultConfigValidity::test_default_profiles_match_expected_tool_matrix; tests/unit/bricks/mcp/test_tool_namespace_middleware.py::TestDefaultToolProfileEnforcement::test_default_profile_grants_filter_list_and_call; tests/architecture/test_issue_4131_mcp_tool_profile_story.py::test_issue_4131_owned_mcp_rows_have_story_contract; tests/e2e/self_contained/mcp/test_issue_4131_mcp_profile_story_e2e.py::test_issue_4131_mcp_profiles_real_protocol_and_perf">tests/unit/bricks/mcp/test_mcp_server_tools.py::TestFileOperationTools::test_read_file_success; tests/unit/bricks/mcp/test_tool_profiles.py::TestDefaultConfigValidity::test_default_profiles_match_expected_tool_matrix; tests/unit/bricks/mcp/test_tool_namespace_middleware.py::TestDefaultToolProfileEnforcement::test_default_profile_grants_filter_list_and_call; tests/architecture/test_issue_4131_mcp_tool_profile_story.py::test_issue_4131_owned_mcp_rows_have_story_contract; tests/e2e/self_contained/mcp/test_issue_4131_mcp_profile_story_e2e.py::test_issue_4131_mcp_profiles_real_protocol_and_perf</a></span>
+    <span>perf: hot</span>
+    <span>owner: <a href="https://github.com/nexi-lab/nexus/issues/4131">#4131</a></span>
     <span>gap: &mdash;</span>
   </div>
 </div>
@@ -6281,10 +6283,10 @@ graph TB
     <span>gap: &mdash;</span>
   </div>
 </div>
-<div class="op" data-op-id="rename.file" data-op-text="rename.file  nexus_rename_file ">
+<div class="op" data-op-id="rename.file" data-op-text="rename.file Rename or move a file through MCP; visible from the coding profile and broader profiles. nexus_rename_file ">
   <div class="op-header">
     <span class="op-id">rename.file</span>
-    <span class="op-summary">&mdash; (no summary yet)</span>
+    <span class="op-summary">&mdash; Rename or move a file through MCP; visible from the coding profile and broader profiles.</span>
   </div>
   <div class="transports">
     <span class="transport-pill" data-t="mcp"><span class="label">MCP</span> <span>nexus_rename_file</span></span>
@@ -6295,10 +6297,10 @@ graph TB
 <span class="profile-badge profile-supported">sandbox</span>
 <span class="profile-badge profile-supported">full</span>
     </span>
-    <span>usage: <span class="todo">TODO</span></span>
-    <span>test: <span class="todo">TODO</span></span>
-    <span>perf: <span class="todo">TODO</span></span>
-    <span>owner: &mdash;</span>
+    <span>usage: <code>CLI: nexus mv /workspace/old.txt /workspace/new.txt; MCP: tools/call nexus_rename_file {&#34;old_path&#34;:&#34;/workspace/old.txt&#34;,&#34;new_path&#34;:&#34;/workspace/new.txt&#34;}.</code></span>
+    <span>test: <a href="../../tests/unit/bricks/mcp/test_tool_profiles.py::TestDefaultConfigValidity::test_default_profiles_match_expected_tool_matrix; tests/unit/bricks/mcp/test_tool_namespace_middleware.py::TestDefaultToolProfileEnforcement::test_default_profile_grants_filter_list_and_call; tests/architecture/test_issue_4131_mcp_tool_profile_story.py::test_issue_4131_owned_mcp_rows_have_story_contract; tests/e2e/self_contained/mcp/test_issue_4131_mcp_profile_story_e2e.py::test_issue_4131_mcp_profiles_real_protocol_and_perf">tests/unit/bricks/mcp/test_tool_profiles.py::TestDefaultConfigValidity::test_default_profiles_match_expected_tool_matrix; tests/unit/bricks/mcp/test_tool_namespace_middleware.py::TestDefaultToolProfileEnforcement::test_default_profile_grants_filter_list_and_call; tests/architecture/test_issue_4131_mcp_tool_profile_story.py::test_issue_4131_owned_mcp_rows_have_story_contract; tests/e2e/self_contained/mcp/test_issue_4131_mcp_profile_story_e2e.py::test_issue_4131_mcp_profiles_real_protocol_and_perf</a></span>
+    <span>perf: hot</span>
+    <span>owner: <a href="https://github.com/nexi-lab/nexus/issues/4131">#4131</a></span>
     <span>gap: &mdash;</span>
   </div>
 </div>
@@ -6576,10 +6578,10 @@ graph TB
     <span>gap: &mdash;</span>
   </div>
 </div>
-<div class="op" data-op-id="write.file" data-op-text="write.file  nexus_write_file ">
+<div class="op" data-op-id="write.file" data-op-text="write.file Write file content through MCP; visible from the coding profile and broader profiles. nexus_write_file ">
   <div class="op-header">
     <span class="op-id">write.file</span>
-    <span class="op-summary">&mdash; (no summary yet)</span>
+    <span class="op-summary">&mdash; Write file content through MCP; visible from the coding profile and broader profiles.</span>
   </div>
   <div class="transports">
     <span class="transport-pill" data-t="mcp"><span class="label">MCP</span> <span>nexus_write_file</span></span>
@@ -6590,10 +6592,10 @@ graph TB
 <span class="profile-badge profile-supported">sandbox</span>
 <span class="profile-badge profile-supported">full</span>
     </span>
-    <span>usage: <span class="todo">TODO</span></span>
-    <span>test: <span class="todo">TODO</span></span>
-    <span>perf: <span class="todo">TODO</span></span>
-    <span>owner: &mdash;</span>
+    <span>usage: <code>CLI: nexus write /workspace/hello.txt &#34;hello&#34;; MCP: tools/call nexus_write_file {&#34;path&#34;:&#34;/workspace/hello.txt&#34;,&#34;content&#34;:&#34;hello&#34;}.</code></span>
+    <span>test: <a href="../../tests/unit/bricks/mcp/test_mcp_server_tools.py::TestFileOperationTools::test_write_file_success; tests/unit/bricks/mcp/test_tool_profiles.py::TestDefaultConfigValidity::test_default_profiles_match_expected_tool_matrix; tests/unit/bricks/mcp/test_tool_namespace_middleware.py::TestDefaultToolProfileEnforcement::test_default_profile_grants_filter_list_and_call; tests/architecture/test_issue_4131_mcp_tool_profile_story.py::test_issue_4131_owned_mcp_rows_have_story_contract; tests/e2e/self_contained/mcp/test_issue_4131_mcp_profile_story_e2e.py::test_issue_4131_mcp_profiles_real_protocol_and_perf">tests/unit/bricks/mcp/test_mcp_server_tools.py::TestFileOperationTools::test_write_file_success; tests/unit/bricks/mcp/test_tool_profiles.py::TestDefaultConfigValidity::test_default_profiles_match_expected_tool_matrix; tests/unit/bricks/mcp/test_tool_namespace_middleware.py::TestDefaultToolProfileEnforcement::test_default_profile_grants_filter_list_and_call; tests/architecture/test_issue_4131_mcp_tool_profile_story.py::test_issue_4131_owned_mcp_rows_have_story_contract; tests/e2e/self_contained/mcp/test_issue_4131_mcp_profile_story_e2e.py::test_issue_4131_mcp_profiles_real_protocol_and_perf</a></span>
+    <span>perf: hot</span>
+    <span>owner: <a href="https://github.com/nexi-lab/nexus/issues/4131">#4131</a></span>
     <span>gap: &mdash;</span>
   </div>
 </div>
@@ -10038,10 +10040,10 @@ graph TB
     <span>gap: &mdash;</span>
   </div>
 </div>
-<div class="op" data-op-id="sandbox.create" data-op-text="sandbox.create  nexus_sandbox_create ">
+<div class="op" data-op-id="sandbox.create" data-op-text="sandbox.create Create a sandbox runtime through MCP when the sandbox provider is available; visible from the execution profile and full profile. nexus_sandbox_create ">
   <div class="op-header">
     <span class="op-id">sandbox.create</span>
-    <span class="op-summary">&mdash; (no summary yet)</span>
+    <span class="op-summary">&mdash; Create a sandbox runtime through MCP when the sandbox provider is available; visible from the execution profile and full profile.</span>
   </div>
   <div class="transports">
     <span class="transport-pill" data-t="mcp"><span class="label">MCP</span> <span>nexus_sandbox_create</span></span>
@@ -10052,17 +10054,17 @@ graph TB
 <span class="profile-badge profile-supported">sandbox</span>
 <span class="profile-badge profile-supported">full</span>
     </span>
-    <span>usage: <span class="todo">TODO</span></span>
-    <span>test: <span class="todo">TODO</span></span>
-    <span>perf: <span class="todo">TODO</span></span>
-    <span>owner: &mdash;</span>
+    <span>usage: <code>CLI: nexus sandbox create demo-box --provider docker; MCP: tools/call nexus_sandbox_create {&#34;name&#34;:&#34;demo-box&#34;,&#34;ttl_minutes&#34;:15}.</code></span>
+    <span>test: <a href="../../tests/unit/bricks/mcp/test_mcp_server_tools.py::TestSandboxTools::test_sandbox_create_success; tests/unit/bricks/mcp/test_tool_profiles.py::TestDefaultConfigValidity::test_default_profiles_match_expected_tool_matrix; tests/unit/bricks/mcp/test_tool_namespace_middleware.py::TestDefaultToolProfileEnforcement::test_default_profile_grants_filter_list_and_call; tests/architecture/test_issue_4131_mcp_tool_profile_story.py::test_issue_4131_owned_mcp_rows_have_story_contract; tests/e2e/self_contained/mcp/test_issue_4131_mcp_profile_story_e2e.py::test_issue_4131_mcp_profiles_real_protocol_and_perf">tests/unit/bricks/mcp/test_mcp_server_tools.py::TestSandboxTools::test_sandbox_create_success; tests/unit/bricks/mcp/test_tool_profiles.py::TestDefaultConfigValidity::test_default_profiles_match_expected_tool_matrix; tests/unit/bricks/mcp/test_tool_namespace_middleware.py::TestDefaultToolProfileEnforcement::test_default_profile_grants_filter_list_and_call; tests/architecture/test_issue_4131_mcp_tool_profile_story.py::test_issue_4131_owned_mcp_rows_have_story_contract; tests/e2e/self_contained/mcp/test_issue_4131_mcp_profile_story_e2e.py::test_issue_4131_mcp_profiles_real_protocol_and_perf</a></span>
+    <span>perf: setup</span>
+    <span>owner: <a href="https://github.com/nexi-lab/nexus/issues/4131">#4131</a></span>
     <span>gap: &mdash;</span>
   </div>
 </div>
-<div class="op" data-op-id="sandbox.list" data-op-text="sandbox.list  nexus_sandbox_list ">
+<div class="op" data-op-id="sandbox.list" data-op-text="sandbox.list List sandbox runtimes through MCP when sandbox support is available; visible from the execution profile and full profile. nexus_sandbox_list ">
   <div class="op-header">
     <span class="op-id">sandbox.list</span>
-    <span class="op-summary">&mdash; (no summary yet)</span>
+    <span class="op-summary">&mdash; List sandbox runtimes through MCP when sandbox support is available; visible from the execution profile and full profile.</span>
   </div>
   <div class="transports">
     <span class="transport-pill" data-t="mcp"><span class="label">MCP</span> <span>nexus_sandbox_list</span></span>
@@ -10073,10 +10075,10 @@ graph TB
 <span class="profile-badge profile-supported">sandbox</span>
 <span class="profile-badge profile-supported">full</span>
     </span>
-    <span>usage: <span class="todo">TODO</span></span>
-    <span>test: <span class="todo">TODO</span></span>
-    <span>perf: <span class="todo">TODO</span></span>
-    <span>owner: &mdash;</span>
+    <span>usage: <code>CLI: nexus sandbox list; MCP: tools/call nexus_sandbox_list {}.</code></span>
+    <span>test: <a href="../../tests/unit/bricks/mcp/test_mcp_server_tools.py::TestSandboxTools::test_sandbox_list_success; tests/unit/bricks/mcp/test_tool_profiles.py::TestDefaultConfigValidity::test_default_profiles_match_expected_tool_matrix; tests/unit/bricks/mcp/test_tool_namespace_middleware.py::TestDefaultToolProfileEnforcement::test_default_profile_grants_filter_list_and_call; tests/architecture/test_issue_4131_mcp_tool_profile_story.py::test_issue_4131_owned_mcp_rows_have_story_contract; tests/e2e/self_contained/mcp/test_issue_4131_mcp_profile_story_e2e.py::test_issue_4131_mcp_profiles_real_protocol_and_perf">tests/unit/bricks/mcp/test_mcp_server_tools.py::TestSandboxTools::test_sandbox_list_success; tests/unit/bricks/mcp/test_tool_profiles.py::TestDefaultConfigValidity::test_default_profiles_match_expected_tool_matrix; tests/unit/bricks/mcp/test_tool_namespace_middleware.py::TestDefaultToolProfileEnforcement::test_default_profile_grants_filter_list_and_call; tests/architecture/test_issue_4131_mcp_tool_profile_story.py::test_issue_4131_owned_mcp_rows_have_story_contract; tests/e2e/self_contained/mcp/test_issue_4131_mcp_profile_story_e2e.py::test_issue_4131_mcp_profiles_real_protocol_and_perf</a></span>
+    <span>perf: control</span>
+    <span>owner: <a href="https://github.com/nexi-lab/nexus/issues/4131">#4131</a></span>
     <span>gap: &mdash;</span>
   </div>
 </div>
@@ -10101,10 +10103,10 @@ graph TB
     <span>gap: &mdash;</span>
   </div>
 </div>
-<div class="op" data-op-id="sandbox.stop" data-op-text="sandbox.stop  nexus_sandbox_stop ">
+<div class="op" data-op-id="sandbox.stop" data-op-text="sandbox.stop Stop a sandbox runtime through MCP when sandbox support is available; visible from the execution profile and full profile. nexus_sandbox_stop ">
   <div class="op-header">
     <span class="op-id">sandbox.stop</span>
-    <span class="op-summary">&mdash; (no summary yet)</span>
+    <span class="op-summary">&mdash; Stop a sandbox runtime through MCP when sandbox support is available; visible from the execution profile and full profile.</span>
   </div>
   <div class="transports">
     <span class="transport-pill" data-t="mcp"><span class="label">MCP</span> <span>nexus_sandbox_stop</span></span>
@@ -10115,10 +10117,10 @@ graph TB
 <span class="profile-badge profile-supported">sandbox</span>
 <span class="profile-badge profile-supported">full</span>
     </span>
-    <span>usage: <span class="todo">TODO</span></span>
-    <span>test: <span class="todo">TODO</span></span>
-    <span>perf: <span class="todo">TODO</span></span>
-    <span>owner: &mdash;</span>
+    <span>usage: <code>CLI: nexus sandbox stop sb_123; MCP: tools/call nexus_sandbox_stop {&#34;sandbox_id&#34;:&#34;sb_123&#34;}.</code></span>
+    <span>test: <a href="../../tests/unit/bricks/mcp/test_mcp_server_tools.py::TestSandboxTools::test_sandbox_stop_success; tests/unit/bricks/mcp/test_tool_profiles.py::TestDefaultConfigValidity::test_default_profiles_match_expected_tool_matrix; tests/unit/bricks/mcp/test_tool_namespace_middleware.py::TestDefaultToolProfileEnforcement::test_default_profile_grants_filter_list_and_call; tests/architecture/test_issue_4131_mcp_tool_profile_story.py::test_issue_4131_owned_mcp_rows_have_story_contract; tests/e2e/self_contained/mcp/test_issue_4131_mcp_profile_story_e2e.py::test_issue_4131_mcp_profiles_real_protocol_and_perf">tests/unit/bricks/mcp/test_mcp_server_tools.py::TestSandboxTools::test_sandbox_stop_success; tests/unit/bricks/mcp/test_tool_profiles.py::TestDefaultConfigValidity::test_default_profiles_match_expected_tool_matrix; tests/unit/bricks/mcp/test_tool_namespace_middleware.py::TestDefaultToolProfileEnforcement::test_default_profile_grants_filter_list_and_call; tests/architecture/test_issue_4131_mcp_tool_profile_story.py::test_issue_4131_owned_mcp_rows_have_story_contract; tests/e2e/self_contained/mcp/test_issue_4131_mcp_profile_story_e2e.py::test_issue_4131_mcp_profiles_real_protocol_and_perf</a></span>
+    <span>perf: control</span>
+    <span>owner: <a href="https://github.com/nexi-lab/nexus/issues/4131">#4131</a></span>
     <span>gap: &mdash;</span>
   </div>
 </div>
@@ -10882,10 +10884,10 @@ graph TB
           </span>
         </summary>
         <div class="module-body">
-<div class="op" data-op-id="execute.workflow" data-op-text="execute.workflow  nexus_execute_workflow ">
+<div class="op" data-op-id="execute.workflow" data-op-text="execute.workflow Execute a named workflow through MCP; visible from the full profile. nexus_execute_workflow ">
   <div class="op-header">
     <span class="op-id">execute.workflow</span>
-    <span class="op-summary">&mdash; (no summary yet)</span>
+    <span class="op-summary">&mdash; Execute a named workflow through MCP; visible from the full profile.</span>
   </div>
   <div class="transports">
     <span class="transport-pill" data-t="mcp"><span class="label">MCP</span> <span>nexus_execute_workflow</span></span>
@@ -10896,17 +10898,17 @@ graph TB
 <span class="profile-badge profile-supported">sandbox</span>
 <span class="profile-badge profile-supported">full</span>
     </span>
-    <span>usage: <span class="todo">TODO</span></span>
-    <span>test: <span class="todo">TODO</span></span>
-    <span>perf: <span class="todo">TODO</span></span>
-    <span>owner: &mdash;</span>
+    <span>usage: <code>CLI: nexus workflows execute tag-incoming; MCP: tools/call nexus_execute_workflow {&#34;name&#34;:&#34;tag-incoming&#34;,&#34;inputs&#34;:&#34;{}&#34;}.</code></span>
+    <span>test: <a href="../../tests/unit/bricks/mcp/test_mcp_server_tools.py::TestWorkflowTools::test_execute_workflow_success; tests/unit/bricks/mcp/test_tool_profiles.py::TestDefaultConfigValidity::test_default_profiles_match_expected_tool_matrix; tests/unit/bricks/mcp/test_tool_namespace_middleware.py::TestDefaultToolProfileEnforcement::test_default_profile_grants_filter_list_and_call; tests/architecture/test_issue_4131_mcp_tool_profile_story.py::test_issue_4131_owned_mcp_rows_have_story_contract; tests/e2e/self_contained/mcp/test_issue_4131_mcp_profile_story_e2e.py::test_issue_4131_mcp_profiles_real_protocol_and_perf">tests/unit/bricks/mcp/test_mcp_server_tools.py::TestWorkflowTools::test_execute_workflow_success; tests/unit/bricks/mcp/test_tool_profiles.py::TestDefaultConfigValidity::test_default_profiles_match_expected_tool_matrix; tests/unit/bricks/mcp/test_tool_namespace_middleware.py::TestDefaultToolProfileEnforcement::test_default_profile_grants_filter_list_and_call; tests/architecture/test_issue_4131_mcp_tool_profile_story.py::test_issue_4131_owned_mcp_rows_have_story_contract; tests/e2e/self_contained/mcp/test_issue_4131_mcp_profile_story_e2e.py::test_issue_4131_mcp_profiles_real_protocol_and_perf</a></span>
+    <span>perf: control</span>
+    <span>owner: <a href="https://github.com/nexi-lab/nexus/issues/4131">#4131</a></span>
     <span>gap: &mdash;</span>
   </div>
 </div>
-<div class="op" data-op-id="list.workflows" data-op-text="list.workflows  nexus_list_workflows ">
+<div class="op" data-op-id="list.workflows" data-op-text="list.workflows List available workflows through MCP; visible from the full profile. nexus_list_workflows ">
   <div class="op-header">
     <span class="op-id">list.workflows</span>
-    <span class="op-summary">&mdash; (no summary yet)</span>
+    <span class="op-summary">&mdash; List available workflows through MCP; visible from the full profile.</span>
   </div>
   <div class="transports">
     <span class="transport-pill" data-t="mcp"><span class="label">MCP</span> <span>nexus_list_workflows</span></span>
@@ -10917,10 +10919,10 @@ graph TB
 <span class="profile-badge profile-supported">sandbox</span>
 <span class="profile-badge profile-supported">full</span>
     </span>
-    <span>usage: <span class="todo">TODO</span></span>
-    <span>test: <span class="todo">TODO</span></span>
-    <span>perf: <span class="todo">TODO</span></span>
-    <span>owner: &mdash;</span>
+    <span>usage: <code>CLI: nexus workflows list; MCP: tools/call nexus_list_workflows {}.</code></span>
+    <span>test: <a href="../../tests/unit/bricks/mcp/test_mcp_server_tools.py::TestWorkflowTools::test_list_workflows_success; tests/unit/bricks/mcp/test_tool_profiles.py::TestDefaultConfigValidity::test_default_profiles_match_expected_tool_matrix; tests/unit/bricks/mcp/test_tool_namespace_middleware.py::TestDefaultToolProfileEnforcement::test_default_profile_grants_filter_list_and_call; tests/architecture/test_issue_4131_mcp_tool_profile_story.py::test_issue_4131_owned_mcp_rows_have_story_contract; tests/e2e/self_contained/mcp/test_issue_4131_mcp_profile_story_e2e.py::test_issue_4131_mcp_profiles_real_protocol_and_perf">tests/unit/bricks/mcp/test_mcp_server_tools.py::TestWorkflowTools::test_list_workflows_success; tests/unit/bricks/mcp/test_tool_profiles.py::TestDefaultConfigValidity::test_default_profiles_match_expected_tool_matrix; tests/unit/bricks/mcp/test_tool_namespace_middleware.py::TestDefaultToolProfileEnforcement::test_default_profile_grants_filter_list_and_call; tests/architecture/test_issue_4131_mcp_tool_profile_story.py::test_issue_4131_owned_mcp_rows_have_story_contract; tests/e2e/self_contained/mcp/test_issue_4131_mcp_profile_story_e2e.py::test_issue_4131_mcp_profiles_real_protocol_and_perf</a></span>
+    <span>perf: control</span>
+    <span>owner: <a href="https://github.com/nexi-lab/nexus/issues/4131">#4131</a></span>
     <span>gap: &mdash;</span>
   </div>
 </div>
@@ -12564,10 +12566,10 @@ graph TB
           </span>
         </summary>
         <div class="module-body">
-<div class="op" data-op-id="hub.admin" data-op-text="hub.admin  nexus_hub_admin ">
+<div class="op" data-op-id="hub.admin" data-op-text="hub.admin Administer hub tokens through the generic MCP hub admin tool; visible from the full profile but still requires an admin bearer token. nexus_hub_admin ">
   <div class="op-header">
     <span class="op-id">hub.admin</span>
-    <span class="op-summary">&mdash; (no summary yet)</span>
+    <span class="op-summary">&mdash; Administer hub tokens through the generic MCP hub admin tool; visible from the full profile but still requires an admin bearer token.</span>
   </div>
   <div class="transports">
     <span class="transport-pill" data-t="mcp"><span class="label">MCP</span> <span>nexus_hub_admin</span></span>
@@ -12578,10 +12580,10 @@ graph TB
 <span class="profile-badge profile-supported">sandbox</span>
 <span class="profile-badge profile-supported">full</span>
     </span>
-    <span>usage: <span class="todo">TODO</span></span>
-    <span>test: <span class="todo">TODO</span></span>
-    <span>perf: <span class="todo">TODO</span></span>
-    <span>owner: &mdash;</span>
+    <span>usage: <code>CLI: nexus hub status --remote https://hub.example.com/mcp --admin-token &#34;$NEXUS_HUB_ADMIN_TOKEN&#34;; MCP: tools/call nexus_hub_admin {&#34;action&#34;:&#34;status&#34;,&#34;arguments&#34;:{}}.</code></span>
+    <span>test: <a href="../../tests/unit/cli/test_hub_remote.py::test_remote_status_calls_mcp_tool_and_renders_json; tests/unit/bricks/mcp/test_tool_profiles.py::TestDefaultConfigValidity::test_default_profiles_match_expected_tool_matrix; tests/unit/bricks/mcp/test_tool_namespace_middleware.py::TestDefaultToolProfileEnforcement::test_default_profile_grants_filter_list_and_call; tests/architecture/test_issue_4131_mcp_tool_profile_story.py::test_issue_4131_owned_mcp_rows_have_story_contract; tests/e2e/self_contained/mcp/test_issue_4131_mcp_profile_story_e2e.py::test_issue_4131_mcp_profiles_real_protocol_and_perf">tests/unit/cli/test_hub_remote.py::test_remote_status_calls_mcp_tool_and_renders_json; tests/unit/bricks/mcp/test_tool_profiles.py::TestDefaultConfigValidity::test_default_profiles_match_expected_tool_matrix; tests/unit/bricks/mcp/test_tool_namespace_middleware.py::TestDefaultToolProfileEnforcement::test_default_profile_grants_filter_list_and_call; tests/architecture/test_issue_4131_mcp_tool_profile_story.py::test_issue_4131_owned_mcp_rows_have_story_contract; tests/e2e/self_contained/mcp/test_issue_4131_mcp_profile_story_e2e.py::test_issue_4131_mcp_profiles_real_protocol_and_perf</a></span>
+    <span>perf: control</span>
+    <span>owner: <a href="https://github.com/nexi-lab/nexus/issues/4131">#4131</a></span>
     <span>gap: &mdash;</span>
   </div>
 </div>

--- a/docs/architecture/api-rpc-surface-coverage.yaml
+++ b/docs/architecture/api-rpc-surface-coverage.yaml
@@ -496,7 +496,7 @@ operations:
   transports:
     grpc_expose:
       name: agent_heartbeat
-      source: src/nexus/services/agents/agent_rpc_service.py:818
+      source: src/nexus/services/agents/agent_rpc_service.py:870
   profiles:
     lite: supported
     sandbox: supported
@@ -513,7 +513,7 @@ operations:
   transports:
     grpc_expose:
       name: agent_list_by_zone
-      source: src/nexus/services/agents/agent_rpc_service.py:826
+      source: src/nexus/services/agents/agent_rpc_service.py:878
   profiles:
     lite: supported
     sandbox: supported
@@ -547,7 +547,7 @@ operations:
   transports:
     grpc_expose:
       name: agent_transition
-      source: src/nexus/services/agents/agent_rpc_service.py:752
+      source: src/nexus/services/agents/agent_rpc_service.py:804
   profiles:
     lite: supported
     sandbox: supported
@@ -3042,7 +3042,7 @@ operations:
   transports:
     grpc_expose:
       name: delete_agent
-      source: src/nexus/services/agents/agent_rpc_service.py:641
+      source: src/nexus/services/agents/agent_rpc_service.py:687
   profiles:
     lite: supported
     sandbox: supported
@@ -3093,7 +3093,7 @@ operations:
   owning_issue: null
 - id: delete.file
   module: filesystem
-  summary: ''
+  summary: Delete a file through MCP; visible from the coding profile and broader profiles.
   transports:
     mcp:
       name: nexus_delete_file
@@ -3102,12 +3102,14 @@ operations:
     lite: supported
     sandbox: supported
     full: supported
-  usage_example: null
-  correctness_test: null
-  perf_class: null
-  perf_link: null
+  usage_example: 'CLI: nexus rm /workspace/old.txt; MCP: tools/call nexus_delete_file {"path":"/workspace/old.txt"}.'
+  correctness_test: tests/unit/bricks/mcp/test_mcp_server_tools.py::TestFileOperationTools::test_delete_file_success; tests/unit/bricks/mcp/test_tool_profiles.py::TestDefaultConfigValidity::test_default_profiles_match_expected_tool_matrix;
+    tests/unit/bricks/mcp/test_tool_namespace_middleware.py::TestDefaultToolProfileEnforcement::test_default_profile_grants_filter_list_and_call;
+    tests/architecture/test_issue_4131_mcp_tool_profile_story.py::test_issue_4131_owned_mcp_rows_have_story_contract; tests/e2e/self_contained/mcp/test_issue_4131_mcp_profile_story_e2e.py::test_issue_4131_mcp_profiles_real_protocol_and_perf
+  perf_class: hot
+  perf_link: tests/benchmarks/bench_permission_hotpath.py::TestMCPToolNamespaceFiltering::test_cached_tool_list_filtering_latency
   gap_issue: null
-  owning_issue: null
+  owning_issue: 4131
 - id: delete.saved_mount
   module: mount
   summary: Delete persisted mount configuration without necessarily deactivating an active runtime mount.
@@ -3320,7 +3322,7 @@ operations:
   owning_issue: null
 - id: edit.file
   module: filesystem
-  summary: ''
+  summary: Apply structured file edits through MCP; visible from the coding profile and broader profiles.
   transports:
     mcp:
       name: nexus_edit_file
@@ -3329,12 +3331,14 @@ operations:
     lite: supported
     sandbox: supported
     full: supported
-  usage_example: null
-  correctness_test: null
-  perf_class: null
-  perf_link: null
+  usage_example: 'CLI: use nexus write/cat for simple edits; MCP: tools/call nexus_edit_file {"path":"/workspace/app.py","edits":[...]}.'
+  correctness_test: tests/unit/bricks/mcp/test_mcp_server_tools.py::TestEditFileTool::test_edit_file_success; tests/unit/bricks/mcp/test_tool_profiles.py::TestDefaultConfigValidity::test_default_profiles_match_expected_tool_matrix;
+    tests/unit/bricks/mcp/test_tool_namespace_middleware.py::TestDefaultToolProfileEnforcement::test_default_profile_grants_filter_list_and_call;
+    tests/architecture/test_issue_4131_mcp_tool_profile_story.py::test_issue_4131_owned_mcp_rows_have_story_contract; tests/e2e/self_contained/mcp/test_issue_4131_mcp_profile_story_e2e.py::test_issue_4131_mcp_profiles_real_protocol_and_perf
+  perf_class: hot
+  perf_link: tests/benchmarks/bench_permission_hotpath.py::TestMCPToolNamespaceFiltering::test_cached_tool_list_filtering_latency
   gap_issue: null
-  owning_issue: null
+  owning_issue: 4131
 - id: events.replay
   module: agent_log
   summary: ''
@@ -3748,7 +3752,7 @@ operations:
   owning_issue: null
 - id: execute.workflow
   module: workflows
-  summary: ''
+  summary: Execute a named workflow through MCP; visible from the full profile.
   transports:
     mcp:
       name: nexus_execute_workflow
@@ -3757,12 +3761,14 @@ operations:
     lite: supported
     sandbox: supported
     full: supported
-  usage_example: null
-  correctness_test: null
-  perf_class: null
-  perf_link: null
+  usage_example: 'CLI: nexus workflows execute tag-incoming; MCP: tools/call nexus_execute_workflow {"name":"tag-incoming","inputs":"{}"}.'
+  correctness_test: tests/unit/bricks/mcp/test_mcp_server_tools.py::TestWorkflowTools::test_execute_workflow_success; tests/unit/bricks/mcp/test_tool_profiles.py::TestDefaultConfigValidity::test_default_profiles_match_expected_tool_matrix;
+    tests/unit/bricks/mcp/test_tool_namespace_middleware.py::TestDefaultToolProfileEnforcement::test_default_profile_grants_filter_list_and_call;
+    tests/architecture/test_issue_4131_mcp_tool_profile_story.py::test_issue_4131_owned_mcp_rows_have_story_contract; tests/e2e/self_contained/mcp/test_issue_4131_mcp_profile_story_e2e.py::test_issue_4131_mcp_profiles_real_protocol_and_perf
+  perf_class: control
+  perf_link: control-plane/workflow execution path; workflow body dominates latency, not MCP namespace filtering
   gap_issue: null
-  owning_issue: null
+  owning_issue: 4131
 - id: exists.batch
   module: filesystem
   summary: ''
@@ -4129,7 +4135,7 @@ operations:
   owning_issue: null
 - id: file.info
   module: filesystem
-  summary: ''
+  summary: Inspect file metadata through MCP; visible from the minimal profile.
   transports:
     mcp:
       name: nexus_file_info
@@ -4138,12 +4144,14 @@ operations:
     lite: supported
     sandbox: supported
     full: supported
-  usage_example: null
-  correctness_test: null
-  perf_class: null
-  perf_link: null
+  usage_example: 'CLI: nexus info /workspace/hello.txt; MCP: tools/call nexus_file_info {"path":"/workspace/hello.txt"}.'
+  correctness_test: tests/unit/bricks/mcp/test_mcp_server_tools.py::TestFileOperationTools::test_file_info_exists; tests/unit/bricks/mcp/test_tool_profiles.py::TestDefaultConfigValidity::test_default_profiles_match_expected_tool_matrix;
+    tests/unit/bricks/mcp/test_tool_namespace_middleware.py::TestDefaultToolProfileEnforcement::test_default_profile_grants_filter_list_and_call;
+    tests/architecture/test_issue_4131_mcp_tool_profile_story.py::test_issue_4131_owned_mcp_rows_have_story_contract; tests/e2e/self_contained/mcp/test_issue_4131_mcp_profile_story_e2e.py::test_issue_4131_mcp_profiles_real_protocol_and_perf
+  perf_class: hot
+  perf_link: tests/benchmarks/bench_permission_hotpath.py::TestMCPToolNamespaceFiltering::test_cached_tool_list_filtering_latency
   gap_issue: null
-  owning_issue: null
+  owning_issue: 4131
 - id: filesystem.append
   module: filesystem
   summary: ''
@@ -4427,6 +4435,9 @@ operations:
     grpc_call:
       name: mkdir
       source: src/nexus/server/_kernel_syscall_dispatch.py:54
+    mcp:
+      name: nexus_mkdir
+      source: src/nexus/config/tool_profiles.yaml:1
   profiles:
     lite: supported
     sandbox: supported
@@ -4643,6 +4654,9 @@ operations:
     grpc_call:
       name: rmdir
       source: src/nexus/server/_kernel_syscall_dispatch.py:57
+    mcp:
+      name: nexus_rmdir
+      source: src/nexus/config/tool_profiles.yaml:1
   profiles:
     lite: supported
     sandbox: supported
@@ -4932,7 +4946,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.get
-      source: src/nexus/remote/kernel_client.py:1054
+      source: src/nexus/remote/kernel_client.py:1055
   profiles:
     lite: supported
     sandbox: supported
@@ -4949,7 +4963,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.heartbeat
-      source: src/nexus/remote/kernel_client.py:1080
+      source: src/nexus/remote/kernel_client.py:1081
   profiles:
     lite: supported
     sandbox: supported
@@ -5034,7 +5048,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.register
-      source: src/nexus/remote/kernel_client.py:1015
+      source: src/nexus/remote/kernel_client.py:1016
   profiles:
     lite: supported
     sandbox: supported
@@ -5102,7 +5116,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.signal
-      source: src/nexus/remote/kernel_client.py:1057
+      source: src/nexus/remote/kernel_client.py:1058
   profiles:
     lite: supported
     sandbox: supported
@@ -5187,7 +5201,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.unregister
-      source: src/nexus/remote/kernel_client.py:1048
+      source: src/nexus/remote/kernel_client.py:1049
   profiles:
     lite: supported
     sandbox: supported
@@ -5266,7 +5280,7 @@ operations:
   transports:
     grpc_expose:
       name: get_agent
-      source: src/nexus/services/agents/agent_rpc_service.py:587
+      source: src/nexus/services/agents/agent_rpc_service.py:633
   profiles:
     lite: supported
     sandbox: supported
@@ -5837,7 +5851,7 @@ operations:
   transports:
     http:
       name: GET /health/detailed
-      source: src/nexus/server/api/core/health.py:67
+      source: src/nexus/server/api/core/health.py:71
   profiles:
     lite: supported
     sandbox: supported
@@ -5854,7 +5868,7 @@ operations:
   transports:
     http:
       name: GET /metrics/pool
-      source: src/nexus/server/api/core/health.py:205
+      source: src/nexus/server/api/core/health.py:209
   profiles:
     lite: supported
     sandbox: supported
@@ -5884,7 +5898,8 @@ operations:
   owning_issue: null
 - id: hub.admin
   module: hub
-  summary: ''
+  summary: Administer hub tokens through the generic MCP hub admin tool; visible from the full profile but still requires
+    an admin bearer token.
   transports:
     mcp:
       name: nexus_hub_admin
@@ -5893,12 +5908,15 @@ operations:
     lite: supported
     sandbox: supported
     full: supported
-  usage_example: null
-  correctness_test: null
-  perf_class: null
-  perf_link: null
+  usage_example: 'CLI: nexus hub status --remote https://hub.example.com/mcp --admin-token "$NEXUS_HUB_ADMIN_TOKEN"; MCP:
+    tools/call nexus_hub_admin {"action":"status","arguments":{}}.'
+  correctness_test: tests/unit/cli/test_hub_remote.py::test_remote_status_calls_mcp_tool_and_renders_json; tests/unit/bricks/mcp/test_tool_profiles.py::TestDefaultConfigValidity::test_default_profiles_match_expected_tool_matrix;
+    tests/unit/bricks/mcp/test_tool_namespace_middleware.py::TestDefaultToolProfileEnforcement::test_default_profile_grants_filter_list_and_call;
+    tests/architecture/test_issue_4131_mcp_tool_profile_story.py::test_issue_4131_owned_mcp_rows_have_story_contract; tests/e2e/self_contained/mcp/test_issue_4131_mcp_profile_story_e2e.py::test_issue_4131_mcp_profiles_real_protocol_and_perf
+  perf_class: control
+  perf_link: admin/control-plane surface; not performance-sensitive compared with remote hub RPC latency
   gap_issue: null
-  owning_issue: null
+  owning_issue: 4131
 - id: hub.cli
   module: hub
   summary: ''
@@ -5945,8 +5963,8 @@ operations:
     lite: unavailable
     sandbox: supported
     full: supported
-  usage_example: 'CLI: nexus hub status --detail --json; remote hub: nexus hub status --remote https://hub.example.com/mcp --admin-token
-    "$NEXUS_HUB_ADMIN_TOKEN" --json'
+  usage_example: 'CLI: nexus hub status --detail --json; remote hub: nexus hub status --remote https://hub.example.com/mcp
+    --admin-token "$NEXUS_HUB_ADMIN_TOKEN" --json'
   correctness_test: tests/unit/cli/test_hub.py::test_hub_status_detail_json_includes_token_last_seen_and_zones; tests/unit/cli/test_hub_remote.py::test_remote_status_calls_mcp_tool_and_renders_json;
     tests/e2e/self_contained/cli/test_hub_flow.py::test_hub_end_to_end_token_lifecycle
   perf_class: control
@@ -6215,10 +6233,10 @@ operations:
   transports:
     grpc_expose:
       name: list_agents
-      source: src/nexus/services/agents/agent_rpc_service.py:531
+      source: src/nexus/services/agents/agent_rpc_service.py:577
     sdk:
       name: _AgentRegistryProxy.list_agents
-      source: src/nexus/remote/kernel_client.py:1083
+      source: src/nexus/remote/kernel_client.py:1084
   profiles:
     lite: supported
     sandbox: supported
@@ -6268,7 +6286,7 @@ operations:
   owning_issue: null
 - id: list.files
   module: filesystem
-  summary: ''
+  summary: List directory contents through MCP; visible from the minimal profile for read-only workspace inspection.
   transports:
     mcp:
       name: nexus_list_files
@@ -6277,12 +6295,14 @@ operations:
     lite: supported
     sandbox: supported
     full: supported
-  usage_example: null
-  correctness_test: null
-  perf_class: null
-  perf_link: null
+  usage_example: 'CLI: nexus ls /workspace -l; MCP: tools/call nexus_list_files {"path":"/workspace","recursive":false}.'
+  correctness_test: tests/unit/bricks/mcp/test_mcp_server_tools.py::TestFileOperationTools::test_list_files_basic; tests/unit/bricks/mcp/test_tool_profiles.py::TestDefaultConfigValidity::test_default_profiles_match_expected_tool_matrix;
+    tests/unit/bricks/mcp/test_tool_namespace_middleware.py::TestDefaultToolProfileEnforcement::test_default_profile_grants_filter_list_and_call;
+    tests/architecture/test_issue_4131_mcp_tool_profile_story.py::test_issue_4131_owned_mcp_rows_have_story_contract; tests/e2e/self_contained/mcp/test_issue_4131_mcp_profile_story_e2e.py::test_issue_4131_mcp_profiles_real_protocol_and_perf
+  perf_class: hot
+  perf_link: tests/benchmarks/bench_permission_hotpath.py::TestMCPToolNamespaceFiltering::test_cached_tool_list_filtering_latency
   gap_issue: null
-  owning_issue: null
+  owning_issue: 4131
 - id: list.incoming_shares
   module: rebac
   summary: List resources shared with a user from shared-* tuples with immediate revoke visibility.
@@ -6361,7 +6381,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.list_processes
-      source: src/nexus/remote/kernel_client.py:1086
+      source: src/nexus/remote/kernel_client.py:1087
   profiles:
     lite: supported
     sandbox: supported
@@ -6459,7 +6479,7 @@ operations:
   owning_issue: 4137
 - id: list.workflows
   module: workflows
-  summary: ''
+  summary: List available workflows through MCP; visible from the full profile.
   transports:
     mcp:
       name: nexus_list_workflows
@@ -6468,12 +6488,14 @@ operations:
     lite: supported
     sandbox: supported
     full: supported
-  usage_example: null
-  correctness_test: null
-  perf_class: null
-  perf_link: null
+  usage_example: 'CLI: nexus workflows list; MCP: tools/call nexus_list_workflows {}.'
+  correctness_test: tests/unit/bricks/mcp/test_mcp_server_tools.py::TestWorkflowTools::test_list_workflows_success; tests/unit/bricks/mcp/test_tool_profiles.py::TestDefaultConfigValidity::test_default_profiles_match_expected_tool_matrix;
+    tests/unit/bricks/mcp/test_tool_namespace_middleware.py::TestDefaultToolProfileEnforcement::test_default_profile_grants_filter_list_and_call;
+    tests/architecture/test_issue_4131_mcp_tool_profile_story.py::test_issue_4131_owned_mcp_rows_have_story_contract; tests/e2e/self_contained/mcp/test_issue_4131_mcp_profile_story_e2e.py::test_issue_4131_mcp_profiles_real_protocol_and_perf
+  perf_class: control
+  perf_link: control-plane inspection; workflow listing is not on the per-tool-call data hot path
   gap_issue: null
-  owning_issue: null
+  owning_issue: 4131
 - id: list.workspaces
   module: workspace
   summary: List workspaces visible to the authenticated user and zone.
@@ -6686,7 +6708,7 @@ operations:
   transports:
     grpc_expose:
       name: mcp_connect
-      source: src/nexus/bricks/mcp/mcp_service.py:528
+      source: src/nexus/bricks/mcp/mcp_service.py:602
   profiles:
     lite: unavailable
     sandbox: supported
@@ -6705,7 +6727,7 @@ operations:
   transports:
     grpc_expose:
       name: mcp_list_mounts
-      source: src/nexus/bricks/mcp/mcp_service.py:144
+      source: src/nexus/bricks/mcp/mcp_service.py:218
   profiles:
     lite: unavailable
     sandbox: supported
@@ -6725,7 +6747,7 @@ operations:
   transports:
     grpc_expose:
       name: mcp_list_tools
-      source: src/nexus/bricks/mcp/mcp_service.py:210
+      source: src/nexus/bricks/mcp/mcp_service.py:284
   profiles:
     lite: unavailable
     sandbox: supported
@@ -6761,7 +6783,7 @@ operations:
   transports:
     grpc_expose:
       name: mcp_mount
-      source: src/nexus/bricks/mcp/mcp_service.py:300
+      source: src/nexus/bricks/mcp/mcp_service.py:374
   profiles:
     lite: unavailable
     sandbox: supported
@@ -6834,7 +6856,7 @@ operations:
   transports:
     grpc_expose:
       name: mcp_sync
-      source: src/nexus/bricks/mcp/mcp_service.py:472
+      source: src/nexus/bricks/mcp/mcp_service.py:546
   profiles:
     lite: unavailable
     sandbox: supported
@@ -6874,7 +6896,7 @@ operations:
   transports:
     grpc_expose:
       name: mcp_unmount
-      source: src/nexus/bricks/mcp/mcp_service.py:423
+      source: src/nexus/bricks/mcp/mcp_service.py:497
   profiles:
     lite: unavailable
     sandbox: supported
@@ -8634,7 +8656,7 @@ operations:
   owning_issue: 4133
 - id: read.file
   module: filesystem
-  summary: ''
+  summary: Read file content through MCP; visible from the minimal profile and inherited by every broader profile.
   transports:
     mcp:
       name: nexus_read_file
@@ -8643,12 +8665,14 @@ operations:
     lite: supported
     sandbox: supported
     full: supported
-  usage_example: null
-  correctness_test: null
-  perf_class: null
-  perf_link: null
+  usage_example: 'CLI: nexus cat /workspace/hello.txt; MCP: tools/call nexus_read_file {"path":"/workspace/hello.txt"}.'
+  correctness_test: tests/unit/bricks/mcp/test_mcp_server_tools.py::TestFileOperationTools::test_read_file_success; tests/unit/bricks/mcp/test_tool_profiles.py::TestDefaultConfigValidity::test_default_profiles_match_expected_tool_matrix;
+    tests/unit/bricks/mcp/test_tool_namespace_middleware.py::TestDefaultToolProfileEnforcement::test_default_profile_grants_filter_list_and_call;
+    tests/architecture/test_issue_4131_mcp_tool_profile_story.py::test_issue_4131_owned_mcp_rows_have_story_contract; tests/e2e/self_contained/mcp/test_issue_4131_mcp_profile_story_e2e.py::test_issue_4131_mcp_profiles_real_protocol_and_perf
+  perf_class: hot
+  perf_link: tests/benchmarks/bench_permission_hotpath.py::TestMCPToolNamespaceFiltering::test_cached_tool_list_filtering_latency
   gap_issue: null
-  owning_issue: null
+  owning_issue: 4131
 - id: read.range
   module: filesystem
   summary: ''
@@ -8913,7 +8937,7 @@ operations:
   transports:
     grpc_expose:
       name: register_agent
-      source: src/nexus/services/agents/agent_rpc_service.py:326
+      source: src/nexus/services/agents/agent_rpc_service.py:358
   profiles:
     lite: supported
     sandbox: supported
@@ -8931,7 +8955,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.register_external
-      source: src/nexus/remote/kernel_client.py:1018
+      source: src/nexus/remote/kernel_client.py:1019
   profiles:
     lite: supported
     sandbox: supported
@@ -9086,7 +9110,7 @@ operations:
   owning_issue: 4133
 - id: rename.file
   module: filesystem
-  summary: ''
+  summary: Rename or move a file through MCP; visible from the coding profile and broader profiles.
   transports:
     mcp:
       name: nexus_rename_file
@@ -9095,12 +9119,14 @@ operations:
     lite: supported
     sandbox: supported
     full: supported
-  usage_example: null
-  correctness_test: null
-  perf_class: null
-  perf_link: null
+  usage_example: 'CLI: nexus mv /workspace/old.txt /workspace/new.txt; MCP: tools/call nexus_rename_file {"old_path":"/workspace/old.txt","new_path":"/workspace/new.txt"}.'
+  correctness_test: tests/unit/bricks/mcp/test_tool_profiles.py::TestDefaultConfigValidity::test_default_profiles_match_expected_tool_matrix;
+    tests/unit/bricks/mcp/test_tool_namespace_middleware.py::TestDefaultToolProfileEnforcement::test_default_profile_grants_filter_list_and_call;
+    tests/architecture/test_issue_4131_mcp_tool_profile_story.py::test_issue_4131_owned_mcp_rows_have_story_contract; tests/e2e/self_contained/mcp/test_issue_4131_mcp_profile_story_e2e.py::test_issue_4131_mcp_profiles_real_protocol_and_perf
+  perf_class: hot
+  perf_link: tests/benchmarks/bench_permission_hotpath.py::TestMCPToolNamespaceFiltering::test_cached_tool_list_filtering_latency
   gap_issue: null
-  owning_issue: null
+  owning_issue: 4131
 - id: revoke.consent
   module: rebac
   summary: Revoke discovery consent by deleting the matching consent_granted tuple.
@@ -9239,7 +9265,8 @@ operations:
   owning_issue: null
 - id: sandbox.create
   module: sandbox
-  summary: ''
+  summary: Create a sandbox runtime through MCP when the sandbox provider is available; visible from the execution profile
+    and full profile.
   transports:
     mcp:
       name: nexus_sandbox_create
@@ -9248,15 +9275,18 @@ operations:
     lite: supported
     sandbox: supported
     full: supported
-  usage_example: null
-  correctness_test: null
-  perf_class: null
-  perf_link: null
+  usage_example: 'CLI: nexus sandbox create demo-box --provider docker; MCP: tools/call nexus_sandbox_create {"name":"demo-box","ttl_minutes":15}.'
+  correctness_test: tests/unit/bricks/mcp/test_mcp_server_tools.py::TestSandboxTools::test_sandbox_create_success; tests/unit/bricks/mcp/test_tool_profiles.py::TestDefaultConfigValidity::test_default_profiles_match_expected_tool_matrix;
+    tests/unit/bricks/mcp/test_tool_namespace_middleware.py::TestDefaultToolProfileEnforcement::test_default_profile_grants_filter_list_and_call;
+    tests/architecture/test_issue_4131_mcp_tool_profile_story.py::test_issue_4131_owned_mcp_rows_have_story_contract; tests/e2e/self_contained/mcp/test_issue_4131_mcp_profile_story_e2e.py::test_issue_4131_mcp_profiles_real_protocol_and_perf
+  perf_class: setup
+  perf_link: setup path; sandbox provider startup dominates latency and this is not a per-request namespace hot path
   gap_issue: null
-  owning_issue: null
+  owning_issue: 4131
 - id: sandbox.list
   module: sandbox
-  summary: ''
+  summary: List sandbox runtimes through MCP when sandbox support is available; visible from the execution profile and full
+    profile.
   transports:
     mcp:
       name: nexus_sandbox_list
@@ -9265,12 +9295,14 @@ operations:
     lite: supported
     sandbox: supported
     full: supported
-  usage_example: null
-  correctness_test: null
-  perf_class: null
-  perf_link: null
+  usage_example: 'CLI: nexus sandbox list; MCP: tools/call nexus_sandbox_list {}.'
+  correctness_test: tests/unit/bricks/mcp/test_mcp_server_tools.py::TestSandboxTools::test_sandbox_list_success; tests/unit/bricks/mcp/test_tool_profiles.py::TestDefaultConfigValidity::test_default_profiles_match_expected_tool_matrix;
+    tests/unit/bricks/mcp/test_tool_namespace_middleware.py::TestDefaultToolProfileEnforcement::test_default_profile_grants_filter_list_and_call;
+    tests/architecture/test_issue_4131_mcp_tool_profile_story.py::test_issue_4131_owned_mcp_rows_have_story_contract; tests/e2e/self_contained/mcp/test_issue_4131_mcp_profile_story_e2e.py::test_issue_4131_mcp_profiles_real_protocol_and_perf
+  perf_class: control
+  perf_link: control-plane inspection; not performance-sensitive compared with sandbox provider API latency
   gap_issue: null
-  owning_issue: null
+  owning_issue: 4131
 - id: sandbox.run
   module: sandbox
   summary: Run a command with Nexus connection env vars injected. Shares the exact state-consumption path as `nexus env` (env_cmd.py
@@ -9292,7 +9324,8 @@ operations:
   owning_issue: null
 - id: sandbox.stop
   module: sandbox
-  summary: ''
+  summary: Stop a sandbox runtime through MCP when sandbox support is available; visible from the execution profile and full
+    profile.
   transports:
     mcp:
       name: nexus_sandbox_stop
@@ -9301,12 +9334,14 @@ operations:
     lite: supported
     sandbox: supported
     full: supported
-  usage_example: null
-  correctness_test: null
-  perf_class: null
-  perf_link: null
+  usage_example: 'CLI: nexus sandbox stop sb_123; MCP: tools/call nexus_sandbox_stop {"sandbox_id":"sb_123"}.'
+  correctness_test: tests/unit/bricks/mcp/test_mcp_server_tools.py::TestSandboxTools::test_sandbox_stop_success; tests/unit/bricks/mcp/test_tool_profiles.py::TestDefaultConfigValidity::test_default_profiles_match_expected_tool_matrix;
+    tests/unit/bricks/mcp/test_tool_namespace_middleware.py::TestDefaultToolProfileEnforcement::test_default_profile_grants_filter_list_and_call;
+    tests/architecture/test_issue_4131_mcp_tool_profile_story.py::test_issue_4131_owned_mcp_rows_have_story_contract; tests/e2e/self_contained/mcp/test_issue_4131_mcp_profile_story_e2e.py::test_issue_4131_mcp_profiles_real_protocol_and_perf
+  perf_class: control
+  perf_link: control-plane teardown; provider latency dominates and this is not a namespace filtering hot path
   gap_issue: null
-  owning_issue: null
+  owning_issue: 4131
 - id: save.mount
   module: mount
   summary: Persist a mount configuration so it can be loaded on demand or restored after restart.
@@ -11616,7 +11651,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.unregister_external
-      source: src/nexus/remote/kernel_client.py:1051
+      source: src/nexus/remote/kernel_client.py:1052
   profiles:
     lite: supported
     sandbox: supported
@@ -11667,7 +11702,7 @@ operations:
   transports:
     grpc_expose:
       name: update_agent
-      source: src/nexus/services/agents/agent_rpc_service.py:442
+      source: src/nexus/services/agents/agent_rpc_service.py:488
   profiles:
     lite: supported
     sandbox: supported
@@ -11722,7 +11757,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.update_state
-      source: src/nexus/remote/kernel_client.py:1069
+      source: src/nexus/remote/kernel_client.py:1070
   profiles:
     lite: supported
     sandbox: supported
@@ -12255,7 +12290,7 @@ operations:
   owning_issue: null
 - id: write.file
   module: filesystem
-  summary: ''
+  summary: Write file content through MCP; visible from the coding profile and broader profiles.
   transports:
     mcp:
       name: nexus_write_file
@@ -12264,12 +12299,14 @@ operations:
     lite: supported
     sandbox: supported
     full: supported
-  usage_example: null
-  correctness_test: null
-  perf_class: null
-  perf_link: null
+  usage_example: 'CLI: nexus write /workspace/hello.txt "hello"; MCP: tools/call nexus_write_file {"path":"/workspace/hello.txt","content":"hello"}.'
+  correctness_test: tests/unit/bricks/mcp/test_mcp_server_tools.py::TestFileOperationTools::test_write_file_success; tests/unit/bricks/mcp/test_tool_profiles.py::TestDefaultConfigValidity::test_default_profiles_match_expected_tool_matrix;
+    tests/unit/bricks/mcp/test_tool_namespace_middleware.py::TestDefaultToolProfileEnforcement::test_default_profile_grants_filter_list_and_call;
+    tests/architecture/test_issue_4131_mcp_tool_profile_story.py::test_issue_4131_owned_mcp_rows_have_story_contract; tests/e2e/self_contained/mcp/test_issue_4131_mcp_profile_story_e2e.py::test_issue_4131_mcp_profiles_real_protocol_and_perf
+  perf_class: hot
+  perf_link: tests/benchmarks/bench_permission_hotpath.py::TestMCPToolNamespaceFiltering::test_cached_tool_list_filtering_latency
   gap_issue: null
-  owning_issue: null
+  owning_issue: 4131
 - id: write.stream
   module: filesystem
   summary: ''
@@ -13952,10 +13989,10 @@ parity_warnings:
 - operation_id: filesystem.mkdir
   has:
   - cli
+  - mcp
   missing:
   - grpc_typed
   - http
-  - mcp
   - sdk
 - operation_id: filesystem.move
   has:
@@ -14024,10 +14061,10 @@ parity_warnings:
 - operation_id: filesystem.rmdir
   has:
   - cli
+  - mcp
   missing:
   - grpc_typed
   - http
-  - mcp
   - sdk
 - operation_id: filesystem.size
   has:
@@ -16403,6 +16440,8 @@ stale_rows:
   reason: present in committed YAML but not detected by extractor
 - operation_id: graph.entity_entity_id
   reason: present in committed YAML but not detected by extractor
+- operation_id: hub.status
+  reason: present in committed YAML but not detected by extractor
 - operation_id: identity.agent_id_identity
   reason: present in committed YAML but not detected by extractor
 - operation_id: identity.agent_id_verify
@@ -16416,6 +16455,8 @@ stale_rows:
 - operation_id: locks.resource:path_acquire
   reason: present in committed YAML but not detected by extractor
 - operation_id: mcp.mounts_name
+  reason: present in committed YAML but not detected by extractor
+- operation_id: mcp.tool_profile_assign
   reason: present in committed YAML but not detected by extractor
 - operation_id: mobile_search.detect
   reason: present in committed YAML but not detected by extractor
@@ -16504,6 +16545,4 @@ stale_rows:
 - operation_id: zone_routes.post
   reason: present in committed YAML but not detected by extractor
 - operation_id: zone_routes.zone_id
-  reason: present in committed YAML but not detected by extractor
-- operation_id: mcp.tool_profile_assign
   reason: present in committed YAML but not detected by extractor

--- a/docs/guides/user-guide.md
+++ b/docs/guides/user-guide.md
@@ -1677,6 +1677,90 @@ export NEXUS_URL="http://localhost:2026"
 export NEXUS_API_KEY="..."
 ```
 
+### 9.5 Shape An Agent's MCP Tool Profile
+
+MCP tool profiles are the normal way to give an agent the smallest useful
+toolbox. They are ReBAC grants over `/tools/<tool-name>`: `tools/list` only
+shows granted tools, and `tools/call` returns `not found` for a hidden tool
+rather than exposing that it exists.
+
+Use the profile CLI to inspect and assign the matrix:
+
+```bash
+nexus mcp profile list
+nexus mcp profile show coding
+nexus mcp profile assign agent demo-agent coding --zone-id sandbox-agent-1
+nexus mcp profile inspect agent demo-agent --zone-id sandbox-agent-1
+```
+
+Default task matrix:
+
+| Profile | Use it when the agent needs to... | Direct tools added by this profile |
+| --- | --- | --- |
+| `minimal` | read and inspect workspace files | `nexus_read_file`, `nexus_list_files`, `nexus_file_info`, `nexus_glob` |
+| `coding` | edit code and search text | `nexus_write_file`, `nexus_edit_file`, `nexus_delete_file`, `nexus_mkdir`, `nexus_rmdir`, `nexus_rename_file`, `nexus_grep` |
+| `search` | search without mutation rights | `nexus_grep`, `nexus_semantic_search` |
+| `execution` | create and use a sandbox runtime | `nexus_python`, `nexus_bash`, `nexus_sandbox_create`, `nexus_sandbox_list`, `nexus_sandbox_stop` |
+| `full` | inspect tools, workflows, and hub admin surfaces | `nexus_discovery_search_tools`, `nexus_discovery_list_servers`, `nexus_discovery_get_tool_details`, `nexus_discovery_load_tools`, `nexus_list_workflows`, `nexus_execute_workflow`, `nexus_hub_admin` |
+
+Inheritance matters: `coding` includes `minimal`, `execution` includes
+`coding`, and `full` includes `execution`. `search` includes only `minimal`, so
+it can grep and semantic-search without write access.
+
+Equivalent MCP JSON-RPC examples:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/list",
+  "params": {}
+}
+```
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "tools/call",
+  "params": {
+    "name": "nexus_read_file",
+    "arguments": {
+      "path": "/workspace/hello.txt"
+    }
+  }
+}
+```
+
+Expected behavior:
+
+- A `minimal` agent can call `nexus_read_file` and `nexus_glob`; a call to
+  `nexus_write_file` returns `not found`.
+- A `coding` agent can call write/edit/delete/grep tools; sandbox execution and
+  discovery tools are hidden.
+- A `search` agent can call grep and semantic search but still cannot mutate
+  files.
+- An `execution` agent can use `nexus_python`, `nexus_bash`, and sandbox
+  lifecycle tools when the sandbox provider is available. If no provider is
+  wired, those execution tools are unavailable at server startup.
+- A `full` agent can use discovery tools and workflow tools. `nexus_hub_admin`
+  still requires an admin bearer token, so a visible tool can still return an
+  admin/auth denial.
+
+Correctness assertion: after assigning a profile, `tools/list` must contain only
+the profile's inherited tools, and `tools/call` for the next-tier hidden tool
+must return `not found`, not a permission-denied message.
+
+Performance classification: `tools/list` filtering and `tools/call` namespace
+checks are hot-path operations covered by the MCP namespace filtering benchmark.
+Profile assignment is setup/control-plane work and is not on the per-tool-call
+latency path.
+
+MCP profile docs link back to the file/search/ReBAC stories in the shared
+surface map: file tools use the filesystem rows, grep/semantic search use the
+search rows, and profile grants/enforcement use the ReBAC-backed tool namespace
+rows.
+
 Packages behind this:
 
 - Workflow engine: `nexus.bricks.workflows`

--- a/docs/superpowers/plans/2026-05-21-issue-4131-mcp-tool-profile-story.md
+++ b/docs/superpowers/plans/2026-05-21-issue-4131-mcp-tool-profile-story.md
@@ -1,0 +1,109 @@
+# Issue 4131 MCP Tool Profile Story Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Complete the MCP tool profile agent story with tests, user docs, and shared surface coverage.
+
+**Architecture:** Keep `src/nexus/config/tool_profiles.yaml` as the profile source, `ToolNamespaceMiddleware` as the enforcement boundary, and `docs/architecture/api-rpc-surface-coverage.yaml` as the shared external-surface model. The guide explains the task workflow; tests lock profile inheritance, per-profile filtering, and contract coverage.
+
+**Tech Stack:** Python, pytest, Click CLI tests, FastMCP test doubles, YAML surface coverage schema, generated static HTML.
+
+---
+
+### Task 1: Profile Matrix Tests
+
+**Files:**
+- Modify: `tests/unit/bricks/mcp/test_tool_profiles.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add a test that loads `src/nexus/config/tool_profiles.yaml` and asserts the inherited matrix for `minimal`, `coding`, `search`, `execution`, and `full`, including sandbox execution tools and discovery tools.
+
+- [ ] **Step 2: Verify red**
+
+Run `uv run pytest tests/unit/bricks/mcp/test_tool_profiles.py::TestDefaultConfigValidity::test_default_profiles_match_expected_tool_matrix -q`.
+Expected before implementation: failure because the test does not exist.
+
+- [ ] **Step 3: Implement minimal test support**
+
+Use the existing `load_profiles()` API and no production code unless the test exposes a real config mismatch.
+
+- [ ] **Step 4: Verify green**
+
+Run the same pytest command and confirm it passes.
+
+### Task 2: Enforcement Tests
+
+**Files:**
+- Modify: `tests/unit/bricks/mcp/test_tool_namespace_middleware.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add a parameterized test that grants each default profile to a subject, lists representative tools, verifies visible tools, and verifies the next-tier or out-of-profile tool returns `not found` from `tools/call`.
+
+- [ ] **Step 2: Verify red**
+
+Run `uv run pytest tests/unit/bricks/mcp/test_tool_namespace_middleware.py::TestDefaultToolProfileEnforcement -q`.
+Expected before implementation: failure because the test class does not exist.
+
+- [ ] **Step 3: Implement minimal test support**
+
+Reuse `MemoryToolGrantReBAC`, `ToolNamespaceMiddleware`, and existing fake context/tool helpers.
+
+- [ ] **Step 4: Verify green**
+
+Run the same pytest command and confirm it passes.
+
+### Task 3: Architecture Contract Test
+
+**Files:**
+- Create: `tests/architecture/test_issue_4131_mcp_tool_profile_story.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Assert all issue 4131 MCP rows have summary, usage example containing both MCP and CLI context where applicable, correctness test links, performance class/link, and owning issue. Assert the user guide includes the profile matrix, profile CLI commands, JSON-RPC `tools/list` and `tools/call` examples, correctness assertion, performance classification, and links to file/search/ReBAC stories.
+
+- [ ] **Step 2: Verify red**
+
+Run `uv run pytest tests/architecture/test_issue_4131_mcp_tool_profile_story.py -q`.
+Expected before docs/YAML implementation: failure on missing rows or guide phrases.
+
+- [ ] **Step 3: Update data/docs**
+
+Populate the relevant MCP rows in `docs/architecture/api-rpc-surface-coverage.yaml`, update `docs/guides/user-guide.md`, and regenerate `docs/architecture/api-rpc-surface-coverage.html`.
+
+- [ ] **Step 4: Verify green**
+
+Run the same pytest command and confirm it passes.
+
+### Task 4: Full Verification
+
+**Files:**
+- Modified docs/tests/YAML/HTML from prior tasks.
+
+- [ ] **Step 1: Run targeted tests**
+
+Run:
+
+```bash
+uv run pytest \
+  tests/unit/bricks/mcp/test_tool_profiles.py \
+  tests/unit/bricks/mcp/test_tool_namespace_middleware.py::TestDefaultToolProfileEnforcement \
+  tests/architecture/test_issue_4131_mcp_tool_profile_story.py \
+  tests/architecture/test_issue_4128_sandbox_rebac_mcp_boundaries.py \
+  tests/architecture/test_issue_4136_full_mcp_mount_oauth_surface.py \
+  -q
+```
+
+- [ ] **Step 2: Run generator/render checks**
+
+Run:
+
+```bash
+uv run python scripts/gen_api_surface_coverage.py
+uv run python scripts/render_api_surface_coverage.py
+```
+
+- [ ] **Step 3: Inspect diff**
+
+Run `git diff -- docs/guides/user-guide.md docs/architecture tests/unit/bricks/mcp docs/superpowers` and verify the diff is scoped to issue 4131.

--- a/docs/superpowers/specs/2026-05-21-issue-4131-mcp-tool-profile-story-design.md
+++ b/docs/superpowers/specs/2026-05-21-issue-4131-mcp-tool-profile-story-design.md
@@ -1,0 +1,39 @@
+# Issue 4131 MCP Tool Profile Story Design
+
+## Goal
+
+Complete the MCP-capable agent story for sandbox-oriented tool profiles by tying the default MCP profile matrix to user documentation, enforcement tests, and the shared API/RPC surface coverage model.
+
+## Recommended Approach
+
+Use the existing `develop` surface-coverage model as the source of truth. Keep the existing product surface because `nexus mcp profile list/show/assign/inspect` already covers profile introspection and assignment. Do not open a missing-surface gap unless implementation discovers a required command or RPC is absent.
+
+## Alternatives Considered
+
+1. Update only `docs/guides/user-guide.md`.
+   This is too narrow because issue 4131 requires tests, matrix coverage, and performance classification.
+
+2. Add a new standalone MCP profile guide.
+   This would be easier to read in isolation but would duplicate the shared surface model and violate the issue comment that says to build the shared understanding first.
+
+3. Update tests, user guide, and `api-rpc-surface-coverage.yaml` together.
+   This is the chosen path because it keeps the guide, contract checks, and rendered architecture map aligned.
+
+## Scope
+
+- Add tests that prove the default profiles `minimal`, `coding`, `search`, `execution`, and `full` have the expected inherited tool matrix.
+- Add tests that exercise namespace filtering and `tools/call` denial behavior for each default profile.
+- Add an architecture contract test for issue 4131 so MCP tool rows and guide content cannot regress.
+- Update the shared coverage YAML rows for MCP file/edit/sandbox/workflow/admin tools that currently lack owner, examples, correctness tests, and performance classification.
+- Update `docs/guides/user-guide.md` to tell the agent tool-use story by task and include CLI plus MCP JSON-RPC examples, expected allowed/denied/unavailable behavior, a correctness assertion, and performance classification.
+- Render the HTML architecture map after YAML updates.
+
+## Out Of Scope
+
+- New MCP tools.
+- Changes to the MCP JSON-RPC protocol server.
+- New benchmark code unless existing benchmark/test evidence is missing for a hot path.
+
+## Missing Surface Decision
+
+No missing-surface issue is needed if the existing `nexus mcp profile list`, `show`, `assign`, and `inspect` commands satisfy profile discovery and assignment. If tests show one of those commands cannot support the documented workflow, the implementation must add a gap row and linked issue before claiming completion.

--- a/scripts/surface_coverage/normalize.py
+++ b/scripts/surface_coverage/normalize.py
@@ -35,6 +35,8 @@ _SDK_DEFAULT_MODULE = "fs"
 _BARE_MCP_TOOL_OVERRIDES = {
     "glob": "search.glob",
     "grep": "search.grep",
+    "mkdir": "filesystem.mkdir",
+    "rmdir": "filesystem.rmdir",
 }
 
 

--- a/src/nexus/bricks/mcp/hub_admin_tool.py
+++ b/src/nexus/bricks/mcp/hub_admin_tool.py
@@ -59,6 +59,8 @@ def register_hub_admin_tool(
             else:
                 return _json_error(400, f"unknown hub admin action: {action}")
             return json.dumps(result, indent=2, default=str)
+        except AttributeError as exc:
+            return _json_error(501, f"hub admin action unavailable: {exc}")
         except NexusPermissionError as exc:
             return _json_error(403, str(exc))
         except NexusError as exc:

--- a/src/nexus/bricks/mcp/mcp_service.py
+++ b/src/nexus/bricks/mcp/mcp_service.py
@@ -138,6 +138,80 @@ class MCPService:
             self._mcp_mount_manager.set_zone(zone_id)
 
     # =========================================================================
+    # Public API: Hub Administration
+    # =========================================================================
+
+    def admin_hub_status(self) -> dict[str, Any]:
+        """Read local hub status for admin MCP callers."""
+        self._require_admin()
+        from nexus.hub import admin_ops
+
+        return admin_ops.get_hub_status(self._hub_session_factory())
+
+    def admin_hub_token_list(self, *, show_revoked: bool = False) -> dict[str, Any]:
+        """List local hub tokens for admin MCP callers."""
+        self._require_admin()
+        from nexus.hub import admin_ops
+
+        return admin_ops.list_hub_tokens(
+            self._hub_session_factory(),
+            show_revoked=show_revoked,
+        )
+
+    def admin_hub_token_create(
+        self,
+        *,
+        name: str,
+        zones: str | None = None,
+        zones_glob: str | None = None,
+        admin: bool = False,
+        expires: str | None = None,
+        user_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Create a local hub token for admin MCP callers."""
+        self._require_admin()
+        from nexus.hub import admin_ops
+
+        return admin_ops.create_hub_token(
+            self._hub_session_factory(),
+            name=name,
+            zones_csv=zones,
+            zones_glob=zones_glob,
+            is_admin=admin,
+            expires=expires,
+            user_id=user_id,
+        )
+
+    def admin_hub_token_revoke(self, *, identifier: str) -> dict[str, Any]:
+        """Revoke a local hub token for admin MCP callers."""
+        self._require_admin()
+        from nexus.hub import admin_ops
+
+        return admin_ops.revoke_hub_token(
+            self._hub_session_factory(),
+            identifier=identifier,
+        )
+
+    def _hub_session_factory(self) -> Any:
+        record_store = getattr(self._filesystem, "_record_store", None)
+        session_factory = getattr(record_store, "session_factory", None)
+        if callable(session_factory):
+            return session_factory
+
+        from nexus.hub import admin_ops
+
+        return admin_ops.get_env_session_factory()
+
+    def _require_admin(self) -> None:
+        context = getattr(self._filesystem, "_init_cred", None)
+        if getattr(context, "is_admin", False):
+            return
+
+        from nexus.contracts.exceptions import NexusPermissionError
+
+        raise NexusPermissionError("hub_admin", "Admin privileges required")
+
+    # =========================================================================
     # Public API: MCP Mount Management
     # =========================================================================
 

--- a/src/nexus/bricks/mcp/middleware.py
+++ b/src/nexus/bricks/mcp/middleware.py
@@ -25,6 +25,7 @@ References:
     - Kong: tool filtering at gateway level
 """
 
+import inspect
 import logging
 import threading
 from collections.abc import Sequence
@@ -103,7 +104,7 @@ class ToolNamespaceMiddleware(Middleware):
         if not self._enabled:
             return all_tools
 
-        subject = self._extract_subject(context)
+        subject = await self._extract_subject_async(context)
         if subject is None:
             # No subject identity → return all tools (backward compat / admin)
             return all_tools
@@ -134,7 +135,7 @@ class ToolNamespaceMiddleware(Middleware):
         if not self._enabled:
             return await call_next(context)
 
-        subject = self._extract_subject(context)
+        subject = await self._extract_subject_async(context)
         if subject is None:
             # No subject identity → allow (backward compat / admin)
             return await call_next(context)
@@ -261,7 +262,7 @@ class ToolNamespaceMiddleware(Middleware):
     # Subject extraction
     # ------------------------------------------------------------------
 
-    def _extract_subject(
+    async def _extract_subject_async(
         self,
         context: MiddlewareContext[Any],
     ) -> tuple[str, str] | None:
@@ -275,6 +276,19 @@ class ToolNamespaceMiddleware(Middleware):
 
         Returns:
             (subject_type, subject_id) tuple, or None if not available.
+        """
+        if context.fastmcp_context is None:
+            return None
+        return await self._extract_subject_from_ctx_async(context.fastmcp_context)
+
+    def _extract_subject(
+        self,
+        context: MiddlewareContext[Any],
+    ) -> tuple[str, str] | None:
+        """Extract subject identity from middleware context synchronously.
+
+        Kept for older sync tests and callers. Runtime middleware hooks use
+        ``_extract_subject_async`` so FastMCP 3.x async context state is awaited.
         """
         if context.fastmcp_context is None:
             return None
@@ -307,6 +321,28 @@ class ToolNamespaceMiddleware(Middleware):
 
         return self._get_visible_tools(subject)
 
+    async def _extract_subject_from_ctx_async(self, ctx: Any) -> tuple[str, str] | None:
+        """Extract subject identity from sync or async FastMCP context state."""
+        if not hasattr(ctx, "get_state"):
+            return None
+
+        try:
+            subject_type = await _maybe_await(ctx.get_state("subject_type"))
+            subject_id = await _maybe_await(ctx.get_state("subject_id"))
+            if subject_type and subject_id:
+                return (str(subject_type), str(subject_id))
+        except Exception as e:
+            logger.warning("Failed to extract subject identity from context: %s", e)
+
+        try:
+            api_key = await _maybe_await(ctx.get_state("api_key"))
+            if api_key:
+                return ("api_key", str(api_key))
+        except Exception as e:
+            logger.warning("Failed to extract API key from context: %s", e)
+
+        return None
+
     def _extract_subject_from_ctx(self, ctx: Any) -> tuple[str, str] | None:
         """Extract subject identity from a FastMCP Context.
 
@@ -323,17 +359,17 @@ class ToolNamespaceMiddleware(Middleware):
             return None
 
         try:
-            subject_type = ctx.get_state("subject_type")
-            subject_id = ctx.get_state("subject_id")
+            subject_type = _sync_state_or_none(ctx, "subject_type")
+            subject_id = _sync_state_or_none(ctx, "subject_id")
             if subject_type and subject_id:
-                return (subject_type, subject_id)
+                return (str(subject_type), str(subject_id))
         except Exception as e:
             logger.warning("Failed to extract subject identity from context: %s", e)
 
         try:
-            api_key = ctx.get_state("api_key")
+            api_key = _sync_state_or_none(ctx, "api_key")
             if api_key:
-                return ("api_key", api_key)
+                return ("api_key", str(api_key))
         except Exception as e:
             logger.warning("Failed to extract API key from context: %s", e)
 
@@ -388,3 +424,18 @@ def _text_content(text: str) -> Any:
     import mcp.types as mt
 
     return mt.TextContent(type="text", text=text)
+
+
+async def _maybe_await(value: Any) -> Any:
+    if inspect.isawaitable(value):
+        return await value
+    return value
+
+
+def _sync_state_or_none(ctx: Any, key: str) -> Any:
+    value = ctx.get_state(key)
+    if inspect.isawaitable(value):
+        if inspect.iscoroutine(value):
+            value.close()
+        return None
+    return value

--- a/src/nexus/bricks/mcp/server.py
+++ b/src/nexus/bricks/mcp/server.py
@@ -12,7 +12,12 @@ import contextvars
 import inspect
 import json
 import logging
+from collections.abc import Coroutine
+from dataclasses import asdict, is_dataclass
+from datetime import date, datetime
+from enum import Enum
 from typing import TYPE_CHECKING, Any, cast
+from uuid import UUID
 
 from cachetools import LRUCache
 from fastmcp import Context, FastMCP
@@ -84,6 +89,18 @@ def reset_request_api_key(token: contextvars.Token[str | None]) -> None:
         token: The token returned by set_request_api_key()
     """
     _request_api_key.reset(token)
+
+
+def _json_default(value: Any) -> Any:
+    if is_dataclass(value) and not isinstance(value, type):
+        return asdict(value)
+    if isinstance(value, Enum):
+        return value.value
+    if isinstance(value, datetime | date):
+        return value.isoformat()
+    if isinstance(value, UUID):
+        return str(value)
+    return str(value)
 
 
 def register_policy_gate_dependency(app: Any, gate: PolicyGate) -> None:
@@ -255,6 +272,76 @@ async def create_mcp_server(
 
         _connection_cache[request_api_key] = new_nx
         return new_nx
+
+    def _service(nx_instance: Any, name: str) -> Any | None:
+        service_fn = getattr(nx_instance, "service", None)
+        if not callable(service_fn):
+            return None
+        try:
+            return service_fn(name)
+        except Exception:
+            return None
+
+    def _workflow_api(nx_instance: Any) -> Any | None:
+        workflows = getattr(nx_instance, "workflows", None)
+        if workflows is not None:
+            return workflows
+        return _service(nx_instance, "workflow_engine")
+
+    def _declared_callable(obj: Any, name: str) -> Any | None:
+        try:
+            inspect.getattr_static(obj, name)
+        except AttributeError:
+            return None
+        value = getattr(obj, name, None)
+        return value if callable(value) else None
+
+    def _run_maybe_async(value: Any) -> Any:
+        if inspect.isawaitable(value):
+            from nexus.lib.sync_bridge import run_sync
+
+            return run_sync(cast(Coroutine[Any, Any, Any], value), timeout=30.0)
+        return value
+
+    def _sandbox_rpc_service(nx_instance: Any) -> Any | None:
+        return _service(nx_instance, "sandbox_rpc")
+
+    def _sandbox_rpc_available(nx_instance: Any) -> bool:
+        service = _sandbox_rpc_service(nx_instance)
+
+        explicit_available = getattr(nx_instance, "sandbox_available", None)
+        if explicit_available is False:
+            return False
+        if explicit_available is True:
+            return True
+
+        if service is None:
+            ensure = getattr(nx_instance, "_ensure_sandbox_manager", None)
+            if callable(ensure):
+                try:
+                    ensure()
+                    service = _sandbox_rpc_service(nx_instance)
+                except Exception:
+                    service = None
+
+        if service is None:
+            return False
+
+        providers_fn = getattr(service, "available_providers", None)
+        if callable(providers_fn):
+            providers = providers_fn()
+            if isinstance(providers, list | tuple | set | frozenset):
+                return bool(providers)
+            return False
+
+        is_available = getattr(service, "is_available", None)
+        if callable(is_available):
+            available = is_available()
+            if isinstance(available, bool):
+                return available
+            return False
+
+        return False
 
     # Create FastMCP server
     mcp = FastMCP(name)
@@ -1456,14 +1543,24 @@ async def create_mcp_server(
             JSON string with list of workflows
         """
         nx_instance = _get_nexus_instance(ctx)
-        if not hasattr(nx_instance, "workflows"):
+        workflows_api = _workflow_api(nx_instance)
+        if workflows_api is None:
             return tool_error(
                 "unavailable",
                 "Workflow system not available (requires NexusFS with workflows enabled).",
             )
 
-        workflows = nx_instance.workflows.list_workflows()
-        return json.dumps(workflows, indent=2)
+        list_fn = _declared_callable(workflows_api, "list_workflows") or _declared_callable(
+            workflows_api, "list"
+        )
+        if not callable(list_fn):
+            return tool_error(
+                "unavailable",
+                "Workflow system not available (workflow API cannot list workflows).",
+            )
+
+        workflows = _run_maybe_async(list_fn())
+        return json.dumps(workflows, indent=2, default=_json_default)
 
     @mcp.tool(
         annotations={
@@ -1487,7 +1584,8 @@ async def create_mcp_server(
             Workflow execution result
         """
         nx_instance = _get_nexus_instance(ctx)
-        if not hasattr(nx_instance, "workflows"):
+        workflows_api = _workflow_api(nx_instance)
+        if workflows_api is None:
             return tool_error(
                 "unavailable",
                 "Workflow system not available (requires NexusFS with workflows enabled).",
@@ -1500,8 +1598,22 @@ async def create_mcp_server(
                 "invalid_input", "Invalid JSON in inputs parameter. Provide valid JSON string."
             )
 
-        result = nx_instance.workflows.execute(name, **input_dict)
-        return json.dumps(result, indent=2)
+        execute_fn = _declared_callable(workflows_api, "execute")
+        trigger_fn = _declared_callable(workflows_api, "trigger_workflow")
+        if execute_fn is not None:
+            result = execute_fn(name, **input_dict)
+        elif trigger_fn is not None:
+            result = trigger_fn(name, input_dict)
+        else:
+            return tool_error(
+                "unavailable",
+                "Workflow system not available (workflow API cannot execute workflows).",
+            )
+
+        result = _run_maybe_async(result)
+        if result is None:
+            return tool_error("not_found", f"Workflow not found or disabled: {name}")
+        return json.dumps(result, indent=2, default=_json_default)
 
     # =========================================================================
     # SANDBOX EXECUTION TOOLS (Conditional Registration)
@@ -1530,19 +1642,7 @@ async def create_mcp_server(
 
     # Check if sandbox support is available
     # First check the explicit sandbox_available property, then probe internals
-    sandbox_available = False
-    try:
-        sa = getattr(_default_nx, "sandbox_available", None)
-        if sa is False:
-            sandbox_available = False
-        elif sa is True:
-            sandbox_available = True
-        elif hasattr(_default_nx, "_ensure_sandbox_manager"):
-            _default_nx._ensure_sandbox_manager()
-            if getattr(_default_nx, "sandbox_available", False):
-                sandbox_available = True
-    except Exception:
-        sandbox_available = False
+    sandbox_available = _sandbox_rpc_available(_default_nx)
 
     # Only register sandbox tools if available
     if sandbox_available:
@@ -1560,7 +1660,10 @@ async def create_mcp_server(
                 Execution result with stdout, stderr, exit_code, and execution time
             """
             nx_instance: Any = _get_nexus_instance(ctx)
-            result = nx_instance.service("sandbox_rpc").sandbox_run(
+            sandbox_rpc = _sandbox_rpc_service(nx_instance)
+            if sandbox_rpc is None:
+                return tool_error("unavailable", "Sandbox RPC service is not available.")
+            result = sandbox_rpc.sandbox_run(
                 sandbox_id=sandbox_id, language="python", code=code, timeout=300
             )
             return _format_sandbox_result(result)
@@ -1578,7 +1681,10 @@ async def create_mcp_server(
                 Execution result with stdout, stderr, exit_code, and execution time
             """
             nx_instance: Any = _get_nexus_instance(ctx)
-            result = nx_instance.service("sandbox_rpc").sandbox_run(
+            sandbox_rpc = _sandbox_rpc_service(nx_instance)
+            if sandbox_rpc is None:
+                return tool_error("unavailable", "Sandbox RPC service is not available.")
+            result = sandbox_rpc.sandbox_run(
                 sandbox_id=sandbox_id, language="bash", code=command, timeout=300
             )
             return _format_sandbox_result(result)
@@ -1586,21 +1692,33 @@ async def create_mcp_server(
         @mcp.tool()
         @handle_tool_errors("creating sandbox")
         def nexus_sandbox_create(
-            name: str, ttl_minutes: int = 10, ctx: Context | None = None
+            name: str,
+            ttl_minutes: int = 10,
+            provider: str | None = None,
+            template_id: str | None = None,
+            ctx: Context | None = None,
         ) -> str:
             """Create a new sandbox for code execution.
 
             Args:
                 name: User-friendly sandbox name
                 ttl_minutes: Idle timeout in minutes (default: 10)
+                provider: Optional sandbox provider (for example, "docker" or "monty")
+                template_id: Optional provider template or image identifier
 
             Returns:
                 JSON string with sandbox_id and metadata
             """
             nx_instance: Any = _get_nexus_instance(ctx)
-            result = nx_instance.service("sandbox_rpc").sandbox_create(
-                name=name, ttl_minutes=ttl_minutes
-            )
+            sandbox_rpc = _sandbox_rpc_service(nx_instance)
+            if sandbox_rpc is None:
+                return tool_error("unavailable", "Sandbox RPC service is not available.")
+            create_kwargs: dict[str, Any] = {"name": name, "ttl_minutes": ttl_minutes}
+            if provider is not None:
+                create_kwargs["provider"] = provider
+            if template_id is not None:
+                create_kwargs["template_id"] = template_id
+            result = sandbox_rpc.sandbox_create(**create_kwargs)
             return json.dumps(result, indent=2)
 
         @mcp.tool()
@@ -1612,7 +1730,10 @@ async def create_mcp_server(
                 JSON string with list of sandboxes
             """
             nx_instance: Any = _get_nexus_instance(ctx)
-            result = nx_instance.service("sandbox_rpc").sandbox_list()
+            sandbox_rpc = _sandbox_rpc_service(nx_instance)
+            if sandbox_rpc is None:
+                return tool_error("unavailable", "Sandbox RPC service is not available.")
+            result = sandbox_rpc.sandbox_list()
             return json.dumps(result, indent=2)
 
         @mcp.tool()
@@ -1627,7 +1748,10 @@ async def create_mcp_server(
                 Success message or error
             """
             nx_instance: Any = _get_nexus_instance(ctx)
-            nx_instance.service("sandbox_rpc").sandbox_stop(sandbox_id)
+            sandbox_rpc = _sandbox_rpc_service(nx_instance)
+            if sandbox_rpc is None:
+                return tool_error("unavailable", "Sandbox RPC service is not available.")
+            sandbox_rpc.sandbox_stop(sandbox_id)
             return f"Successfully stopped sandbox {sandbox_id}"
 
     # =========================================================================

--- a/src/nexus/bricks/sandbox/sandbox_docker_provider.py
+++ b/src/nexus/bricks/sandbox/sandbox_docker_provider.py
@@ -429,7 +429,7 @@ class DockerSandboxProvider(SandboxProvider):
 
         try:
             # Stop and remove container
-            await asyncio.to_thread(container.stop, timeout=5)
+            await asyncio.to_thread(container.stop, timeout=1)
             await asyncio.to_thread(container.remove)
             logger.info("Destroyed Docker sandbox: %s", sandbox_id)
         except Exception as e:
@@ -614,7 +614,7 @@ class DockerSandboxProvider(SandboxProvider):
                 container_name,
             )
             try:
-                existing_container.stop(timeout=5)
+                existing_container.stop(timeout=1)
             except Exception as stop_err:
                 logger.debug("Error stopping container (may already be stopped): %s", stop_err)
             existing_container.remove(force=True)

--- a/src/nexus/bricks/sandbox/sandbox_rpc_service.py
+++ b/src/nexus/bricks/sandbox/sandbox_rpc_service.py
@@ -1,0 +1,250 @@
+"""Synchronous RPC facade for sandbox lifecycle operations.
+
+The sandbox brick exposes async provider and manager APIs. CLI, MCP, and RPC
+surfaces are mostly synchronous, so this facade is the service-registry boundary
+that bridges sync callers to ``SandboxManager``.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import asdict, is_dataclass
+from typing import Any, TypedDict, cast
+
+from nexus.bricks.sandbox.sandbox_manager import SandboxManager
+from nexus.contracts.constants import ROOT_ZONE_ID
+from nexus.lib.sync_bridge import run_sync
+
+
+class _RecordStoreShim:
+    def __init__(self, session_factory: Any) -> None:
+        self.session_factory = session_factory
+
+
+class _SandboxIdentity(TypedDict):
+    user_id: str
+    zone_id: str
+    agent_id: str | None
+
+
+def _dictify(value: Any) -> Any:
+    if is_dataclass(value) and not isinstance(value, type):
+        return asdict(value)
+    if isinstance(value, list):
+        return [_dictify(item) for item in value]
+    if isinstance(value, dict):
+        return {key: _dictify(item) for key, item in value.items()}
+    return value
+
+
+def _dict_result(value: Any) -> dict[str, Any]:
+    return cast(dict[str, Any], _dictify(value))
+
+
+def _dict_list_result(value: Any) -> list[dict[str, Any]]:
+    return cast(list[dict[str, Any]], _dictify(value))
+
+
+class SandboxRPCService:
+    """Sync service-registry API for sandbox management."""
+
+    def __init__(
+        self,
+        *,
+        session_factory: Any,
+        default_context: Any = None,
+        config: Any = None,
+        manager: SandboxManager | None = None,
+    ) -> None:
+        self._default_context = default_context
+        self._manager = manager or SandboxManager(
+            record_store=cast(Any, _RecordStoreShim(session_factory)),
+            e2b_api_key=os.getenv("E2B_API_KEY"),
+            e2b_team_id=os.getenv("E2B_TEAM_ID"),
+            e2b_template_id=os.getenv("E2B_TEMPLATE_ID"),
+            config=config,
+        )
+
+    def available_providers(self) -> list[str]:
+        registry = getattr(self._manager, "_registry", None)
+        if registry is None:
+            return []
+        return list(registry.available_names())
+
+    def is_available(self) -> bool:
+        return bool(self.available_providers())
+
+    def sandbox_create(
+        self,
+        *,
+        name: str,
+        ttl_minutes: int = 10,
+        provider: str | None = None,
+        template_id: str | None = None,
+        context: Any = None,
+    ) -> dict[str, Any]:
+        identity = self._identity(context)
+        result = run_sync(
+            self._manager.create_sandbox(
+                name=name,
+                user_id=identity["user_id"],
+                zone_id=identity["zone_id"],
+                agent_id=identity["agent_id"],
+                ttl_minutes=ttl_minutes,
+                provider=provider,
+                template_id=template_id,
+            ),
+            timeout=120.0,
+        )
+        return _dict_result(result)
+
+    def sandbox_get_or_create(
+        self,
+        *,
+        name: str,
+        ttl_minutes: int = 10,
+        provider: str | None = None,
+        template_id: str | None = None,
+        verify_status: bool = True,
+        context: Any = None,
+    ) -> dict[str, Any]:
+        identity = self._identity(context)
+        result = run_sync(
+            self._manager.get_or_create_sandbox(
+                name=name,
+                user_id=identity["user_id"],
+                zone_id=identity["zone_id"],
+                agent_id=identity["agent_id"],
+                ttl_minutes=ttl_minutes,
+                provider=provider,
+                template_id=template_id,
+                verify_status=verify_status,
+            ),
+            timeout=120.0,
+        )
+        return _dict_result(result)
+
+    def sandbox_run(
+        self,
+        *,
+        sandbox_id: str,
+        language: str,
+        code: str,
+        timeout: int = 300,
+        context: Any = None,  # noqa: ARG002
+        as_script: bool = False,
+    ) -> dict[str, Any]:
+        result = run_sync(
+            self._manager.run_code(
+                sandbox_id=sandbox_id,
+                language=language,
+                code=code,
+                timeout=timeout,
+                as_script=as_script,
+            ),
+            timeout=timeout + 5.0,
+        )
+        return _dict_result(result)
+
+    def sandbox_pause(self, *, sandbox_id: str, context: Any = None) -> dict[str, Any]:
+        _ = context
+        return _dict_result(run_sync(self._manager.pause_sandbox(sandbox_id), timeout=30.0))
+
+    def sandbox_resume(self, *, sandbox_id: str, context: Any = None) -> dict[str, Any]:
+        _ = context
+        return _dict_result(run_sync(self._manager.resume_sandbox(sandbox_id), timeout=30.0))
+
+    def sandbox_stop(self, sandbox_id: str, context: Any = None) -> dict[str, Any]:  # noqa: ARG002
+        return _dict_result(run_sync(self._manager.stop_sandbox(sandbox_id), timeout=30.0))
+
+    def sandbox_list(
+        self,
+        *,
+        context: Any = None,
+        verify_status: bool = False,
+        user_id: str | None = None,
+        zone_id: str | None = None,
+        agent_id: str | None = None,
+        status: str | None = None,
+    ) -> list[dict[str, Any]]:
+        identity = self._identity(context)
+        result = run_sync(
+            self._manager.list_sandboxes(
+                user_id=user_id or identity["user_id"],
+                zone_id=zone_id,
+                agent_id=agent_id,
+                status=status,
+                verify_status=verify_status,
+            ),
+            timeout=30.0,
+        )
+        return _dict_list_result(result)
+
+    def sandbox_status(self, *, sandbox_id: str, context: Any = None) -> dict[str, Any]:
+        _ = context
+        return _dict_result(run_sync(self._manager.get_sandbox_status(sandbox_id), timeout=30.0))
+
+    def sandbox_connect(
+        self,
+        *,
+        sandbox_id: str,
+        provider: str = "e2b",
+        sandbox_api_key: str | None = None,
+        mount_path: str = "/mnt/nexus",
+        nexus_url: str | None = None,
+        nexus_api_key: str | None = None,
+        agent_id: str | None = None,
+        context: Any = None,  # noqa: ARG002
+    ) -> dict[str, Any]:
+        return _dict_result(
+            run_sync(
+                self._manager.connect_sandbox(
+                    sandbox_id=sandbox_id,
+                    provider=provider,
+                    sandbox_api_key=sandbox_api_key,
+                    mount_path=mount_path,
+                    nexus_url=nexus_url,
+                    nexus_api_key=nexus_api_key,
+                    agent_id=agent_id,
+                ),
+                timeout=120.0,
+            )
+        )
+
+    def sandbox_disconnect(
+        self,
+        *,
+        sandbox_id: str,
+        provider: str = "e2b",
+        sandbox_api_key: str | None = None,
+        context: Any = None,  # noqa: ARG002
+    ) -> dict[str, Any]:
+        return _dict_result(
+            run_sync(
+                self._manager.disconnect_sandbox(
+                    sandbox_id=sandbox_id,
+                    provider=provider,
+                    sandbox_api_key=sandbox_api_key,
+                ),
+                timeout=30.0,
+            )
+        )
+
+    def _identity(self, context: Any = None) -> _SandboxIdentity:
+        source = context or self._default_context
+        user_id = self._get(source, "user_id") or "system"
+        zone_id = self._get(source, "zone_id") or ROOT_ZONE_ID
+        agent_id = self._get(source, "agent_id")
+        return {
+            "user_id": str(user_id),
+            "zone_id": str(zone_id),
+            "agent_id": str(agent_id) if agent_id is not None else None,
+        }
+
+    @staticmethod
+    def _get(source: Any, key: str) -> Any:
+        if source is None:
+            return None
+        if isinstance(source, dict):
+            return source.get(key)
+        return getattr(source, key, None)

--- a/src/nexus/factory/_wired.py
+++ b/src/nexus/factory/_wired.py
@@ -588,7 +588,7 @@ def _boot_post_kernel_services(
     sandbox_rpc_service: Any = None
     if _on("sandbox"):
         try:
-            from nexus.sandbox.sandbox_rpc_service import SandboxRPCService
+            from nexus.bricks.sandbox.sandbox_rpc_service import SandboxRPCService
 
             sandbox_rpc_service = SandboxRPCService(
                 session_factory=_nx_session_factory,

--- a/src/nexus/factory/service_routing.py
+++ b/src/nexus/factory/service_routing.py
@@ -61,7 +61,18 @@ _CANONICAL_EXPORTS: dict[str, tuple[str, ...]] = {
         "acp_history",
     ),
     "user_provisioning": ("provision_user", "deprovision_user"),
-    "sandbox_rpc": ("sandbox_create", "sandbox_run", "sandbox_list", "sandbox_status"),
+    "sandbox_rpc": (
+        "sandbox_create",
+        "sandbox_get_or_create",
+        "sandbox_run",
+        "sandbox_pause",
+        "sandbox_resume",
+        "sandbox_stop",
+        "sandbox_list",
+        "sandbox_status",
+        "sandbox_connect",
+        "sandbox_disconnect",
+    ),
     "metadata_export": ("export_metadata", "import_metadata"),
 }
 

--- a/src/nexus/utils/edit_engine.py
+++ b/src/nexus/utils/edit_engine.py
@@ -27,16 +27,22 @@ References:
 import difflib
 import re
 from dataclasses import dataclass, field
-from typing import Literal
+from importlib.util import find_spec
+from typing import Any, Literal
 
-# Try to use rapidfuzz for 10-100x faster fuzzy matching (Rust-backed)
-# Falls back to difflib if not available
-try:
-    from rapidfuzz import fuzz as rapidfuzz_fuzz
+# Try to use rapidfuzz for 10-100x faster fuzzy matching (Rust-backed).
+# Keep the import lazy so exact-match edits do not pay fuzzy startup cost.
+RAPIDFUZZ_AVAILABLE = find_spec("rapidfuzz") is not None
+_rapidfuzz_fuzz: Any | None = None
 
-    RAPIDFUZZ_AVAILABLE = True
-except ImportError:
-    RAPIDFUZZ_AVAILABLE = False
+
+def _rapidfuzz_ratio(s1: str, s2: str) -> float:
+    global _rapidfuzz_fuzz
+    if _rapidfuzz_fuzz is None:
+        from rapidfuzz import fuzz
+
+        _rapidfuzz_fuzz = fuzz
+    return float(_rapidfuzz_fuzz.ratio(s1, s2)) / 100.0
 
 
 @dataclass(slots=True)
@@ -530,8 +536,7 @@ class EditEngine:
             Similarity ratio between 0.0 and 1.0.
         """
         if RAPIDFUZZ_AVAILABLE:
-            # rapidfuzz returns 0-100, convert to 0-1
-            return float(rapidfuzz_fuzz.ratio(s1, s2)) / 100.0
+            return _rapidfuzz_ratio(s1, s2)
         else:
             # difflib fallback
             return difflib.SequenceMatcher(None, s1, s2).ratio()

--- a/tests/architecture/test_issue_4131_mcp_tool_profile_story.py
+++ b/tests/architecture/test_issue_4131_mcp_tool_profile_story.py
@@ -1,0 +1,129 @@
+"""Coverage contract checks for issue #4131.
+
+The MCP tool profile story is complete only when the shared surface model,
+default profile matrix, enforcement tests, and user guide agree.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from scripts.surface_coverage.schema import ProfileStatus, load_yaml
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_COVERAGE_YAML = _REPO_ROOT / "docs/architecture/api-rpc-surface-coverage.yaml"
+_TOOL_PROFILES = _REPO_ROOT / "src/nexus/config/tool_profiles.yaml"
+_USER_GUIDE = _REPO_ROOT / "docs/guides/user-guide.md"
+
+_ISSUE_4131_OWNED_ROWS = {
+    "delete.file",
+    "edit.file",
+    "execute.workflow",
+    "file.info",
+    "hub.admin",
+    "list.files",
+    "list.workflows",
+    "read.file",
+    "rename.file",
+    "sandbox.create",
+    "sandbox.list",
+    "sandbox.stop",
+    "write.file",
+}
+
+_RELATED_PROFILE_ROWS = {
+    *_ISSUE_4131_OWNED_ROWS,
+    "discovery.get_tool_details",
+    "discovery.list_servers",
+    "discovery.load_tools",
+    "discovery.search_tools",
+    "mcp.tool_profile_assign",
+    "search.glob",
+    "search.grep",
+    "semantic.search",
+}
+
+_EXPECTED_PROFILE_TABLE_ROWS = {
+    "minimal": ["nexus_read_file", "nexus_list_files", "nexus_file_info", "nexus_glob"],
+    "coding": ["nexus_write_file", "nexus_edit_file", "nexus_delete_file", "nexus_grep"],
+    "search": ["nexus_grep", "nexus_semantic_search"],
+    "execution": [
+        "nexus_python",
+        "nexus_bash",
+        "nexus_sandbox_create",
+        "nexus_sandbox_list",
+        "nexus_sandbox_stop",
+    ],
+    "full": [
+        "nexus_discovery_search_tools",
+        "nexus_list_workflows",
+        "nexus_execute_workflow",
+        "nexus_hub_admin",
+    ],
+}
+
+
+def _operations_by_id():
+    return {op.id: op for op in load_yaml(_COVERAGE_YAML).operations}
+
+
+def _assert_linked_paths_exist(link_field: str) -> None:
+    for part in link_field.split(";"):
+        target = part.strip()
+        if not target or target.startswith("N/A") or target.startswith("setup/"):
+            continue
+        path_part = target.split("::", 1)[0].strip()
+        assert (_REPO_ROOT / path_part).exists(), f"missing linked path: {path_part}"
+
+
+def test_issue_4131_owned_mcp_rows_have_story_contract() -> None:
+    ops = _operations_by_id()
+    missing = sorted(_ISSUE_4131_OWNED_ROWS - set(ops))
+    assert not missing, f"missing #4131 operation rows: {missing}"
+
+    for op_id in sorted(_ISSUE_4131_OWNED_ROWS):
+        op = ops[op_id]
+        assert op.owning_issue == 4131, op_id
+        assert op.summary.strip(), op_id
+        assert op.usage_example and "MCP:" in op.usage_example, op_id
+        assert op.correctness_test, op_id
+        _assert_linked_paths_exist(op.correctness_test)
+        assert "test_issue_4131_mcp_tool_profile_story.py" in op.correctness_test, op_id
+        assert op.perf_class is not None, op_id
+        assert op.perf_link and op.perf_link.strip(), op_id
+        assert op.gap_issue is None, op_id
+
+
+def test_issue_4131_related_mcp_rows_have_profile_story_metadata() -> None:
+    ops = _operations_by_id()
+    for op_id in sorted(_RELATED_PROFILE_ROWS):
+        op = ops[op_id]
+        assert op.summary.strip(), op_id
+        assert op.usage_example, op_id
+        assert op.correctness_test, op_id
+        assert op.perf_class is not None, op_id
+        assert op.perf_link, op_id
+        assert any(status == ProfileStatus.SUPPORTED for status in op.profiles.values()), op_id
+
+
+def test_default_profile_matrix_is_documented_in_user_guide() -> None:
+    guide = _USER_GUIDE.read_text(encoding="utf-8")
+    raw = yaml.safe_load(_TOOL_PROFILES.read_text(encoding="utf-8"))
+
+    assert "Shape An Agent's MCP Tool Profile" in guide
+    assert "nexus mcp profile list" in guide
+    assert "nexus mcp profile assign agent demo-agent coding" in guide
+    assert "nexus mcp profile inspect agent demo-agent" in guide
+    assert '"method": "tools/list"' in guide
+    assert '"method": "tools/call"' in guide
+    assert "Correctness assertion:" in guide
+    assert "Performance classification:" in guide
+    assert "file/search/ReBAC stories" in guide
+
+    for profile_name, direct_tools in _EXPECTED_PROFILE_TABLE_ROWS.items():
+        assert profile_name in raw["profiles"], profile_name
+        assert f"| `{profile_name}` |" in guide
+        for tool_name in direct_tools:
+            assert tool_name in guide, f"{profile_name} missing {tool_name}"

--- a/tests/architecture/test_normalize.py
+++ b/tests/architecture/test_normalize.py
@@ -62,6 +62,8 @@ def test_normalize_http(method, path, expected):
         ("nexus_rebac_grant", "rebac.grant"),
         ("nexus_glob", "search.glob"),
         ("nexus_grep", "search.grep"),
+        ("nexus_mkdir", "filesystem.mkdir"),
+        ("nexus_rmdir", "filesystem.rmdir"),
     ],
 )
 def test_normalize_mcp(raw, expected):

--- a/tests/e2e/self_contained/mcp/test_issue_4131_mcp_profile_story_e2e.py
+++ b/tests/e2e/self_contained/mcp/test_issue_4131_mcp_profile_story_e2e.py
@@ -1,0 +1,569 @@
+"""Real MCP profile story E2E and timings for issue #4131."""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastmcp import Client
+from sqlalchemy import create_engine
+
+from nexus.bricks.mcp.middleware import ToolNamespaceMiddleware
+from nexus.bricks.mcp.profiles import grant_tools_for_profile, load_profiles
+from nexus.bricks.mcp.server import create_mcp_server, reset_request_api_key, set_request_api_key
+from nexus.bricks.rebac.consistency.metastore_namespace_store import MetastoreNamespaceStore
+from nexus.bricks.rebac.consistency.metastore_version_store import MetastoreVersionStore
+from nexus.bricks.rebac.manager import EnhancedReBACManager
+from nexus.bricks.workflows.actions import BaseAction
+from nexus.bricks.workflows.types import (
+    ActionResult,
+    WorkflowAction,
+    WorkflowContext,
+    WorkflowDefinition,
+)
+from nexus.contracts.types import OperationContext
+from nexus.storage.models import Base
+from tests.testkit.metadata import InMemoryNexusFS
+
+pytestmark = pytest.mark.e2e
+
+
+EXPECTED_PROFILE_TOOLS: dict[str, set[str]] = {
+    "minimal": {
+        "nexus_read_file",
+        "nexus_list_files",
+        "nexus_file_info",
+        "nexus_glob",
+    },
+    "coding": {
+        "nexus_read_file",
+        "nexus_list_files",
+        "nexus_file_info",
+        "nexus_glob",
+        "nexus_write_file",
+        "nexus_edit_file",
+        "nexus_delete_file",
+        "nexus_mkdir",
+        "nexus_rmdir",
+        "nexus_rename_file",
+        "nexus_grep",
+    },
+    "search": {
+        "nexus_read_file",
+        "nexus_list_files",
+        "nexus_file_info",
+        "nexus_glob",
+        "nexus_grep",
+        "nexus_semantic_search",
+    },
+    "execution": {
+        "nexus_read_file",
+        "nexus_list_files",
+        "nexus_file_info",
+        "nexus_glob",
+        "nexus_write_file",
+        "nexus_edit_file",
+        "nexus_delete_file",
+        "nexus_mkdir",
+        "nexus_rmdir",
+        "nexus_rename_file",
+        "nexus_grep",
+        "nexus_python",
+        "nexus_bash",
+        "nexus_sandbox_create",
+        "nexus_sandbox_list",
+        "nexus_sandbox_stop",
+    },
+    "full": {
+        "nexus_read_file",
+        "nexus_list_files",
+        "nexus_file_info",
+        "nexus_glob",
+        "nexus_write_file",
+        "nexus_edit_file",
+        "nexus_delete_file",
+        "nexus_mkdir",
+        "nexus_rmdir",
+        "nexus_rename_file",
+        "nexus_grep",
+        "nexus_python",
+        "nexus_bash",
+        "nexus_sandbox_create",
+        "nexus_sandbox_list",
+        "nexus_sandbox_stop",
+        "nexus_semantic_search",
+        "nexus_list_workflows",
+        "nexus_execute_workflow",
+        "nexus_discovery_search_tools",
+        "nexus_discovery_list_servers",
+        "nexus_discovery_get_tool_details",
+        "nexus_discovery_load_tools",
+        "nexus_hub_admin",
+    },
+}
+
+OPTIONAL_SANDBOX_TOOLS = {
+    "nexus_python",
+    "nexus_bash",
+    "nexus_sandbox_create",
+    "nexus_sandbox_list",
+    "nexus_sandbox_stop",
+}
+
+
+class _NoopWorkflowAction(BaseAction):
+    async def execute(self, context: WorkflowContext) -> ActionResult:
+        return ActionResult(
+            action_name=self.name,
+            success=True,
+            output={"trigger": context.trigger_context},
+        )
+
+
+DISCOVERY_INDEXED_TOOLS = {
+    "nexus_read_file",
+    "nexus_write_file",
+    "nexus_edit_file",
+    "nexus_list_files",
+    "nexus_delete_file",
+    "nexus_mkdir",
+    "nexus_rmdir",
+    "nexus_rename_file",
+    "nexus_file_info",
+    "nexus_glob",
+    "nexus_grep",
+    "nexus_semantic_search",
+    "nexus_list_workflows",
+    "nexus_execute_workflow",
+}
+
+
+@dataclass
+class PerfRecord:
+    api: str
+    elapsed_ms: float
+    status: str
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[4]
+
+
+def _resolve_cluster_binary() -> Path | None:
+    root = _repo_root()
+    for directory in (
+        root / "target" / "debug",
+        root / "target" / "release",
+        root / "rust" / "target" / "debug",
+        root / "rust" / "target" / "release",
+    ):
+        for name in ("nexusd-cluster", "nexus-cluster"):
+            candidate = directory / name
+            if candidate.exists() and os.access(candidate, os.X_OK):
+                return candidate
+    return None
+
+
+def _text(result: Any) -> str:
+    return "\n".join(getattr(item, "text", str(item)) for item in result.content)
+
+
+def _decode_json_result(result: Any) -> Any:
+    return json.loads(_text(result))
+
+
+async def _timed_list(client: Client, api: str, records: list[PerfRecord]) -> list[str]:
+    start = time.perf_counter()
+    tools = await client.list_tools()
+    elapsed_ms = (time.perf_counter() - start) * 1000
+    names = sorted(tool.name for tool in tools)
+    records.append(PerfRecord(api=api, elapsed_ms=elapsed_ms, status=f"{len(names)} tools"))
+    return names
+
+
+async def _timed_call(
+    client: Client,
+    api: str,
+    arguments: dict[str, Any],
+    records: list[PerfRecord],
+    *,
+    record_api: str | None = None,
+) -> Any:
+    start = time.perf_counter()
+    result = await client.call_tool(api, arguments, raise_on_error=False)
+    elapsed_ms = (time.perf_counter() - start) * 1000
+    text = _text(result)
+    status = "ok"
+    if text.startswith("Error:"):
+        status = "expected_error"
+    else:
+        with contextlib.suppress(json.JSONDecodeError):
+            payload = json.loads(text)
+            if isinstance(payload, dict) and payload.get("error"):
+                status = "expected_error"
+    records.append(PerfRecord(api=record_api or api, elapsed_ms=elapsed_ms, status=status))
+    return result
+
+
+def _print_perf(records: list[PerfRecord]) -> None:
+    print("\nISSUE_4131_MCP_E2E_PERF")
+    for record in records:
+        print(f"{record.api}: {record.elapsed_ms:.2f} ms ({record.status})")
+
+
+@pytest.mark.asyncio
+async def test_issue_4131_mcp_profiles_real_protocol_and_perf(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cluster = _resolve_cluster_binary()
+    if cluster is None:
+        pytest.skip(
+            "issue #4131 real MCP E2E requires nexusd-cluster/nexus-cluster; "
+            "build it with `cargo build -p nexus-cluster`"
+        )
+
+    monkeypatch.setenv("NEXUS_KERNEL_BINARY", str(cluster))
+    monkeypatch.setenv("NEXUS_ENFORCE_PERMISSIONS", "false")
+    monkeypatch.setenv("NEXUS_ENABLE_WRITE_BUFFER", "false")
+    monkeypatch.setenv("NEXUS_ACTIVITY_ENABLED", "0")
+    monkeypatch.setenv("NEXUS_ACTIVITY_DB_PATH", str(tmp_path / "activity.db"))
+    monkeypatch.setenv("NEXUS_TXTAI_USE_API_EMBEDDINGS", "false")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+
+    import nexus
+
+    nx = nexus.connect(
+        config={
+            "data_dir": str(tmp_path / "data"),
+            "profile": "full",
+            "database_url": f"sqlite:///{tmp_path / 'records.db'}",
+            "enforce_permissions": False,
+        }
+    )
+    nx._init_cred = OperationContext(user_id="admin", groups=[], is_admin=True)
+    workflow_engine = nx.service("workflow_engine")
+    assert workflow_engine is not None
+    workflow_engine.action_registry["noop"] = _NoopWorkflowAction
+    workflow_engine.load_workflow(
+        WorkflowDefinition(
+            name="issue4131_noop",
+            version="1.0",
+            actions=[WorkflowAction(name="noop", type="noop")],
+        ),
+        enabled=True,
+    )
+    sandbox_rpc = nx.service("sandbox_rpc")
+    sandbox_providers = (
+        sandbox_rpc.available_providers()
+        if sandbox_rpc is not None and hasattr(sandbox_rpc, "available_providers")
+        else []
+    )
+    records: list[PerfRecord] = []
+
+    try:
+        engine = create_engine("sqlite:///:memory:")
+        Base.metadata.create_all(engine)
+        rebac = EnhancedReBACManager(
+            engine=engine,
+            cache_ttl_seconds=1,
+            version_store=MetastoreVersionStore(InMemoryNexusFS()),
+            namespace_store=MetastoreNamespaceStore(InMemoryNexusFS()),
+        )
+        middleware = ToolNamespaceMiddleware(
+            rebac_manager=rebac,
+            zone_id=None,
+            cache_ttl=60,
+            revision_window=1,
+        )
+        server = await create_mcp_server(nx=nx, tool_namespace_middleware=middleware)
+        profiles = load_profiles(_repo_root() / "src" / "nexus" / "config" / "tool_profiles.yaml")
+
+        async with Client(server, timeout=30) as unfiltered:
+            registered = set(await _timed_list(unfiltered, "tools/list unfiltered", records))
+
+        for profile_name, expected_tools in EXPECTED_PROFILE_TOOLS.items():
+            subject_id = f"issue4131-{profile_name}"
+            grant_tools_for_profile(
+                rebac_manager=rebac,
+                subject=("api_key", subject_id),
+                profile=profiles.get_profile(profile_name),
+            )
+            middleware.invalidate()
+            token = set_request_api_key(subject_id)
+            try:
+                async with Client(server, timeout=30) as client:
+                    names = set(await _timed_list(client, f"tools/list {profile_name}", records))
+            finally:
+                reset_request_api_key(token)
+
+            expected_visible = expected_tools & registered
+            missing_optional = expected_tools - registered
+            assert missing_optional <= OPTIONAL_SANDBOX_TOOLS
+            assert names == expected_visible
+
+        full_subject = "issue4131-full-calls"
+        grant_tools_for_profile(
+            rebac_manager=rebac,
+            subject=("api_key", full_subject),
+            profile=profiles.get_profile("full"),
+        )
+        middleware.invalidate()
+        token = set_request_api_key(full_subject)
+        try:
+            async with Client(server, timeout=30) as client:
+                await _timed_call(client, "nexus_mkdir", {"path": "/issue4131"}, records)
+                await _timed_call(
+                    client,
+                    "nexus_write_file",
+                    {"path": "/issue4131/api.txt", "content": "needle before\n"},
+                    records,
+                )
+
+                read_result = await _timed_call(
+                    client, "nexus_read_file", {"path": "/issue4131/api.txt"}, records
+                )
+                assert "needle before" in _text(read_result)
+
+                info = _decode_json_result(
+                    await _timed_call(
+                        client, "nexus_file_info", {"path": "/issue4131/api.txt"}, records
+                    )
+                )
+                assert info["exists"] is True
+                assert info["is_directory"] is False
+
+                listed = _decode_json_result(
+                    await _timed_call(client, "nexus_list_files", {"path": "/issue4131"}, records)
+                )
+                assert listed["count"] >= 1
+
+                globbed = _decode_json_result(
+                    await _timed_call(
+                        client,
+                        "nexus_glob",
+                        {
+                            "pattern": "*.txt",
+                            "path": "/issue4131",
+                            "files": ["/issue4131/api.txt"],
+                        },
+                        records,
+                    )
+                )
+                assert "/issue4131/api.txt" in globbed["items"]
+
+                grep = _decode_json_result(
+                    await _timed_call(
+                        client,
+                        "nexus_grep",
+                        {
+                            "pattern": "needle",
+                            "path": "/issue4131",
+                            "files": ["/issue4131/api.txt"],
+                        },
+                        records,
+                    )
+                )
+                assert grep["count"] >= 1
+
+                semantic = _text(
+                    await _timed_call(
+                        client,
+                        "nexus_semantic_search",
+                        {"query": "needle", "path": "/issue4131", "search_mode": "keyword"},
+                        records,
+                    )
+                )
+                assert semantic.startswith("{") or "Semantic search not available" in semantic
+
+                edit = _decode_json_result(
+                    await _timed_call(
+                        client,
+                        "nexus_edit_file",
+                        {
+                            "path": "/issue4131/api.txt",
+                            "edits": [{"old_str": "before", "new_str": "after"}],
+                        },
+                        records,
+                    )
+                )
+                assert edit["success"] is True
+
+                await _timed_call(
+                    client,
+                    "nexus_rename_file",
+                    {
+                        "old_path": "/issue4131/api.txt",
+                        "new_path": "/issue4131/api-renamed.txt",
+                    },
+                    records,
+                )
+                renamed = await _timed_call(
+                    client, "nexus_read_file", {"path": "/issue4131/api-renamed.txt"}, records
+                )
+                assert "needle after" in _text(renamed)
+
+                medium_content = "".join(f"line {i}: value\n" for i in range(2000))
+                await _timed_call(
+                    client,
+                    "nexus_write_file",
+                    {"path": "/issue4131/medium.txt", "content": medium_content},
+                    records,
+                    record_api="nexus_write_file medium_2k",
+                )
+                medium_edit = _decode_json_result(
+                    await _timed_call(
+                        client,
+                        "nexus_edit_file",
+                        {
+                            "path": "/issue4131/medium.txt",
+                            "edits": [
+                                {
+                                    "old_str": "line 1500: value",
+                                    "new_str": "line 1500: changed",
+                                }
+                            ],
+                        },
+                        records,
+                        record_api="nexus_edit_file medium_2k_exact",
+                    )
+                )
+                assert medium_edit["success"] is True
+                assert records[-1].elapsed_ms < 1500
+
+                search_tools = _decode_json_result(
+                    await _timed_call(
+                        client,
+                        "nexus_discovery_search_tools",
+                        {"query": "read file", "top_k": 5},
+                        records,
+                    )
+                )
+                assert any(tool["name"] == "nexus_read_file" for tool in search_tools["tools"])
+
+                servers = _decode_json_result(
+                    await _timed_call(client, "nexus_discovery_list_servers", {}, records)
+                )
+                assert servers["total_tools"] == len(
+                    EXPECTED_PROFILE_TOOLS["full"] & registered & DISCOVERY_INDEXED_TOOLS
+                )
+
+                details = _decode_json_result(
+                    await _timed_call(
+                        client,
+                        "nexus_discovery_get_tool_details",
+                        {"tool_name": "nexus_read_file"},
+                        records,
+                    )
+                )
+                assert details["found"] is True
+
+                loaded = _decode_json_result(
+                    await _timed_call(
+                        client,
+                        "nexus_discovery_load_tools",
+                        {"tool_names": ["nexus_read_file", "nexus_write_file"]},
+                        records,
+                    )
+                )
+                assert (
+                    "nexus_read_file" in loaded["loaded"]
+                    or "nexus_read_file" in loaded["already_loaded"]
+                )
+
+                workflows = _decode_json_result(
+                    await _timed_call(client, "nexus_list_workflows", {}, records)
+                )
+                assert any(item["name"] == "issue4131_noop" for item in workflows)
+
+                workflow_exec = _decode_json_result(
+                    await _timed_call(
+                        client,
+                        "nexus_execute_workflow",
+                        {"name": "issue4131_noop", "inputs": '{"source": "mcp-e2e"}'},
+                        records,
+                    )
+                )
+                assert workflow_exec["workflow_name"] == "issue4131_noop"
+                assert workflow_exec["status"] == "succeeded"
+
+                hub_admin = _decode_json_result(
+                    await _timed_call(
+                        client,
+                        "nexus_hub_admin",
+                        {"action": "status", "arguments": {}},
+                        records,
+                    )
+                )
+                assert hub_admin["postgres"] == "ok"
+
+                if registered >= OPTIONAL_SANDBOX_TOOLS:
+                    create_args: dict[str, Any] = {"name": "issue4131-sandbox", "ttl_minutes": 1}
+                    docker_template = os.getenv("NEXUS_ISSUE4131_DOCKER_TEMPLATE")
+                    if "docker" in sandbox_providers and docker_template:
+                        create_args["provider"] = "docker"
+                        create_args["template_id"] = docker_template
+                    elif "monty" in sandbox_providers:
+                        create_args["provider"] = "monty"
+                    sandbox_create = await _timed_call(
+                        client,
+                        "nexus_sandbox_create",
+                        create_args,
+                        records,
+                    )
+                    sandbox_create_text = _text(sandbox_create)
+                    if '"error"' not in sandbox_create_text and not sandbox_create_text.startswith(
+                        "Error:"
+                    ):
+                        sandbox_info = json.loads(sandbox_create_text)
+                        sandbox_id = sandbox_info["sandbox_id"]
+                        await _timed_call(client, "nexus_sandbox_list", {}, records)
+                        await _timed_call(
+                            client,
+                            "nexus_python",
+                            {"sandbox_id": sandbox_id, "code": 'print("issue4131 sandbox")'},
+                            records,
+                        )
+                        await _timed_call(
+                            client,
+                            "nexus_bash",
+                            {"sandbox_id": sandbox_id, "command": "echo issue4131"},
+                            records,
+                        )
+                        await _timed_call(
+                            client,
+                            "nexus_sandbox_stop",
+                            {"sandbox_id": sandbox_id},
+                            records,
+                        )
+                else:
+                    for sandbox_tool in sorted(OPTIONAL_SANDBOX_TOOLS):
+                        if sandbox_tool not in registered:
+                            records.append(PerfRecord(sandbox_tool, 0.0, "not_registered"))
+
+                await _timed_call(
+                    client, "nexus_delete_file", {"path": "/issue4131/api-renamed.txt"}, records
+                )
+                await _timed_call(
+                    client, "nexus_delete_file", {"path": "/issue4131/medium.txt"}, records
+                )
+                await _timed_call(
+                    client,
+                    "nexus_rmdir",
+                    {"path": "/issue4131", "recursive": True},
+                    records,
+                )
+        finally:
+            reset_request_api_key(token)
+    finally:
+        _print_perf(records)
+        close = getattr(nx, "close", None)
+        if callable(close):
+            close()

--- a/tests/unit/bricks/mcp/test_hub_admin_tool.py
+++ b/tests/unit/bricks/mcp/test_hub_admin_tool.py
@@ -3,11 +3,17 @@
 from __future__ import annotations
 
 import json
+from types import SimpleNamespace
 from unittest.mock import Mock
 
 import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
 
+from nexus.bricks.mcp.mcp_service import MCPService
 from nexus.bricks.mcp.server import create_mcp_server
+from nexus.contracts.types import OperationContext
+from nexus.storage.models import Base
 from tests.unit.bricks.mcp.test_mcp_server_tools import get_tool, tool_exists
 
 
@@ -79,3 +85,38 @@ async def test_nexus_hub_admin_unknown_action_has_400_status():
     payload = json.loads(result)
     assert payload["error"]["status"] == 400
     assert "unknown hub admin action" in payload["error"]["message"]
+
+
+@pytest.mark.asyncio
+async def test_nexus_hub_admin_status_uses_local_mcp_service():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    session_factory = sessionmaker(bind=engine)
+    filesystem = SimpleNamespace(
+        _record_store=SimpleNamespace(session_factory=session_factory),
+        _init_cred=OperationContext(user_id="admin", groups=[], is_admin=True),
+    )
+    service = MCPService(filesystem=filesystem)
+    nx = SimpleNamespace(service=lambda name: service if name == "mcp" else None)
+    server = await create_mcp_server(nx=nx)
+
+    tool = get_tool(server, "nexus_hub_admin")
+    result = await tool.fn(action="status", arguments={})
+
+    payload = json.loads(result)
+    assert payload["postgres"] == "ok"
+    assert payload["tokens"] == {"active": 0, "revoked": 0}
+
+
+@pytest.mark.asyncio
+async def test_nexus_hub_admin_missing_backend_method_has_501_status():
+    nx = Mock()
+    nx.service.return_value = object()
+    server = await create_mcp_server(nx=nx)
+
+    tool = get_tool(server, "nexus_hub_admin")
+    result = await tool.fn(action="status", arguments={})
+
+    payload = json.loads(result)
+    assert payload["error"]["status"] == 501
+    assert "unavailable" in payload["error"]["message"]

--- a/tests/unit/bricks/mcp/test_mcp_server_tools.py
+++ b/tests/unit/bricks/mcp/test_mcp_server_tools.py
@@ -1026,6 +1026,24 @@ class TestSearchTools:
 class TestWorkflowTools:
     """Test suite for workflow tools."""
 
+    async def test_list_workflows_uses_service_registry_workflow_engine(self):
+        """Test listing workflows through the factory-wired workflow_engine service."""
+        workflow_engine = Mock()
+        workflow_engine.list_workflows = Mock(
+            return_value=[{"name": "service_workflow", "version": "1.0", "enabled": True}]
+        )
+        nx = Mock()
+        del nx.workflows
+        nx.service.side_effect = lambda name: workflow_engine if name == "workflow_engine" else None
+        server = await create_mcp_server(nx=nx)
+
+        list_tool = get_tool(server, "nexus_list_workflows")
+        result = list_tool.fn()
+
+        workflows = json.loads(result)
+        assert workflows[0]["name"] == "service_workflow"
+        workflow_engine.list_workflows.assert_called_once()
+
     async def test_list_workflows_success(self, mock_nx_with_workflows):
         """Test listing workflows successfully."""
         server = await create_mcp_server(nx=mock_nx_with_workflows)
@@ -1075,6 +1093,26 @@ class TestWorkflowTools:
             "test_workflow", param="value"
         )
 
+    async def test_execute_workflow_uses_service_registry_workflow_engine(self):
+        """Test executing workflows through the factory-wired workflow_engine service."""
+        workflow_engine = Mock()
+        workflow_engine.trigger_workflow = AsyncMock(
+            return_value={"status": "success", "workflow_name": "service_workflow"}
+        )
+        nx = Mock()
+        del nx.workflows
+        nx.service.side_effect = lambda name: workflow_engine if name == "workflow_engine" else None
+        server = await create_mcp_server(nx=nx)
+
+        exec_tool = get_tool(server, "nexus_execute_workflow")
+        result = exec_tool.fn(name="service_workflow", inputs='{"param": "value"}')
+
+        output = json.loads(result)
+        assert output["status"] == "success"
+        workflow_engine.trigger_workflow.assert_awaited_once_with(
+            "service_workflow", {"param": "value"}
+        )
+
     async def test_execute_workflow_no_inputs(self, mock_nx_with_workflows):
         """Test executing workflow without inputs."""
         server = await create_mcp_server(nx=mock_nx_with_workflows)
@@ -1116,6 +1154,22 @@ class TestWorkflowTools:
 
 class TestSandboxAvailability:
     """Test suite for sandbox availability detection."""
+
+    async def test_sandbox_available_from_service_registry(self):
+        """Test sandbox tools register when sandbox_rpc service is available."""
+        sandbox_rpc = Mock()
+        sandbox_rpc.available_providers.return_value = ["test"]
+        nx = Mock()
+        del nx.sandbox_available
+        nx.service.side_effect = lambda name: sandbox_rpc if name == "sandbox_rpc" else None
+
+        server = await create_mcp_server(nx=nx)
+
+        assert tool_exists(server, "nexus_python")
+        assert tool_exists(server, "nexus_bash")
+        assert tool_exists(server, "nexus_sandbox_create")
+        assert tool_exists(server, "nexus_sandbox_list")
+        assert tool_exists(server, "nexus_sandbox_stop")
 
     async def test_sandbox_available_with_docker(self, mock_nx_with_sandbox):
         """Test sandbox tools registered when Docker provider available."""

--- a/tests/unit/bricks/mcp/test_tool_namespace_middleware.py
+++ b/tests/unit/bricks/mcp/test_tool_namespace_middleware.py
@@ -11,6 +11,7 @@ Tests cover:
 import time
 from collections.abc import Sequence
 from dataclasses import dataclass
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import MagicMock
@@ -18,7 +19,11 @@ from unittest.mock import MagicMock
 import pytest
 
 from nexus.bricks.mcp.middleware import ToolNamespaceMiddleware
-from nexus.bricks.mcp.profiles import grant_tools_for_profile, load_profiles_from_dict
+from nexus.bricks.mcp.profiles import (
+    grant_tools_for_profile,
+    load_profiles,
+    load_profiles_from_dict,
+)
 
 # ---------------------------------------------------------------------------
 # Test helpers
@@ -44,6 +49,21 @@ class FakeContext:
         return self._state[key]
 
     def set_state(self, key: str, value: Any) -> None:
+        self._state[key] = value
+
+
+class AsyncFakeContext:
+    """FastMCP 3.x-style context where get_state/set_state are awaitable."""
+
+    def __init__(self, state: dict[str, Any] | None = None):
+        self._state = state or {}
+
+    async def get_state(self, key: str) -> Any:
+        if key not in self._state:
+            raise KeyError(key)
+        return self._state[key]
+
+    async def set_state(self, key: str, value: Any) -> None:
         self._state[key] = value
 
 
@@ -89,6 +109,30 @@ def make_middleware(
         zone_id=zone_id,
         enabled=enabled,
     )
+
+
+def make_subject_asserting_middleware(expected_subject: tuple[str, str]) -> ToolNamespaceMiddleware:
+    """Middleware whose ReBAC double proves the extracted subject value."""
+    rebac = MagicMock()
+    rebac.get_zone_revision.return_value = 0
+
+    def list_objects(
+        *,
+        subject: tuple[str, str],
+        permission: str,
+        object_type: str,
+        zone_id: str | None = None,
+        limit: int,
+    ) -> list[tuple[str, str]]:
+        assert subject == expected_subject
+        assert permission == "read"
+        assert object_type == "file"
+        assert zone_id is None
+        assert limit == 10_000
+        return [("file", "/tools/nexus_read_file")]
+
+    rebac.rebac_list_objects.side_effect = list_objects
+    return ToolNamespaceMiddleware(rebac_manager=rebac)
 
 
 class MemoryToolGrantReBAC:
@@ -157,6 +201,26 @@ class TestOnListTools:
         result = await mw.on_list_tools(ctx, call_next)  # type: ignore[arg-type]
         names = [t.name for t in result]
         assert names == ["nexus_read_file", "nexus_list_files"]
+
+    @pytest.mark.asyncio
+    async def test_async_fastmcp_context_state_filters_tools(self):
+        """FastMCP 3.x exposes Context.get_state as async."""
+        mw = make_subject_asserting_middleware(("agent", "A"))
+
+        all_tools = [
+            FakeTool(name="nexus_read_file"),
+            FakeTool(name="nexus_write_file"),
+        ]
+        ctx = FakeMiddlewareContext(
+            fastmcp_context=AsyncFakeContext({"subject_type": "agent", "subject_id": "A"}),
+            method="tools/list",
+        )
+
+        async def call_next(context: Any) -> Sequence[Any]:
+            return all_tools
+
+        result = await mw.on_list_tools(ctx, call_next)  # type: ignore[arg-type]
+        assert [t.name for t in result] == ["nexus_read_file"]
 
     @pytest.mark.asyncio
     async def test_no_grants_returns_empty(self):
@@ -232,6 +296,24 @@ class TestOnCallTool:
         ctx = FakeMiddlewareContext(
             message=FakeCallToolParams(name="nexus_read_file"),
             fastmcp_context=FakeContext({"subject_type": "agent", "subject_id": "A"}),
+        )
+
+        expected_result = MagicMock()
+
+        async def call_next(context: Any) -> Any:
+            return expected_result
+
+        result = await mw.on_call_tool(ctx, call_next)  # type: ignore[arg-type]
+        assert result is expected_result
+
+    @pytest.mark.asyncio
+    async def test_async_fastmcp_context_state_allows_visible_call(self):
+        """FastMCP 3.x async context state must not hide granted tools."""
+        mw = make_subject_asserting_middleware(("agent", "A"))
+
+        ctx = FakeMiddlewareContext(
+            message=FakeCallToolParams(name="nexus_read_file"),
+            fastmcp_context=AsyncFakeContext({"subject_type": "agent", "subject_id": "A"}),
         )
 
         expected_result = MagicMock()
@@ -360,6 +442,96 @@ class TestProfileGrantIntegration:
         denied_text = denied.content[0].text
         assert "not found" in denied_text.lower()
         assert "permission" not in denied_text.lower()
+
+
+class TestDefaultToolProfileEnforcement:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("profile_name", "visible", "hidden"),
+        [
+            (
+                "minimal",
+                ["nexus_read_file", "nexus_list_files", "nexus_file_info", "nexus_glob"],
+                "nexus_write_file",
+            ),
+            (
+                "coding",
+                ["nexus_read_file", "nexus_write_file", "nexus_edit_file", "nexus_grep"],
+                "nexus_python",
+            ),
+            (
+                "search",
+                ["nexus_read_file", "nexus_grep", "nexus_semantic_search"],
+                "nexus_write_file",
+            ),
+            (
+                "execution",
+                ["nexus_write_file", "nexus_python", "nexus_bash", "nexus_sandbox_create"],
+                "nexus_discovery_search_tools",
+            ),
+            (
+                "full",
+                [
+                    "nexus_python",
+                    "nexus_discovery_search_tools",
+                    "nexus_list_workflows",
+                    "nexus_hub_admin",
+                ],
+                "nexus_context_branch",
+            ),
+        ],
+    )
+    async def test_default_profile_grants_filter_list_and_call(
+        self,
+        profile_name: str,
+        visible: list[str],
+        hidden: str,
+    ) -> None:
+        config_path = Path(__file__).parents[4] / "src" / "nexus" / "config" / "tool_profiles.yaml"
+        config = load_profiles(config_path)
+        profile = config.get_profile(profile_name)
+        assert profile is not None
+
+        rebac = MemoryToolGrantReBAC()
+        rebac_manager = cast(Any, rebac)
+        grant_tools_for_profile(
+            rebac_manager=rebac_manager,
+            subject=("agent", profile_name),
+            profile=profile,
+            zone_id="sandbox-agent-4131",
+        )
+
+        mw = ToolNamespaceMiddleware(rebac_manager=rebac_manager, zone_id="sandbox-agent-4131")
+        ctx = FakeMiddlewareContext(
+            fastmcp_context=FakeContext({"subject_type": "agent", "subject_id": profile_name}),
+        )
+        all_tools = [FakeTool(name=name) for name in [*visible, hidden]]
+
+        async def list_next(context: Any) -> Sequence[Any]:
+            return all_tools
+
+        listed = await mw.on_list_tools(cast(Any, ctx), cast(Any, list_next))
+        assert {tool.name for tool in listed} == set(visible)
+
+        allowed_result = MagicMock(name=f"{profile_name}-allowed")
+
+        async def call_next(context: Any) -> Any:
+            return allowed_result
+
+        allowed_ctx = FakeMiddlewareContext(
+            message=FakeCallToolParams(name=visible[0]),
+            fastmcp_context=ctx.fastmcp_context,
+        )
+        assert await mw.on_call_tool(cast(Any, allowed_ctx), cast(Any, call_next)) is allowed_result
+
+        hidden_ctx = FakeMiddlewareContext(
+            message=FakeCallToolParams(name=hidden),
+            fastmcp_context=ctx.fastmcp_context,
+        )
+        denied = await mw.on_call_tool(cast(Any, hidden_ctx), cast(Any, call_next))
+        denied_text = denied.content[0].text.lower()
+        assert "not found" in denied_text
+        assert "permission" not in denied_text
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/bricks/mcp/test_tool_profiles.py
+++ b/tests/unit/bricks/mcp/test_tool_profiles.py
@@ -400,7 +400,95 @@ class TestGrantToolsFailure:
 class TestDefaultConfigValidity:
     """Validate that default tool_profiles.yaml tool names match registered MCP tools."""
 
-    def test_default_yaml_tool_names_exist_in_server(self):
+    def test_default_profiles_match_expected_tool_matrix(self):
+        """Default profiles must encode the documented inherited tool matrix."""
+        config_path = Path(__file__).parents[4] / "src" / "nexus" / "config" / "tool_profiles.yaml"
+        config = load_profiles(config_path)
+
+        expected = {
+            "minimal": {
+                "nexus_file_info",
+                "nexus_glob",
+                "nexus_list_files",
+                "nexus_read_file",
+            },
+            "coding": {
+                "nexus_delete_file",
+                "nexus_edit_file",
+                "nexus_file_info",
+                "nexus_glob",
+                "nexus_grep",
+                "nexus_list_files",
+                "nexus_mkdir",
+                "nexus_read_file",
+                "nexus_rename_file",
+                "nexus_rmdir",
+                "nexus_write_file",
+            },
+            "search": {
+                "nexus_file_info",
+                "nexus_glob",
+                "nexus_grep",
+                "nexus_list_files",
+                "nexus_read_file",
+                "nexus_semantic_search",
+            },
+            "execution": {
+                "nexus_bash",
+                "nexus_delete_file",
+                "nexus_edit_file",
+                "nexus_file_info",
+                "nexus_glob",
+                "nexus_grep",
+                "nexus_list_files",
+                "nexus_mkdir",
+                "nexus_python",
+                "nexus_read_file",
+                "nexus_rename_file",
+                "nexus_rmdir",
+                "nexus_sandbox_create",
+                "nexus_sandbox_list",
+                "nexus_sandbox_stop",
+                "nexus_write_file",
+            },
+            "full": {
+                "nexus_bash",
+                "nexus_delete_file",
+                "nexus_discovery_get_tool_details",
+                "nexus_discovery_list_servers",
+                "nexus_discovery_load_tools",
+                "nexus_discovery_search_tools",
+                "nexus_edit_file",
+                "nexus_execute_workflow",
+                "nexus_file_info",
+                "nexus_glob",
+                "nexus_grep",
+                "nexus_hub_admin",
+                "nexus_list_files",
+                "nexus_list_workflows",
+                "nexus_mkdir",
+                "nexus_python",
+                "nexus_read_file",
+                "nexus_rename_file",
+                "nexus_rmdir",
+                "nexus_sandbox_create",
+                "nexus_sandbox_list",
+                "nexus_sandbox_stop",
+                "nexus_semantic_search",
+                "nexus_write_file",
+            },
+        }
+
+        assert set(config.profile_names) == set(expected)
+        for profile_name, tools in expected.items():
+            profile = config.get_profile(profile_name)
+            assert profile is not None
+            assert profile.tools == tools
+
+        assert config.get_default() == config.get_profile("minimal")
+
+    @pytest.mark.asyncio
+    async def test_default_yaml_tool_names_exist_in_server(self):
         """All tool names in default YAML should match registered MCP tools.
 
         Sandbox tools (nexus_python, nexus_bash, nexus_sandbox_*) are
@@ -415,7 +503,7 @@ class TestDefaultConfigValidity:
         OPTIONAL_TOOL_PREFIXES = ("nexus_python", "nexus_bash", "nexus_sandbox_")
 
         # Load the default config
-        config_path = Path(__file__).parents[3] / "src" / "nexus" / "config" / "tool_profiles.yaml"
+        config_path = Path(__file__).parents[4] / "src" / "nexus" / "config" / "tool_profiles.yaml"
         if not config_path.exists():
             pytest.skip("Default tool_profiles.yaml not found")
 
@@ -442,7 +530,7 @@ class TestDefaultConfigValidity:
                 "errors": [],
             }
         )
-        server = create_mcp_server(nx=mock_nx)
+        server = await create_mcp_server(nx=mock_nx)
         # FastMCP 2.x used per-type managers (``_tool_manager._tools``) but
         # 3.x replaced them with a single ``_local_provider._components``
         # registry keyed by ``"tool:<name>@..."``. Support both.

--- a/tests/unit/utils/test_edit_engine.py
+++ b/tests/unit/utils/test_edit_engine.py
@@ -13,6 +13,9 @@ Tests cover:
 - Error handling and edge cases
 """
 
+import subprocess
+import sys
+
 import pytest
 
 from nexus.utils.edit_engine import (
@@ -437,6 +440,21 @@ class TestEditResult:
 
 class TestRapidFuzzIntegration:
     """Tests for rapidfuzz integration."""
+
+    def test_import_does_not_load_rapidfuzz(self):
+        """Exact-match edit startup should not import fuzzy matcher dependencies."""
+        completed = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                ("import sys; import nexus.utils.edit_engine; print('rapidfuzz' in sys.modules)"),
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+        assert completed.stdout.strip() == "False"
 
     def test_rapidfuzz_availability(self):
         """Test that rapidfuzz availability is detected."""


### PR DESCRIPTION
## Summary

Closes the remaining issue #4131 MCP/profile/RPC coverage gaps by making the profile story executable end to end instead of only documented.

- Adds architecture coverage for MCP tool profiles and updates generated coverage docs.
- Enforces profile-visible tools through MCP namespace middleware and profile grant tests.
- Wires workflow, discovery, hub admin, and sandbox tools through real service/RPC paths.
- Adds a sandbox RPC service facade and fixes sandbox service routing/imports.
- Improves cold exact-edit latency by lazy-loading fuzzy edit dependencies.
- Reduces Docker sandbox stop latency for disposable test sandboxes.
- Adds real MCP E2E coverage, including Monty and Docker-backed sandbox execution.

## Root Cause

The issue #4131 surface had several documented/profiled APIs whose real MCP call path was incomplete or not exercised end to end: workflow tools only worked through one API shape, hub admin was CLI-oriented, sandbox availability/routing did not expose the real service facade, and the E2E coverage did not prove the profile/RPC surface matched the documented matrix.

## Validation

- `uv run pytest tests/unit/utils/test_edit_engine.py tests/unit/bricks/mcp/test_mcp_server_tools.py tests/unit/bricks/mcp/test_hub_admin_tool.py tests/unit/bricks/mcp/test_tool_profiles.py tests/unit/bricks/mcp/test_tool_namespace_middleware.py tests/unit/cli/test_mcp_profile_cli.py tests/architecture/test_issue_4131_mcp_tool_profile_story.py tests/architecture/test_normalize.py -q`
- `uv run --extra sandbox-monty pytest tests/e2e/self_contained/mcp/test_issue_4131_mcp_profile_story_e2e.py -q -s -p no:xdist -o addopts=`
- `NEXUS_ISSUE4131_DOCKER_TEMPLATE=ghcr.io/nexi-lab/nexus:latest uv run --extra docker --extra sandbox-monty pytest tests/e2e/self_contained/mcp/test_issue_4131_mcp_profile_story_e2e.py -q -s -p no:xdist -o addopts=`
- `uv run --with ruff ruff check src/nexus/bricks/mcp/server.py src/nexus/bricks/mcp/mcp_service.py src/nexus/bricks/mcp/middleware.py src/nexus/bricks/sandbox/sandbox_rpc_service.py src/nexus/bricks/sandbox/sandbox_docker_provider.py src/nexus/factory/_wired.py src/nexus/factory/service_routing.py src/nexus/utils/edit_engine.py tests/e2e/self_contained/mcp/test_issue_4131_mcp_profile_story_e2e.py tests/unit/bricks/mcp/test_mcp_server_tools.py tests/unit/bricks/mcp/test_hub_admin_tool.py tests/unit/bricks/mcp/test_tool_namespace_middleware.py tests/unit/utils/test_edit_engine.py`
- `uv run mypy src/nexus/bricks/sandbox/sandbox_rpc_service.py src/nexus/bricks/mcp/server.py src/nexus/bricks/mcp/middleware.py`
- `uv run python -m py_compile src/nexus/bricks/mcp/server.py src/nexus/bricks/mcp/mcp_service.py src/nexus/bricks/mcp/middleware.py src/nexus/bricks/sandbox/sandbox_rpc_service.py src/nexus/bricks/sandbox/sandbox_docker_provider.py src/nexus/factory/_wired.py src/nexus/factory/service_routing.py src/nexus/utils/edit_engine.py tests/e2e/self_contained/mcp/test_issue_4131_mcp_profile_story_e2e.py tests/unit/bricks/mcp/test_mcp_server_tools.py tests/unit/bricks/mcp/test_hub_admin_tool.py tests/unit/utils/test_edit_engine.py`
- `git diff --check`
- Pre-commit hooks during commit: passed (`ruff`, `ruff format`, `mypy`, boundary checks, file checks).
