### PR TITLE
fix(kernel): clean up PR #4225 — collapse edit() bifurcation + promote is_loopback_url

### DIFF
--- a/docs/surface-coverage/api-rpc-surface-coverage.yaml
+++ b/docs/surface-coverage/api-rpc-surface-coverage.yaml
@@ -7886,7 +7886,7 @@ operations:
   transports:
     grpc_expose:
       name: read_batch
-      source: src/nexus/core/nexus_fs_content.py:1618
+      source: src/nexus/core/nexus_fs_content.py:1613
     sdk:
       name: KernelClient.read_batch
       source: src/nexus/remote/kernel_client.py:452
@@ -11181,7 +11181,7 @@ operations:
   transports:
     grpc_expose:
       name: write_batch
-      source: src/nexus/core/nexus_fs_content.py:1456
+      source: src/nexus/core/nexus_fs_content.py:1451
     sdk:
       name: KernelClient.write_batch
       source: src/nexus/remote/kernel_client.py:901

--- a/src/nexus/cli/api_client.py
+++ b/src/nexus/cli/api_client.py
@@ -44,7 +44,7 @@ def _normalize_loopback_url(url: str) -> str:
     return urlunparse(parsed._replace(netloc=netloc))
 
 
-def _is_loopback_url(url: str) -> bool:
+def is_loopback_url(url: str) -> bool:
     parsed = urlparse(url)
     return parsed.hostname in {"localhost", "127.0.0.1", "::1"}
 
@@ -63,7 +63,7 @@ class NexusApiClient:
         self._base_url = _normalize_loopback_url(resolved.rstrip("/"))
         self._api_key = api_key or os.environ.get("NEXUS_API_KEY", "")
         self._timeout = timeout
-        self._trust_env = not _is_loopback_url(self._base_url)
+        self._trust_env = not is_loopback_url(self._base_url)
 
     def _headers(self) -> dict[str, str]:
         headers: dict[str, str] = {"Accept": "application/json"}

