### PR TITLE
[codex] fix Docker E2E health and read latency

### DIFF
--- a/docs/surface-coverage/api-rpc-surface-coverage.yaml
+++ b/docs/surface-coverage/api-rpc-surface-coverage.yaml
@@ -3553,7 +3553,7 @@ operations:
       source: src/nexus/cli/commands/file_ops.py:1
     grpc_expose:
       name: append
-      source: src/nexus/core/nexus_fs_content.py:1073
+      source: src/nexus/core/nexus_fs_content.py:1072
   profiles:
     lite: supported
     sandbox: supported
@@ -3674,7 +3674,7 @@ operations:
   transports:
     grpc_expose:
       name: edit
-      source: src/nexus/core/nexus_fs_content.py:1194
+      source: src/nexus/core/nexus_fs_content.py:1193
   profiles:
     lite: supported
     sandbox: supported
@@ -4096,7 +4096,7 @@ operations:
   transports:
     grpc_expose:
       name: stream
-      source: src/nexus/core/nexus_fs_content.py:472
+      source: src/nexus/core/nexus_fs_content.py:471
   profiles:
     lite: supported
     sandbox: supported
@@ -7886,7 +7886,7 @@ operations:
   transports:
     grpc_expose:
       name: read_batch
-      source: src/nexus/core/nexus_fs_content.py:1600
+      source: src/nexus/core/nexus_fs_content.py:1599
     sdk:
       name: KernelClient.read_batch
       source: src/nexus/remote/kernel_client.py:452
@@ -7908,7 +7908,7 @@ operations:
   transports:
     grpc_expose:
       name: read_bulk
-      source: src/nexus/core/nexus_fs_content.py:234
+      source: src/nexus/core/nexus_fs_content.py:233
   profiles:
     lite: supported
     sandbox: supported
@@ -7944,7 +7944,7 @@ operations:
   transports:
     grpc_expose:
       name: read_range
-      source: src/nexus/core/nexus_fs_content.py:407
+      source: src/nexus/core/nexus_fs_content.py:406
   profiles:
     lite: supported
     sandbox: supported
@@ -9890,7 +9890,7 @@ operations:
   transports:
     grpc_expose:
       name: stream_range
-      source: src/nexus/core/nexus_fs_content.py:520
+      source: src/nexus/core/nexus_fs_content.py:519
   profiles:
     lite: supported
     sandbox: supported
@@ -11181,7 +11181,7 @@ operations:
   transports:
     grpc_expose:
       name: write_batch
-      source: src/nexus/core/nexus_fs_content.py:1438
+      source: src/nexus/core/nexus_fs_content.py:1437
     sdk:
       name: KernelClient.write_batch
       source: src/nexus/remote/kernel_client.py:901
@@ -11220,7 +11220,7 @@ operations:
   transports:
     grpc_expose:
       name: write_stream
-      source: src/nexus/core/nexus_fs_content.py:562
+      source: src/nexus/core/nexus_fs_content.py:561
   profiles:
     lite: supported
     sandbox: supported

--- a/src/nexus/cli/commands/status.py
+++ b/src/nexus/cli/commands/status.py
@@ -205,7 +205,16 @@ def _server_health(
     endpoint requires authentication and no *api_key* is provided.
     """
 
-    def public_health(client: Any) -> dict[str, Any] | None:
+    def public_health(client: Any | None = None) -> dict[str, Any] | None:
+        if client is None:
+            try:
+                import httpx
+
+                with httpx.Client(timeout=timeout) as public_client:
+                    return public_health(public_client)
+            except Exception:
+                return None
+
         try:
             fallback = client.get(f"{base_url}/health")
         except Exception:
@@ -229,14 +238,14 @@ def _server_health(
             try:
                 resp = client.get(f"{base_url}/health/detailed")
             except (httpx.TimeoutException, httpx.RequestError):
-                return public_health(client)
+                return public_health()
             if resp.status_code == 200:
                 result: dict[str, Any] = resp.json()
                 return result
             # Detailed endpoint may require admin auth — fall back to
             # the public /health endpoint so we still report "healthy".
             if resp.status_code in (401, 403):
-                return public_health(client)
+                return public_health()
             return {"status": "error", "http_status": resp.status_code}
     except Exception:
         return None

--- a/src/nexus/core/nexus_fs_content.py
+++ b/src/nexus/core/nexus_fs_content.py
@@ -111,11 +111,9 @@ class ContentMixin:
             timeout_ms: For DT_PIPE / DT_STREAM, how long to block waiting
                 for data. ``0`` is O_NONBLOCK (nowait pop, return immediately
                 with empty data if pipe drained). Default ``None`` uses the
-                long-poll default (5000 ms). Hot polling loops MUST pass
-                ``timeout_ms=0`` to avoid blocking the asyncio event loop —
-                the Rust kernel's ``pipe_read_blocking`` releases the GIL
-                but a 5 s wait per empty poll still starves uvicorn's
-                accept loop. Issue #3699.
+                non-blocking path so regular-file reads do not accidentally
+                pay an IPC wait budget. IPC consumers that want long-poll
+                behavior must pass a non-zero timeout explicitly.
         """
 
         start = time.perf_counter()
@@ -167,10 +165,11 @@ class ContentMixin:
                     ),
                 )
             _rust_ctx = self._build_rust_ctx(context, _is_admin)
-            # DT_STREAM uses 30s timeout (long-poll); DT_PIPE uses 5s.
             # The caller's `offset` param doubles as the stream cursor position.
