### PR TITLE
[codex] build(search): add section-aware grep

### DIFF
--- a/docs/surface-coverage/api-rpc-surface-coverage.yaml
+++ b/docs/surface-coverage/api-rpc-surface-coverage.yaml
@@ -5332,7 +5332,7 @@ operations:
   transports:
     grpc_expose:
       name: initialize_semantic_search
-      source: src/nexus/bricks/search/search_service.py:4492
+      source: src/nexus/bricks/search/search_service.py:4746
   profiles:
     lite: supported
     sandbox: supported
@@ -8390,7 +8390,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/expand
-      source: src/nexus/server/api/v2/routers/search.py:1340
+      source: src/nexus/server/api/v2/routers/search.py:1380
   profiles:
     lite: supported
     sandbox: supported
@@ -8414,7 +8414,7 @@ operations:
       source: src/nexus/bricks/search/search_service.py:1782
     http:
       name: POST /api/v2/search/glob
-      source: src/nexus/server/api/v2/routers/search.py:1221
+      source: src/nexus/server/api/v2/routers/search.py:1261
     mcp:
       name: nexus_glob
       source: src/nexus/config/tool_profiles.yaml:1
@@ -8441,7 +8441,7 @@ operations:
       source: src/nexus/bricks/search/search_service.py:2092
     http:
       name: POST /api/v2/search/grep
-      source: src/nexus/server/api/v2/routers/search.py:1100
+      source: src/nexus/server/api/v2/routers/search.py:1138
     mcp:
       name: nexus_grep
       source: src/nexus/config/tool_profiles.yaml:1
@@ -8494,7 +8494,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/index
-      source: src/nexus/server/api/v2/routers/search.py:1283
+      source: src/nexus/server/api/v2/routers/search.py:1323
   profiles:
     lite: supported
     sandbox: supported
@@ -8512,7 +8512,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/index-directory
-      source: src/nexus/server/api/v2/routers/search.py:1482
+      source: src/nexus/server/api/v2/routers/search.py:1522
   profiles:
     lite: supported
     sandbox: supported
@@ -8529,7 +8529,7 @@ operations:
   transports:
     http:
       name: GET /api/v2/search/indexed-dirs
-      source: src/nexus/server/api/v2/routers/search.py:1700
+      source: src/nexus/server/api/v2/routers/search.py:1740
   profiles:
     lite: supported
     sandbox: supported
@@ -8546,7 +8546,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/indexing-mode
-      source: src/nexus/server/api/v2/routers/search.py:1737
+      source: src/nexus/server/api/v2/routers/search.py:1777
   profiles:
     lite: supported
     sandbox: supported
@@ -8563,7 +8563,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/locate
-      source: src/nexus/server/api/v2/routers/search.py:1918
+      source: src/nexus/server/api/v2/routers/search.py:1958
   profiles:
     lite: supported
     sandbox: supported
@@ -8580,7 +8580,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/purge-unscoped
-      source: src/nexus/server/api/v2/routers/search.py:1864
+      source: src/nexus/server/api/v2/routers/search.py:1904
   profiles:
     lite: supported
     sandbox: supported
@@ -8633,7 +8633,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/refresh
-      source: src/nexus/server/api/v2/routers/search.py:1319
+      source: src/nexus/server/api/v2/routers/search.py:1359
   profiles:
     lite: supported
     sandbox: supported
@@ -8890,7 +8890,7 @@ operations:
   transports:
     grpc_expose:
       name: semantic_search
-      source: src/nexus/bricks/search/search_service.py:4085
+      source: src/nexus/bricks/search/search_service.py:4339
     mcp:
       name: nexus_semantic_search
       source: src/nexus/config/tool_profiles.yaml:1
@@ -8911,7 +8911,7 @@ operations:
   transports:
     grpc_expose:
       name: semantic_search_index
-      source: src/nexus/bricks/search/search_service.py:4407
+      source: src/nexus/bricks/search/search_service.py:4661
   profiles:
     lite: supported
     sandbox: supported
@@ -8928,7 +8928,7 @@ operations:
   transports:
     grpc_expose:
       name: semantic_search_stats
-      source: src/nexus/bricks/search/search_service.py:4444
+      source: src/nexus/bricks/search/search_service.py:4698
   profiles:
     lite: supported
     sandbox: supported

--- a/src/nexus/bricks/mcp/server.py
+++ b/src/nexus/bricks/mcp/server.py
@@ -1171,6 +1171,7 @@ async def create_mcp_server(
         after_context: int = 0,
         invert_match: bool = False,
         block_type: str | None = None,
+        section: str | None = None,
         ctx: Context | None = None,
     ) -> str:
         """Search file contents using regex pattern with pagination.
@@ -1199,6 +1200,10 @@ async def create_mcp_server(
                 ``"frontmatter"``, ``"paragraph"``, ``"blockquote"``,
                 ``"list"``, ``"heading"``. Non-markdown files pass
                 through unfiltered. Omit for default full-file search.
+            section: Restrict matches to a markdown or parsed-content
+                section heading (#4186), e.g. ``"API"`` or ``"## API"``.
+                Missing sections return an empty result envelope rather
+                than falling back to whole-file search.
 
         Returns:
             Formatted string with paginated search results containing:
@@ -1267,6 +1272,8 @@ async def create_mcp_server(
             grep_kwargs["invert_match"] = True
         if block_type is not None:
             grep_kwargs["block_type"] = block_type
+        if section is not None:
+            grep_kwargs["section"] = section
 
         # SearchService.grep() is async in local mode but the
         # RemoteServiceProxy returns a sync result. Handle both.
@@ -1328,6 +1335,9 @@ async def create_mcp_server(
         }
         if multi_zone_ambiguous:
             extras["multi_zone_ambiguous"] = True
+        if section is not None:
+            extras["section_filter"] = section
+            extras["section_status"] = "matched" if post_filter_count else "no_matches"
 
         result = build_paginated_list_response(
             items=paginated_results,

--- a/src/nexus/bricks/search/search_service.py
+++ b/src/nexus/bricks/search/search_service.py
@@ -2104,6 +2104,7 @@ class SearchService:
         invert_match: bool = False,
         files: builtins.list[str] | None = None,
         block_type: str | None = None,
+        section: str | None = None,
     ) -> builtins.list[dict[str, Any]]:
         """Public grep entry point with activity-event instrumentation (#3791).
 
@@ -2133,6 +2134,7 @@ class SearchService:
                 invert_match=invert_match,
                 files=files,
                 block_type=block_type,
+                section=section,
             )
         except Exception:
             emit(
@@ -2167,6 +2169,7 @@ class SearchService:
         invert_match: bool = False,
         files: builtins.list[str] | None = None,
         block_type: str | None = None,
+        section: str | None = None,
     ) -> builtins.list[dict[str, Any]]:
         r"""Search file contents using regex patterns.
 
@@ -2197,6 +2200,11 @@ class SearchService:
                 ``"table"``, ``"frontmatter"``.  Non-markdown files
                 (or markdown files without ``md_structure`` metadata)
                 pass through unfiltered.
+            section: #4186: optional markdown/parsed-content section
+                filter. Matches may be specified as heading text
+                (``"API"``) or a markdown heading (``"## API"``).
+                Files without ``md_structure`` metadata fail closed so
+                grep never falls back to whole-file results.
         """
         if path and path != "/":
             path = self._validate_path(path)
