### PR TITLE
chore: scrub stale PyO3/cdylib references from Rust workspace comments

### DIFF
--- a/rust/backends/src/storage/remote.rs
+++ b/rust/backends/src/storage/remote.rs
@@ -61,11 +61,11 @@ fn to_server_path(zone_path: &str, backend_path: &str) -> String {
     } else {
         format!("/{backend_path}")
     };
-    if zone_path.is_empty() || zone_path == "/" {
-        bp
-    } else if bp
-        .trim_start_matches('/')
-        .starts_with(zone_path.trim_start_matches('/'))
+    if zone_path.is_empty()
+        || zone_path == "/"
+        || bp
+            .trim_start_matches('/')
+            .starts_with(zone_path.trim_start_matches('/'))
     {
         bp
     } else {

--- a/rust/backends/src/transports/api/ai/anthropic/streaming.rs
+++ b/rust/backends/src/transports/api/ai/anthropic/streaming.rs
@@ -1,10 +1,10 @@
 //! Anthropic streaming pipeline — SSE event decode → DT_STREAM → CAS persist.
 //!
-//! Called from `PyKernel::llm_start_streaming` under `py.detach(...)`, same as
-//! the OpenAI path. Writes text deltas to the DT_STREAM, persists the session
-//! envelope via `CASEngine::write_content_tracked`, emits a terminal `done`
-//! control frame carrying the session hash. All under the shared tokio
-//! runtime — no per-backend worker pools.
+//! Driven from the kernel `llm_start_streaming` syscall, same as the OpenAI
+//! path. Writes text deltas to the DT_STREAM, persists the session envelope
+//! via `CASEngine::write_content_tracked`, emits a terminal `done` control
+//! frame carrying the session hash. All under the shared tokio runtime —
+//! no per-backend worker pools.
 //!
 //! Wire shape (Anthropic Messages API):
 //!   - POST `{base_url}/v1/messages` with `x-api-key`, `anthropic-version`.

--- a/rust/backends/src/transports/api/ai/openai/mod.rs
+++ b/rust/backends/src/transports/api/ai/openai/mod.rs
@@ -29,8 +29,7 @@ pub(crate) struct OpenAIBackend {
     pub(crate) api_key: String,
     pub(crate) default_model: String,
     /// CAS engine rooted at the per-mount spool dir. `as_cas()` exposes this
-    /// to the `PyKernel::cas_*` surface so Python callers can read/write on
-    /// LLM mounts without the legacy `CASOpenAIBackend` Python wrapper.
+    /// to the kernel `cas_*` surface so callers can read/write on LLM mounts.
     pub(crate) engine: CASEngine,
     /// Shared reqwest HTTP client — one TCP/H2 pool is reused across every
     /// chat completion + streaming call on this mount.
@@ -72,7 +71,7 @@ impl OpenAIBackend {
         })
     }
 
-    /// Expose the CASEngine to the `PyKernel::cas_*` surface.
+    /// Expose the CASEngine to the kernel `cas_*` surface.
     pub(crate) fn engine(&self) -> &CASEngine {
         &self.engine
     }

--- a/rust/backends/src/transports/api/ai/openai/streaming.rs
+++ b/rust/backends/src/transports/api/ai/openai/streaming.rs
@@ -1,11 +1,9 @@
 //! OpenAI streaming pipeline — SSE decode → DT_STREAM → CAS persist.
 //!
-//! Called from `PyKernel::llm_start_streaming` under `py.detach(...)`.
-//! Everything below runs without the GIL; the only Python round-trip is the
-//! return value of the containing syscall.
+//! Driven from the kernel `llm_start_streaming` syscall; runs entirely on
+//! the kernel-shared tokio runtime.
 //!
-//! The state machine mirrors the Python `CASOpenAIBackend._run_stream` that
-//! this replaces:
+//! The state machine:
 //!   1. HTTP POST `{base_url}/chat/completions` with `stream=true`.
 //!   2. SSE decode — accumulate `choices[].delta.content` into `token`
 //!      frames, append each to the DT_STREAM at `stream_path`. Tool-call

--- a/rust/lib/src/transport_primitives/peer_blob_client.rs
+++ b/rust/lib/src/transport_primitives/peer_blob_client.rs
@@ -48,15 +48,16 @@ pub trait PeerBlobClient: Send + Sync {
 }
 
 /// No-op fallback used at `Kernel::new` so the `peer_client` field
