### PR TITLE
fix(federation): stop gRPC accept-path starvation on the shared 2-worker runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -754,6 +754,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1993,6 +2002,7 @@ dependencies = [
  "tokio",
  "tonic",
  "tracing",
+ "tracing-appender",
  "tracing-subscriber",
  "transport",
 ]
@@ -3318,6 +3328,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3684,6 +3700,19 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
+dependencies = [
+ "crossbeam-channel",
+ "symlink",
+ "thiserror 2.0.18",
+ "time",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/rust/contracts/src/constants.rs
+++ b/rust/contracts/src/constants.rs
@@ -145,3 +145,37 @@ pub const GRPC_HTTP2_KEEPALIVE_TIMEOUT_SECS: u64 = 10;
 /// layer can't reach (e.g. when the peer process disappears
 /// silently without RST). 60s aligns with common Linux defaults.
 pub const GRPC_TCP_KEEPALIVE_SECS: u64 = 60;
+
+// ── tokio runtime sizing ───────────────────────────────────────────
+
+/// Floor on worker threads for a runtime that hosts a tonic gRPC
+/// server alongside the raft transport loops.
+///
+/// The federation server multiplexes latency-sensitive work (the
+/// accept loop + per-connection HTTP/2 handshakes) with blocking work
+/// (each zone's `transport_loop` performs synchronous redb disk I/O in
+/// `advance`). If the worker pool is too small, a burst of blocking
+/// loop work — or a flood of inbound connection attempts — can starve
+/// the accept/handshake path: new connections complete the TCP
+/// handshake (kernel backlog) but never receive an HTTP/2 SETTINGS
+/// frame, so clients time out while existing connections limp along.
+/// Four workers keep the accept path live even on a 2-core host
+/// running multiple zones.
+pub const MIN_SERVER_RUNTIME_WORKERS: usize = 4;
+
+/// Worker-thread count for a multi-threaded tokio runtime, sized to the
+/// host's available parallelism with a floor of `min_workers`.
+///
+/// SSOT for "how many workers should this runtime get?" — every
+/// `Builder::new_multi_thread()` site shares it so the daemon's outer
+/// runtime and the federation server's inner runtime scale identically
+/// instead of drifting to ad-hoc hardcoded counts. IO-bound gRPC + raft
+/// work wants roughly one worker per logical core (cgroup / affinity
+/// constrained), which `available_parallelism` reports.
+#[must_use]
+pub fn recommended_worker_threads(min_workers: usize) -> usize {
+    std::thread::available_parallelism()
+        .map(std::num::NonZeroUsize::get)
+        .unwrap_or(min_workers)
+        .max(min_workers)
+}

--- a/rust/contracts/src/lib.rs
+++ b/rust/contracts/src/lib.rs
@@ -10,8 +10,9 @@ pub mod lock_state;
 pub mod operation_context;
 pub mod rust_service;
 pub use constants::{
-    env, is_system_path, BLAKE3_EMPTY, LOCKS_PATH_PREFIX, MAX_GRPC_MESSAGE_BYTES, ROOT_ZONE_ID,
-    SHARE_REGISTRY_PREFIX, SYSTEM_PATH_PREFIX, VFS_ROOT,
+    env, is_system_path, recommended_worker_threads, BLAKE3_EMPTY, LOCKS_PATH_PREFIX,
+    MAX_GRPC_MESSAGE_BYTES, MIN_SERVER_RUNTIME_WORKERS, ROOT_ZONE_ID, SHARE_REGISTRY_PREFIX,
+    SYSTEM_PATH_PREFIX, VFS_ROOT,
 };
 pub use lock_state::{HolderInfo, LockAcquireResult, LockEntry, LockInfo, LockState, Locks};
 pub use operation_context::OperationContext;

--- a/rust/profiles/cluster/Cargo.toml
+++ b/rust/profiles/cluster/Cargo.toml
@@ -34,6 +34,10 @@ clap = { version = "4", features = ["derive", "env"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "signal", "time"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+# Non-blocking log writer: a dedicated thread owns stdout so high-frequency
+# logging can never block tokio worker threads (which would starve the gRPC
+# server's accept/handshake path on the shared runtime).
+tracing-appender = "0.2"
 gethostname = "1.1"
 
 # C3 will add a workspace [profile.release.package."nexus-cluster"]

--- a/rust/profiles/cluster/src/main.rs
+++ b/rust/profiles/cluster/src/main.rs
@@ -144,7 +144,9 @@ enum Cmd {
 }
 
 fn main() -> Result<()> {
-    install_tracing();
+    // Held until `main` returns so the non-blocking log writer thread stays
+    // alive and flushes on shutdown.
+    let _tracing_guard = install_tracing();
     let args = Args::parse();
     // Size the multi-thread runtime against the host: federation
     // gRPC + raft IO is IO-bound, so the kernel `available_parallelism`
@@ -153,9 +155,7 @@ fn main() -> Result<()> {
     // worker count — when the platform can't report a value (e.g.
     // bare-metal probes that aren't WASI-style sandboxed but lack
     // `_SC_NPROCESSORS_ONLN`).
-    let workers = std::thread::available_parallelism()
-        .map(std::num::NonZeroUsize::get)
-        .unwrap_or(2);
+    let workers = contracts::recommended_worker_threads(2);
     tokio::runtime::Builder::new_multi_thread()
         .worker_threads(workers)
         .enable_all()
@@ -407,7 +407,8 @@ async fn run_daemon(common: CommonArgs) -> Result<()> {
                 &peer_addrs_for_bootstrap,
                 bootstrap_new,
                 /* max_attempts */ None, // daemon boot — retry forever
-                /* as_learner   */ false, // root cluster votes; learners are for share/join
+                /* as_learner   */
+                false, // root cluster votes; learners are for share/join
             )
         })
         .await
@@ -620,14 +621,28 @@ async fn run_join(
     Ok(())
 }
 
-fn install_tracing() {
+/// Install the global tracing subscriber with a non-blocking stdout
+/// writer. The returned [`WorkerGuard`] MUST be held for the lifetime of
+/// the process — dropping it flushes buffered lines and stops the writer
+/// thread, so logs emitted after the drop are lost.
+///
+/// The non-blocking writer hands every log line to a dedicated thread
+/// instead of writing stdout inline. Under a slow or stalled stdout sink
+/// the default `fmt()` writer blocks the calling tokio worker in a
+/// `write()` syscall; at high log frequency that can stall enough workers
+/// to starve the gRPC server's accept/handshake path. Decoupling the I/O
+/// keeps the runtime responsive regardless of log volume.
+fn install_tracing() -> tracing_appender::non_blocking::WorkerGuard {
+    let (non_blocking, guard) = tracing_appender::non_blocking(std::io::stdout());
     tracing_subscriber::fmt()
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
                 tracing_subscriber::EnvFilter::new("nexusd_cluster=info,nexus_raft=info")
             }),
         )
+        .with_writer(non_blocking)
         .init();
+    guard
 }
 
 fn resolve_hostname(cli: Option<&str>) -> String {

--- a/rust/raft/src/raft/node.rs
+++ b/rust/raft/src/raft/node.rs
@@ -1492,12 +1492,25 @@ impl<S: StateMachine + 'static> ZoneConsensusDriver<S> {
         }
 
         // 3. Apply committed entries — NO lock drop needed, we own raw_node
+        //
+        // raft-rs ready contract: the `Ready` taken above MUST be
+        // acknowledged via `advance(ready)` + `advance_apply()` exactly
+        // once. Returning early on an apply error would leak the `Ready`,
+        // so raft-rs re-delivers the SAME committed entries on every
+        // subsequent tick — an infinite apply-error loop whose log spam
+        // and worker churn can starve the shared tokio runtime (the gRPC
+        // server then stops completing new HTTP/2 handshakes). So we
+        // capture any apply error, finish the ready lifecycle, and only
+        // surface the error afterwards — it fires once, not every tick.
         let committed = ready.take_committed_entries();
+        let mut apply_err = None;
         if !committed.is_empty() {
             tracing::debug!(count = committed.len(), "raft.apply");
-            self.apply_entries(committed).await?;
-            // Fresh apply pointer may unblock linearizable reads.
-            self.resolve_ready_reads().await;
+            match self.apply_entries(committed).await {
+                // Fresh apply pointer may unblock linearizable reads.
+                Ok(()) => self.resolve_ready_reads().await,
+                Err(e) => apply_err = Some(e),
+            }
         }
 
         // Advance the ready — NO TOCTOU: we never dropped ownership
@@ -1510,14 +1523,21 @@ impl<S: StateMachine + 'static> ZoneConsensusDriver<S> {
 
         if !light_rd.committed_entries().is_empty() {
             let committed = light_rd.take_committed_entries();
-            self.apply_entries(committed).await?;
-            self.resolve_ready_reads().await;
+            match self.apply_entries(committed).await {
+                Ok(()) => self.resolve_ready_reads().await,
+                Err(e) => apply_err = apply_err.or(Some(e)),
+            }
         }
 
         self.raw_node.advance_apply();
 
         // Update cached status for handle reads
         self.update_cached_status();
+
+        // Surface any apply error now that the ready lifecycle is closed.
+        if let Some(e) = apply_err {
+            return Err(e);
+        }
 
         // Layer 2: Witness campaign suppression (TiKV pattern).
         if self.config.is_witness {
@@ -1579,10 +1599,30 @@ impl<S: StateMachine + 'static> ZoneConsensusDriver<S> {
                     let cc: ConfChange = protobuf::Message::parse_from_bytes(&entry.data)
                         .map_err(|e| RaftError::Serialization(e.to_string()))?;
 
-                    let cs = self
-                        .raw_node
-                        .apply_conf_change(&cc)
-                        .map_err(|e| RaftError::Raft(e.to_string()))?;
+                    // raft-rs contract (RawNode::apply_conf_change): a
+                    // ConfChange may be rejected, in which case
+                    // apply_conf_change must NOT be retried. On rejection
+                    // mark the committed entry applied (Noop) so
+                    // applied_index advances past it — otherwise raft-rs
+                    // re-delivers the same entry every tick, wedging the
+                    // zone in an apply-error loop. The common rejection is
+                    // "removed all voters" on a wipe-rejoined zone.
+                    let cs = match self.raw_node.apply_conf_change(&cc) {
+                        Ok(cs) => cs,
+                        Err(e) => {
+                            tracing::warn!(
+                                index = entry.index,
+                                node_id = cc.node_id,
+                                error = %e,
+                                "raft.conf_change.rejected — advancing past rejected change",
+                            );
+                            if let Some(tx) = self.pending_conf_changes.remove(&cc.node_id) {
+                                let _ = tx.send(Err(RaftError::Raft(e.to_string())));
+                            }
+                            sm.apply(entry.index, &Command::Noop)?;
+                            continue;
+                        }
+                    };
 
                     self.raw_node
                         .mut_store()
@@ -1624,10 +1664,27 @@ impl<S: StateMachine + 'static> ZoneConsensusDriver<S> {
                     let cc: ConfChangeV2 = protobuf::Message::parse_from_bytes(&entry.data)
                         .map_err(|e| RaftError::Serialization(e.to_string()))?;
 
-                    let cs = self
-                        .raw_node
-                        .apply_conf_change(&cc)
-                        .map_err(|e| RaftError::Raft(e.to_string()))?;
+                    // See EntryConfChange above — same raft-rs rejection
+                    // contract. Notify every pending caller in the batch.
+                    let cs = match self.raw_node.apply_conf_change(&cc) {
+                        Ok(cs) => cs,
+                        Err(e) => {
+                            tracing::warn!(
+                                index = entry.index,
+                                num_changes = cc.changes.len(),
+                                error = %e,
+                                "raft.conf_change_v2.rejected — advancing past rejected change",
+                            );
+                            for single in &cc.changes {
+                                if let Some(tx) = self.pending_conf_changes.remove(&single.node_id)
+                                {
+                                    let _ = tx.send(Err(RaftError::Raft(e.to_string())));
+                                }
+                            }
+                            sm.apply(entry.index, &Command::Noop)?;
+                            continue;
+                        }
+                    };
 
                     self.raw_node
                         .mut_store()
@@ -1924,6 +1981,91 @@ mod tests {
             .with_state_machine(|sm| sm.get_metadata("/nonexistent"))
             .await;
         assert!(result.unwrap().is_none());
+    }
+
+    /// Regression: a committed ConfChange that empties the voter set makes
+    /// raft-rs `apply_conf_change` return "removed all voters". The driver
+    /// must treat it as a *rejected* change — advance `applied_index` past
+    /// it and keep returning `Ok` — rather than propagating the error and
+    /// leaking the `Ready`, which previously re-delivered the same entry
+    /// every tick (an infinite apply-error loop that starved the shared
+    /// tokio runtime and stalled the gRPC server's new-connection path).
+    #[tokio::test]
+    async fn test_advance_recovers_from_rejected_conf_change() {
+        let dir = TempDir::new().unwrap();
+        let storage = RaftStorage::open(dir.path()).unwrap();
+        let cs = ConfState {
+            voters: vec![1],
+            ..Default::default()
+        };
+        storage.set_conf_state(&cs).unwrap();
+        let store = RedbStore::open(dir.path().join("sm")).unwrap();
+        let state_machine = FullStateMachine::new(&store).unwrap();
+
+        let config = RaftConfig {
+            id: 1,
+            peers: vec![],
+            skip_bootstrap: true,
+            tick_interval: Duration::from_millis(10),
+            ..Default::default()
+        };
+        let (handle, mut driver) =
+            ZoneConsensus::new(config, storage, state_machine, None).unwrap();
+
+        // Drive the single voter to self-elect.
+        for _ in 0..100 {
+            driver.process_messages();
+            driver
+                .advance()
+                .await
+                .expect("advance before conf change must be Ok");
+            if handle.is_leader() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        assert!(handle.is_leader(), "single voter must self-elect to leader");
+
+        // Propose removing the only voter. On a single-voter group this
+        // commits via self-ack, then fails at apply with "removed all
+        // voters" — exactly the wipe-rejoin failure mode.
+        let mut cc = ConfChange::default();
+        cc.set_change_type(ConfChangeType::RemoveNode);
+        cc.node_id = 1;
+        driver
+            .raw_node
+            .propose_conf_change(vec![], cc)
+            .expect("propose RemoveNode");
+
+        let applied_before = handle.applied_index();
+
+        // Every advance() must stay Ok and applied_index must move past the
+        // rejected entry. On the pre-fix code advance() returned Err here
+        // forever and applied_index never advanced.
+        for _ in 0..50 {
+            driver.process_messages();
+            driver
+                .advance()
+                .await
+                .expect("advance must stay Ok after a rejected conf change");
+            if handle.applied_index() > applied_before {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+
+        assert!(
+            handle.applied_index() > applied_before,
+            "applied_index must advance past the rejected conf change \
+             (was {applied_before}, now {})",
+            handle.applied_index(),
+        );
+        // The rejected self-removal left membership unchanged, so the node
+        // is still a working leader.
+        assert!(
+            handle.is_leader(),
+            "leader must survive a rejected self-removal",
+        );
     }
 
     /// Mini transport loop for tests — mirrors production TransportLoop.

--- a/rust/raft/src/zone_manager.rs
+++ b/rust/raft/src/zone_manager.rs
@@ -349,8 +349,20 @@ impl ZoneManager {
             RaftError::Config(format!("Invalid bind address '{}': {}", bind_addr, e))
         })?;
 
+        // This runtime hosts BOTH the tonic gRPC server (accept loop +
+        // per-connection HTTP/2 handshakes for raft and VFS) and every
+        // zone's `transport_loop` (which does synchronous redb disk I/O
+        // in `advance`). A hardcoded 2-worker pool starves the
+        // accept/handshake path under load — new connections finish the
+        // TCP handshake but never get an HTTP/2 SETTINGS frame, so peers
+        // see most join/replication dials time out while heartbeats on
+        // established connections survive. Size to the host like the
+        // outer daemon runtime, with a floor that keeps the accept path
+        // live even on small multi-zone hosts.
+        let worker_threads =
+            contracts::recommended_worker_threads(contracts::MIN_SERVER_RUNTIME_WORKERS);
         let runtime = tokio::runtime::Builder::new_multi_thread()
-            .worker_threads(2)
+            .worker_threads(worker_threads)
             .enable_all()
             .thread_name("nexus-zone-mgr")
             .build()


### PR DESCRIPTION
## Root cause

`ZoneManager`'s tokio runtime is hardcoded to **2 worker threads**
(`rust/raft/src/zone_manager.rs`), while the rest of the daemon
host-sizes to `available_parallelism`. That single runtime multiplexes:

- the tonic gRPC server — accept loop **and** every per-connection HTTP/2
  handshake, for both the raft transport and the co-hosted VFS service;
- every zone's `transport_loop`, which performs **synchronous redb disk
  I/O** in `advance()` (append / set_hard_state / apply_snapshot).

Under a flood of inbound connection attempts (e.g. a peer retrying a
zone join), the latency-sensitive accept/handshake path competes with
blocking loop work for just two workers and mostly loses. New
connections complete the TCP handshake (kernel backlog) but never
receive an HTTP/2 SETTINGS frame, so the client's dial times out. Peers
on already-established connections keep exchanging keepalive/heartbeats,
and outbound client traffic is unaffected — so the node looks "up" while
most new inbound dials fail.

The observed signature was ~24% of dials establishing and ~76% timing
out. A partial (not total) failure rate is the fingerprint of **worker
starvation**, not a crashed server or a lock deadlock (either of which
would give 0% establishment).

## Fix

**1. Host-size the federation server runtime.** Size `ZoneManager`'s
runtime to the host like the outer daemon runtime, via a shared
`contracts::recommended_worker_threads()` helper — one SSOT for both
runtime-construction sites — with a `MIN_SERVER_RUNTIME_WORKERS` floor
that keeps the accept path live even on small multi-zone hosts.

**2. Non-blocking tracing writer.** The default `fmt()` subscriber writes
stdout inline, so a slow/stalled sink blocks the calling worker in
`write()` — especially costly when workers are scarce. A dedicated
writer thread decouples log I/O from the worker pool.

**3. (Secondary) Raft apply-path contract correctness.** Independent of
the starvation fix, two `advance()` correctness issues:
- always acknowledge the `Ready` via `advance(ready)` + `advance_apply()`
  even when applying committed entries fails (raw_node contract);
- treat a `apply_conf_change` rejection (e.g. "removed all voters" on a
  wipe-rejoined zone) as a rejection per raft-rs's contract — notify the
  waiting caller, advance past the entry, continue — instead of
  propagating it as a fatal error. Covered by a regression test.

## Verification

- `cargo clippy --all-features` clean on contracts / raft / cluster.
- `cargo fmt --check` clean on the gated crates (raft, profiles/cluster).
- New regression test `test_advance_recovers_from_rejected_conf_change`
  passes; existing raft lib tests green.

## Not in this PR (follow-ups)

- Offload `advance()`'s synchronous redb I/O to `spawn_blocking` so a
  blocking storage write can never occupy an async worker (the deeper
  "no blocking work on async workers" fix; invasive, perf-sensitive).
- Consolidate the nested daemon/`ZoneManager` runtimes.

## Honest validation note

This is the strongest-evidenced root cause with a principled fix, but the
definitive confirmation is the cross-machine federation smoke (a peer
joining a shared zone over the real network), which requires the peer to
run a rebuilt binary. That end-to-end check is not part of this PR.