@@ -2207,6 +2215,8 @@ class SearchService:
                 f"Invalid block_type {block_type!r}. "
                 f"Valid values: {', '.join(sorted(VALID_BLOCK_TYPES))}"
             )
+        if section is not None and not section.strip():
+            raise ValueError("section must be a non-empty string")
 
         flags = re.IGNORECASE if ignore_case else 0
         try:
@@ -2214,11 +2224,13 @@ class SearchService:
         except re.error as e:
             raise ValueError(f"Invalid regex pattern: {e}") from e
 
-        # Issue #3720: over-fetch when block_type filtering will discard
-        # some matches.  The original max_results is restored after
-        # post-filtering so callers see the expected result count.
+        structural_filter = block_type is not None or section is not None
+
+        # Issue #3720/#4186: over-fetch when structural filtering will
+        # discard some matches.  The original max_results is restored
+        # after post-filtering so callers see the expected result count.
         original_max_results = max_results
-        if block_type is not None:
+        if structural_filter:
             max_results = min(
                 max_results * _BLOCK_TYPE_OVERFETCH_FACTOR,
                 max(max_results, _BLOCK_TYPE_OVERFETCH_CAP),
@@ -2292,11 +2304,11 @@ class SearchService:
         # threshold lives in ``FILES_FILTER_TRIGRAM_THRESHOLD`` and is
         # benchmark-backed.
         zone_id, _, _ = self._get_routing_params(context)
-        if block_type is not None:
-            # Issue #3720 (Codex R2+R5): block_type MUST use SEQUENTIAL
+        if structural_filter:
+            # Issue #3720/#4186: structural filters MUST use SEQUENTIAL
             # to ensure ALL files (cached + uncached) are searched.
             # CACHED_TEXT skips files_needing_raw; TRIGRAM/ZOEKT return
-            # a fixed page that may miss qualifying block matches.
+            # a fixed page that may miss qualifying structural matches.
             strategy = SearchStrategy.SEQUENTIAL
         elif needs_python_path:
             # Force a Python-loop strategy so context/invert flags take
@@ -2378,11 +2390,14 @@ class SearchService:
                     trigram_results = [
                         r for r in trigram_results if r.get("file") in _files_filter_set
                     ][:max_results]
-                # Issue #3720: apply block_type post-filter before returning.
+                # Issue #3720/#4186: apply structural post-filters before returning.
+                if section is not None:
+                    trigram_results = self._filter_results_by_section(trigram_results, section)
                 if block_type is not None:
                     trigram_results = self._filter_results_by_block_type(
                         trigram_results, block_type
                     )
+                if structural_filter:
                     return trigram_results[:original_max_results]
                 return trigram_results
             strategy = SearchStrategy.RUST_BULK  # Fallback
@@ -2398,9 +2413,12 @@ class SearchService:
                 context=context,
             )
             if zoekt_results is not None:
-                # Issue #3720: apply block_type post-filter before returning.
+                # Issue #3720/#4186: apply structural post-filters before returning.
+                if section is not None:
+                    zoekt_results = self._filter_results_by_section(zoekt_results, section)
                 if block_type is not None:
                     zoekt_results = self._filter_results_by_block_type(zoekt_results, block_type)
+                if structural_filter:
                     return zoekt_results[:original_max_results]
                 return zoekt_results
             strategy = SearchStrategy.RUST_BULK
@@ -2411,25 +2429,45 @@ class SearchService:
                 if len(results) >= max_results:
                     break
                 lines = text.splitlines()
-                results.extend(
-                    self._grep_lines(
-                        regex=regex,
-                        lines=lines,
-                        file_path=file_path,
-                        before_context=before_context,
-                        after_context=after_context,
-                        invert_match=invert_match,
-                        max_results=max_results - len(results),
+                if section is not None:
+                    section_info = self._section_range_and_meta(file_path, section)
+                    if section_info is None:
+                        continue
+                    range_start, range_end, section_meta = section_info
+                    results.extend(
+                        self._grep_lines_in_section(
+                            regex=regex,
+                            lines=lines,
+                            file_path=file_path,
+                            range_start=range_start,
+                            range_end=range_end,
+                            section_meta=section_meta,
+                            before_context=before_context,
+                            after_context=after_context,
+                            invert_match=invert_match,
+                            max_results=max_results - len(results),
+                        )
                     )
-                )
+                else:
+                    results.extend(
+                        self._grep_lines(
+                            regex=regex,
+                            lines=lines,
+                            file_path=file_path,
+                            before_context=before_context,
+                            after_context=after_context,
+                            invert_match=invert_match,
+                            max_results=max_results - len(results),
+                        )
+                    )
             if (
                 strategy == SearchStrategy.CACHED_TEXT
-                and block_type is None
+                and not structural_filter
                 and len(results) >= max_results
             ):
                 return results[:max_results]
 
-        if block_type is None and len(results) >= max_results:
+        if not structural_filter and len(results) >= max_results:
             return results[:max_results]
 
         # Process remaining files needing raw content
@@ -2458,13 +2496,17 @@ class SearchService:
                         before_context=before_context,
                         after_context=after_context,
                         invert_match=invert_match,
-                        force_python_path=needs_python_path,
+                        force_python_path=needs_python_path or structural_filter,
+                        section=section,
                     )
                 )
 
-        # Issue #3720: post-filter by block_type when requested.
+        # Issue #4186/#3720: post-filter by section/block_type when requested.
+        if section is not None:
+            results = self._filter_results_by_section(results, section)
         if block_type is not None:
             results = self._filter_results_by_block_type(results, block_type)
+        if structural_filter:
             max_results = original_max_results
 
         return results[:max_results]
@@ -2556,6 +2598,68 @@ class SearchService:
 
         return results
 
