### PR TITLE
chore(search,rebac): #4250 follow-ups — freshness comment, recall-bound doc, ContextVar cleanup

### DIFF
--- a/src/nexus/bricks/rebac/enforcer.py
+++ b/src/nexus/bricks/rebac/enforcer.py
@@ -1313,6 +1313,10 @@ class PermissionEnforcer:
 
         subject = ("user", user_id)
         checks_by_path, checks = _dedupe_checks_by_path(subject, paths)
+        # rebac_check_bulk is graph-fresh on its own: BulkPermissionChecker
+        # forces a fresh Rust graph per call (tuple_version = time_ns()), so
+        # the process-global GRAPH_CACHE cannot leak stale results across call
+        # sites. A separate freshness workaround here would be redundant.
         results = self.rebac_manager.rebac_check_bulk(checks, zone_id=zone_id)
 
         return [

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -245,6 +245,11 @@ class SearchDaemon:
     """
 
     def _search_timing_var(self) -> ContextVar[dict[str, float] | None]:
+        """Per-instance ContextVar holding the request-local timing snapshot.
+
+        Created lazily on first access — the sole creation path, so instances
+        that skip ``__init__`` (test doubles, subclasses) still work.
+        """
         timing_var = self.__dict__.get("_last_search_timing_var")
         if timing_var is None:
             timing_var = ContextVar(
@@ -372,11 +377,9 @@ class SearchDaemon:
         self._fts_backend: Any = None
         self._vector_backend: Any = None
         self._embedding_client: Any = None
-        self._last_search_timing_var: ContextVar[dict[str, float] | None] = ContextVar(
-            f"search_daemon_{id(self)}_last_search_timing",
-            default=None,
-        )
-        self.last_search_timing: dict[str, float] = {}
+        # ContextVar is created lazily by _search_timing_var(); the setter
+        # below routes through it, so no separate eager construction here.
+        self.last_search_timing = {}
 
         # Skeleton index (Issue #3725) — in-memory BM25-lite for /locate endpoint.
         # Bootstrapped from document_skeleton DB rows; no file reads on restart (13B).

--- a/src/nexus/bricks/search/pg_fts_backend.py
+++ b/src/nexus/bricks/search/pg_fts_backend.py
@@ -404,6 +404,14 @@ class PgFtsBackend:
         preserves the #3980 rare-phrase behavior without a corpus-wide page
         aggregation CTE on the query hot path.
 
+        Recall bound: only the top ``page_candidate_limit(k)`` chunk matches
+        (``max(k * 8, 64)``) are considered. A page surfaces iff at least one
+        of its chunks ranks within that candidate window. For pathologically
+        long documents whose only match is a low-BM25 chunk ranked beyond the
+        window, the page can be missed — the retired CTE path scored the whole
+        page_text and had no such bound. Widen the multiplier if recall on
+        very long documents regresses.
+
         Args:
             query: BM25 search query string.
             path: Path prefix filter (e.g. "/zone/subdir/").


### PR DESCRIPTION
## Summary

Three small follow-ups to the merged PR #4250 (search latency + ReBAC fallback). All service-tier; no kernel/ABI/cluster surface touched. Each is an independent commit.

1. **`docs(rebac)`** — comment at `PermissionEnforcer._filter_search_bulk` documenting that `rebac_check_bulk` is graph-fresh on its own (`BulkPermissionChecker.check_bulk` forces a fresh Rust graph per call via `tuple_version = time_ns()`; L1 entries invalidate on tuple writes). PR #4250 removed an enforcer-side `time_ns()` workaround that *looked* load-bearing; this note prevents it being resurrected. Verified the freshness guarantee is preserved, not lost.

2. **`docs(search)`** — document the page-search recall bound on `PgFtsBackend.keyword_search_pages`. The retired corpus-wide CTE scored full `page_text`; the new over-fetch (`max(k*8, 64)` chunk candidates) surfaces a page only if one of its chunks ranks within the candidate window. Makes the multiplier a known, tunable knob.

3. **`refactor(search)`** — single-source the daemon's request-local timing `ContextVar`. It was created both eagerly in `__init__` and lazily in `_search_timing_var()`; drop the eager path and let the lazy getter be the sole creation site (it already covers instances that skip `__init__`). One mechanism, identical behavior.

## Context

These are the non-blocking observations from a kernel-team audit of #4250. #4250 itself was clean (no forbidden-zone violations). These three close the documentation/cleanup loose ends; none change runtime behavior except the ContextVar refactor (which is behavior-preserving).

## Validation

- `mypy src/nexus/bricks/search/daemon.py src/nexus/bricks/search/pg_fts_backend.py src/nexus/bricks/rebac/enforcer.py` — Success, no issues
- `ruff check` + `ruff format --check` — all pass, already formatted
- `pytest` targeted suites (pg_fts, daemon routing, search rebac filter, enforcer inheritance, permission filter chain, workflow dispatch) — **74 passed, 5 skipped**

## Test plan

- [ ] CI green
- [ ] No regression in search / rebac suites