### PR TITLE
feat(cluster): NEXUS_S3_* startup mount config for nexusd-cluster (bridge-3, #4263)

### DIFF
--- a/docs/operations/nexusd-cluster-s3-mounts.md
+++ b/docs/operations/nexusd-cluster-s3-mounts.md
@@ -1,0 +1,93 @@
+# nexusd-cluster: S3-compatible mounts
+
+`nexusd-cluster` can mount one S3-compatible bucket (AWS S3, Cloudflare
+R2, MinIO) at startup, alongside the local host-fs root at `/`. The
+mount is declared with environment variables (or the equivalent flags)
+and is built by the same `ObjectStoreProvider` the gRPC mount path uses.
+
+> **Build requirement.** The default slim binary does **not** include
+> the S3 driver. Build with the `driver-s3` feature:
+>
+> ```bash
+> cargo build -p nexus-cluster --features driver-s3
+> ```
+>
+> If `NEXUS_S3_BUCKET` is set on a binary built without `driver-s3`, the
+> daemon **fails fast at startup** with
+> `driver 's3' not enabled in current deployment profile`.
+
+## Configuration
+
+| Env | Flag | Required | Default | Notes |
+|-----|------|----------|---------|-------|
+| `NEXUS_S3_BUCKET` | `--s3-bucket` | declares the mount | — | Set this to enable an S3 mount. |
+| `NEXUS_S3_REGION` | `--s3-region` | yes (if bucket) | — | AWS region; Cloudflare R2 uses `auto`. |
+| `NEXUS_S3_ACCESS_KEY_ID` | `--s3-access-key-id` | yes (if bucket) | — | Prefer env over flag. |
+| `NEXUS_S3_SECRET_ACCESS_KEY` | `--s3-secret-access-key` | yes (if bucket) | — | Prefer env over flag. |
+| `NEXUS_S3_ENDPOINT` | `--s3-endpoint` | no | — | Custom endpoint (R2/MinIO). Omit for AWS. |
+| `NEXUS_S3_PREFIX` | `--s3-prefix` | no | `` (empty) | Key prefix within the bucket. |
+| `NEXUS_S3_MOUNT` | `--s3-mount` | no | `/s3` | Mount point. Must be a non-root path. |
+
+**Security:** pass credentials via environment variables, not flags.
+Flag values appear in the process's `argv`, which is world-readable via
+`ps`. In Kubernetes, source the keys from a `Secret`; under systemd, use
+an `EnvironmentFile` with `0600` permissions.
+
+## Example — AWS S3
+
+```bash
+export NEXUS_S3_BUCKET=my-prod-bucket
+export NEXUS_S3_REGION=us-east-1
+export NEXUS_S3_ACCESS_KEY_ID=AKIA...
+export NEXUS_S3_SECRET_ACCESS_KEY=...
+export NEXUS_S3_PREFIX=nexus/data        # optional
+export NEXUS_S3_MOUNT=/s3                 # optional (default)
+
+nexusd-cluster --bootstrap-mode static
+```
+
+Files written under `/s3/...` land in `s3://my-prod-bucket/nexus/data/...`.
+The local host-fs root at `/` is unaffected.
+
+## Example — Cloudflare R2
+
+R2 is S3-compatible via a custom endpoint and `region=auto`:
+
+```bash
+export NEXUS_S3_BUCKET=my-r2-bucket
+export NEXUS_S3_REGION=auto
+export NEXUS_S3_ACCESS_KEY_ID=...        # from R2 "Manage R2 API Tokens"
+export NEXUS_S3_SECRET_ACCESS_KEY=...
+export NEXUS_S3_ENDPOINT=https://<account-id>.r2.cloudflarestorage.com
+export NEXUS_S3_MOUNT=/r2
+
+nexusd-cluster --bootstrap-mode static
+```
+
+> R2 API tokens must have **Object Read & Write** permission — a
+> read-only token passes a bucket check but fails writes with `403
+> AccessDenied`.
+
+## Fail-fast behavior
+
+The daemon refuses to start (non-zero exit, message on stderr) when:
+
+- `NEXUS_S3_BUCKET` is set but `NEXUS_S3_REGION`,
+  `NEXUS_S3_ACCESS_KEY_ID`, or `NEXUS_S3_SECRET_ACCESS_KEY` is missing or
+  empty — the error names the missing variable.
+- `NEXUS_S3_MOUNT` is `/` (or only slashes) — `/` is reserved for the
+  local host-fs root.
+- The binary was built without `--features driver-s3` — the driver gate
+  rejects the `s3` driver.
+
+A bad endpoint or unreachable bucket is **not** a startup failure: the
+backend is constructed without network I/O, so the first read/write to
+the mount surfaces the error instead.
+
+## Scope
+
+- One S3 mount per daemon. Multiple mounts are not yet supported.
+- The mount is node-local; it is not replicated across the federation.
+  Each node that needs the bucket sets `NEXUS_S3_*` independently.
+- GCS startup mounts are not wired (the mechanism is identical; track
+  separately).

--- a/docs/superpowers/plans/2026-05-31-bridge3-cluster-s3-mount-config.md
+++ b/docs/superpowers/plans/2026-05-31-bridge3-cluster-s3-mount-config.md
@@ -1,0 +1,874 @@
+# bridge-3: nexusd-cluster S3 Mount Config Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let an operator declare a single S3-compatible mount for `nexusd-cluster` via `NEXUS_S3_*` env/flags; at startup the daemon builds the backend through the registered `ObjectStoreProvider` and mounts it at a sub-path, failing fast on misconfiguration.
+
+**Architecture:** Add `NEXUS_S3_*` clap globals to `CommonArgs`. A pure `resolve_s3_mount_config()` validates them into an `S3MountConfig` (unit-testable, no kernel). `mount_declared_s3()` calls that, then builds via `get_provider().build(backend_type="s3", …)` — the same SSOT path the gRPC bridge uses — and mounts via `kernel.mount(mount_point, …)`. Wired into `run_daemon` after the root `/` mount, before the VFS gRPC server serves. The default slim binary lacks the `driver-s3` arm, so declaring S3 on it fails fast via the driver gate.
+
+**Tech Stack:** Rust (clap, anyhow, tokio), `nexus-cluster` profile crate, `DefaultObjectStoreProvider` (backends crate), pytest integration test against Cloudflare R2.
+
+**Spec:** `docs/superpowers/specs/2026-05-31-cluster-s3-mount-config-design.md`
+
+---
+
+## File Structure
+
+- **Modify** `rust/profiles/cluster/src/main.rs` — add `NEXUS_S3_*` fields to `CommonArgs`; add `S3MountConfig` + `resolve_s3_mount_config()` + `mount_declared_s3()`; call from `run_daemon`; add `#[cfg(test)] mod tests`. (This file currently has NO test module — Task 2 creates the first one.)
+- **Modify** `tests/integration/test_typed_grpc_cluster.py` — add a `cluster_grpc_s3` fixture (boots with `NEXUS_S3_*` env) and `test_startup_s3_mount_round_trips`.
+- **Create** `docs/operations/nexusd-cluster-s3-mounts.md` — operator doc.
+
+No Cargo / driver-gate changes: the `driver-s3` feature and the `set_enabled_drivers([… "s3"])` gate already exist from bridge-2 (#4262).
+
+---
+
+## Background facts the engineer needs (verified against the tree)
+
+- **Provider build path** (mirror exactly): `rust/transport/src/grpc.rs::setattr_mount` (lines ~237–311) constructs `ObjectStoreProviderArgs`, calls `provider.build(&args)`, then mounts. Reuse this shape.
+- **Provider import:** `use kernel::hal::object_store_provider::{get_provider, ObjectStoreProviderArgs};`
+- **`ObjectStoreProviderArgs` has NO `Default`** — every one of its ~40 fields must be listed in the struct literal (Task 3 shows the complete literal).
+- **Kernel accessors:** `kernel.peer_client_arc() -> Arc<dyn PeerBlobClient>`, `kernel.self_address_string() -> Option<String>`, `kernel.runtime() -> &Arc<tokio::runtime::Runtime>`. The `peer_client` / `self_address` locals must outlive the args struct (it borrows them).
+- **Mount API:** `kernel.mount(path, MountOptions::new("s3").with_backend(backend))` — `MountOptions::new` defaults zone to `root`, io_profile `"memory"`. (`use kernel::kernel::convenience::{KernelConvenience, MountOptions};` is already imported in main.rs.)
+- **`build()` on the slim binary:** `backend_type:"s3"` hits the gate first (`is_driver_enabled("s3")`); slim build's gate set is `["path_local","remote"]` → returns `Err("driver 's3' not enabled in current deployment profile")` before the (absent) match arm. This IS the fail-fast path.
+- **Provider `s3` arm required args** (`rust/backends/src/provider.rs:176–193`): `s3_bucket`, `aws_region`, `aws_access_key`, `aws_secret_key` required; `s3_prefix` defaults to `""`; `s3_endpoint` optional.
+- **Run all cargo commands from `rust/`** (the workspace root is `rust/Cargo.toml`).
+
+---
+
+### Task 1: Add `NEXUS_S3_*` config fields to `CommonArgs`
+
+**Files:**
+- Modify: `rust/profiles/cluster/src/main.rs` (the `CommonArgs` struct, currently ends at line ~101 with `bootstrap_mode`)
+
+- [ ] **Step 1: Add the seven S3 fields to `CommonArgs`**
+
+In `rust/profiles/cluster/src/main.rs`, inside `struct CommonArgs { … }`, immediately after the `bootstrap_mode` field (the last field, ~line 100), add:
+
+```rust
+    /// S3-compatible bucket to mount (AWS S3 / Cloudflare R2 / MinIO).
+    /// Presence of this var DECLARES an S3 mount; when unset the daemon
+    /// boots with only the local `/` root mount, exactly as before.
+    #[arg(long, env = "NEXUS_S3_BUCKET", global = true)]
+    s3_bucket: Option<String>,
+
+    /// AWS region for the S3 mount. Required when `NEXUS_S3_BUCKET` is
+    /// set. Cloudflare R2 uses `auto`.
+    #[arg(long, env = "NEXUS_S3_REGION", global = true)]
+    s3_region: Option<String>,
+
+    /// Access key id for the S3 mount. Required when `NEXUS_S3_BUCKET`
+    /// is set. Prefer the env var over the flag so the secret does not
+    /// land in `argv` (visible via `ps`).
+    #[arg(long, env = "NEXUS_S3_ACCESS_KEY_ID", global = true)]
+    s3_access_key_id: Option<String>,
+
+    /// Secret access key for the S3 mount. Required when
+    /// `NEXUS_S3_BUCKET` is set. Prefer the env var over the flag.
+    #[arg(long, env = "NEXUS_S3_SECRET_ACCESS_KEY", global = true)]
+    s3_secret_access_key: Option<String>,
+
+    /// Custom S3-compatible endpoint (Cloudflare R2 / MinIO). Omit for
+    /// AWS S3 (virtual-hosted addressing is derived from bucket+region).
+    #[arg(long, env = "NEXUS_S3_ENDPOINT", global = true)]
+    s3_endpoint: Option<String>,
+
+    /// Key prefix within the bucket. Optional; defaults to empty (bucket
+    /// root).
+    #[arg(long, env = "NEXUS_S3_PREFIX", global = true)]
+    s3_prefix: Option<String>,
+
+    /// VFS mount point for the S3 backend. Must be a non-root absolute
+    /// path; defaults to `/s3`. `/` is reserved for the local host-fs
+    /// root mount.
+    #[arg(long, env = "NEXUS_S3_MOUNT", global = true)]
+    s3_mount: Option<String>,
+```
+
+- [ ] **Step 2: Verify it compiles (default + s3 feature)**
+
+Run (from `rust/`):
+```bash
+cargo build -p nexus-cluster
+cargo build -p nexus-cluster --features driver-s3
+```
+Expected: both succeed. (Fields are unused so far → expect `dead_code` warnings; acceptable, resolved in Task 2/3.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add rust/profiles/cluster/src/main.rs
+git commit -m "feat(cluster): add NEXUS_S3_* config args to CommonArgs (bridge-3, #4263)"
+```
+
+---
+
+### Task 2: `S3MountConfig` + `resolve_s3_mount_config` validation helper (TDD)
+
+This is the pure, testable core: validates `CommonArgs` → an `S3MountConfig` or a clear error, with no kernel dependency.
+
+**Files:**
+- Modify: `rust/profiles/cluster/src/main.rs` (add struct + fn near the other free functions, e.g. just above `install_tracing`; add `#[cfg(test)] mod tests` at end of file)
+
+- [ ] **Step 1: Write the failing tests**
+
+At the END of `rust/profiles/cluster/src/main.rs`, add a test module. Note `CommonArgs` fields are private but the test module is in the same file, so a struct-literal helper works:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a `CommonArgs` with all non-S3 fields at their inert
+    /// defaults, so each test sets only the S3 fields it exercises.
+    fn base_args() -> CommonArgs {
+        CommonArgs {
+            hostname: None,
+            bind_addr: DEFAULT_BIND.to_string(),
+            data_dir: PathBuf::from("./nexus-cluster-data"),
+            peers: String::new(),
+            no_tls: false,
+            root_path: None,
+            bootstrap_mode: None,
+            s3_bucket: None,
+            s3_region: None,
+            s3_access_key_id: None,
+            s3_secret_access_key: None,
+            s3_endpoint: None,
+            s3_prefix: None,
+            s3_mount: None,
+        }
+    }
+
+    /// Fully-populated S3 args for the happy-path tests.
+    fn s3_args() -> CommonArgs {
+        CommonArgs {
+            s3_bucket: Some("my-bucket".into()),
+            s3_region: Some("auto".into()),
+            s3_access_key_id: Some("AKID".into()),
+            s3_secret_access_key: Some("SECRET".into()),
+            ..base_args()
+        }
+    }
+
+    #[test]
+    fn no_bucket_is_no_mount() {
+        let cfg = resolve_s3_mount_config(&base_args()).expect("ok");
+        assert!(cfg.is_none(), "no NEXUS_S3_BUCKET → no mount declared");
+    }
+
+    #[test]
+    fn full_config_resolves_with_default_mount_point() {
+        let cfg = resolve_s3_mount_config(&s3_args()).expect("ok").expect("some");
+        assert_eq!(cfg.bucket, "my-bucket");
+        assert_eq!(cfg.region, "auto");
+        assert_eq!(cfg.access_key, "AKID");
+        assert_eq!(cfg.secret_key, "SECRET");
+        assert_eq!(cfg.mount_point, "/s3", "defaults to /s3");
+        assert_eq!(cfg.prefix, None);
+        assert_eq!(cfg.endpoint, None);
+    }
+
+    #[test]
+    fn custom_mount_point_and_optional_fields_pass_through() {
+        let args = CommonArgs {
+            s3_mount: Some("/cloud".into()),
+            s3_prefix: Some("team/data".into()),
+            s3_endpoint: Some("https://acct.r2.cloudflarestorage.com".into()),
+            ..s3_args()
+        };
+        let cfg = resolve_s3_mount_config(&args).expect("ok").expect("some");
+        assert_eq!(cfg.mount_point, "/cloud");
+        assert_eq!(cfg.prefix.as_deref(), Some("team/data"));
+        assert_eq!(
+            cfg.endpoint.as_deref(),
+            Some("https://acct.r2.cloudflarestorage.com")
+        );
+    }
+
+    #[test]
+    fn missing_region_errors_naming_the_env_var() {
+        let args = CommonArgs { s3_region: None, ..s3_args() };
+        let err = resolve_s3_mount_config(&args).unwrap_err().to_string();
+        assert!(err.contains("NEXUS_S3_REGION"), "err was: {err}");
+    }
+
+    #[test]
+    fn missing_access_key_errors_naming_the_env_var() {
+        let args = CommonArgs { s3_access_key_id: None, ..s3_args() };
+        let err = resolve_s3_mount_config(&args).unwrap_err().to_string();
+        assert!(err.contains("NEXUS_S3_ACCESS_KEY_ID"), "err was: {err}");
+    }
+
+    #[test]
+    fn missing_secret_key_errors_naming_the_env_var() {
+        let args = CommonArgs { s3_secret_access_key: None, ..s3_args() };
+        let err = resolve_s3_mount_config(&args).unwrap_err().to_string();
+        assert!(err.contains("NEXUS_S3_SECRET_ACCESS_KEY"), "err was: {err}");
+    }
+
+    #[test]
+    fn root_mount_point_is_rejected() {
+        let args = CommonArgs { s3_mount: Some("/".into()), ..s3_args() };
+        let err = resolve_s3_mount_config(&args).unwrap_err().to_string();
+        assert!(err.contains("sub-path"), "err was: {err}");
+    }
+
+    #[test]
+    fn trailing_slash_only_mount_point_is_rejected() {
+        let args = CommonArgs { s3_mount: Some("///".into()), ..s3_args() };
+        let err = resolve_s3_mount_config(&args).unwrap_err().to_string();
+        assert!(err.contains("sub-path"), "err was: {err}");
+    }
+
+    #[test]
+    fn empty_string_required_field_is_treated_as_missing() {
+        // An exported-but-empty env var arrives as Some(""); it must not
+        // build a degenerate backend.
+        let args = CommonArgs { s3_region: Some(String::new()), ..s3_args() };
+        let err = resolve_s3_mount_config(&args).unwrap_err().to_string();
+        assert!(err.contains("NEXUS_S3_REGION"), "err was: {err}");
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run (from `rust/`):
+```bash
+cargo test -p nexus-cluster
+```
+Expected: FAIL — `cannot find type S3MountConfig` / `cannot find function resolve_s3_mount_config`.
+
+- [ ] **Step 3: Implement `S3MountConfig` + `resolve_s3_mount_config`**
+
+In `rust/profiles/cluster/src/main.rs`, add just above `fn install_tracing`:
+
+```rust
+/// Validated S3-compatible mount declaration, resolved from `CommonArgs`.
+///
+/// Produced by [`resolve_s3_mount_config`]; consumed by
+/// [`mount_declared_s3`]. Owns its strings so it outlives the borrowed
+/// `ObjectStoreProviderArgs` built from it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct S3MountConfig {
+    bucket: String,
+    region: String,
+    access_key: String,
+    secret_key: String,
+    endpoint: Option<String>,
+    prefix: Option<String>,
+    mount_point: String,
+}
+
+/// Treat a present-but-empty string (e.g. an exported-but-empty env
+/// var) as absent, so it triggers the required-field error instead of
+/// building a degenerate backend.
+fn nonempty_owned(v: &Option<String>) -> Option<&str> {
+    v.as_deref().filter(|s| !s.is_empty())
+}
+
+/// Parse + validate the `NEXUS_S3_*` declaration.
+///
+///   * `Ok(None)`        — no `NEXUS_S3_BUCKET`; no S3 mount declared.
+///   * `Ok(Some(cfg))`   — a fully-validated mount.
+///   * `Err(_)`          — bucket set but a required field is missing /
+///                         empty, or the mount point is illegal. The
+///                         message names the offending env var.
+fn resolve_s3_mount_config(common: &CommonArgs) -> Result<Option<S3MountConfig>> {
+    let Some(bucket) = nonempty_owned(&common.s3_bucket) else {
+        return Ok(None); // not declared
+    };
+
+    let region = nonempty_owned(&common.s3_region).ok_or_else(|| {
+        anyhow::anyhow!("NEXUS_S3_REGION is required when NEXUS_S3_BUCKET is set")
+    })?;
+    let access_key = nonempty_owned(&common.s3_access_key_id).ok_or_else(|| {
+        anyhow::anyhow!("NEXUS_S3_ACCESS_KEY_ID is required when NEXUS_S3_BUCKET is set")
+    })?;
+    let secret_key = nonempty_owned(&common.s3_secret_access_key).ok_or_else(|| {
+        anyhow::anyhow!("NEXUS_S3_SECRET_ACCESS_KEY is required when NEXUS_S3_BUCKET is set")
+    })?;
+
+    let mount_point = nonempty_owned(&common.s3_mount).unwrap_or("/s3");
+    if mount_point.trim_end_matches('/').is_empty() {
+        anyhow::bail!(
+            "NEXUS_S3_MOUNT must be a sub-path (e.g. \"/s3\"); \"/\" is \
+             reserved for the local host-fs root mount"
+        );
+    }
+
+    Ok(Some(S3MountConfig {
+        bucket: bucket.to_string(),
+        region: region.to_string(),
+        access_key: access_key.to_string(),
+        secret_key: secret_key.to_string(),
+        endpoint: nonempty_owned(&common.s3_endpoint).map(str::to_string),
+        prefix: nonempty_owned(&common.s3_prefix).map(str::to_string),
+        mount_point: mount_point.to_string(),
+    }))
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run (from `rust/`):
+```bash
+cargo test -p nexus-cluster
+```
+Expected: PASS — all 9 tests in `mod tests` green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add rust/profiles/cluster/src/main.rs
+git commit -m "feat(cluster): validate NEXUS_S3_* into S3MountConfig (bridge-3, #4263)"
+```
+
+---
+
+### Task 3: `mount_declared_s3` + wire into `run_daemon`
+
+**Files:**
+- Modify: `rust/profiles/cluster/src/main.rs` (add `mount_declared_s3` near `resolve_s3_mount_config`; add imports; add one call in `run_daemon`)
+
+- [ ] **Step 1: Add the provider import**
+
+At the top of `rust/profiles/cluster/src/main.rs`, change the existing line:
+```rust
+use kernel::hal::object_store_provider::{set_enabled_drivers, set_provider};
+```
+to:
+```rust
+use kernel::hal::object_store_provider::{
+    get_provider, set_enabled_drivers, set_provider, ObjectStoreProviderArgs,
+};
+```
+
+- [ ] **Step 2: Implement `mount_declared_s3`**
+
+In `rust/profiles/cluster/src/main.rs`, immediately after `resolve_s3_mount_config`, add. The `ObjectStoreProviderArgs` literal lists every field (no `Default`); it mirrors `grpc.rs::setattr_mount`:
+
+```rust
+/// Construct + mount the declared S3 backend at boot, if any.
+///
+/// No-op when `NEXUS_S3_BUCKET` is unset. Builds through the registered
+/// `ObjectStoreProvider` (the same path the gRPC bridge uses), so the
+/// driver gate is honored: on a slim binary without `--features
+/// driver-s3`, `build` returns the gate error and this fails fast.
+fn mount_declared_s3(kernel: &Arc<Kernel>, common: &CommonArgs) -> Result<()> {
+    let Some(cfg) = resolve_s3_mount_config(common)? else {
+        return Ok(()); // no S3 mount declared
+    };
+
+    let provider = get_provider()
+        .ok_or_else(|| anyhow::anyhow!("no ObjectStoreProvider registered"))?;
+
+    // Locals the args borrow from must outlive `args`.
+    let peer_client = kernel.peer_client_arc();
+    let self_address = kernel.self_address_string();
+
+    let args = ObjectStoreProviderArgs {
+        backend_type: "s3",
+        backend_name: "s3",
+        mount_path: Some(cfg.mount_point.as_str()),
+        local_root: None,
+        fsync: false,
+        follow_symlinks: false,
+        openai_base_url: None,
+        openai_api_key: None,
+        openai_model: None,
+        openai_blob_root: None,
+        anthropic_base_url: None,
+        anthropic_api_key: None,
+        anthropic_model: None,
+        anthropic_blob_root: None,
+        s3_bucket: Some(cfg.bucket.as_str()),
+        s3_prefix: cfg.prefix.as_deref(),
+        aws_region: Some(cfg.region.as_str()),
+        aws_access_key: Some(cfg.access_key.as_str()),
+        aws_secret_key: Some(cfg.secret_key.as_str()),
+        s3_endpoint: cfg.endpoint.as_deref(),
+        gcs_bucket: None,
+        gcs_prefix: None,
+        access_token: None,
+        root_folder_id: None,
+        bot_token: None,
+        default_channel: None,
+        hn_stories_per_feed: None,
+        hn_include_comments: None,
+        cli_command: None,
+        cli_service: None,
+        cli_auth_env_json: None,
+        x_bearer_token: None,
+        server_address: None,
+        remote_auth_token: None,
+        remote_ca_pem: None,
+        remote_cert_pem: None,
+        remote_key_pem: None,
+        remote_timeout: 0.0,
+        peer_client: &peer_client,
+        self_address: self_address.as_deref(),
+        runtime: kernel.runtime(),
+    };
+
+    let built = provider.build(&args).map_err(|e| {
+        anyhow::anyhow!(
+            "failed to build S3 backend for mount '{}' (bucket '{}'): {e}",
+            cfg.mount_point,
+            cfg.bucket,
+        )
+    })?;
+    let backend = built
+        .backend
+        .ok_or_else(|| anyhow::anyhow!("ObjectStoreProvider returned no backend for S3 mount"))?;
+
+    kernel
+        .mount(
+            &cfg.mount_point,
+            MountOptions::new("s3").with_backend(backend),
+        )
+        .map_err(|e| anyhow::anyhow!("mount S3 at '{}': {e:?}", cfg.mount_point))?;
+
+    tracing::info!(
+        bucket = %cfg.bucket,
+        mount_point = %cfg.mount_point,
+        endpoint = ?cfg.endpoint,
+        "mounted S3-compatible backend",
+    );
+    Ok(())
+}
+```
+
+- [ ] **Step 3: Call it from `run_daemon` after the root mount**
+
+In `run_daemon`, find the root-mount block ending with (around line 403–406):
+```rust
+    tracing::info!(
+        root_fs = %root_fs.display(),
+        "mounted host-fs at \"/\" via PathLocalBackend",
+    );
+```
+Immediately AFTER that `tracing::info!(...)` call (and before the `// Build VFS gRPC service …` comment / `let vfs_auth` line), insert:
+```rust
+
+    // ── Optional S3-compatible mount declared via NEXUS_S3_* ──
+    // Built through the same provider the gRPC bridge uses, so the
+    // driver gate fails fast on a slim binary without `driver-s3`.
+    // Runs before the VFS gRPC server serves so the mount is live.
+    mount_declared_s3(&kernel, &common)?;
+```
+
+- [ ] **Step 4: Verify it compiles, both feature sets**
+
+Run (from `rust/`):
+```bash
+cargo build -p nexus-cluster
+cargo build -p nexus-cluster --features driver-s3
+```
+Expected: both succeed, no `dead_code` warnings for the S3 fields anymore.
+
+- [ ] **Step 5: Verify the slim binary fails fast when S3 is declared without the driver**
+
+Run (from `rust/`):
+```bash
+cargo build -p nexus-cluster
+NEXUS_S3_BUCKET=b NEXUS_S3_REGION=auto \
+NEXUS_S3_ACCESS_KEY_ID=k NEXUS_S3_SECRET_ACCESS_KEY=s \
+./target/debug/nexusd-cluster --no-tls --hostname 127.0.0.1 \
+  --bind-addr 127.0.0.1:0 --data-dir /tmp/nexus-bridge3-failfast \
+  --bootstrap-mode static; echo "exit=$?"
+```
+Expected: process exits non-zero; stderr/log contains `failed to build S3 backend` … `driver 's3' not enabled in current deployment profile`. (Clean up: `rm -rf /tmp/nexus-bridge3-failfast`.)
+
+- [ ] **Step 6: Run the unit tests again (no regressions)**
+
+Run (from `rust/`):
+```bash
+cargo test -p nexus-cluster
+```
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add rust/profiles/cluster/src/main.rs
+git commit -m "feat(cluster): mount declared S3 backend at startup via provider (bridge-3, #4263)"
+```
+
+---
+
+### Task 4: Integration test — startup S3 mount round-trips against R2
+
+Reuses the bridge-2 harness in `tests/integration/test_typed_grpc_cluster.py` (`_r2_env`, `requires_e2e`, `requires_r2`, and the `_resolve_worktree_cluster_binary` helper). Adds a fixture that boots the daemon with `NEXUS_S3_*` set, then asserts a write/read round-trip through the startup mount (no gRPC `Setattr` — the mount comes from config).
+
+**Files:**
+- Modify: `tests/integration/test_typed_grpc_cluster.py`
+
+- [ ] **Step 1: Write the failing test + fixture**
+
+Append to the END of `tests/integration/test_typed_grpc_cluster.py`:
+
+```python
+# ── bridge-3 (#4263): S3 mount declared via NEXUS_S3_* at startup ─────────────
+
+
+@pytest.fixture()
+def cluster_grpc_s3(tmp_path: Path) -> Iterator[str]:
+    """Boot ``nexus-cluster`` with ``NEXUS_S3_*`` set so the daemon mounts
+    an S3-compatible backend at ``/s3`` at startup, and yield ``host:port``.
+
+    Skips cleanly when the binary or R2 creds are absent. Maps the test's
+    ``NEXUS_R2_*`` creds onto the daemon's ``NEXUS_S3_*`` surface.
+    """
+    nexus_cluster = _resolve_worktree_cluster_binary()
+    if not nexus_cluster:
+        pytest.skip(
+            "nexus-cluster binary not in worktree rust/target (build with "
+            "`cargo build -p nexus-cluster --features driver-s3`)"
+        )
+    env_r2 = _r2_env()
+    if env_r2 is None:
+        pytest.skip("startup S3 mount E2E requires NEXUS_R2_* creds")
+
+    data_dir = tmp_path / "data"
+    log_path = tmp_path / "cluster.log"
+    log_handle = log_path.open("wb")
+    proc: subprocess.Popen | None = None
+    addr: str | None = None
+
+    s3_env = {
+        "NEXUS_S3_BUCKET": env_r2["NEXUS_R2_BUCKET"],
+        "NEXUS_S3_REGION": env_r2["NEXUS_R2_REGION"],
+        "NEXUS_S3_ACCESS_KEY_ID": env_r2["NEXUS_R2_ACCESS_KEY_ID"],
+        "NEXUS_S3_SECRET_ACCESS_KEY": env_r2["NEXUS_R2_SECRET_ACCESS_KEY"],
+        "NEXUS_S3_ENDPOINT": env_r2["NEXUS_R2_ENDPOINT"],
+        "NEXUS_S3_MOUNT": "/s3",
+    }
+
+    def _cleanup() -> None:
+        if proc is not None:
+            with contextlib.suppress(ProcessLookupError):
+                proc.terminate()
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                with contextlib.suppress(ProcessLookupError):
+                    proc.kill()
+                with contextlib.suppress(subprocess.TimeoutExpired):
+                    proc.wait(timeout=5)
+        log_handle.close()
+
+    try:
+        last_err = ""
+        for _attempt in range(5):
+            s = socket.socket()
+            try:
+                s.bind(("127.0.0.1", 0))
+                port = s.getsockname()[1]
+            finally:
+                s.close()
+            candidate_addr = f"127.0.0.1:{port}"
+            proc = subprocess.Popen(
+                [
+                    nexus_cluster,
+                    "--no-tls",
+                    "--hostname",
+                    "127.0.0.1",
+                    "--bind-addr",
+                    candidate_addr,
+                    "--data-dir",
+                    str(data_dir),
+                    "--bootstrap-mode",
+                    "static",
+                ],
+                env={
+                    **os.environ,
+                    **s3_env,
+                    "RUST_LOG": os.environ.get("RUST_LOG") or "info,nexus_raft=info",
+                },
+                stdout=log_handle,
+                stderr=subprocess.STDOUT,
+            )
+            deadline = time.monotonic() + 20
+            bound = False
+            while time.monotonic() < deadline:
+                if proc.poll() is not None:
+                    last_err = (
+                        f"nexus-cluster exited early (rc={proc.returncode}); "
+                        f"log: {log_path.read_text()[-600:]}"
+                    )
+                    # A driver-not-compiled exit is an explicit skip signal.
+                    if "not enabled" in log_path.read_text():
+                        pytest.skip(
+                            "cluster binary lacks the s3 driver — rebuild with "
+                            "`cargo build -p nexus-cluster --features driver-s3`"
+                        )
+                    break
+                try:
+                    with socket.create_connection(("127.0.0.1", port), timeout=0.5):
+                        bound = True
+                        break
+                except OSError:
+                    time.sleep(0.2)
+            if bound:
+                addr = candidate_addr
+                break
+            with contextlib.suppress(ProcessLookupError):
+                proc.terminate()
+            with contextlib.suppress(subprocess.TimeoutExpired):
+                proc.wait(timeout=5)
+            proc = None
+
+        if addr is None:
+            raise AssertionError(
+                f"nexus-cluster (S3 startup) failed to bind; last err: "
+                f"{last_err or 'timed out'}"
+            )
+        yield addr
+    except BaseException:
+        _cleanup()
+        raise
+    else:
+        _cleanup()
+
+
+@requires_e2e
+@requires_r2
+def test_startup_s3_mount_round_trips(cluster_grpc_s3):
+    """bridge-3 (#4263) E2E — the daemon mounts S3/R2 at ``/s3`` from
+    ``NEXUS_S3_*`` config at startup (no gRPC Setattr), and a write/read
+    through that mount round-trips against real R2.
+    """
+    import grpc
+
+    from nexus.grpc.vfs import vfs_pb2, vfs_pb2_grpc
+
+    ch = grpc.insecure_channel(cluster_grpc_s3)
+    stub = vfs_pb2_grpc.NexusVFSServiceStub(ch)
+
+    obj_path = f"/s3/bridge3-startup-{os.getpid()}.txt"
+    body = b"startup-s3-mount-through-rust-" + str(os.getpid()).encode()
+
+    try:
+        w = stub.Write(vfs_pb2.WriteRequest(path=obj_path, content=body), timeout=30)
+        assert not w.is_error, w.error_payload
+        assert w.size == len(body)
+
+        r = stub.Read(vfs_pb2.ReadRequest(path=obj_path), timeout=30)
+        assert not r.is_error, r.error_payload
+        assert r.content == body, "read-back bytes differ — R2 round-trip broken"
+    finally:
+        with contextlib.suppress(Exception):
+            stub.Delete(vfs_pb2.DeleteRequest(path=obj_path), timeout=30)
+```
+
+- [ ] **Step 2: Verify it skips cleanly without the gate/creds**
+
+Run (from repo root):
+```bash
+python -m pytest tests/integration/test_typed_grpc_cluster.py::test_startup_s3_mount_round_trips -v
+```
+Expected: SKIPPED (`NEXUS_E2E != "1"`), no collection/syntax error.
+
+- [ ] **Step 3: Verify it passes against real R2**
+
+Build the s3 binary and run with creds (creds live in a gitignored file, e.g. `/tmp/nexus-r2.env`, per the bridge-2 precedent):
+```bash
+( cd rust && cargo build -p nexus-cluster --features driver-s3 )
+set -a; . /tmp/nexus-r2.env; set +a
+NEXUS_E2E=1 python -m pytest \
+  tests/integration/test_typed_grpc_cluster.py::test_startup_s3_mount_round_trips -v
+```
+Expected: PASS (1 passed). If it SKIPS with "lacks the s3 driver", the build step did not produce the s3 binary in `rust/target/debug` — rebuild.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/integration/test_typed_grpc_cluster.py
+git commit -m "test(cluster): E2E startup S3 mount round-trips via R2 (bridge-3, #4263)"
+```
+
+---
+
+### Task 5: Operator documentation
+
+**Files:**
+- Create: `docs/operations/nexusd-cluster-s3-mounts.md`
+
+- [ ] **Step 1: Write the doc**
+
+Create `docs/operations/nexusd-cluster-s3-mounts.md` with:
+
+````markdown
+# nexusd-cluster: S3-compatible mounts
+
+`nexusd-cluster` can mount one S3-compatible bucket (AWS S3, Cloudflare
+R2, MinIO) at startup, alongside the local host-fs root at `/`. The
+mount is declared with environment variables (or the equivalent flags)
+and is built by the same `ObjectStoreProvider` the gRPC mount path uses.
+
+> **Build requirement.** The default slim binary does **not** include
+> the S3 driver. Build with the `driver-s3` feature:
+>
+> ```bash
+> cargo build -p nexus-cluster --features driver-s3
+> ```
+>
+> If `NEXUS_S3_BUCKET` is set on a binary built without `driver-s3`, the
+> daemon **fails fast at startup** with
+> `driver 's3' not enabled in current deployment profile`.
+
+## Configuration
+
+| Env | Flag | Required | Default | Notes |
+|-----|------|----------|---------|-------|
+| `NEXUS_S3_BUCKET` | `--s3-bucket` | declares the mount | — | Set this to enable an S3 mount. |
+| `NEXUS_S3_REGION` | `--s3-region` | yes (if bucket) | — | AWS region; Cloudflare R2 uses `auto`. |
+| `NEXUS_S3_ACCESS_KEY_ID` | `--s3-access-key-id` | yes (if bucket) | — | Prefer env over flag. |
+| `NEXUS_S3_SECRET_ACCESS_KEY` | `--s3-secret-access-key` | yes (if bucket) | — | Prefer env over flag. |
+| `NEXUS_S3_ENDPOINT` | `--s3-endpoint` | no | — | Custom endpoint (R2/MinIO). Omit for AWS. |
+| `NEXUS_S3_PREFIX` | `--s3-prefix` | no | `` (empty) | Key prefix within the bucket. |
+| `NEXUS_S3_MOUNT` | `--s3-mount` | no | `/s3` | Mount point. Must be a non-root path. |
+
+**Security:** pass credentials via environment variables, not flags.
+Flag values appear in the process's `argv`, which is world-readable via
+`ps`. In Kubernetes, source the keys from a `Secret`; under systemd, use
+an `EnvironmentFile` with `0600` permissions.
+
+## Example — AWS S3
+
+```bash
+export NEXUS_S3_BUCKET=my-prod-bucket
+export NEXUS_S3_REGION=us-east-1
+export NEXUS_S3_ACCESS_KEY_ID=AKIA...
+export NEXUS_S3_SECRET_ACCESS_KEY=...
+export NEXUS_S3_PREFIX=nexus/data        # optional
+export NEXUS_S3_MOUNT=/s3                 # optional (default)
+
+nexusd-cluster --bootstrap-mode static
+```
+
+Files written under `/s3/...` land in `s3://my-prod-bucket/nexus/data/...`.
+The local host-fs root at `/` is unaffected.
+
+## Example — Cloudflare R2
+
+R2 is S3-compatible via a custom endpoint and `region=auto`:
+
+```bash
+export NEXUS_S3_BUCKET=my-r2-bucket
+export NEXUS_S3_REGION=auto
+export NEXUS_S3_ACCESS_KEY_ID=...        # from R2 "Manage R2 API Tokens"
+export NEXUS_S3_SECRET_ACCESS_KEY=...
+export NEXUS_S3_ENDPOINT=https://<account-id>.r2.cloudflarestorage.com
+export NEXUS_S3_MOUNT=/r2
+
+nexusd-cluster --bootstrap-mode static --features-built-with driver-s3
+```
+
+> R2 API tokens must have **Object Read & Write** permission — a
+> read-only token passes a bucket check but fails writes with `403
+> AccessDenied`.
+
+## Fail-fast behavior
+
+The daemon refuses to start (non-zero exit, message on stderr) when:
+
+- `NEXUS_S3_BUCKET` is set but `NEXUS_S3_REGION`,
+  `NEXUS_S3_ACCESS_KEY_ID`, or `NEXUS_S3_SECRET_ACCESS_KEY` is missing or
+  empty — the error names the missing variable.
+- `NEXUS_S3_MOUNT` is `/` (or only slashes) — `/` is reserved for the
+  local host-fs root.
+- The binary was built without `--features driver-s3` — the driver gate
+  rejects the `s3` driver.
+
+A bad endpoint or unreachable bucket is **not** a startup failure: the
+backend is constructed without network I/O, so the first read/write to
+the mount surfaces the error instead.
+
+## Scope
+
+- One S3 mount per daemon. Multiple mounts are not yet supported.
+- The mount is node-local; it is not replicated across the federation.
+  Each node that needs the bucket sets `NEXUS_S3_*` independently.
+- GCS startup mounts are not wired (the mechanism is identical; track
+  separately).
+````
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/operations/nexusd-cluster-s3-mounts.md
+git commit -m "docs(ops): document nexusd-cluster NEXUS_S3_* startup mounts (bridge-3, #4263)"
+```
+
+---
+
+### Task 6: Final verification — fmt, clippy, full test
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Format check**
+
+Run (from `rust/`):
+```bash
+cargo fmt -p nexus-cluster -- --check
+```
+Expected: clean (no diff). If it reports changes, run `cargo fmt -p nexus-cluster` and re-commit.
+
+- [ ] **Step 2: Clippy, both feature sets, deny warnings**
+
+Run (from `rust/`):
+```bash
+cargo clippy -p nexus-cluster -- -D warnings
+cargo clippy -p nexus-cluster --features driver-s3 -- -D warnings
+```
+Expected: both clean. (CI's lint gate covers the cluster crate, so this must pass.)
+
+- [ ] **Step 3: Full cluster unit tests**
+
+Run (from `rust/`):
+```bash
+cargo test -p nexus-cluster
+cargo test -p nexus-cluster --features driver-s3
+```
+Expected: PASS for both. (The `resolve_s3_mount_config` tests are feature-independent and run in both.)
+
+- [ ] **Step 4: Confirm the default slim binary is unchanged in behavior**
+
+Boot the slim binary with NO S3 env and confirm it still comes up (the `mount_declared_s3` no-op path):
+```bash
+( cd rust && cargo build -p nexus-cluster )
+./rust/target/debug/nexusd-cluster --no-tls --hostname 127.0.0.1 \
+  --bind-addr 127.0.0.1:2126 --data-dir /tmp/nexus-bridge3-slim \
+  --bootstrap-mode static &
+sleep 3; curl -sf localhost:2126 >/dev/null 2>&1; echo "booted ok"; kill %1
+rm -rf /tmp/nexus-bridge3-slim
+```
+Expected: daemon boots (no S3 mount log line), no error. (`curl` may not speak gRPC — the point is the process stays up; check the log shows `mounted host-fs at "/"` and no S3 line.)
+
+- [ ] **Step 5: No-op commit guard**
+
+Nothing to commit here unless fmt fixed something. Confirm clean tree:
+```bash
+git status --short
+```
+Expected: clean (all prior tasks committed).
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Config surface (7 `NEXUS_S3_*` clap+env vars, namespaced creds) → Task 1.
+- Validation / `S3MountConfig` → Task 2.
+- Boot wiring through provider after root mount → Task 3 (steps 2–3).
+- Fail-fast: missing field / illegal mount / driver-not-compiled → Task 2 tests + Task 3 step 5.
+- Sub-path mount, local `/` intact → default `/s3`, root rejected (Task 2); root mount untouched (Task 3 inserts *after* it).
+- Integration test against R2 → Task 4.
+- Operator docs → Task 5.
+- fmt/clippy/test gates → Task 6.
+
+**Placeholder scan:** none — every code step is complete; the `ObjectStoreProviderArgs` literal is fully spelled out (no `..`).
+
+**Type consistency:** `resolve_s3_mount_config(&CommonArgs) -> Result<Option<S3MountConfig>>` and `mount_declared_s3(&Arc<Kernel>, &CommonArgs) -> Result<()>` used identically across tasks. `S3MountConfig` fields (`bucket/region/access_key/secret_key/endpoint/prefix/mount_point`) match between the struct def (Task 2 step 3), the tests (Task 2 step 1), and the consumer (Task 3 step 2). `nonempty_owned` defined once (Task 2) and reused (Task 3 not needed — config already owns clean strings). Kernel accessors (`peer_client_arc`, `self_address_string`, `runtime`) match verified signatures.

--- a/docs/superpowers/specs/2026-05-31-cluster-s3-mount-config-design.md
+++ b/docs/superpowers/specs/2026-05-31-cluster-s3-mount-config-design.md
@@ -1,0 +1,164 @@
+# bridge-3: nexusd-cluster startup/config mount for S3-compatible backends
+
+**Issue:** [#4263](https://github.com/nexi-lab/nexus/issues/4263) — part of epic [#4259](https://github.com/nexi-lab/nexus/issues/4259) (Approach 1, connector-first).
+**Depends on:** #4261 (bridge-1: `DefaultObjectStoreProvider` + driver gate) and #4262 (bridge-2: backend params over gRPC + Rust-side mount construction), both merged into `develop`.
+**Date:** 2026-05-31
+
+## Problem
+
+`nexusd-cluster` (`rust/profiles/cluster/src/main.rs`) mounts `PathLocalBackend` at `/` at boot and exposes no config/env path to declare a cloud mount. After bridge-1/bridge-2, the daemon registers `DefaultObjectStoreProvider` and the gRPC `setattr_mount` path can build S3 backends from wire params — but there is no *startup-time* surface for an operator to declare an S3 mount. bridge-3 closes that gap, completing Approach 1 (connector) of the epic.
+
+## Goal
+
+Let an operator declare a single S3-compatible mount (AWS S3 / Cloudflare R2 / MinIO) for `nexusd-cluster` via config/env. At startup, after the provider is registered and the root `/` mount is in place, construct the declared backend through the registered provider and mount it at an operator-chosen sub-path. Misconfiguration fails fast with a clear, env-var-named error.
+
+## Scope
+
+### In scope
+- A clap-arg-with-env-fallback config surface for **one** S3 mount (mirrors every existing cluster knob).
+- Boot-time construction of the S3 backend **through the registered `ObjectStoreProvider`** (the same SSOT path the gRPC bridge uses) and mount via `Kernel::mount`.
+- Fail-fast validation: missing required fields, driver not compiled in, illegal mount point.
+- Operator docs in `docs/operations/nexusd-cluster-config.md`.
+- Rust unit tests for validation + an env-gated integration test booting against Cloudflare R2.
+
+### Out of scope
+- Multiple S3 mounts in one daemon (use the future JSON-config escape hatch).
+- Replacing the `/` root with S3 (operator chose: keep local root, mount S3 at a sub-path).
+- GCS startup mounts (identical pattern, separate `driver-gcs` feature — not requested here).
+- Federation/replication of the S3 mount across nodes (each node mounts independently from its own env).
+- Dedup-in-Rust / CAS-over-S3 (epic Approach 2, deferred).
+
+## Configuration surface
+
+New global args on `CommonArgs` in `rust/profiles/cluster/src/main.rs`, each a clap `#[arg(long, env = "…", global = true)]`, following the established `NEXUS_*` pattern (`NEXUS_ROOT_FS`, `NEXUS_PEERS`, etc.). `NEXUS_S3_BUCKET` is the **trigger**: when unset, the daemon behaves exactly as today (no S3 mount, byte-identical boot). When set, the remaining required fields are validated.
+
+| Env | Flag | Required | Default | Notes |
+|-----|------|----------|---------|-------|
+| `NEXUS_S3_BUCKET` | `--s3-bucket` | trigger | — | Presence declares an S3 mount. |
+| `NEXUS_S3_REGION` | `--s3-region` | yes (if bucket) | — | AWS region; Cloudflare R2 uses `auto`. |
+| `NEXUS_S3_ACCESS_KEY_ID` | `--s3-access-key-id` | yes (if bucket) | — | **Prefer env over flag** (argv is world-readable via `ps`). |
+| `NEXUS_S3_SECRET_ACCESS_KEY` | `--s3-secret-access-key` | yes (if bucket) | — | **Prefer env over flag.** |
+| `NEXUS_S3_ENDPOINT` | `--s3-endpoint` | no | — | Custom S3-compatible endpoint (R2/MinIO). Omit → AWS addressing. |
+| `NEXUS_S3_PREFIX` | `--s3-prefix` | no | `` (empty) | Key prefix within the bucket. |
+| `NEXUS_S3_MOUNT` | `--s3-mount` | no | `/s3` | VFS mount point. Must be a non-root absolute path. |
+
+**Credential naming decision:** namespaced `NEXUS_S3_ACCESS_KEY_ID` / `NEXUS_S3_SECRET_ACCESS_KEY` rather than the conventional `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`. Rationale: collision-free and consistent with the rest of the `NEXUS_*` surface; the daemon may run in environments where ambient `AWS_*` vars mean something else. (A future enhancement could fall back to `AWS_*` when the namespaced vars are unset; not in scope.)
+
+## Architecture & boot wiring
+
+The new logic lives in one place: a helper `mount_declared_s3(&kernel, &common) -> Result<()>` called from `run_daemon`, immediately **after** the root `/` mount and **before** `build_vfs_routes` / `open_zone_manager`, so the S3 mount is live before the VFS gRPC server begins serving.
+
+Ordering within `run_daemon` (current → new):
+1. provider registration: `set_provider(DefaultObjectStoreProvider)` + `set_enabled_drivers([...])`. *(unchanged — already present)*
+2. root `/` mount via `PathLocalBackend`. *(unchanged)*
+3. **NEW:** `mount_declared_s3(&kernel, &common)?` — no-op when `NEXUS_S3_BUCKET` unset.
+4. `build_vfs_routes(...)` → `open_zone_manager(...)` → bootstrap → serve. *(unchanged)*
+
+### Construction path — through the provider (SSOT)
+
+`mount_declared_s3` does **not** call `S3Backend::new` directly. It builds an `ObjectStoreProviderArgs` with `backend_type: "s3"` and the S3 fields, calls `get_provider().build(&args)`, then mounts the result:
+
+```rust
+fn mount_declared_s3(kernel: &Arc<Kernel>, common: &CommonArgs) -> Result<()> {
+    let Some(bucket) = common.s3_bucket.as_deref() else { return Ok(()); }; // trigger
+
+    // fail-fast required-field checks with env-var-named errors (see below)
+    let region = common.s3_region.as_deref()
+        .ok_or_else(|| anyhow!("NEXUS_S3_REGION is required when NEXUS_S3_BUCKET is set"))?;
+    let access_key = common.s3_access_key_id.as_deref()
+        .ok_or_else(|| anyhow!("NEXUS_S3_ACCESS_KEY_ID is required when NEXUS_S3_BUCKET is set"))?;
+    let secret_key = common.s3_secret_access_key.as_deref()
+        .ok_or_else(|| anyhow!("NEXUS_S3_SECRET_ACCESS_KEY is required when NEXUS_S3_BUCKET is set"))?;
+
+    let mount_point = common.s3_mount.as_deref().unwrap_or("/s3");
+    if mount_point.trim_end_matches('/').is_empty() {
+        bail!("NEXUS_S3_MOUNT must be a sub-path; \"/\" is reserved for the local host-fs root");
+    }
+
+    let provider = get_provider()
+        .ok_or_else(|| anyhow!("no ObjectStoreProvider registered"))?;
+    let peer_client = kernel.peer_client_arc();
+    let self_address = kernel.self_address_string();
+    let args = ObjectStoreProviderArgs {
+        backend_type: "s3",
+        backend_name: "s3",
+        mount_path: Some(mount_point),
+        s3_bucket: Some(bucket),
+        s3_prefix: common.s3_prefix.as_deref(),       // None → provider defaults to ""
+        aws_region: Some(region),
+        aws_access_key: Some(access_key),
+        aws_secret_key: Some(secret_key),
+        s3_endpoint: common.s3_endpoint.as_deref(),
+        // all other fields: None / defaults, mirroring grpc.rs::setattr_mount
+        peer_client: &peer_client,
+        self_address: self_address.as_deref(),
+        runtime: kernel.runtime(),
+        ..
+    };
+    let built = provider.build(&args)
+        .map_err(|e| anyhow!("failed to build S3 backend for {mount_point}: {e}"))?;
+    let backend = built.backend
+        .ok_or_else(|| anyhow!("provider returned no backend for S3 mount"))?;
+
+    kernel.mount(mount_point, MountOptions::new("s3").with_backend(backend))
+        .map_err(|e| anyhow!("mount S3 at {mount_point}: {e:?}"))?;
+    tracing::info!(bucket, mount_point, "mounted S3-compatible backend");
+    Ok(())
+}
+```
+
+Reusing the provider means a single S3 construction site shared with the gRPC bridge, and the driver gate (`is_driver_enabled("s3")`) is honored automatically.
+
+The exact `ObjectStoreProviderArgs` field set mirrors `VfsServiceImpl::setattr_mount` in `rust/transport/src/grpc.rs` (the `..` above is shorthand for the ~25 `None`/default fields; the struct has no `Default`, so the implementation lists them explicitly, exactly as `setattr_mount` does).
+
+## Error handling — fail fast (AC #4)
+
+| Misconfiguration | Detection | Result |
+|------------------|-----------|--------|
+| `driver-s3` not compiled into the binary | gate excludes `"s3"`; `provider.build` returns `driver 's3' not enabled in current deployment profile` | `mount_declared_s3` returns `Err` → `run_daemon` aborts before serving |
+| `NEXUS_S3_BUCKET` set, region/creds missing | explicit `ok_or_else` checks in `mount_declared_s3` | `Err` with the exact missing env-var name → abort |
+| `NEXUS_S3_MOUNT` = `/` (or `///`) | `trim_end_matches('/').is_empty()` check | `Err` "must be a sub-path; / is reserved" → abort |
+| Bad endpoint / unreachable bucket | surfaces lazily on first I/O (S3Backend is constructed eagerly but does no network I/O at build) | first read/write returns a backend error; not a boot failure (matches S3Backend semantics) |
+
+All boot-path errors propagate as `anyhow::Error` out of `run_daemon`, so the process exits non-zero with the message on stderr — the established fail-fast pattern for `bootstrap_mode`, TLS, and root-mount failures.
+
+The default slim binary (no `driver-s3`) with `NEXUS_S3_BUCKET` set fails fast at startup with the gate error rather than silently ignoring the config — an operator who declares an S3 mount on a binary that can't serve it learns immediately.
+
+## Mount semantics
+
+Node-local mount, exactly like the boot `/` mount: the S3 backend is mounted at `NEXUS_S3_MOUNT` (default `/s3`) on this node's kernel; the `/` `PathLocalBackend` host-fs mount stays intact and unmodified. Both coexist. Every node that sets the env vars mounts the same bucket independently — there is no raft replication of this mount (consistent with the per-node `/` root mount and out of scope per the epic).
+
+## Testing
+
+### Rust unit tests (`rust/profiles/cluster/src/main.rs`, `#[cfg(test)]`)
+A small pure validation helper is extracted so the field/mount-point checks are testable without a live kernel:
+- `NEXUS_S3_BUCKET` set + region missing → `Err` naming `NEXUS_S3_REGION`.
+- bucket + creds missing → `Err` naming the missing credential var.
+- mount point defaults to `/s3` when unset.
+- mount point `/` → `Err`.
+- bucket unset → `Ok(None)` / no-op (daemon behaves as today).
+
+### Integration test (AC #3) — `tests/integration/`
+Mirrors the bridge-2 E2E (`test_typed_grpc_cluster.py::test_s3_r2_dt_mount_builds_backend_and_round_trips`):
+- Build `nexusd-cluster` with `--features driver-s3`.
+- Boot the daemon with `NEXUS_S3_*` env pointing at **Cloudflare R2** (team precedent; `region=auto`, custom endpoint). The bridge-2 fixture's `--hostname 127.0.0.1` fix is required so the single-voter zone becomes healthy.
+- Over the VFS gRPC service, write a file under `<NEXUS_S3_MOUNT>/…` and read it back; assert the round-trip.
+- Env-gated (`NEXUS_E2E=1` + `NEXUS_R2_*`); skips cleanly when the binary lacks `driver-s3` ("not enabled") or creds are absent.
+
+R2 over MinIO confirmed by the operator: the team already uses Cloudflare R2 for bridge-2 E2E, the Rust `S3Backend` is proven against it live (`s3.rs::tests::live_r2_round_trip`), and it needs no local container.
+
+## Documentation
+
+The `nexusd-cluster` env surface (`NEXUS_ROOT_FS`, `NEXUS_BOOTSTRAP_MODE`, `NEXUS_FEDERATION_*`, …) is not currently documented anywhere under `docs/`. Rather than retrofit a full daemon-config reference (out of scope), create a new focused operator doc **`docs/operations/nexusd-cluster-s3-mounts.md`** covering just this feature:
+1. A quick-reference table of the seven `NEXUS_S3_*` vars.
+2. The `driver-s3` build requirement (`cargo build -p nexus-cluster --features driver-s3`) — the default slim binary does not ship the S3 arm and fails fast if `NEXUS_S3_BUCKET` is set.
+3. A worked AWS example and a worked Cloudflare R2 example (custom endpoint + `region=auto`).
+4. The credentials-in-env security note (prefer env over `--flag` to keep secrets out of `argv`).
+5. The fail-fast behaviors (missing required field, illegal mount point, driver not compiled).
+
+## Acceptance criteria mapping
+
+- **Operator can declare an S3 mount via config/env** → the `NEXUS_S3_*` clap/env surface.
+- **Startup mounts the declared backend (in addition to the local root)** → `mount_declared_s3` after the `/` mount; `/` stays intact, S3 at `/s3`.
+- **Integration: boots with an S3 mount against object storage and serves read/write through Rust E2E** → the R2 integration test.
+- **Misconfiguration fails fast with a clear error** → the error-handling table; env-var-named messages; driver-not-compiled gate error.

--- a/rust/profiles/cluster/src/main.rs
+++ b/rust/profiles/cluster/src/main.rs
@@ -16,6 +16,7 @@
 //! Sudowork's primary deployment path is the static topology env vars
 //! consumed at daemon startup; share/join are operator escape hatches.
 
+use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
@@ -774,6 +775,25 @@ fn nonempty_owned(v: &Option<String>) -> Option<&str> {
     v.as_deref().filter(|s| !s.trim().is_empty())
 }
 
+/// Return the colliding `NEXUS_FEDERATION_MOUNTS` path if `mount_point`
+/// (the declared S3 mount) shares a VFS path with a static federation
+/// mount. Both resolve to the same canonical key under the root zone, and
+/// `VFSRouter::add` overwrites an occupied key — so a collision would let
+/// federation topology silently replace the S3 backend. Comparison is
+/// trailing-slash-insensitive to match mount-path normalization.
+fn federation_mount_collision<'a>(
+    mount_point: &str,
+    fed_mounts: &'a BTreeMap<String, String>,
+) -> Option<&'a str> {
+    let mp = mount_point.trim_end_matches('/');
+    for path in fed_mounts.keys() {
+        if path.trim_end_matches('/') == mp {
+            return Some(path.as_str());
+        }
+    }
+    None
+}
+
 /// Parse + validate the `NEXUS_S3_*` declaration.
 ///
 ///   * `Ok(None)`        — no `NEXUS_S3_BUCKET`; no S3 mount declared.
@@ -856,6 +876,20 @@ fn mount_declared_s3(kernel: &Arc<Kernel>, common: &CommonArgs) -> Result<()> {
     let Some(cfg) = resolve_s3_mount_config(common)? else {
         return Ok(()); // no S3 mount declared
     };
+
+    // Fail fast on a mount-point collision with static federation topology:
+    // a `NEXUS_FEDERATION_MOUNTS` entry at the same VFS path would later
+    // overwrite this backend (`VFSRouter::add` replaces an occupied canonical
+    // key), silently re-routing the mount's traffic. Catch it at boot rather
+    // than mis-placing data.
+    let (_zones, fed_mounts) = parse_federation_env();
+    if let Some(fed_path) = federation_mount_collision(&cfg.mount_point, &fed_mounts) {
+        anyhow::bail!(
+            "NEXUS_S3_MOUNT {:?} collides with a NEXUS_FEDERATION_MOUNTS entry at \
+             {fed_path:?}; choose a different S3 mount point",
+            cfg.mount_point,
+        );
+    }
 
     let provider =
         get_provider().ok_or_else(|| anyhow::anyhow!("no ObjectStoreProvider registered"))?;
@@ -1194,6 +1228,21 @@ mod tests {
             let err = resolve_s3_mount_config(&args).unwrap_err().to_string();
             assert!(err.contains(var), "expected {var} in err, got: {err}");
         }
+    }
+
+    #[test]
+    fn federation_mount_collision_detection() {
+        let mut m = BTreeMap::new();
+        m.insert("/corp".to_string(), "corp".to_string());
+        m.insert("/family".to_string(), "family".to_string());
+        // Exact collision.
+        assert_eq!(federation_mount_collision("/corp", &m), Some("/corp"));
+        // Trailing-slash-insensitive (both sides normalized).
+        assert_eq!(federation_mount_collision("/corp/", &m), Some("/corp"));
+        // No collision for a distinct path.
+        assert_eq!(federation_mount_collision("/s3", &m), None);
+        // Empty federation map never collides.
+        assert_eq!(federation_mount_collision("/s3", &BTreeMap::new()), None);
     }
 
     #[test]

--- a/rust/profiles/cluster/src/main.rs
+++ b/rust/profiles/cluster/src/main.rs
@@ -776,8 +776,8 @@ fn nonempty_owned(v: &Option<String>) -> Option<&str> {
 ///   * `Ok(None)`        — no `NEXUS_S3_BUCKET`; no S3 mount declared.
 ///   * `Ok(Some(cfg))`   — a fully-validated mount.
 ///   * `Err(_)`          — bucket set but a required field is missing /
-///                         empty, or the mount point is illegal. The
-///                         message names the offending env var.
+///     empty, or the mount point is illegal. The
+///     message names the offending env var.
 fn resolve_s3_mount_config(common: &CommonArgs) -> Result<Option<S3MountConfig>> {
     let Some(bucket) = nonempty_owned(&common.s3_bucket) else {
         return Ok(None); // not declared

--- a/rust/profiles/cluster/src/main.rs
+++ b/rust/profiles/cluster/src/main.rs
@@ -740,6 +740,70 @@ async fn run_join(
     Ok(())
 }
 
+/// Validated S3-compatible mount declaration, resolved from `CommonArgs`.
+///
+/// Produced by [`resolve_s3_mount_config`]; consumed by
+/// [`mount_declared_s3`]. Owns its strings so it outlives the borrowed
+/// `ObjectStoreProviderArgs` built from it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct S3MountConfig {
+    bucket: String,
+    region: String,
+    access_key: String,
+    secret_key: String,
+    endpoint: Option<String>,
+    prefix: Option<String>,
+    mount_point: String,
+}
+
+/// Treat a present-but-empty string (e.g. an exported-but-empty env
+/// var) as absent, so it triggers the required-field error instead of
+/// building a degenerate backend.
+fn nonempty_owned(v: &Option<String>) -> Option<&str> {
+    v.as_deref().filter(|s| !s.is_empty())
+}
+
+/// Parse + validate the `NEXUS_S3_*` declaration.
+///
+///   * `Ok(None)`        — no `NEXUS_S3_BUCKET`; no S3 mount declared.
+///   * `Ok(Some(cfg))`   — a fully-validated mount.
+///   * `Err(_)`          — bucket set but a required field is missing /
+///                         empty, or the mount point is illegal. The
+///                         message names the offending env var.
+fn resolve_s3_mount_config(common: &CommonArgs) -> Result<Option<S3MountConfig>> {
+    let Some(bucket) = nonempty_owned(&common.s3_bucket) else {
+        return Ok(None); // not declared
+    };
+
+    let region = nonempty_owned(&common.s3_region).ok_or_else(|| {
+        anyhow::anyhow!("NEXUS_S3_REGION is required when NEXUS_S3_BUCKET is set")
+    })?;
+    let access_key = nonempty_owned(&common.s3_access_key_id).ok_or_else(|| {
+        anyhow::anyhow!("NEXUS_S3_ACCESS_KEY_ID is required when NEXUS_S3_BUCKET is set")
+    })?;
+    let secret_key = nonempty_owned(&common.s3_secret_access_key).ok_or_else(|| {
+        anyhow::anyhow!("NEXUS_S3_SECRET_ACCESS_KEY is required when NEXUS_S3_BUCKET is set")
+    })?;
+
+    let mount_point = nonempty_owned(&common.s3_mount).unwrap_or("/s3");
+    if mount_point.trim_end_matches('/').is_empty() {
+        anyhow::bail!(
+            "NEXUS_S3_MOUNT must be a sub-path (e.g. \"/s3\"); \"/\" is \
+             reserved for the local host-fs root mount"
+        );
+    }
+
+    Ok(Some(S3MountConfig {
+        bucket: bucket.to_string(),
+        region: region.to_string(),
+        access_key: access_key.to_string(),
+        secret_key: secret_key.to_string(),
+        endpoint: nonempty_owned(&common.s3_endpoint).map(str::to_string),
+        prefix: nonempty_owned(&common.s3_prefix).map(str::to_string),
+        mount_point: mount_point.to_string(),
+    }))
+}
+
 /// Install the global tracing subscriber with a non-blocking stdout
 /// writer. The returned [`WorkerGuard`] MUST be held for the lifetime of
 /// the process — dropping it flushes buffered lines and stops the writer
@@ -785,4 +849,120 @@ async fn wait_for_shutdown() {
 async fn wait_for_shutdown() {
     let _ = tokio::signal::ctrl_c().await;
     tracing::info!("Received Ctrl+C");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a `CommonArgs` with all non-S3 fields at their inert
+    /// defaults, so each test sets only the S3 fields it exercises.
+    fn base_args() -> CommonArgs {
+        CommonArgs {
+            hostname: None,
+            bind_addr: DEFAULT_BIND.to_string(),
+            data_dir: PathBuf::from("./nexus-cluster-data"),
+            peers: String::new(),
+            no_tls: false,
+            root_path: None,
+            bootstrap_mode: None,
+            s3_bucket: None,
+            s3_region: None,
+            s3_access_key_id: None,
+            s3_secret_access_key: None,
+            s3_endpoint: None,
+            s3_prefix: None,
+            s3_mount: None,
+        }
+    }
+
+    /// Fully-populated S3 args for the happy-path tests.
+    fn s3_args() -> CommonArgs {
+        CommonArgs {
+            s3_bucket: Some("my-bucket".into()),
+            s3_region: Some("auto".into()),
+            s3_access_key_id: Some("AKID".into()),
+            s3_secret_access_key: Some("SECRET".into()),
+            ..base_args()
+        }
+    }
+
+    #[test]
+    fn no_bucket_is_no_mount() {
+        let cfg = resolve_s3_mount_config(&base_args()).expect("ok");
+        assert!(cfg.is_none(), "no NEXUS_S3_BUCKET → no mount declared");
+    }
+
+    #[test]
+    fn full_config_resolves_with_default_mount_point() {
+        let cfg = resolve_s3_mount_config(&s3_args()).expect("ok").expect("some");
+        assert_eq!(cfg.bucket, "my-bucket");
+        assert_eq!(cfg.region, "auto");
+        assert_eq!(cfg.access_key, "AKID");
+        assert_eq!(cfg.secret_key, "SECRET");
+        assert_eq!(cfg.mount_point, "/s3", "defaults to /s3");
+        assert_eq!(cfg.prefix, None);
+        assert_eq!(cfg.endpoint, None);
+    }
+
+    #[test]
+    fn custom_mount_point_and_optional_fields_pass_through() {
+        let args = CommonArgs {
+            s3_mount: Some("/cloud".into()),
+            s3_prefix: Some("team/data".into()),
+            s3_endpoint: Some("https://acct.r2.cloudflarestorage.com".into()),
+            ..s3_args()
+        };
+        let cfg = resolve_s3_mount_config(&args).expect("ok").expect("some");
+        assert_eq!(cfg.mount_point, "/cloud");
+        assert_eq!(cfg.prefix.as_deref(), Some("team/data"));
+        assert_eq!(
+            cfg.endpoint.as_deref(),
+            Some("https://acct.r2.cloudflarestorage.com")
+        );
+    }
+
+    #[test]
+    fn missing_region_errors_naming_the_env_var() {
+        let args = CommonArgs { s3_region: None, ..s3_args() };
+        let err = resolve_s3_mount_config(&args).unwrap_err().to_string();
+        assert!(err.contains("NEXUS_S3_REGION"), "err was: {err}");
+    }
+
+    #[test]
+    fn missing_access_key_errors_naming_the_env_var() {
+        let args = CommonArgs { s3_access_key_id: None, ..s3_args() };
+        let err = resolve_s3_mount_config(&args).unwrap_err().to_string();
+        assert!(err.contains("NEXUS_S3_ACCESS_KEY_ID"), "err was: {err}");
+    }
+
+    #[test]
+    fn missing_secret_key_errors_naming_the_env_var() {
+        let args = CommonArgs { s3_secret_access_key: None, ..s3_args() };
+        let err = resolve_s3_mount_config(&args).unwrap_err().to_string();
+        assert!(err.contains("NEXUS_S3_SECRET_ACCESS_KEY"), "err was: {err}");
+    }
+
+    #[test]
+    fn root_mount_point_is_rejected() {
+        let args = CommonArgs { s3_mount: Some("/".into()), ..s3_args() };
+        let err = resolve_s3_mount_config(&args).unwrap_err().to_string();
+        assert!(err.contains("sub-path"), "err was: {err}");
+    }
+
+    #[test]
+    fn trailing_slash_only_mount_point_is_rejected() {
+        let args = CommonArgs { s3_mount: Some("///".into()), ..s3_args() };
+        let err = resolve_s3_mount_config(&args).unwrap_err().to_string();
+        assert!(err.contains("sub-path"), "err was: {err}");
+    }
+
+    #[test]
+    fn empty_string_required_field_is_treated_as_missing() {
+        // An exported-but-empty env var arrives as Some(""); it must not
+        // build a degenerate backend.
+        let args = CommonArgs { s3_region: Some(String::new()), ..s3_args() };
+        let err = resolve_s3_mount_config(&args).unwrap_err().to_string();
+        assert!(err.contains("NEXUS_S3_REGION"), "err was: {err}");
+    }
 }

--- a/rust/profiles/cluster/src/main.rs
+++ b/rust/profiles/cluster/src/main.rs
@@ -450,7 +450,8 @@ async fn run_daemon(common: CommonArgs) -> Result<()> {
     // Built through the same provider the gRPC bridge uses, so the
     // driver gate fails fast on a slim binary without `driver-s3`.
     // Runs before the VFS gRPC server serves so the mount is live.
-    mount_declared_s3(&kernel, &common)?;
+    // Re-verified after the coordinator replays persisted mounts (below).
+    let s3_mount_point = mount_declared_s3(&kernel, &common)?;
 
     // Build VFS gRPC service as tonic Routes — co-hosted on the raft
     // port via ZoneManager. Uses NoAuth (mTLS is the boundary).
@@ -547,6 +548,14 @@ async fn run_daemon(common: CommonArgs) -> Result<()> {
         coord.install_with_kernel(zm.clone(), zm.runtime_handle(), &self_address, &kernel);
         coord
     };
+
+    // `install_with_kernel` replayed any DT_MOUNT entries persisted in the
+    // root zone's raft state. If one of those federation mounts sits at the
+    // declared S3 mount point, it just overwrote the S3 backend — fail fast
+    // rather than silently serve the wrong zone under that path.
+    if let Some(mount_point) = &s3_mount_point {
+        verify_s3_mount_not_shadowed(&kernel, mount_point)?;
+    }
 
     // Outbound peer-blob client — installs a `PeerBlobClient` over
     // the kernel-shared tokio runtime, replacing the `NoopPeerBlobClient`
@@ -866,15 +875,18 @@ fn resolve_s3_mount_config(common: &CommonArgs) -> Result<Option<S3MountConfig>>
     }))
 }
 
-/// Construct + mount the declared S3 backend at boot, if any.
+/// Construct + mount the declared S3 backend at boot, if any. Returns the
+/// VFS mount point on success so the caller can re-verify it after the
+/// federation coordinator replays persisted mounts (see
+/// [`verify_s3_mount_not_shadowed`]).
 ///
-/// No-op when `NEXUS_S3_BUCKET` is unset. Builds through the registered
-/// `ObjectStoreProvider` (the same path the gRPC bridge uses), so the
-/// driver gate is honored: on a slim binary without `--features
+/// `Ok(None)` when `NEXUS_S3_BUCKET` is unset. Builds through the
+/// registered `ObjectStoreProvider` (the same path the gRPC bridge uses),
+/// so the driver gate is honored: on a slim binary without `--features
 /// driver-s3`, `build` returns the gate error and this fails fast.
-fn mount_declared_s3(kernel: &Arc<Kernel>, common: &CommonArgs) -> Result<()> {
+fn mount_declared_s3(kernel: &Arc<Kernel>, common: &CommonArgs) -> Result<Option<String>> {
     let Some(cfg) = resolve_s3_mount_config(common)? else {
-        return Ok(()); // no S3 mount declared
+        return Ok(None); // no S3 mount declared
     };
 
     // Fail fast on a mount-point collision with static federation topology:
@@ -969,6 +981,33 @@ fn mount_declared_s3(kernel: &Arc<Kernel>, common: &CommonArgs) -> Result<()> {
         endpoint = cfg.endpoint.as_deref().unwrap_or("default (AWS)"),
         "mounted S3-compatible backend",
     );
+    Ok(Some(cfg.mount_point))
+}
+
+/// Fail fast if the S3 mount at `mount_point` was shadowed by a
+/// federation mount the coordinator replayed from persisted raft state at
+/// startup. The env-time collision check ([`federation_mount_collision`])
+/// only sees the current `NEXUS_FEDERATION_MOUNTS`; a DT_MOUNT persisted
+/// by a prior `share`/`join` is replayed by `install_with_kernel` *after*
+/// the S3 mount is installed, and `VFSRouter::add` overwrites the occupied
+/// canonical key — so the route would silently resolve to the federation
+/// zone instead of the bucket. A federation mount carries a
+/// `target_zone_id`; the S3 local mount does not, so that field is the
+/// discriminator. Call after the coordinator install/replay completes.
+fn verify_s3_mount_not_shadowed(kernel: &Arc<Kernel>, mount_point: &str) -> Result<()> {
+    let router = kernel.vfs_router_arc();
+    // Extract the shadowing target zone (if any) into an owned value so the
+    // dashmap `Ref` is dropped before `router` at the end of the function.
+    let shadow_zone: Option<String> = router
+        .get(mount_point, contracts::ROOT_ZONE_ID)
+        .and_then(|entry| entry.target_zone_id.clone());
+    if let Some(zone) = shadow_zone {
+        anyhow::bail!(
+            "NEXUS_S3_MOUNT {mount_point:?} was shadowed by a persisted federation \
+             mount (target zone {zone:?}) replayed at startup; unmount it \
+             (`nexusd-cluster unmount {mount_point}`) before serving S3 there",
+        );
+    }
     Ok(())
 }
 
@@ -1243,6 +1282,31 @@ mod tests {
         assert_eq!(federation_mount_collision("/s3", &m), None);
         // Empty federation map never collides.
         assert_eq!(federation_mount_collision("/s3", &BTreeMap::new()), None);
+    }
+
+    #[test]
+    fn shadowed_s3_mount_is_detected() {
+        // A persisted federation mount replayed at the S3 path carries a
+        // target_zone_id → must be detected as a shadow and fail fast.
+        let kernel = Arc::new(Kernel::new());
+        let router = kernel.vfs_router_arc();
+        router.add_federation_mount("/s3", contracts::ROOT_ZONE_ID, None, "corp", false);
+        let err = verify_s3_mount_not_shadowed(&kernel, "/s3")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("shadowed"), "err was: {err}");
+    }
+
+    #[test]
+    fn unshadowed_s3_mount_passes_verification() {
+        // A plain local mount (no target_zone_id), as the S3 mount installs,
+        // is not a shadow → verification passes. Absence of any mount also
+        // passes (nothing to shadow).
+        let kernel = Arc::new(Kernel::new());
+        let router = kernel.vfs_router_arc();
+        router.add_mount("/s3", contracts::ROOT_ZONE_ID, None, false);
+        assert!(verify_s3_mount_not_shadowed(&kernel, "/s3").is_ok());
+        assert!(verify_s3_mount_not_shadowed(&kernel, "/never-mounted").is_ok());
     }
 
     #[test]

--- a/rust/profiles/cluster/src/main.rs
+++ b/rust/profiles/cluster/src/main.rs
@@ -793,8 +793,28 @@ fn resolve_s3_mount_config(common: &CommonArgs) -> Result<Option<S3MountConfig>>
         anyhow::anyhow!("NEXUS_S3_SECRET_ACCESS_KEY is required when NEXUS_S3_BUCKET is set")
     })?;
 
