### PR TITLE
fix(kernel): restore sys_read Issue #3699 contract + status.py revert PR #4224 patches

### DIFF
--- a/docs/surface-coverage/api-rpc-surface-coverage.yaml
+++ b/docs/surface-coverage/api-rpc-surface-coverage.yaml
@@ -3553,7 +3553,7 @@ operations:
       source: src/nexus/cli/commands/file_ops.py:1
     grpc_expose:
       name: append
-      source: src/nexus/core/nexus_fs_content.py:1072
+      source: src/nexus/core/nexus_fs_content.py:1080
   profiles:
     lite: supported
     sandbox: supported
@@ -3674,7 +3674,7 @@ operations:
   transports:
     grpc_expose:
       name: edit
-      source: src/nexus/core/nexus_fs_content.py:1193
+      source: src/nexus/core/nexus_fs_content.py:1201
   profiles:
     lite: supported
     sandbox: supported
@@ -4096,7 +4096,7 @@ operations:
   transports:
     grpc_expose:
       name: stream
-      source: src/nexus/core/nexus_fs_content.py:471
+      source: src/nexus/core/nexus_fs_content.py:479
   profiles:
     lite: supported
     sandbox: supported
@@ -7886,7 +7886,7 @@ operations:
   transports:
     grpc_expose:
       name: read_batch
-      source: src/nexus/core/nexus_fs_content.py:1599
+      source: src/nexus/core/nexus_fs_content.py:1607
     sdk:
       name: KernelClient.read_batch
       source: src/nexus/remote/kernel_client.py:452
@@ -7908,7 +7908,7 @@ operations:
   transports:
     grpc_expose:
       name: read_bulk
-      source: src/nexus/core/nexus_fs_content.py:233
+      source: src/nexus/core/nexus_fs_content.py:241
   profiles:
     lite: supported
     sandbox: supported
@@ -7944,7 +7944,7 @@ operations:
   transports:
     grpc_expose:
       name: read_range
-      source: src/nexus/core/nexus_fs_content.py:406
+      source: src/nexus/core/nexus_fs_content.py:414
   profiles:
     lite: supported
     sandbox: supported
@@ -9890,7 +9890,7 @@ operations:
   transports:
     grpc_expose:
       name: stream_range
-      source: src/nexus/core/nexus_fs_content.py:519
+      source: src/nexus/core/nexus_fs_content.py:527
   profiles:
     lite: supported
     sandbox: supported
@@ -11181,7 +11181,7 @@ operations:
   transports:
     grpc_expose:
       name: write_batch
-      source: src/nexus/core/nexus_fs_content.py:1437
+      source: src/nexus/core/nexus_fs_content.py:1445
     sdk:
       name: KernelClient.write_batch
       source: src/nexus/remote/kernel_client.py:901
@@ -11220,7 +11220,7 @@ operations:
   transports:
     grpc_expose:
       name: write_stream
-      source: src/nexus/core/nexus_fs_content.py:561
+      source: src/nexus/core/nexus_fs_content.py:569
   profiles:
     lite: supported
     sandbox: supported

