### PR TITLE
refactor: migrate bare phase literals to ZonePhase enum

### DIFF
--- a/src/nexus/bricks/auth/providers/database_key.py
+++ b/src/nexus/bricks/auth/providers/database_key.py
@@ -17,6 +17,7 @@ from nexus.bricks.auth.constants import (
     get_hmac_secret,
 )
 from nexus.bricks.auth.providers.base import AuthProvider, AuthResult
+from nexus.contracts.zone_phase import ZonePhase
 
 if TYPE_CHECKING:
     from nexus.storage.record_store import RecordStoreABC
@@ -152,7 +153,7 @@ class DatabaseAPIKeyAuth(AuthProvider):
             # unmigrated row) — treat it as inactive.
             for zid in [z for z, _ in zone_perm_rows]:
                 zone = session.scalar(select(ZoneModel).where(ZoneModel.zone_id == zid))
-                if zone is None or zone.phase != "Active" or zone.deleted_at is not None:
+                if zone is None or zone.phase != ZonePhase.ACTIVE or zone.deleted_at is not None:
                     logger.warning(
                         "UNAUTHORIZED: API key %s zone %r is not active "
                         "(zone_row=%r, phase=%s, deleted_at=%s)",
@@ -318,7 +319,7 @@ class DatabaseAPIKeyAuth(AuthProvider):
             from nexus.storage.models import ZoneModel
 
             zone = session.scalar(select(ZoneModel).where(ZoneModel.zone_id == zone_id))
-            if zone is None or zone.phase != "Active" or zone.deleted_at is not None:
+            if zone is None or zone.phase != ZonePhase.ACTIVE or zone.deleted_at is not None:
                 raise ValueError(
                     f"DatabaseAPIKeyAuth.create_key: zone {zone_id!r} is not active "
                     "(missing, Terminating, or soft-deleted); create or restore "

--- a/src/nexus/bricks/auth/tests/test_auth_database_key.py
+++ b/src/nexus/bricks/auth/tests/test_auth_database_key.py
@@ -6,6 +6,7 @@ import pytest
 from sqlalchemy import select
 
 from nexus.bricks.auth.providers.database_key import DatabaseAPIKeyAuth
+from nexus.contracts.zone_phase import ZonePhase
 from nexus.storage.models import APIKeyModel
 from tests.testkit.records import InMemoryRecordStore
 
@@ -31,7 +32,7 @@ def session_factory(record_store):
 
     sf = record_store.session_factory
     with sf() as s:
-        s.add(ZoneModel(zone_id="org_acme", name="org_acme", phase="Active"))
+        s.add(ZoneModel(zone_id="org_acme", name="org_acme", phase=ZonePhase.ACTIVE))
         s.commit()
     return sf
 

--- a/src/nexus/bricks/auth/zone_helpers.py
+++ b/src/nexus/bricks/auth/zone_helpers.py
@@ -9,6 +9,7 @@ import re
 from sqlalchemy.orm import Session
 
 from nexus.bricks.auth.constants import RESERVED_ZONE_IDS
+from nexus.contracts.zone_phase import ZonePhase
 from nexus.storage.models import ZoneModel
 
 
@@ -106,7 +107,7 @@ def create_zone(
         domain=domain,
         description=description,
         settings=settings,
-        phase="Active",
+        phase=ZonePhase.ACTIVE,
         finalizers="[]",
         created_at=datetime.now(UTC),
         updated_at=datetime.now(UTC),

--- a/src/nexus/cli/commands/hub.py
+++ b/src/nexus/cli/commands/hub.py
@@ -22,6 +22,7 @@ from nexus.cli.commands._hub_common import (
     get_session_factory,
 )
 from nexus.cli.commands._hub_remote import HubRemoteError, call_hub_admin_tool
+from nexus.contracts.zone_phase import ZonePhase
 from nexus.hub.admin_ops import (
     HubAdminAmbiguousTargetError,
     HubAdminError,
@@ -293,7 +294,7 @@ def token_zones_add(name: str, zone_id: str, permissions: str) -> None:
             session.execute(
                 select(ZoneModel)
                 .where(ZoneModel.zone_id == zone_id)
-                .where(ZoneModel.phase == "Active")
+                .where(ZoneModel.phase == ZonePhase.ACTIVE)
                 .where(ZoneModel.deleted_at.is_(None))
             )
             .scalars()
@@ -482,7 +483,7 @@ def _collect_zone_ids(session: Any) -> list[str]:
     rows = (
         session.execute(
             select(ZoneModel.zone_id)
-            .where(ZoneModel.phase == "Active")
+            .where(ZoneModel.phase == ZonePhase.ACTIVE)
             .where(ZoneModel.deleted_at.is_(None))
             .order_by(ZoneModel.zone_id.asc())
         )

--- a/src/nexus/contracts/auth_store_types.py
+++ b/src/nexus/contracts/auth_store_types.py
@@ -10,6 +10,8 @@ Issue #2436: Move auth/ to bricks/auth/ with Protocol DI.
 from dataclasses import dataclass
 from datetime import datetime
 
+from nexus.contracts.zone_phase import ZonePhase
+
 
 @dataclass(frozen=True)
 class UserDTO:
@@ -94,7 +96,7 @@ class ZoneDTO:
     name: str
     domain: str | None = None
     description: str | None = None
-    phase: str = "Active"
+    phase: str = ZonePhase.ACTIVE
     created_at: datetime | None = None
     updated_at: datetime | None = None
 

--- a/src/nexus/hub/admin_ops.py
+++ b/src/nexus/hub/admin_ops.py
@@ -13,6 +13,7 @@ from sqlalchemy import create_engine, func, select
 from sqlalchemy.orm import Session, sessionmaker
 
 from nexus.cli.commands._hub_common import parse_duration
+from nexus.contracts.zone_phase import ZonePhase
 from nexus.storage.api_key_ops import (
     create_api_key,
     get_primary_zones_for_keys,
@@ -148,7 +149,7 @@ def create_hub_token(
             for entry in zones:
                 zid = entry[0] if isinstance(entry, tuple) else entry
                 if not session.scalar(select(ZoneModel).where(ZoneModel.zone_id == zid)):
-                    session.add(ZoneModel(zone_id=zid, name=zid, phase="Active"))
+                    session.add(ZoneModel(zone_id=zid, name=zid, phase=ZonePhase.ACTIVE))
             session.flush()
 
         try:
@@ -191,7 +192,7 @@ def _resolve_create_zones(
         active = (
             session.execute(
                 select(ZoneModel)
-                .where(ZoneModel.phase == "Active")
+                .where(ZoneModel.phase == ZonePhase.ACTIVE)
                 .where(ZoneModel.deleted_at.is_(None))
             )
             .scalars()
@@ -222,7 +223,7 @@ def _validate_active_zones(session: Any, zones: list[str | tuple[str, str]]) -> 
             session.execute(
                 select(ZoneModel)
                 .where(ZoneModel.zone_id == zid)
-                .where(ZoneModel.phase == "Active")
+                .where(ZoneModel.phase == ZonePhase.ACTIVE)
                 .where(ZoneModel.deleted_at.is_(None))
             )
             .scalars()
@@ -234,7 +235,7 @@ def _validate_active_zones(session: Any, zones: list[str | tuple[str, str]]) -> 
             z.zone_id
             for z in session.execute(
                 select(ZoneModel)
-                .where(ZoneModel.phase == "Active")
+                .where(ZoneModel.phase == ZonePhase.ACTIVE)
                 .where(ZoneModel.deleted_at.is_(None))
             )
             .scalars()

--- a/src/nexus/server/auth/zone_routes.py
+++ b/src/nexus/server/auth/zone_routes.py
@@ -441,7 +441,7 @@ async def list_zones(
             # Global admins see all active zones
             stmt = (
                 select(ZoneModel)
-                .where(ZoneModel.phase != "Terminated")
+                .where(ZoneModel.phase != ZonePhase.TERMINATED)
                 .order_by(ZoneModel.created_at.desc())
                 .limit(limit)
                 .offset(offset)
@@ -453,7 +453,7 @@ async def list_zones(
                 session.scalar(
                     select(func.count())
                     .select_from(ZoneModel)
-                    .where(ZoneModel.phase != "Terminated")
+                    .where(ZoneModel.phase != ZonePhase.TERMINATED)
                 )
                 or 0
             )
@@ -478,7 +478,7 @@ async def list_zones(
             stmt = (
                 select(ZoneModel)
                 .where(
-                    ZoneModel.phase != "Terminated",
+                    ZoneModel.phase != ZonePhase.TERMINATED,
                     ZoneModel.zone_id.in_(user_zone_ids),
                 )
                 .order_by(ZoneModel.created_at.desc())

--- a/src/nexus/storage/api_key_ops.py
+++ b/src/nexus/storage/api_key_ops.py
@@ -17,6 +17,8 @@ import secrets
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
+from nexus.contracts.zone_phase import ZonePhase
+
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
 
@@ -169,7 +171,7 @@ def create_api_key(
         active_rows = session.execute(
             sa_select(ZoneModel.zone_id)
             .where(ZoneModel.zone_id.in_(requested))
-            .where(ZoneModel.phase == "Active")
+            .where(ZoneModel.phase == ZonePhase.ACTIVE)
             .where(ZoneModel.deleted_at.is_(None))
         )
         active = {row[0] for row in active_rows}

--- a/src/nexus/storage/auth_stores/sqlalchemy_api_key_store.py
+++ b/src/nexus/storage/auth_stores/sqlalchemy_api_key_store.py
@@ -12,6 +12,7 @@ from sqlalchemy.exc import OperationalError, ProgrammingError
 from sqlalchemy.orm import Session
 
 from nexus.contracts.auth_store_types import APIKeyDTO
+from nexus.contracts.zone_phase import ZonePhase
 from nexus.storage.models import APIKeyModel, APIKeyZoneModel
 
 logger = logging.getLogger(__name__)
@@ -81,7 +82,7 @@ class SQLAlchemyAPIKeyStore:
                 from nexus.storage.models import ZoneModel
 
                 zone = session.scalar(select(ZoneModel).where(ZoneModel.zone_id == zone_id))
-                if zone is None or zone.phase != "Active" or zone.deleted_at is not None:
+                if zone is None or zone.phase != ZonePhase.ACTIVE or zone.deleted_at is not None:
                     raise ValueError(
                         f"SQLAlchemyAPIKeyStore.create_key: zone {zone_id!r} is not active "
                         "(missing, Terminating, or soft-deleted); create or restore "

--- a/src/nexus/storage/auth_stores/sqlalchemy_zone_store.py
+++ b/src/nexus/storage/auth_stores/sqlalchemy_zone_store.py
@@ -9,6 +9,7 @@ from datetime import UTC, datetime
 from sqlalchemy.orm import Session
 
 from nexus.contracts.auth_store_types import ZoneDTO
+from nexus.contracts.zone_phase import ZonePhase
 from nexus.storage.models import ZoneModel
 
 
@@ -46,7 +47,7 @@ class SQLAlchemyZoneStore:
             domain=domain,
             description=description,
             settings=settings,
-            phase="Active",
+            phase=ZonePhase.ACTIVE,
             finalizers="[]",
             created_at=now,
             updated_at=now,

--- a/src/nexus/storage/models/auth.py
+++ b/src/nexus/storage/models/auth.py
@@ -13,6 +13,7 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from nexus.contracts.constants import ROOT_ZONE_ID
 from nexus.contracts.exceptions import ValidationError
+from nexus.contracts.zone_phase import ZonePhase
 from nexus.storage.models._base import Base, uuid_pk
 
 if TYPE_CHECKING:
@@ -372,7 +373,7 @@ class ZoneModel(Base):
     @property
     def is_active(self) -> bool:
         """Backward-compatible property: Active phase means active."""
-        return self.phase == "Active"
+        return self.phase == ZonePhase.ACTIVE
 
     @property
     def parsed_finalizers(self) -> list[str]:

--- a/src/nexus/storage/zone_bootstrap.py
+++ b/src/nexus/storage/zone_bootstrap.py
@@ -24,6 +24,8 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Protocol
 
+from nexus.contracts.zone_phase import ZonePhase
+
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
 
@@ -82,7 +84,7 @@ def ensure_root_zone(session_factory: _SessionFactory) -> None:
             ZoneModel(
                 zone_id=ROOT_ZONE_ID,
                 name="Root",
-                phase="Active",
+                phase=ZonePhase.ACTIVE,
                 finalizers="[]",
                 created_at=datetime.now(UTC),
                 updated_at=datetime.now(UTC),
@@ -116,7 +118,7 @@ def _assert_root_zone_active(zone: "ZoneModel") -> None:
     bootstrap look healthy while every default agent registration /
     root-token call still failed at request time.
     """
-    if zone.phase != "Active" or zone.deleted_at is not None:
+    if zone.phase != ZonePhase.ACTIVE or zone.deleted_at is not None:
         raise RuntimeError(
             f"default zone {zone.zone_id!r} is not usable: "
             f"phase={zone.phase!r} deleted_at={zone.deleted_at!r}. "


### PR DESCRIPTION
## Summary

Four commits, one per layer, migrating bare \`\"Active\"\` / \`\"Terminating\"\` / \`\"Terminated\"\` string literals to the \`ZonePhase\` StrEnum that already lives at \`nexus.contracts.zone_phase\`.

- **Commit 1 — server + contracts** (\`zone_routes.py\`, \`auth_store_types.py\`): three \`ZoneModel.phase != ZonePhase.TERMINATED\` comparisons in \`list_zones\`; \`ZoneDTO.phase\` dataclass default.
- **Commit 2 — storage** (\`models/auth.py\` \`is_active\` property; \`zone_bootstrap.py\`; \`sqlalchemy_zone_store.py\`; \`sqlalchemy_api_key_store.py\`; \`api_key_ops.py\`): all production \`phase == \"Active\"\` / \`phase != \"Active\"\` lookups and \`ZoneModel(phase=…)\` constructions.
- **Commit 3 — bricks/auth** (\`providers/database_key.py\`; \`zone_helpers.py\`; \`tests/test_auth_database_key.py\`): two lifecycle gate comparisons in the database key provider; \`create_zone\` insert; test seed.
- **Commit 4 — cli + hub** (\`cli/commands/hub.py\`; \`hub/admin_ops.py\`): hub-key target validation + zone listing; \`create_hub_token\` bootstrap insert; \`_resolve_create_zones\` glob path; \`_validate_active_zones\` lookups.

\`ZonePhase\` is a \`StrEnum\`, so DB writes, JSON serialization, and \`==\` comparisons are wire-identical to the bare strings — this is a pure readability + grep-ability refactor.

## Intentional leave-alones

| File | Why |
|---|---|
| \`src/nexus/cli/commands/admin.py:363\` | UI status string, not a zone phase |
| \`src/nexus/cli/commands/identity.py:132\` | Rich table column header |
| \`src/nexus/storage/models/auth.py:354\` | SQLAlchemy \`mapped_column(default=...)\` — must remain a string literal for the column default |
| \`src/nexus/server/auth/zone_routes.py:65\` | Pydantic \`ZoneResponse.phase\` default (out of scope per the migration plan) |
| Docstring mentions of \`phase=\"Active\"\` / \`\"Terminated\"\` | Documentation, not code paths |
| Alembic migration string literals | DB DDL doesn't speak Python enums |
| Existing test fixtures outside the listed 11 files | Out of scope |

## Verification

- \`grep -rn '\"Active\"\|\"Terminating\"\|\"Terminated\"' src/nexus/ --include=\"*.py\"\` matches only the leave-alone set + the \`ZonePhase\` enum definition itself + two docstring mentions.
- \`pytest tests/unit/storage/auth_stores/ tests/unit/storage/models/ tests/unit/hub/test_admin_ops.py tests/unit/cli/test_hub.py src/nexus/bricks/auth/tests/test_auth_database_key.py\` — all green locally.
- Pre-commit (ruff + ruff-format + mypy) green on every commit.

## Test plan

- [x] Targeted unit tests pass locally.
- [x] Pre-commit green on every commit.
- [ ] CI full suite green.