### PR TITLE
refactor(raft): route raft gRPC clients through transport_primitives::create_channel

### DIFF
--- a/rust/raft/src/transport/client.rs
+++ b/rust/raft/src/transport/client.rs
@@ -84,6 +84,29 @@ impl Default for ClientConfig {
     }
 }
 
+/// Translate the raft [`ClientConfig`] (+ a TLS snapshot) into the shared
+/// [`lib::transport_primitives::ClientConfig`] so every raft gRPC client goes
+/// through the one [`lib::transport_primitives::create_channel`] Endpoint
+/// builder instead of hand-rolling its own.
+///
+/// Deliberately does NOT set `keep_alive_while_idle`: raft already keeps the
+/// connection busy with heartbeats, and idle H2 PINGs risk tripping a peer's
+/// ping-strike policy (GOAWAY / BrokenPipe). Matches the config the rest of
+/// nexus's gRPC clients use.
+fn channel_config(
+    config: &ClientConfig,
+    tls: Option<super::TlsConfig>,
+) -> lib::transport_primitives::ClientConfig {
+    lib::transport_primitives::ClientConfig {
+        connect_timeout: config.connect_timeout,
+        request_timeout: config.request_timeout,
+        tcp_keepalive: None,
+        http2_keepalive_interval: Some(config.keep_alive_interval),
+        http2_keepalive_timeout: Some(config.keep_alive_timeout),
+        tls,
+    }
+}
+
 /// A cached client entry with its creation timestamp for TTL eviction.
 struct CachedClient {
     client: RaftClient,
@@ -207,30 +230,11 @@ impl RaftClient {
             tls_snapshot.is_some()
         );
 
-        let mut ep = Endpoint::from_shared(endpoint.to_string())
-            .map_err(|e| TransportError::InvalidAddress(e.to_string()))?
-            .connect_timeout(config.connect_timeout)
-            .timeout(config.request_timeout)
-            .http2_keep_alive_interval(config.keep_alive_interval)
-            .keep_alive_timeout(config.keep_alive_timeout)
-            // Ping even when the connection is idle — raft heartbeats are
-            // frequent enough that this rarely matters in steady state, but
-            // when a peer is temporarily down and no outbound messages queue
-            // to it, this is what keeps detection latency bounded.
-            .keep_alive_while_idle(true);
-
-        if let Some(ref tls) = tls_snapshot {
-            let identity = tonic::transport::Identity::from_pem(&tls.cert_pem, &tls.key_pem);
-            let ca = tonic::transport::Certificate::from_pem(&tls.ca_pem);
-            let tls_config = tonic::transport::ClientTlsConfig::new()
-                .identity(identity)
-                .ca_certificate(ca);
-            ep = ep
-                .tls_config(tls_config)
-                .map_err(|e| TransportError::Connection(format!("TLS config error: {}", e)))?;
-        }
-
-        let channel = ep.connect().await?;
+        let channel = lib::transport_primitives::create_channel(
+            endpoint,
+            &channel_config(&config, tls_snapshot),
+        )
+        .await?;
         let inner = ZoneTransportServiceClient::new(channel);
 
         tracing::info!("Connected to Raft node at {}", endpoint);
@@ -342,25 +346,11 @@ impl RaftApiClient {
             tls_snapshot.is_some()
         );
 
-        let mut ep = Endpoint::from_shared(endpoint.to_string())
-            .map_err(|e| TransportError::InvalidAddress(e.to_string()))?
-            .connect_timeout(config.connect_timeout)
-            .timeout(config.request_timeout)
-            .http2_keep_alive_interval(config.keep_alive_interval)
-            .keep_alive_timeout(config.keep_alive_timeout);
-
-        if let Some(ref tls) = tls_snapshot {
-            let identity = tonic::transport::Identity::from_pem(&tls.cert_pem, &tls.key_pem);
-            let ca = tonic::transport::Certificate::from_pem(&tls.ca_pem);
-            let tls_config = tonic::transport::ClientTlsConfig::new()
-                .identity(identity)
-                .ca_certificate(ca);
-            ep = ep
-                .tls_config(tls_config)
-                .map_err(|e| TransportError::Connection(format!("TLS config error: {}", e)))?;
-        }
-
-        let channel = ep.connect().await?;
+        let channel = lib::transport_primitives::create_channel(
+            endpoint,
+            &channel_config(&config, tls_snapshot),
+        )
+        .await?;
         let inner = ZoneApiServiceClient::new(channel);
 
         tracing::info!("Connected to Raft API at {}", endpoint);


### PR DESCRIPTION
## What

`RaftClient::connect` and `RaftApiClient::connect` each hand-rolled their own
tonic `Endpoint` (timeouts, HTTP/2 keepalive, TLS), duplicating setup and
drifting from `lib::transport_primitives::create_channel` — the shared builder
the rest of nexus's gRPC clients (and our own server side, via
`apply_server_limits`) already use. This consolidates both raft client connects
onto `create_channel` via a small `channel_config()` translator.

raft's `transport::{TlsConfig, Result, TransportError}` are already re-exports
of lib's (`transport/mod.rs`), so the consolidation needs **no** type conversion
or error mapping.

## Why it matters

Pure SSOT/DRY cleanup. Today every nexus gRPC client other than raft uses
`transport_primitives::create_channel`; raft was the lone holdout with a
parallel `ClientConfig` struct that drifted as we tuned keepalive elsewhere
(e.g. #4234 retuned defaults but had to skip raft because raft had its own
copy). After this PR there is exactly one place where the channel-building
policy lives.

Side effect: drops `keep_alive_while_idle(true)` from the raft path, matching
the default everywhere else. raft already keeps the connection busy with
~100ms heartbeats and recovers stale peers via `report_unreachable` + the 60s
client-pool TTL, so the idle ping is redundant.

> Earlier framing of this change as the prime suspect for the Win↔Mac
> sharedzone replication wedge has been **withdrawn**. PR #4293 (DT_MOUNT
> apply-cb wiring for `nexusd-cluster` boot) was the actual fix for the
> wedge. This PR is now strictly a transport-client SSOT consolidation
> with no claimed user-visible behaviour change.

## Scope

- Consolidated: `RaftClient::connect` (ZoneTransportService — the raft
  heartbeat/append/snapshot path) and `RaftApiClient::connect` (ZoneApiService).
- Left as-is: the three one-shot admin RPC helpers (`call_join_cluster`,
  `call_join_zone_rpc`, `call_delete_zone`) — plaintext one-shots with a single
  caller timeout and no keepalive footgun; touching a working path for marginal
  gain isn't worth the risk.

## Principle check

- **SSOT/DRY**: one `create_channel` for every raft gRPC client (server side
  already shared). Net −10 lines.
- **raft contract**: transport-layer only; no raft-rs semantics touched. Failure
  detection still via heartbeats + `report_unreachable` + pool TTL.
- **No boundary leak**: raft→lib is an existing (grpc-gated) dependency.
- **perf**: connect-time only; slightly less idle network chatter.

## Verification

- `cargo clippy -p raft --all-features` clean.
- Full raft suite green: 174 lib unit tests + integration tests pass
  (`NEXUS_DOCKER_TEST=0`; the docker-cluster test needs an external compose
  cluster).
- Cross-machine smoke deferred to a follow-up after the joiner-side DT_MOUNT
  apply-cb path lands; not gated on this PR since this is now a strict SSOT
  refactor with no claimed correctness fix.
