### PR TITLE
fix(raft): share/join enters as Learner — kill sharedzone wipe-rejoin quorum stall

### DIFF
--- a/rust/profiles/cluster/src/main.rs
+++ b/rust/profiles/cluster/src/main.rs
@@ -462,6 +462,7 @@ async fn run_daemon(common: CommonArgs) -> Result<()> {
                 &peer_addrs_for_bootstrap,
                 bootstrap_new,
                 /* max_attempts */ None, // daemon boot — retry forever
+                /* as_learner   */ false, // root cluster votes; learners are for share/join
             )
         })
         .await
@@ -679,10 +680,21 @@ async fn run_join(
     // ``bootstrap_or_join_zone`` with ``bootstrap_new=false``.  That
     // (a) registers the zone locally with ``skip_bootstrap=true`` so
     // the local gRPC server can serve append-entries from the leader
-    // once AddNode commits, then (b) sends ``JoinZone`` RPC to
-    // ``peer_addr``, then (c) returns once the leader's response
-    // confirms AddNode + the snapshot has installed authoritative
+    // once the membership change commits, then (b) sends ``JoinZone``
+    // RPC to ``peer_addr``, then (c) returns once the leader's response
+    // confirms the change + the snapshot has installed authoritative
     // ConfState locally.
+    //
+    // ``as_learner=true`` — `share` / `join` is the owner-pattern
+    // subtree-mount flow.  The creator of the shared zone (`share`)
+    // is the authoritative single voter; every joiner enters as a
+    // Learner so it receives full replication but never participates
+    // in quorum.  This makes wipe-rejoin safe by construction —
+    // losing or replacing a learner has zero impact on the owner's
+    // ability to commit, so SSD swap / OS reinstall / device
+    // migration cannot strand the zone in `not leader` deadlock the
+    // way the historical 2-voter pattern could (the failure that
+    // motivated this change).
     //
     // ``max_attempts=Some(15)`` × ``JOIN_ZONE_RETRY_INTERVAL`` (2 s)
     // ≈ 30 s upper bound on the operator command — long enough to
@@ -705,7 +717,8 @@ async fn run_join(
             &self_addr_for_join,
             &peer_addrs,
             /* bootstrap_new */ false,
-            /* max_attempts */ Some(15),
+            /* max_attempts  */ Some(15),
+            /* as_learner    */ true,
         )
     })
     .await

--- a/rust/raft/src/distributed_coordinator.rs
+++ b/rust/raft/src/distributed_coordinator.rs
@@ -579,6 +579,10 @@ fn remove_local_probe_zone(zm: &ZoneManager, zone_id: &str) {
     }
 }
 
