### PR TITLE
fix(raft): bump per-call send timeout 5s → 30s — let snapshots finish

### DIFF
--- a/rust/raft/src/transport/transport_loop.rs
+++ b/rust/raft/src/transport/transport_loop.rs
@@ -59,8 +59,25 @@ const EC_BACKOFF_BASE: Duration = Duration::from_millis(100);
 const EC_BACKOFF_CAP: Duration = Duration::from_secs(60);
 
 /// Timeout for individual Raft consensus message sends.
-/// Kept short because Raft heartbeats/votes must be fast.
-const RAFT_SEND_TIMEOUT: StdDuration = StdDuration::from_secs(5);
+///
+/// Sized to absorb a `MsgSnapshot` transfer (KB-MB of state machine
+/// bytes over a WAN path) plus initial connect setup, not just a
+/// bare heartbeat round-trip.  The previous 5s was tuned for "raft
+/// heartbeats must be fast" and is correct for that case alone, but
+/// the same `send_raft_message` call also delivers snapshots to a
+/// newly joined Learner — those routinely exceed 5s over Tailscale
+/// or DERP, leading to client-side cancellation that the *peer*
+/// never sees as a failure (the server-side receive may complete
+/// after our timeout already aborted the RPC), keeping replication
+/// permanently stuck after Mac (Learner) join.  30 s aligns with
+/// the keep-alive interval (PR #4234) and gives the snapshot path
+/// adequate room while still bounding the spawned task lifetime.
+///
+/// Real unreachable-peer detection lives elsewhere: tonic's H2
+/// keep-alive (30 s ping / 10 s timeout) and raft-rs `Progress`
+/// state managed via `report_unreachable` (PR #4230) handle it on
+/// their own time scales without depending on this per-call cap.
+const RAFT_SEND_TIMEOUT: StdDuration = StdDuration::from_secs(30);
 
 /// Timeout for a single EC replication send.
 ///


### PR DESCRIPTION
## Summary

Bump `RAFT_SEND_TIMEOUT` per-call wrapper from 5s → 30s. PR #4234 fixed keep-alive PINGs on a tonic Channel; this fixes the **other** independent 5-second cap that was still cancelling outbound raft RPCs client-side before the server-side receive could complete.

## Why

After PR #4234 stopped the keep-alive PONG timeout flood, the next cross-machine smoke run showed:

- **0 H2 KeepAliveTimedOut** ✓ (keep-alive fix worked)
- **>1000 `Raft message send timeout after 5s peer=<mac_id>`** ← still there
- Mac side saw **zero** failures — connection ESTABLISHED, app-level VfsService gRPC byte-exact in both directions
- Mac state machine still at snapshot index 5 from initial join; no AppendEntries arrived

The 5 s wrapper at `transport_loop.rs::RAFT_SEND_TIMEOUT` wraps **every** outbound raft message send including the initial `MsgSnapshot` to a newly joined Learner.  Those carry the full state-machine payload (KB to MB) and routinely exceed 5 s over Tailscale or DERP relays.  Win's client cancels the RPC before Mac's server-side receive completes, so Win logs "send timeout" while Mac never sees a request — the asymmetric failure mode Mac reported.

The 5 s value was correct for the message it was sized for (heartbeats / votes on a same-LAN docker-network path).  It is wrong for the same path's snapshot deliveries, and our `send_raft_message` doesn't differentiate.

## Fix

```diff
- /// Kept short because Raft heartbeats/votes must be fast.
- const RAFT_SEND_TIMEOUT: StdDuration = StdDuration::from_secs(5);
+ const RAFT_SEND_TIMEOUT: StdDuration = StdDuration::from_secs(30);
```

Docstring rewritten to point at the recovery layers (`report_unreachable` from PR #4230, tonic H2 keep-alive from PR #4234) that the wrapper no longer competes with.

Existing range-sanity assertion `RAFT_SEND_TIMEOUT.as_secs() <= 30` happens to be the new ceiling — preserved as a pin.

## Architectural verification (7 principles)

| Principle | Result |
|---|---|
| raft-rs contract | ✓ Recovery / retry layered correctly: tonic keep-alive (transport health) + raft-rs Progress via report_unreachable (protocol state) — this wrapper is now a pure spawned-task safety bound, not a recovery mechanism |
| Simplest contract | ✓ Single value, single rationale (cover the slowest message type); no msg-type-dependent special-casing |
| Architecturally correct | ✓ Failure detection where it belongs (raft-rs Progress); no double-timing-out |
| Data SSOT | ✓ |
| DRY | ✓ One timeout, one place, covers all messages including snapshots |
| Rust-first | ✓ |
| Perf-first | ✓ Steady-state heartbeats return in <100ms regardless of the wrapper cap; the new ceiling only affects pathological cases |
| Systemic, not patch | ✓ Aligns with #4230 (recovery via Progress) and #4234 (transport keep-alive); the three together form the consistent recovery model |

## Test plan

- [x] `cargo test -p raft@0.1.0 --features grpc` — 183 tests pass (173 lib + 10 integration), zero regressions
- [x] `cargo check -p raft@0.1.0` clean
- [x] Existing `test_peer_send_timeout_constant` passes (its `<= 30` ceiling now matches exactly)
- [ ] CI: full pipeline
- [ ] Cross-machine: Mac wipe-rejoin → snapshot delivery completes → state machine catches up → `grpcurl Read /shared/win-hello.txt` returns byte-exact content (the smoke that has been blocked all day)
