### PR TITLE
docs: delete moved-to-nexus-vfs redirect stubs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,4 +10,4 @@
 > or kernel contracts require **kernel team (@elfenlieds7) approval**
 > before merge (CODEOWNERS enforced). Do NOT add new crates or dependencies
 > to `rust/kernel/` without kernel team design review. Do NOT bypass syscalls
-> by calling ObjectStore/Metastore directly. Read `docs/architecture/KERNEL-ARCHITECTURE.md`.
+> by calling ObjectStore/Metastore directly. Read `KERNEL-ARCHITECTURE.md (nexus-vfs)`.

--- a/.pre-commit-hooks/check_syscall_boundary.py
+++ b/.pre-commit-hooks/check_syscall_boundary.py
@@ -25,7 +25,7 @@ Kernel-internal callers (nexus.core, nexus.kernel_helpers, the CAS GC in
 nexus.backends) are intentionally NOT scanned — they are the kernel /
 wrapper layer and may use the pillars directly.
 
-Reference: docs/architecture/KERNEL-ARCHITECTURE.md §2.5
+Reference: KERNEL-ARCHITECTURE.md (nexus-vfs) §2.5
 """
 
 import ast

--- a/dockerfiles/docker-compose.dynamic-federation-test.yml
+++ b/dockerfiles/docker-compose.dynamic-federation-test.yml
@@ -69,7 +69,7 @@ services:
       NEXUS_ADVERTISE_ADDR: nexus-1:2126
       # Address book lists OTHER nodes only — self enters the cluster
       # via NEXUS_BOOTSTRAP_NEW=1 (founder) or AddNode (joiner), not
-      # the address book.  See docs/architecture/federation-memo.md
+      # the address book.  See federation-architecture.md (nexus-vfs)
       # §6.3.1 and `validate_peers_excludes_self`.
       NEXUS_PEERS: "nexus-2:2126,witness:2126"
       NEXUS_RAFT_TLS: "false"

--- a/docs/architecture/KERNEL-ARCHITECTURE.md
+++ b/docs/architecture/KERNEL-ARCHITECTURE.md
@@ -1,3 +1,0 @@
-> **Moved to [nexus-vfs](https://github.com/nexi-lab/nexus-vfs/blob/main/README.md)**
->
-> This document is now maintained in the nexus-vfs repository alongside the Rust kernel code it describes.

--- a/docs/architecture/federation-memo.md
+++ b/docs/architecture/federation-memo.md
@@ -1,3 +1,0 @@
-> **Moved to [nexus-vfs](https://github.com/nexi-lab/nexus-vfs/blob/main/docs/federation-architecture.md)**
->
-> This document is now maintained in the nexus-vfs repository alongside the Rust kernel code it describes.

--- a/docs/architecture/llm-cas-kv-cache.md
+++ b/docs/architecture/llm-cas-kv-cache.md
@@ -1,3 +1,0 @@
-> **Moved to [nexus-vfs](https://github.com/nexi-lab/nexus-vfs/blob/main/docs/llm-cas-kv-cache.md)**
->
-> This document is now maintained in the nexus-vfs repository alongside the Rust kernel code it describes.

--- a/docs/architecture/lock-architecture.md
+++ b/docs/architecture/lock-architecture.md
@@ -1,3 +1,0 @@
-> **Moved to [nexus-vfs](https://github.com/nexi-lab/nexus-vfs/blob/main/docs/lock-architecture.md)**
->
-> This document is now maintained in the nexus-vfs repository alongside the Rust kernel code it describes.

--- a/docs/architecture/service-driver-deployment-matrix.md
+++ b/docs/architecture/service-driver-deployment-matrix.md
@@ -1,0 +1,129 @@
+# Service & Driver Deployment Matrix
+
+> Global view of every service, hook, and driver across both repos,
+> classified by deployment mode. See KERNEL-ARCHITECTURE.md (nexus-vfs) §1
+> for the three deployment modes and their trade-offs.
+
+## Deployment Modes
+
+| Mode | Mechanism | Hot-swap | Perf | VFS hooks |
+|------|-----------|----------|------|-----------|
+| **Compiled-in** | Cargo feature gate / Python wiring | No (recompile) | Best | Full |
+| **dylib** | `PluginLoader` + `dlopen` | Yes | Good (~ns C ABI) | Limited (dispatch OK, hooks need C ABI wrapper) |
+| **gRPC sidecar** | Separate process, `ManagedServiceGrpcProxy` | Inherent | ~100us | No |
+
+---
+
+## 1. Kernel Hooks (NativeInterceptHook / PathResolver / MutationObserver)
+
+All hooks are compiled-in. dylib hooks (Phase 5B) are deferred — they
+would require a C ABI wrapper since Rust trait objects are not stable
+across `dlopen` boundaries.
+
+| Hook | Repo | Module | Mode | Notes |
+|------|------|--------|------|-------|
+| AuditHook | nexus-vfs | `rust/services/src/audit/` | Compiled-in | File operation audit trail |
+| MailboxStampingHook | nexus-vfs | `rust/services/src/managed_agent/` | Compiled-in | `/chat-with-me` mailbox stamping |
+| WorkspaceBoundaryHook | nexus-vfs | `rust/services/src/managed_agent/` | Compiled-in | Agent workspace boundary enforcement |
+| RebacPermissionCheckHook | nexus | `src/nexus/bricks/rebac/` | Compiled-in | Permission pre-check |
+| SyncPermissionWriteHook | nexus | `src/nexus/bricks/rebac/` | Compiled-in | Permission sync on write |
+| DeferredPermissionHook | nexus | `src/nexus/bricks/rebac/` | Compiled-in | Deferred permission buffering |
+| DynamicViewerReadHook | nexus | `src/nexus/bricks/rebac/` | Compiled-in | Dynamic viewer expansion |
+| TigerCacheWriteHook | nexus | `src/nexus/bricks/rebac/cache/tiger/` | Compiled-in | Tiger cache invalidation (write) |
+| TigerCacheRenameHook | nexus | `src/nexus/bricks/rebac/cache/tiger/` | Compiled-in | Tiger cache invalidation (rename) |
+| ReadmeResolverHook | nexus | `src/nexus/bricks/parsers/` | Compiled-in | PathResolver: README virtual paths |
+| AutoParseHook | nexus | `src/nexus/bricks/parsers/` | Compiled-in | Structured parsing on read |
+| MarkdownStructureHook | nexus | `src/nexus/bricks/parsers/` | Compiled-in | Markdown AST extraction |
+
+---
+
+## 2. Rust Services (RustService trait)
+
+| Service | Repo | Module | Mode | Cargo Feature | Notes |
+|---------|------|--------|------|---------------|-------|
+| ManagedAgentService | nexus-vfs | `rust/services/src/managed_agent/` | Compiled-in | `service-managed-agent` | Mailbox + workspace hooks |
+| AcpService | nexus-vfs | `rust/services/src/acp/` | Compiled-in | `service-acp` | Subprocess + ACP-over-stdio |
+| TasksService | nexus-vfs | `rust/services/src/tasks/` | Compiled-in | `service-tasks` | Durable task queue (fjall) |
+| MatrixAdapterService | nexus-vfs | `rust/services/src/matrix_adapter/` | Compiled-in | `service-matrix-adapter` | Matrix CS v3 adapter |
+| PasswordVaultService | nexus-vfs | `rust/services/src/password_vault/` | Compiled-in | `service-password-vault` | Password vault domain logic |
+| AgentStatusResolver | nexus-vfs | `rust/services/src/agents/` | Compiled-in | `service-agents` | Procfs-style agent status |
+
+---
+
+## 3. Python Services (Bricks — wired via syscall enlist)
+
+| Service | Repo | Module | Exports | Mode |
+|---------|------|--------|---------|------|
+| search | nexus | `src/nexus/bricks/search/` | glob, grep, list, semantic_search | Compiled-in |
+| federation | nexus | `src/nexus/bricks/` | federation_* (6 methods) | Compiled-in |
+| rebac | nexus | `src/nexus/bricks/rebac/` | rebac_check, rebac_create, rebac_list_tuples, rebac_expand | Compiled-in |
+| mount | nexus | `src/nexus/bricks/mount/` | add_mount, remove_mount, list_mounts | Compiled-in |
+| mount_persist | nexus | `src/nexus/bricks/mount/` | save/load/list/delete saved mounts | Compiled-in |
+| mcp | nexus | `src/nexus/bricks/mcp/` | mcp_list_mounts, mcp_connect | Compiled-in |
+| oauth | nexus | `src/nexus/bricks/auth/oauth/` | list_providers, list/revoke credentials | Compiled-in |
+| share_link | nexus | `src/nexus/bricks/share_link/` | create/get/list/revoke share links | Compiled-in |
+| time_travel | nexus | `src/nexus/bricks/versioning/` | get/list files at operation | Compiled-in |
+| operations | nexus | `src/nexus/bricks/` | list/get/undo operations | Compiled-in |
+| agent_rpc | nexus | `src/nexus/bricks/` | register/update/list/get/delete agents | Compiled-in |
+| acp_rpc | nexus | `src/nexus/bricks/` | acp_call, acp_list_agents, etc. | Compiled-in |
+| sandbox_rpc | nexus | `src/nexus/bricks/sandbox/` | sandbox_create/run/pause/resume/stop/list | Compiled-in |
+| metadata_export | nexus | `src/nexus/bricks/` | export/import metadata | Compiled-in |
+
+---
+
+## 4. Drivers / Backends (ObjectStore trait)
+
+### Storage Backends
+
+| Backend | Repo | Module | `backend_type` | Cargo Feature | Mode |
+|---------|------|--------|----------------|---------------|------|
+| PathLocalBackend | nexus-vfs | `rust/backends/src/storage/` | `path_local` | `driver-path-local` | Compiled-in |
+| CasLocalBackend | nexus-vfs | `rust/backends/src/storage/` | `cas-local` | `driver-cas-local` | Compiled-in |
+| LocalConnectorBackend | nexus-vfs | `rust/backends/src/storage/` | `local_connector` | `driver-local-connector` | Compiled-in |
+| RemoteBackend | nexus-vfs | `rust/backends/src/storage/` | `remote` | `driver-remote` | Compiled-in (gRPC client) |
+| S3Transport | nexus-vfs | `rust/backends/src/transports/blob/` | `s3` | `driver-s3` | Compiled-in |
+| GcsBackend | nexus-vfs | `rust/backends/src/transports/blob/` | `gcs` | `driver-gcs` | Compiled-in |
+
+### API Connectors
+
+| Backend | Repo | Module | `backend_type` | Mode |
+|---------|------|--------|----------------|------|
+| CliTransport | nexus-vfs | `rust/backends/src/transports/api/` | `cli` | Compiled-in |
+| GdriveBackend | nexus-vfs | `rust/backends/src/transports/api/google/` | `gdrive` | Compiled-in |
+| GmailBackend | nexus-vfs | `rust/backends/src/transports/api/google/` | `gmail` | Compiled-in |
+| HNBackend | nexus-vfs | `rust/backends/src/transports/api/social/` | `hn` | Compiled-in |
+| XBackend | nexus-vfs | `rust/backends/src/transports/api/social/` | `x` | Compiled-in |
+| SlackBackend | nexus-vfs | `rust/backends/src/transports/api/social/` | `slack` | Compiled-in |
+| OpenAIBackend | nexus-vfs | `rust/backends/src/transports/api/ai/` | `openai` | Compiled-in |
+| AnthropicBackend | nexus-vfs | `rust/backends/src/transports/api/ai/` | `anthropic` | Compiled-in |
+
+---
+
+## 5. dylib Plugins (Future)
+
+| Plugin | Repo | Module | Status | Notes |
+|--------|------|--------|--------|-------|
+| vault | nexus | `rust/plugins/vault/` (planned) | Phase 6 — deferred | First dylib plugin guinea pig. Depends on `nexus-plugin-abi` |
+
+Infrastructure in place:
+- `PluginLoader` + `DylibRustService` wrapper (nexus-vfs `rust/kernel/src/kernel/plugins/`)
+- `nexus-plugin-abi` crate with C ABI types + `declare_service_plugin!` macro
+- `plugin.*` gRPC dispatch surface + `--plugin-dir` CLI flag
+- Hook-aware service lifecycle: unhook → drain → replace → rehook
+
+**Limitation**: VFS hooks for dylib plugins require a C ABI wrapper layer
+(Phase 5B, deferred). Current dylib support covers RPC dispatch only.
+Service hot-swap (load/unload/reload) works today; hook hot-swap does not.
+
+---
+
+## 6. gRPC Sidecar (Future)
+
+No production gRPC sidecar services exist today. The infrastructure
+(`ManagedServiceGrpcProxy`) is available for language-agnostic services
+(Python, Go, etc.) that run as separate processes.
+
+| Candidate | Rationale |
+|-----------|-----------|
+| Python bricks | If performance isolation is needed |
+| Third-party integrations | Language-agnostic extensibility |

--- a/docs/architecture/service-driver-deployment-matrix.md
+++ b/docs/architecture/service-driver-deployment-matrix.md
@@ -6,11 +6,14 @@
 
 ## Deployment Modes
 
-| Mode | Mechanism | Hot-swap | Perf | VFS hooks |
-|------|-----------|----------|------|-----------|
-| **Compiled-in** | Cargo feature gate / Python wiring | No (recompile) | Best | Full |
-| **dylib** | `PluginLoader` + `dlopen` | Yes | Good (~ns C ABI) | Limited (dispatch OK, hooks need C ABI wrapper) |
-| **gRPC sidecar** | Separate process, `ManagedServiceGrpcProxy` | Inherent | ~100us | No |
+| Mode | Runtime swap | VFS hooks |
+|------|-------------|-----------|
+| **Compiled-in** | Instance swap (same binary) | Full |
+| **dylib** | Code swap (new `.so`) + instance swap | RPC dispatch; VFS hooks require C ABI wrapper |
+| **gRPC sidecar** | Process restart (independent lifecycle) | Out-of-process |
+
+See KERNEL-ARCHITECTURE.md (nexus-vfs) §1 for mechanism details, perf
+characteristics, and the instance swap lifecycle (unhook→drain→replace→rehook).
 
 ---
 
@@ -99,31 +102,14 @@ across `dlopen` boundaries.
 
 ---
 
-## 5. dylib Plugins (Future)
+## 5. dylib Plugin Infrastructure
 
-| Plugin | Repo | Module | Status | Notes |
-|--------|------|--------|--------|-------|
-| vault | nexus | `rust/plugins/vault/` (planned) | Phase 6 — deferred | First dylib plugin guinea pig. Depends on `nexus-plugin-abi` |
+Plugin loading is handled by `PluginLoader` (nexus-vfs
+`rust/kernel/src/kernel/plugins/`) with C ABI contracts defined in the
+`nexus-plugin-abi` crate. The `declare_service_plugin!` macro generates
+the required `extern "C"` symbols from a Rust impl.
 
-Infrastructure in place:
-- `PluginLoader` + `DylibRustService` wrapper (nexus-vfs `rust/kernel/src/kernel/plugins/`)
-- `nexus-plugin-abi` crate with C ABI types + `declare_service_plugin!` macro
-- `plugin.*` gRPC dispatch surface + `--plugin-dir` CLI flag
-- Hook-aware service lifecycle: unhook → drain → replace → rehook
+Runtime surface: `plugin.load` / `plugin.unload` / `plugin.list` gRPC
+RPCs, `--plugin-dir` CLI flag for directory auto-load.
 
-**Limitation**: VFS hooks for dylib plugins require a C ABI wrapper layer
-(Phase 5B, deferred). Current dylib support covers RPC dispatch only.
-Service hot-swap (load/unload/reload) works today; hook hot-swap does not.
-
----
-
-## 6. gRPC Sidecar (Future)
-
-No production gRPC sidecar services exist today. The infrastructure
-(`ManagedServiceGrpcProxy`) is available for language-agnostic services
-(Python, Go, etc.) that run as separate processes.
-
-| Candidate | Rationale |
-|-----------|-----------|
-| Python bricks | If performance isolation is needed |
-| Third-party integrations | Language-agnostic extensibility |
+See KERNEL-ARCHITECTURE.md (nexus-vfs) §10 for the full plugin architecture.

--- a/docs/architecture/syscall-design.md
+++ b/docs/architecture/syscall-design.md
@@ -1,3 +1,0 @@
-> **Moved to [nexus-vfs](https://github.com/nexi-lab/nexus-vfs/blob/main/docs/syscall-design.md)**
->
-> This document is now maintained in the nexus-vfs repository alongside the Rust kernel code it describes.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -194,7 +194,7 @@ nav:
     - Architecture: paths/architecture.md
   - Trust Boundary: getting-started/trust-boundary.md
   - Architecture:
-    - Kernel Architecture: architecture/KERNEL-ARCHITECTURE.md
+    # - Kernel Architecture: architecture/KERNEL-ARCHITECTURE.md  # moved to nexus-vfs
     - Backend Architecture: architecture/backend-architecture.md
     - CLI Design: architecture/cli-design.md
   - Agents:

--- a/rust/services/src/lib.rs
+++ b/rust/services/src/lib.rs
@@ -1,6 +1,6 @@
 //! `services` — kernel-adjacent service-tier impls (parallel-layers crate).
 //!
-//! Per `docs/architecture/KERNEL-ARCHITECTURE.md` §1, services sit
+//! Per `KERNEL-ARCHITECTURE.md (nexus-vfs)` §1, services sit
 //! parallel to the kernel: they consume kernel primitives (syscalls,
 //! `NativeInterceptHook`, `PathResolver`, `ServiceRegistry`) without
 //! adding new kernel surface.  The line between "kernel primitive"

--- a/src/nexus/bricks/context_manifest/__init__.py
+++ b/src/nexus/bricks/context_manifest/__init__.py
@@ -22,7 +22,7 @@ Public API:
         - ``ALLOWED_VARIABLES`` — whitelist of allowed template variables
 
 References:
-    - docs/architecture/KERNEL-ARCHITECTURE.md
+    - KERNEL-ARCHITECTURE.md (nexus-vfs)
     - Issue #1341: Context manifest with deterministic pre-execution
 """
 