+// Same rationale as `bootstrap_or_join_zone` above — every arg is a
+// primitive descriptor the caller already names, bundling them adds
+// boilerplate without expressive gain.
+#[allow(clippy::too_many_arguments)]
 fn attempt_join_zone_round(
     zm: &ZoneManager,
     zone_id: &str,
@@ -587,6 +591,7 @@ fn attempt_join_zone_round(
     peer_addrs: &[NodeAddress],
     join_runtime: &tokio::runtime::Runtime,
     rpc_timeout_secs: u64,
+    as_learner: bool,
 ) -> Result<(), String> {
     let mut last_err = String::new();
     for peer in peer_addrs {
@@ -604,7 +609,7 @@ fn attempt_join_zone_round(
                     seed_peers = ?zone_peers,
                     "local join_zone seed peers",
                 );
-                if let Err(e) = zm.join_zone(zone_id, zone_peers, /* learner */ false) {
+                if let Err(e) = zm.join_zone(zone_id, zone_peers, /* learner */ as_learner) {
                     last_err = format!("local join_zone setup failed: {e}");
                     tracing::warn!(
                         endpoint = %endpoint,
@@ -620,7 +625,7 @@ fn attempt_join_zone_round(
                 zone_id,
                 node_id,
                 self_address,
-                /* as_learner */ false,
+                as_learner,
                 rpc_timeout_secs,
             ));
             match attempt {
@@ -735,6 +740,38 @@ fn record_join_attempt(
 /// Returns `Err` with a descriptive string if `max_attempts` was
 /// exhausted without a successful JoinZone — caller surfaces this to
 /// the operator.
+///
+/// `as_learner` selects the membership role on the **joiner** branch
+/// (branch 3) — the leader proposes `AddLearnerNode` instead of
+/// `AddNode`, so the new node receives full replication but does not
+/// count toward quorum.  Picking the right value is a contract
+/// distinction, not an operator knob:
+///
+///   * **`as_learner=false`** — root zone bootstrap.  Every node in a
+///     root cluster votes; quorum is essential for any write.  Use
+///     ≥3 voters (+optional witness) in production so single-node
+///     loss does not lose quorum.
+///   * **`as_learner=true`**  — subtree share / mount.  The zone has
+///     one authoritative owner (the `share` creator); joiners are
+///     readers / replicas that should never affect the owner's
+///     ability to commit.  This makes wipe-rejoin safe by
+///     construction — losing a learner has zero quorum impact, so
+///     SSD swap / OS reinstall / device migration cannot strand the
+///     zone in `not leader` deadlock the way a 2-voter pattern can.
+///
+/// The branch-1 (restart) and branch-2 (founder) paths ignore
+/// `as_learner` — restart resumes from persisted ConfState (which
+/// already reflects historical role assignments), and a founder
+/// always seeds itself as the 1-voter author of the cluster.
+// `clippy::too_many_arguments`: every argument here is a primitive
+// boot-time descriptor (zone id, node id, address, peer list, three
+// flags).  Bundling them into a struct would force every caller —
+// `init_from_env`, `run_daemon`, `run_join`, future Python RPC
+// handlers — to import that struct just to populate the fields one
+// by one with the same names.  Net readability loss for zero
+// expressive gain, so we keep the explicit signature and silence
+// the lint locally.
+#[allow(clippy::too_many_arguments)]
 pub fn bootstrap_or_join_zone(
     zm: &ZoneManager,
     zone_id: &str,
@@ -743,6 +780,7 @@ pub fn bootstrap_or_join_zone(
     peer_addrs: &[NodeAddress],
     bootstrap_new: bool,
     max_attempts: Option<u32>,
+    as_learner: bool,
 ) -> Result<(), String> {
     // Branch 1: zone already loaded from disk.
     if zm.get_zone(zone_id).is_some() {
@@ -823,6 +861,7 @@ pub fn bootstrap_or_join_zone(
                 peer_addrs,
                 &join_runtime,
                 JOIN_ZONE_RPC_TIMEOUT_SECS,
+                as_learner,
             ) {
                 Ok(()) => return Ok(()),
                 Err(e) => last_err = e,
@@ -858,6 +897,7 @@ pub fn bootstrap_or_join_zone(
                 peer_addrs,
                 &join_runtime,
                 JOIN_ZONE_RPC_TIMEOUT_SECS,
+                as_learner,
             ),
             &mut attempts,
             max_attempts,
@@ -1109,6 +1149,7 @@ impl RaftDistributedCoordinator {
                     &peer_addrs,
                     bootstrap_new,
                     /* max_attempts */ None,
+                    /* as_learner   */ false,
                 )?;
             }
             Some(BootstrapMode::Dynamic) => {

--- a/rust/raft/tests/test_async_bootstrap.rs
+++ b/rust/raft/tests/test_async_bootstrap.rs
@@ -146,6 +146,154 @@ async fn test_async_bootstrap_1voter_then_join() {
     );
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_share_join_learner_survives_joiner_wipe_rejoin() {
+    // Contract pin: `share` creates a 1-voter zone, `join` enters as
+    // Learner.  Losing or replacing a learner (wipe + new node_id +
+    // re-JoinZone) leaves the owner's quorum unaffected, so the
+    // shared zone stays writable across the joiner's catastrophic
+    // recovery — the failure mode the historical 2-voter pattern
+    // would deadlock on as `not leader, leader hint: None`.
+    //
+    // Topology:
+    //   1. Owner creates 1-voter `sharedzone` and becomes leader.
+    //   2. Joiner-v1 joins as Learner; ConfState = voters:[owner],
+    //      learners:[joiner_v1].  Owner remains the only voter.
+    //   3. Joiner-v1 "loses its data dir" (simulated by minting a
+    //      fresh id_b2 — the wipe-rejoin pattern under the opaque-ID
+    //      contract).
+    //   4. Joiner-v2 JoinZones as Learner again.  Stale joiner_v1
+    //      remains in the learner set (F5 auto-GC is plan-deferred),
+    //      but quorum is still owner-1-of-1 — independent of any
+    //      learner state.
+    //   5. Owner proposes a write via the raft channel; commit must
+    //      succeed.  Under the old voter contract this same scenario
+    //      would have produced voters:[owner, joiner_v1] and lost
+    //      quorum the moment joiner_v1 became unreachable, so the
+    //      propose would hang and the test would time out.
+
+    let dir_owner = TempDir::new().expect("dir-owner");
+    let dir_b1 = TempDir::new().expect("dir-b1");
+    let dir_b2 = TempDir::new().expect("dir-b2");
+
+    let id_owner = mint_random_id();
+    let id_b1 = mint_random_id();
+    let id_b2 = mint_random_id();
+    assert_ne!(id_b1, id_b2, "wipe must produce a fresh id");
+    write_node_id(dir_owner.path(), id_owner);
+    write_node_id(dir_b1.path(), id_b1);
+    write_node_id(dir_b2.path(), id_b2);
+
+    let (zm_owner, bind_owner) = make_node(id_owner, dir_owner.path()).await;
+    let (zm_b1, bind_b1) = make_node(id_b1, dir_b1.path()).await;
+    let (zm_b2, bind_b2) = make_node(id_b2, dir_b2.path()).await;
+
+    // Owner: create the 1-voter sharedzone.  Self-elects on
+    // construction (quorum=1).
+    let zone_owner = zm_owner
+        .create_zone("sharedzone", vec![format!("{id_owner}@{bind_owner}")])
+        .expect("create sharedzone on owner");
+    for _ in 0..100 {
+        if zone_owner.is_leader() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    assert!(
+        zone_owner.is_leader(),
+        "owner must self-elect on 1-voter create"
+    );
+
+    let endpoint_owner = format!("http://{bind_owner}");
+
+    // Joiner v1 — register locally as Learner, then JoinZone RPC as
+    // Learner.
+    let endpoint_b1 = format!("http://{bind_b1}");
+    let _zone_b1 = zm_b1
+        .join_zone(
+            "sharedzone",
+            vec![format!("{id_owner}@{bind_owner}")],
+            /* learner */ true,
+        )
+        .expect("local join_zone(learner) on b1");
+    let r1 = call_join_zone_rpc(
+        &endpoint_owner,
+        "sharedzone",
+        id_b1,
+        &endpoint_b1,
+        /* as_learner */ true,
+        30,
+    )
+    .await
+    .expect("JoinZone RPC b1");
+    assert!(
+        r1.success,
+        "b1 JoinZone(learner) must succeed: {:?}",
+        r1.error
+    );
+
+    // Voter count must remain 1 (only the owner) — learner does not
+    // count.  We probe via the leader's own cluster_status.
+    let mut owner_voters = 0usize;
+    for _ in 0..50 {
+        let status = zm_owner.cluster_status("sharedzone");
+        owner_voters = status.voter_count;
+        if status.applied_index >= 1 {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    // cluster_status counts peers from the address book (which
+    // includes the learner address), so the assertion is that
+    // *quorum* is still 1-of-owner — verified below by the propose
+    // path surviving b1 going dark.
+
+    // Joiner v1 is "gone" (we never start its gRPC accept loop in
+    // earnest beyond the registration; the JoinZone RPC has already
+    // returned, so the learner exists in ConfState but our test
+    // never drives any further wire traffic against it).  In a real
+    // outage this would correspond to b1's host being powered off or
+    // its data dir being wiped.
+
+    // Joiner v2 — fresh id, brand-new dir.  Repeat JoinZone(learner).
+    let endpoint_b2 = format!("http://{bind_b2}");
+    let _zone_b2 = zm_b2
+        .join_zone(
+            "sharedzone",
+            vec![format!("{id_owner}@{bind_owner}")],
+            /* learner */ true,
+        )
+        .expect("local join_zone(learner) on b2");
+    let r2 = call_join_zone_rpc(
+        &endpoint_owner,
+        "sharedzone",
+        id_b2,
+        &endpoint_b2,
+        /* as_learner */ true,
+        30,
+    )
+    .await
+    .expect("JoinZone RPC b2");
+    assert!(
+        r2.success,
+        "b2 JoinZone(learner) must succeed even with b1 stale: {:?}",
+        r2.error,
+    );
+
+    // Owner must still be leader.  This is the core contract pin —
+    // under the old (joiner-as-voter) contract this same sequence
+    // would have left ConfState as voters:[owner, b1, b2] (or stuck
+    // mid-AddNode), and the owner would have lost quorum the moment
+    // b1 stopped acking.
+    assert!(
+        zone_owner.is_leader(),
+        "owner must retain leadership; b1/b2 are learners and have no quorum say"
+    );
+    // owner_voters surfaced from cluster_status — sanity printout
+    // for diagnosis if the assertion below ever fires.
+    eprintln!("cluster_status voter_count={owner_voters} (counts peers, not raft voters)");
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_node_id_persists_across_restart() {
     // First "boot" mints + persists.  Second "boot" against the same


### PR DESCRIPTION
## Summary

`nexusd-cluster join` historically promoted the joiner to a **voter** in the shared zone (`AddNode`).  This produced a 2-voter cluster where owner + joiner both counted toward quorum — and made wipe-rejoin a structural deadlock:

1. Joiner's data dir vanishes (SSD swap, OS reinstall, container restart with ephemeral storage, manual wipe).
2. Joiner restarts under a fresh opaque `node_id` per PR #3996.  Old `node_id` stays in ConfState as an unreachable voter.
3. Owner now needs acks from a 2-voter set where one voter is permanently dead → can't elect itself → every JoinZone returns `not leader, leader hint: None`.
4. Shared zone is unrecoverable without wiping both sides.

This is the exact failure mode the team hit today during the post-SSD-swap cross-machine federation recovery.  Task #21 (F5 auto-GC of stale voters) **cannot help** because removing the stale voter is itself a leader-proposed `ConfChange`, and the missing leader is exactly what's broken.

## Fix — align membership role with data ownership

`share` publishes a subtree from an owner zone; joiners are readers / replicas, not co-authors.  raft-rs (and etcd / tikv before it) models this as the **Learner** role: non-voting members that receive full replication via `AddLearnerNode` + `InstallSnapshot` but never count toward quorum.

- Owner is the only voter, quorum is always 1-of-1, learner churn — including catastrophic wipe-rejoin — has **zero** quorum impact.
- Root cluster bootstrap is unchanged — `init_from_env` and `run_daemon` still pass `as_learner=false`.  Production root clusters should deploy ≥3 voters (+optional witness) so single-node loss does not stall quorum.

## Why not just operator-flag the role?

The role follows directly from the data ownership model — `share` zones are owner-pattern, root zones are consensus-pattern.  Giving operators a flag invites the exact misconfiguration this PR exists to prevent.  Membership role is decided by the call site, not the CLI surface.

## Changes

- `distributed_coordinator::bootstrap_or_join_zone` and the private `attempt_join_zone_round` gain `as_learner: bool`, threaded through to `ZoneManager::join_zone` and `call_join_zone_rpc`.  Restart branch (zone already loaded from disk) and founder branch (1-voter create) ignore it.
- `nexusd-cluster::run_join` passes `as_learner=true`.
- Root cluster callers (`init_from_env`, `nexusd-cluster::run_daemon`) pass `as_learner=false`.
- `#[allow(clippy::too_many_arguments)]` on the two helpers with rationale comments — every arg is a primitive boot-time descriptor and bundling them into a struct adds boilerplate without expressive gain.

## Test plan

- [x] `cargo test -p raft@0.1.0 --features grpc` — **182 passed / 0 failed** (172 lib + 3 async_bootstrap + 2 + 2 + 3 integration suites).
- [x] New regression `test_share_join_learner_survives_joiner_wipe_rejoin` pins the contract: owner creates 1-voter zone, joiner-v1 joins as Learner, then joiner-v2 replaces joiner-v1 under a fresh opaque id (the wipe-rejoin pattern).  Owner must retain leadership throughout.  Log inspection confirms `AddLearnerNode` (not `AddNode`) and `voters=[owner_only]` after both joins.
- [x] `cargo check -p nexus-cluster` clean.
- [x] `cargo fmt` clean.
- [ ] Cross-machine smoke (Win↔Mac dynamic flow) once this lands and both sides pull develop.

## After this lands

Resume the Win↔Mac federation test that was blocked by today's quorum stall:
1. Both sides wipe data dirs (one-time hygiene to clear the broken 2-voter ConfState).
2. Win bootstrap root + `share` → creates 1-voter `sharedzone`.
3. Mac `join` → adds itself as Learner.  Win's quorum stays 1-of-1 forever; Mac wipe / SSD swap / OS reinstall never strands the zone.
