### PR TITLE
fix(raft): relax transport keep-alive defaults — Tailscale-friendly, recovery via Progress

### DIFF
--- a/rust/raft/src/transport/client.rs
+++ b/rust/raft/src/transport/client.rs
@@ -44,25 +44,41 @@ pub struct ClientConfig {
 
 impl Default for ClientConfig {
     fn default() -> Self {
-        // Raft peer transport: tight timeouts + aggressive HTTP/2 keep-alive so
-        // a dead peer's Channel is invalidated by the TCP/H2 stack in a few
-        // seconds, not after the default 10s/20s defaults. When a node restarts
-        // (test failover or a real operator bounce), the next raft send on a
-        // stale cached client must NOT pay a 5-second connect timeout while the
-        // kernel's ``SYN_SENT`` retries finally give up — that latency is the
-        // post-restart catchup flake we keep seeing in the federation E2E.
+        // Industry-standard gRPC keep-alive numbers — same shape as
+        // etcd / TiKV / Consul defaults.  Covers same-LAN, docker-
+        // network, and WAN-via-Tailscale paths with the same config.
         //
-        // The numbers below are load-bearing:
-        // - ``connect_timeout=2s``: raft peers are same-LAN/docker-network; a
-        //   connect that takes longer means the peer is not accepting.
-        // - ``keep_alive_interval=2s`` + ``keep_alive_timeout=3s``: H2 PING
-        //   every 2s, connection declared dead after 3s of no PONG. Total
-        //   detection latency ~5s even when no raft message is in flight.
+        // Recovery from a stale peer (node restart, network blip) is
+        // driven by raft-rs's own `Progress` state machine — the
+        // transport layer reports send failures back via
+        // `report_unreachable` / `report_snapshot` and raft-rs
+        // transitions the peer to `Probe` state, retrying on the
+        // next tick.  Aggressive transport-level fast-fail
+        // (`connect_timeout=2s`, `keep_alive_interval=2s`,
+        // `keep_alive_timeout=3s` — the previous defaults) is no
+        // longer needed for recovery and actively breaks on paths
+        // with normal latency jitter: a Tailscale WAN hop's PING
+        // round-trip can exceed 3s under DERP fallback or NAT
+        // hole-punch warmup, which would tear down an otherwise
+        // healthy connection.
+        //
+        // The values:
+        // - `connect_timeout=10s`: covers Tailscale first-connect
+        //   warmup, DERP relay round-trip, and slow same-LAN setup
+        //   while still failing-loud on truly unreachable peers.
+        // - `keep_alive_interval=30s`: H2 PING only when the
+        //   connection has been idle 30s — for raft this is
+        //   essentially never (heartbeats flow every ~100ms), so
+        //   PINGs only fire when the raft tick stops, which is
+        //   itself the failure signal.
+        // - `keep_alive_timeout=10s`: PONG must arrive within 10s.
+        //   Big enough to absorb WAN jitter, small enough that a
+        //   real outage is detected within a tick or two.
         Self {
-            connect_timeout: Duration::from_secs(2),
+            connect_timeout: Duration::from_secs(10),
             request_timeout: Duration::from_secs(10),
-            keep_alive_interval: Duration::from_secs(2),
-            keep_alive_timeout: Duration::from_secs(3),
+            keep_alive_interval: Duration::from_secs(30),
+            keep_alive_timeout: Duration::from_secs(10),
             tls: Arc::new(std::sync::RwLock::new(None)),
         }
     }
@@ -800,11 +816,15 @@ mod tests {
 
     #[test]
     fn test_client_config_default() {
+        // Industry-standard gRPC defaults (etcd / TiKV / Consul shape).
+        // Recovery now lives in raft-rs Progress via the report_*
+        // path, so transport-level keepalive can tolerate WAN
+        // (Tailscale) jitter without tearing down healthy connections.
         let config = ClientConfig::default();
-        assert_eq!(config.connect_timeout, Duration::from_secs(2));
+        assert_eq!(config.connect_timeout, Duration::from_secs(10));
         assert_eq!(config.request_timeout, Duration::from_secs(10));
-        assert_eq!(config.keep_alive_interval, Duration::from_secs(2));
-        assert_eq!(config.keep_alive_timeout, Duration::from_secs(3));
+        assert_eq!(config.keep_alive_interval, Duration::from_secs(30));
+        assert_eq!(config.keep_alive_timeout, Duration::from_secs(10));
     }
 
     // ---------------------------------------------------------------


### PR DESCRIPTION
## Summary

Relax the raft-transport gRPC client keep-alive defaults from same-LAN-tuned (2s ping / 3s timeout / 2s connect) to industry-standard (30s ping / 10s timeout / 10s connect).

The previous tight values were chosen to detect a stale TCP from a restarted peer faster than the kernel's `SYN_SENT` retries. After PR #4230 (driver-side `report_unreachable` / `report_snapshot` wiring), recovery from any send failure is driven by raft-rs's `Progress` state machine — the transport reports the failure, raft-rs transitions the peer to `Probe`, and the next tick retries.  Transport-level fast-fail is no longer load-bearing for recovery.

The tight numbers are now actively harmful on any WAN path.  Surfaced today on the Win↔Mac sharedzone path:

- **`NexusVfsService` gRPC on the same TCP port (using tonic's ~30s defaults) succeeded byte-exact in BOTH directions** via `grpcurl` — proved the wire path is healthy.
- **Raft transport on the same TCP connections was tearing itself down with `Http2 KeepAliveTimedOut` every few seconds** — Tailscale PING RTT can exceed 3s during DERP fallback or NAT hole-punch warmup.

## Fix

Single 1-file change.  `ClientConfig::default()`:

```diff
- connect_timeout:      2s   (was: docker fast-fail)
- keep_alive_interval:  2s
- keep_alive_timeout:   3s
+ connect_timeout:     10s   (Tailscale + DERP fallback friendly)
+ keep_alive_interval: 30s   (PING fires only when raft tick stops — itself a failure signal)
+ keep_alive_timeout:  10s   (absorbs WAN jitter; real outage still detected within a tick or two)
```

`test_client_config_default` updated to pin the new values plus a comment explaining why relaxation is safe under the post-PR-#4230 driver contract.

## Architectural verification (7 principles)

| Principle | Result |
|---|---|
| raft-rs contract | ✓ Progress recovery now flows through `report_unreachable` / `report_snapshot` (PR #4230); transport keep-alive is no longer a recovery path |
| Simplest contract | ✓ Same defaults as etcd / TiKV / Consul — one fewer magic non-standard knob |
| Architecturally correct | ✓ Detection of unreachable peers concentrated in raft-rs Progress, where it belongs |
| Data SSOT | ✓ `ClientConfig::default()` is the single source for transport timing |
| DRY | ✓ Same config covers same-LAN, docker-network, and WAN-via-Tailscale paths |
| Rust-first | ✓ |
| Perf-first | ✓ 15× fewer H2 PING frames in the steady state (raft heartbeats already flow every ~100ms, idle PINGs are pure overhead) |
| Systemic, not patch | ✓ Closes the entire class of "tight keep-alive triggers on WAN latency jitter" failures by aligning with the protocol's intended recovery model |

## Test plan

- [x] `cargo test -p raft@0.1.0 --features grpc` — 184 tests pass (174 lib + 10 integration), zero regressions
- [x] `cargo check -p raft@0.1.0` clean
- [x] `test_client_config_default` updated to pin new values
- [ ] CI: full pipeline (federation E2E is the closest existing test to docker post-restart behavior — should still pass since raft-rs Progress now handles the recovery)
- [ ] Cross-machine: Mac wipe-rejoin → AppendEntries should flow Win→Mac for the first time (the blocker this PR closes)

## After this lands

Resume task #27 L3 CRUD cross-machine smoke. The Win→Mac raft transport should sustain Tailscale paths reliably; `grpcurl Read /shared/win-hello.txt` from Mac should return byte-exact content; `grpcurl Write` from Mac should round-trip via forward-to-leader.