--- a/src/nexus/contracts/protocols/chunked_upload.py
+++ b/src/nexus/contracts/protocols/chunked_upload.py
@@ -5,7 +5,7 @@ Defines the contract for tus.io resumable chunked uploads.
 Existing implementation: ``nexus.bricks.upload.chunked_upload_service.ChunkedUploadService``
 
 References:
-    - docs/design/KERNEL-ARCHITECTURE.md §1 (service DI)
+    - KERNEL-ARCHITECTURE.md (nexus-vfs) §1 (service DI)
 """
 
 from typing import TYPE_CHECKING, Protocol, runtime_checkable

--- a/src/nexus/contracts/protocols/entity_registry.py
+++ b/src/nexus/contracts/protocols/entity_registry.py
@@ -4,7 +4,7 @@ Service contract for entity registration and lookup.
 Existing implementation: ``nexus.bricks.rebac.entity_registry.EntityRegistry`` (sync).
 
 References:
-    - docs/architecture/KERNEL-ARCHITECTURE.md §3
+    - KERNEL-ARCHITECTURE.md (nexus-vfs) §3
     - Issue #2133: Break circular runtime imports between services/ and core/
     - Issue #2359: Moved from core/protocols/ to services/protocols/ (service tier)
 """

--- a/src/nexus/contracts/protocols/mcp.py
+++ b/src/nexus/contracts/protocols/mcp.py
@@ -6,7 +6,7 @@ Existing implementation: ``nexus.bricks.mcp.mcp_service.MCPService``.
 Storage Affinity: **ObjectStore** — MCP tool definitions stored as JSON files.
 
 References:
