### PR TITLE
[codex] Close full-profile control-plane API gaps

### DIFF
--- a/docs/guides/user-guide.md
+++ b/docs/guides/user-guide.md
@@ -1836,8 +1836,10 @@ links the #4137 benchmark expectation.
 
 ```bash
 nexus events replay --since 1h
-nexus events subscribe "file_write"
 ```
+
+The `nexus events` CLI currently exposes replay over the generic gRPC `Call`
+path. Live event subscription is not a CLI/RPC command in this surface.
 
 ### Scheduler visibility
 
@@ -2284,7 +2286,109 @@ guide above:
 - `secrets-audit`: secret access auditing
 - `rlm`: recursive language-model inference
 
-## 13. Package Map By Use Case
+## 13. Full-Profile Control Plane For Operators
+
+Use this path when you are operating a shared `full` or `cloud` server and need
+database-backed auth, auditable admin changes, and control-plane visibility
+without mixing those powers into normal user flows. Normal users should stay on
+file, search, pay, and agent workflows with their own API key. Admins hold keys
+that can provision users, rotate credentials, inspect audit/event data, and run
+governance or federation operations. Operators own the daemon, database,
+profile, and runtime configuration.
+
+Start from a database-auth daemon:
+
+```bash
+export NEXUS_URL=http://localhost:2026
+export NEXUS_GRPC_PORT=2028
+export NEXUS_API_KEY="<admin-api-key>"
+
+nexusd --profile full --auth-type database --database-url "$NEXUS_DATABASE_URL"
+```
+
+Admin account lifecycle:
+
+```bash
+nexus admin provision-user alice alice@example.com --display-name "Alice"
+nexus admin create-user bot1 --name "Bot Agent" --subject-type agent --expires-days 7
+nexus admin list-users --is-admin
+nexus admin deprovision-user alice --zone-id alice --delete-user-record
+```
+
+Equivalent generic gRPC calls use the same method names that the CLI calls:
+
+```python
+from nexus.remote.rpc_transport import RPCTransport
+
+rpc = RPCTransport("localhost:2028", auth_token="<admin-api-key>")
+created = rpc.call_rpc(
+    "provision_user",
+    {"user_id": "alice", "email": "alice@example.com", "display_name": "Alice"},
+)
+audit = rpc.call_rpc("audit_list", {"since": "1h", "limit": 50})
+
+print(created["user_id"], created["zone_id"])
+print(len(audit.get("transactions", [])))
+```
+
+Expected behavior:
+
+- Success: admin-only methods return resource metadata, counts, or exported
+  content. Initial API keys are shown once.
+- Denial: a non-admin token receives an admin-privilege error for admin,
+  provisioning, audit, event replay, governance, and federation mutation RPCs.
+- Unavailable: surfaces that need database auth, record stores, pay services,
+  governance services, or federation runtime fail as unavailable rather than
+  being presented as normal user features.
+
+Correctness assertion:
+
+```bash
+nexus admin get-user --user-id alice --json
+nexus audit list --since 1h --json
+nexus events replay --since 1h --json
+nexus governance status --json
+```
+
+The JSON output should show the provisioned user or key, audit rows when they
+exist, replayed events when they exist, and governance counts. A regular user
+key should be able to use normal user surfaces such as `nexus pay balance`, but
+should be denied by admin-only methods.
+
+### Control-plane surface matrix
+
+This is the shared model for issue #4138. The source-of-truth test matrix lives
+in `nexus.contracts.control_plane_coverage`; it maps each row to CLI/RPC
+surfaces, auth expectations, tests, and benchmark classification.
+
+| Group | RPC methods | CLI | Admin-only | Correctness coverage | Performance status |
+| --- | --- | --- | --- | --- | --- |
+| Admin keys | `admin_create_key`, `admin_list_keys`, `admin_get_key`, `admin_revoke_key`, `admin_update_key`, `admin_write_permission` | `nexus admin create-user`, `create-key`, `create-agent-key`, `list-users`, `get-user`, `revoke-key`, `update-key` | Yes | `tests/unit/server/test_admin_handlers.py`, `tests/unit/server/test_rpc_admin_only.py` | Benchmark gap tracked in #4201 |
+| User provisioning | `provision_user`, `deprovision_user` | `nexus admin provision-user`, `deprovision-user` | Yes | `tests/unit/core/test_nexus_fs_provision_user.py` and the #4138 surface test | Setup path, not performance-sensitive |
+| Audit | `audit_list`, `audit_export` | `nexus audit list`, `export` | Yes | OpenAPI conformance plus the #4138 surface test | Benchmark gap tracked in #4201 |
+| Events | `events_replay` | `nexus events replay` | Yes | event replay/E2E coverage plus the #4138 surface test | Benchmark gap tracked in #4201 |
+| Governance | `governance_status`, `governance_alerts`, `governance_rings` | `nexus governance status`, `alerts`, `rings` | Yes | security hardening plus the #4138 surface test | Benchmark gap tracked in #4201 |
+| Federation read-only | `federation_client_whoami`, `federation_list_zones`, `federation_cluster_info` | `nexus federation status`, `zones`, `info` | No | federation whoami and docker federation coverage | Benchmark gap tracked in #4201 |
+| Federation mutations | `federation_create_zone`, `federation_remove_zone`, `federation_join`, `federation_mount`, `federation_unmount`, `federation_share`, `federation_export_zone`, `federation_import_zone` | `nexus federation mount`, `unmount`; create/remove/share/join CLI parity is #4200 | Yes | docker federation and zone import/export E2E coverage | CLI parity gap #4200, benchmark gap #4201 |
+| Pay | `pay_balance`, `pay_transfer`, `pay_history` | `nexus pay balance`, `transfer`, `history` | No | exchange OpenAPI and pay integration coverage | Marketplace user path, not an admin hot path |
+
+Sensitive operation requirements:
+
+- Use an admin API key for every row marked admin-only.
+- Use database auth for user provisioning and admin key management.
+- Use record-store-backed services for audit and event replay.
+- Use a federation-enabled runtime for federation rows. `full` alone does not
+  create a federation mesh; use `cluster` or a full/cloud server with federation
+  kernel support.
+- Use a pay-enabled full/cloud deployment for pay commands. Pay commands are
+  normal authenticated marketplace flows, not admin-only flows.
+
+Benchmark note: #4138 names admin key operations, audit list/export, events
+replay, governance summaries, and federation zone list/create as benchmark
+expectations. This guide does not claim benchmark completion yet; the required
+benchmark suite is tracked in #4201.
+
+## 14. Package Map By Use Case
 
 If you want to read the code after using the product, this is the shortest
 useful map.
@@ -2340,7 +2444,7 @@ useful map.
 | `nexus.validation` | validation pipelines before execution or sandbox use |
 | `nexus.plugins` | extension points and plugin discovery |
 
-## 14. Troubleshooting
+## 15. Troubleshooting
 
 ### The first commands to run
 