+    @staticmethod
+    def _grep_lines_in_section(
+        regex: re.Pattern[str],
+        lines: builtins.list[str],
+        file_path: str,
+        range_start: int,
+        range_end: int,
+        section_meta: dict[str, Any],
+        before_context: int = 0,
+        after_context: int = 0,
+        invert_match: bool = False,
+        max_results: int = 100,
+    ) -> builtins.list[dict[str, Any]]:
+        """Search only match lines inside a stored section line range."""
+        results: builtins.list[dict[str, Any]] = []
+        if max_results <= 0:
+            return results
+
+        start = max(0, min(range_start, len(lines)))
+        end = max(start, min(range_end, len(lines)))
+        for idx in range(start, end):
+            if len(results) >= max_results:
+                break
+
+            line = lines[idx]
+            match_obj = regex.search(line)
+            if invert_match:
+                if match_obj:
+                    continue
+                entry: dict[str, Any] = {
+                    "file": file_path,
+                    "line": idx + 1,
+                    "content": line,
+                    "section": section_meta,
+                }
+            else:
+                if match_obj is None:
+                    continue
+                entry = {
+                    "file": file_path,
+                    "line": idx + 1,
+                    "content": line,
+                    "match": match_obj.group(0),
+                    "section": section_meta,
+                }
+
+            if before_context > 0 or after_context > 0:
+                b_start = max(0, idx - before_context)
+                a_end = min(len(lines), idx + after_context + 1)
+                if before_context > 0:
+                    entry["before_context"] = [
+                        {"line": i + 1, "content": lines[i]} for i in range(b_start, idx)
+                    ]
+                if after_context > 0:
+                    entry["after_context"] = [
+                        {"line": i + 1, "content": lines[i]} for i in range(idx + 1, a_end)
+                    ]
+
+            results.append(entry)
+
+        return results
+
     def _filter_results_by_block_type(
         self,
         results: builtins.list[dict[str, Any]],
@@ -2572,9 +2676,6 @@ class SearchService:
         Works directly with the raw JSON dict to avoid cross-brick
         imports (``nexus.bricks.parsers`` is a separate brick).
         """
-        import json as _json
-
-        MD_STRUCTURE_KEY = "md_structure"  # noqa: N806
         _V2_BLOCK_TYPES = frozenset({"paragraph", "blockquote", "list", "heading"})
 
         # Group results by file so we fetch metadata once per file.
@@ -2591,28 +2692,14 @@ class SearchService:
                 filtered.extend(file_results)
                 continue
 
-            # Fetch md_structure metadata for this file.
-            raw = self._kernel.get_xattr(file_path, MD_STRUCTURE_KEY)
-            if not isinstance(raw, (dict, str)):
-                raw = None
-            if raw is None:
-                legacy_get = getattr(self.metadata, "get_file_metadata", None)
-                if callable(legacy_get):
-                    raw = legacy_get(file_path, MD_STRUCTURE_KEY)
-            if raw is None:
+            data = self._load_md_structure_data(file_path)
+            if data is None:
                 # Issue #3720 (Codex R6): recognized markdown without
                 # metadata → fail closed.
                 logger.debug(
                     "No md_structure for %s — excluding results (fail closed)",
                     file_path,
                 )
-                continue
-
-            try:
-                data: dict[str, Any] = raw if isinstance(raw, dict) else _json.loads(raw)
-            except Exception:
-                # Issue #3720 (Codex R7): fail closed on corrupt metadata.
-                logger.debug("Corrupt md_structure for %s — excluding results", file_path)
                 continue
 
             # Issue #3720 (Codex R1+R2): v1 indices don't contain the
@@ -2663,6 +2750,152 @@ class SearchService:
 
         return filtered
 
+    def _load_md_structure_data(self, file_path: str) -> dict[str, Any] | None:
+        """Load stored md_structure metadata across old and new metastore APIs."""
+        import json as _json
+
+        getters = (
+            getattr(self._kernel, "get_xattr", None),
+            getattr(self._kernel, "metastore_get_file_metadata", None),
+            getattr(self.metadata, "get_file_metadata", None),
+        )
+        seen: set[int] = set()
+        for getter in getters:
+            if not callable(getter) or id(getter) in seen:
+                continue
+            seen.add(id(getter))
+            try:
+                raw = getter(file_path, "md_structure")
+            except Exception:
+                continue
+            if raw is None:
+                continue
+            if isinstance(raw, dict):
+                return raw
+            try:
+                loaded = _json.loads(raw)
+            except Exception:
+                continue
+            if isinstance(loaded, dict):
+                return loaded
+        return None
+
+    @staticmethod
+    def _normalize_section_query(section: str) -> tuple[str, int | None]:
+        stripped = section.strip()
+        match = re.match(r"^(#{1,6})\s+(.+)$", stripped)
+        if match:
+            return match.group(2).strip(), len(match.group(1))
+        return stripped, None
+
+    @classmethod
+    def _find_section_metadata(
+        cls,
+        data: dict[str, Any],
+        section: str,
+    ) -> dict[str, Any] | None:
+        heading_query, requested_depth = cls._normalize_section_query(section)
+        lower = heading_query.lower()
+
+        def _eligible(sec: dict[str, Any]) -> bool:
+            if requested_depth is not None and sec.get("depth") != requested_depth:
+                return False
+            return bool(sec.get("heading"))
+
+        sections = [sec for sec in data.get("sections", []) if _eligible(sec)]
+        for sec in sections:
+            if str(sec.get("heading", "")).lower() == lower:
+                return sec
+        for sec in sections:
+            if lower in str(sec.get("heading", "")).lower():
+                return sec
+        return None
+
+    def _section_range_and_meta(
+        self,
+        file_path: str,
+        section: str,
+    ) -> tuple[int, int, dict[str, Any]] | None:
+        data = self._load_md_structure_data(file_path)
+        if data is None:
+            logger.debug(
+                "No md_structure for %s - excluding section-filtered results",
+                file_path,
+            )
+            return None
+
+        matched_section = self._find_section_metadata(data, section)
+        if matched_section is None:
+            return None
+
+        try:
+            range_start = int(matched_section["line_start"])
+            range_end = int(matched_section["line_end"])
+        except (KeyError, TypeError, ValueError):
+            logger.debug(
+                "Malformed md_structure section for %s - excluding results",
+                file_path,
+            )
+            return None
+        if range_start < 0 or range_end < range_start:
+            logger.debug(
+                "Invalid md_structure section range for %s - excluding results",
+                file_path,
+            )
+            return None
+
+        section_meta = {
+            "heading": matched_section.get("heading", ""),
+            "depth": matched_section.get("depth"),
+            "line_start": range_start + 1,
+            "line_end": range_end,
+        }
+        return range_start, range_end, section_meta
+
+    def _filter_results_by_section(
+        self,
+        results: builtins.list[dict[str, Any]],
+        section: str,
+    ) -> builtins.list[dict[str, Any]]:
+        """Post-filter grep results to lines inside a heading-delimited section.
+
+        Issue #4186. Uses stored ``md_structure`` metadata and does not
+        parse file content during grep. Files with missing/corrupt
+        structure metadata fail closed to avoid whole-file fallback.
+        """
+        by_file: dict[str, builtins.list[dict[str, Any]]] = {}
+        for r in results:
+            by_file.setdefault(r.get("file", ""), []).append(r)
+
+        filtered: builtins.list[dict[str, Any]] = []
+        start = time.monotonic()
+
+        for file_path, file_results in by_file.items():
+            section_info = self._section_range_and_meta(file_path, section)
+            if section_info is None:
+                continue
+            range_start, range_end, section_meta = section_info
+
+            for r in file_results:
+                line_0 = r.get("line", 0) - 1
+                if range_start <= line_0 < range_end:
+                    out = dict(r)
+                    out["section"] = section_meta
+                    filtered.append(out)
+
+        elapsed_ms = (time.monotonic() - start) * 1000
+        if elapsed_ms > 5:
+            logger.debug(
+                "[GREP] Issue #4186: section=%r filter took %.1f ms (%d→%d results, %d files)",
+                section,
+                elapsed_ms,
+                len(results),
+                len(filtered),
+                len(by_file),
+            )
+
+        return filtered
+
     async def _grep_raw_content(
         self,
         regex: re.Pattern[str],
@@ -2676,6 +2909,7 @@ class SearchService:
         after_context: int = 0,
         invert_match: bool = False,
         force_python_path: bool = False,
+        section: str | None = None,
     ) -> builtins.list[dict[str, Any]]:
         """Process files needing raw content read (mmap, Rust bulk, sequential).
 
@@ -2751,17 +2985,37 @@ class SearchService:
                     except UnicodeDecodeError:
                         continue
                     lines = text.splitlines()
-                    results.extend(
-                        self._grep_lines(
-                            regex=regex,
-                            lines=lines,
-                            file_path=file_path,
-                            before_context=before_context,
-                            after_context=after_context,
-                            invert_match=invert_match,
-                            max_results=remaining_results - len(results),
+                    if section is not None:
+                        section_info = self._section_range_and_meta(file_path, section)
+                        if section_info is None:
+                            continue
+                        range_start, range_end, section_meta = section_info
+                        results.extend(
+                            self._grep_lines_in_section(
+                                regex=regex,
+                                lines=lines,
+                                file_path=file_path,
+                                range_start=range_start,
+                                range_end=range_end,
+                                section_meta=section_meta,
+                                before_context=before_context,
+                                after_context=after_context,
+                                invert_match=invert_match,
+                                max_results=remaining_results - len(results),
+                            )
                         )
-                    )
+                    else:
+                        results.extend(
+                            self._grep_lines(
+                                regex=regex,
+                                lines=lines,
+                                file_path=file_path,
+                                before_context=before_context,
+                                after_context=after_context,
+                                invert_match=invert_match,
+                                max_results=remaining_results - len(results),
+                            )
+                        )
                 except Exception as e:
                     logger.debug("Failed to grep file %s: %s", file_path, e)
                     continue

--- a/src/nexus/cli/commands/search.py
+++ b/src/nexus/cli/commands/search.py
@@ -330,6 +330,16 @@ def glob(
         "Non-markdown files pass through unfiltered."
     ),
 )
+@click.option(
+    "--in-section",
+    "section",
+    type=str,
+    default=None,
+    help=(
+        "Restrict matches to a markdown/parsed-content section heading "
+        "(#4186), e.g. 'API' or '## API'."
+    ),
+)
 @add_output_options
 @add_backend_options
 def grep(
@@ -349,6 +359,7 @@ def grep(
     files: tuple[str, ...],
     files_from: str | None,
     block_type: str | None,
+    section: str | None,
     output_opts: OutputOptions,
     remote_url: str | None,
     remote_api_key: str | None,
@@ -368,6 +379,7 @@ def grep(
 
     \b
         nexus grep "revenue" -f "**/*.pdf" --search-mode=parsed
+        nexus grep "status" /workspace/spec.md --in-section "## API"
     """
 
     async def _impl() -> None:
@@ -407,6 +419,8 @@ def grep(
                         grep_kwargs["files"] = files_list
                     if block_type is not None:
                         grep_kwargs["block_type"] = block_type
+                    if section is not None:
+                        grep_kwargs["section"] = section
 
                     result = await _await_service_result(
                         nx.service("search").grep(pattern, **grep_kwargs)

--- a/src/nexus/contracts/protocols/search.py
+++ b/src/nexus/contracts/protocols/search.py
@@ -119,6 +119,9 @@ class SearchProtocol(Protocol):
         before_context: int = 0,
         after_context: int = 0,
         invert_match: bool = False,
+        files: builtins.list[str] | None = None,
+        block_type: str | None = None,
+        section: str | None = None,
     ) -> builtins.list[dict[str, Any]]: ...
 
     # ── Async operations (semantic search requires I/O) ─────────────────

--- a/src/nexus/server/_rpc_params_generated.py
+++ b/src/nexus/server/_rpc_params_generated.py
@@ -543,6 +543,7 @@ class GrepParams:
     invert_match: bool = False
     files: list[str] | None = None
     block_type: str | None = None
+    section: str | None = None
 
 
 @dataclass

--- a/src/nexus/server/api/v2/routers/search.py
+++ b/src/nexus/server/api/v2/routers/search.py
@@ -735,6 +735,7 @@ async def _do_grep_operation(
     invert_match: bool,
     files: list[str] | None,
     block_type: str | None = None,
+    section: str | None = None,
 ) -> dict[str, Any]:
     """Execute a grep request and assemble the paginated response.
 
@@ -791,6 +792,8 @@ async def _do_grep_operation(
             # Issue #3720: only forward block_type when set (backward compat).
             if block_type is not None:
                 grep_kwargs["block_type"] = block_type
+            if section is not None:
+                grep_kwargs["section"] = section
             raw_results = await search_service.grep(**grep_kwargs)
         except (ValueError, InvalidPathError) as exc:
             # Client errors from SearchService:
@@ -874,6 +877,9 @@ async def _do_grep_operation(
         }
         if multi_zone_ambiguous:
             extras["multi_zone_ambiguous"] = True
+        if section is not None:
+            extras["section_filter"] = section
+            extras["section_status"] = "matched" if post_filter_count else "no_matches"
         return build_paginated_list_response(
             items=paginated,
             total=total,
@@ -1035,6 +1041,26 @@ def _body_get_files(body: dict[str, Any]) -> list[str] | None:
     return raw
 
 
+def _resolve_section_filter(section: str | None, in_section: str | None) -> str | None:
+    """Resolve the canonical section filter from supported aliases."""
+    if section is not None and not isinstance(section, str):
+        raise HTTPException(status_code=400, detail="Field 'section' must be a string")
+    if in_section is not None and not isinstance(in_section, str):
+        raise HTTPException(status_code=400, detail="Field 'in_section' must be a string")
+    values = [value for value in (section, in_section) if value is not None]
+    if not values:
+        return None
+    if len(values) == 2 and values[0] != values[1]:
+        raise HTTPException(
+            status_code=400,
+            detail="Fields 'section' and 'in_section' must match when both are provided",
+        )
+    resolved = values[0]
+    if not resolved.strip():
+        raise HTTPException(status_code=400, detail="section must be a non-empty string")
+    return resolved
+
+
 @router.get("/grep")
 async def search_grep(
     request: Request,
@@ -1061,6 +1087,17 @@ async def search_grep(
             "blockquote, list, heading. Non-markdown files pass through "
             "unfiltered."
         ),
+    ),
+    section: str | None = Query(
+        None,
+        description=(
+            "Restrict matches to a markdown/parsed-content section heading "
+            "(#4186), e.g. 'API' or '## API'."
+        ),
+    ),
+    in_section: str | None = Query(
+        None,
+        description="Alias for section, matching the CLI --in-section flag (#4186).",
     ),
     auth_result: dict[str, Any] = Depends(require_auth),
 ) -> dict[str, Any]:
@@ -1094,6 +1131,7 @@ async def search_grep(
         invert_match=invert_match,
         files=files,
         block_type=block_type,
+        section=_resolve_section_filter(section, in_section),
     )
 
 
@@ -1165,6 +1203,7 @@ async def search_grep_post(
     block_type = body.get("block_type")
     if block_type is not None and not isinstance(block_type, str):
         raise HTTPException(status_code=400, detail="Field 'block_type' must be a string")
+    section = _resolve_section_filter(body.get("section"), body.get("in_section"))
 
     return await _do_grep_operation(
         request,
@@ -1179,6 +1218,7 @@ async def search_grep_post(
         invert_match=invert_match,
         files=files,
         block_type=block_type,
+        section=section,
     )
 
 

--- a/src/nexus/server/rpc/handlers/filesystem.py
+++ b/src/nexus/server/rpc/handlers/filesystem.py
@@ -89,12 +89,20 @@ async def handle_grep(nexus_fs: "NexusFS", params: Any, context: Any) -> dict[st
     # way through to SearchService.
     if hasattr(params, "files") and params.files is not None:
         kwargs["files"] = params.files
+    if hasattr(params, "block_type") and params.block_type is not None:
+        kwargs["block_type"] = params.block_type
+    if hasattr(params, "section") and params.section is not None:
+        kwargs["section"] = params.section
 
     search = nexus_fs.service("search")
     assert search is not None, "SearchService required for grep"
     results = await search.grep(params.pattern, **kwargs)
     results = [unscope_result(r) for r in results]
-    return {"results": results}
+    response: dict[str, Any] = {"results": results}
+    if hasattr(params, "section") and params.section is not None:
+        response["section_filter"] = params.section
+        response["section_status"] = "matched" if results else "no_matches"
+    return response
 
 
 def handle_search(nexus_fs: "NexusFS", params: Any, context: Any) -> dict[str, Any]:

--- a/tests/benchmarks/test_search_benchmarks.py
+++ b/tests/benchmarks/test_search_benchmarks.py
@@ -6,7 +6,9 @@ These benchmarks compare Python regex vs Rust grep implementation.
 See issue #570 for context.
 """
 
+import json
 import re
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -113,6 +115,60 @@ class TestPythonRegexBenchmarks:
 
         result = benchmark(search)
         assert len(result) == 500
+
+
+@pytest.mark.benchmark_hash
+class TestSectionAwareGrepBenchmarks:
+    """Benchmarks for section-aware grep post-filtering (#4186)."""
+
+    def test_section_filter_uses_cached_structure_ranges(self, benchmark):
+        """Section filtering should reuse md_structure ranges, not reparse content."""
+        from nexus.bricks.search.search_service import SearchService
+
+        metadata_store = MagicMock()
+        section_index = {
+            "version": 2,
+            "content_id": "bench-doc",
+            "sections": [
+                {
+                    "heading": "Intro",
+                    "depth": 1,
+                    "line_start": 0,
+                    "line_end": 500,
+                    "blocks": [],
+                },
+                {
+                    "heading": "API",
+                    "depth": 2,
+                    "line_start": 500,
+                    "line_end": 1500,
+                    "blocks": [],
+                },
+            ],
+        }
+        metadata_store.metastore_get_file_metadata.return_value = json.dumps(section_index)
+        service = SearchService(
+            metadata_store=metadata_store,
+            nexus_fs=None,
+            enforce_permissions=False,
+        )
+        grep_results = [
+            {"file": "/bench.md", "line": line, "content": f"needle {line}", "match": "needle"}
+            for line in range(1, 2001)
+        ]
+
+        def filter_once():
+            metadata_store.metastore_get_file_metadata.reset_mock()
+            filtered = service._filter_results_by_section(grep_results, "## API")
+            metadata_store.metastore_get_file_metadata.assert_called_once_with(
+                "/bench.md", "md_structure"
+            )
+            return filtered
+
+        result = benchmark(filter_once)
+        assert len(result) == 1000
+        assert result[0]["line"] == 501
+        assert result[-1]["line"] == 1500
 
 
 # =============================================================================

--- a/tests/integration/server/api/v2/routers/test_search_http_grep_glob.py
+++ b/tests/integration/server/api/v2/routers/test_search_http_grep_glob.py
@@ -310,6 +310,52 @@ class TestGrepBlockType:
         assert data["count"] == 5
 
 
+class TestGrepSection:
+    """#4186: section filtering via HTTP grep endpoints."""
+
+    def test_get_section_forwarded(self) -> None:
+        """GET ?section=API forwards to SearchService."""
+        svc = _make_search_service(grep_return=[])
+        client = TestClient(_build_app(search_service=svc))
+        resp = client.get("/api/v2/search/grep?pattern=needle&section=API")
+        assert resp.status_code == 200
+        kwargs = svc.grep.await_args.kwargs
+        assert kwargs["section"] == "API"
+        assert resp.json()["section_filter"] == "API"
+
+    def test_get_in_section_alias_forwarded(self) -> None:
+        """GET ?in_section=## API is accepted as the CLI-friendly alias."""
+        svc = _make_search_service(grep_return=[])
+        client = TestClient(_build_app(search_service=svc))
+        client.get("/api/v2/search/grep?pattern=needle&in_section=%23%23%20API")
+        kwargs = svc.grep.await_args.kwargs
+        assert kwargs["section"] == "## API"
+
+    def test_post_in_section_alias_forwarded(self) -> None:
+        """POST in_section in JSON body forwards as SearchService.section."""
+        svc = _make_search_service(grep_return=[])
+        client = TestClient(_build_app(search_service=svc))
+        resp = client.post(
+            "/api/v2/search/grep",
+            json={"pattern": "needle", "in_section": "## API"},
+        )
+        assert resp.status_code == 200
+        kwargs = svc.grep.await_args.kwargs
+        assert kwargs["section"] == "## API"
+        assert resp.json()["section_status"] == "no_matches"
+
+    def test_post_section_non_string_returns_400(self) -> None:
+        """POST section aliases must be strings or null."""
+        svc = _make_search_service(grep_return=[])
+        client = TestClient(_build_app(search_service=svc))
+        resp = client.post(
+            "/api/v2/search/grep",
+            json={"pattern": "needle", "section": 123},
+        )
+        assert resp.status_code == 400
+        assert "section" in resp.json()["detail"]
+
+
 class TestGlobHappyPath:
     def test_basic_match_returns_paths(self) -> None:
         svc = _make_search_service(glob_return=["/a.py", "/b.py", "/c.py"])

--- a/tests/integration/services/test_search_service.py
+++ b/tests/integration/services/test_search_service.py
@@ -8,7 +8,7 @@ PermissionEnforcer, DriverLifecycleCoordinator (DLC), and NexusFSGateway.
 """
 
 import re
-from unittest.mock import ANY, AsyncMock, MagicMock, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, call, patch
 
 import pytest
 
@@ -30,9 +30,24 @@ def mock_metadata_store():
     """Create a mock MetastoreABC."""
     store = MagicMock()
     store.list_paths.return_value = []
+    store.list.return_value = []
+    store.metastore_list.side_effect = lambda prefix="": store.list(prefix)
     store.get_file_metadata.return_value = None
     store.get_file_metadata_bulk.return_value = {}
     store.get_searchable_text_bulk.return_value = {}
+
+    def _get_file_metadata(path, key):
+        return store.get_file_metadata(path, key)
+
+    def _get_file_metadata_bulk(paths, key):
+        if key == "parsed_text":
+            return store.get_searchable_text_bulk(paths)
+        return store.get_file_metadata_bulk(paths, key)
+
+    store.get_xattr.side_effect = _get_file_metadata
+    store.get_xattr_bulk.side_effect = _get_file_metadata_bulk
+    store.metastore_get_file_metadata.side_effect = _get_file_metadata
+    store.metastore_get_file_metadata_bulk.side_effect = _get_file_metadata_bulk
     return store
 
 
@@ -71,11 +86,15 @@ def mock_gateway():
     """Create a mock NexusFSGateway."""
     gw = MagicMock()
     gw.read = AsyncMock(return_value=b"test content")
+    gw.read_file = gw.read
     gw.read_bulk.return_value = {}
     gw._get_context_identity.return_value = (None, None, False)
+    gw.get_routing_params = gw._get_context_identity
     gw._descendant_checker.has_access.return_value = True
+    gw.has_descendant_access = gw._descendant_checker.has_access
     gw.record_read_if_tracking.return_value = None
     gw.SessionLocal = MagicMock()
+    gw.session_factory = gw.SessionLocal
     gw.backend = MagicMock()
     gw.sys_readdir.return_value = []
     return gw
@@ -415,8 +434,7 @@ class TestGatewayDelegation:
 
         assert entries == expected_entries
         assert mock_gateway.sys_readdir.call_args_list == [
-            (("/workspace",), {"recursive": False, "details": True, "context": ANY}),
-            (("/workspace/src",), {"recursive": False, "details": True, "context": ANY}),
+            call("/workspace", recursive=True, details=True, context=ANY),
         ]
 
     async def test_read_converts_str_to_bytes(self, service, mock_gateway):
@@ -1871,3 +1889,281 @@ class TestGrepBlockTypeOverfetch:
         assert "table" in msg
         assert "frontmatter" in msg
         assert "paragraph" in msg
+
+
+# =============================================================================
+# Issue #4186: section-aware grep
+# =============================================================================
+
+_MD_WITH_SECTIONS = """\
+# Intro
+needle outside target
+
+## API
+needle inside api
+api details
+
+## Guide
+needle inside guide
+"""
+
+
+def _make_section_md_structure_json(path: str = "/doc.md"):
+    """Build md_structure JSON for section-aware grep tests."""
+    import json
+
+    return json.dumps(
+        {
+            "version": 2,
+            "content_id": f"{path}:abc123",
+            "tokens_est_method": "bytes/4",
+            "sections": [
+                {
+                    "heading": "Intro",
+                    "depth": 1,
+                    "byte_start": 0,
+                    "byte_end": len(_MD_WITH_SECTIONS.encode()),
+                    "line_start": 0,
+                    "line_end": 9,
+                    "tokens_est": 20,
+                    "blocks": [],
+                },
+                {
+                    "heading": "API",
+                    "depth": 2,
+                    "byte_start": 32,
+                    "byte_end": 68,
+                    "line_start": 3,
+                    "line_end": 7,
+                    "tokens_est": 10,
+                    "blocks": [
+                        {
+                            "type": "heading",
+                            "byte_start": 32,
+                            "byte_end": 39,
+                            "line_start": 3,
+                            "line_end": 4,
+                        },
+                        {
+                            "type": "paragraph",
+                            "byte_start": 39,
+                            "byte_end": 68,
+                            "line_start": 4,
+                            "line_end": 6,
+                        },
+                    ],
+                },
+                {
+                    "heading": "Guide",
+                    "depth": 2,
+                    "byte_start": 69,
+                    "byte_end": len(_MD_WITH_SECTIONS.encode()),
+                    "line_start": 7,
+                    "line_end": 9,
+                    "tokens_est": 8,
+                    "blocks": [],
+                },
+            ],
+        }
+    )
+
+
+def _make_section_md_structure_json_for_ranges(
+    *, path: str, text: str, api_start: int, api_end: int
+):
+    """Build md_structure JSON with API range supplied by the test."""
+    import json
+
+    return json.dumps(
+        {
+            "version": 2,
+            "content_id": f"{path}:abc123",
+            "tokens_est_method": "bytes/4",
+            "sections": [
+                {
+                    "heading": "Intro",
+                    "depth": 1,
+                    "byte_start": 0,
+                    "byte_end": len(text.encode()),
+                    "line_start": 0,
+                    "line_end": api_start,
+                    "tokens_est": 20,
+                    "blocks": [],
+                },
+                {
+                    "heading": "API",
+                    "depth": 2,
+                    "byte_start": 0,
+                    "byte_end": len(text.encode()),
+                    "line_start": api_start,
+                    "line_end": api_end,
+                    "tokens_est": 10,
+                    "blocks": [],
+                },
+            ],
+        }
+    )
+
+
+class TestGrepSectionFilter:
+    """Issue #4186: section filtering for grep."""
+
+    @pytest.fixture
+    def service_with_sections(self, mock_metadata_store, mock_gateway):
+        mock_gateway._get_context_identity.return_value = (None, None, False)
+        mock_metadata_store.list_paths.return_value = ["/doc.md", "/report.pdf"]
+        mock_metadata_store.get_searchable_text_bulk.side_effect = lambda paths: {
+            path: _MD_WITH_SECTIONS for path in paths if path in {"/doc.md", "/report.pdf"}
+        }
+        mock_metadata_store.get_xattr_bulk.side_effect = lambda paths, key: {
+            path: _MD_WITH_SECTIONS
+            for path in paths
+            if key == "parsed_text" and path in {"/doc.md", "/report.pdf"}
+        }
+        mock_metadata_store.metastore_get_file_metadata_bulk.side_effect = (
+            mock_metadata_store.get_xattr_bulk.side_effect
+        )
+
+        def _get_file_metadata(path, key):
+            if key == "md_structure" and path in {"/doc.md", "/report.pdf"}:
+                return _make_section_md_structure_json(path)
+            return None
+
+        mock_metadata_store.get_file_metadata.side_effect = _get_file_metadata
+        mock_metadata_store.metastore_get_file_metadata.side_effect = _get_file_metadata
+        return SearchService(
+            metadata_store=mock_metadata_store,
+            nexus_fs=mock_gateway,
+            enforce_permissions=False,
+        )
+
+    async def test_section_filter_returns_only_matches_inside_heading(
+        self, service_with_sections, context
+    ):
+        """section='## API' keeps only matches inside that heading range."""
+        with patch.object(service_with_sections, "list", return_value=["/doc.md"]):
+            results = await service_with_sections.grep(
+                pattern="needle",
+                section="## API",
+                context=context,
+            )
+
+        assert [r["content"] for r in results] == ["needle inside api"]
+        assert results[0]["section"] == {
+            "heading": "API",
+            "depth": 2,
+            "line_start": 4,
+            "line_end": 7,
+        }
+
+    async def test_missing_section_returns_empty_not_whole_file(
+        self, service_with_sections, context
+    ):
+        """A missing section must not fall back to whole-file grep results."""
+        with patch.object(service_with_sections, "list", return_value=["/doc.md"]):
+            results = await service_with_sections.grep(
+                pattern="needle",
+                section="## Missing",
+                context=context,
+            )
+
+        assert results == []
+
+    async def test_section_filter_scans_past_pre_section_matches(
+        self, service_with_sections, context
+    ):
+        """Matches before the target heading must not exhaust the result window."""
+        outside_lines = "\n".join(f"needle outside {i}" for i in range(20))
+        text = f"# Intro\n{outside_lines}\n## API\nneedle inside api\n"
+        lines = text.splitlines()
+        api_start = lines.index("## API")
+        api_end = len(lines)
+
+        def _get_xattr(path, key):
+            if path == "/large.md" and key == "md_structure":
+                return _make_section_md_structure_json_for_ranges(
+                    path=path,
+                    text=text,
+                    api_start=api_start,
+                    api_end=api_end,
+                )
+            return None
+
+        metadata = service_with_sections.metadata
+        metadata.get_xattr.side_effect = _get_xattr
+        metadata.metastore_get_file_metadata.side_effect = _get_xattr
+        metadata.get_file_metadata.side_effect = _get_xattr
+        metadata.get_xattr_bulk.side_effect = lambda paths, key: {
+            path: text for path in paths if key == "parsed_text" and path == "/large.md"
+        }
+        metadata.metastore_get_file_metadata_bulk.side_effect = metadata.get_xattr_bulk.side_effect
+        metadata.get_searchable_text_bulk.side_effect = lambda paths: {
+            path: text for path in paths if path == "/large.md"
+        }
+
+        with patch.object(service_with_sections, "list", return_value=["/large.md"]):
+            results = await service_with_sections.grep(
+                pattern="needle",
+                section="## API",
+                max_results=1,
+                context=context,
+            )
+
+        assert [r["content"] for r in results] == ["needle inside api"]
+
+    async def test_section_filter_scans_raw_content_past_pre_section_matches(
+        self, service_with_sections, context
+    ):
+        """Uncached file scans must apply max_results after section selection."""
+        outside_lines = "\n".join(f"needle outside {i}" for i in range(20))
+        text = f"# Intro\n{outside_lines}\n## API\nneedle inside raw api\n"
+        lines = text.splitlines()
+        api_start = lines.index("## API")
+        api_end = len(lines)
+
+        def _get_xattr(path, key):
+            if path == "/raw.md" and key == "md_structure":
+                return _make_section_md_structure_json_for_ranges(
+                    path=path,
+                    text=text,
+                    api_start=api_start,
+                    api_end=api_end,
+                )
+            return None
+
+        metadata = service_with_sections.metadata
+        metadata.get_xattr.side_effect = _get_xattr
+        metadata.metastore_get_file_metadata.side_effect = _get_xattr
+        metadata.get_file_metadata.side_effect = _get_xattr
+        metadata.get_searchable_text_bulk.side_effect = lambda paths: {}
+        metadata.get_xattr_bulk.side_effect = lambda paths, key: {}
+        metadata.metastore_get_file_metadata_bulk.side_effect = metadata.get_xattr_bulk.side_effect
+
+        with (
+            patch.object(service_with_sections, "list", return_value=["/raw.md"]),
+            patch.object(service_with_sections, "_read", new=AsyncMock(return_value=text.encode())),
+        ):
+            results = await service_with_sections.grep(
+                pattern="needle",
+                section="## API",
+                max_results=1,
+                context=context,
+            )
+
+        assert [r["content"] for r in results] == ["needle inside raw api"]
+
+    async def test_section_filter_uses_md_structure_for_parsed_non_markdown_text(
+        self, service_with_sections, context
+    ):
+        """Parsed text with md_structure metadata is section-filtered even for non-md paths."""
+        with patch.object(service_with_sections, "list", return_value=["/report.pdf"]):
+            results = await service_with_sections.grep(
+                pattern="needle",
+                section="API",
+                search_mode="parsed",
+                context=context,
+            )
+
+        assert [r["file"] for r in results] == ["/report.pdf"]
+        assert [r["content"] for r in results] == ["needle inside api"]
+        assert results[0]["section"]["heading"] == "API"

--- a/tests/unit/bricks/mcp/test_mcp_server_tools.py
+++ b/tests/unit/bricks/mcp/test_mcp_server_tools.py
@@ -917,6 +917,30 @@ class TestSearchTools:
         kwargs = mock_nx_basic._mock_search.grep.call_args.kwargs
         assert "block_type" not in kwargs
 
+    async def test_grep_section_forwarded(self, mock_nx_basic):
+        """#4186: section flows through MCP to SearchService."""
+        mock_nx_basic._mock_search.grep.return_value = []
+        server = await create_mcp_server(nx=mock_nx_basic)
+
+        grep_tool = get_tool(server, "nexus_grep")
+        result = await grep_tool.fn(pattern="needle", section="## API")
+
+        kwargs = mock_nx_basic._mock_search.grep.call_args.kwargs
+        assert kwargs["section"] == "## API"
+        response = json.loads(result)
+        assert response["section_filter"] == "## API"
+
+    async def test_grep_section_none_omitted_from_kwargs(self, mock_nx_basic):
+        """#4186: default section=None must not be sent to older servers."""
+        mock_nx_basic._mock_search.grep.return_value = []
+        server = await create_mcp_server(nx=mock_nx_basic)
+
+        grep_tool = get_tool(server, "nexus_grep")
+        await grep_tool.fn(pattern="needle")
+
+        kwargs = mock_nx_basic._mock_search.grep.call_args.kwargs
+        assert "section" not in kwargs
+
     async def test_grep_error(self, mock_nx_basic):
         """Test grep error handling."""
         mock_nx_basic._mock_search.grep.side_effect = ValueError("Invalid regex")

--- a/tests/unit/cli/test_commands_smoke.py
+++ b/tests/unit/cli/test_commands_smoke.py
@@ -455,6 +455,23 @@ class TestGrepCommand:
         assert "after_context" not in kwargs
         assert "invert_match" not in kwargs
 
+    def test_grep_in_section_forwarded(self) -> None:
+        """--in-section forwards the requested section to grep."""
+        nx = _make_mock_nx()
+        nx.service("search").grep.return_value = {"results": []}
+
+        runner = CliRunner()
+        with _patch_search_open_filesystem(nx):
+            result = runner.invoke(
+                grep,
+                ["needle", "--in-section", "## API", "--json"],
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == 0
+        kwargs = nx.service("search").grep.call_args.kwargs
+        assert kwargs["section"] == "## API"
+
     def test_grep_l_mode_prints_plain_filenames_for_piping(self) -> None:
         """-l output must be one filename per line, unadorned, pipe-safe."""
         nx = _make_mock_nx()

--- a/tests/unit/server/rpc/handlers/test_filesystem_grep.py
+++ b/tests/unit/server/rpc/handlers/test_filesystem_grep.py
@@ -1,0 +1,25 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from nexus.server.rpc.handlers.filesystem import handle_grep
+
+
+@pytest.mark.asyncio
+async def test_handle_grep_forwards_section_to_search_service() -> None:
+    search = MagicMock()
+    search.grep = AsyncMock(return_value=[])
+    nexus_fs = MagicMock()
+    nexus_fs.service.return_value = search
+    params = SimpleNamespace(pattern="needle", section="## API")
+    context = object()
+
+    result = await handle_grep(nexus_fs, params, context)
+
+    assert result == {
+        "results": [],
+        "section_filter": "## API",
+        "section_status": "no_matches",
+    }
+    search.grep.assert_awaited_once_with("needle", context=context, section="## API")


### PR DESCRIPTION
## Summary

Implements issue #4186 by adding a section-aware grep surface across the core search service and external entry points.

- Adds `section` support to `SearchService.grep`, filtering hits through stored `md_structure` section ranges and failing closed when section metadata is missing or corrupt.
- Exposes section filtering through HTTP (`section` / `in_section`), CLI (`--in-section`), MCP (`section`), and RPC (`GrepParams.section`).
- Adds response metadata for section-filtered calls, including `section_filter` and `section_status` where surfaces return an envelope.
- Fixes RPC grep forwarding for the existing `block_type` parameter while wiring `section`.
- Updates stale search-service test fixtures so the full service test file exercises current gateway and metastore APIs.

## Validation

- `python3 -m pytest -n 0 tests/integration/services/test_search_service.py tests/integration/server/api/v2/routers/test_search_http_grep_glob.py tests/unit/cli/test_commands_smoke.py::TestGrepCommand tests/unit/bricks/mcp/test_mcp_server_tools.py::TestSearchTools tests/unit/server/rpc/handlers/test_filesystem_grep.py tests/benchmarks/test_search_benchmarks.py::TestSectionAwareGrepBenchmarks::test_section_filter_uses_cached_structure_ranges -q`
- `python3 -m pytest -n 0 tests/integration/services/test_search_service.py::TestGrepSectionFilter -q`
- `python3 -m ruff check src/nexus/bricks/search/search_service.py src/nexus/server/api/v2/routers/search.py src/nexus/cli/commands/search.py src/nexus/bricks/mcp/server.py src/nexus/server/rpc/handlers/filesystem.py src/nexus/server/_rpc_params_generated.py src/nexus/contracts/protocols/search.py tests/integration/services/test_search_service.py tests/integration/server/api/v2/routers/test_search_http_grep_glob.py tests/unit/cli/test_commands_smoke.py tests/unit/bricks/mcp/test_mcp_server_tools.py tests/unit/server/rpc/handlers/test_filesystem_grep.py tests/benchmarks/test_search_benchmarks.py`
- `git diff --cached --check`
- pre-commit on commit: whitespace, ruff, ruff format, mypy, file size, brick import checks, and configured sync checks passed

## Notes

The default `python3 -m pytest` run stalled at xdist node startup in this worktree before executing tests. Wider unrelated search integration sweeps also have existing failures unrelated to this change, including stale `MountService(router=...)` test construction, txtai tests writing to `/app` on a read-only filesystem, a missing `nexus.bricks.search.lifecycle_adapter` import, and one SQL-sanitization assertion drift.
