### PR TITLE
fix(kernel): audit fixes for PR #4274 — stale docs + remote metastore canonicalization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1742,7 +1742,7 @@ dependencies = [
 
 [[package]]
 name = "kernel"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "ahash",
  "base64",

--- a/docs/architecture/KERNEL-ARCHITECTURE.md
+++ b/docs/architecture/KERNEL-ARCHITECTURE.md
@@ -898,7 +898,7 @@ Boot wiring:
 Coordinator methods all take `kernel: &Kernel` so the unit-struct impl
 forwards into kernel-side primitives without holding back-references.
 The §3.B.2 `ObjectStoreProvider` slot uses the same pattern: trait in
-`kernel::hal::object_store_provider`, impl in `backends::factory`,
+`kernel::hal::object_store_provider`, impl in `backends::provider`,
 boot hook in `nexus-cluster` main.
 
 #### Kernel boundary — gRPC (not FFI)

--- a/docs/architecture/KERNEL-ARCHITECTURE.md
+++ b/docs/architecture/KERNEL-ARCHITECTURE.md
@@ -578,7 +578,9 @@ Manager).
 
 #### 3.B.2 `ObjectStoreProvider`
 
-Single method: `construct(args: ObjectStoreProviderArgs) -> Arc<dyn ObjectStore>`.
+Single method: `build(args: &ObjectStoreProviderArgs) -> Result<ObjectStoreBuildResult, String>`.
+`ObjectStoreBuildResult` bundles `Option<Arc<dyn ObjectStore>>` (the backend)
+and `Option<Arc<dyn MetaStore>>` (remote metastore, for `"remote"` backends).
 
 `Kernel::sys_setattr("backend", …)` and the mount path use this to instantiate
 backends through trait dispatch. Cycle break is identical to the §3.A pattern:

--- a/rust/kernel/src/kernel/mod.rs
+++ b/rust/kernel/src/kernel/mod.rs
@@ -1479,8 +1479,17 @@ impl Kernel {
                 }
                 // Install remote metastore on the VFS route entry if the
                 // backend provider produced one (remote backends only).
+                //
+                // Key it with the SAME canonicalization the route itself
+                // uses (`canonicalize_mount_path`), not a raw `format!`.
+                // For a root mount (`path == "/"`) the raw form produced
+                // `/{zone}/` while the route is keyed `/{zone}`, so the
+                // metastore landed on a dead placeholder entry and a
+                // remote root mount silently fell back to the local
+                // metastore. Non-root paths already matched; this only
+                // corrects the root case.
                 if let Some(rms) = remote_metastore {
-                    let canonical_key = format!("/{zone_id}{path}");
+                    let canonical_key = crate::vfs_router::canonicalize_mount_path(path, zone_id);
                     self.vfs_router.install_metastore(&canonical_key, rms);
                 }
                 // Dispatch FileEventType::Mount to MutationObservers so


### PR DESCRIPTION
## Summary

Kernel team audit findings from PR #4274 (bridge-1, #4261):

- **Commit 1**: Fix KERNEL-ARCHITECTURE.md §3.B.2 stale method signature — doc said `construct() -> Arc<dyn ObjectStore>` but actual trait is `build() -> Result<ObjectStoreBuildResult, String>`
- **Commit 2**: Fix stale module path `backends::factory` -> `backends::provider` in KERNEL-ARCHITECTURE.md
- **Commit 3**: Fix remote metastore key canonicalization bug in `sys_setattr(DT_MOUNT)` — root mounts (`path == "/"`) produced `/{zone}/` (trailing slash) instead of `/{zone}`, causing remote root metastore to land on a dead VFS key. Use `canonicalize_mount_path` for consistency.

## Test plan

- [x] `cargo check -p kernel` — clean
- [x] `cargo clippy -p kernel -- -D warnings` — clean
- [x] `cargo test -p kernel` — all pass
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)