### PR TITLE
fix(raft): store_snapshot atomically advances HardState — sender-side F7 companion

### DIFF
--- a/rust/raft/src/raft/storage.rs
+++ b/rust/raft/src/raft/storage.rs
@@ -160,14 +160,75 @@ impl RaftStorage {
 
     /// Store a snapshot without clearing existing entries.
     ///
-    /// Used by the leader after ConfChange(AddNode) to prepare a snapshot
-    /// that raft-rs sends to lagging followers via `Storage::snapshot()`.
-    /// Unlike [`apply_snapshot`], this preserves existing log entries
-    /// (the leader still needs them for other followers).
+    /// Used by the leader after ConfChange(AddNode/AddLearnerNode) to
+    /// prepare a snapshot that raft-rs sends to lagging followers via
+    /// `Storage::snapshot()`.  Unlike [`apply_snapshot`], this
+    /// preserves existing log entries (the leader still needs them
+    /// for other followers).
+    ///
+    /// Both the snapshot bytes and the `HardState` advance are
+    /// committed in a **single redb WriteTransaction** so an abrupt
+    /// termination (Ctrl+C, OOM kill, power loss, SIGKILL) between
+    /// the two cannot leave storage with a persisted snapshot at
+    /// index N but a `HardState.commit < N`.  raft-rs panics at
+    /// `RaftLog::commit_to` (`hs.commit X is out of range
+    /// [first_index, last_index]`) on the next restart when this
+    /// invariant breaks — surfaced today during cross-machine
+    /// federation testing on the **leader** side (F7's atomic
+    /// `apply_snapshot` closed the symmetrical receiver-side window).
+    ///
+    /// `HardState.vote` is preserved verbatim — a snapshot carries no
+    /// vote information.
     pub fn store_snapshot(&self, snapshot: &Snapshot) -> Result<()> {
-        let value = protobuf::Message::write_to_bytes(snapshot)
+        let meta = snapshot.get_metadata();
+        let snapshot_bytes = protobuf::Message::write_to_bytes(snapshot)
             .map_err(|e| RaftError::Serialization(e.to_string()))?;
-        self.state.set(KEY_SNAPSHOT, &value)?;
+
+        let db = self.state.raw_db();
+        let state_def = redb::TableDefinition::<&[u8], &[u8]>::new(self.state.name());
+
+        let write_txn = db
+            .begin_write()
+            .map_err(|e| RaftError::Storage(e.to_string()))?;
+        {
+            let mut state_table = write_txn
+                .open_table(state_def)
+                .map_err(|e| RaftError::Storage(e.to_string()))?;
+
+            state_table
+                .insert(KEY_SNAPSHOT, snapshot_bytes.as_slice())
+                .map_err(|e| RaftError::Storage(e.to_string()))?;
+
+            // Read current HardState within this txn, advance term and
+            // commit to at least the snapshot's, preserve vote, write
+            // back atomically.  A snapshot represents committed state
+            // by definition, so persisting it without simultaneously
+            // advancing `hs.commit` would violate the raft protocol
+            // invariant on the next restart.
+            let mut hs: HardState = match state_table
+                .get(KEY_HARD_STATE)
+                .map_err(|e| RaftError::Storage(e.to_string()))?
+            {
+                Some(bytes) => protobuf::Message::parse_from_bytes(bytes.value())
+                    .map_err(|e| RaftError::Serialization(e.to_string()))?,
+                None => HardState::default(),
+            };
+            if hs.commit < meta.index {
+                hs.commit = meta.index;
+            }
+            if hs.term < meta.term {
+                hs.term = meta.term;
+            }
+            let hs_bytes = protobuf::Message::write_to_bytes(&hs)
+                .map_err(|e| RaftError::Serialization(e.to_string()))?;
+            state_table
+                .insert(KEY_HARD_STATE, hs_bytes.as_slice())
+                .map_err(|e| RaftError::Storage(e.to_string()))?;
+        }
+        write_txn
+            .commit()
+            .map_err(|e| RaftError::Storage(e.to_string()))?;
+
         Ok(())
     }
 

--- a/rust/raft/src/raft/storage.rs
+++ b/rust/raft/src/raft/storage.rs
@@ -804,4 +804,66 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn test_store_snapshot_persists_hardstate_advance_across_reopen() {
+        // Sender-side companion to `test_apply_snapshot_persists_across_reopen`.
+        //
+        // Pins the raft protocol invariant that `HardState.commit >=
+        // snapshot.metadata.index` holds **even when the leader writes
+        // its own snapshot** via `store_snapshot` (post-AddNode catch-
+        // up snapshot for a new follower) — not just when receiving
+        // one via `apply_snapshot`.
+        //
+        // Pre-F8 (PR following #4215), `store_snapshot` wrote only
+        // `KEY_SNAPSHOT` and left `HardState` to the driver's separate
+        // `set_hard_state` in the same Ready iteration.  An abrupt
+        // termination between the two writes stranded storage with a
+        // persisted snapshot at index N but a `HardState.commit < N`,
+        // panicking raft-rs at next boot.  Surfaced today as Win's
+        // `sharedzone` reopen failing with `hs.commit 0 is out of
+        // range [5, 6]` after the leader had stored an index-6 snapshot
+        // for the newly joined Learner.
+        //
+        // Test drops `RaftStorage` without `flush()` to mirror the
+        // abrupt-termination path — any invariant we rely on must
+        // survive the redb commit alone.
+        let dir = TempDir::new().unwrap();
+        {
+            let storage = RaftStorage::open(dir.path()).unwrap();
+            // Seed log entries so the leader-style store_snapshot scenario
+            // is realistic: log [1..=6] with snapshot at index=6 term=2.
+            let entries: Vec<Entry> = (1..=6)
+                .map(|i| Entry {
+                    index: i,
+                    term: 2,
+                    ..Default::default()
+                })
+                .collect();
+            storage.append(&entries).unwrap();
+            let snap = make_snapshot(6, 2, &[100]);
+            storage.store_snapshot(&snap).unwrap();
+        }
+
+        {
+            let storage = RaftStorage::open(dir.path()).unwrap();
+            let stored = storage.snapshot(0, 0).unwrap();
+            assert_eq!(stored.get_metadata().index, 6);
+            assert_eq!(stored.get_metadata().term, 2);
+
+            // The crash-safety invariant — without this, the next
+            // raft-rs init would panic at RaftLog::commit_to.
+            let state = storage.initial_state().unwrap();
+            assert!(
+                state.hard_state.commit >= 6,
+                "hs.commit ({}) must be >= store_snapshot index (6) — F8 invariant",
+                state.hard_state.commit,
+            );
+            assert!(
+                state.hard_state.term >= 2,
+                "hs.term ({}) must be >= store_snapshot term (2) — F8 invariant",
+                state.hard_state.term,
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Sender-side companion to F7 (PR #4215).

F7 made `apply_snapshot` (receiver side) write the snapshot bytes and the `HardState` advancement in a single redb WriteTransaction, closing the abrupt-termination window that left raft storage in the `RaftLog::commit_to` panic state on the **follower** side after a snapshot install.

The same vulnerability lived on the **leader** side via `store_snapshot` — called after `ConfChange(AddNode/AddLearnerNode)` to persist the catch-up snapshot the leader will hand to a newly joined follower. `store_snapshot` wrote only `KEY_SNAPSHOT` and left `HardState` to the driver's separate `set_hard_state` in the same Ready iteration. An abrupt termination between the two redb commits stranded the leader's own storage with `KEY_SNAPSHOT.metadata.index = N` and `HardState.commit < N` — next boot panics at `raft.rs:2786` with `hs.commit X is out of range [first_index, last_index]`.

**Surfaced today during cross-machine federation smoke**: Win was the `sharedzone` leader; after Mac (Learner) joined, Win called `store_snapshot(index=6, term=2)` for the catch-up. A subsequent daemon termination caught storage between that commit and the next HardState flush. Next daemon start: `hs.commit 0 is out of range [5, 6], raft_id: 6506583143468527700`. Data dir unrecoverable without a full wipe.

## Fix

Pull the HardState advancement into `store_snapshot`'s redb WriteTransaction, mirroring F7 exactly:

1. Write `KEY_SNAPSHOT` (snapshot bytes).
2. Read current `HardState`, advance `term` / `commit` to at least the snapshot's, preserve `vote`, write back atomically.

redb commits the whole txn as one fsync. The window between snapshot persistence and HardState advancement closes by construction.

`compact` (which trims superseded log entries and advances `first_index`) intentionally stays in a separate txn — it is a disk-space optimisation, not a correctness invariant. raft-rs's `RaftLog::initial_state` handles the case where snapshot and log entries overlap.

## Architectural verification (raft contract + 7 principles)

| Principle | Result |
|---|---|
| raft-rs contract `hs.commit >= snapshot.metadata.index` | ✓ enforced atomically in storage layer on both sender and receiver paths |
| Simplest contract | ✓ `store_snapshot` is now self-contained — caller needs zero raft-protocol awareness |
| Architecturally correct (no boundary leak) | ✓ invariant internalised in storage layer; driver / state-machine don't need to coordinate |
| Data SSOT | ✓ invariant enforced in exactly one place per path (apply_snapshot for receiver, store_snapshot for sender) |
| DRY | ✓ same pattern as F7; future snapshot-writing call sites can adopt the same shape |
| Rust-first | ✓ |
| Perf | ✓ same fsync count — one redb commit, just consistent |
| Systemic (not patch-over-patch) | ✓ closes the entire sender-side window; combined with F7, every snapshot persistence path in the storage layer maintains the protocol invariant atomically |

## Test plan

- [x] **Commit 1 + Commit 2 (bisect-safe)**: each commit compiles, lints clean.
- [x] `cargo test -p raft@0.1.0 --features grpc --lib raft::storage::tests` — 11 / 11 pass, including new `test_store_snapshot_persists_hardstate_advance_across_reopen`.
- [x] Full `cargo test -p raft@0.1.0 --features grpc` — 182 tests pass (172 lib + 10 integration), zero regressions.
- [x] `cargo check -p raft@0.1.0` clean.
- [ ] CI: full pipeline including Federation E2E and cluster-binary builds.

## Commits

1. `fix(raft): store_snapshot atomically advances HardState` — bare fix, no test changes.
2. `test(raft): pin HardState atomicity in store_snapshot` — adds sender-side regression test paired with the existing receiver-side `test_apply_snapshot_persists_across_reopen`.

## After this lands

The combined F7 + F8 invariant covers every snapshot-write path in our redb storage. Resume the Win↔Mac federation cross-machine smoke (task #27 L3 CRUD) with a clean Win sharedzone rebuild.
