### PR TITLE
[codex] fix Docker E2E status, latency, and macOS DNS

### DIFF
--- a/docs/surface-coverage/api-rpc-surface-coverage.yaml
+++ b/docs/surface-coverage/api-rpc-surface-coverage.yaml
@@ -7886,7 +7886,7 @@ operations:
   transports:
     grpc_expose:
       name: read_batch
-      source: src/nexus/core/nexus_fs_content.py:1607
+      source: src/nexus/core/nexus_fs_content.py:1618
     sdk:
       name: KernelClient.read_batch
       source: src/nexus/remote/kernel_client.py:452
@@ -11181,7 +11181,7 @@ operations:
   transports:
     grpc_expose:
       name: write_batch
-      source: src/nexus/core/nexus_fs_content.py:1445
+      source: src/nexus/core/nexus_fs_content.py:1456
     sdk:
       name: KernelClient.write_batch
       source: src/nexus/remote/kernel_client.py:901

--- a/src/nexus/cli/commands/status.py
+++ b/src/nexus/cli/commands/status.py
@@ -211,6 +211,10 @@ def _server_health(
     ``src/nexus/server/api/core/health.py:71-206``, so a tighter budget
     times out under realistic load.
     """
+    from nexus.cli.api_client import _is_loopback_url
+
+    base_url = base_url.rstrip("/")
+    trust_env = not _is_loopback_url(base_url)
 
     def public_health(client: Any) -> dict[str, Any] | None:
         try:
@@ -229,7 +233,7 @@ def _server_health(
         if api_key:
             headers["Authorization"] = f"Bearer {api_key}"
 
-        with httpx.Client(timeout=timeout, headers=headers) as client:
+        with httpx.Client(timeout=timeout, headers=headers, trust_env=trust_env) as client:
             if not api_key:
                 return public_health(client)
 

--- a/src/nexus/core/nexus_fs_content.py
+++ b/src/nexus/core/nexus_fs_content.py
@@ -1324,12 +1324,23 @@ class ContentMixin:
         from nexus.utils.edit_engine import EditEngine
         from nexus.utils.edit_engine import EditOperation as EditOp
 
-        # Read current content with metadata (via Tier 2 convenience)
-        result = self.read(path, context=context, return_metadata=True)
-        assert isinstance(result, dict), "Expected dict when return_metadata=True"
-
-        content_bytes: bytes = result["content"]
-        current_content_id = result.get("content_id")
+        current_content_id = None
+        if if_match is None:
+            content_raw = self.sys_read(path, context=context)
+            content_bytes = (
+                content_raw.get("data", b"") if isinstance(content_raw, dict) else content_raw
+            )
+            if isinstance(content_bytes, str):
+                content_bytes = content_bytes.encode("utf-8")
+            elif not isinstance(content_bytes, bytes):
+                content_bytes = bytes(content_bytes)
+        else:
+            # OCC needs the current content_id. Plain/preview edits avoid the
+            # metadata stat round trip and read only the file bytes.
+            result = self.read(path, context=context, return_metadata=True)
+            assert isinstance(result, dict), "Expected dict when return_metadata=True"
+            content_bytes = result["content"]
+            current_content_id = result.get("content_id")
 
         # Check content_id if provided (optimistic concurrency control)
         if if_match is not None and current_content_id != if_match:

--- a/tests/unit/cli/test_status.py
+++ b/tests/unit/cli/test_status.py
@@ -56,6 +56,7 @@ class TestServerHealth:
 
         assert result == {"status": "healthy", "service": "nexus-rpc"}
         mock_client.get.assert_called_once_with("http://localhost:2026/health")
+        mock_client_cls.assert_called_once_with(timeout=5.0, headers={}, trust_env=False)
 
     @patch("httpx.Client")
     def test_returns_none_on_connection_error(self, mock_client_cls: MagicMock) -> None:
@@ -99,7 +100,6 @@ class TestServerHealth:
 
         assert result == {"status": "healthy", "service": "nexus-rpc"}
         assert mock_client.get.call_count == 2
-
 
 # ---------------------------------------------------------------------------
 # _collect_status

--- a/tests/unit/cli/test_status.py
+++ b/tests/unit/cli/test_status.py
@@ -101,6 +101,7 @@ class TestServerHealth:
         assert result == {"status": "healthy", "service": "nexus-rpc"}
         assert mock_client.get.call_count == 2
 
+
 # ---------------------------------------------------------------------------
 # _collect_status
 # ---------------------------------------------------------------------------

--- a/tests/unit/core/test_nexus_fs_content_metrics.py
+++ b/tests/unit/core/test_nexus_fs_content_metrics.py
@@ -253,6 +253,28 @@ class _MutatingHookHarness(_Harness):
         self._kernel = _MutatingHookKernel()
 
 
+class _EditHarness(_Harness):
+    def __init__(self) -> None:
+        super().__init__()
+        self.stat_calls = 0
+
+    def sys_stat(
+        self,
+        path: str,
+        *,
+        context: object | None = None,
+        **_kwargs: object,
+    ) -> dict[str, object]:
+        self.stat_calls += 1
+        return {
+            "content_id": "cid",
+            "version": 1,
+            "gen": 1,
+            "modified_at": None,
+            "size": 3,
+        }
+
+
 def test_sys_read_records_backend_latency_and_bytes() -> None:
     harness = _Harness()
     before_bytes = _sample("nexus_read_bytes_total", tier="backend")
@@ -283,6 +305,25 @@ def test_sys_read_preserves_explicit_ipc_timeout() -> None:
     assert harness.sys_read("/file.txt", timeout_ms=250) == b"abc"
 
     assert harness._kernel.read_timeouts == [250]
+
+
+def test_edit_preview_without_if_match_does_not_stat() -> None:
+    harness = _EditHarness()
+
+    result = harness.edit("/file.txt", [("abc", "abd")], preview=True)
+
+    assert result["success"] is True
+    assert result["preview"] is True
+    assert harness.stat_calls == 0
+
+
+def test_edit_with_if_match_reads_metadata_for_occ() -> None:
+    harness = _EditHarness()
+
+    result = harness.edit("/file.txt", [("abc", "abd")], if_match="cid", preview=True)
+
+    assert result["success"] is True
+    assert harness.stat_calls == 1
 
 
 def test_sys_read_records_virtual_resolver_reads() -> None:

--- a/tests/unit/server/api/v2/test_remaining_zone_runner_surfaces.py
+++ b/tests/unit/server/api/v2/test_remaining_zone_runner_surfaces.py
@@ -132,7 +132,7 @@ def test_create_subscription_runs_in_auth_zone_runner() -> None:
     with TestClient(app) as client:
         response = client.post(
             "/api/v2/subscriptions",
-            json={"event_types": ["file_write"], "url": "https://example.com/hook"},
+            json={"event_types": ["file_write"], "url": "https://1.1.1.1/hook"},
         )
 
     assert response.status_code == 201


### PR DESCRIPTION
## Summary

Fixes the follow-up failures from the merged Docker E2E PR and the macOS subscription test failure:

- keep `nexus status` loopback health probes off environment proxies, matching `NexusApiClient`, so Docker loopback health checks do not report `server_reachable=false` while `/health` is healthy
- avoid the unnecessary metadata/stat path for non-OCC `edit` preview calls, which removes the slow permission/stat round trip hit by the Docker E2E RPC latency gate
- keep the macOS subscription zone-runner test independent of DNS by using an IP-literal webhook URL while preserving URL/SSRF validation
- refresh the generated API/RPC surface source anchors shifted by the `nexus_fs_content.py` edit

## Validation

- `python3 -m pytest tests/unit/cli/test_status.py::TestServerHealth::test_detailed_timeout_falls_back_to_public_health_without_bearer -q`
- `python3 -m pytest tests/unit/core/test_nexus_fs_content_metrics.py::test_edit_preview_without_if_match_does_not_stat tests/unit/core/test_nexus_fs_content_metrics.py::test_edit_with_if_match_reads_metadata_for_occ -q`
- `python3 -m pytest tests/unit/core/test_nexus_fs_content_metrics.py -q`
- `python3 -m pytest tests/unit/cli/test_status.py -q`
- `uv run ruff check src/nexus/core/nexus_fs_content.py src/nexus/cli/commands/status.py tests/unit/core/test_nexus_fs_content_metrics.py tests/unit/cli/test_status.py`
- `uv run ruff format --check src/nexus/core/nexus_fs_content.py src/nexus/cli/commands/status.py tests/unit/core/test_nexus_fs_content_metrics.py tests/unit/cli/test_status.py`
- `uv run python scripts/gen_api_surface_coverage.py`
- `uv run python scripts/render_api_surface_coverage.py`
- `uv run --no-sync python scripts/validate_api_surface_coverage.py --coverage docs/surface-coverage/api-rpc-surface-coverage.yaml`
- `uv run --no-sync python -m pytest tests/surface_coverage/test_inventory.py tests/surface_coverage/test_validate.py tests/surface_coverage/test_runtime_discovery.py tests/surface_coverage/test_gap_backlog.py tests/surface_coverage/test_merge.py -q`
- `git diff --check`
- commit hook suite: ruff, ruff format, mypy, file-size, type-ignore, and boundary checks
