### PR TITLE
fix(raft): report transport send failures back to raft-rs — unblock cross-machine replication

### DIFF
--- a/rust/raft/src/raft/node.rs
+++ b/rust/raft/src/raft/node.rs
@@ -1938,6 +1938,32 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_driver_report_unreachable_and_snapshot_are_safe_pass_throughs() {
+        // Pin the contract that transport_loop relies on: the driver
+        // exposes `report_unreachable` and `report_snapshot` that
+        // never panic, even when the peer_id is unknown to raft-rs
+        // (the realistic case — a freshly-joined Learner reporting
+        // failure before its Progress entry has been populated, or
+        // a stale peer_id from a wipe-rejoin still queued in the
+        // mpsc channel).  raft-rs's underlying `report_*` calls
+        // no-op gracefully on unknown peers, but we want a guard at
+        // our boundary too so a future raft-rs version change
+        // doesn't silently destabilise the driver loop.
+        let (_handle, mut driver, _dir) = create_test_node();
+
+        // Unknown peer — must be a no-op, not a panic.
+        driver.report_unreachable(9_999_999);
+        driver.report_snapshot(9_999_999, raft::SnapshotStatus::Failure);
+        driver.report_snapshot(9_999_999, raft::SnapshotStatus::Finish);
+
+        // Self id — also safe (raft-rs no-ops; we never send to self
+        // but the failure channel could in theory deliver one).
+        let self_id = driver.config().id;
+        driver.report_unreachable(self_id);
+        driver.report_snapshot(self_id, raft::SnapshotStatus::Failure);
+    }
+
+    #[tokio::test]
     async fn test_witness_node() {
         let dir = TempDir::new().unwrap();
         let storage = RaftStorage::open(dir.path()).unwrap();

--- a/rust/raft/src/raft/node.rs
+++ b/rust/raft/src/raft/node.rs
@@ -1291,6 +1291,37 @@ impl<S: StateMachine + 'static> ZoneConsensusDriver<S> {
         self.replication_log.as_ref()
     }
 
+    /// Tell raft-rs that a peer became unreachable.
+    ///
+    /// Required by raft-rs's driver contract — when the transport
+    /// layer fails to deliver a message to ``peer_id``, the driver
+    /// must call this so the leader's Progress tracker for that
+    /// peer transitions out of ``Replicate`` state and resumes
+    /// probing.  Without it, raft-rs assumes "no response yet,
+    /// peer just slow" and stalls AppendEntries forever after the
+    /// first transport hiccup — the failure mode that surfaced on
+    /// the Win→Mac sharedzone path today.
+    ///
+    /// Idempotent and cheap (raft-rs no-ops when the peer is
+    /// already in a non-Replicate state).
+    pub fn report_unreachable(&mut self, peer_id: u64) {
+        self.raw_node.report_unreachable(peer_id);
+    }
+
+    /// Tell raft-rs whether a snapshot send to ``peer_id`` succeeded.
+    ///
+    /// Companion to [`report_unreachable`].  When the transport
+    /// layer fails to deliver a ``MsgSnapshot`` (or successfully
+    /// delivers one), the driver must call this so raft-rs's
+    /// Progress tracker for that peer can leave the ``Snapshot``
+    /// state — either by retrying the snapshot on failure, or by
+    /// resuming normal AppendEntries replication on success.
+    /// Without it, a single snapshot send failure freezes
+    /// replication to that peer permanently.
+    pub fn report_snapshot(&mut self, peer_id: u64, status: raft::SnapshotStatus) {
+        self.raw_node.report_snapshot(peer_id, status);
+    }
+
     /// Drain all pending messages from the channel and process them.
     ///
     /// Each message is executed **sequentially** on `raw_node`, which is the

--- a/rust/raft/src/transport/transport_loop.rs
+++ b/rust/raft/src/transport/transport_loop.rs
@@ -30,13 +30,28 @@ use super::proto::nexus::raft::EcReplicationEntry;
 use super::{NodeAddress, SharedPeerMap};
 use crate::raft::{StateMachine, ZoneConsensusDriver};
 use protobuf::Message as ProtobufV2Message;
+use raft::eraftpb::MessageType;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use tokio::sync::watch;
+use tokio::sync::{mpsc, watch};
 use tokio::task::JoinSet;
 
 use std::time::Duration as StdDuration;
+
+/// A transport send that failed — surfaced back from a spawned send task
+/// to the driver loop so raft-rs can be told and the affected peer's
+/// `Progress` tracker can leave its stuck state.
+///
+/// `is_snapshot` distinguishes a `MsgSnapshot` failure (needs
+/// `report_snapshot(peer, Failure)`) from any other message-type
+/// failure (needs `report_unreachable(peer)`).  Both are required
+/// to keep raft-rs's state machine honest under flaky transports.
+#[derive(Debug, Clone, Copy)]
+struct TransportFailure {
+    peer_id: u64,
+    is_snapshot: bool,
+}
 
 /// Base backoff interval for EC replication retries.
 const EC_BACKOFF_BASE: Duration = Duration::from_millis(100);
