### PR TITLE
feat(versioning): snapshot-on-write closes historical-read gap (service-tier, no kernel ABI)

### DIFF
--- a/.pre-commit-hooks/check_kernel_leak.py
+++ b/.pre-commit-hooks/check_kernel_leak.py
@@ -58,8 +58,9 @@ def main() -> int:
         if not guarded_dir.exists():
             continue
         for py_file in guarded_dir.rglob("*.py"):
-            # Skip test files inside bricks/
-            if "/tests/" in str(py_file):
+            # Skip test files inside bricks/ — use as_posix() so the
+            # "/tests/" match works on Windows (native paths use "\").
+            if "/tests/" in py_file.as_posix():
                 continue
             errors.extend(_check_file(py_file))
     if errors:

--- a/src/nexus/bricks/versioning/operation_undo_service.py
+++ b/src/nexus/bricks/versioning/operation_undo_service.py
@@ -96,7 +96,7 @@ class OperationUndoService:
     def _undo_write(self, operation: Any) -> UndoResult:
         """Undo a write: restore previous content or delete new file."""
         if operation.snapshot_hash:
-            old_content = self._read_content_from_cas(operation.path, operation.snapshot_hash)
+            old_content = self._read_snapshot(operation)
             self._write(operation.path, old_content)
             return UndoResult(
                 success=True,
@@ -124,7 +124,7 @@ class OperationUndoService:
                 path=operation.path,
             )
 
-        content = self._read_content_from_cas(operation.path, operation.snapshot_hash)
+        content = self._read_snapshot(operation)
         self._write(operation.path, content)
 
         # NOTE: metadata restoration (chown/chgrp/chmod) is intentionally
@@ -169,25 +169,29 @@ class OperationUndoService:
     # Internal helpers
     # ------------------------------------------------------------------
 
-    def _read_content_from_cas(self, path: str, content_id: str) -> bytes:  # noqa: ARG002
-        """Read content via the kernel syscall path (§2.5 mediation).
+    def _read_snapshot(self, operation: Any) -> bytes:
+        """Read the pre-write snapshot bytes for ``operation`` via the syscall.
 
-        Architectural gap (FOLLOW-UP — same as TimeTravelService._read_snapshot):
-            ``content_id`` is the hash of the OLD bytes recorded by the write
-            observer at log time. The bytes are in CAS keyed by that hash,
-            but service tier cannot reach them by hash (§2.5). This method
-            currently returns ``sys_read_raw(path)`` which is the CURRENT
-            bytes at the path — wrong for any undo-after-write where the
-            current content already differs. The systematic fix is a
-            kernel-side snapshot-on-write that publishes pre-write bytes to
-            a path-addressed namespace; that change belongs in rust/kernel,
-            not here.
+        Snapshots live at ``/__sys__/versioning/{sha256(path)}/{op_id}.bin`` —
+        published by the write observer's OBSERVE-stage hook when the write
+        that produced ``operation`` was committed. Both sides derive the path
+        from ``nexus.contracts.versioning_path`` so the convention is SSOT.
 
-            ``content_id`` is kept in the signature for the future migration
-            but is unused today.
+        Reads through ``sys_read_raw`` (§2.5 — service tier never touches CAS
+        by hash). The snapshot entry is metadata-only and points back at the
+        original ``content_id``, so this round-trip costs one path resolve plus
+        one CAS fetch — no byte copy at write time.
+
+        Raises ``RuntimeError`` if no kernel is wired; propagates the kernel's
+        ``NexusFileNotFoundError`` if the snapshot was never published (legacy
+        operation log entries from before the observer was wired, or paths the
+        observer skips).
         """
+        from nexus.contracts.versioning_path import versioning_snapshot_path
+
         _kernel = getattr(self._dlc, "_kernel", None) if self._dlc else None
         if _kernel is None:
-            raise RuntimeError(f"No kernel available for CAS read: {path}")
-        result: bytes = _kernel.sys_read_raw(path, "root")
+            raise RuntimeError(f"No kernel available for snapshot read: {operation.path}")
+        snap_path = versioning_snapshot_path(operation.path, operation.operation_id)
+        result: bytes = _kernel.sys_read_raw(snap_path, "root")
         return result

--- a/src/nexus/bricks/versioning/time_travel_service.py
+++ b/src/nexus/bricks/versioning/time_travel_service.py
@@ -16,7 +16,6 @@ References:
     - services/protocols/time_travel.py          (TimeTravelProtocol)
 """
 
