### PR TITLE
fix(#4259): vault persistent storage — inject PathLocalBackend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,6 +216,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "backends"
+version = "0.1.0"
+source = "git+https://github.com/nexi-lab/nexus-vfs#893e4fb260137b665d697708bc48a4fd625f1d38"
+dependencies = [
+ "ahash",
+ "base64",
+ "blake3",
+ "chrono",
+ "contracts",
+ "crc32fast",
+ "dashmap",
+ "encoding_rs",
+ "fastcdc",
+ "futures",
+ "globset",
+ "kernel",
+ "lib",
+ "libc",
+ "lru",
+ "memchr",
+ "memmap2",
+ "parking_lot",
+ "prost",
+ "rayon",
+ "redb",
+ "regex",
+ "roaring",
+ "serde",
+ "serde_json",
+ "simdutf8",
+ "tempfile",
+ "tokio",
+ "tonic",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "base32"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -454,7 +492,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs#79cbd061658a46b4e680e23b73b35734ebc899ee"
+source = "git+https://github.com/nexi-lab/nexus-vfs#893e4fb260137b665d697708bc48a4fd625f1d38"
 dependencies = [
  "parking_lot",
  "serde",
@@ -613,6 +651,15 @@ name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "enum_dispatch"
@@ -1142,7 +1189,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs#79cbd061658a46b4e680e23b73b35734ebc899ee"
+source = "git+https://github.com/nexi-lab/nexus-vfs#893e4fb260137b665d697708bc48a4fd625f1d38"
 dependencies = [
  "ahash",
  "base64",
@@ -1196,7 +1243,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs#79cbd061658a46b4e680e23b73b35734ebc899ee"
+source = "git+https://github.com/nexi-lab/nexus-vfs#893e4fb260137b665d697708bc48a4fd625f1d38"
 dependencies = [
  "ahash",
  "base64",
@@ -1348,6 +1395,7 @@ name = "nexus-vault"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "backends",
  "clap",
  "kernel",
  "services",
@@ -2016,6 +2064,12 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "siphasher"

--- a/rust/profiles/vault/Cargo.toml
+++ b/rust/profiles/vault/Cargo.toml
@@ -19,6 +19,8 @@ services = { workspace = true, features = ["service-password-vault"] }
 # `PasswordVaultServiceImpl::new_with_kernel()` so all storage goes
 # through kernel syscalls (cross-repo integration seam).
 kernel = { workspace = true }
+# PathLocalBackend for persistent vault content storage on local disk.
+backends = { workspace = true, features = ["driver-path-local"] }
 # tonic for the gRPC server. Same version family as services / cluster
 # / raft (workspace-pinned).
 tonic = { workspace = true }

--- a/rust/profiles/vault/src/main.rs
+++ b/rust/profiles/vault/src/main.rs
@@ -92,9 +92,9 @@ async fn main() -> Result<()> {
         "starting nexusd-vault"
     );
 
-    // Create kernel with persistent metastore so vault data survives
-    // restarts. All vault I/O goes through kernel syscalls (the
-    // cross-repo integration seam).
+    // Create kernel with persistent metastore + PathLocalBackend so
+    // vault data survives restarts. All vault I/O goes through kernel
+    // syscalls (the cross-repo integration seam).
     let kernel = Arc::new(Kernel::new());
     let meta_path = args.data_dir.join("vault-meta.redb");
     if let Some(p) = meta_path.to_str() {
@@ -103,8 +103,17 @@ async fn main() -> Result<()> {
             .map_err(|e| anyhow::anyhow!("set vault metastore path: {e:?}"))?;
     }
 
-    let svc = PasswordVaultServiceImpl::new_with_kernel(kernel, "/vault", &master_key_path)
-        .context("open vault")?;
+    // PathLocalBackend stores vault content (encrypted bincode blobs)
+    // on local disk at data_dir/content/. Persistent across restarts.
+    let content_dir = args.data_dir.join("content");
+    let backend: Arc<dyn kernel::abc::object_store::ObjectStore> = Arc::new(
+        backends::storage::path_local::PathLocalBackend::new(&content_dir, /* fsync */ true)
+            .context("create PathLocalBackend for vault content")?,
+    );
+
+    let svc =
+        PasswordVaultServiceImpl::new_with_kernel(kernel, "/vault", &master_key_path, backend)
+            .context("open vault")?;
 
     Server::builder()
         .add_service(PasswordVaultServiceServer::new(svc))

--- a/rust/services/src/password_vault/mod.rs
+++ b/rust/services/src/password_vault/mod.rs
@@ -119,46 +119,39 @@ pub struct PasswordVaultServiceImpl {
 }
 
 impl PasswordVaultServiceImpl {
-    /// Open or create a vault backed by an in-process kernel, with
-    /// the master key at `master_key_path` (32 bytes, generated +
-    /// persisted on first call).
-    ///
-    /// Convenience wrapper: creates a `Kernel::new()` internally and
-    /// delegates to `new_with_kernel`. Suitable for tests and the
-    /// default vault binary boot (no external kernel needed).
+    /// Convenience wrapper for tests: creates a Kernel + in-memory
+    /// backend internally. Not for production — content is ephemeral.
     pub fn new(data_dir: &Path, master_key_path: &Path) -> Result<Self, PasswordVaultError> {
         use kernel::kernel::Kernel;
 
         let kernel = std::sync::Arc::new(Kernel::new());
+        let backend = std::sync::Arc::new(storage::MemBackend::new());
 
-        // Point metastore at persistent path when a real data_dir is given,
-        // so vault data survives restarts.
+        // Point metastore at persistent path when a real data_dir is given.
         let meta_path = data_dir.join("vault-meta.redb");
         if let Some(p) = meta_path.to_str() {
             let _ = kernel.set_metastore_path(p);
         }
 
-        Self::new_with_kernel(kernel, "/vault", master_key_path)
+        Self::new_with_kernel(kernel, "/vault", master_key_path, backend)
     }
 
-    /// Create a vault service on an existing kernel.
+    /// Create a vault service on an existing kernel with a caller-
+    /// provided backend for content storage.
     ///
-    /// The kernel handles all storage via syscalls — no direct redb
-    /// dependency. `root` is the VFS path prefix for vault data
-    /// (e.g. `"/vault"`); the storage layer registers a mount and
-    /// creates directory structure underneath.
+    /// - Tests: pass `MemBackend` (ephemeral, fast)
+    /// - Production: pass `PathLocalBackend` (persistent, fsync)
     ///
-    /// This is the primary constructor for cross-repo integration:
-    /// ```text
-    /// nexus repo (Rust service)  ──in-process──>  nexus-vfs repo (kernel)
-    ///     services crate                            kernel crate (git dep)
-    /// ```
+    /// The backend choice is the only difference between ephemeral
+    /// (test) and durable (production) vault storage; kernel metastore
+    /// handles metadata in both cases.
     pub fn new_with_kernel(
         kernel: std::sync::Arc<kernel::kernel::Kernel>,
         root: &str,
         master_key_path: &Path,
+        backend: std::sync::Arc<dyn kernel::abc::object_store::ObjectStore>,
     ) -> Result<Self, PasswordVaultError> {
-        let storage = storage::Storage::new(kernel, root)?;
+        let storage = storage::Storage::new(kernel, root, backend)?;
         let master_key = crypto::load_or_create_master_key(master_key_path)?;
         Ok(Self {
             inner: Arc::new(Inner {
@@ -1207,10 +1200,12 @@ mod e2e_integration {
     fn kernel_service() -> (Arc<Kernel>, PasswordVaultServiceImpl) {
         let kernel = Arc::new(Kernel::new());
         let dir = tempfile::TempDir::new().unwrap();
+        let backend = Arc::new(super::storage::MemBackend::new());
         let svc = PasswordVaultServiceImpl::new_with_kernel(
             kernel.clone(),
             "/vault",
             &dir.path().join("master.key"),
+            backend,
         )
         .unwrap();
         (kernel, svc)

--- a/rust/services/src/password_vault/storage.rs
+++ b/rust/services/src/password_vault/storage.rs
@@ -31,15 +31,14 @@ const DT_MOUNT: i32 = 2;
 
 /// Minimal in-memory ObjectStore — stores vault entry blobs in a
 /// HashMap keyed by content_id. Thread-safe via `parking_lot::Mutex`.
-/// No persistence; the kernel metastore (redb) provides durable
-/// metadata, and the vault binary can swap in a persistent backend
-/// (CasLocal, PathLocal) when data survival across restarts is needed.
-struct MemBackend {
+/// Suitable for tests only; production uses a persistent backend
+/// (PathLocalBackend) injected by the vault binary.
+pub(crate) struct MemBackend {
     data: parking_lot::Mutex<HashMap<String, Vec<u8>>>,
 }
 
 impl MemBackend {
-    fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             data: parking_lot::Mutex::new(HashMap::new()),
         }
@@ -96,20 +95,28 @@ pub(crate) struct Storage {
 }
 
 impl Storage {
-    /// Create storage backed by kernel syscalls. Mounts an in-memory
-    /// ObjectStore backend and creates directory structure (`entries/`,
-    /// `versions/`) under `root`.
-    pub(crate) fn new(kernel: Arc<Kernel>, root: &str) -> Result<Self, PasswordVaultError> {
+    /// Create storage backed by kernel syscalls. Mounts `backend` at
+    /// `root` and creates directory structure (`entries/`, `versions/`).
+    ///
+    /// The caller chooses the backend:
+    /// - Tests: `MemBackend` (ephemeral, fast)
+    /// - Production: `PathLocalBackend` (persistent, fsync)
+    pub(crate) fn new(
+        kernel: Arc<Kernel>,
+        root: &str,
+        backend: Arc<dyn ObjectStore>,
+    ) -> Result<Self, PasswordVaultError> {
         let root = root.trim_end_matches('/').to_string();
+        let backend_name = backend.name().to_string();
 
-        // Mount with an in-memory backend so DT_REG content (bincode
-        // blobs) can be written/read via kernel syscalls.
+        // Mount the caller-provided backend at `root` so DT_REG
+        // content (bincode blobs) can be written/read via syscalls.
         kernel
             .sys_setattr(
                 &root,
                 DT_MOUNT,
-                /* backend_name */ "vault-mem",
-                /* backend */ Some(Arc::new(MemBackend::new())),
+                /* backend_name */ &backend_name,
+                /* backend */ Some(backend),
                 /* metastore */ None,
                 /* raft_backend */ None,
                 /* io_profile */ "memory",
@@ -312,7 +319,7 @@ mod tests {
 
     fn fresh() -> Storage {
         let kernel = Arc::new(Kernel::new());
-        Storage::new(kernel, "/vault").unwrap()
+        Storage::new(kernel, "/vault", Arc::new(MemBackend::new())).unwrap()
     }
 
     fn entry(version: u32, ct: &[u8]) -> StoredEntry {


### PR DESCRIPTION
## Summary
- Fix production data-loss bug: vault content was stored in ephemeral `MemBackend` (HashMap), lost on restart
- `Storage::new()` now takes `Arc<dyn ObjectStore>` — caller decides persistence strategy
- Vault binary uses `PathLocalBackend` (fsync=true, local disk at `data_dir/content/`)
- Tests continue to use `MemBackend` (fast, ephemeral)
- `services` crate does NOT depend on `backends` (invariant preserved); injection at profile binary layer

## Test plan
- [x] All 44 vault tests pass
- [x] `cargo check -p nexus-vault` — vault binary compiles with PathLocalBackend
- [x] `cargo clippy -p services --features service-password-vault -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)