### PR TITLE
ci: add repo-boundary gate (forbid kernel-tier paths)

### DIFF
--- a/.github/workflows/repo-boundary.yml
+++ b/.github/workflows/repo-boundary.yml
@@ -1,0 +1,52 @@
+name: Repo Boundary
+
+# DRY between nexus + nexus-vfs.  Kernel-tier code (contracts / lib /
+# transport / kernel / backends / raft + profiles/cluster + proto)
+# was moved to nexus-vfs in #4259 and MUST NOT reappear here — the
+# dual-repo split was made specifically to prevent that drift.
+#
+# Companion gate in nexus-vfs forbids the service-tier paths
+# (rust/services, rust/profiles/vault).  Either gate firing means the
+# cross-repo boundary is being violated; the fix is to move the
+# offending path back to the correct repo, not to disable the gate.
+
+on:
+  pull_request:
+  push:
+    branches: [develop, main]
+
+jobs:
+  forbid-kernel-tier-paths:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Forbid kernel-tier paths
+        run: |
+          set -e
+          forbidden=(
+            rust/contracts
+            rust/lib
+            rust/transport
+            rust/kernel
+            rust/backends
+            rust/raft
+            rust/profiles/cluster
+            proto
+          )
+          violations=()
+          for p in "${forbidden[@]}"; do
+            if [ -e "$p" ]; then
+              violations+=("$p")
+            fi
+          done
+          if [ "${#violations[@]}" -gt 0 ]; then
+            for v in "${violations[@]}"; do
+              echo "::error::path '$v' belongs in nexus-vfs (kernel-tier SSOT), not nexus"
+            done
+            echo ""
+            echo "If you intentionally meant to move this path into nexus, update"
+            echo "the boundary list in .github/workflows/repo-boundary.yml in BOTH"
+            echo "repos and document the move in the PR body."
+            exit 1
+          fi
+          echo "Repo boundary OK — no kernel-tier paths present."


### PR DESCRIPTION
## What

L2 enforcement of the DRY split between **nexus** (service tier — \`rust/services\`, \`rust/profiles/vault\`) and **nexus-vfs** (kernel tier — \`rust/contracts\`, \`rust/lib\`, \`rust/transport\`, \`rust/kernel\`, \`rust/backends\`, \`rust/raft\`, \`rust/profiles/cluster\`, \`proto/\`).

New workflow \`.github/workflows/repo-boundary.yml\` runs on every PR + every push to develop/main and fails fast if any forbidden kernel-tier path appears in this repo.  Companion gate added to nexus-vfs in a parallel PR forbids the service-tier paths there.

## Why

The dual-repo split was made in #4259 to enforce DRY, but the enforcement layer was the workspace \`Cargo.toml\` member list — a *soft* fence that doesn't stop a contributor from accidentally re-adding a forbidden directory.

This gap was just demonstrated by a cross-repo audit: nexus-vfs's previous fresh-import (\`9ff22c042\`, 2026-06-02) was done from a stale local nexus clone and silently fell ~40 files behind nexus develop's kernel-tier evolution.  No automation caught it.  The bug surfaced only when a Mac learner in cross-machine federation smoke testing returned \`NOT_FOUND\` for a remote read.

CI gates on both repos close that gap permanently.

## What it actually does

\`\`\`yaml
forbidden=(
  rust/contracts rust/lib rust/transport rust/kernel
  rust/backends rust/raft rust/profiles/cluster proto
)
\`\`\`

For each path, the workflow checks with \`[ -e \$p ]\` and emits \`::error::\` + \`exit 1\` if any is present.  Output points the contributor at the correct destination repo.

## Companion PR

https://github.com/nexi-lab/nexus-vfs/pull/<TBD> — the symmetric gate forbidding service-tier paths in nexus-vfs.

## Test plan

- This PR adds no kernel-tier paths, so the gate passes on this PR itself.
- After merge, any subsequent PR that re-introduces (say) \`rust/raft/\` will fail \`Forbid kernel-tier paths\` with a clear error pointing at nexus-vfs.