-import hashlib
 import json
 from collections.abc import Callable
 from contextlib import suppress
@@ -27,24 +26,11 @@ from sqlalchemy.orm import Session
 
 from nexus.contracts.exceptions import NexusFileNotFoundError
 from nexus.contracts.types import OperationContext
+from nexus.contracts.versioning_path import versioning_snapshot_path
 from nexus.storage.models import FilePathModel, OperationLogModel
 
 if TYPE_CHECKING:
     from nexus.core.nexus_fs import NexusFS
-
-# §2.5 syscall surface for versioning snapshots. Pattern C migration: each
-# snapshot of a file's pre-write bytes lives at
-#   /__sys__/versioning/{path_hash}/{operation_id}.bin
-# path_hash is sha256 of the original virtual path (hex) to keep the
-# directory shape flat. New writes populate this namespace; legacy
-# hash-addressed snapshots (recorded before this migration) are
-# unreachable from the service tier — KERNEL-ARCHITECTURE.md §2.5.
-_VERSIONING_PATH_PREFIX = "/__sys__/versioning"
-
-
-def _versioning_path(virtual_path: str, operation_id: str) -> str:
-    path_hash = hashlib.sha256(virtual_path.encode("utf-8")).hexdigest()
-    return f"{_VERSIONING_PATH_PREFIX}/{path_hash}/{operation_id}.bin"
 
 
 class TimeTravelService:
@@ -98,7 +84,7 @@ class TimeTravelService:
                 f"Snapshot for {virtual_path} at operation {operation_id} unavailable: "
                 "no NexusFS handle"
             )
-        path = _versioning_path(virtual_path, operation_id)
+        path = versioning_snapshot_path(virtual_path, operation_id)
         sys_ctx = OperationContext(user_id="system", groups=[], is_system=True)
         try:
             # sys_read returns bytes when return_metadata is not set.