-    - docs/design/KERNEL-ARCHITECTURE.md
+    - KERNEL-ARCHITECTURE.md (nexus-vfs)
     - Issue #988: Extract MCP service from NexusFS
 """
 

--- a/src/nexus/contracts/protocols/mount_persist.py
+++ b/src/nexus/contracts/protocols/mount_persist.py
@@ -5,7 +5,7 @@ Defines the contract for persisting and loading mount configurations in the DB.
 Existing implementation: ``nexus.bricks.mount.mount_persist_service.MountPersistService``
 
 References:
-    - docs/design/KERNEL-ARCHITECTURE.md §1 (service DI)
+    - KERNEL-ARCHITECTURE.md (nexus-vfs) §1 (service DI)
 """
 
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable

--- a/src/nexus/contracts/protocols/parse.py
+++ b/src/nexus/contracts/protocols/parse.py
@@ -6,7 +6,7 @@ Existing implementation: ``nexus.parsers.registry.ParserRegistry``.
 Storage Affinity: **ObjectStore** — parsed content derives from stored files.
 
 References:
-    - docs/design/KERNEL-ARCHITECTURE.md
+    - KERNEL-ARCHITECTURE.md (nexus-vfs)
     - ops-scenario-matrix.md (parsing is a core service domain)
 """
 

--- a/src/nexus/contracts/protocols/payment.py
+++ b/src/nexus/contracts/protocols/payment.py
@@ -8,7 +8,7 @@ Concrete implementations live in ``nexus.bricks.pay.protocol``.
 Storage Affinity: **RecordStore** — transaction records + audit trail.
 
 References:
-    - docs/architecture/KERNEL-ARCHITECTURE.md §3
+    - KERNEL-ARCHITECTURE.md (nexus-vfs) §3
     - docs/architecture/data-storage-matrix.md (Four Pillars)
     - Issue #1357: Extensible protocol dispatch for agent commerce
     - Issue #2286: Protocol types moved here from bricks/pay/protocol.py

--- a/src/nexus/contracts/protocols/permission.py
+++ b/src/nexus/contracts/protocols/permission.py
@@ -16,7 +16,7 @@ Storage Affinity: **RecordStore** — relationship tuples stored in SQL.
 
 References:
     - https://www.usenix.org/system/files/atc19-pang.pdf (Zanzibar paper)
-    - docs/architecture/KERNEL-ARCHITECTURE.md
+    - KERNEL-ARCHITECTURE.md (nexus-vfs)
     - Issue #1459: Decompose ReBAC module
 """
 

