### PR TITLE
docs(readme): add distributed topology — node roles + profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,15 @@
   <img alt="Nexus" src="assets/logo.png" width="180">
 </picture>
 
-### The filesystem & context plane for AI agents
+### Distributed VFS kernel for multi-agent systems
 
-Give every agent one place to read, write, search, remember, and collaborate — from a single-file script to a fleet of thousands.
+The infrastructure layer that decides how agents coexist — storage, communication, permissions, coordination.
 
 [![CI](https://github.com/nexi-lab/nexus/actions/workflows/test.yml/badge.svg)](https://github.com/nexi-lab/nexus/actions/workflows/test.yml)
 [![PyPI](https://img.shields.io/pypi/v/nexus-ai-fs?color=blue)](https://pypi.org/project/nexus-ai-fs/)
 [![nexus-fs](https://img.shields.io/pypi/v/nexus-fs?label=nexus-fs&color=blue)](https://pypi.org/project/nexus-fs/)
 [![@nexus-ai-fs/tui](https://img.shields.io/npm/v/@nexus-ai-fs/tui?label=@nexus-ai-fs/tui&color=blue)](https://www.npmjs.com/package/@nexus-ai-fs/tui)
-[![Python 3.12+](https://img.shields.io/badge/python-3.12+-3776AB?logo=python&logoColor=white)](https://www.python.org/downloads/)
+[![Python 3.14+](https://img.shields.io/badge/python-3.14+-3776AB?logo=python&logoColor=white)](https://www.python.org/downloads/)
 [![License](https://img.shields.io/badge/license-Apache_2.0-blue)](LICENSE)
 [![Discord](https://img.shields.io/badge/Discord-community-5865F2?logo=discord&logoColor=white)](https://discord.gg/nexus)
 
@@ -24,41 +24,69 @@ Give every agent one place to read, write, search, remember, and collaborate —
 
 ---
 
-## Why Nexus
+## Why Nexus exists
 
-Every agent framework gives you tool calling. None gives you a shared filesystem. Without one, agents duplicate files, lose context between runs, step on each other's writes, and can't discover what's already been built.
+The hard problem isn't making one agent work. It's making many agents work together reliably across nodes.
 
-Nexus fixes this. One VFS-style interface — start embedded in a single Python process, scale to a daemon-backed deployment with auth, permissions, federation, and multi-tenant isolation. No code changes.
+Agent harnesses (LangGraph, CrewAI, AutoGen) decide **what** agents do — tool calls, chains, memory loops. But when agents collaborate, every harness re-invents the same unsolved problems: shared storage, permission boundaries, inter-agent messaging, distributed coordination. And every time, the answers are different, fragile, and non-composable.
 
-## How it works
+Nexus is the layer underneath. A distributed VFS kernel — like Linux for AI agents — that provides the primitives any harness needs but none should build:
+
+**Steering engineering** — infrastructure that sets boundaries and rules so agents operate safely at scale:
+- Permission boundaries (ReBAC) — agents only touch what they're allowed to
+- IPC primitives (DT_PIPE ~0.5us, DT_STREAM append-only log) — zero-copy inter-agent messaging
+- Process isolation (ProcessTable, workspace boundaries) — agent crashes don't cascade
+- Distributed coordination (Raft consensus, advisory locks) — multi-node without split-brain
+
+**Context engineering** — infrastructure that gives agents the right information at the right time:
+- Unified VFS namespace — all data under one path tree, not scattered APIs
+- Semantic search (BM25S + pgvector + section-aware grep) — precise context retrieval
+- CAS dedup + content chunking — efficient storage and retrieval at scale
+- Federation reads — transparent cross-node data access, agents don't need to know where data lives
+
+**Production distributed topology** — not a single-node toy; a full IT infrastructure for agent organizations:
+
+| Node role | Profile | What it does |
+|---|---|---|
+| **Hub** | `full` | Central server — Postgres, Dragonfly, all 35+ bricks, auth, search |
+| **Worker** | `sandbox` | Agent execution sandbox — SQLite + BM25S, zero external deps |
+| **Gateway** | `remote` | Thin RPC client — zero local storage, routes to hub |
+| **Auditor** | `cluster` + audit | Centralized audit log — every operation across all nodes |
+| **Federation peer** | `cloud` | Full + Raft consensus + multi-tenant — spans data centers |
+| **Edge** | `lite` / `embedded` | Pi, Jetson, MCU — local-first with federation sync |
+
+These compose like corporate IT: gateway nodes front the traffic, hubs serve the workload, workers run agents in isolation, auditors watch everything, federation peers replicate across regions. One binary, different profiles.
+
+One interface. Start embedded in a single Python process, scale to a federated cluster across data centers. No code changes.
+
+> *Built by [SudoClaw](https://github.com/nexi-lab) — we focus on making agents deliver quality work, with token economy.*
+
+## Architecture
 
 ```
-┌─────────────────────────────────────────────────────────────────────────┐
-│  BRICKS (runtime-loadable)                                              │
-│  ReBAC · Auth · Agents · Delegation · Search · Memory · Governance      │
-│  Workflows · Pay · MCP · Snapshots · Catalog · Identity · 25+ more      │
-└─────────────────────────────────────────────────────────────────────────┘
-                              ↓ protocol interface
-┌─────────────────────────────────────────────────────────────────────────┐
-│  KERNEL                                                                 │
-│  VFS · Metastore · ObjectStore · Syscall dispatch · Pipes ·             │
-│  Lock manager · Three-phase write (LSM hooks) · CAS dedup              │
-└─────────────────────────────────────────────────────────────────────────┘
-                              ↓ dependency injection
-┌─────────────────────────────────────────────────────────────────────────┐
-│  DRIVERS                                                                │
-│  redb · PostgreSQL (pgvector) · S3 · GCS · Dragonfly · Zoekt · gRPC    │
-└─────────────────────────────────────────────────────────────────────────┘
++-----------------------------------------------------------------------+
+|  BRICKS (runtime-loadable, 35+)                                       |
+|  ReBAC . Auth . Agents . Delegation . Search . Memory . Governance    |
+|  Workflows . Pay . MCP . Sandbox . Catalog . Identity . 25+ more      |
++-----------------------------------------------------------------------+
+                              | protocol interface
++-----------------------------------------------------------------------+
+|  KERNEL (pure Rust, ~5 MB binary)                                     |
+|  VFS . Syscall dispatch . Metastore . CAS . Pipes . Streams .        |
+|  Lock manager . FileWatcher . Permission gate . Federation (Raft)     |
++-----------------------------------------------------------------------+
+                              | dependency injection
++-----------------------------------------------------------------------+
+|  DRIVERS (hot-swappable)                                              |
+|  redb . PostgreSQL (pgvector) . S3 . GCS . Dragonfly . BM25S . gRPC  |
++-----------------------------------------------------------------------+
 ```
 
-**Kernel** never changes. **Drivers** swap at config time. **Bricks** mount and unmount at runtime — like `insmod`/`rmmod` for an AI filesystem.
+**Kernel** is pure Rust — a ~5 MB static binary (`nexusd-cluster`) that runs VFS + Raft + IPC + ReBAC + 4-pillar storage with zero Python dependency. It exposes 14 syscalls and never changes.
 
-## Requirements
+**Drivers** swap at mount time via `sys_setattr`. Hot-plug any storage backend without restart.
 
-- **Python 3.14+** (Nexus dropped support for 3.12/3.13 in vNEXT). Bare-metal
-  `pip install nexus` requires a Rust toolchain because `pdf-inspector` builds
-  from sdist until upstream ships cp314 wheels. The official Docker image
-  ships Rust and handles this automatically.
+**Bricks** mount and unmount at runtime via `service_enlist` / `service_swap` — like `insmod`/`rmmod` for an AI filesystem.
 
 ## Get started in 30 seconds
 
@@ -67,7 +95,7 @@ Nexus fixes this. One VFS-style interface — start embedded in a single Python 
 ```bash
 pip install nexus-ai-fs                       # CLI + SDK
 nexus init --preset demo                       # writes nexus.yaml + nexus-stack.yml
-nexus up                                       # pulls image, starts Nexus + Postgres + Dragonfly + Zoekt
+nexus up                                       # pulls image, starts Nexus + Postgres + Dragonfly
 eval $(nexus env)                              # load connection vars into your shell
 ```
 
@@ -100,21 +128,17 @@ nexus write /hello.txt "hello world"
 nexus cat /hello.txt
 nexus ls /
 nexus search query "hello" --mode hybrid
-nexus versions history /hello.txt
+nexus grep "TODO" -f "**/*.py"
 ```
 
 ### Terminal UI
 
-The TUI is a separate TypeScript package built on OpenTUI:
-
 ```bash
-bunx @nexus-ai-fs/tui                                        # published package, connects to localhost:2026
-bunx @nexus-ai-fs/tui --url http://remote:2026 --api-key KEY # connect to remote instance
-cd packages/nexus-api-client && npm install && npm run build && cd -  # build sibling dependency once in a fresh checkout
-cd packages/nexus-tui && bun install && bun run src/index.tsx          # local development from this repo
+bunx @nexus-ai-fs/tui                                        # connects to localhost:2026
+bunx @nexus-ai-fs/tui --url http://remote:2026 --api-key KEY # connect to remote
 ```
 
-File explorer, API inspector, monitoring dashboard, agent lifecycle management, and more — all from your terminal.
+File explorer, API inspector, monitoring dashboard, agent lifecycle management, and more.
 
 ## What you get
 
@@ -123,23 +147,24 @@ File explorer, API inspector, monitoring dashboard, agent lifecycle management, 
 | **Filesystem** | POSIX-style read/write/mkdir/ls with CAS dedup | Shared workspace — no more temp files |
 | **Versioning** | Every write creates an immutable version | Rollback mistakes, diff changes, audit trails |
 | **Snapshots** | Atomic multi-file transactions | Commit or rollback a batch of changes together |
-| **Search** | Keyword + semantic + hybrid, powered by Zoekt + pgvector | Find anything by content or meaning |
+| **Search** | BM25S + semantic + hybrid + section-aware grep | Find anything by content, meaning, or structure |
 | **Memory** | Persistent agent memory with consolidation + versioning | Remember across runs and sessions |
 | **Delegation** | SSH-style agent-to-agent permission narrowing | Safely sub-delegate work with scoped access |
 | **ReBAC** | Relationship-based access control (Google Zanzibar model) | Fine-grained per-file, per-agent permissions |
 | **MCP** | Mount external MCP servers, expose Nexus as 30+ MCP tools | Bridge any tool ecosystem |
-| **Workflows** | Trigger → condition → action pipelines | Automate file processing, notifications, etc. |
+| **Workflows** | Trigger / condition / action pipelines | Automate file processing, notifications, etc. |
 | **Governance** | Fraud detection, collusion rings, trust scores | Safety rails for autonomous agent fleets |
 | **Pay** | Credit ledger with reserves, policies, approvals | Metered compute for multi-tenant deployments |
-| **IPC** | Inbox-based inter-agent messaging via pipes | Agents talk to each other without polling |
+| **IPC** | DT_PIPE (FIFO) + DT_STREAM (append-only log) | Sub-microsecond inter-agent messaging |
 | **Federation** | Multi-zone Raft consensus with mTLS TOFU | Span data centers without a central coordinator |
+| **Sandbox** | Docker-backed execution environments | Isolated code execution per agent |
 
 <details>
-<summary><strong>All bricks and system services →</strong></summary>
+<summary><strong>All bricks and system services</strong></summary>
 
-**Bricks (runtime-loadable):** Access Manifests · Auth (API key, OAuth, mTLS) · Catalog (schema extraction) · Context Manifests · Delegation · Discovery · Identity (DID + credentials) · IPC (pipes) · MCP · Mount · Parsers (50+ formats via pdf-inspector) · Pay · Portability (import/export) · ReBAC · Sandbox (Docker) · Search · Share Links (capability URLs) · Snapshots · Task Manager · TUS Uploads (resumable) · Versioning · Workflows · Workspace
+**Bricks (runtime-loadable):** A2A Protocol . Access Manifests . Agent Log . Approvals . Archive . Artifact Index . Auth (API key, OAuth, mTLS) . Catalog (schema extraction) . Context Manifests . Delegation . Discovery . Filesystem . Governance . Identity (DID + credentials) . IPC (pipes + streams) . MCP . Mount . Parsers (50+ formats) . Pay . Portability (import/export) . ReBAC . Reputation . Sandbox (Docker) . Secrets . Search . Share Links (capability URLs) . Snapshots . Task Manager . Tools . Upload (TUS resumable) . Versioning . Watch . Workflows . Workspace
 
-**System services:** Agent Registry · Agent Runtime · Event Bus · Event Log · Namespace · Scheduler (fair-share, priority tiers) · Sync · Lifecycle
+**System services:** Agent Registry . Agent Runtime . Event Bus . Namespace . Scheduler (fair-share, priority tiers)
 
 </details>
 
@@ -170,7 +195,7 @@ Every major agent framework works out of the box:
 | Preset | Services | Auth | Use case |
 |---|---|---|---|
 | `local` | None (embedded) | None | Single-process scripts, notebooks |
-| `shared` | Nexus + Postgres + Dragonfly + Zoekt | Static API key | Team dev, multi-agent staging |
+| `shared` | Nexus + Postgres + Dragonfly | Static API key | Team dev, multi-agent staging |
 | `demo` | Same as shared | Database-backed | Demos, seed data, evaluation |
 
 ```bash
@@ -191,27 +216,13 @@ nexus init --preset shared --with nats --with mcp --with frontend
 # GPU acceleration
 nexus init --preset shared --accelerator cuda
 
-# Pin to a specific version
-nexus init --preset shared --image-tag 0.9.4
-
-# Build from local source (for contributors)
-nexus up --build                              # build + tag as nexus:local-{hash}
-nexus up                                      # reuses local build (no pull)
-nexus up --pull                               # discard local build, pull from remote
-
 # Stack lifecycle
-nexus stop                                    # pause containers (fast, no teardown)
-nexus start                                   # resume paused containers (fast)
-nexus down                                    # stop and remove containers
+nexus stop                                    # pause containers
+nexus start                                   # resume
+nexus down                                    # stop and remove
 nexus logs                                    # tail logs
 nexus restart                                 # down + up
-nexus upgrade                                 # pull latest image for your channel
-
-# Environment variables
-nexus env                                     # print export statements for your shell
-nexus env --json                              # machine-readable
-nexus env --dotenv > .env                     # write .env file
-nexus run python my_agent.py                  # run command with env vars injected
+nexus upgrade                                 # pull latest image
 ```
 
 ### Docker image
@@ -238,26 +249,38 @@ Four pillars, separated by access pattern — not by domain:
 
 The kernel starts with just a Metastore. Everything else is layered on without changing a line of kernel code.
 
-### Cold tiering (Issue #3406)
+## Performance
 
-Sealed CAS volumes are automatically uploaded to S3/GCS when they go quiet, cutting cold storage costs by ~80%. The local redb index is retained for O(1) lookups; reads use a single HTTP range request.
+### Agent-level: context engineering
 
-Add to your `nexus.yaml`:
+Nexus Dynamic Discovery vs loading all tools into the LLM context (POC on [BFCL benchmark](https://gorilla.cs.berkeley.edu/leaderboard.html)):
 
-```yaml
-tiering:
-  enabled: true
-  quiet_period: 3600          # seconds before a sealed volume is tiered
-  min_volume_size: 104857600  # 100 MB minimum
-  cloud_backend: s3           # or gcs
-  cloud_bucket: my-bucket
-```
+| Metric | Static (all tools in context) | Nexus Dynamic Discovery |
+|---|---|---|
+| Irrelevance detection accuracy | 40-80% | **100%** |
+| Token consumption (65 tools) | ~276K | **~61K (78% reduction)** |
+| Hallucination on irrelevant tools | frequent | **zero** |
+| ECCA-R (cost per reliable answer) | high | **2x better** |
 
-Features: write-ahead crash recovery, LRU volume cache with burst detection, streaming downloads (no full-volume RAM buffering), automatic rehydration for burst read patterns.
+Dynamic Discovery only loads relevant tools on demand via score-based search, so the LLM sees a clean context instead of 65+ tool definitions. Details: [nexus-benchmarks](https://github.com/nexi-lab/nexus-benchmarks).
 
-**Credentials**: AWS env vars / `~/.aws/credentials` / IAM role for S3, or Application Default Credentials for GCS.
+### Kernel-level: steering overhead is negligible
 
-**`nexus-fs` (slim package)**: Tiering requires `nexus-ai-fs` (full package). The slim `nexus-fs` package excludes `nexus/services/` where the tiering service lives. If using `nexus-fs`, install cloud extras separately: `pip install nexus-fs[s3]` or `nexus-fs[gcs]`.
+Kernel syscall latency (pure Rust, PathLocal + redb, Apple M-series):
+
+| Syscall | Latency | What's included |
+|---|---|---|
+| `sys_stat` | **~727 ns** | redb lookup + permission lease check |
+| `sys_read` 1 KB | **~3.4 us** | permission + CAS resolve + hook dispatch + I/O |
+| `sys_readdir` 100 entries | **~68 us** | metastore + backend merge |
+| `sys_rename` | **~6.6 us** | atomic metastore + backend |
+
+The full steering stack (permission check, CAS resolution, hook dispatch, metastore lookup) adds < 2 us to a read. An LLM call takes 100-1000 ms. The infrastructure is invisible at agent-interaction timescales.
+
+## Requirements
+
+- **Python 3.14+** for the SDK and CLI
+- **Rust toolchain** only needed for building from source (the Docker image and `nexusd-cluster` binary ship pre-built)
 
 ## Contributing
 
@@ -271,17 +294,6 @@ uv run pytest tests/
 
 For semantic search work: `uv sync --extra semantic-search`
 
-**After cloning, pulling, or switching branches that touch `rust/`**, rebuild the Rust extensions:
-
-```bash
-just setup        # rebuild all crates (requires: cargo install just)
-just doctor       # verify the binary matches current source
-```
-
-Or per-crate: `maturin develop --release -m rust/nexus_kernel/Cargo.toml`
-
-> **Why?** `PYTHONPATH=src` only affects pure-Python imports. Native extensions (`nexus_kernel.so`) resolve via site-packages and must be explicitly rebuilt after Rust changes. A stale binary imports silently but fails at runtime with a cryptic `AttributeError`. See [#3712](https://github.com/nexi-lab/nexus/issues/3712).
-
 Claude Code users: see `CLAUDE.md` (local-only, not committed) for the full contributor guide.
 
 ## Troubleshooting
@@ -290,32 +302,6 @@ Claude Code users: see `CLAUDE.md` (local-only, not committed) for the full cont
 <summary><code>ModuleNotFoundError: No module named 'nexus'</code></summary>
 
 Install from PyPI: `pip install nexus-ai-fs`. The package name on PyPI is `nexus-ai-fs`, not `nexus`.
-
-</details>
-
-<details>
-<summary><code>AttributeError: 'Kernel' object has no attribute '...'</code></summary>
-
-The installed `nexus_kernel` binary is stale. Rebuild:
-
-```bash
-just setup
-# or: maturin develop --release -m rust/nexus_kernel/Cargo.toml
-```
-
-</details>
-
-<details>
-<summary><code>maturin develop</code> fails at the repo root</summary>
-
-Point maturin at a crate manifest: `maturin develop --release -m rust/nexus_kernel/Cargo.toml`
-
-</details>
-
-<details>
-<summary><code>faiss-cpu</code> resolution fails</summary>
-
-Only install semantic search extras on platforms with compatible `txtai`/`faiss-cpu` wheels: `pip install "nexus-ai-fs[semantic-search]"`
 
 </details>
 


### PR DESCRIPTION
## Summary

Add 'Production distributed topology' section to README explaining how deployment profiles compose into a full agent IT infrastructure:

| Node role | Profile | What it does |
|---|---|---|
| Hub | full | Central server with all bricks |
| Worker | sandbox | Agent execution sandbox |
| Gateway | remote | Thin RPC client |
| Auditor | cluster + audit | Centralized audit log |
| Federation peer | cloud | Full + Raft + multi-tenant |
| Edge | lite / embedded | Local-first with federation sync |

Key message: one binary, different profiles — composes like corporate IT but for agent organizations.

## Test plan
- [x] Docs only, no code changes