--- a/src/nexus/bricks/versioning/time_travel_service.py
+++ b/src/nexus/bricks/versioning/time_travel_service.py
@@ -63,21 +63,19 @@ class TimeTravelService:
     def _read_snapshot(self, virtual_path: str, operation_id: str) -> bytes:
         """Read a versioning snapshot through the §2.5 syscall surface.
 
-        Architectural gap (FOLLOW-UP — kernel-side snapshot syscall):
-            The service-tier write observer (storage/record_store_write_observer.py)
-            only records ``snapshot_hash = old_metadata.content_id`` — the
-            hash of the pre-write CAS bytes. It does **not** write a
-            path-addressed copy of those bytes anywhere. The kernel-internal
-            ObjectStore retains the bytes by hash, but service-tier code
-            cannot reach them by hash (§2.5). So this path
-              /__sys__/versioning/{path_hash}/{operation_id}.bin
-            is currently never populated by anyone, and every call to
-            _read_snapshot raises NexusFileNotFoundError. ``get_file_at_operation``
-            still works for the "live current bytes" branch (it uses
-            sys_read(path) for current_path); only historical snapshot reads
-            fail. The systematic fix is a kernel-side snapshot-on-write that
-            also publishes the pre-write bytes to this path namespace —
-            that change belongs in rust/kernel, not here.
+        Snapshots are published by the write observer
+        (``storage/record_store_write_observer.py``) immediately after each
+        write/delete that has prior content: a metadata-only entry at
+        ``/__sys__/versioning/{sha256(path)}/{operation_id}.bin`` whose
+        ``content_id`` references the same CAS object as the pre-write
+        bytes (no byte copy). ``sys_read`` of the snapshot path returns
+        those bytes.
+
+        Raises NexusFileNotFoundError when no snapshot exists for the op —
+        either because it predates the snapshot-on-write feature, or
+        because the write originated from a path that bypasses the
+        observer (e.g. internal /__sys__/ writes that the observer skips
+        to avoid recursion).
         """
         if self._nexus_fs is None:
             raise NexusFileNotFoundError(
@@ -91,11 +89,9 @@ class TimeTravelService:
             return cast(bytes, self._nexus_fs.sys_read(path, context=sys_ctx))
         except (FileNotFoundError, NexusFileNotFoundError) as exc:
             raise NexusFileNotFoundError(
-                f"Snapshot for {virtual_path} at operation {operation_id} not found at {path}. "
-                "Historical snapshot bytes are not yet service-reachable: the kernel "
-                "write observer records the hash but does not publish a path-addressed "
-                "copy. Live current-file reads still work; historical reads require a "
-                "kernel-side snapshot syscall (architectural follow-up — see §2.5)."
+                f"Snapshot for {virtual_path} at operation {operation_id} not found at "
+                f"{path}. The write observer may not have published a snapshot for this "
+                "op (legacy data, or an internal path the observer skips)."
             ) from exc
 
     # ------------------------------------------------------------------

--- a/src/nexus/contracts/versioning_path.py
+++ b/src/nexus/contracts/versioning_path.py
@@ -1,0 +1,32 @@
+"""Versioning history syscall-path convention (§2.5).
+
+Single source of truth for the path scheme that holds pre-write snapshots
+of file content. Used by:
+
+  - The write observer (``nexus.storage.record_store_write_observer``),
+    which publishes a metadata entry pointing at the OLD ``content_id``
+    after each overwrite/delete.
+  - ``TimeTravelService`` / ``OperationUndoService``
+    (``nexus.bricks.versioning.*``), which read the snapshot through
+    ``sys_read`` at the same path.
+
+Both sides MUST derive the path here so they agree (no shadow SSOT).
+"""
+
+import hashlib
+
+# Path namespace for versioning-history snapshots. Each snapshot is keyed by
+# (sha256-of-virtual-path, operation_id) — a hash-bucketed flat directory
+# layout keyed by the OperationLogModel.operation_id that produced the write.
+VERSIONING_PATH_PREFIX = "/__sys__/versioning"
+
+
+def versioning_snapshot_path(virtual_path: str, operation_id: str) -> str:
+    """Canonical syscall path for a pre-write snapshot of ``virtual_path``.
+
+    ``operation_id`` is the OperationLogModel.operation_id of the write that
+    overwrote/deleted the content — the same key TimeTravelService uses to
+    look up historical bytes.
+    """
+    path_hash = hashlib.sha256(virtual_path.encode("utf-8")).hexdigest()
+    return f"{VERSIONING_PATH_PREFIX}/{path_hash}/{operation_id}.bin"

--- a/src/nexus/factory/_lifecycle.py
+++ b/src/nexus/factory/_lifecycle.py
@@ -155,7 +155,11 @@ def _wire_services(
     # Services that need cleanup at close() register callbacks here.
     # Callbacks run BEFORE pillar
     # close (metadata_store, record_store) to ensure DB connections are still open.
+    # Write observer publishes /__sys__/versioning/ snapshot entries via
+    # sys_setattr, so it needs the kernel-tier NexusFS handle.
     _wo = _svc.get("write_observer")
+    if _wo is not None and hasattr(_wo, "attach_filesystem"):
+        _wo.attach_filesystem(nx)
     if _wo is not None and hasattr(_wo, "flush_sync"):
 
         def _close_write_observer() -> None:

--- a/src/nexus/storage/record_store_write_observer.py
+++ b/src/nexus/storage/record_store_write_observer.py
@@ -28,10 +28,13 @@ Issue #900: Replaced snapshot_hash/metadata_snapshot params with metadata.
 """
 
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from nexus.contracts.metadata import FileMetadata
 from nexus.storage.record_store import RecordStoreABC
+
+if TYPE_CHECKING:
+    from nexus.core.nexus_fs import NexusFS
 
 logger = logging.getLogger(__name__)
 
@@ -55,11 +58,25 @@ class RecordStoreWriteObserver:
     ) -> None:
         self._session_factory = record_store.session_factory
         self._strict_mode = strict_mode
+        # NexusFS handle for publishing versioning-history snapshot entries
+        # (`/__sys__/versioning/{path_hash}/{op_id}.bin` pointing at the OLD
+        # content_id). Attached post-kernel-boot — the observer is created
+        # in Tier 1 (pre-NexusFS) so the kernel can be wired with it.
+        self._nexus_fs: Any = None
 
         # Post-flush hooks: called after successful commit (Issue #2978)
         # Same interface as the OBSERVE-phase RecordStoreWriteObserver so the factory
         # can wire extraction hooks regardless of which observer is active.
         self._post_flush_hooks: list = []
+
+    def attach_filesystem(self, nexus_fs: "NexusFS") -> None:
+        """Attach the NexusFS handle once the kernel tier exists.
+
+        Enables versioning snapshot-on-write — see ``_snapshot_old_content``.
+        Without it, audit logging still works; only the snapshot publishing
+        is skipped (TimeTravelService historical reads degrade to NotFound).
+        """
+        self._nexus_fs = nexus_fs
 
     def register_post_flush_hook(self, hook: object) -> None:
         """Register a callback invoked after each successful write commit.

--- a/src/nexus/storage/record_store_write_observer.py
+++ b/src/nexus/storage/record_store_write_observer.py
@@ -78,6 +78,65 @@ class RecordStoreWriteObserver:
         """
         self._nexus_fs = nexus_fs
 
+    def _snapshot_old_content(
+        self,
+        operation_id: str,
+        path: str,
+        old_metadata: dict[str, Any] | None,
+    ) -> None:
+        """Publish a versioning snapshot pointing at the OLD content_id.
+
+        Creates a metadata-only entry at
+        ``/__sys__/versioning/{path_hash}/{operation_id}.bin`` whose
+        ``content_id`` references the same CAS object as the pre-write
+        content. No byte copy — CAS already holds the bytes; the entry
+        is both an access path for TimeTravelService and a GC root that
+        keeps the old object alive.
+
+        Best-effort: a failure here doesn't abort the write. The audit
+        log already carries snapshot_hash; only TimeTravelService /
+        OperationUndoService historical reads for THIS op_id degrade.
+
+        No-op when:
+            * NexusFS not yet attached (early boot)
+            * old_metadata is missing or has no content_id (new file)
+            * the write IS a snapshot publish (skip recursive cases)
+        """
+        if self._nexus_fs is None or old_metadata is None:
+            return
+        old_content_id = old_metadata.get("content_id")
+        if not old_content_id:
+            return
+        from nexus.contracts.versioning_path import (
+            VERSIONING_PATH_PREFIX,
+            versioning_snapshot_path,
+        )
+
+        if path.startswith(VERSIONING_PATH_PREFIX + "/"):
+            return
+
+        snap_path = versioning_snapshot_path(path, operation_id)
+        try:
+            from nexus.contracts.types import OperationContext
+
+            sys_ctx = OperationContext(user_id="system", groups=[], is_system=True)
+            self._nexus_fs.sys_setattr(
+                snap_path,
+                context=sys_ctx,
+                entry_type=0,
+                content_id=old_content_id,
+                size=int(old_metadata.get("size") or 0),
+                mime_type=old_metadata.get("mime_type"),
+                version=int(old_metadata.get("version") or 1),
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "Versioning snapshot for op %s on %s failed (best-effort): %s",
+                operation_id,
+                path,
+                exc,
+            )
+
     def register_post_flush_hook(self, hook: object) -> None:
         """Register a callback invoked after each successful write commit.
 
@@ -152,7 +211,7 @@ class RecordStoreWriteObserver:
         try:
             with self._session_factory() as session:
                 urn = self._build_urn(path, zone_id)
-                OperationLogger(session).log_operation(
+                operation_id = OperationLogger(session).log_operation(
                     operation_type="write",
                     path=path,
                     zone_id=zone_id,
@@ -166,6 +225,11 @@ class RecordStoreWriteObserver:
                 )
                 VersionRecorder(session).record_write(metadata, is_new=is_new)
                 session.commit()
+
+            # Versioning snapshot — published AFTER the audit row commits so
+            # a snapshot-write failure can't leave operation_log referencing
+            # a snapshot that does not exist.
+            self._snapshot_old_content(operation_id, path, old_metadata)
 
             # Post-flush hooks: extraction, lineage, etc. (Issue #2978, #3417)
             self._run_post_flush_hooks(
@@ -317,7 +381,7 @@ class RecordStoreWriteObserver:
         try:
             with self._session_factory() as session:
                 urn = self._build_urn(path, zone_id)
-                OperationLogger(session).log_operation(
+                operation_id = OperationLogger(session).log_operation(
                     operation_type="delete",
                     path=path,
                     zone_id=zone_id,
@@ -332,6 +396,11 @@ class RecordStoreWriteObserver:
                 VersionRecorder(session).record_delete(path)
                 AspectService(session).soft_delete_entity_aspects(urn)
                 session.commit()
+
+            # Versioning snapshot — captures the deleted content so
+            # OperationUndoService can restore it via sys_read of the
+            # snapshot path. ``metadata`` here IS the pre-delete metadata.
+            self._snapshot_old_content(operation_id, path, metadata)
         except Exception as e:
             self._handle_error("delete", path, e)
 

--- a/tests/unit/services/test_operation_undo_service.py
+++ b/tests/unit/services/test_operation_undo_service.py
@@ -45,8 +45,13 @@ def _make_service(
 
 
 def _op(op_type: str, **kwargs: object) -> SimpleNamespace:
-    """Build a fake OperationLogModel-like object."""
+    """Build a fake OperationLogModel-like object.
+
+    ``operation_id`` is required for snapshot lookups — _read_snapshot
+    derives the /__sys__/versioning/{sha256(path)}/{op_id}.bin path from it.
+    """
     defaults = {
+        "operation_id": "op-test-id",
         "operation_type": op_type,
         "path": "/workspace/test.txt",
         "new_path": None,

--- a/tests/unit/storage/test_record_store_write_observer.py
+++ b/tests/unit/storage/test_record_store_write_observer.py
@@ -510,3 +510,162 @@ class TestPostFlushHookSync:
         syncer.register_post_flush_hook(lambda events: calls.append("hook2"))
 
         assert len(syncer._post_flush_hooks) == 2
+
+
+# =========================================================================
+# Snapshot-on-write — publishes pre-write bytes to /__sys__/versioning/
+# =========================================================================
+
+
+class TestSnapshotOnWrite:
+    """The OBSERVE-stage write hook publishes a metadata-only snapshot entry
+    pointing at the pre-write content_id, so TimeTravelService /
+    OperationUndoService can read historical bytes by path.
+    """
+
+    def test_overwrite_publishes_snapshot_at_versioning_path(
+        self,
+        syncer: RecordStoreWriteObserver,
+        record_store: SQLAlchemyRecordStore,
+    ) -> None:
+        from nexus.contracts.versioning_path import versioning_snapshot_path
+
+        fake_fs = MagicMock()
+        syncer.attach_filesystem(fake_fs)
+
+        old_metadata = {
+            "content_id": "old-hash-v1",
+            "size": 11,
+            "mime_type": "text/plain",
+            "version": 1,
+        }
+        new_meta = _make_metadata("/doc.txt", content_id="new-hash-v2", version=2)
+        syncer.on_write(
+            new_meta,
+            is_new=False,
+            path="/doc.txt",
+            old_metadata=old_metadata,
+            zone_id=ROOT_ZONE_ID,
+        )
+
+        # Snapshot path uses the operation_id from the freshly logged op row.
+        with record_store.session_factory() as session:
+            op = session.query(OperationLogModel).filter(OperationLogModel.path == "/doc.txt").one()
+            expected_path = versioning_snapshot_path("/doc.txt", op.operation_id)
+
+        fake_fs.sys_setattr.assert_called_once()
+        call_args = fake_fs.sys_setattr.call_args
+        assert call_args.args[0] == expected_path
+        # Snapshot entry points at the OLD CAS content, not the new one.
+        assert call_args.kwargs["content_id"] == "old-hash-v1"
+        assert call_args.kwargs["size"] == 11
+        assert call_args.kwargs["version"] == 1
+
+    def test_new_file_does_not_publish_snapshot(
+        self,
+        syncer: RecordStoreWriteObserver,
+    ) -> None:
+        fake_fs = MagicMock()
+        syncer.attach_filesystem(fake_fs)
+
+        new_meta = _make_metadata("/fresh.txt", content_id="h1")
+        syncer.on_write(
+            new_meta,
+            is_new=True,
+            path="/fresh.txt",
+            old_metadata=None,
+            zone_id=ROOT_ZONE_ID,
+        )
+
+        fake_fs.sys_setattr.assert_not_called()
+
+    def test_write_under_versioning_prefix_is_not_self_snapshotted(
+        self,
+        syncer: RecordStoreWriteObserver,
+    ) -> None:
+        """Observer must skip writes under /__sys__/versioning/ to avoid recursion."""
+        fake_fs = MagicMock()
+        syncer.attach_filesystem(fake_fs)
+
+        old_metadata = {"content_id": "old-snap-hash", "size": 5, "version": 1}
+        snap_meta = _make_metadata(
+            "/__sys__/versioning/deadbeef/op123.bin", content_id="new-snap-hash"
+        )
+        syncer.on_write(
+            snap_meta,
+            is_new=False,
+            path="/__sys__/versioning/deadbeef/op123.bin",
+            old_metadata=old_metadata,
+            zone_id=ROOT_ZONE_ID,
+        )
+
+        fake_fs.sys_setattr.assert_not_called()
+
+    def test_delete_publishes_snapshot_of_doomed_content(
+        self,
+        syncer: RecordStoreWriteObserver,
+        record_store: SQLAlchemyRecordStore,
+    ) -> None:
+        from nexus.contracts.versioning_path import versioning_snapshot_path
+
+        # First create a file so on_delete sees it.
+        m = _make_metadata("/doomed.txt", content_id="doomed-hash")
+        syncer.on_write(m, is_new=True, path="/doomed.txt", zone_id=ROOT_ZONE_ID)
+
+        fake_fs = MagicMock()
+        syncer.attach_filesystem(fake_fs)
+
+        # Kernel passes the pre-delete metadata so the snapshot captures the
+        # doomed CAS content_id; without it, on_delete cannot publish anything.
+        pre_delete = {
+            "content_id": "doomed-hash",
+            "size": 7,
+            "mime_type": "text/plain",
+            "version": 1,
+        }
+        syncer.on_delete(path="/doomed.txt", metadata=pre_delete, zone_id=ROOT_ZONE_ID)
+
+        with record_store.session_factory() as session:
+            del_op = (
+                session.query(OperationLogModel)
+                .filter(
+                    OperationLogModel.path == "/doomed.txt",
+                    OperationLogModel.operation_type == "delete",
+                )
+                .one()
+            )
+            expected_path = versioning_snapshot_path("/doomed.txt", del_op.operation_id)
+
+        fake_fs.sys_setattr.assert_called_once()
+        call_args = fake_fs.sys_setattr.call_args
+        assert call_args.args[0] == expected_path
+        assert call_args.kwargs["content_id"] == "doomed-hash"
+
+    def test_snapshot_publish_failure_does_not_break_write(
+        self,
+        syncer: RecordStoreWriteObserver,
+        record_store: SQLAlchemyRecordStore,
+    ) -> None:
+        """sys_setattr failure is best-effort — the audit row still commits."""
+        fake_fs = MagicMock()
+        fake_fs.sys_setattr.side_effect = RuntimeError("kernel down")
+        syncer.attach_filesystem(fake_fs)
+
+        old_metadata = {"content_id": "old-hash", "size": 3, "version": 1}
+        new_meta = _make_metadata("/best-effort.txt", content_id="new-hash", version=2)
+        # Should not raise.
+        syncer.on_write(
+            new_meta,
+            is_new=False,
+            path="/best-effort.txt",
+            old_metadata=old_metadata,
+            zone_id=ROOT_ZONE_ID,
+        )
+
+        with record_store.session_factory() as session:
+            ops = (
+                session.query(OperationLogModel)
+                .filter(OperationLogModel.path == "/best-effort.txt")
+                .all()
+            )
+            assert len(ops) == 1


### PR DESCRIPTION
## Summary

Closes the architectural gap noted as #4175 follow-up item #2: TimeTravelService and OperationUndoService previously could not read historical bytes because nothing published pre-write snapshots at the path they expected. This PR wires the service-tier write observer to publish those snapshots (no kernel ABI change, per the principle that service features should not bend the kernel ABI).

- **SSOT for the snapshot-path scheme** (`src/nexus/contracts/versioning_path.py`): one module both the observer (writer) and TimeTravelService/OperationUndoService (readers) import — no shadow convention.
- **`RecordStoreWriteObserver.attach_filesystem(nx)` + `_snapshot_old_content`**: after each `on_write` / `on_delete` commits the audit row, publish a metadata-only entry at `/__sys__/versioning/{sha256(path)}/{op_id}.bin` whose `content_id` references the OLD CAS object. No byte copy at write time — the snapshot entry shares the existing CAS object and doubles as a GC root.
- **Consumers read through the syscall**: `TimeTravelService._read_snapshot` and `OperationUndoService._read_snapshot(operation)` now `sys_read_raw` the snapshot path. The undo change is a real bug fix — the old `_read_content_from_cas(path, content_id)` returned `sys_read_raw(path)` (LIVE bytes), which was wrong for undo-after-write where current bytes already differ from what we want to restore.
- **Re-entrancy guard**: `sys_setattr` is not on `SyncAuditWriteInterceptor.hook_spec` (only write/write_batch/delete/rename/mkdir/rmdir hooks), so observer-issued `sys_setattr` can't re-trigger `on_write`. Belt-and-suspenders: observer also skips paths under `/__sys__/versioning/`.
- **Best-effort failure mode**: snapshot publish runs AFTER the audit row commits, so a snapshot failure cannot leave the operation log referencing a snapshot that does not exist.
- **+1 unrelated tiny CI fix** carried in the same branch: `check_kernel_leak.py` now compares the path as POSIX on Windows too (Issue #4175 follow-up #3 — see `7d52fc503` original commit).

`on_write_batch` is intentionally not modified: the kernel batch context lacks per-item `old_metadata`, which is an upstream limitation to fix in the batch hook contract — out of scope for this PR.

Item #1 from the #4175 follow-up list (native Rust recursive `sys_readdir` + removing `metastore_list_paginated` from the public surface) is still open and tracked in memory.

## Commits

1. `fix(ci): check_kernel_leak skips test files on Windows too` — pre-existing #4175 follow-up #3.
2. `refactor(contracts): hoist versioning snapshot path scheme to a shared module` — SSOT split.
3. `refactor(write-observer): accept NexusFS via post-boot attach` — wiring scaffold only.
4. `feat(versioning): snapshot-on-write publishes /__sys__/versioning/ entries` — observer change.
5. `feat(versioning): consumers read pre-write bytes from snapshot path` — TimeTravelService docstring + OperationUndoService bug fix.
6. `test(write-observer): cover snapshot-on-write hook` — 5 unit tests covering overwrite, fresh-write, recursion-guard, delete, and best-effort failure modes.

## Test plan

- [x] `tests/unit/storage/test_record_store_write_observer.py` — all 25 tests pass (5 new + 20 pre-existing).
- [ ] `tests/integration/storage/test_time_travel.py` — `test_time_travel_read_file_history`, `test_time_travel_file_deleted`, `test_time_travel_diff_operations` etc. should now pass end-to-end where they previously could not read the snapshot (verify on CI — local Windows blocked by missing nexusd-cluster binary).
- [ ] CI green, including kernel + raft Rust tests (we touch no Rust code).
- [ ] No regression in `tests/integration/storage/test_piped_write_observer_flush.py`.