-/// always carries an `Arc<dyn PeerBlobClient>` — non-cdylib Rust tests
-/// and WASM builds keep the same call shape. Each method errors out
-/// with "PeerBlobClient not installed"; the cdylib's transport-tier
-/// install hook replaces this with the real rpc-side impl.
+/// always carries an `Arc<dyn PeerBlobClient>` — Rust unit tests and
+/// WASM builds keep the same call shape. Each method errors out with
+/// "PeerBlobClient not installed"; the transport-tier install hook
+/// replaces this with the real rpc-side impl on the production boot
+/// path.
 pub struct NoopPeerBlobClient;
 
 impl PeerBlobClient for NoopPeerBlobClient {
     fn fetch(&self, _addr: &str, _content_id: &str) -> PeerBlobResult<Vec<u8>> {
-        Err("PeerBlobClient not installed (non-cdylib build)".into())
+        Err("PeerBlobClient not installed".into())
     }
 }
 

--- a/rust/profiles/cluster/Cargo.toml
+++ b/rust/profiles/cluster/Cargo.toml
@@ -12,8 +12,8 @@ path = "src/main.rs"
 
 [dependencies]
 # raft owns federation orchestration (ZoneManager, bootstrap_tls, etc.).
-# Only the grpc feature — skipping pyo3 saves ~3 MB on the stripped
-# binary, and this crate has no Python boundary.
+# Only the grpc feature — that is all this binary needs and dropping the
+# others keeps the stripped binary small.
 raft = { workspace = true, default-features = false, features = ["grpc"] }
 # Workspace contracts (ROOT_ZONE_ID, etc.)
 contracts = { workspace = true }
@@ -24,9 +24,8 @@ contracts = { workspace = true }
 kernel = { workspace = true }
 backends = { workspace = true, default-features = false, features = ["driver-path-local", "driver-remote"] }
 # VFS gRPC server (port 2028) + auth provider (NoAuth — mTLS is the
-# cluster-internal authentication boundary). No python feature;
-# cluster binary has zero PyO3 and never pulls the services
-# post-syscall-hooks tier.
+# cluster-internal authentication boundary). Cluster binary never pulls
+# the services post-syscall-hooks tier — keep the dep set minimal.
 transport = { workspace = true }
 
 tonic = { workspace = true }

--- a/rust/raft/src/distributed_coordinator.rs
+++ b/rust/raft/src/distributed_coordinator.rs
@@ -3,9 +3,9 @@
 //! `RaftDistributedCoordinator` is the raft-crate impl of the
 //! `DistributedCoordinator` trait the kernel exposes. The Cargo edge
 //! runs `raft → kernel`; the kernel installs an
-//! `Arc<dyn DistributedCoordinator>` into its `federation` slot via the
-//! cdylib boot path, and federation-aware syscalls dispatch through the
-//! trait.
+//! `Arc<dyn DistributedCoordinator>` into its `federation` slot from
+//! the binary boot path, and federation-aware syscalls dispatch through
+//! the trait.
 //!
 //! ## Provider shape
 //!

--- a/rust/raft/src/lib.rs
+++ b/rust/raft/src/lib.rs
@@ -43,9 +43,9 @@
 //!
 //! Part of Issue #1159: P2P Federation and Consensus Zones
 
-// The mimalloc `#[global_allocator]` lives in the final cdylib
-// (nexus-cluster). An rlib cannot declare a global allocator — only the
-// final binary (cdylib/bin) can.
+// The mimalloc `#[global_allocator]` lives in the final binary
+// (nexus-cluster / nexusd / vault). An rlib cannot declare a global
+// allocator — only the final binary can.
 
 pub mod storage;
 

--- a/rust/raft/src/transport/client.rs
+++ b/rust/raft/src/transport/client.rs
@@ -632,7 +632,7 @@ pub struct ClusterInfoResult {
 }
 
 // =============================================================================
-// JoinCluster client — shared by fullnodes (via PyO3) and witness binary
+// JoinCluster client — shared by cluster nodes and witness binary
 // =============================================================================
 
 /// Result of a successful JoinCluster call.