--- a/src/nexus/contracts/protocols/permission_enforcer.py
+++ b/src/nexus/contracts/protocols/permission_enforcer.py
@@ -4,7 +4,7 @@ Service contract for path-level permission enforcement.
 Existing implementation: ``nexus.bricks.rebac.enforcer.PermissionEnforcer`` (sync).
 
 References:
-    - docs/architecture/KERNEL-ARCHITECTURE.md §3
+    - KERNEL-ARCHITECTURE.md (nexus-vfs) §3
     - Issue #2133: Break circular runtime imports between services/ and core/
     - Issue #2359: Moved from core/protocols/ to services/protocols/ (service tier)
 """

--- a/src/nexus/contracts/protocols/scheduler.py
+++ b/src/nexus/contracts/protocols/scheduler.py
@@ -9,7 +9,7 @@ the scheduler from the pay service (LEGO 3.3).
 Storage Affinity: **CacheStore** -- ephemeral work queue (Dragonfly sorted set).
 
 References:
-    - docs/architecture/KERNEL-ARCHITECTURE.md 3
+    - KERNEL-ARCHITECTURE.md (nexus-vfs) 3
     - docs/architecture/data-storage-matrix.md (Four Pillars)
     - docs/design/NEXUS-LEGO-ARCHITECTURE.md 2.4, 4.2
     - Issue #1383: Define 6 kernel protocol interfaces

--- a/src/nexus/contracts/protocols/service_lifecycle.py
+++ b/src/nexus/contracts/protocols/service_lifecycle.py
@@ -64,7 +64,7 @@ Linux analogy:
     request.
 
 References:
-    - docs/architecture/KERNEL-ARCHITECTURE.md
+    - KERNEL-ARCHITECTURE.md (nexus-vfs)
     - Issue #1452: Service lifecycle / hot-swap
     - Issue #1577: HotSwappable + PersistentService protocols
     - Issue #1580: Auto-lifecycle for background services

--- a/src/nexus/contracts/wirable_fs.py
+++ b/src/nexus/contracts/wirable_fs.py
@@ -5,7 +5,7 @@ This replaces the ``Any`` type on the ``nx`` parameter, giving the wiring
 layer typed attribute access instead of ``getattr()`` calls.
 
 References:
-    - docs/architecture/KERNEL-ARCHITECTURE.md §3
+    - KERNEL-ARCHITECTURE.md (nexus-vfs) §3
     - Issue #2133: Break circular runtime imports between services/ and core/
     - Issue #2359: Moved from core/protocols/ to contracts/ (cross-tier)
 """