--- a/src/nexus/cli/commands/status.py
+++ b/src/nexus/cli/commands/status.py
@@ -196,13 +196,20 @@ def _enrich_with_image_info(
 
 
 def _server_health(
-    base_url: str, api_key: str | None = None, timeout: float = 1.5
+    base_url: str, api_key: str | None = None, timeout: float = 5.0
 ) -> dict[str, Any] | None:
     """Query the running server's ``/health/detailed`` endpoint.
 
     Returns the JSON payload or *None* if the server is unreachable.
     Falls back to the public ``/health`` endpoint when the detailed
     endpoint requires authentication and no *api_key* is provided.
+
+    The 5s default matches the Docker E2E ``curl --max-time 5`` budget
+    (``.github/workflows/docker-publish.yml``); ``/health/detailed``
+    legitimately runs ~9 sub-checks (including async Redis-backed
+    ``durable_invalidation.health_check()``) per
+    ``src/nexus/server/api/core/health.py:71-206``, so a tighter budget
+    times out under realistic load.
     """
 
     def public_health(client: Any) -> dict[str, Any] | None:

--- a/src/nexus/cli/commands/status.py
+++ b/src/nexus/cli/commands/status.py
@@ -205,16 +205,7 @@ def _server_health(
     endpoint requires authentication and no *api_key* is provided.
     """
 
-    def public_health(client: Any | None = None) -> dict[str, Any] | None:
-        if client is None:
-            try:
-                import httpx
-
-                with httpx.Client(timeout=timeout) as public_client:
-                    return public_health(public_client)
-            except Exception:
-                return None
-
+    def public_health(client: Any) -> dict[str, Any] | None:
         try:
             fallback = client.get(f"{base_url}/health")
         except Exception:
@@ -238,14 +229,21 @@ def _server_health(
             try:
                 resp = client.get(f"{base_url}/health/detailed")
             except (httpx.TimeoutException, httpx.RequestError):
-                return public_health()
+                # Surface the failure rather than masking it with an
+                # unauthenticated public /health probe — silent fallback
+                # makes monitoring report green while authenticated
+                # callers still hang.
+                return {
+                    "status": "degraded",
+                    "reason": "detailed health check timed out",
+                }
             if resp.status_code == 200:
                 result: dict[str, Any] = resp.json()
                 return result
             # Detailed endpoint may require admin auth — fall back to
             # the public /health endpoint so we still report "healthy".
             if resp.status_code in (401, 403):
-                return public_health()
+                return public_health(client)
             return {"status": "error", "http_status": resp.status_code}
     except Exception:
         return None

--- a/src/nexus/core/nexus_fs_content.py
+++ b/src/nexus/core/nexus_fs_content.py
@@ -111,9 +111,16 @@ class ContentMixin:
             timeout_ms: For DT_PIPE / DT_STREAM, how long to block waiting
                 for data. ``0`` is O_NONBLOCK (nowait pop, return immediately
                 with empty data if pipe drained). Default ``None`` uses the
-                non-blocking path so regular-file reads do not accidentally
-                pay an IPC wait budget. IPC consumers that want long-poll
-                behavior must pass a non-zero timeout explicitly.
+                long-poll default (5000 ms). Hot polling loops MUST pass
+                ``timeout_ms=0`` to avoid blocking the asyncio event loop —
+                the Rust kernel's ``pipe_read_blocking`` releases the GIL
+                but a 5 s wait per empty poll still starves uvicorn's
+                accept loop. Issue #3699.
+
+                DT_REG ignores ``timeout_ms`` entirely: per-type dispatch
+                lives in ``rust/kernel/src/kernel/io.rs`` (lines 255–305) —
+                only DT_PIPE / DT_STREAM consult it. Regular-file reads
+                never pay the IPC wait budget regardless of this value.
         """
 
         start = time.perf_counter()
@@ -165,11 +172,12 @@ class ContentMixin:
                     ),
                 )
             _rust_ctx = self._build_rust_ctx(context, _is_admin)
+            # DT_STREAM uses 30s timeout (long-poll); DT_PIPE uses 5s.
             # The caller's `offset` param doubles as the stream cursor position.
-            # Default to O_NONBLOCK: regular-file reads must not inherit a
-            # DT_PIPE/DT_STREAM wait budget. Long-poll IPC callers pass an
-            # explicit non-zero timeout.
-            _timeout_ms = 0 if timeout_ms is None else int(timeout_ms)
+            # ``timeout_ms=0`` from the caller selects O_NONBLOCK (Issue #3699).
+            # Per-type dispatch lives in rust/kernel/src/kernel/io.rs:255-305 —
+            # DT_PIPE/DT_STREAM consult ``timeout_ms``, DT_REG ignores it.
+            _timeout_ms = 5000 if timeout_ms is None else int(timeout_ms)
             result = self._kernel.sys_read(path, _rust_ctx, _timeout_ms, offset)
 
             # DT_STREAM: return dict with next_offset for cursor advancement.

--- a/src/nexus/factory/zoekt_pipe_consumer.py
+++ b/src/nexus/factory/zoekt_pipe_consumer.py
@@ -185,7 +185,9 @@ class ZoektPipeConsumer:
             # If nothing pending, block until first event (in thread to avoid blocking event loop)
             if not pending_paths and not has_sync:
                 try:
-                    first = await asyncio.to_thread(nx.sys_read, _ZOEKT_PIPE_PATH)
+                    # timeout_ms=0 (O_NONBLOCK): own asyncio.sleep paces the loop;
+                    # the long-poll default would starve the event loop. Issue #3699.
+                    first = await asyncio.to_thread(nx.sys_read, _ZOEKT_PIPE_PATH, timeout_ms=0)
                 except NexusFileNotFoundError:
                     logger.debug("Zoekt pipe closed, consumer exiting")
                     break

--- a/tests/unit/cli/test_status.py
+++ b/tests/unit/cli/test_status.py
@@ -64,16 +64,33 @@ class TestServerHealth:
         assert result is None
 
     @patch("httpx.Client")