--- a/rust/services/Cargo.toml
+++ b/rust/services/Cargo.toml
@@ -36,8 +36,9 @@ contracts = { workspace = true }
 # — the in-tree Rust API surface is `Kernel::register_native_hook` /
 # `Kernel::prepare_audit_stream` / `kernel::core::dispatch::*`).
 # `default-features = false` keeps the kernel runtime defaults
-# (mimalloc allocator, connector HTTP stack, py-hook adapters) off so
-# this rlib stays slim; the cdylib pulls them via its own kernel dep.
+# (mimalloc allocator, connector HTTP stack) off so this rlib stays
+# slim; final binaries pull them via their own kernel dep with whatever
+# feature set they need.
 kernel = { workspace = true }
 # **HARD INVARIANT** — services ⊥ backends ⊥ raft. Services that need
 # backend or raft-replicated behaviour reach it through `kernel.sys_*`

--- a/rust/services/src/acp/service.rs
+++ b/rust/services/src/acp/service.rs
@@ -23,8 +23,10 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, OnceLock, RwLock};
 
 /// Process-wide handle to the installed AcpService. Set by
-/// [`AcpService::install`] so the hand-written PyO3 surface can find
-/// the instance without downcasting through `Arc<dyn RustService>`.
+/// [`AcpService::install`] so cross-callsite reach (set_agent_registry,
+/// register_on_terminate, gRPC handler) lands on the same instance the
+/// kernel ServiceRegistry holds — without downcasting through
+/// `Arc<dyn RustService>`.
 static ACP_SVC_HANDLE: OnceLock<Arc<AcpService<Kernel>>> = OnceLock::new();
 
 use dashmap::DashMap;

