### PR TITLE
docs(cli): rewrite nexusd section for nexusd-cluster Rust binary

### DIFF
--- a/docs/architecture/cli-design.md
+++ b/docs/architecture/cli-design.md
@@ -55,32 +55,38 @@ nexus doctor --json
 nexus profile use production
 ```
 
-### `nexusd` — Node Daemon (local, long-running process)
+### `nexusd-cluster` — Node Daemon (Rust binary)
 
-Starts and runs the Nexus node. Manages local storage, serves RPC,
-participates in federation. Like `sshd`, `dockerd`, `systemd` — the `d`
+A self-contained ~5 MB Rust binary (`rust/profiles/cluster/`) that runs the
+Nexus node. Manages local storage via redb, serves VFS gRPC, and participates
+in multi-zone Raft federation. Like `sshd`, `dockerd`, `systemd` — the `d`
 suffix is the Unix daemon convention.
 
 ```
-nexusd [flags]
+nexusd-cluster [flags]
+nexusd-cluster share <path> --zone-id <id> [--mount-at <path>]
+nexusd-cluster join <peer> <zone-id> <local-path>
 ```
 
 Examples:
 ```bash
-# Start with defaults (port 2026, auto-detect profile)
-nexusd
+# Start daemon (static bootstrap — env-driven cluster formation)
+nexusd-cluster --bootstrap-mode static --data-dir /var/lib/nexus
 
-# Explicit configuration
-nexusd --port 2026 --host 0.0.0.0 --data-dir /var/lib/nexus
+# Start with explicit peers
+nexusd-cluster --bootstrap-mode static --peers 2@nexus-2:2126,3@nexus-3:2126
 
-# With config file
-nexusd --config /etc/nexus/config.yaml
+# Restart from persisted state
+nexusd-cluster --bootstrap-mode restart
 
-# Join federation on startup
-nexusd --join peer1.example.com:2026 --zone us-west
+# Dynamic mode — rootless, operator drives create_zone via runtime API
+nexusd-cluster --bootstrap-mode dynamic
 
-# Foreground with debug logging
-nexusd --log-level debug
+# Detach a subtree into a new federation zone
+nexusd-cluster share /data/shared --zone-id shared-zone --mount-at /data/shared
+
+# Mount a remote zone locally
+nexusd-cluster join 2@nexus-2:2126 shared-zone /mnt/shared
 ```
 
 ## Why Not "server"?
@@ -105,75 +111,68 @@ a long-running background process without implying centralized architecture.
 | `admin`, `rebac`, `versions` | `nexus` | Management via RPC |
 | `status`, `doctor` | `nexus` | Health checks via RPC |
 | `profile`, `connect`, `config` | `nexus` | Local CLI config (no RPC) |
-| Start daemon | `nexusd` | Starts the node process |
-| `join` (federation) | `nexusd` | Node-local operation |
-| FUSE `mount` / `unmount` | `nexusd` | Node-local, needs local NexusFS |
-| `mcp serve` | `nexusd` | Starts MCP adapter process |
+| Start daemon | `nexusd-cluster` | Starts the node process |
+| `share` (federation) | `nexusd-cluster share` | Detach subtree into new zone |
+| `join` (federation) | `nexusd-cluster join` | Mount remote zone locally |
 
-## Removed Commands
+## Entry Points
 
-| Command | Removed in | Reason |
-|---------|------------|--------|
-| `nexus serve` | PR #2842 | Replaced by `nexusd` |
-| `nexus start` | PR #2842 | Replaced by `nexusd` |
-| `nexus up/down/logs` | This PR | Thin docker-compose wrapper, no added value |
+| Binary | Source | Language |
+|--------|--------|----------|
+| `nexus` | `src/nexus/cli` (`pyproject.toml` script) | Python |
+| `nexusd-cluster` | `rust/profiles/cluster/src/main.rs` (`cargo build -p nexus-cluster`) | Rust |
 
-Developers who used `docker compose` can continue doing so. The
-`docker-entrypoint.sh` is updated to call `nexusd` instead of `nexus serve`.
+The Python `nexus` CLI spawns or connects to `nexusd-cluster` via gRPC
+(`RPCTransport`). The two binaries live in separate repos: `nexus` in the
+monorepo, `nexusd-cluster` in `nexus-vfs`.
 
-## Entry Points (pyproject.toml)
+## `nexusd-cluster` Startup Sequence
 
-```toml
-[project.scripts]
-nexus  = "nexus.cli:main"
-nexusd = "nexus.daemon:main"
-```
+1. Parse CLI flags + env vars (clap)
+2. Install tracing subscriber (non-blocking stdout writer)
+3. Build tokio multi-thread runtime (worker count = available parallelism)
+4. Register `ObjectStoreProvider` (backends crate)
+5. Create `Kernel` + mount host-fs at `/` via `PathLocalBackend`
+6. Build VFS gRPC service (tonic Routes, co-hosted on raft port)
+7. Open `ZoneManager` (TLS bootstrap, peer address book, node identity)
+8. Bootstrap root zone (static / restart / dynamic mode)
+9. Bootstrap static federation topology from `NEXUS_FEDERATION_ZONES` / `_MOUNTS`
+10. Install `RaftDistributedCoordinator` (DT_MOUNT apply-cb, blob-fetcher, self-address)
+11. Install outbound `PeerBlobClient` (cross-node content fetch)
+12. Start topology convergence loop (10s tick)
+13. `wait_for_shutdown()` (SIGTERM / Ctrl+C)
+14. Drain: abort topology loop → `ZoneManager.shutdown()` → drop kernel
 
-## `nexusd` Startup Sequence
-
-1. Parse CLI flags + load config (YAML file + env vars)
-2. Initialize storage pillars (Metastore, RecordStore, ObjectStore)
-3. Create NexusFS via factory orchestrator
-4. Create FastAPI app (`create_app()`)
-5. Run uvicorn server (blocking)
-   - Lifespan context handles 11 async startup phases
-   - Graceful shutdown on SIGTERM in reverse order
+Source of truth: `rust/profiles/cluster/src/main.rs::run_daemon()`.
 
 ## Environment Variables
 
-`nexusd` reads all configuration from environment variables (same as before):
+`nexusd-cluster` reads configuration from CLI flags and environment variables:
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `NEXUS_HOST` | `0.0.0.0` | Bind address |
-| `NEXUS_PORT` | `2026` | HTTP/gRPC port |
-| `NEXUS_DATA_DIR` | `~/.nexus/data` | Local data directory |
-| `NEXUS_PROFILE` | `auto` | Deployment profile |
-| `NEXUS_DATABASE_URL` | — | PostgreSQL connection string |
-| `NEXUS_API_KEY` | — | Admin API key |
-| `NEXUS_GRPC_PORT` | `2028` | Separate gRPC port (if needed) |
-| `NEXUS_LOG_LEVEL` | `info` | Logging verbosity |
+| `NEXUS_HOSTNAME` | OS hostname | Node hostname for peer addressing |
+| `NEXUS_BIND_ADDR` | `0.0.0.0:2126` | gRPC bind address (raft + VFS) |
+| `NEXUS_DATA_DIR` | `./nexus-cluster-data` | Persistent data directory (TLS + redb) |
+| `NEXUS_PEERS` | (empty) | Comma-separated raft peers (`id@host:port`) |
+| `NEXUS_ROOT_FS` | `<data_dir>/root` | Host-fs directory mounted at `/` |
+| `NEXUS_BOOTSTRAP_MODE` | (required) | `static`, `dynamic`, or `restart` |
+| `NEXUS_NO_TLS` | `false` | Disable TLS (plaintext gRPC for local testing) |
+| `NEXUS_FEDERATION_ZONES` | (empty) | Static federation zone definitions |
+| `NEXUS_FEDERATION_MOUNTS` | (empty) | Static federation mount topology |
+| `RUST_LOG` / `NEXUS_LOG_LEVEL` | `info` | Logging verbosity (tracing EnvFilter) |
 
 ## Docker Integration
 
 ```dockerfile