@@ -120,6 +135,18 @@ pub struct TransportLoop<S: StateMachine + 'static> {
     self_address: String,
     /// Per-peer EC replication tracking (peer_id → state).
     ec_peer_state: HashMap<u64, PeerReplicationState>,
+    /// Sender half of the transport-failure channel.  Cloned into each
+    /// `send_messages_fire_and_forget` task so a transport-level send
+    /// error (network down, HTTP/2 keepalive timeout, tonic transport
+    /// error) can be reported back to this loop without holding a
+    /// reference to the driver across `await` points.
+    failure_tx: mpsc::UnboundedSender<TransportFailure>,
+    /// Receiver half of the transport-failure channel.  Drained at the
+    /// top of each [`Self::run`] iteration and translated into
+    /// `driver.report_unreachable` / `driver.report_snapshot(_, Failure)`
+    /// calls — without those, raft-rs's `Progress` tracker stays in
+    /// `Replicate` / `Snapshot` state forever after a single failure.
+    failure_rx: mpsc::UnboundedReceiver<TransportFailure>,
 }
 
 impl<S: StateMachine + Send + Sync + 'static> TransportLoop<S> {
@@ -134,6 +161,7 @@ impl<S: StateMachine + Send + Sync + 'static> TransportLoop<S> {
     ) -> Self {
         let tick_interval = driver.config().tick_interval;
         let node_id = driver.config().id;
+        let (failure_tx, failure_rx) = mpsc::unbounded_channel();
         Self {
             driver,
             peers,
@@ -143,6 +171,8 @@ impl<S: StateMachine + Send + Sync + 'static> TransportLoop<S> {
             node_id,
             self_address: String::new(),
             ec_peer_state: HashMap::new(),
+            failure_tx,
+            failure_rx,
         }
     }
 
@@ -188,6 +218,22 @@ impl<S: StateMachine + Send + Sync + 'static> TransportLoop<S> {
                 _ = shutdown.changed() => {
                     tracing::info!("Transport loop shutting down");
                     break;
+                }
+            }
+
+            // 0. Drain any transport send failures reported by previously
+            //    spawned send tasks and forward them to raft-rs.  Must
+            //    run before `process_messages` / `advance` so the next
+            //    tick's outgoing-message set reflects the updated
+            //    `Progress` state (peer in Probe rather than stuck in
+            //    Replicate / Snapshot).  Cheap: non-blocking try_recv
+            //    drain, returns immediately when the channel is empty
+            //    (the steady-state happy path).
+            while let Ok(failure) = self.failure_rx.try_recv() {
+                self.driver.report_unreachable(failure.peer_id);
+                if failure.is_snapshot {
+                    self.driver
+                        .report_snapshot(failure.peer_id, raft::SnapshotStatus::Failure);
                 }
             }
 
@@ -251,9 +297,18 @@ impl<S: StateMachine + Send + Sync + 'static> TransportLoop<S> {
                 }
             };
 
+            // Capture the message type *before* the move into the spawned
+            // task so we can report a `MsgSnapshot` failure correctly.
+            // A failed snapshot send needs both `report_unreachable` and
+            // `report_snapshot(_, Failure)` — without the latter, the
+            // peer's Progress stays in the `Snapshot` state and raft-rs
+            // never retries.
+            let is_snapshot = msg.get_msg_type() == MessageType::MsgSnapshot;
+
             let client_pool = self.client_pool.clone();
             let zone_id = self.zone_id.clone();
             let self_address = self.self_address.clone();
+            let failure_tx = self.failure_tx.clone();
 
             tokio::spawn(async move {
                 let result = tokio::time::timeout(
@@ -262,11 +317,12 @@ impl<S: StateMachine + Send + Sync + 'static> TransportLoop<S> {
                 )
                 .await;
 
-                match result {
-                    Ok(Ok(())) => {}
+                let send_failed = match result {
+                    Ok(Ok(())) => false,
                     Ok(Err(e)) => {
                         tracing::warn!(peer = target_id, "Raft message send failed: {}", e);
                         client_pool.remove(target_id).await;
+                        true
                     }
                     Err(_elapsed) => {
                         tracing::warn!(
@@ -275,7 +331,19 @@ impl<S: StateMachine + Send + Sync + 'static> TransportLoop<S> {
                             RAFT_SEND_TIMEOUT,
                         );
                         client_pool.remove(target_id).await;
+                        true
                     }
+                };
+
+                if send_failed {
+                    // Best-effort signal back to the driver loop.  If the
+                    // receiver was dropped (loop is shutting down) the
+                    // send is a no-op; that is fine because the driver
+                    // is on its way out anyway.
+                    let _ = failure_tx.send(TransportFailure {
+                        peer_id: target_id,
+                        is_snapshot,
+                    });
                 }
             });
         }


