### PR TITLE
docs(integration): §5.4 align audit auto-wire with §5.3 Mount observer

### DIFF
--- a/docs/architecture/nexus-integration-architecture.md
+++ b/docs/architecture/nexus-integration-architecture.md
@@ -551,7 +551,7 @@ Each production node shares a 1:1 zone with the audit-node. `AuditHook` writes f
 
 ```
 Production nexusd (node A)
-    │  AuditHook → /__sys__/audit/traces/  (auto-wired by zone_create(audit=true))
+    │  AuditHook → /__sys__/audit/traces/  (auto-wired by the Mount observer, §5.3)
     │
     └──► Shared zone: zone-A-audit
               Raft cluster: [node-A voter, audit-node learner]
@@ -568,7 +568,7 @@ Audit nexusd (audit-node)
     └── local collect/gather: reads all /__sys__/audit/traces/ streams, aggregates
 ```
 
-The 1:1 zone holds `AuditRecord` only — formatted by `AuditHook`, with no production-zone metadata or lock commands. audit-node joins via `zone_join(zone_id, as_learner=true, audit=true)` so the production zone's voter quorum is unaffected; audit loss is preferable to blocking production writes.
+The 1:1 zone holds `AuditRecord` only — formatted by `AuditHook`, with no production-zone metadata or lock commands. The audit-node joins the shared zone as a learner, so the production zone's voter quorum is unaffected; audit loss is preferable to blocking production writes.
 
 ### 5.5 AuditRecord schema
 


### PR DESCRIPTION
## Summary

Follow-up to #4255. §5.4 still referenced a `zone_create(audit=true)` / `zone_join(..., audit=true)` API that §5.3 supersedes:

- §5.3 (the current model): audit auto-wiring is driven by the `FileEventType::Mount` observer registered by `services::audit::install_root`; `zone_create` is a raft-layer operation, not a syscall, and there is no `audit=true` flag.

This PR rewords the §5.4 diagram annotation and the learner-join sentence to match, keeping SSOT by pointing at §5.3 (no API restatement).

## Test plan

- [ ] doc-only; markdown renders; §5.3 ↔ §5.4 now consistent
- [ ] CI all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)