### PR TITLE
feat(scripts): add resolve_local_endpoint() — sidestep Tailscale-Win hairpin quirk at resolver SSOT

### DIFF
--- a/scripts/_tailscale_peers.py
+++ b/scripts/_tailscale_peers.py
@@ -79,7 +79,17 @@ def _tailscale_status_json() -> dict:
 
 
 def resolve_self_ip() -> str:
-    """Return this node's primary Tailscale IPv4 address."""
+    """Return this node's primary Tailscale IPv4 address.
+
+    Use for **publishing** the node's address to other peers — e.g.
+    as ``NEXUS_HOSTNAME`` (so peers can dial back in) or as the
+    ``self_address`` recorded in raft ConfState.  For **connecting
+    to this node's own daemon**, use :func:`resolve_local_endpoint`
+    instead — going through the Tailscale IP triggers a Windows-side
+    hairpinning quirk where ``grpcurl`` (and other Go-net-stack
+    clients) time out even though ``Test-NetConnection`` at TCP
+    level succeeds.
+    """
     data = _tailscale_status_json()
     self_node = data.get("Self") or {}
     ips: list[str] = list(self_node.get("TailscaleIPs") or [])
@@ -90,6 +100,25 @@ def resolve_self_ip() -> str:
             "Run `tailscale status` to diagnose."
         )
     return ipv4[0]
+
+
+def resolve_local_endpoint() -> str:
+    """Return the address to use for connecting to this node's own daemon.
+
+    Always returns ``"127.0.0.1"`` — never the Tailscale IP — because
+    on Windows the Tailscale TUN's hairpin path (host connecting to
+    its own ``100.64.0.x`` IP) trips a Go-net-stack interaction that
+    times out at TCP dial time, even though the kernel-level TCP
+    handshake itself succeeds.  Looping through the loopback
+    interface is universally fast and avoids the Tailscale data
+    plane entirely for self-connect traffic.
+
+    Use whenever a script / test / debug invocation needs to reach
+    the local ``nexusd-cluster`` (or any local daemon) listening on
+    ``0.0.0.0``.  For peer-facing publication of this node's
+    address, use :func:`resolve_self_ip` instead.
+    """
+    return "127.0.0.1"
 
 
 def resolve_peer(hostname_pattern: str, *, online_only: bool = True) -> str:
@@ -159,13 +188,17 @@ def main(argv: Iterable[str] | None = None) -> int:
     if not args or args[0] in {"-h", "--help"}:
         print(__doc__)
         print("\nUsage:")
-        print("  python -m scripts._tailscale_peers self")
+        print("  python -m scripts._tailscale_peers self    # Tailscale IP (publish to peers)")
+        print("  python -m scripts._tailscale_peers local   # Loopback (connect to own daemon)")
         print("  python -m scripts._tailscale_peers peer <hostname-prefix>")
         return 0
 
     cmd = args[0]
     if cmd == "self":
         print(resolve_self_ip())
+        return 0
+    if cmd == "local":
+        print(resolve_local_endpoint())
         return 0
     if cmd == "peer":
         if len(args) < 2:

--- a/tests/unit/scripts/test_tailscale_peers.py
+++ b/tests/unit/scripts/test_tailscale_peers.py
@@ -67,6 +67,19 @@ def test_resolve_self_ipv4_only(fake_status):
     assert tp.resolve_self_ip() == "100.64.0.27"
 
 
+def test_resolve_local_endpoint_is_loopback():
+    # `resolve_local_endpoint` is the connect-to-self primitive and must
+    # always return loopback, regardless of Tailscale state.  Going
+    # through the Tailscale IP on Windows triggers a Go-net-stack
+    # hairpin quirk that times out; loopback is universally fast and
+    # avoids the Tailscale data plane entirely for self-connect.
+    #
+    # No `fake_status` fixture — the helper must not depend on
+    # Tailscale being installed or up to resolve "talk to my own
+    # daemon".
+    assert tp.resolve_local_endpoint() == "127.0.0.1"
+
+
 def test_resolve_peer_exact_match(fake_status):
     # Exact hostname match on a Peer block — no stale collision, no
     # filtering noise.


### PR DESCRIPTION
## Summary

Add `resolve_local_endpoint()` to `scripts/_tailscale_peers.py` — the SSOT primitive for "connect to this node's own daemon". Returns `127.0.0.1` unconditionally, sidestepping a Tailscale-on-Windows hairpin quirk that times out `grpcurl` / Go-net-stack clients dialling the host's own Tailscale IP.

## Why

Surfaced today when smoke-debugging the cross-machine federation:

```
$ tailscale ip        → 100.64.0.27
$ Test-NetConnection 100.64.0.27 -Port 2126 → TcpTestSucceeded: True   (.NET socket)
$ grpcurl ... 100.64.0.27:2126 ...                                      (Go net.Dial)
  Failed to dial target host "100.64.0.27:2126": context deadline exceeded
$ grpcurl ... 127.0.0.1:2126 ...                                        (loopback)
  ✓ works
```

Root cause sits upstream — the Tailscale Windows TUN's hairpin path (host connecting to its own `100.64.0.x` IP) trips a Go-net-stack interaction. We don't own that fix.

Writing "remember to use `127.0.0.1`" into developer memory or per-script README would push the cognitive load onto every future contributor. The right systematic fix is to encode the decision at our SSOT layer so no caller needs to know.

## What

Two clear functions, each with single semantic:

- `resolve_self_ip()` — Tailscale IP. **Publish** to peers (`NEXUS_HOSTNAME`, raft ConfState).  *(unchanged; docstring clarified)*
- `resolve_local_endpoint()` — `127.0.0.1`. **Connect** to own daemon. *(new)*

CLI exposes both for shell substitution:

```bash
WIN_IP=$(python -m scripts._tailscale_peers self)    # 100.64.0.27  → use as peer in --peers
ENDPOINT=$(python -m scripts._tailscale_peers local) # 127.0.0.1    → grpcurl / nexus client target
```

Regression test pins both contracts (`test_resolve_local_endpoint_is_loopback`, `test_resolve_self_ipv4_only`). The local-endpoint test has no `fake_status` dependency — the helper must work even when Tailscale is not installed or up.

## Verification (7 principles)

| Principle | Result |
|---|---|
| Simplest contract | ✓ One function name per intent |
| Architecturally correct | ✓ Quirk fully encapsulated at resolver boundary; no caller knows |
| Data SSOT | ✓ "Connect to own daemon" decision in exactly one place |
| DRY | ✓ Replaces what would otherwise be N hardcoded `127.0.0.1` literals scattered through smoke scripts and docs |
| Rust-first | △ Python — but in `scripts/_tailscale_peers.py` (dev/test tooling, established Python module from PR #4170); Rust `nexus` CLI per cli-design.md will grow its own equivalent when built |
| Perf-first | ✓ Returns a string constant — zero cost; faster than `resolve_self_ip` (which shells out to `tailscale status`) |
| Systemic, not patch | ✓ Fix lives at the right layer (resolver SSOT); not a per-script workaround, not a route-table hack, not developer memory |

## Test plan

- [x] `pytest tests/unit/scripts/test_tailscale_peers.py -v` — 10/10 pass
- [x] `python -m scripts._tailscale_peers local` prints `127.0.0.1`
- [x] Functional: `$(python -m scripts._tailscale_peers local):2126` unblocks grpcurl call against the local daemon end-to-end
- [ ] CI: lint + unit tests on linux/macos