### PR DESCRIPTION
## Summary

Close the missing half of raft-rs's driver contract — application must call `RawNode::report_unreachable(peer)` when a transport send fails, and `RawNode::report_snapshot(peer, status)` when a `MsgSnapshot` resolves. Our transport layer was silently swallowing every send failure (just `tracing::warn!` + evict client from pool). raft-rs's `Progress` tracker for the affected peer therefore stayed in `Replicate` / `Snapshot` state forever after the first transport hiccup, freezing replication permanently to that peer.

**Surfaced today** during cross-machine federation smoke: Win→Mac sharedzone replication died after the first `Http2 KeepAliveTimedOut` (~01:42 UTC). 109 failures in the next 8 minutes, then total silence on Win's side for 1+ hour even though both daemons stayed up and TCP was healthy on both sides. Mac's Learner state machine never advanced past the join snapshot (index 5). Restarting Win cleared the in-memory Progress state but reproducing the smoke replays the same failure.

## Fix

Three small focused commits (bisect-safe — each compiles, lints clean, tests green):

1. **`feat(raft): add report_unreachable / report_snapshot pass-throughs on driver`**
   Behavior-neutral. `ZoneConsensusDriver` gains two thin `&mut self` wrappers around `RawNode::report_*` so the transport layer can pipe failures back without touching `raw_node` directly.

2. **`fix(raft): pipe transport send failures back to driver via mpsc`**
   - `TransportLoop` gains an unbounded `mpsc::UnboundedSender<TransportFailure>` cloned into every `send_messages_fire_and_forget` spawn task; matching receiver lives on `TransportLoop`.
   - Spawn tasks emit `TransportFailure { peer_id, is_snapshot }` on send error / timeout (best-effort — dropped receiver during shutdown is a no-op).
   - Driver loop drains the failure channel at the very top of every iteration (before `process_messages` / `advance`) and forwards each failure to `driver.report_unreachable` (+ `driver.report_snapshot(_, Failure)` when the original message was a `MsgSnapshot`).
   - `is_snapshot` captured *before* the message moves into the spawn task — borrowing inside the closure would force ownership juggling for no gain. Unbounded channel is safe: failure rate is bounded by raft heartbeat cadence (≤O(peers) per tick); a bounded channel would risk dropping reports.

3. **`test(raft): pin driver report_* pass-through API surface`**
   Unit test that `report_unreachable` / `report_snapshot` never panic on unknown peer ids, the local node's own id, and both `SnapshotStatus` variants. Pins the contract a future raft-rs upgrade must preserve.

## Architectural verification (raft contract + 7 principles)

| Principle | Result |
|---|---|
| raft-rs driver contract | ✓ `RawNode::report_unreachable` / `report_snapshot` now invoked from the application as the upstream design intends |
| Simplest contract | ✓ Two thin pass-through methods; one mpsc channel; one drain loop at top of the existing driver tick. No new abstractions, no new traits |
| Architecturally correct | ✓ Driver still owns `raw_node` exclusively (no lock across `await`); transport failures cross the boundary via a channel, not a shared reference |
| Data SSOT | ✓ raft-rs `Progress` state remains the single source of truth for "is this peer reachable"; we just stop hiding events from it |
| DRY | ✓ One drain loop covers every zone, every peer, every message type |
| Rust-first | ✓ |
| Perf-first | ✓ `try_recv` drain at top of tick is a non-blocking peek; happy path (empty channel) is one branch. Failure path was already O(spawn-task overhead) — adding a single `send` per failure is negligible |
| Systemic, not patch | ✓ Closes the entire class of "transport hiccup → permanently stuck Progress" failures; subsumes the surface symptom F-transport-keepalive (task #36) was tracking |

## Test plan

- [x] Each commit individually compiles + passes lint + passes tests (bisect-safe)
- [x] `cargo test -p raft@0.1.0 --features grpc --lib raft::node::tests::test_driver_report` — new regression test passes
- [x] Full `cargo test -p raft@0.1.0 --features grpc` — 183 tests pass (173 lib + 10 integration), zero regressions
- [x] `cargo check -p raft@0.1.0` clean
- [ ] CI: full pipeline including Federation E2E
- [ ] Cross-machine: Mac wipe-rejoin sharedzone after this lands — Progress no longer freezes; AppendEntries flow to Learner reliably (the smoke that surfaced this bug becomes the end-to-end gate)

## After this lands

Resume task #27 L3 CRUD cross-machine smoke. The current Mac daemon's frozen state is recoverable via wipe-rejoin (new node_id → fresh Progress entry from raft-rs's POV → bug-free path). Closes task #37 and subsumes task #36.