-    let mount_point = nonempty_owned(&common.s3_mount).unwrap_or("/s3");
-    if mount_point.trim_end_matches('/').is_empty() {
+    // Normalize the mount point to the same canonical shape the kernel
+    // router uses for lookups, so a configured value can't silently
+    // mis-route. The router strips trailing slashes and walks ancestors on
+    // lookup; a stored `/s3/` key would never match `/s3/file`, sending
+    // writes to the local root instead. Require an absolute path and reject
+    // `..` traversal / NUL, matching the rest of the syscall path's
+    // path contract.
+    let raw_mount = nonempty_owned(&common.s3_mount).unwrap_or("/s3");
+    if !raw_mount.starts_with('/') {
+        anyhow::bail!(
+            "NEXUS_S3_MOUNT must be an absolute path starting with \"/\" \
+             (got {raw_mount:?})"
+        );
+    }
+    if raw_mount.split('/').any(|seg| seg == "..") {
+        anyhow::bail!("NEXUS_S3_MOUNT must not contain \"..\" path segments (got {raw_mount:?})");
+    }
+    if raw_mount.contains('\0') {
+        anyhow::bail!("NEXUS_S3_MOUNT must not contain NUL bytes");
+    }
+    let mount_point = raw_mount.trim_end_matches('/');
+    if mount_point.is_empty() {
         anyhow::bail!(
             "NEXUS_S3_MOUNT must be a sub-path (e.g. \"/s3\"); \"/\" is \
              reserved for the local host-fs root mount"
@@ -1072,6 +1092,48 @@ mod tests {
         };
         let err = resolve_s3_mount_config(&args).unwrap_err().to_string();
         assert!(err.contains("sub-path"), "err was: {err}");
+    }
+
+    #[test]
+    fn trailing_slash_is_trimmed_to_canonical_mount_point() {
+        // `/s3/` must canonicalize to `/s3` — the kernel router strips
+        // trailing slashes on lookup, so a stored `/s3/` key would never
+        // match `/s3/file` and writes would silently fall through to the
+        // local root mount.
+        for raw in ["/s3/", "/s3///", "/cloud/data/"] {
+            let args = CommonArgs {
+                s3_mount: Some(raw.into()),
+                ..s3_args()
+            };
+            let cfg = resolve_s3_mount_config(&args).expect("ok").expect("some");
+            assert_eq!(
+                cfg.mount_point,
+                raw.trim_end_matches('/'),
+                "trailing slash not trimmed for {raw:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn relative_mount_point_is_rejected() {
+        // A non-absolute mount point can't be routed; reject it rather than
+        // register a key the syscall path treats as invalid.
+        let args = CommonArgs {
+            s3_mount: Some("s3".into()),
+            ..s3_args()
+        };
+        let err = resolve_s3_mount_config(&args).unwrap_err().to_string();
+        assert!(err.contains("absolute"), "err was: {err}");
+    }
+
+    #[test]
+    fn parent_dir_traversal_mount_point_is_rejected() {
+        let args = CommonArgs {
+            s3_mount: Some("/s3/../etc".into()),
+            ..s3_args()
+        };
+        let err = resolve_s3_mount_config(&args).unwrap_err().to_string();
+        assert!(err.contains(".."), "err was: {err}");
     }
 
     #[test]

--- a/rust/profiles/cluster/src/main.rs
+++ b/rust/profiles/cluster/src/main.rs
@@ -98,6 +98,44 @@ struct CommonArgs {
     /// validator since they always operate on existing state.
     #[arg(long, env = "NEXUS_BOOTSTRAP_MODE", global = true)]
     bootstrap_mode: Option<String>,
+
+    /// S3-compatible bucket to mount (AWS S3 / Cloudflare R2 / MinIO).
+    /// Presence of this var DECLARES an S3 mount; when unset the daemon
+    /// boots with only the local `/` root mount, exactly as before.
+    #[arg(long, env = "NEXUS_S3_BUCKET", global = true)]
+    s3_bucket: Option<String>,
+
+    /// AWS region for the S3 mount. Required when `NEXUS_S3_BUCKET` is
+    /// set. Cloudflare R2 uses `auto`.
+    #[arg(long, env = "NEXUS_S3_REGION", global = true)]
+    s3_region: Option<String>,
+
+    /// Access key id for the S3 mount. Required when `NEXUS_S3_BUCKET`
+    /// is set. Prefer the env var over the flag so the secret does not
+    /// land in `argv` (visible via `ps`).
+    #[arg(long, env = "NEXUS_S3_ACCESS_KEY_ID", global = true)]
+    s3_access_key_id: Option<String>,
+
+    /// Secret access key for the S3 mount. Required when
+    /// `NEXUS_S3_BUCKET` is set. Prefer the env var over the flag.
+    #[arg(long, env = "NEXUS_S3_SECRET_ACCESS_KEY", global = true)]
+    s3_secret_access_key: Option<String>,
+
+    /// Custom S3-compatible endpoint (Cloudflare R2 / MinIO). Omit for
+    /// AWS S3 (virtual-hosted addressing is derived from bucket+region).
+    #[arg(long, env = "NEXUS_S3_ENDPOINT", global = true)]
+    s3_endpoint: Option<String>,
+
+    /// Key prefix within the bucket. Optional; defaults to empty (bucket
+    /// root).
+    #[arg(long, env = "NEXUS_S3_PREFIX", global = true)]
+    s3_prefix: Option<String>,
+
+    /// VFS mount point for the S3 backend. Must be a non-root absolute
+    /// path; defaults to `/s3`. `/` is reserved for the local host-fs
+    /// root mount.
+    #[arg(long, env = "NEXUS_S3_MOUNT", global = true)]
+    s3_mount: Option<String>,
 }
 
 impl CommonArgs {

--- a/rust/profiles/cluster/src/main.rs
+++ b/rust/profiles/cluster/src/main.rs
@@ -823,8 +823,8 @@ fn mount_declared_s3(kernel: &Arc<Kernel>, common: &CommonArgs) -> Result<()> {
         return Ok(()); // no S3 mount declared
     };
 
-    let provider = get_provider()
-        .ok_or_else(|| anyhow::anyhow!("no ObjectStoreProvider registered"))?;
+    let provider =
+        get_provider().ok_or_else(|| anyhow::anyhow!("no ObjectStoreProvider registered"))?;
 
     // Locals the args borrow from must outlive `args`.
     let peer_client = kernel.peer_client_arc();
@@ -995,7 +995,9 @@ mod tests {
 
     #[test]
     fn full_config_resolves_with_default_mount_point() {
-        let cfg = resolve_s3_mount_config(&s3_args()).expect("ok").expect("some");
+        let cfg = resolve_s3_mount_config(&s3_args())
+            .expect("ok")
+            .expect("some");
         assert_eq!(cfg.bucket, "my-bucket");
         assert_eq!(cfg.region, "auto");
         assert_eq!(cfg.access_key, "AKID");
@@ -1024,35 +1026,50 @@ mod tests {
 
     #[test]
     fn missing_region_errors_naming_the_env_var() {
-        let args = CommonArgs { s3_region: None, ..s3_args() };
+        let args = CommonArgs {
+            s3_region: None,
+            ..s3_args()
+        };
         let err = resolve_s3_mount_config(&args).unwrap_err().to_string();
         assert!(err.contains("NEXUS_S3_REGION"), "err was: {err}");
     }
 
     #[test]
     fn missing_access_key_errors_naming_the_env_var() {
-        let args = CommonArgs { s3_access_key_id: None, ..s3_args() };
+        let args = CommonArgs {
+            s3_access_key_id: None,
+            ..s3_args()
+        };
         let err = resolve_s3_mount_config(&args).unwrap_err().to_string();
         assert!(err.contains("NEXUS_S3_ACCESS_KEY_ID"), "err was: {err}");
     }
 
     #[test]
     fn missing_secret_key_errors_naming_the_env_var() {
-        let args = CommonArgs { s3_secret_access_key: None, ..s3_args() };
+        let args = CommonArgs {
+            s3_secret_access_key: None,
+            ..s3_args()
+        };
         let err = resolve_s3_mount_config(&args).unwrap_err().to_string();
         assert!(err.contains("NEXUS_S3_SECRET_ACCESS_KEY"), "err was: {err}");
     }
 
     #[test]
     fn root_mount_point_is_rejected() {
-        let args = CommonArgs { s3_mount: Some("/".into()), ..s3_args() };
+        let args = CommonArgs {
+            s3_mount: Some("/".into()),
+            ..s3_args()
+        };
         let err = resolve_s3_mount_config(&args).unwrap_err().to_string();
         assert!(err.contains("sub-path"), "err was: {err}");
     }
 
     #[test]
     fn trailing_slash_only_mount_point_is_rejected() {
-        let args = CommonArgs { s3_mount: Some("///".into()), ..s3_args() };
+        let args = CommonArgs {
+            s3_mount: Some("///".into()),
+            ..s3_args()
+        };
         let err = resolve_s3_mount_config(&args).unwrap_err().to_string();
         assert!(err.contains("sub-path"), "err was: {err}");
     }
@@ -1061,7 +1078,10 @@ mod tests {
     fn empty_string_required_field_is_treated_as_missing() {
         // An exported-but-empty env var arrives as Some(""); it must not
         // build a degenerate backend.
-        let args = CommonArgs { s3_region: Some(String::new()), ..s3_args() };
+        let args = CommonArgs {
+            s3_region: Some(String::new()),
+            ..s3_args()
+        };
         let err = resolve_s3_mount_config(&args).unwrap_err().to_string();
         assert!(err.contains("NEXUS_S3_REGION"), "err was: {err}");
     }

--- a/rust/profiles/cluster/src/main.rs
+++ b/rust/profiles/cluster/src/main.rs
@@ -764,11 +764,14 @@ struct S3MountConfig {
     mount_point: String,
 }
 
-/// Treat a present-but-empty string (e.g. an exported-but-empty env
-/// var) as absent, so it triggers the required-field error instead of
-/// building a degenerate backend.
+/// Treat a present-but-blank string (an exported-but-empty or
+/// whitespace-only env var, e.g. a poorly-templated Secret) as absent,
+/// so a required field triggers the env-var-named error and an optional
+/// one (prefix / endpoint) falls back to its default instead of building
+/// a degenerate backend (literal whitespace prefix / malformed host).
+/// Returns the original (untrimmed) value when non-blank.
 fn nonempty_owned(v: &Option<String>) -> Option<&str> {
-    v.as_deref().filter(|s| !s.is_empty())
+    v.as_deref().filter(|s| !s.trim().is_empty())
 }
 
 /// Parse + validate the `NEXUS_S3_*` declaration.
@@ -1166,6 +1169,30 @@ mod tests {
             };
             let err = resolve_s3_mount_config(&args).unwrap_err().to_string();
             assert!(err.contains("NEXUS_S3_BUCKET"), "err was: {err}");
+        }
+    }
+
+    #[test]
+    fn whitespace_only_required_fields_fail_fast() {
+        // Whitespace-only required fields (e.g. a poorly-templated Secret)
+        // must fail fast naming the var, not build a degenerate backend that
+        // only errors on first I/O.
+        let cases: [(fn(&mut CommonArgs), &str); 3] = [
+            (|a| a.s3_region = Some("   ".into()), "NEXUS_S3_REGION"),
+            (
+                |a| a.s3_access_key_id = Some("  ".into()),
+                "NEXUS_S3_ACCESS_KEY_ID",
+            ),
+            (
+                |a| a.s3_secret_access_key = Some(" ".into()),
+                "NEXUS_S3_SECRET_ACCESS_KEY",
+            ),
+        ];
+        for (mutate, var) in cases {
+            let mut args = s3_args();
+            mutate(&mut args);
+            let err = resolve_s3_mount_config(&args).unwrap_err().to_string();
+            assert!(err.contains(var), "expected {var} in err, got: {err}");
         }
     }
 

--- a/rust/profiles/cluster/src/main.rs
+++ b/rust/profiles/cluster/src/main.rs
@@ -779,8 +779,19 @@ fn nonempty_owned(v: &Option<String>) -> Option<&str> {
 ///     empty, or the mount point is illegal. The
 ///     message names the offending env var.
 fn resolve_s3_mount_config(common: &CommonArgs) -> Result<Option<S3MountConfig>> {
-    let Some(bucket) = nonempty_owned(&common.s3_bucket) else {
-        return Ok(None); // not declared
+    // `NEXUS_S3_BUCKET` is the declaration trigger. Distinguish "truly
+    // absent" (`None` → no S3 mount, boot exactly as before) from "present
+    // but blank" (`Some("")` / whitespace → a typo'd or empty-Secret config
+    // that must fail fast, not silently disable the mount and let `/s3`
+    // writes fall through to the local root). clap surfaces an
+    // exported-empty env var as `Some("")`, so this case is reachable.
+    let bucket = match common.s3_bucket.as_deref() {
+        None => return Ok(None),
+        Some(b) if b.trim().is_empty() => anyhow::bail!(
+            "NEXUS_S3_BUCKET is set but blank; unset it to disable the S3 \
+             mount, or provide a bucket name"
+        ),
+        Some(b) => b,
     };
 
     let region = nonempty_owned(&common.s3_region).ok_or_else(|| {
@@ -1134,6 +1145,28 @@ mod tests {
         };
         let err = resolve_s3_mount_config(&args).unwrap_err().to_string();
         assert!(err.contains(".."), "err was: {err}");
+    }
+
+    #[test]
+    fn truly_absent_bucket_is_no_mount() {
+        // Unset NEXUS_S3_BUCKET (None) → no S3 mount declared; boot as before.
+        let cfg = resolve_s3_mount_config(&base_args()).expect("ok");
+        assert!(cfg.is_none());
+    }
+
+    #[test]
+    fn present_but_blank_bucket_fails_fast() {
+        // An exported-but-empty / whitespace `NEXUS_S3_BUCKET` (e.g. a k8s
+        // Secret typo) must fail fast naming the var, NOT silently disable the
+        // mount and let `/s3` writes fall through to the local root.
+        for blank in ["", "   "] {
+            let args = CommonArgs {
+                s3_bucket: Some(blank.into()),
+                ..s3_args()
+            };
+            let err = resolve_s3_mount_config(&args).unwrap_err().to_string();
+            assert!(err.contains("NEXUS_S3_BUCKET"), "err was: {err}");
+        }
     }
 
     #[test]

--- a/rust/profiles/cluster/src/main.rs
+++ b/rust/profiles/cluster/src/main.rs
@@ -25,7 +25,9 @@ use backends::provider::DefaultObjectStoreProvider;
 use backends::storage::path_local::PathLocalBackend;
 use clap::{Parser, Subcommand};
 use kernel::abc::object_store::ObjectStore;
-use kernel::hal::object_store_provider::{set_enabled_drivers, set_provider};
+use kernel::hal::object_store_provider::{
+    get_provider, set_enabled_drivers, set_provider, ObjectStoreProviderArgs,
+};
 use kernel::kernel::convenience::{KernelConvenience, MountOptions};
 use kernel::kernel::Kernel;
 
@@ -443,6 +445,12 @@ async fn run_daemon(common: CommonArgs) -> Result<()> {
         "mounted host-fs at \"/\" via PathLocalBackend",
     );
 
+    // ── Optional S3-compatible mount declared via NEXUS_S3_* ──
+    // Built through the same provider the gRPC bridge uses, so the
+    // driver gate fails fast on a slim binary without `driver-s3`.
+    // Runs before the VFS gRPC server serves so the mount is live.
+    mount_declared_s3(&kernel, &common)?;
+
     // Build VFS gRPC service as tonic Routes — co-hosted on the raft
     // port via ZoneManager. Uses NoAuth (mTLS is the boundary).
     let vfs_auth: Arc<dyn transport::auth::AuthProvider> = Arc::new(transport::auth::NoAuth);
@@ -802,6 +810,95 @@ fn resolve_s3_mount_config(common: &CommonArgs) -> Result<Option<S3MountConfig>>
         prefix: nonempty_owned(&common.s3_prefix).map(str::to_string),
         mount_point: mount_point.to_string(),
     }))
+}
+
+/// Construct + mount the declared S3 backend at boot, if any.
+///
+/// No-op when `NEXUS_S3_BUCKET` is unset. Builds through the registered
+/// `ObjectStoreProvider` (the same path the gRPC bridge uses), so the
+/// driver gate is honored: on a slim binary without `--features
+/// driver-s3`, `build` returns the gate error and this fails fast.
+fn mount_declared_s3(kernel: &Arc<Kernel>, common: &CommonArgs) -> Result<()> {
+    let Some(cfg) = resolve_s3_mount_config(common)? else {
+        return Ok(()); // no S3 mount declared
+    };
+
+    let provider = get_provider()
+        .ok_or_else(|| anyhow::anyhow!("no ObjectStoreProvider registered"))?;
+
+    // Locals the args borrow from must outlive `args`.
+    let peer_client = kernel.peer_client_arc();
+    let self_address = kernel.self_address_string();
+
+    let args = ObjectStoreProviderArgs {
+        backend_type: "s3",
+        backend_name: "s3",
+        mount_path: Some(cfg.mount_point.as_str()),
+        local_root: None,
+        fsync: false,
+        follow_symlinks: false,
+        openai_base_url: None,
+        openai_api_key: None,
+        openai_model: None,
+        openai_blob_root: None,
+        anthropic_base_url: None,
+        anthropic_api_key: None,
+        anthropic_model: None,
+        anthropic_blob_root: None,
+        s3_bucket: Some(cfg.bucket.as_str()),
+        s3_prefix: cfg.prefix.as_deref(),
+        aws_region: Some(cfg.region.as_str()),
+        aws_access_key: Some(cfg.access_key.as_str()),
+        aws_secret_key: Some(cfg.secret_key.as_str()),
+        s3_endpoint: cfg.endpoint.as_deref(),
+        gcs_bucket: None,
+        gcs_prefix: None,
+        access_token: None,
+        root_folder_id: None,
+        bot_token: None,
+        default_channel: None,
+        hn_stories_per_feed: None,
+        hn_include_comments: None,
+        cli_command: None,
+        cli_service: None,
+        cli_auth_env_json: None,
+        x_bearer_token: None,
+        server_address: None,
+        remote_auth_token: None,
+        remote_ca_pem: None,
+        remote_cert_pem: None,
+        remote_key_pem: None,
+        remote_timeout: 0.0,
+        peer_client: &peer_client,
+        self_address: self_address.as_deref(),
+        runtime: kernel.runtime(),
+    };
+
+    let built = provider.build(&args).map_err(|e| {
+        anyhow::anyhow!(
+            "failed to build S3 backend for mount '{}' (bucket '{}'): {e}",
+            cfg.mount_point,
+            cfg.bucket,
+        )
+    })?;
+    let backend = built
+        .backend
+        .ok_or_else(|| anyhow::anyhow!("ObjectStoreProvider returned no backend for S3 mount"))?;
+
+    kernel
+        .mount(
+            &cfg.mount_point,
+            MountOptions::new("s3").with_backend(backend),
+        )
+        .map_err(|e| anyhow::anyhow!("mount S3 at '{}': {e:?}", cfg.mount_point))?;
+
+    tracing::info!(
+        bucket = %cfg.bucket,
+        mount_point = %cfg.mount_point,
+        endpoint = ?cfg.endpoint,
+        "mounted S3-compatible backend",
+    );
+    Ok(())
 }
 
 /// Install the global tracing subscriber with a non-blocking stdout

--- a/rust/profiles/cluster/src/main.rs
+++ b/rust/profiles/cluster/src/main.rs
@@ -881,6 +881,8 @@ fn mount_declared_s3(kernel: &Arc<Kernel>, common: &CommonArgs) -> Result<()> {
             cfg.bucket,
         )
     })?;
+    // DefaultObjectStoreProvider always returns Some for s3 on Ok; this
+    // guard covers a custom provider that signals "no backend" via None.
     let backend = built
         .backend
         .ok_or_else(|| anyhow::anyhow!("ObjectStoreProvider returned no backend for S3 mount"))?;
@@ -895,7 +897,8 @@ fn mount_declared_s3(kernel: &Arc<Kernel>, common: &CommonArgs) -> Result<()> {
     tracing::info!(
         bucket = %cfg.bucket,
         mount_point = %cfg.mount_point,
-        endpoint = ?cfg.endpoint,
+        prefix = cfg.prefix.as_deref().unwrap_or(""),
+        endpoint = cfg.endpoint.as_deref().unwrap_or("default (AWS)"),
         "mounted S3-compatible backend",
     );
     Ok(())

--- a/tests/integration/test_typed_grpc_cluster.py
+++ b/tests/integration/test_typed_grpc_cluster.py
@@ -353,6 +353,107 @@ def test_s3_r2_dt_mount_builds_backend_and_round_trips(cluster_grpc):
 # ── bridge-3 (#4263): S3 mount declared via NEXUS_S3_* at startup ─────────────
 
 
+def _s3_env_from_r2(env_r2: dict[str, str]) -> dict[str, str]:
+    """Map the test's ``NEXUS_R2_*`` creds onto the daemon's ``NEXUS_S3_*``
+    startup-mount surface (mount point ``/s3``)."""
+    return {
+        "NEXUS_S3_BUCKET": env_r2["NEXUS_R2_BUCKET"],
+        "NEXUS_S3_REGION": env_r2["NEXUS_R2_REGION"],
+        "NEXUS_S3_ACCESS_KEY_ID": env_r2["NEXUS_R2_ACCESS_KEY_ID"],
+        "NEXUS_S3_SECRET_ACCESS_KEY": env_r2["NEXUS_R2_SECRET_ACCESS_KEY"],
+        "NEXUS_S3_ENDPOINT": env_r2["NEXUS_R2_ENDPOINT"],
+        "NEXUS_S3_MOUNT": "/s3",
+    }
+
+
+def _spawn_cluster_s3(
+    binary: str,
+    data_dir: Path,
+    s3_env: dict[str, str],
+    log_handle,
+    log_path: Path,
+) -> tuple[subprocess.Popen, str]:
+    """Boot ``nexus-cluster`` with an S3 startup mount on ``data_dir`` and
+    return ``(proc, "host:port")`` once the gRPC port accepts connections.
+
+    Retries a few ephemeral ports (TOCTOU between pick and bind). Raises
+    ``AssertionError`` if it never binds; calls ``pytest.skip`` when the
+    binary lacks the ``driver-s3`` arm (so the gate is a clean skip, not a
+    confusing failure).
+    """
+    last_err = ""
+    for _attempt in range(5):
+        s = socket.socket()
+        try:
+            s.bind(("127.0.0.1", 0))
+            port = s.getsockname()[1]
+        finally:
+            s.close()
+        addr = f"127.0.0.1:{port}"
+        proc = subprocess.Popen(
+            [
+                binary,
+                "--no-tls",
+                "--hostname",
+                "127.0.0.1",
+                "--bind-addr",
+                addr,
+                "--data-dir",
+                str(data_dir),
+                "--bootstrap-mode",
+                "static",
+            ],
+            env={
+                **os.environ,
+                **s3_env,
+                "RUST_LOG": os.environ.get("RUST_LOG") or "info,nexus_raft=info",
+            },
+            stdout=log_handle,
+            stderr=subprocess.STDOUT,
+        )
+        deadline = time.monotonic() + 20
+        while time.monotonic() < deadline:
+            if proc.poll() is not None:
+                log_text = log_path.read_text()
+                last_err = (
+                    f"nexus-cluster exited early (rc={proc.returncode}); log: {log_text[-600:]}"
+                )
+                # A driver-not-compiled exit is an explicit skip signal.
+                if "not enabled" in log_text:
+                    pytest.skip(
+                        "cluster binary lacks the s3 driver — rebuild with "
+                        "`cargo build -p nexus-cluster --features driver-s3`"
+                    )
+                break
+            try:
+                with socket.create_connection(("127.0.0.1", port), timeout=0.5):
+                    return proc, addr
+            except OSError:
+                time.sleep(0.2)
+        with contextlib.suppress(ProcessLookupError):
+            proc.terminate()
+        with contextlib.suppress(subprocess.TimeoutExpired):
+            proc.wait(timeout=5)
+    raise AssertionError(
+        f"nexus-cluster (S3 startup) failed to bind; last err: {last_err or 'timed out'}"
+    )
+
+
+def _terminate(proc: subprocess.Popen | None) -> None:
+    """SIGTERM then SIGKILL-after-grace teardown for a spawned daemon."""
+    if proc is None:
+        return
+    with contextlib.suppress(ProcessLookupError):
+        proc.terminate()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        with contextlib.suppress(ProcessLookupError):
+            proc.kill()
+        with contextlib.suppress(subprocess.TimeoutExpired):
+            proc.wait(timeout=5)
+
+
 @pytest.fixture()
 def cluster_grpc_s3(tmp_path: Path) -> Iterator[str]:
     """Boot ``nexus-cluster`` with ``NEXUS_S3_*`` set so the daemon mounts
@@ -375,101 +476,14 @@ def cluster_grpc_s3(tmp_path: Path) -> Iterator[str]:
     log_path = tmp_path / "cluster.log"
     log_handle = log_path.open("wb")
     proc: subprocess.Popen | None = None
-    addr: str | None = None
-
-    s3_env = {
-        "NEXUS_S3_BUCKET": env_r2["NEXUS_R2_BUCKET"],
-        "NEXUS_S3_REGION": env_r2["NEXUS_R2_REGION"],
-        "NEXUS_S3_ACCESS_KEY_ID": env_r2["NEXUS_R2_ACCESS_KEY_ID"],
-        "NEXUS_S3_SECRET_ACCESS_KEY": env_r2["NEXUS_R2_SECRET_ACCESS_KEY"],
-        "NEXUS_S3_ENDPOINT": env_r2["NEXUS_R2_ENDPOINT"],
-        "NEXUS_S3_MOUNT": "/s3",
-    }
-
-    def _cleanup() -> None:
-        if proc is not None:
-            with contextlib.suppress(ProcessLookupError):
-                proc.terminate()
-            try:
-                proc.wait(timeout=5)
-            except subprocess.TimeoutExpired:
-                with contextlib.suppress(ProcessLookupError):
-                    proc.kill()
-                with contextlib.suppress(subprocess.TimeoutExpired):
-                    proc.wait(timeout=5)
-        log_handle.close()
+    s3_env = _s3_env_from_r2(env_r2)
 
     try:
-        last_err = ""
-        for _attempt in range(5):
-            s = socket.socket()
-            try:
-                s.bind(("127.0.0.1", 0))
-                port = s.getsockname()[1]
-            finally:
-                s.close()
-            candidate_addr = f"127.0.0.1:{port}"
-            proc = subprocess.Popen(
-                [
-                    nexus_cluster,
-                    "--no-tls",
-                    "--hostname",
-                    "127.0.0.1",
-                    "--bind-addr",
-                    candidate_addr,
-                    "--data-dir",
-                    str(data_dir),
-                    "--bootstrap-mode",
-                    "static",
-                ],
-                env={
-                    **os.environ,
-                    **s3_env,
-                    "RUST_LOG": os.environ.get("RUST_LOG") or "info,nexus_raft=info",
-                },
-                stdout=log_handle,
-                stderr=subprocess.STDOUT,
-            )
-            deadline = time.monotonic() + 20
-            bound = False
-            while time.monotonic() < deadline:
-                if proc.poll() is not None:
-                    log_text = log_path.read_text()
-                    last_err = (
-                        f"nexus-cluster exited early (rc={proc.returncode}); log: {log_text[-600:]}"
-                    )
-                    # A driver-not-compiled exit is an explicit skip signal.
-                    if "not enabled" in log_text:
-                        pytest.skip(
-                            "cluster binary lacks the s3 driver — rebuild with "
-                            "`cargo build -p nexus-cluster --features driver-s3`"
-                        )
-                    break
-                try:
-                    with socket.create_connection(("127.0.0.1", port), timeout=0.5):
-                        bound = True
-                        break
-                except OSError:
-                    time.sleep(0.2)
-            if bound:
-                addr = candidate_addr
-                break
-            with contextlib.suppress(ProcessLookupError):
-                proc.terminate()
-            with contextlib.suppress(subprocess.TimeoutExpired):
-                proc.wait(timeout=5)
-            proc = None
-
-        if addr is None:
-            raise AssertionError(
-                f"nexus-cluster (S3 startup) failed to bind; last err: {last_err or 'timed out'}"
-            )
+        proc, addr = _spawn_cluster_s3(nexus_cluster, data_dir, s3_env, log_handle, log_path)
         yield addr
-    except BaseException:
-        _cleanup()
-        raise
-    else:
-        _cleanup()
+    finally:
+        _terminate(proc)
+        log_handle.close()
 
 
 @requires_e2e
@@ -500,3 +514,70 @@ def test_startup_s3_mount_round_trips(cluster_grpc_s3):
     finally:
         with contextlib.suppress(Exception):
             stub.Delete(vfs_pb2.DeleteRequest(path=obj_path), timeout=30)
+
+
+@requires_e2e
+@requires_r2
+def test_startup_s3_mount_survives_restart(tmp_path: Path):
+    """bridge-3 (#4263) — metadata for objects written through the startup
+    S3 mount survives a daemon restart on the same data dir.
+
+    Guards against the startup mount's path→content_id metadata landing in a
+    non-durable boot metastore: write via ``/s3`` in one process, stop the
+    daemon, reboot it on the *same* data dir + bucket config, and read the
+    same path back. A regression that routed startup-mount metadata to a
+    throwaway store would write+read fine in one process (the round-trip
+    test) but fail this read-after-restart.
+    """
+    import grpc
+
+    from nexus.grpc.vfs import vfs_pb2, vfs_pb2_grpc
+
+    binary = _resolve_worktree_cluster_binary()
+    if not binary:
+        pytest.skip(
+            "nexus-cluster binary not built (`cargo build -p nexus-cluster --features driver-s3`)"
+        )
+    env_r2 = _r2_env()
+    assert env_r2 is not None  # guarded by @requires_r2
+    s3_env = _s3_env_from_r2(env_r2)
+
+    data_dir = tmp_path / "data"
+    obj_path = f"/s3/bridge3-restart-{os.getpid()}.txt"
+    body = b"startup-s3-survives-restart-" + str(os.getpid()).encode()
+
+    # ---- Boot 1: write through /s3, confirm the round-trip ----
+    log1 = tmp_path / "boot1.log"
+    h1 = log1.open("wb")
+    proc1: subprocess.Popen | None = None
+    try:
+        proc1, addr1 = _spawn_cluster_s3(binary, data_dir, s3_env, h1, log1)
+        stub1 = vfs_pb2_grpc.NexusVFSServiceStub(grpc.insecure_channel(addr1))
+        w = stub1.Write(vfs_pb2.WriteRequest(path=obj_path, content=body), timeout=30)
+        assert not w.is_error, w.error_payload
+        assert w.size == len(body)
+    finally:
+        _terminate(proc1)
+        h1.close()
+
+    # ---- Boot 2: SAME data dir, fresh process — metadata must persist ----
+    log2 = tmp_path / "boot2.log"
+    h2 = log2.open("wb")
+    proc2: subprocess.Popen | None = None
+    addr2: str | None = None
+    try:
+        proc2, addr2 = _spawn_cluster_s3(binary, data_dir, s3_env, h2, log2)
+        stub2 = vfs_pb2_grpc.NexusVFSServiceStub(grpc.insecure_channel(addr2))
+        r = stub2.Read(vfs_pb2.ReadRequest(path=obj_path), timeout=30)
+        assert not r.is_error, (
+            "read after restart failed — startup S3 mount metadata is not "
+            f"durable across restart: {r.error_payload!r}"
+        )
+        assert r.content == body, "read-back bytes differ after restart"
+    finally:
+        if addr2 is not None:
+            with contextlib.suppress(Exception):
+                stub_cleanup = vfs_pb2_grpc.NexusVFSServiceStub(grpc.insecure_channel(addr2))
+                stub_cleanup.Delete(vfs_pb2.DeleteRequest(path=obj_path), timeout=30)
+        _terminate(proc2)
+        h2.close()

--- a/tests/integration/test_typed_grpc_cluster.py
+++ b/tests/integration/test_typed_grpc_cluster.py
@@ -348,3 +348,155 @@ def test_s3_r2_dt_mount_builds_backend_and_round_trips(cluster_grpc):
         # Best-effort cleanup of the test object.
         with contextlib.suppress(Exception):
             stub.Delete(vfs_pb2.DeleteRequest(path=obj_path), timeout=30)
+
+
+# ── bridge-3 (#4263): S3 mount declared via NEXUS_S3_* at startup ─────────────
+
+
+@pytest.fixture()
+def cluster_grpc_s3(tmp_path: Path) -> Iterator[str]:
+    """Boot ``nexus-cluster`` with ``NEXUS_S3_*`` set so the daemon mounts
+    an S3-compatible backend at ``/s3`` at startup, and yield ``host:port``.
+
+    Skips cleanly when the binary or R2 creds are absent. Maps the test's
+    ``NEXUS_R2_*`` creds onto the daemon's ``NEXUS_S3_*`` surface.
+    """
+    nexus_cluster = _resolve_worktree_cluster_binary()
+    if not nexus_cluster:
+        pytest.skip(
+            "nexus-cluster binary not in worktree rust/target (build with "
+            "`cargo build -p nexus-cluster --features driver-s3`)"
+        )
+    env_r2 = _r2_env()
+    if env_r2 is None:
+        pytest.skip("startup S3 mount E2E requires NEXUS_R2_* creds")
+
+    data_dir = tmp_path / "data"
+    log_path = tmp_path / "cluster.log"
+    log_handle = log_path.open("wb")
+    proc: subprocess.Popen | None = None
+    addr: str | None = None
+
+    s3_env = {
+        "NEXUS_S3_BUCKET": env_r2["NEXUS_R2_BUCKET"],
+        "NEXUS_S3_REGION": env_r2["NEXUS_R2_REGION"],
+        "NEXUS_S3_ACCESS_KEY_ID": env_r2["NEXUS_R2_ACCESS_KEY_ID"],
+        "NEXUS_S3_SECRET_ACCESS_KEY": env_r2["NEXUS_R2_SECRET_ACCESS_KEY"],
+        "NEXUS_S3_ENDPOINT": env_r2["NEXUS_R2_ENDPOINT"],
+        "NEXUS_S3_MOUNT": "/s3",
+    }
+
+    def _cleanup() -> None:
+        if proc is not None:
+            with contextlib.suppress(ProcessLookupError):
+                proc.terminate()
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                with contextlib.suppress(ProcessLookupError):
+                    proc.kill()
+                with contextlib.suppress(subprocess.TimeoutExpired):
+                    proc.wait(timeout=5)
+        log_handle.close()
+
+    try:
+        last_err = ""
+        for _attempt in range(5):
+            s = socket.socket()
+            try:
+                s.bind(("127.0.0.1", 0))
+                port = s.getsockname()[1]
+            finally:
+                s.close()
+            candidate_addr = f"127.0.0.1:{port}"
+            proc = subprocess.Popen(
+                [
+                    nexus_cluster,
+                    "--no-tls",
+                    "--hostname",
+                    "127.0.0.1",
+                    "--bind-addr",
+                    candidate_addr,
+                    "--data-dir",
+                    str(data_dir),
+                    "--bootstrap-mode",
+                    "static",
+                ],
+                env={
+                    **os.environ,
+                    **s3_env,
+                    "RUST_LOG": os.environ.get("RUST_LOG") or "info,nexus_raft=info",
+                },
+                stdout=log_handle,
+                stderr=subprocess.STDOUT,
+            )
+            deadline = time.monotonic() + 20
+            bound = False
+            while time.monotonic() < deadline:
+                if proc.poll() is not None:
+                    log_text = log_path.read_text()
+                    last_err = (
+                        f"nexus-cluster exited early (rc={proc.returncode}); log: {log_text[-600:]}"
+                    )
+                    # A driver-not-compiled exit is an explicit skip signal.
+                    if "not enabled" in log_text:
+                        pytest.skip(
+                            "cluster binary lacks the s3 driver — rebuild with "
+                            "`cargo build -p nexus-cluster --features driver-s3`"
+                        )
+                    break
+                try:
+                    with socket.create_connection(("127.0.0.1", port), timeout=0.5):
+                        bound = True
+                        break
+                except OSError:
+                    time.sleep(0.2)
+            if bound:
+                addr = candidate_addr
+                break
+            with contextlib.suppress(ProcessLookupError):
+                proc.terminate()
+            with contextlib.suppress(subprocess.TimeoutExpired):
+                proc.wait(timeout=5)
+            proc = None
+
+        if addr is None:
+            raise AssertionError(
+                f"nexus-cluster (S3 startup) failed to bind; last err: {last_err or 'timed out'}"
+            )
+        yield addr
+    except BaseException:
+        _cleanup()
+        raise
+    else:
+        _cleanup()
+
+
+@requires_e2e
+@requires_r2
+def test_startup_s3_mount_round_trips(cluster_grpc_s3):
+    """bridge-3 (#4263) E2E — the daemon mounts S3/R2 at ``/s3`` from
+    ``NEXUS_S3_*`` config at startup (no gRPC Setattr), and a write/read
+    through that mount round-trips against real R2.
+    """
+    import grpc
+
+    from nexus.grpc.vfs import vfs_pb2, vfs_pb2_grpc
+
+    ch = grpc.insecure_channel(cluster_grpc_s3)
+    stub = vfs_pb2_grpc.NexusVFSServiceStub(ch)
+
+    obj_path = f"/s3/bridge3-startup-{os.getpid()}.txt"
+    body = b"startup-s3-mount-through-rust-" + str(os.getpid()).encode()
+
+    try:
+        w = stub.Write(vfs_pb2.WriteRequest(path=obj_path, content=body), timeout=30)
+        assert not w.is_error, w.error_payload
+        assert w.size == len(body)
+
+        r = stub.Read(vfs_pb2.ReadRequest(path=obj_path), timeout=30)
+        assert not r.is_error, r.error_payload
+        assert r.content == body, "read-back bytes differ — R2 round-trip broken"
+    finally:
+        with contextlib.suppress(Exception):
+            stub.Delete(vfs_pb2.DeleteRequest(path=obj_path), timeout=30)


### PR DESCRIPTION
Part of epic #4259 (Approach 1, connector-first). Closes #4263. Builds on #4261 (bridge-1: `ObjectStoreProvider` + driver gate) and #4262 (bridge-2: backend params over gRPC).

## What

Lets an operator declare a single S3-compatible mount (AWS S3 / Cloudflare R2 / MinIO) for `nexusd-cluster` via env/flags. At startup the daemon builds the backend through the already-registered `ObjectStoreProvider` (the same path the gRPC `setattr_mount` uses) and mounts it at a sub-path, alongside the existing local `/` root mount.

```
NEXUS_S3_BUCKET=my-bucket        # trigger; unset → boots exactly as before
NEXUS_S3_REGION=auto             # R2 uses "auto"
NEXUS_S3_ACCESS_KEY_ID=...       # prefer env over flag (argv hygiene)
NEXUS_S3_SECRET_ACCESS_KEY=...
NEXUS_S3_ENDPOINT=https://<acct>.r2.cloudflarestorage.com   # optional (R2/MinIO)
NEXUS_S3_PREFIX=team/data        # optional
NEXUS_S3_MOUNT=/s3               # optional (default /s3); must be a non-root absolute path
```

The `driver-s3` aws-sdk arm stays feature-gated, so the **default slim release binary is unchanged** (size delta from this PR's always-compiled config/mount code: **+2 KiB**, well under the 12.5 MiB macOS-arm64 budget). Build with `--features driver-s3` to enable S3.

## Fail-fast (AC #4)

Misconfiguration aborts startup with a clear, env-var-named error:
- missing/blank/whitespace `NEXUS_S3_REGION` / `_ACCESS_KEY_ID` / `_SECRET_ACCESS_KEY`
- blank `NEXUS_S3_BUCKET` (set-but-empty Secret typo — doesn't silently disable the mount)
- `NEXUS_S3_MOUNT` = `/`, relative, or containing `..`
- `driver-s3` not compiled in (driver gate)
- `NEXUS_S3_MOUNT` colliding with a `NEXUS_FEDERATION_MOUNTS` entry
- a persisted federation mount shadowing the S3 path after restart (detected post-replay)

Lazy backend construction (bad endpoint/creds surface on first I/O, not boot) is intentional — matches the shipped gRPC mount path and the boot `/` mount; an eager write-probe would break read-only mounts.

## Files

- `rust/profiles/cluster/src/main.rs` — `NEXUS_S3_*` args, `resolve_s3_mount_config`, `mount_declared_s3`, collision + shadow guards, 18 unit tests
- `tests/integration/test_typed_grpc_cluster.py` — `test_startup_s3_mount_round_trips` + `test_startup_s3_mount_survives_restart` (env-gated; skip cleanly without `NEXUS_E2E=1` + creds + `driver-s3`)
- `docs/operations/nexusd-cluster-s3-mounts.md` — operator doc

## Test plan

- [x] `cargo test -p nexus-cluster` (+ `--features driver-s3`): 18/18 both
- [x] `cargo clippy -p nexus-cluster -- -D warnings` (+ `--features driver-s3`): clean
- [x] `cargo fmt -p nexus-cluster --check`: clean
- [x] Release size gate: 11.85 MiB < 12.5 MiB budget (+2 KiB delta)
- [x] E2E vs MinIO: write/read round-trip through `/s3` (object confirmed server-side); restart-persistence; trailing-slash routing; collision + driver-gate + blank fail-fast all proven on a live daemon
- [x] Live Cloudflare R2: daemon boots + mounts + SigV4 request reaches R2 (read-only token → `AccessDenied`, i.e. signature valid)
- [x] Adversarial review-loop: 8 rounds, converged to approve (5 findings fixed, 1 refuted, 1 by-design)