--- a/src/nexus/cli/commands/status.py
+++ b/src/nexus/cli/commands/status.py
@@ -211,10 +211,10 @@ def _server_health(
     ``src/nexus/server/api/core/health.py:71-206``, so a tighter budget
     times out under realistic load.
     """
-    from nexus.cli.api_client import _is_loopback_url
+    from nexus.cli.api_client import is_loopback_url
 
     base_url = base_url.rstrip("/")
-    trust_env = not _is_loopback_url(base_url)
+    trust_env = not is_loopback_url(base_url)
 
     def public_health(client: Any) -> dict[str, Any] | None:
         try:

--- a/src/nexus/core/nexus_fs_content.py
+++ b/src/nexus/core/nexus_fs_content.py
@@ -1324,23 +1324,18 @@ class ContentMixin:
         from nexus.utils.edit_engine import EditEngine
         from nexus.utils.edit_engine import EditOperation as EditOp
 
-        current_content_id = None
-        if if_match is None:
-            content_raw = self.sys_read(path, context=context)
-            content_bytes = (
-                content_raw.get("data", b"") if isinstance(content_raw, dict) else content_raw
-            )
-            if isinstance(content_bytes, str):
-                content_bytes = content_bytes.encode("utf-8")
-            elif not isinstance(content_bytes, bytes):
-                content_bytes = bytes(content_bytes)
-        else:
-            # OCC needs the current content_id. Plain/preview edits avoid the
-            # metadata stat round trip and read only the file bytes.
-            result = self.read(path, context=context, return_metadata=True)
-            assert isinstance(result, dict), "Expected dict when return_metadata=True"
-            content_bytes = result["content"]
-            current_content_id = result.get("content_id")
+        # edit() operates on DT_REG: sys_read returns bytes per the Tier 1
+        # contract (syscall-design.md §2). Non-OCC paths skip the sys_stat
+        # round trip — only the if_match branch needs content_id.
+        content_bytes = self.sys_read(path, context=context)
+        assert isinstance(content_bytes, bytes), (
+            "edit() requires DT_REG (sys_read should return bytes)"
+        )
+
+        current_content_id: str | None = None
+        if if_match is not None:
+            meta = self.sys_stat(path, context=context)
+            current_content_id = meta.get("content_id") if meta else None
 
         # Check content_id if provided (optimistic concurrency control)
         if if_match is not None and current_content_id != if_match:


### PR DESCRIPTION
## Context

PR #4225 (commits `215742f08` + `911552e13` + `8c54f5151`, author @windoliver, non-kernel-team) merged to `develop` 2026-05-25 03:53Z, bundling four changes:

| # | Change | Verdict |
|---|---|---|
| 1 | macOS subscription test: `example.com` → `1.1.1.1` (DNS-free) | ✅ Keep as-is |
| 2 | `nexus status` loopback `trust_env=False` (matches `NexusApiClient`) | ✅ Logic correct; only the **import** is cleaned up here |
| 3 | `edit()` perf optimization bypassing the metadata stat round trip | ⚠️ Architecturally smelly — cleaned up here |
| 4 | YAML surface-coverage regen | ✅ Keep as-is |

Two architectural smells in (2) + (3) are addressed below. Notably, this PR touches `src/nexus/core/` — a CODEOWNERS-protected path — and is opened by the kernel team (we are `@elfenlieds7`); we'll self-approve once CI green.

## What this PR changes

### A. Collapse `edit()` OCC bifurcation (`nexus_fs_content.py`)

#4225 (commit `911552e13`) split `_edit_locked()` into two read paths:

```python
if if_match is None:
    content_raw = self.sys_read(path, context=context)
    content_bytes = (content_raw.get("data", b"") if isinstance(content_raw, dict) else content_raw)
    if isinstance(content_bytes, str): content_bytes = content_bytes.encode("utf-8")
    elif not isinstance(content_bytes, bytes): content_bytes = bytes(content_bytes)
else:
    result = self.read(path, context=context, return_metadata=True)  # ← Tier 2 from inside Tier 1
    ...
```

Per `docs/architecture/syscall-design.md` §2, Tier 2 `read(return_metadata=True)` is itself defined as `sys_stat + sys_read`. Calling Tier 2 from inside Tier 1 to obtain content_id is the layering inverted.

Replace with one linear path that composes Tier 1 syscalls directly:

```python
content_bytes = self.sys_read(path, context=context)                     # always — DT_REG is bytes
assert isinstance(content_bytes, bytes), "edit() requires DT_REG..."

current_content_id: str | None = None
if if_match is not None:                                                 # only OCC needs stat
    meta = self.sys_stat(path, context=context)
    current_content_id = meta.get("content_id") if meta else None
```

**Wins:**
- **Same perf characteristic as #4225** — non-OCC `edit()` still skips the stat (this is a clarity / SSOT cleanup, not a perf regression).
- Single linear path — no `if/else` content-read bifurcation.
- No defensive type coercion (`isinstance(content_raw, dict)`, `isinstance(content_bytes, str)`, `bytes(content_bytes)`) — `edit()` is DT_REG only, so the bytes-assert documents the invariant cheaply.
- No Tier 2 → Tier 1 re-entry; Tier 1 syscalls composed directly.

The "real" fix — letting `sys_read` optionally return `content_id` so OCC needs a single syscall — is a Tier 1 ABI extension and kernel-team Rust work. Tracked separately in #4232.

### B. Promote `_is_loopback_url` → `is_loopback_url`

#4225 added a second consumer of `_is_loopback_url` in `nexus.cli.commands.status` (`status.py:214`), importing it across module boundaries — but the underscore prefix marks the symbol as module-private.

Drop the underscore so it's a proper public CLI util. Kept co-located in `api_client.py` — a single cross-file import inside `cli/` does not justify a new module.

## Preserved from #4225 (NOT touched)

- ✅ macOS subscription test `1.1.1.1` DNS-free fix
- ✅ `status.py` `trust_env=False` **logic** (only the import line is updated)
- ✅ YAML regen approach (we regenerate via `scripts/gen_api_surface_coverage.py` — SSOT-compliant)

## Commits (small, one concern each)

1. `refactor(kernel): collapse edit() OCC bifurcation into single sys_read + conditional sys_stat`
2. `refactor(cli): rename _is_loopback_url → is_loopback_url for cross-module reuse`
3. `refactor(cli): status.py uses public is_loopback_url helper`
4. `chore(surface-coverage): regenerate api-rpc-surface-coverage.yaml after edit() bifurcation collapse`

## Verification

```
~/.nexus/nexus_env/python.exe -m pytest \
    tests/unit/core/test_nexus_fs_content_metrics.py \
    tests/unit/cli/test_status.py \
    tests/unit/cli/test_api_client.py
# 41 passed in 14.05s
```

Both `test_edit_preview_without_if_match_does_not_stat` (asserts `stat_calls == 0`) and `test_edit_with_if_match_reads_metadata_for_occ` (asserts `stat_calls == 1`) pass unchanged — perf invariant preserved.

Broader: `tests/unit/core/` runs 811 passed, 0 failed (ignoring `test_rebac.py` which has a pre-existing missing `freezegun` dep on the local env).

## Follow-ups (filed separately)

- #4231 — Enforce CODEOWNERS review on `develop` branch protection (repo-settings, not code; admins only). Both #4224 and #4225 bypassed CODEOWNERS within ~2h of each other.
- #4232 — Tier 1 `sys_read` should optionally return `content_id` to eliminate the OCC stat round trip. Kernel-team Rust ABI work — the "real" fix that would have saved #4225 from needing to optimize this at all.

## Forbidden zones (re-confirmed)

| Zone | This PR |
|---|---|
| Rust kernel code / primitives | Not touched |
| Kernel ABI / syscall / hook ABI fingerprint | Not touched |
| `nexusd-cluster` (services, drivers, packaging, startup) | Not touched |
| `src/nexus/core/` Python kernel-tier | **Touched, with kernel-team review (we are kernel team @elfenlieds7)** |

## Merge plan

- Merge with `gh pr merge --merge --admin` (preserve commits, no squash) per kernel-team policy.
- Self-approve as `@elfenlieds7`.