--- a/src/nexus/server/lifespan/_async_engines.py
+++ b/src/nexus/server/lifespan/_async_engines.py
@@ -7,7 +7,7 @@ Disposing them from a worker thread (where ``NexusFS.close()`` runs) raises
 The FastAPI lifespan must await this on its own loop *before* dispatching
 ``NexusFS.aclose`` to a worker thread. This module is the helper that does
 the loop-bound async dispose; kernel code stays sync per
-``docs/architecture/KERNEL-ARCHITECTURE.md``.
+``KERNEL-ARCHITECTURE.md (nexus-vfs)``.
 """
 
 from __future__ import annotations

--- a/src/nexus/services/audit_node/__init__.py
+++ b/src/nexus/services/audit_node/__init__.py
@@ -10,7 +10,7 @@ The audit-node does NOT register an ``AuditHook`` of its own — it
 only consumes the streams produced by production nodes.  This keeps
 the audit-node's local zone free of self-generated noise.
 
-Architectural references: ``docs/architecture/KERNEL-ARCHITECTURE.md``
+Architectural references: ``KERNEL-ARCHITECTURE.md (nexus-vfs)``
 § federation, ``sudowork-2/docs/tech/nexus-integration-architecture.md``
 § Audit Trace.
 """


### PR DESCRIPTION
## Summary
- Delete 5 redirect stub files in `docs/architecture/` (KERNEL-ARCHITECTURE, federation-memo, syscall-design, lock-architecture, llm-cas-kv-cache) — SSOT now lives in nexus-vfs
- Update 19 active code files with cross-references pointing at the deleted stubs → `(nexus-vfs)` suffix
- Add `service-driver-deployment-matrix.md` — global inventory of every service, hook, and driver across both repos, classified by deployment mode

## Test plan
- [x] Pre-commit hooks pass (all 3 commits)
- [ ] CI green
- [ ] `grep -r 'docs/architecture/KERNEL-ARCHITECTURE.md' --include='*.py' --include='*.rs'` returns 0 in active code

🤖 Generated with [Claude Code](https://claude.com/claude-code)