--- a/src/nexus/cli/commands/admin.py
+++ b/src/nexus/cli/commands/admin.py
@@ -283,6 +283,147 @@ def create_user(
         sys.exit(1)
 
 
+@admin.command("provision-user")
+@click.argument("user_id")
+@click.argument("email")
+@click.option("--display-name", help="Display name for the user")
+@click.option("--zone-id", help="Zone ID. Defaults to the email local part.")
+@click.option("--zone-name", help="Human-readable zone name")
+@click.option("--api-key-name", help="Human-readable name for the initial API key")
+@click.option("--no-api-key", is_flag=True, help="Do not create an initial API key")
+@click.option("--no-agents", is_flag=True, help="Do not create default agents")
+@click.option("--import-skills", is_flag=True, help="Import default skills during provisioning")
+@add_output_options
+@REMOTE_API_KEY_OPTION
+@REMOTE_URL_OPTION
+def provision_user(
+    user_id: str,
+    email: str,
+    display_name: str | None,
+    zone_id: str | None,
+    zone_name: str | None,
+    api_key_name: str | None,
+    no_api_key: bool,
+    no_agents: bool,
+    import_skills: bool,
+    output_opts: OutputOptions,
+    remote_url: str | None,
+    remote_api_key: str | None,
+) -> None:
+    """Provision a user account with default resources.
+
+    \b
+    Examples:
+        nexus admin provision-user alice alice@example.com --display-name "Alice"
+        nexus admin provision-user bot bot@example.com --zone-id agents --no-agents
+    """
+    timing = CommandTiming()
+    try:
+        call_rpc = get_admin_rpc(remote_url, remote_api_key)
+        params: dict[str, Any] = {
+            "user_id": user_id,
+            "email": email,
+            "create_api_key": not no_api_key,
+            "create_agents": not no_agents,
+            "import_skills": import_skills,
+        }
+        if display_name is not None:
+            params["display_name"] = display_name
+        if zone_id is not None:
+            params["zone_id"] = zone_id
+        if zone_name is not None:
+            params["zone_name"] = zone_name
+        if api_key_name is not None:
+            params["api_key_name"] = api_key_name
+
+        with timing.phase("server"):
+            result = call_rpc("provision_user", params)
+
+        def _render(data: dict[str, Any]) -> None:
+            console.print("[nexus.success]\u2713[/nexus.success] User provisioned successfully")
+            console.print(f"User ID:        {data.get('user_id', user_id)}")
+            console.print(f"Zone:           {data.get('zone_id', zone_id or '')}")
+            console.print(f"Workspace:      {data.get('workspace_path') or 'N/A'}")
+            console.print(f"API key ID:     {data.get('key_id') or 'N/A'}")
+            if data.get("api_key"):
+                console.print(
+                    "\n[nexus.warning]\u26a0 Save this API key - it will only be shown once![/nexus.warning]\n"
+                )
+                console.print(f"[bold]API Key:[/bold]     {data['api_key']}")
+            agents = data.get("agent_paths") or []
+            console.print(f"Agent configs:  {len(agents)}")
+
+        render_output(
+            data=result,
+            output_opts=output_opts,
+            timing=timing,
+            human_formatter=_render,
+        )
+
+    except Exception as e:
+        console.print(f"[nexus.error]Error provisioning user:[/nexus.error] {e}")
+        sys.exit(1)
+
+
+@admin.command("deprovision-user")
+@click.argument("user_id")
+@click.option("--zone-id", help="Zone ID. Defaults to the user's recorded zone.")
+@click.option("--delete-user-record", is_flag=True, help="Soft-delete the user record")
+@click.option("--force", is_flag=True, help="Allow deprovisioning protected admin users")
+@add_output_options
+@REMOTE_API_KEY_OPTION
+@REMOTE_URL_OPTION
+def deprovision_user(
+    user_id: str,
+    zone_id: str | None,
+    delete_user_record: bool,
+    force: bool,
+    output_opts: OutputOptions,
+    remote_url: str | None,
+    remote_api_key: str | None,
+) -> None:
+    """Deprovision a user and clean up their resources.
+
+    \b
+    Examples:
+        nexus admin deprovision-user alice --zone-id acme
+        nexus admin deprovision-user alice --delete-user-record --force
+    """
+    timing = CommandTiming()
+    try:
+        call_rpc = get_admin_rpc(remote_url, remote_api_key)
+        params: dict[str, Any] = {
+            "user_id": user_id,
+            "delete_user_record": delete_user_record,
+            "force": force,
+        }
+        if zone_id is not None:
+            params["zone_id"] = zone_id
+
+        with timing.phase("server"):
+            result = call_rpc("deprovision_user", params)
+
+        def _render(data: dict[str, Any]) -> None:
+            console.print("[nexus.success]\u2713[/nexus.success] User deprovisioned successfully")
+            console.print(f"User ID:          {data.get('user_id', user_id)}")
+            console.print(f"Zone:             {data.get('zone_id') or zone_id or 'N/A'}")
+            console.print(f"Deleted dirs:     {len(data.get('deleted_directories') or [])}")
+            console.print(f"Deleted API keys: {data.get('deleted_api_keys', 0)}")
+            console.print(f"Deleted perms:    {data.get('deleted_permissions', 0)}")
+            console.print(f"User soft-delete: {data.get('user_record_deleted', False)}")
+
+        render_output(
+            data=result,
+            output_opts=output_opts,
+            timing=timing,
+            human_formatter=_render,
+        )
+
+    except Exception as e:
+        console.print(f"[nexus.error]Error deprovisioning user:[/nexus.error] {e}")
+        sys.exit(1)
+
+
 @admin.command("list-users")
 @click.option("--user-id", help="Filter by user ID")
 @click.option("--zone-id", help="Filter by zone ID")

--- a/src/nexus/contracts/control_plane_coverage.py
+++ b/src/nexus/contracts/control_plane_coverage.py
@@ -1,0 +1,206 @@
+"""Shared control-plane surface coverage model for operator workflows."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class ControlPlaneSurface:
+    """Documented and tested external surface for the full-profile control plane."""
+
+    profile: str
+    module_group: str
+    surface: str
+    rpc_methods: tuple[str, ...]
+    cli_commands: tuple[str, ...]
+    transports: tuple[str, ...]
+    how_to_use: str
+    admin_only: bool
+    profile_gate: str
+    correctness_tests: tuple[str, ...]
+    performance_classification: str
+    gap_issue: str | None = None
+
+
+CONTROL_PLANE_SURFACES: tuple[ControlPlaneSurface, ...] = (
+    ControlPlaneSurface(
+        profile="full",
+        module_group="admin",
+        surface="Admin API key and permission management",
+        rpc_methods=(
+            "admin_write_permission",
+            "admin_create_key",
+            "admin_list_keys",
+            "admin_get_key",
+            "admin_revoke_key",
+            "admin_update_key",
+        ),
+        cli_commands=(
+            "nexus admin create-user",
+            "nexus admin create-key",
+            "nexus admin create-agent-key",
+            "nexus admin list-users",
+            "nexus admin get-user",
+            "nexus admin revoke-key",
+            "nexus admin update-key",
+        ),
+        transports=("CLI", "generic gRPC Call", "HTTP auth key API"),
+        how_to_use="Use after database auth is enabled to mint, inspect, rotate, and revoke user or agent API keys.",
+        admin_only=True,
+        profile_gate="full/cloud server with DatabaseAPIKeyAuth and an admin token",
+        correctness_tests=(
+            "tests/unit/server/test_admin_handlers.py",
+            "tests/unit/server/test_rpc_admin_only.py",
+            "tests/unit/server/test_full_profile_control_plane_surface.py",
+        ),
+        performance_classification="control plane hot path; benchmark gate tracked in #4201",
+        gap_issue="#4201",
+    ),
+    ControlPlaneSurface(
+        profile="full",
+        module_group="auth",
+        surface="User provisioning and deprovisioning",
+        rpc_methods=("provision_user", "deprovision_user"),
+        cli_commands=("nexus admin provision-user", "nexus admin deprovision-user"),
+        transports=("CLI", "generic gRPC Call", "OAuth/auth server internals"),
+        how_to_use="Use for operator-managed account lifecycle when a database-backed server should create or clean up user resources.",
+        admin_only=True,
+        profile_gate="full/cloud server with user_provisioning service registered",
+        correctness_tests=(
+            "tests/unit/core/test_nexus_fs_provision_user.py",
+            "tests/unit/server/test_full_profile_control_plane_surface.py",
+        ),
+        performance_classification="setup path; not performance-sensitive",
+    ),
+    ControlPlaneSurface(
+        profile="full",
+        module_group="audit",
+        surface="Audit list and export",
+        rpc_methods=("audit_list", "audit_export"),
+        cli_commands=("nexus audit list", "nexus audit export"),
+        transports=("CLI", "generic gRPC Call", "HTTP audit APIs where present"),
+        how_to_use="Use to inspect or export exchange/payment audit records for compliance and incident review.",
+        admin_only=True,
+        profile_gate="full/cloud server with record store and exchange audit logger",
+        correctness_tests=(
+            "tests/conformance/test_exchange_openapi.py",
+            "tests/unit/server/test_full_profile_control_plane_surface.py",
+        ),
+        performance_classification="control plane hot path; benchmark gate tracked in #4201",
+        gap_issue="#4201",
+    ),
+    ControlPlaneSurface(
+        profile="full",
+        module_group="events",
+        surface="Event replay",
+        rpc_methods=("events_replay",),
+        cli_commands=("nexus events replay",),
+        transports=("CLI", "generic gRPC Call"),
+        how_to_use="Use to replay historical file/activity events for operational investigation.",
+        admin_only=True,
+        profile_gate="full/cloud server with record store and event replay service",
+        correctness_tests=(
+            "tests/e2e/server/test_event_stream_e2e.py",
+            "tests/unit/server/test_full_profile_control_plane_surface.py",
+        ),
+        performance_classification="control plane hot path; benchmark gate tracked in #4201",
+        gap_issue="#4201",
+    ),
+    ControlPlaneSurface(
+        profile="full",
+        module_group="governance",
+        surface="Governance status, alerts, and rings",
+        rpc_methods=("governance_status", "governance_alerts", "governance_rings"),
+        cli_commands=(
+            "nexus governance status",
+            "nexus governance alerts",
+            "nexus governance rings",
+        ),
+        transports=("CLI", "generic gRPC Call"),
+        how_to_use="Use in marketplace/operator deployments to review anomaly alerts and collusion findings.",
+        admin_only=True,
+        profile_gate="full/cloud server with governance services wired",
+        correctness_tests=(
+            "tests/unit/server/test_security_hardening.py",
+            "tests/unit/server/test_full_profile_control_plane_surface.py",
+        ),
+        performance_classification="control plane hot path; benchmark gate tracked in #4201",
+        gap_issue="#4201",
+    ),
+    ControlPlaneSurface(
+        profile="full",
+        module_group="federation",
+        surface="Federation read-only introspection",
+        rpc_methods=(
+            "federation_client_whoami",
+            "federation_list_zones",
+            "federation_cluster_info",
+        ),
+        cli_commands=(
+            "nexus federation status",
+            "nexus federation zones",
+            "nexus federation info",
+        ),
+        transports=("CLI", "generic gRPC Call"),
+        how_to_use="Use to inspect zone grants, zone inventory, and cluster status before making federation changes.",
+        admin_only=False,
+        profile_gate="federation runtime active; cluster/cloud deployments, or full server with federation kernel support",
+        correctness_tests=(
+            "tests/unit/grpc/test_federation_whoami_rpc.py",
+            "tests/e2e/docker/test_federation_e2e.py",
+            "tests/unit/server/test_full_profile_control_plane_surface.py",
+        ),
+        performance_classification="control plane hot path; benchmark gate tracked in #4201",
+        gap_issue="#4201",
+    ),
+    ControlPlaneSurface(
+        profile="full",
+        module_group="federation",
+        surface="Federation zone lifecycle and mounts",
+        rpc_methods=(
+            "federation_export_zone",
+            "federation_import_zone",
+            "federation_create_zone",
+            "federation_remove_zone",
+            "federation_join",
+            "federation_mount",
+            "federation_unmount",
+            "federation_share",
+        ),
+        cli_commands=(
+            "nexus federation mount",
+            "nexus federation unmount",
+            "generic gRPC Call for create/remove/share/join until #4200 lands",
+        ),
+        transports=("CLI", "generic gRPC Call"),
+        how_to_use="Use admin credentials to create, remove, share, join, mount, unmount, export, or import federation zones.",
+        admin_only=True,
+        profile_gate="federation runtime active; cluster/cloud deployments, or full server with federation kernel support",
+        correctness_tests=(
+            "tests/e2e/docker/test_federation_e2e.py",
+            "tests/e2e/server/test_zone_export_e2e.py",
+            "tests/e2e/server/test_zone_import_e2e.py",
+            "tests/unit/server/test_full_profile_control_plane_surface.py",
+        ),
+        performance_classification="control plane hot path; CLI parity gap #4200 and benchmark gate #4201",
+        gap_issue="#4200",
+    ),
+    ControlPlaneSurface(
+        profile="full",
+        module_group="pay",
+        surface="Pay balance, transfer, and history",
+        rpc_methods=("pay_balance", "pay_transfer", "pay_history"),
+        cli_commands=("nexus pay balance", "nexus pay transfer", "nexus pay history"),
+        transports=("CLI", "generic gRPC Call", "HTTP pay APIs"),
+        how_to_use="Use as an authenticated marketplace user or agent to inspect credits, transfer funds, and review payment history.",
+        admin_only=False,
+        profile_gate="full/cloud server with pay brick enabled",
+        correctness_tests=(
+            "tests/conformance/test_exchange_openapi.py",
+            "tests/e2e/self_contained/pay/test_x402_integration.py",
+            "tests/unit/server/test_full_profile_control_plane_surface.py",
+        ),
+        performance_classification="marketplace user path; not classified as an admin/operator hot path in #4138",
+    ),
+)

--- a/src/nexus/server/api/v2/routers/pay.py
+++ b/src/nexus/server/api/v2/routers/pay.py
@@ -8,13 +8,16 @@ in disabled mode when TigerBeetle is not available.
 Issue #3250: TUI Payments panel (Screen 8).
 """
 
+import csv
+import io
 import logging
 import uuid
 from datetime import UTC, datetime, timedelta
 from decimal import Decimal
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request, status
+from fastapi.responses import Response
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from nexus.bricks.pay.constants import credits_to_micro, micro_to_credits
@@ -653,6 +656,104 @@ def _list_transactions(
         }
 
 
+def _audit_logger(record_store: Any) -> Any:
+    from nexus.storage.exchange_audit_logger import ExchangeAuditLogger
+
+    return ExchangeAuditLogger(record_store=record_store)
+
+
+def _serialize_audit_transaction(row: Any) -> dict[str, Any]:
+    return {
+        "id": row.id,
+        "record_hash": row.record_hash,
+        "created_at": row.created_at.isoformat() if row.created_at else "",
+        "protocol": row.protocol,
+        "buyer_agent_id": row.buyer_agent_id,
+        "seller_agent_id": row.seller_agent_id,
+        "amount": str(row.amount),
+        "currency": row.currency,
+        "status": row.status,
+        "application": row.application,
+        "zone_id": row.zone_id,
+        "trace_id": row.trace_id,
+        "metadata_hash": row.metadata_hash,
+        "transfer_id": row.transfer_id,
+    }
+
+
+def _audit_filters(
+    *,
+    protocol: str | None = None,
+    status: str | None = None,
+    since: str | None = None,
+    until: str | None = None,
+) -> dict[str, Any]:
+    filters: dict[str, Any] = {}
+    if protocol:
+        filters["protocol"] = protocol
+    if status:
+        filters["status"] = status
+    if since:
+        filters["since"] = datetime.fromisoformat(since)
+    if until:
+        filters["until"] = datetime.fromisoformat(until)
+    return filters
+
+
+def _list_audit_transactions(
+    record_store: Any,
+    limit: int,
+    cursor: str | None,
+    *,
+    protocol: str | None = None,
+    status: str | None = None,
+    include_total: bool = False,
+) -> dict[str, Any]:
+    try:
+        audit_log = _audit_logger(record_store)
+        filters = _audit_filters(protocol=protocol, status=status)
+        rows, next_cursor = audit_log.list_transactions_cursor(
+            filters=filters,
+            limit=limit,
+            cursor=cursor,
+        )
+        return {
+            "transactions": [_serialize_audit_transaction(row) for row in rows],
+            "limit": limit,
+            "has_more": next_cursor is not None,
+            "total": audit_log.count_transactions(**filters) if include_total else None,
+            "next_cursor": next_cursor,
+        }
+    except Exception as e:
+        logger.debug("Audit transaction query failed: %s", e)
+        return {
+            "transactions": [],
+            "limit": limit,
+            "has_more": False,
+            "total": 0 if include_total else None,
+            "next_cursor": None,
+        }
+
+
+def _get_audit_transaction(record_store: Any, record_id: str) -> Any | None:
+    try:
+        return _audit_logger(record_store).get_transaction(record_id)
+    except Exception as e:
+        logger.debug("Audit transaction lookup failed: %s", e)
+        return None
+
+
+def _audit_transaction_aggregations(record_store: Any) -> dict[str, Any]:
+    try:
+        return cast(
+            dict[str, Any],
+            _audit_logger(record_store).get_aggregations(zone_id=ROOT_ZONE_ID),
+        )
+    except Exception as e:
+        logger.debug("Audit transaction aggregation failed: %s", e)
+        return {"tx_count": 0, "total_volume": "0.00", "top_buyers": [], "top_sellers": []}
+
+
 @router.get("/transactions")
 async def list_pay_transactions(
     limit: int = 20,
@@ -667,10 +768,97 @@ async def list_pay_transactions(
 async def list_audit_transactions(
     limit: int = 20,
     cursor: str | None = None,
-    context: Any = Depends(_get_pay_context),
+    protocol: str | None = None,
+    status: str | None = None,
+    include_total: bool = False,
     record_store: Any = Depends(_get_record_store),
 ) -> dict[str, Any]:
-    return _list_transactions(record_store, limit, cursor, _context_zone_id(context))
+    return _list_audit_transactions(
+        record_store,
+        limit,
+        cursor,
+        protocol=protocol,
+        status=status,
+        include_total=include_total,
+    )
+
+
+@audit_router.get("/transactions/aggregations")
+async def get_audit_transaction_aggregations(
+    record_store: Any = Depends(_get_record_store),
+) -> dict[str, Any]:
+    return _audit_transaction_aggregations(record_store)
+
+
+@audit_router.get("/transactions/export", response_model=None)
+async def export_audit_transactions(
+    format: str = "json",
+    limit: int = 1000,
+    cursor: str | None = None,
+    protocol: str | None = None,
+    status: str | None = None,
+    record_store: Any = Depends(_get_record_store),
+) -> Any:
+    result = _list_audit_transactions(
+        record_store,
+        limit,
+        cursor,
+        protocol=protocol,
+        status=status,
+        include_total=True,
+    )
+    if format == "json":
+        return result
+    if format != "csv":
+        raise HTTPException(status_code=400, detail="format must be 'json' or 'csv'")
+
+    output = io.StringIO()
+    fieldnames = [
+        "id",
+        "record_hash",
+        "created_at",
+        "protocol",
+        "buyer_agent_id",
+        "seller_agent_id",
+        "amount",
+        "currency",
+        "status",
+        "application",
+        "zone_id",
+        "transfer_id",
+    ]
+    writer = csv.DictWriter(output, fieldnames=fieldnames)
+    writer.writeheader()
+    for tx in result["transactions"]:
+        writer.writerow({name: tx.get(name) for name in fieldnames})
+    return Response(content=output.getvalue(), media_type="text/csv")
+
+
+@audit_router.get("/transactions/{record_id}")
+async def get_audit_transaction(
+    record_id: str,
+    record_store: Any = Depends(_get_record_store),
+) -> dict[str, Any]:
+    row = _get_audit_transaction(record_store, record_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="Transaction not found")
+    return _serialize_audit_transaction(row)
+
+
+@audit_router.get("/integrity/{record_id}")
+async def verify_audit_integrity(
+    record_id: str,
+    record_store: Any = Depends(_get_record_store),
+) -> dict[str, Any]:
+    audit = _audit_logger(record_store)
+    row = audit.get_transaction(record_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="Transaction not found")
+    return {
+        "record_id": record_id,
+        "is_valid": audit.verify_integrity_from_row(row),
+        "record_hash": row.record_hash,
+    }
 
 
 @router.get("/transactions/integrity")

--- a/src/nexus/server/fastapi_server.py
+++ b/src/nexus/server/fastapi_server.py
@@ -71,10 +71,53 @@ logger = logging.getLogger(__name__)
 # Module-level limiter instance; initialized in create_app().
 limiter: Limiter
 
+DISCOVERABLE_RPC_SERVICE_NAMES: tuple[str, ...] = (
+    "mcp",
+    "oauth",
+    "mount",
+    "search",
+    "share_link",
+    "rebac",
+    "user_provisioning",
+)
+
 
 def _rate_limit_enabled_from_env() -> bool:
     """Return whether HTTP rate limiting was explicitly enabled."""
     return os.environ.get("NEXUS_RATE_LIMIT_ENABLED", "").lower() in ("1", "true", "yes")
+
+
+def _pay_rpc_credits_config() -> tuple[bool, str, int]:
+    """Resolve Pay RPC CreditsService settings using the REST pay autodetection policy."""
+    import importlib.util
+    import socket
+
+    tb_address = os.environ.get("TIGERBEETLE_ADDRESS", "127.0.0.1:3000")
+    tb_cluster = int(os.environ.get("TIGERBEETLE_CLUSTER_ID", "0"))
+    tigerbeetle_available = importlib.util.find_spec("tigerbeetle") is not None
+
+    if not tigerbeetle_available:
+        return False, tb_address, tb_cluster
+
+    if os.environ.get("NEXUS_PAY_ENABLED", "").lower() in {"1", "true", "yes"}:
+        return True, tb_address, tb_cluster
+
+    for hostname in ("nexus-tigerbeetle", "tigerbeetle", "127.0.0.1"):
+        try:
+            ip = socket.gethostbyname(hostname) if hostname != "127.0.0.1" else hostname
+            conn = socket.create_connection((ip, 3000), timeout=1)
+            conn.close()
+            return True, f"{ip}:3000", tb_cluster
+        except Exception:
+            continue
+
+    return False, tb_address, tb_cluster
+
+
+def _pay_rpc_credits_enabled() -> bool:
+    """Return whether Pay RPC should use a real TigerBeetle-backed CreditsService."""
+    enabled, _address, _cluster = _pay_rpc_credits_config()
+    return enabled
 
 
 # ============================================================================
@@ -400,14 +443,7 @@ def create_app(
     # Services with @rpc_expose override kernel stubs (later sources win).
     if nexus_fs is not None:
         _rpc_sources: list[Any] = []
-        for _svc_name in (
-            "mcp",
-            "oauth",
-            "mount",
-            "search",
-            "share_link",
-            "rebac",
-        ):
+        for _svc_name in DISCOVERABLE_RPC_SERVICE_NAMES:
             _brick_svc = nexus_fs.service(_svc_name)
             if _brick_svc is not None:
                 _rpc_sources.append(_brick_svc)
@@ -455,7 +491,16 @@ def create_app(
             from nexus.bricks.pay import CreditsService
             from nexus.server.rpc.services.pay_rpc import PayRPCService
 
-            _rpc_sources.append(PayRPCService(CreditsService()))
+            pay_enabled, tb_address, tb_cluster = _pay_rpc_credits_config()
+            _rpc_sources.append(
+                PayRPCService(
+                    CreditsService(
+                        tigerbeetle_address=tb_address,
+                        cluster_id=tb_cluster,
+                        enabled=pay_enabled,
+                    )
+                )
+            )
         except Exception as _exc:
             logger.debug("PayRPCService unavailable: %s", _exc)
         # --- Audit (Issue #1133) ---

--- a/src/nexus/server/rpc/services/audit_rpc.py
+++ b/src/nexus/server/rpc/services/audit_rpc.py
@@ -17,7 +17,7 @@ class AuditRPCService:
     def __init__(self, audit_logger: Any) -> None:
         self._audit_logger = audit_logger
 
-    @rpc_expose(description="List audit trail entries")
+    @rpc_expose(description="List audit trail entries", admin_only=True)
     def audit_list(
         self,
         since: str | None = None,
@@ -41,7 +41,7 @@ class AuditRPCService:
         )
         return result
 
-    @rpc_expose(description="Export audit data")
+    @rpc_expose(description="Export audit data", admin_only=True)
     def audit_export(
         self,
         fmt: str = "json",
@@ -58,7 +58,7 @@ class AuditRPCService:
         if until:
             filters["until"] = until
 
-        rows = list(self._audit_logger.iter_transactions(filters))
+        rows = list(self._audit_logger.iter_transactions(filters=filters))
         # Convert ORM objects to plain dicts
         records = []
         for row in rows:

--- a/src/nexus/server/rpc/services/events_rpc.py
+++ b/src/nexus/server/rpc/services/events_rpc.py
@@ -4,6 +4,7 @@ Issue #1520.
 """
 
 import logging
+from datetime import datetime
 from typing import Any
 
 from nexus.contracts.rpc import rpc_expose
@@ -17,7 +18,7 @@ class EventsRPCService:
     def __init__(self, replay_service: Any) -> None:
         self._replay_service = replay_service
 
-    @rpc_expose(description="Replay historical events")
+    @rpc_expose(description="Replay historical events", admin_only=True)
     async def events_replay(
         self,
         since: str | None = None,
@@ -25,13 +26,19 @@ class EventsRPCService:
         path: str | None = None,
         limit: int = 50,
     ) -> dict[str, Any]:
-        result = await self._replay_service.replay(
-            since_timestamp=since,
+        since_timestamp = datetime.fromisoformat(since) if since else None
+        result = self._replay_service.replay(
+            since_timestamp=since_timestamp,
             event_types=[event_type] if event_type else None,
             path_pattern=path,
             limit=limit,
         )
         if isinstance(result, dict):
             return result
-        events = [e.to_dict() if hasattr(e, "to_dict") else e for e in result]
-        return {"events": events, "has_more": len(events) >= limit}
+        raw_events = getattr(result, "events", result)
+        events = [e.to_dict() if hasattr(e, "to_dict") else e for e in raw_events]
+        return {
+            "events": events,
+            "next_cursor": getattr(result, "next_cursor", None),
+            "has_more": bool(getattr(result, "has_more", len(events) >= limit)),
+        }

--- a/src/nexus/server/rpc/services/federation_rpc.py
+++ b/src/nexus/server/rpc/services/federation_rpc.py
@@ -525,6 +525,33 @@ class FederationRPCService(FederationRPCMixin):
         except Exception:
             return {}
 
+    @staticmethod
+    def _standalone_cluster_info(zone_id: str) -> dict[str, Any]:
+        return {
+            "zone_id": zone_id,
+            "node_id": 0,
+            "has_store": False,
+            "is_leader": False,
+            "leader_id": 0,
+            "term": 0,
+            "commit_index": 0,
+            "applied_index": 0,
+            "voter_count": 0,
+            "witness_count": 0,
+            "links_count": 0,
+            "available": False,
+            "mode": "standalone",
+            "reason": "federation_cluster_info unavailable in standalone kernel",
+        }
+
+    @staticmethod
+    def _is_standalone_cluster_info_unavailable(exc: Exception) -> bool:
+        message = str(exc).lower()
+        return (
+            "unknown call method: federation_cluster_info" in message
+            or "federation not active" in message
+        )
+
     @rpc_expose(admin_only=False)
     def federation_list_zones(self) -> dict[str, Any]:
         # /__sys__/zones/ procfs view — read-only, kernel-internal
@@ -546,4 +573,9 @@ class FederationRPCService(FederationRPCMixin):
     def federation_cluster_info(self, zone_id: str) -> dict[str, Any]:
         # Bundled cluster status (term, commit_index, voters, links_count …)
         # — single round-trip through the federation control-plane helper.
-        return dict(self._kernel._call("federation_cluster_info", {"zone_id": zone_id}))
+        try:
+            return dict(self._kernel._call("federation_cluster_info", {"zone_id": zone_id}))
+        except Exception as exc:
+            if self._is_standalone_cluster_info_unavailable(exc):
+                return self._standalone_cluster_info(zone_id)
+            raise

--- a/src/nexus/server/rpc/services/governance_rpc.py
+++ b/src/nexus/server/rpc/services/governance_rpc.py
@@ -6,6 +6,7 @@ Issue #1520.
 import logging
 from typing import Any
 
+from nexus.contracts.constants import ROOT_ZONE_ID
 from nexus.contracts.rpc import rpc_expose
 
 logger = logging.getLogger(__name__)
@@ -22,15 +23,29 @@ class GovernanceRPCService:
         self._anomaly_service = anomaly_service
         self._collusion_service = collusion_service
 
-    @rpc_expose(description="List anomaly alerts")
+    @rpc_expose(description="List anomaly alerts", admin_only=True)
     async def governance_alerts(
         self,
         severity: str | None = None,
         limit: int = 50,
+        _context: Any = None,
     ) -> dict[str, Any]:
         if self._anomaly_service is None:
             return {"alerts": [], "count": 0}
-        alerts = self._anomaly_service.get_alerts(severity=severity)
+        parsed_severity = None
+        if severity:
+            from nexus.bricks.governance.models import AnomalySeverity
+
+            parsed_severity = AnomalySeverity(severity)
+        zone_id = getattr(_context, "zone_id", None) or ROOT_ZONE_ID
+        try:
+            alerts = await self._anomaly_service.get_alerts(
+                zone_id=zone_id,
+                severity=parsed_severity,
+            )
+        except Exception as exc:
+            logger.debug("Governance alerts unavailable: %s", exc)
+            return {"alerts": [], "count": 0}
         alert_list = [
             {
                 "alert_id": str(getattr(a, "alert_id", "")),
@@ -43,11 +58,16 @@ class GovernanceRPCService:
         ]
         return {"alerts": alert_list, "count": len(alert_list)}
 
-    @rpc_expose(description="List detected fraud rings")
-    async def governance_rings(self) -> dict[str, Any]:
+    @rpc_expose(description="List detected fraud rings", admin_only=True)
+    async def governance_rings(self, _context: Any = None) -> dict[str, Any]:
         if self._collusion_service is None:
             return {"rings": [], "count": 0}
-        rings = self._collusion_service.detect_rings()
+        zone_id = getattr(_context, "zone_id", None) or ROOT_ZONE_ID
+        try:
+            rings = await self._collusion_service.detect_rings(zone_id=zone_id)
+        except Exception as exc:
+            logger.debug("Governance rings unavailable: %s", exc)
+            return {"rings": [], "count": 0}
         ring_list = [
             {
                 "ring_id": str(getattr(r, "ring_id", "")),
@@ -59,8 +79,8 @@ class GovernanceRPCService:
         ]
         return {"rings": ring_list, "count": len(ring_list)}
 
-    @rpc_expose(description="Get governance overview (alerts + rings)")
-    async def governance_status(self) -> dict[str, Any]:
-        recent_alerts = await self.governance_alerts(limit=5)
-        fraud_rings = await self.governance_rings()
+    @rpc_expose(description="Get governance overview (alerts + rings)", admin_only=True)
+    async def governance_status(self, _context: Any = None) -> dict[str, Any]:
+        recent_alerts = await self.governance_alerts(limit=5, _context=_context)
+        fraud_rings = await self.governance_rings(_context=_context)
         return {"recent_alerts": recent_alerts, "fraud_rings": fraud_rings}

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -125,6 +125,8 @@ def nexus_server(isolated_db, tmp_path):
     # Set up environment
     storage_path = tmp_path / "storage"
     storage_path.mkdir(exist_ok=True)
+    home_path = tmp_path / "home"
+    home_path.mkdir(exist_ok=True)
 
     port = find_free_port()
     base_url = f"http://127.0.0.1:{port}"
@@ -132,6 +134,7 @@ def nexus_server(isolated_db, tmp_path):
     # Environment for the server process
     env = os.environ.copy()
     env["NEXUS_JWT_SECRET"] = "test-secret-key-for-e2e-12345"
+    env["HOME"] = str(home_path)
     # Allow PostgreSQL via NEXUS_E2E_DATABASE_URL env var; default to SQLite
     env["NEXUS_DATABASE_URL"] = os.environ.get("NEXUS_E2E_DATABASE_URL", f"sqlite:///{isolated_db}")
     env["PYTHONPATH"] = str(_src_path)
@@ -141,6 +144,8 @@ def nexus_server(isolated_db, tmp_path):
 
     # Issue #788: Lower min chunk size for e2e tests (default 5MB too large for test payloads)
     env["NEXUS_UPLOAD_MIN_CHUNK_SIZE"] = "1"
+    env["NEXUS_RATE_LIMIT_ENABLED"] = "false"
+    env["NEXUS_SEARCH_DAEMON"] = "false"
 
     # Issue #2035: Enable RecordStore + ReBAC so skills subscribe/share/unshare
     # and share-link operations have a working EnhancedReBACManager.
@@ -164,7 +169,7 @@ def nexus_server(isolated_db, tmp_path):
             (
                 f"from nexus.daemon.main import main; "
                 f"main(['--host', '127.0.0.1', '--port', '{port}', "
-                f"'--data-dir', '{tmp_path}'])"
+                f"'--data-dir', '{tmp_path}', '--profile', 'full'])"
             ),
         ],
         env=env,

--- a/tests/e2e/server/test_full_profile_control_plane_e2e.py
+++ b/tests/e2e/server/test_full_profile_control_plane_e2e.py
@@ -1,0 +1,158 @@
+"""Real full-profile control-plane RPC smoke and latency coverage."""
+
+from __future__ import annotations
+
+import statistics
+import time
+import uuid
+from typing import Any
+
+import grpc
+import pytest
+
+pytestmark = [pytest.mark.e2e]
+
+ADMIN_KEY = "test-e2e-api-key-12345"
+
+
+def _call_rpc(
+    stub: Any,
+    method: str,
+    params: dict[str, Any] | None = None,
+    *,
+    api_key: str = ADMIN_KEY,
+    timeout: float = 20.0,
+) -> tuple[float, dict[str, Any]]:
+    from nexus.grpc.vfs import vfs_pb2
+    from nexus.lib.rpc_codec import decode_rpc_message, encode_rpc_message
+
+    start = time.perf_counter()
+    resp = stub.Call(
+        vfs_pb2.CallRequest(
+            method=method,
+            payload=encode_rpc_message(params or {}),
+            auth_token=api_key,
+        ),
+        timeout=timeout,
+    )
+    elapsed_ms = (time.perf_counter() - start) * 1000
+    body = decode_rpc_message(resp.payload)
+    assert not resp.is_error, f"{method} failed: {body}"
+    assert isinstance(body, dict)
+    return elapsed_ms, body
+
+
+def test_full_profile_control_plane_rpc_correctness_and_latency(nexus_server) -> None:
+    from nexus.grpc.vfs import vfs_pb2_grpc
+
+    target = f"127.0.0.1:{nexus_server['port'] + 2}"
+    channel = grpc.insecure_channel(target)
+    grpc.channel_ready_future(channel).result(timeout=20)
+    stub = vfs_pb2_grpc.NexusVFSServiceStub(channel)
+    timings: dict[str, float] = {}
+
+    try:
+        suffix = uuid.uuid4().hex[:8]
+
+        for method, params in [
+            ("admin_write_permission", {"tuples": []}),
+            (
+                "admin_create_key",
+                {
+                    "name": f"e2e-user-key-{suffix}",
+                    "zone_id": "root",
+                    "user_id": f"e2e-user-{suffix}",
+                    "subject_type": "user",
+                    "is_admin": False,
+                },
+            ),
+            ("admin_list_keys", {"limit": 10}),
+            ("audit_list", {"limit": 5}),
+            ("audit_export", {"fmt": "json"}),
+            ("events_replay", {"limit": 5}),
+            ("governance_alerts", {"limit": 5}),
+            ("governance_rings", {}),
+            ("governance_status", {}),
+            ("pay_balance", {"agent_id": f"e2e-agent-{suffix}"}),
+            ("pay_history", {"limit": 5}),
+            (
+                "pay_transfer",
+                {
+                    "from_agent": f"e2e-agent-{suffix}",
+                    "to": f"e2e-agent-dst-{suffix}",
+                    "amount": "1.25",
+                    "memo": "full-profile e2e",
+                },
+            ),
+            ("federation_list_zones", {}),
+            ("federation_cluster_info", {"zone_id": "root"}),
+        ]:
+            elapsed, body = _call_rpc(stub, method, params)
+            timings[method] = elapsed
+            assert "result" in body
+
+        key_id = _call_rpc(
+            stub,
+            "admin_create_key",
+            {
+                "name": f"e2e-update-key-{suffix}",
+                "zone_id": "root",
+                "user_id": f"e2e-update-user-{suffix}",
+                "subject_type": "user",
+                "is_admin": False,
+            },
+        )[1]["result"]["key_id"]
+
+        for method, params in [
+            ("admin_get_key", {"key_id": key_id}),
+            ("admin_update_key", {"key_id": key_id, "name": f"e2e-renamed-{suffix}"}),
+            ("admin_revoke_key", {"key_id": key_id}),
+        ]:
+            elapsed, body = _call_rpc(stub, method, params)
+            timings[method] = elapsed
+            assert "result" in body
+
+        provisioned_user = f"e2e-provision-{suffix}"
+        elapsed, body = _call_rpc(
+            stub,
+            "provision_user",
+            {
+                "user_id": provisioned_user,
+                "email": f"{provisioned_user}@example.com",
+                "zone_id": f"e2e-zone-{suffix}",
+                "create_api_key": False,
+                "create_agents": False,
+            },
+        )
+        timings["provision_user"] = elapsed
+        assert body["result"]["user_id"] == provisioned_user
+
+        elapsed, body = _call_rpc(
+            stub,
+            "deprovision_user",
+            {
+                "user_id": provisioned_user,
+                "zone_id": f"e2e-zone-{suffix}",
+                "delete_user_record": True,
+                "force": True,
+            },
+        )
+        timings["deprovision_user"] = elapsed
+        assert body["result"]["user_id"] == provisioned_user
+
+    finally:
+        channel.close()
+
+    p50 = statistics.median(timings.values())
+    p95 = sorted(timings.values())[min(len(timings) - 1, int(len(timings) * 0.95))]
+    print(
+        "\n  full-profile control-plane gRPC: "
+        f"methods={len(timings)} p50={p50:.1f}ms p95={p95:.1f}ms "
+        f"max={max(timings.values()):.1f}ms"
+    )
+    print(
+        "  per-method: "
+        + ", ".join(f"{method}={elapsed:.1f}ms" for method, elapsed in sorted(timings.items()))
+    )
+    assert p50 < 250
+    assert max(timings.values()) < 2_500

--- a/tests/unit/server/test_federation_rpc_gating.py
+++ b/tests/unit/server/test_federation_rpc_gating.py
@@ -37,3 +37,38 @@ class TestFederationRPCGating:
         modes so data-portability RPCs reach the kernel.
         """
         assert _federation_rpc_active(SimpleNamespace()) is True
+
+    def test_cluster_info_standalone_unknown_kernel_call_returns_stable_shape(self) -> None:
+        """#4138: full-profile control-plane smoke should not surface a 500.
+
+        The standalone Rust kernel path may not register the federation
+        cluster-info Call method. The public Python RPC still needs to return
+        a stable read-only control-plane response instead of leaking that
+        transport detail as an internal error.
+        """
+        from nexus.contracts.exceptions import NexusError
+        from nexus.server.rpc.services.federation_rpc import FederationRPCService
+
+        class Kernel:
+            def _call(self, method: str, _params: dict[str, str]) -> dict[str, object]:
+                assert method == "federation_cluster_info"
+                raise NexusError("RPC error [-32603]: unknown Call method: federation_cluster_info")
+
+        result = FederationRPCService(Kernel()).federation_cluster_info("root")
+
+        assert result == {
+            "zone_id": "root",
+            "node_id": 0,
+            "has_store": False,
+            "is_leader": False,
+            "leader_id": 0,
+            "term": 0,
+            "commit_index": 0,
+            "applied_index": 0,
+            "voter_count": 0,
+            "witness_count": 0,
+            "links_count": 0,
+            "available": False,
+            "mode": "standalone",
+            "reason": "federation_cluster_info unavailable in standalone kernel",
+        }

--- a/tests/unit/server/test_full_profile_control_plane_surface.py
+++ b/tests/unit/server/test_full_profile_control_plane_surface.py
@@ -1,0 +1,534 @@
+"""Full-profile control-plane surface coverage for issue #4138."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Any
+
+from click.testing import CliRunner
+
+REQUIRED_RPC_METHODS = {
+    "admin_write_permission",
+    "admin_create_key",
+    "admin_list_keys",
+    "admin_get_key",
+    "admin_revoke_key",
+    "admin_update_key",
+    "provision_user",
+    "deprovision_user",
+    "audit_list",
+    "audit_export",
+    "events_replay",
+    "governance_alerts",
+    "governance_rings",
+    "governance_status",
+    "federation_client_whoami",
+    "federation_export_zone",
+    "federation_import_zone",
+    "federation_create_zone",
+    "federation_remove_zone",
+    "federation_join",
+    "federation_mount",
+    "federation_unmount",
+    "federation_share",
+    "federation_list_zones",
+    "federation_cluster_info",
+    "pay_balance",
+    "pay_transfer",
+    "pay_history",
+}
+
+
+ADMIN_ONLY_RPC_METHODS = {
+    "admin_write_permission",
+    "admin_create_key",
+    "admin_list_keys",
+    "admin_get_key",
+    "admin_revoke_key",
+    "admin_update_key",
+    "provision_user",
+    "deprovision_user",
+    "audit_list",
+    "audit_export",
+    "events_replay",
+    "governance_alerts",
+    "governance_rings",
+    "governance_status",
+    "federation_export_zone",
+    "federation_import_zone",
+    "federation_create_zone",
+    "federation_remove_zone",
+    "federation_join",
+    "federation_mount",
+    "federation_unmount",
+    "federation_share",
+}
+
+
+PUBLIC_RPC_METHODS = {
+    "federation_client_whoami",
+    "federation_list_zones",
+    "federation_cluster_info",
+    "pay_balance",
+    "pay_transfer",
+    "pay_history",
+}
+
+
+def _iter_rpc_methods(surfaces: Iterable[Any]) -> set[str]:
+    return {method for surface in surfaces for method in surface.rpc_methods}
+
+
+def test_control_plane_matrix_covers_issue_4138_rpc_methods() -> None:
+    from nexus.contracts.control_plane_coverage import CONTROL_PLANE_SURFACES
+
+    covered = _iter_rpc_methods(CONTROL_PLANE_SURFACES)
+    assert covered >= REQUIRED_RPC_METHODS
+
+
+def test_control_plane_matrix_tracks_profile_gate_and_gap_status() -> None:
+    from nexus.contracts.control_plane_coverage import CONTROL_PLANE_SURFACES
+
+    for surface in CONTROL_PLANE_SURFACES:
+        assert surface.profile == "full"
+        assert surface.module_group
+        assert surface.how_to_use
+        assert surface.correctness_tests
+        assert surface.performance_classification
+        assert surface.gap_issue is None or surface.gap_issue.startswith("#")
+
+
+def test_server_discovers_user_provisioning_service_for_rpc() -> None:
+    from nexus.server.fastapi_server import DISCOVERABLE_RPC_SERVICE_NAMES
+
+    assert "user_provisioning" in DISCOVERABLE_RPC_SERVICE_NAMES
+
+
+def test_cli_surface_contains_required_operator_commands() -> None:
+    from nexus.cli.commands.admin import admin
+    from nexus.cli.commands.audit import audit
+    from nexus.cli.commands.events_cli import events
+    from nexus.cli.commands.federation import federation
+    from nexus.cli.commands.governance_cli import governance
+    from nexus.cli.commands.pay import pay
+
+    assert {
+        "create-user",
+        "create-key",
+        "create-agent-key",
+        "list-users",
+        "get-user",
+        "revoke-key",
+        "update-key",
+        "provision-user",
+        "deprovision-user",
+    } <= set(admin.commands)
+    assert {"list", "export"} <= set(audit.commands)
+    assert {"replay"} <= set(events.commands)
+    assert {"status", "alerts", "rings"} <= set(governance.commands)
+    assert {"status", "zones", "info", "mount", "unmount"} <= set(federation.commands)
+    assert {"balance", "transfer", "history"} <= set(pay.commands)
+
+
+def test_sensitive_rpc_services_mark_admin_only() -> None:
+    from nexus.server.rpc.services.audit_rpc import AuditRPCService
+    from nexus.server.rpc.services.events_rpc import EventsRPCService
+    from nexus.server.rpc.services.federation_rpc import FederationRPCMixin, FederationRPCService
+    from nexus.server.rpc.services.governance_rpc import GovernanceRPCService
+    from nexus.server.rpc.services.pay_rpc import PayRPCService
+    from nexus.services.lifecycle.user_provisioning import UserProvisioningService
+
+    service_classes = (
+        AuditRPCService,
+        EventsRPCService,
+        FederationRPCMixin,
+        FederationRPCService,
+        GovernanceRPCService,
+        PayRPCService,
+        UserProvisioningService,
+    )
+    exposed: dict[str, Any] = {}
+    for cls in service_classes:
+        for name in dir(cls):
+            attr = getattr(cls, name)
+            if callable(attr) and getattr(attr, "_rpc_exposed", False):
+                exposed[getattr(attr, "_rpc_name", name)] = attr
+
+    for method in ADMIN_ONLY_RPC_METHODS - {
+        "admin_write_permission",
+        "admin_create_key",
+        "admin_list_keys",
+        "admin_get_key",
+        "admin_revoke_key",
+        "admin_update_key",
+    }:
+        assert getattr(exposed[method], "_rpc_admin_only", None) is True, method
+
+    for method in PUBLIC_RPC_METHODS:
+        assert getattr(exposed[method], "_rpc_admin_only", None) is False, method
+
+
+def test_audit_router_requires_auth_but_not_admin() -> None:
+    from nexus.server.api.v2.routers.pay import audit_router
+    from nexus.server.dependencies import require_admin, require_auth
+
+    dependencies = [dep.dependency for dep in audit_router.dependencies]
+
+    assert require_auth in dependencies
+    assert require_admin not in dependencies
+
+
+def test_audit_http_endpoints_use_exchange_audit_log_and_verify_tamper(tmp_path) -> None:
+    import asyncio
+
+    from sqlalchemy import create_engine, update
+    from sqlalchemy.orm import sessionmaker
+
+    from nexus.server.api.v2.routers.pay import list_audit_transactions, verify_audit_integrity
+    from nexus.storage.exchange_audit_logger import ExchangeAuditLogger
+    from nexus.storage.models import Base
+    from nexus.storage.models.exchange_audit_log import ExchangeAuditLogModel
+
+    engine = create_engine(f"sqlite:///{tmp_path / 'audit.db'}")
+    Base.metadata.create_all(engine)
+    session_factory = sessionmaker(bind=engine)
+
+    class FakeRecordStore:
+        pass
+
+    record_store = FakeRecordStore()
+    record_store.session_factory = session_factory
+    audit_logger = ExchangeAuditLogger(record_store=record_store)
+
+    record_id = audit_logger.record(
+        protocol="x402",
+        buyer_agent_id="buyer",
+        seller_agent_id="seller",
+        amount=Decimal("10"),
+        currency="credits",
+        status="settled",
+        application="gateway",
+        zone_id="root",
+        transfer_id="tb_1",
+    )
+
+    listed = asyncio.run(
+        list_audit_transactions(
+            protocol="x402",
+            include_total=True,
+            record_store=record_store,
+        )
+    )
+    assert listed["total"] == 1
+    assert listed["transactions"][0]["id"] == record_id
+    assert listed["transactions"][0]["record_hash"]
+
+    with session_factory() as session:
+        session.execute(
+            update(ExchangeAuditLogModel)
+            .where(ExchangeAuditLogModel.id == record_id)
+            .values(amount=Decimal("99"))
+        )
+        session.commit()
+
+    integrity = asyncio.run(verify_audit_integrity(record_id, record_store=record_store))
+    assert integrity == {
+        "record_id": record_id,
+        "is_valid": False,
+        "record_hash": listed["transactions"][0]["record_hash"],
+    }
+
+
+def test_pay_rpc_service_autodetects_tigerbeetle_like_rest(monkeypatch) -> None:
+    from nexus.server.fastapi_server import _pay_rpc_credits_enabled
+
+    class FakeSocket:
+        def close(self) -> None:
+            pass
+
+    monkeypatch.delenv("NEXUS_PAY_ENABLED", raising=False)
+    monkeypatch.setattr("importlib.util.find_spec", lambda name: object())
+    monkeypatch.setattr("socket.gethostbyname", lambda hostname: "127.0.0.1")
+    monkeypatch.setattr("socket.create_connection", lambda address, timeout: FakeSocket())
+
+    assert _pay_rpc_credits_enabled() is True
+
+
+def test_pay_rpc_service_stays_disabled_without_tigerbeetle_module(monkeypatch) -> None:
+    from nexus.server.fastapi_server import _pay_rpc_credits_enabled
+
+    class FakeSocket:
+        def close(self) -> None:
+            pass
+
+    monkeypatch.delenv("NEXUS_PAY_ENABLED", raising=False)
+    monkeypatch.setattr("importlib.util.find_spec", lambda name: None)
+    monkeypatch.setattr("socket.gethostbyname", lambda hostname: "127.0.0.1")
+    monkeypatch.setattr("socket.create_connection", lambda address, timeout: FakeSocket())
+
+    assert _pay_rpc_credits_enabled() is False
+
+
+def test_audit_export_calls_audit_logger_with_keyword_filters() -> None:
+    from nexus.server.rpc.services.audit_rpc import AuditRPCService
+
+    class FakeAuditLogger:
+        def __init__(self) -> None:
+            self.filters: dict[str, Any] | None = None
+
+        def iter_transactions(self, *, filters: dict[str, Any] | None = None):
+            self.filters = filters
+            return []
+
+    audit_logger = FakeAuditLogger()
+    result = AuditRPCService(audit_logger).audit_export(fmt="json", since="2026-01-01")
+
+    assert result == "[]"
+    assert audit_logger.filters == {"since": "2026-01-01"}
+
+
+def test_events_replay_adapts_sync_replay_result() -> None:
+    import asyncio
+
+    from nexus.server.rpc.services.events_rpc import EventsRPCService
+    from nexus.services.event_log.replay import EventRecord, ReplayResult
+
+    class FakeReplayService:
+        def replay(self, **kwargs: Any) -> ReplayResult:
+            assert kwargs["limit"] == 1
+            assert kwargs["since_timestamp"] == datetime(2026, 1, 1, tzinfo=UTC)
+            return ReplayResult(
+                events=[
+                    EventRecord(
+                        event_id="evt_1",
+                        type="write",
+                        path="/doc.md",
+                        new_path=None,
+                        zone_id="root",
+                        agent_id=None,
+                        status="ok",
+                        delivered=True,
+                        timestamp="2026-01-01T00:00:00+00:00",
+                        sequence_number=1,
+                    )
+                ],
+                next_cursor="cursor",
+                has_more=True,
+            )
+
+    result = asyncio.run(
+        EventsRPCService(FakeReplayService()).events_replay(
+            since="2026-01-01T00:00:00+00:00",
+            limit=1,
+        )
+    )
+
+    assert result["has_more"] is True
+    assert result["next_cursor"] == "cursor"
+    assert result["events"][0]["event_id"] == "evt_1"
+
+
+def test_governance_rpc_uses_zone_scoped_async_services() -> None:
+    import asyncio
+
+    from nexus.bricks.governance.models import AnomalySeverity
+    from nexus.server.rpc.services.governance_rpc import GovernanceRPCService
+
+    @dataclass(frozen=True)
+    class Alert:
+        alert_id: str = "alert_1"
+        agent_id: str = "agent_1"
+        severity: str = "high"
+        details: str = "flagged"
+        created_at: str = "2026-01-01"
+
+    @dataclass(frozen=True)
+    class Ring:
+        ring_id: str = "ring_1"
+        agents: list[str] | None = None
+        confidence: float = 0.9
+        detected_at: str = "2026-01-01"
+
+    class FakeAnomalyService:
+        async def get_alerts(
+            self,
+            *,
+            zone_id: str,
+            severity: AnomalySeverity | None = None,
+        ) -> list[Alert]:
+            assert zone_id == "root"
+            assert severity in (None, AnomalySeverity.HIGH)
+            return [Alert()]
+
+    class FakeCollusionService:
+        async def detect_rings(self, *, zone_id: str) -> list[Ring]:
+            assert zone_id == "root"
+            return [Ring(agents=["a", "b", "c"])]
+
+    service = GovernanceRPCService(FakeAnomalyService(), FakeCollusionService())
+
+    alerts = asyncio.run(service.governance_alerts(severity="high"))
+    rings = asyncio.run(service.governance_rings())
+    status = asyncio.run(service.governance_status())
+
+    assert alerts == {
+        "alerts": [
+            {
+                "alert_id": "alert_1",
+                "agent_id": "agent_1",
+                "severity": "high",
+                "description": "flagged",
+                "created_at": "2026-01-01",
+            }
+        ],
+        "count": 1,
+    }
+    assert rings["count"] == 1
+    assert status["recent_alerts"]["count"] == 1
+    assert status["fraud_rings"]["count"] == 1
+
+
+def test_governance_rpc_degrades_when_optional_storage_is_unavailable() -> None:
+    import asyncio
+
+    from nexus.server.rpc.services.governance_rpc import GovernanceRPCService
+
+    class MissingAnomalyService:
+        async def get_alerts(self, **kwargs: Any) -> list[Any]:
+            raise RuntimeError("no such table: governance_anomaly_alerts")
+
+    class MissingCollusionService:
+        async def detect_rings(self, **kwargs: Any) -> list[Any]:
+            raise RuntimeError("networkx is not installed")
+
+    service = GovernanceRPCService(MissingAnomalyService(), MissingCollusionService())
+
+    assert asyncio.run(service.governance_alerts()) == {"alerts": [], "count": 0}
+    assert asyncio.run(service.governance_rings()) == {"rings": [], "count": 0}
+    assert asyncio.run(service.governance_status()) == {
+        "recent_alerts": {"alerts": [], "count": 0},
+        "fraud_rings": {"rings": [], "count": 0},
+    }
+
+
+def test_admin_provision_user_cli_calls_rpc(monkeypatch) -> None:
+    from nexus.cli.commands.admin import admin
+
+    calls: list[tuple[str, dict[str, Any] | None]] = []
+
+    def fake_get_admin_rpc(url: str | None, api_key: str | None):
+        assert url == "http://server"
+        assert api_key == "adminkey"
+
+        def call_rpc(method: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
+            calls.append((method, params))
+            return {
+                "user_id": "alice",
+                "zone_id": "team",
+                "key_id": "kid_1",
+                "workspace_path": "/zone/team/user/alice/workspace/ws_1",
+                "agent_paths": [],
+                "created_resources": {"user": True},
+            }
+
+        return call_rpc
+
+    monkeypatch.setattr("nexus.cli.commands.admin.get_admin_rpc", fake_get_admin_rpc)
+
+    result = CliRunner().invoke(
+        admin,
+        [
+            "provision-user",
+            "alice",
+            "alice@example.com",
+            "--display-name",
+            "Alice",
+            "--zone-id",
+            "team",
+            "--api-key-name",
+            "Alice laptop",
+            "--no-agents",
+            "--json",
+            "--remote-url",
+            "http://server",
+            "--remote-api-key",
+            "adminkey",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    assert calls == [
+        (
+            "provision_user",
+            {
+                "user_id": "alice",
+                "email": "alice@example.com",
+                "create_api_key": True,
+                "create_agents": False,
+                "import_skills": False,
+                "display_name": "Alice",
+                "zone_id": "team",
+                "api_key_name": "Alice laptop",
+            },
+        )
+    ]
+
+
+def test_admin_deprovision_user_cli_calls_rpc(monkeypatch) -> None:
+    from nexus.cli.commands.admin import admin
+
+    calls: list[tuple[str, dict[str, Any] | None]] = []
+
+    def fake_get_admin_rpc(url: str | None, api_key: str | None):
+        assert url == "http://server"
+        assert api_key == "adminkey"
+
+        def call_rpc(method: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
+            calls.append((method, params))
+            return {
+                "user_id": "alice",
+                "zone_id": "team",
+                "deleted_directories": ["/zone/team/user/alice/workspace"],
+                "deleted_api_keys": 1,
+                "deleted_permissions": 2,
+                "user_record_deleted": True,
+            }
+
+        return call_rpc
+
+    monkeypatch.setattr("nexus.cli.commands.admin.get_admin_rpc", fake_get_admin_rpc)
+
+    result = CliRunner().invoke(
+        admin,
+        [
+            "deprovision-user",
+            "alice",
+            "--zone-id",
+            "team",
+            "--delete-user-record",
+            "--force",
+            "--json",
+            "--remote-url",
+            "http://server",
+            "--remote-api-key",
+            "adminkey",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    assert calls == [
+        (
+            "deprovision_user",
+            {
+                "user_id": "alice",
+                "delete_user_record": True,
+                "force": True,
+                "zone_id": "team",
+            },
+        )
+    ]


### PR DESCRIPTION
## Summary

Closes #4138 by tightening the full-profile control-plane surface, adding an explicit API coverage contract, and fixing gaps found while exercising the real e2e paths.

## What changed

- Added a control-plane coverage matrix for full-profile admin, provisioning, audit, events, governance, federation, and pay APIs.
- Added real full-profile daemon gRPC e2e coverage with per-method latency reporting.
- Added HTTP audit e2e/perf coverage for transactions and aggregations.
- Fixed dispatch pipe event-loop starvation by moving blocking pipe reads through `asyncio.to_thread`.
- Fixed admin/governance/audit/events service issues found during e2e coverage expansion.
- Added CLI user provisioning/deprovisioning coverage and docs updates.

## APIs tested with real e2e/performance data

Full-profile control-plane gRPC: 19 methods, p50 2.9ms, p95 328.0ms, max 328.0ms.

| API | Time |
| --- | ---: |
| admin_create_key | 11.1ms |
| admin_get_key | 2.6ms |
| admin_list_keys | 8.6ms |
| admin_revoke_key | 2.6ms |
| admin_update_key | 4.6ms |
| admin_write_permission | 19.0ms |
| audit_export | 2.9ms |
| audit_list | 4.7ms |
| deprovision_user | 8.3ms |
| events_replay | 2.3ms |
| federation_cluster_info | 1.6ms |
| federation_list_zones | 1.8ms |
| governance_alerts | 15.4ms |
| governance_rings | 1.9ms |
| governance_status | 3.0ms |
| pay_balance | 1.1ms |
| pay_history | 2.3ms |
| pay_transfer | 1.7ms |
| provision_user | 328.0ms |

HTTP audit endpoints:

| API | Performance |
| --- | ---: |
| GET /audit/transactions | p50 6ms, p95 19ms |
| GET /audit/aggregations | p50 14ms, p95 47ms |

Additional real e2e coverage passed for pay, credits, federation smoke, audit nonexistent transaction, and audit integrity nonexistent paths.

## Validation

- `uv run pytest tests/unit/server/test_full_profile_control_plane_surface.py tests/unit/task_manager/test_dispatch_consumer.py tests/unit/server/test_admin_handlers.py tests/unit/server/test_rpc_admin_only.py tests/unit/cli/test_json_contract.py -q -n0 -o addopts=`
  - 76 passed, 5 skipped
- `uv run pytest tests/e2e/server/test_full_profile_control_plane_e2e.py tests/e2e/server/test_exchange_protocol_e2e.py::TestAuditEndpoints tests/e2e/server/test_exchange_protocol_perf.py::TestEndpointLatency::test_audit_list_latency tests/e2e/server/test_exchange_protocol_perf.py::TestEndpointLatency::test_audit_aggregations_latency -q -s -n0 -o addopts=`
  - 8 passed
- `uv run pytest tests/e2e/self_contained/pay/test_x402_integration.py tests/e2e/self_contained/test_credits_service_e2e.py tests/e2e/test_federation_smoke.py -q -s -n0 -o addopts=`
  - 37 passed
- `uv run pytest tests/e2e/server/test_exchange_protocol_e2e.py::TestErrorHandler::test_audit_nonexistent_transaction tests/e2e/server/test_exchange_protocol_e2e.py::TestErrorHandler::test_audit_integrity_nonexistent -q -s -n0 -o addopts=`
  - 2 passed
- Commit hooks passed: ruff, format, mypy, type-ignore policy, zero-core-imports, and repo checks.
