### PR TITLE
fix(raft): drop manual snapshot+compact on AddNode — unblock cross-machine Learner replication

### DIFF
--- a/rust/raft/src/raft/node.rs
+++ b/rust/raft/src/raft/node.rs
@@ -51,7 +51,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use raft::eraftpb::{
-    ConfChange, ConfChangeType, ConfChangeV2, ConfState, Entry, EntryType, Message, Snapshot,
+    ConfChange, ConfChangeType, ConfChangeV2, ConfState, Entry, EntryType, Message,
 };
 use raft::{Config, RawNode, Storage};
 use slog::{o, Logger};
@@ -1615,53 +1615,6 @@ impl<S: StateMachine + 'static> ZoneConsensusDriver<S> {
                     );
                     sm.apply(entry.index, &Command::Noop)?;
 
-                    // After AddNode: create snapshot and compact log so raft-rs
-                    // sends snapshot (not AppendEntries) to the new follower.
-                    // Per raft contract: the initial ConfState is only in the
-                    // snapshot — new followers MUST receive a snapshot to learn
-                    // about all voters. Without this, the joiner would only see
-                    // voters added via ConfChange entries, missing the bootstrap
-                    // voters.
-                    if matches!(
-                        cc.get_change_type(),
-                        ConfChangeType::AddNode | ConfChangeType::AddLearnerNode
-                    ) {
-                        let sm_data = sm.snapshot().map_err(|e| {
-                            RaftError::Storage(format!("snapshot for new voter: {e}"))
-                        })?;
-                        let mut snapshot = Snapshot::new();
-                        {
-                            let meta = snapshot.mut_metadata();
-                            meta.index = entry.index;
-                            meta.term = entry.term;
-                            *meta.mut_conf_state() = cs.clone();
-                        }
-                        snapshot.data = sm_data.into();
-
-                        // Store snapshot WITHOUT clearing entries (we are the
-                        // leader and need entries for other followers).
-                        self.raw_node
-                            .mut_store()
-                            .store_snapshot(&snapshot)
-                            .map_err(|e| RaftError::Storage(format!("store snapshot: {e}")))?;
-                        // Compact log up to this entry so raft-rs detects
-                        // Compacted when probing the new follower and falls
-                        // back to sending the snapshot.
-                        self.raw_node
-                            .mut_store()
-                            .compact(entry.index)
-                            .map_err(|e| {
-                                RaftError::Storage(format!("compact after AddNode: {e}"))
-                            })?;
-
-                        tracing::info!(
-                            index = entry.index,
-                            node_id = cc.node_id,
-                            voters = ?cs.voters,
-                            "Created snapshot and compacted log for new voter catch-up"
-                        );
-                    }
-
                     // Notify waiting JoinZone caller (if any)
                     if let Some(tx) = self.pending_conf_changes.remove(&cc.node_id) {
                         let _ = tx.send(Ok(cs));
@@ -1681,14 +1634,11 @@ impl<S: StateMachine + 'static> ZoneConsensusDriver<S> {
                         .set_conf_state(&cs)
                         .map_err(|e| RaftError::Storage(e.to_string()))?;
 
-                    let mut has_add = false;
-
                     #[cfg(all(feature = "grpc", has_protos))]
                     if let Some(ref peer_map) = self.peer_map {
                         for single in &cc.changes {
                             match single.get_change_type() {
                                 ConfChangeType::AddNode | ConfChangeType::AddLearnerNode => {
-                                    has_add = true;
                                     if let Some(address) =
                                         node_address_from_conf_context(single.node_id, &cc.context)
                                     {
@@ -1702,20 +1652,6 @@ impl<S: StateMachine + 'static> ZoneConsensusDriver<S> {
                         }
                     }
 
-                    // Without grpc feature, still detect AddNode for snapshot creation
-                    #[cfg(not(all(feature = "grpc", has_protos)))]
-                    {
-                        for single in &cc.changes {
-                            if matches!(
-                                single.get_change_type(),
-                                ConfChangeType::AddNode | ConfChangeType::AddLearnerNode
-                            ) {
-                                has_add = true;
-                                break;
-                            }
-                        }
-                    }
-
                     tracing::info!(
                         index = entry.index,
                         num_changes = cc.changes.len(),
@@ -1723,31 +1659,6 @@ impl<S: StateMachine + 'static> ZoneConsensusDriver<S> {
                         "raft.conf_change_v2.applied",
                     );
                     sm.apply(entry.index, &Command::Noop)?;
-
-                    if has_add {
-                        let sm_data = sm.snapshot().map_err(|e| {
-                            RaftError::Storage(format!("snapshot for new voter: {e}"))
-                        })?;
-                        let mut snapshot = Snapshot::new();
-                        {
-                            let meta = snapshot.mut_metadata();
-                            meta.index = entry.index;
-                            meta.term = entry.term;
-                            *meta.mut_conf_state() = cs.clone();
-                        }
-                        snapshot.data = sm_data.into();
-
-                        self.raw_node
-                            .mut_store()
-                            .store_snapshot(&snapshot)
-                            .map_err(|e| RaftError::Storage(format!("store snapshot: {e}")))?;
-                        self.raw_node
-                            .mut_store()
-                            .compact(entry.index)
-                            .map_err(|e| {
-                                RaftError::Storage(format!("compact after AddNode v2: {e}"))
-                            })?;
-                    }
 
                     // Notify waiting JoinZone callers for each added node
                     for single in &cc.changes {


### PR DESCRIPTION
## Summary

Drop the synchronous `store_snapshot + compact(entry.index)` block that ran on every `AddNode` / `AddLearnerNode` apply (both `EntryConfChange` and `EntryConfChangeV2` paths).  Trust raft-rs's normal `Progress` + log replication to deliver the AddNode entry to the new follower — that is the canonical path documented in the raft thesis and used by etcd / tikv.

The manual snapshot/compact was added for "snapshot-based catch-up of joiners" under an older contract.  Under today's opaque-ID + JoinZone contract it is wrong: it truncates the leader's log to `entry.index`, which interacts badly with raft-rs's `Progress` state machine and silently stalls replication to the new Learner.

## Why

Surfaced today on Win → Mac sharedzone after the three prior transport-layer fixes already shipped (#4230 driver `report_*`, #4234 keep-alive defaults, #4235 send timeout):

* Leader Win applied `AddLearnerNode` at index 7; our manual code ran `store_snapshot + compact(7)`.
* Win sent 2 `MsgAppend` probes; Mac rejected (empty local log), `hint_index = 0`.
* Leader's `Progress[Mac]` went idle from there — **only `MsgHeartbeat` flowed (520 PONGs in 30 s), zero `MsgSnapshot` ever emitted**.
* Mac's storage never received `win-hello.txt` (index 6) nor the `AddLearnerNode` itself (index 7); `Read /shared/win-hello.txt` returned `-32007`.
* The same TCP connection carried byte-exact `NexusVfsService` gRPC in both directions, proving the wire path was healthy.  The stall lived in the raft layer.

What was supposed to happen vs. what did:

* **Intended** by the deleted code:  `compact(7)` triggers raft-rs to take the `Storage::entries` → `Compacted` path on a probe, fall back to `MsgSnapshot`, deliver the snapshot we stored, follower applies, catches up.
* **Actual**:  raft-rs's `Progress` state machine and our manual snapshot ended up out of step.  The leader's outgoing queue produced neither further `MsgAppend` probes nor a `MsgSnapshot`.  Replication permanently stuck.

## Fix

```diff
- // After AddNode: create snapshot and compact log so raft-rs
- // sends snapshot (not AppendEntries) to the new follower.
- if matches!(cc.get_change_type(), AddNode | AddLearnerNode) {
-     let sm_data = sm.snapshot()?;
-     let mut snapshot = Snapshot::new();
-     snapshot.mut_metadata().index = entry.index;
-     // ...
-     self.raw_node.mut_store().store_snapshot(&snapshot)?;
-     self.raw_node.mut_store().compact(entry.index)?;
- }
+ // (deleted — raft-rs delivers the AddNode entry via normal log
+ // replication, and the new follower learns ConfState by applying
+ // it through the state machine, same as etcd / tikv.)
```

Removed in both `EntryConfChange` and `EntryConfChangeV2` apply paths.  Also drops the dead `Snapshot` type import and the unused `has_add` accumulator.

The receiver-side heartbeat-commit clamp at `parse_and_step_message:391-418` already prevents the stale-commit panic that the original manual snapshot was trying to prevent.  The existing regression `test_handle_heartbeat_on_empty_follower_with_stale_commit_panics` still passes.

Snapshot lifecycle on the leader is now bounded by the workload (no automatic periodic compaction).  Wiring a `applied_index`-driven snapshot loop is a separate concern tracked as F-snapshot-lifecycle; out of scope here.

## Architectural verification (7 principles)

| Principle | Result |
|---|---|
| raft contract (100%) | ✓ joiners learn ConfState through normal log replication — the canonical raft path |
| Simplest contract | ✓ ~70 LOC of custom snapshot orchestration removed; trust raft-rs's `Progress` |
| Architecturally correct | ✓ pure raft-crate change; no kernel syscall boundary touched; no shared state contract changed |
| Data SSOT | ✓ snapshot lifecycle back to a single owner (raft-rs `RawNode`) |
| DRY | ✓ stops duplicating raft-rs's compaction decision logic |
| Rust-first | ✓ |
| Perf-first | ✓ removes per-AddNode state-machine serialize + redb write + compact transaction |
| Systemic, not patch | ✓ closes the entire class of bugs where the manual snapshot+compact and raft-rs `Progress` get out of step |

## Test plan

- [x] `cargo test -p raft@0.1.0 --features grpc` — 183 tests pass (173 lib + 10 integration), zero regressions
- [x] `cargo check -p raft@0.1.0` clean (Snapshot import + has_add cleaned up)
- [x] `test_handle_heartbeat_on_empty_follower_with_stale_commit_panics` still pinned green — the receiver-side clamp covers the heartbeat-panic class
- [ ] CI: full pipeline (federation E2E is the closest test — multi-node docker raft with the new path should be the strongest signal short of cross-machine)
- [ ] Cross-machine: Win → Mac sharedzone `Read /shared/win-hello.txt` returns byte-exact content (the smoke that has been blocked all day)

## Follow-ups (out of scope)

* **F-snapshot-lifecycle**: wire periodic `applied_index`-driven snapshot + compact on the leader so long-running clusters don't accumulate unbounded log.  raft-rs has no built-in snapshot interval; we own this loop.  Not needed for any current scenario in-repo.
* F5 — auto-GC of stale voters in ConfState (existing follow-up; unchanged by this PR).