-            # ``timeout_ms=0`` from the caller selects O_NONBLOCK (Issue #3699).
-            _timeout_ms = 5000 if timeout_ms is None else int(timeout_ms)
+            # Default to O_NONBLOCK: regular-file reads must not inherit a
+            # DT_PIPE/DT_STREAM wait budget. Long-poll IPC callers pass an
+            # explicit non-zero timeout.
+            _timeout_ms = 0 if timeout_ms is None else int(timeout_ms)
             result = self._kernel.sys_read(path, _rust_ctx, _timeout_ms, offset)
 
             # DT_STREAM: return dict with next_offset for cursor advancement.

--- a/tests/unit/cli/test_status.py
+++ b/tests/unit/cli/test_status.py
@@ -83,6 +83,35 @@ class TestServerHealth:
         assert result == {"status": "healthy", "service": "nexus-rpc"}
         assert mock_client.get.call_count == 2
 
+    def test_detailed_timeout_falls_back_to_public_health_without_bearer(self) -> None:
+        """The public fallback must not reuse the bearer that made detailed health slow."""
+        clients: list[MagicMock] = []
+
+        def _client_factory(*, timeout: float, headers: dict[str, str] | None = None) -> MagicMock:
+            client = MagicMock()
+            client.headers_seen = headers or {}
+            client.__enter__ = lambda s: client
+            client.__exit__ = MagicMock(return_value=False)
+            clients.append(client)
+
+            if headers and headers.get("Authorization"):
+                client.get.side_effect = httpx.TimeoutException("authenticated health timed out")
+            else:
+                fallback_resp = MagicMock(status_code=200)
+                fallback_resp.json.return_value = {"status": "healthy", "service": "nexus-rpc"}
+                client.get.return_value = fallback_resp
+
+            return client
+
+        with patch("httpx.Client", side_effect=_client_factory):
+            result = _server_health("http://localhost:2026", api_key="sk-test")
+
+        assert result == {"status": "healthy", "service": "nexus-rpc"}
+        assert [client.headers_seen for client in clients] == [
+            {"Authorization": "Bearer sk-test"},
+            {},
+        ]
+
 
 # ---------------------------------------------------------------------------
 # _collect_status

--- a/tests/unit/core/test_nexus_fs_content_metrics.py
+++ b/tests/unit/core/test_nexus_fs_content_metrics.py
@@ -22,9 +22,11 @@ class _Kernel:
     def __init__(self) -> None:
         self.sys_read_calls = 0
         self.sys_write_calls = 0
+        self.read_timeouts: list[int] = []
 
     def sys_read(self, path: str, _ctx: object, _timeout_ms: int, _offset: int = 0) -> Any:
         self.sys_read_calls += 1
+        self.read_timeouts.append(_timeout_ms)
         return SimpleNamespace(
             data=b"abc",
             post_hook_needed=False,
@@ -260,6 +262,22 @@ def test_sys_read_records_backend_latency_and_bytes() -> None:
 
     assert _sample("nexus_read_bytes_total", tier="backend") == before_bytes + 3
     assert _sample("nexus_read_latency_seconds_count", tier="backend") == before_count + 1
+
+
+def test_sys_read_defaults_to_nonblocking_regular_read() -> None:
+    harness = _Harness()
+
+    assert harness.sys_read("/file.txt") == b"abc"
+
+    assert harness._kernel.read_timeouts == [0]
+
+
+def test_sys_read_preserves_explicit_ipc_timeout() -> None:
+    harness = _Harness()
+
+    assert harness.sys_read("/file.txt", timeout_ms=250) == b"abc"
+
+    assert harness._kernel.read_timeouts == [250]
 
 
 def test_sys_read_records_virtual_resolver_reads() -> None:


### PR DESCRIPTION
## Summary

Fixes the develop Docker Publish E2E failure from run 26364236757 by addressing the two failing smoke checks:

- regular `sys_read` calls now default to non-blocking timeout `0` instead of inheriting the 5000ms IPC wait budget, removing the ~5s edit/read latency seen by the build perf E2E
- `nexus status` now falls back to public `/health` using a fresh unauthenticated client when authenticated `/health/detailed` times out or is unauthorized

## Root Cause

The Docker E2E script showed the container health endpoint was reachable, but `nexus status` reported the server as unreachable and edit-preview RPC latency was around 4943ms. The latency came from default file reads passing a 5000ms timeout into the Rust kernel path. The status failure was made worse by reusing authenticated client headers for the public health fallback after detailed health failed.

## Validation

- `python3 -m pytest tests/unit/cli/test_status.py tests/unit/core/test_nexus_fs_content_metrics.py -q`
- `python3 -m pytest tests/unit/remote/test_kernel_client_hooks.py tests/unit/services/test_workflow_dispatch.py tests/unit/bricks/search/test_skeleton_pipe_consumer.py tests/unit/task_manager/test_dispatch_consumer.py tests/unit/test_docker_publish_smoke_config.py tests/unit/ci/test_workflow_guards.py -q`
- `uv run ruff check src/nexus/cli/commands/status.py src/nexus/core/nexus_fs_content.py tests/unit/cli/test_status.py tests/unit/core/test_nexus_fs_content_metrics.py`
- `uv run ruff format --check src/nexus/cli/commands/status.py src/nexus/core/nexus_fs_content.py tests/unit/cli/test_status.py tests/unit/core/test_nexus_fs_content_metrics.py`
- `git diff --check`
