### PR TITLE
ci: add proto sync check for password_vault.proto drift

### DIFF
--- a/scripts/check_proto_sync.sh
+++ b/scripts/check_proto_sync.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Verify password_vault.proto stays in sync with nexus-vfs SSOT.
+# Run in CI to catch drift before it reaches production.
+set -euo pipefail
+
+LOCAL="rust/services/proto/nexus/password_vault/v1/password_vault.proto"
+REMOTE_URL="https://raw.githubusercontent.com/nexi-lab/nexus-vfs/main/proto/nexus/password_vault/v1/password_vault.proto"
+
+if [ ! -f "$LOCAL" ]; then
+    echo "SKIP: $LOCAL not found (service-password-vault feature not present)"
+    exit 0
+fi
+
+REMOTE=$(curl -sfL "$REMOTE_URL") || { echo "WARN: could not fetch nexus-vfs proto (network); skipping sync check"; exit 0; }
+
+if ! diff <(echo "$REMOTE") "$LOCAL" > /dev/null 2>&1; then
+    echo "ERROR: password_vault.proto has drifted from nexus-vfs SSOT"
+    echo "  local:  $LOCAL"
+    echo "  remote: $REMOTE_URL"
+    diff <(echo "$REMOTE") "$LOCAL" || true
+    exit 1
+fi
+
+echo "OK: password_vault.proto in sync with nexus-vfs"


### PR DESCRIPTION
## Summary

`password_vault.proto` exists in both repos (nexus `rust/services/proto/` and nexus-vfs `proto/`). nexus-vfs is SSOT. Two different teams maintain the repos — drift risk is real.

Adds `scripts/check_proto_sync.sh` that fetches the nexus-vfs SSOT and diffs against the local copy, failing on any mismatch. Can be wired into CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)