-    def test_falls_back_to_public_health_when_detailed_times_out(
-        self, mock_client_cls: MagicMock
-    ) -> None:
+    def test_returns_degraded_when_detailed_times_out(self, mock_client_cls: MagicMock) -> None:
+        """Timeout on authenticated /health/detailed surfaces as degraded —
+        never silently fall back to unauth /health, which would mask the real
+        failure while authenticated callers still hang."""
         mock_client = MagicMock()
+        mock_client.get.side_effect = httpx.TimeoutException("detailed health timed out")
+        mock_client.__enter__ = lambda s: mock_client
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client_cls.return_value = mock_client
+
+        result = _server_health("http://localhost:2026", api_key="sk-test")
+
+        assert result is not None
+        assert result["status"] == "degraded"
+        assert "timed out" in result["reason"]
+        assert mock_client.get.call_count == 1
+
+    @patch("httpx.Client")
+    def test_falls_back_to_public_health_on_401_403(self, mock_client_cls: MagicMock) -> None:
+        """Detailed endpoint may require admin auth — preserve the original
+        a0252a5f9 fallback to the public /health probe so we still report a
+        useful status when the supplied key lacks admin scope."""
+        mock_client = MagicMock()
+        detailed_resp = MagicMock(status_code=403)
         fallback_resp = MagicMock(status_code=200)
         fallback_resp.json.return_value = {"status": "healthy", "service": "nexus-rpc"}
-        mock_client.get.side_effect = [
-            httpx.TimeoutException("detailed health timed out"),
-            fallback_resp,
-        ]
+        mock_client.get.side_effect = [detailed_resp, fallback_resp]
         mock_client.__enter__ = lambda s: mock_client
         mock_client.__exit__ = MagicMock(return_value=False)
         mock_client_cls.return_value = mock_client
@@ -82,35 +99,6 @@ class TestServerHealth:
 
         assert result == {"status": "healthy", "service": "nexus-rpc"}
         assert mock_client.get.call_count == 2
-
-    def test_detailed_timeout_falls_back_to_public_health_without_bearer(self) -> None:
-        """The public fallback must not reuse the bearer that made detailed health slow."""
-        clients: list[MagicMock] = []
-
-        def _client_factory(*, timeout: float, headers: dict[str, str] | None = None) -> MagicMock:
-            client = MagicMock()
-            client.headers_seen = headers or {}
-            client.__enter__ = lambda s: client
-            client.__exit__ = MagicMock(return_value=False)
-            clients.append(client)
-
-            if headers and headers.get("Authorization"):
-                client.get.side_effect = httpx.TimeoutException("authenticated health timed out")
-            else:
-                fallback_resp = MagicMock(status_code=200)
-                fallback_resp.json.return_value = {"status": "healthy", "service": "nexus-rpc"}
-                client.get.return_value = fallback_resp
-
-            return client
-
-        with patch("httpx.Client", side_effect=_client_factory):
-            result = _server_health("http://localhost:2026", api_key="sk-test")
-
-        assert result == {"status": "healthy", "service": "nexus-rpc"}
-        assert [client.headers_seen for client in clients] == [
-            {"Authorization": "Bearer sk-test"},
-            {},
-        ]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/core/test_nexus_fs_content_metrics.py
+++ b/tests/unit/core/test_nexus_fs_content_metrics.py
@@ -264,12 +264,17 @@ def test_sys_read_records_backend_latency_and_bytes() -> None:
     assert _sample("nexus_read_latency_seconds_count", tier="backend") == before_count + 1
 
 
-def test_sys_read_defaults_to_nonblocking_regular_read() -> None:
+def test_sys_read_defaults_to_longpoll_budget() -> None:
+    """sys_read(timeout_ms=None) must pass the 5000ms long-poll default to the
+    kernel — the Issue #3699 opt-out contract. DT_REG ignores timeout_ms per
+    rust/kernel/src/kernel/io.rs:255-305, so this default is safe for regular
+    reads while preserving correct IPC blocking for DT_PIPE / DT_STREAM
+    consumers that don't opt out."""
     harness = _Harness()
 
     assert harness.sys_read("/file.txt") == b"abc"
 
-    assert harness._kernel.read_timeouts == [0]
+    assert harness._kernel.read_timeouts == [5000]
 
 
 def test_sys_read_preserves_explicit_ipc_timeout() -> None:


### PR DESCRIPTION
## Summary