-# Dockerfile — entrypoint calls nexusd directly
-ENTRYPOINT ["nexusd"]
-CMD ["--port", "2026"]
+ENTRYPOINT ["nexusd-cluster"]
+CMD ["--bootstrap-mode", "static"]
 ```
 
 ```bash
 # docker-entrypoint.sh
-exec nexusd --port "${NEXUS_PORT:-2026}" --host "${NEXUS_HOST:-0.0.0.0}"
+exec nexusd-cluster \
+  --bind-addr "0.0.0.0:${NEXUS_PORT:-2126}" \
+  --data-dir "${NEXUS_DATA_DIR:-/var/lib/nexus}" \
+  --bootstrap-mode "${NEXUS_BOOTSTRAP_MODE:-static}"
 ```
-
-## Migration Guide
-
-| Before (pre-PR #2842) | After |
-|------------------------|-------|
-| `nexus serve --port 2026` | `nexusd --port 2026` |
-| `nexus start` | `nexusd` |
-| `nexus mount /mnt` | `nexusd mount /mnt` |
-| `nexus up --profile server` | `docker compose --profile server up` |
-| `nexus down` | `docker compose down` |
-| `nexus logs` | `docker compose logs` |


### PR DESCRIPTION
## Summary

- Rewrite `nexusd` → `nexusd-cluster` throughout cli-design.md (pure Rust binary, ~5 MB)
- Rewrite startup sequence: 14-step Rust boot replacing old 5-step Python/FastAPI/uvicorn
- Update environment variables for `nexusd-cluster` (NEXUS_BIND_ADDR, NEXUS_BOOTSTRAP_MODE, NEXUS_PEERS, etc.)
- Delete stale pyproject.toml entry points, update Docker integration and command ownership table

Part of dylib hot-swap Phase 0 (architecture docs). Companion PR in nexus-vfs for KERNEL-ARCHITECTURE.md §10 Plugin Architecture.

## Test plan

- [ ] Review doc accuracy against `rust/profiles/cluster/src/main.rs`
- [ ] Verify no broken cross-references

🤖 Generated with [Claude Code](https://claude.com/claude-code)