--- a/rust/services/src/acp/service.rs
+++ b/rust/services/src/acp/service.rs
@@ -386,18 +386,16 @@ impl<K: KernelAbi> AcpService<K> {
 // `install` + `handle` live in a `K = Kernel` specific impl because
 // the global `ACP_SVC_HANDLE` is concretely typed
 // `OnceLock<Arc<AcpService<Kernel>>>` — production has a single
-// kernel instance per process and this matches the cdylib boot
-// path.  A future `K = MockKernel` test fixture builds an
-// `AcpService` via `new` directly and bypasses this lookup table.
+// kernel instance per process and this matches the boot path. A
+// future `K = MockKernel` test fixture builds an `AcpService` via
+// `new` directly and bypasses this lookup table.
 impl AcpService<Kernel> {
-    /// Install the AcpService into a kernel's `ServiceRegistry`.
-    /// Called from the cdylib post-construction (PyKernel boot)
-    /// because `Arc<Kernel>` is only available after the wrapping
-    /// step.
+    /// Install the AcpService into a kernel's `ServiceRegistry`. Called
+    /// from the boot path once `Arc<Kernel>` is available.
     ///
     /// Stores the concrete Arc<AcpService> in [`ACP_SVC_HANDLE`] so
-    /// the PyO3 wiring (set_agent_registry, register_on_terminate)
-    /// can reach the same instance the registry holds without
+    /// cross-callsite reach (set_agent_registry, register_on_terminate)
+    /// can land on the same instance the registry holds without
     /// downcasting `Arc<dyn RustService>`. The handle is process-wide;
     /// a second `install` against a different kernel instance is
     /// rejected by the underlying ServiceRegistry duplicate check.
@@ -409,7 +407,7 @@ impl AcpService<Kernel> {
 
     /// Look up the installed AcpService instance. `None` when
     /// install hasn't been called yet (e.g. tests that bypass the
-    /// PyKernel boot path).
+    /// production boot path).
     pub(crate) fn handle() -> Option<Arc<Self>> {
         ACP_SVC_HANDLE.get().cloned()
     }

--- a/rust/services/src/acp/service.rs
+++ b/rust/services/src/acp/service.rs
@@ -13,9 +13,8 @@
 //!   * [`super::observer::AgentObserver`]   -- session/update accumulator
 //!
 //! AgentRegistry is reached through an injectable [`AgentRegistry`]
-//! trait. Today's PyO3-wired bridge lands in commit 21; commit 20
-//! provides the trait + a unit-test mock so the orchestration logic
-//! is testable without a Python runtime.
+//! trait so the orchestration logic in `call_agent` stays testable
+//! against a unit-test mock without standing up the real registry.
 
 #![allow(dead_code)]
 

--- a/rust/services/src/acp/service.rs
+++ b/rust/services/src/acp/service.rs
@@ -52,11 +52,10 @@ use std::time::Duration;
 
 // ── AgentRegistry trait ─────────────────────────────────────────────────
 
-/// Subset of the Python `AgentRegistry` surface AcpService depends on.
-/// Today AgentRegistry stays Python (commit 21 wires a PyO3 impl);
-/// commit 20 isolates the dependency behind this trait so the
-/// orchestration logic in [`AcpService::call_agent`] is testable
-/// without a live Python interpreter.
+/// Subset of the AgentRegistry surface AcpService depends on. The
+/// trait isolates the dependency so the orchestration logic in
+/// [`AcpService::call_agent`] is testable against a unit-test mock
+/// without instantiating the production registry.
 pub(crate) trait AgentRegistry: Send + Sync {
     /// Allocate a pid for an unmanaged agent. `name` follows the
     /// Python convention `acp:<config.name>`.

--- a/rust/services/src/acp/subprocess.rs
+++ b/rust/services/src/acp/subprocess.rs
@@ -497,8 +497,8 @@ mod tests {
     /// a metastore mount at `/{zone}/proc/...`, so `unregister_pipes`
     /// can't reach the kernel-side StdioPipeBackend to close its
     /// dup'd fd, the subprocess never sees EOF on stdin, and `wait`
-    /// hangs. Run this test against a fully-wired kernel (boot via
-    /// PyKernel + factory) where the proc-tree mount is present:
+    /// hangs. Run this test against a fully-wired kernel (the boot
+    /// path that mounts the proc-tree):
     ///   `cargo test acp::subprocess::tests::cat_roundtrip -- --ignored`
     /// The roundtrip portion of the test (write -> read -> assert
     /// echoed bytes) does pass; only the EOF / wait teardown trips on

--- a/rust/services/src/audit/mod.rs
+++ b/rust/services/src/audit/mod.rs
@@ -66,7 +66,7 @@ pub struct AuditRecord {
 
 /// VFS audit hook — implements `NativeInterceptHook` so it can be registered
 /// with `kernel.register_native_hook` and receive post-dispatch callbacks
-/// without crossing the PyO3 boundary.
+/// directly from the kernel dispatch path.
 ///
 /// Holds an `Arc<K>` to the kernel + the audit stream path; on each
 /// post-hook the record is serialised in a background thread and

--- a/rust/services/src/managed_agent/mod.rs
+++ b/rust/services/src/managed_agent/mod.rs
@@ -1008,8 +1008,7 @@ mod tests {
 
     /// Procfs lifecycle tests — exercise start_session through a real
     /// `Kernel` and assert the metastore carries the dirents + DT_LINK
-    /// rows the integration doc §2.2 promises.  Pure-Rust setup, no
-    /// PyO3.
+    /// rows the integration doc §2.2 promises.
     mod procfs {
         use super::*;
         use kernel::core::agents::registry::AgentSignal;
@@ -1047,7 +1046,7 @@ mod tests {
         }
 
         /// Build a `ManagedAgentService` with a real Kernel inside —
-        /// the only setup needed is `Kernel::new` (no PyO3 boot).
+        /// the only setup needed is `Kernel::new`.
         fn svc_with_kernel() -> (Arc<Kernel>, ManagedAgentService<Kernel>) {
             let k = Arc::new(Kernel::new());
             let svc = ManagedAgentService::new(Arc::clone(&k), Arc::clone(k.agent_registry()));

--- a/rust/services/src/managed_agent/mod.rs
+++ b/rust/services/src/managed_agent/mod.rs
@@ -283,11 +283,10 @@ impl<K: KernelAbi> ManagedAgentService<K> {
     pub(crate) const NAME: &'static str = "managed_agent";
 
     /// Service constructor.  Production callers reach this through
-    /// [`ManagedAgentService::<Kernel>::install`] which wraps the
-    /// cdylib's freshly-built `Kernel`; tests instantiate directly
-    /// with a `Kernel::new()` (cheap in-memory construction) so the
-    /// per-pid procfs entries land in the same metastore the
-    /// assertion helpers read back.
+    /// [`ManagedAgentService::<Kernel>::install`] against the boot-time
+    /// `Arc<Kernel>`; tests instantiate directly with a `Kernel::new()`
+    /// (cheap in-memory construction) so the per-pid procfs entries
+    /// land in the same metastore the assertion helpers read back.
     pub(crate) fn new(kernel: Arc<K>, agent_registry: Arc<AgentRegistry>) -> Self {
         Self {
             kernel,

--- a/rust/services/src/managed_agent/mod.rs
+++ b/rust/services/src/managed_agent/mod.rs
@@ -77,9 +77,8 @@ pub fn install_managed_agent_with_spawn(
 }
 
 /// Install ManagedAgentService on `kernel` without a runtime body
-/// (procfs + AgentRegistry only). Mirrors the existing pyo3 path
-/// `services::python::nx_managed_agent_install` for callers that
-/// don't ship a runtime.
+/// (procfs + AgentRegistry only) — for callers that do not ship a
+/// runtime spawn provider.
 pub fn install_managed_agent(kernel: &Arc<kernel::kernel::Kernel>) -> Result<(), String> {
     ManagedAgentService::<kernel::kernel::Kernel>::install(kernel)
 }

--- a/rust/transport/Cargo.toml
+++ b/rust/transport/Cargo.toml
@@ -16,8 +16,8 @@ contracts = { workspace = true }
 # Transport depends on kernel for the in-tree Rust API surface
 # (`Kernel`, `KernelError`, `OperationContext`, `vfs_proto` generated
 # stubs). `default-features = false` keeps the kernel runtime defaults
-# (mimalloc allocator, connectors HTTP, py-hook adapters) off in this
-# rlib; the cdylib pulls them via its own kernel dep.
+# (mimalloc allocator, connectors HTTP) off in this rlib; final binaries
+# pull them via their own kernel dep with whatever feature set they need.
 kernel = { workspace = true }
 backends = { workspace = true, default-features = false, features = ["driver-path-local", "driver-remote"] }
 # `lib::transport_primitives` (TLS / pool / addressing / TOFU /


### PR DESCRIPTION
## Summary

Comment hygiene sweep — drops past-tense PyO3 and cdylib references from doc comments across the Rust workspace. All workspace crates have been PyO3-free for a while (no `#[pymodule]`, no `crate-type = [\"cdylib\"]`, no `nexus_runtime` crate, no `PyKernel` struct), but the comments still framed code in terms of those vanished boundaries. New readers landing on these modules were getting misleading mental models.

Each commit is one file (or one closely-related file group) per concern — safe to revert any single one without affecting the others. Zero behavioral change in any of them except the very last bonus fix.

## Scope

15 chore commits restate doc comments against current architecture:

- `cluster/Cargo.toml` — drop \"skipping pyo3 saves ~3 MB\" past-tense framing
- `services/Cargo.toml`, `transport/Cargo.toml` — drop \"cdylib pulls them via its own kernel dep\"
- `services/managed_agent` — drop reference to deleted `services::python::nx_managed_agent_install`, drop \"cdylib\" + \"no PyO3 boot\" qualifiers
- `services/acp` — module doc (\"commit 21 PyO3 bridge\"), `ACP_SVC_HANDLE` doc (\"hand-written PyO3 surface\"), `AgentRegistry` trait doc (\"AgentRegistry stays Python\"), `install`/`handle` docs (\"cdylib post-construction PyKernel boot\")
- `services/audit` — drop \"without crossing the PyO3 boundary\" qualifier
- `raft/lib.rs` — restate global allocator placement against actual binary surface
- `raft/distributed_coordinator.rs` — drop \"cdylib boot path\"
- `raft/transport/client.rs` — `fullnodes (via PyO3)` → `cluster nodes`
- `backends/ai/{openai,anthropic}` — drop `PyKernel::llm_start_streaming` / `py.detach(...)` framing
- `lib/transport_primitives/peer_blob_client.rs` — drop \"non-cdylib build\" from doc and from user-facing error string

1 bonus fix commit:
- `backends/storage/remote.rs` — collapse redundant if-else branch (clippy `if_same_then_else`). Pre-existing lint that broke `profiles/cluster` clippy (transitive compile of backends); CI gates clippy on profiles/cluster so this was a baseline-clearing fix.

## Test plan

- [x] `cargo check --workspace --tests` — clean
- [x] `cargo clippy` on the 4 CI-gated crates (lib, kernel, raft --all-features, profiles/cluster) — clean
- [x] `cargo test -p kernel --lib` — 343/0 (matches baseline)
- [ ] CI green