Kernel-team cleanup of [PR #4224](https://github.com/nexi-lab/nexus/pull/4224) (\`6dba9dc27\`),
which silently inverted a documented kernel-tier contract and added a status
fallback that masks real failures. Three issues addressed, all in Python +
docs + tests — **no Rust kernel changes** (\`rust/kernel/src/kernel/io.rs:255-305\`
already does per-type dispatch correctly).

### 1. \`sys_read\` Python wrapper default flipped (kernel contract regression)

- **Pre-#4224** (\`40116158a\`): \`timeout_ms=None\` → \`5000\` (long-poll default
  per Issue #3699; hot-loop callers MUST pass \`timeout_ms=0\`).
- **Post-#4224**: \`timeout_ms=None\` → \`0\` (silent flip; docstring rewritten).

PR #4224's stated justification — "regular-file reads were inheriting the 5000ms
IPC wait budget" — is **physically impossible**. Per
[\`rust/kernel/src/kernel/io.rs:255-305\`](https://github.com/nexi-lab/nexus/blob/develop/rust/kernel/src/kernel/io.rs#L255-L305),
the dispatch is per-\`entry_type\`:

- \`DT_PIPE\` / \`DT_STREAM\`: consult \`timeout_ms\` (nowait if 0, else blocking)
- \`DT_REG\`: ignores \`timeout_ms\` entirely (FDT fast path → content_id → backend)

So regular-file reads never paid the IPC wait budget regardless of the default.

**Blast radius** of the post-#4224 default-flip: only one Python consumer
(\`src/nexus/factory/zoekt_pipe_consumer.py:188\`) was relying on the default
and silently switched semantics; this PR makes its intent explicit.

### 2. \`status.py\` \`/health/detailed\` fallback now masks slow-detailed signal

PR #4224 extended the legit \`401/403\` fallback (\`a0252a5f9\`) to also trigger
on \`httpx.TimeoutException\`, and added a self-recursing \`public_health()\` that
builds a fresh unauthenticated client. Net effect: when authenticated
\`/health/detailed\` times out, \`nexus status\` reports "healthy" via unauth
\`/health\` while real authenticated callers still hang.

Real root cause of the Docker E2E "server unreachable" symptom: the 1.5s
default budget is too tight for \`/health/detailed\` (~9 sub-checks including
async Redis-backed \`durable_invalidation.health_check()\` per
\`src/nexus/server/api/core/health.py:71-206\`). Raised to 5s to match the
Docker E2E \`curl --max-time 5\` budget in \`.github/workflows/docker-publish.yml\`.

### 3. Coverage YAML hand-edited (DRY/SSOT regression)

PR #4224 hand-patched 9 line-number entries in
\`docs/surface-coverage/api-rpc-surface-coverage.yaml\` — that file is
**generated** by \`scripts/gen_api_surface_coverage.py\` (PR #4182).
Regenerated as a separate commit.

## Commits (one per concern; preserve granularity)

1. \`revert(kernel): restore sys_read timeout_ms=5000 default — Issue #3699 contract\`
2. \`fix(zoekt): pass explicit timeout_ms=0 to sys_read — Issue #3699\`
3. \`test(kernel): assert sys_read default-None passes 5000ms long-poll budget\`
4. \`revert(cli): drop status.py timeout→unauth-fallback (masks real signal)\`
5. \`fix(cli): raise _server_health default timeout 1.5s→5s for /health/detailed legitimate cost\`
6. \`test(cli): rework _server_health tests for degraded-on-timeout + 401/403 fallback only\`
7. \`chore(surface-coverage): regenerate api-rpc-surface-coverage.yaml after kernel-tier line shifts\`

## Out of scope

- **Real ~5s edit-preview latency** (the 4943ms RPC PR #4224 was actually trying
  to fix) is unexplained after this revert. Likely VFS lock contention, slow
  CI-runner backend, or sync hook latency. Tracked in a separate follow-up
  issue — needs instrumentation work, not a contract flip.
- **Rust kernel changes** — none. \`io.rs:255-305\` already does per-type
  dispatch correctly. A sentinel + Rust per-type default would only re-derive
  what's there.
- **Parallelizing \`/health/detailed\` sub-checks** — legit follow-up but
  separate from "stop the masking". Raising the timeout to 5s is sufficient.

## Test plan

- [x] \`pytest tests/unit/cli/test_status.py tests/unit/core/test_nexus_fs_content_metrics.py -q\` green locally
- [x] \`scripts/gen_api_surface_coverage.py\` re-run produces no further diff
- [ ] CI green (unit + integration + Docker E2E)
- [ ] Manual verification: \`nexus status\` against a server with slow \`/health/detailed\` shows \`degraded\` rather than silently green