### PR TITLE
feat(r2): signed-URL read path + opt-in driver-s3 cluster build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -86,19 +86,27 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # afford the larger binary). Requires nexus-vfs with the opt-in driver-s3
 # cluster feature.
 #
-# `--rev` PIN: without it the cargo-install layer is cached against an unchanged
-# command and reuses a STALE (pre-bridge-2 #4262) cluster, which acks DT_MOUNT
-# but never installs it (created=false) → edge E2E mount-setup failure. Pinning
-# makes the build reproducible and busts that cache. This rev is nexus-vfs main
-# plus the opt-in driver-s3 feature (#27); validated end-to-end (boots clean,
-# 0 panics, installs DT_MOUNT, perms-demo + R2 read/write + hybrid search green).
-# Bump alongside the nexus-vfs git pin in Cargo.lock.
+# REV is a build-arg, NOT a hardcoded edge. `cargo install --git` lives in a
+# Docker RUN layer that caches by command string, so a bare `--branch main`
+# would FREEZE at the first-built binary forever — exactly how the stale,
+# pre-bridge-2 (#4262) cluster shipped (acked DT_MOUNT but never installed it,
+# created=false → edge E2E mount-setup failure). Putting the resolved rev in
+# the command both busts that cache and makes the build reproducible.
+#   - Default below = a known-good rev for reproducible local builds.
+#   - Edge: CI passes `--build-arg NEXUS_VFS_REV=$(git ls-remote …main | sha)`.
+#   - Downstream pins the *image*, not this file.
+# SSOT once #27 lands on nexus-vfs main: bump the default to the merged-main rev
+# (or derive it from the nexus-vfs pin in Cargo.lock). The default below is a
+# TEMPORARY integration pin to the unmerged #27 branch tip so the R2 e2e can
+# run pre-merge.
 ENV CARGO_NET_RETRY=10 \
     CARGO_HTTP_TIMEOUT=120
+# Override for edge/CI or a different pin: --build-arg NEXUS_VFS_REV=<sha|tag>
+ARG NEXUS_VFS_REV=ca9d67439bb7e339795a2475a7bffccf2f10305d
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,id=cargo-install-${TARGETARCH},target=/root/.cargo/target \
-    cargo install --git https://github.com/nexi-lab/nexus-vfs --rev ca9d67439bb7e339795a2475a7bffccf2f10305d --features driver-s3 --bin nexusd-cluster nexus-cluster && \
+    cargo install --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --features driver-s3 --bin nexusd-cluster nexus-cluster && \
     cp /root/.cargo/bin/nexusd-cluster /build/nexusd-cluster
 
 # ---------- Copy real application source and reinstall local package ----------

--- a/Dockerfile
+++ b/Dockerfile
@@ -77,14 +77,16 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=cache,target=/root/.cache/pip \
     uv pip install --system -i "$(cat /tmp/pip_index)" ".[${NEXUS_PROFILE_EXTRAS}]"
 
-# ---------- Install nexusd-cluster binary from nexus-vfs (Issue #3125, #4259) ----------
+# ---------- Install nexusd-full binary from nexus-vfs (Issue #3125, #4259) ----------
 # Kernel-tier Rust (including the cluster binary) migrated to the nexus-vfs
 # repo. Install the pre-built binary via `cargo install` from the git repo.
 #
-# `--features driver-s3` opts the cluster into S3/R2 serving (the standalone
-# slim cluster stays local+remote only under its size gate; the full image can
-# afford the larger binary). Requires nexus-vfs with the opt-in driver-s3
-# cluster feature.
+# We install `nexusd-full` — the `full` profile = `nexusd-cluster` (Raft + IPC +
+# federation) PLUS the S3/R2 object-store driver. Per the nexus-vfs#27 kernel-team
+# review, `driver-s3` is NOT a feature on `nexusd-cluster` (that binary stays pure
+# local+remote and under its size gate); the S3-serving binary is this separate
+# profile. It is symlinked to `nexus-cluster` below so the Python runtime spawns
+# it unchanged.
 #
 # REV is a build-arg, NOT a hardcoded edge. `cargo install --git` lives in a
 # Docker RUN layer that caches by command string, so a bare `--branch main`
@@ -102,12 +104,12 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ENV CARGO_NET_RETRY=10 \
     CARGO_HTTP_TIMEOUT=120
 # Override for edge/CI or a different pin: --build-arg NEXUS_VFS_REV=<sha|tag>
-ARG NEXUS_VFS_REV=ca9d67439bb7e339795a2475a7bffccf2f10305d
+ARG NEXUS_VFS_REV=f4227a21bc8a7546477bc3851bd9407f3579f925
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,id=cargo-install-${TARGETARCH},target=/root/.cargo/target \
-    cargo install --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --features driver-s3 --bin nexusd-cluster nexus-cluster && \
-    cp /root/.cargo/bin/nexusd-cluster /build/nexusd-cluster
+    cargo install --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-full nexus-full && \
+    cp /root/.cargo/bin/nexusd-full /build/nexusd-full
 
 # ---------- Copy real application source and reinstall local package ----------
 COPY src/ ./src/
@@ -194,14 +196,15 @@ COPY --from=builder /usr/local/lib/python3.14/site-packages /usr/local/lib/pytho
 COPY --from=builder /usr/local/bin/nexus /usr/local/bin/nexus
 COPY --from=builder /usr/local/bin/nexusd /usr/local/bin/nexusd
 COPY --from=builder /usr/local/bin/alembic /usr/local/bin/alembic
-COPY --from=builder /build/nexusd-cluster /usr/local/bin/nexusd-cluster
-# Python factory boot spawns "nexus-cluster" (without d) via subprocess.
-RUN ln -s /usr/local/bin/nexusd-cluster /usr/local/bin/nexus-cluster
+COPY --from=builder /build/nexusd-full /usr/local/bin/nexusd-full
+# Python factory boot spawns "nexus-cluster" (without d) via subprocess; point
+# that name at the full binary (cluster + S3/R2 driver) so usage is unchanged.
+RUN ln -s /usr/local/bin/nexusd-full /usr/local/bin/nexus-cluster
 
 
 # ---------- Build-time smoke tests (Issue #3125, #3134) ----------
-# Verify nexusd-cluster binary is present and executable.
-RUN nexusd-cluster --version || echo "nexusd-cluster binary OK"
+# Verify nexusd-full binary is present and executable.
+RUN nexusd-full --version || echo "nexusd-full binary OK"
 # Extras-gated imports.
 # SANDBOX profile deliberately excludes pgvector/docker/fastembed/psutil (Issue #3778).
 RUN set -eux; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -80,12 +80,25 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # ---------- Install nexusd-cluster binary from nexus-vfs (Issue #3125, #4259) ----------
 # Kernel-tier Rust (including the cluster binary) migrated to the nexus-vfs
 # repo. Install the pre-built binary via `cargo install` from the git repo.
+#
+# `--features driver-s3` opts the cluster into S3/R2 serving (the standalone
+# slim cluster stays local+remote only under its size gate; the full image can
+# afford the larger binary). Requires nexus-vfs with the opt-in driver-s3
+# cluster feature.
+#
+# `--rev` PIN: without it the cargo-install layer is cached against an unchanged
+# command and reuses a STALE (pre-bridge-2 #4262) cluster, which acks DT_MOUNT
+# but never installs it (created=false) → edge E2E mount-setup failure. Pinning
+# makes the build reproducible and busts that cache. This rev is nexus-vfs main
+# plus the opt-in driver-s3 feature (#27); validated end-to-end (boots clean,
+# 0 panics, installs DT_MOUNT, perms-demo + R2 read/write + hybrid search green).
+# Bump alongside the nexus-vfs git pin in Cargo.lock.
 ENV CARGO_NET_RETRY=10 \
     CARGO_HTTP_TIMEOUT=120
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,id=cargo-install-${TARGETARCH},target=/root/.cargo/target \
-    cargo install --git https://github.com/nexi-lab/nexus-vfs --bin nexusd-cluster nexus-cluster && \
+    cargo install --git https://github.com/nexi-lab/nexus-vfs --rev ca9d67439bb7e339795a2475a7bffccf2f10305d --features driver-s3 --bin nexusd-cluster nexus-cluster && \
     cp /root/.cargo/bin/nexusd-cluster /build/nexusd-cluster
 
 # ---------- Copy real application source and reinstall local package ----------

--- a/Dockerfile
+++ b/Dockerfile
@@ -200,11 +200,19 @@ COPY --from=builder /build/nexusd-full /usr/local/bin/nexusd-full
 # Python factory boot spawns "nexus-cluster" (without d) via subprocess; point
 # that name at the full binary (cluster + S3/R2 driver) so usage is unchanged.
 RUN ln -s /usr/local/bin/nexusd-full /usr/local/bin/nexus-cluster
+# Back-compat: preserve the historic `nexusd-cluster` name. Repo consumers still
+# exec it directly (e.g. the federation E2E joiner entrypoint), and nexusd-full
+# is a strict superset of the old slim cluster binary, so the alias is
+# behaviorally identical.
+RUN ln -s /usr/local/bin/nexusd-full /usr/local/bin/nexusd-cluster
 
 
 # ---------- Build-time smoke tests (Issue #3125, #3134) ----------
-# Verify nexusd-full binary is present and executable.
-RUN nexusd-full --version || echo "nexusd-full binary OK"
+# Fail the build if any expected cluster binary name is missing or not on PATH
+# (don't mask failures with `|| echo`), then verify the binary actually runs.
+RUN for b in nexusd-full nexus-cluster nexusd-cluster; do \
+        command -v "$b" >/dev/null 2>&1 || { echo "missing cluster binary: $b" >&2; exit 1; }; \
+    done && nexusd-full --version
 # Extras-gated imports.
 # SANDBOX profile deliberately excludes pgvector/docker/fastembed/psutil (Issue #3778).
 RUN set -eux; \

--- a/docs/surface-coverage/api-rpc-surface-coverage.yaml
+++ b/docs/surface-coverage/api-rpc-surface-coverage.yaml
@@ -950,7 +950,7 @@ operations:
   transports:
     http:
       name: POST /batch/read
-      source: src/nexus/server/api/v2/routers/async_files.py:1951
+      source: src/nexus/server/api/v2/routers/async_files.py:1975
   profiles:
     lite: supported
     sandbox: unavailable
@@ -969,7 +969,7 @@ operations:
   transports:
     http:
       name: POST /batch/write
-      source: src/nexus/server/api/v2/routers/async_files.py:1902
+      source: src/nexus/server/api/v2/routers/async_files.py:1926
   profiles:
     lite: supported
     sandbox: unavailable
@@ -988,7 +988,7 @@ operations:
   transports:
     http:
       name: POST /copy
-      source: src/nexus/server/api/v2/routers/async_files.py:2127
+      source: src/nexus/server/api/v2/routers/async_files.py:2151
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1007,7 +1007,7 @@ operations:
   transports:
     http:
       name: POST /copy-bulk
-      source: src/nexus/server/api/v2/routers/async_files.py:2226
+      source: src/nexus/server/api/v2/routers/async_files.py:2250
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1026,7 +1026,7 @@ operations:
   transports:
     http:
       name: DELETE /delete
-      source: src/nexus/server/api/v2/routers/async_files.py:1433
+      source: src/nexus/server/api/v2/routers/async_files.py:1457
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1044,7 +1044,7 @@ operations:
   transports:
     http:
       name: GET /exists
-      source: src/nexus/server/api/v2/routers/async_files.py:1509
+      source: src/nexus/server/api/v2/routers/async_files.py:1533
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1062,7 +1062,7 @@ operations:
   transports:
     http:
       name: GET /glob
-      source: src/nexus/server/api/v2/routers/async_files.py:2303
+      source: src/nexus/server/api/v2/routers/async_files.py:2327
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1080,7 +1080,7 @@ operations:
   transports:
     http:
       name: GET /grep
-      source: src/nexus/server/api/v2/routers/async_files.py:2354
+      source: src/nexus/server/api/v2/routers/async_files.py:2378
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1099,7 +1099,7 @@ operations:
   transports:
     http:
       name: GET /list
-      source: src/nexus/server/api/v2/routers/async_files.py:1538
+      source: src/nexus/server/api/v2/routers/async_files.py:1562
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1117,7 +1117,7 @@ operations:
   transports:
     http:
       name: GET /md-structure
-      source: src/nexus/server/api/v2/routers/async_files.py:1335
+      source: src/nexus/server/api/v2/routers/async_files.py:1359
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1135,7 +1135,7 @@ operations:
   transports:
     http:
       name: GET /metadata
-      source: src/nexus/server/api/v2/routers/async_files.py:1814
+      source: src/nexus/server/api/v2/routers/async_files.py:1838
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1153,7 +1153,7 @@ operations:
   transports:
     http:
       name: POST /mkdir
-      source: src/nexus/server/api/v2/routers/async_files.py:1776
+      source: src/nexus/server/api/v2/routers/async_files.py:1800
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1208,7 +1208,7 @@ operations:
   transports:
     http:
       name: POST /rename
-      source: src/nexus/server/api/v2/routers/async_files.py:2089
+      source: src/nexus/server/api/v2/routers/async_files.py:2113
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1226,7 +1226,7 @@ operations:
   transports:
     http:
       name: POST /rename-batch
-      source: src/nexus/server/api/v2/routers/async_files.py:2184
+      source: src/nexus/server/api/v2/routers/async_files.py:2208
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1244,7 +1244,7 @@ operations:
   transports:
     http:
       name: GET /stream
-      source: src/nexus/server/api/v2/routers/async_files.py:2025
+      source: src/nexus/server/api/v2/routers/async_files.py:2049
   profiles:
     lite: supported
     sandbox: unavailable

--- a/docs/surface-coverage/api-rpc-surface-coverage.yaml
+++ b/docs/surface-coverage/api-rpc-surface-coverage.yaml
@@ -950,7 +950,7 @@ operations:
   transports:
     http:
       name: POST /batch/read
-      source: src/nexus/server/api/v2/routers/async_files.py:1929
+      source: src/nexus/server/api/v2/routers/async_files.py:1940
   profiles:
     lite: supported
     sandbox: unavailable
@@ -969,7 +969,7 @@ operations:
   transports:
     http:
       name: POST /batch/write
-      source: src/nexus/server/api/v2/routers/async_files.py:1880
+      source: src/nexus/server/api/v2/routers/async_files.py:1891
   profiles:
     lite: supported
     sandbox: unavailable
@@ -988,7 +988,7 @@ operations:
   transports:
     http:
       name: POST /copy
-      source: src/nexus/server/api/v2/routers/async_files.py:2105
+      source: src/nexus/server/api/v2/routers/async_files.py:2116
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1007,7 +1007,7 @@ operations:
   transports:
     http:
       name: POST /copy-bulk
-      source: src/nexus/server/api/v2/routers/async_files.py:2204
+      source: src/nexus/server/api/v2/routers/async_files.py:2215
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1026,7 +1026,7 @@ operations:
   transports:
     http:
       name: DELETE /delete
-      source: src/nexus/server/api/v2/routers/async_files.py:1411
+      source: src/nexus/server/api/v2/routers/async_files.py:1422
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1044,7 +1044,7 @@ operations:
   transports:
     http:
       name: GET /exists
-      source: src/nexus/server/api/v2/routers/async_files.py:1487
+      source: src/nexus/server/api/v2/routers/async_files.py:1498
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1062,7 +1062,7 @@ operations:
   transports:
     http:
       name: GET /glob
-      source: src/nexus/server/api/v2/routers/async_files.py:2281
+      source: src/nexus/server/api/v2/routers/async_files.py:2292
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1080,7 +1080,7 @@ operations:
   transports:
     http:
       name: GET /grep
-      source: src/nexus/server/api/v2/routers/async_files.py:2332
+      source: src/nexus/server/api/v2/routers/async_files.py:2343
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1099,7 +1099,7 @@ operations:
   transports:
     http:
       name: GET /list
-      source: src/nexus/server/api/v2/routers/async_files.py:1516
+      source: src/nexus/server/api/v2/routers/async_files.py:1527
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1117,7 +1117,7 @@ operations:
   transports:
     http:
       name: GET /md-structure
-      source: src/nexus/server/api/v2/routers/async_files.py:1313
+      source: src/nexus/server/api/v2/routers/async_files.py:1324
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1135,7 +1135,7 @@ operations:
   transports:
     http:
       name: GET /metadata
-      source: src/nexus/server/api/v2/routers/async_files.py:1792
+      source: src/nexus/server/api/v2/routers/async_files.py:1803
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1153,7 +1153,7 @@ operations:
   transports:
     http:
       name: POST /mkdir
-      source: src/nexus/server/api/v2/routers/async_files.py:1754
+      source: src/nexus/server/api/v2/routers/async_files.py:1765
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1208,7 +1208,7 @@ operations:
   transports:
     http:
       name: POST /rename
-      source: src/nexus/server/api/v2/routers/async_files.py:2067
+      source: src/nexus/server/api/v2/routers/async_files.py:2078
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1226,7 +1226,7 @@ operations:
   transports:
     http:
       name: POST /rename-batch
-      source: src/nexus/server/api/v2/routers/async_files.py:2162
+      source: src/nexus/server/api/v2/routers/async_files.py:2173
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1244,7 +1244,7 @@ operations:
   transports:
     http:
       name: GET /stream
-      source: src/nexus/server/api/v2/routers/async_files.py:2003
+      source: src/nexus/server/api/v2/routers/async_files.py:2014
   profiles:
     lite: supported
     sandbox: unavailable

--- a/docs/surface-coverage/api-rpc-surface-coverage.yaml
+++ b/docs/surface-coverage/api-rpc-surface-coverage.yaml
@@ -950,7 +950,7 @@ operations:
   transports:
     http:
       name: POST /batch/read
-      source: src/nexus/server/api/v2/routers/async_files.py:1940
+      source: src/nexus/server/api/v2/routers/async_files.py:1951
   profiles:
     lite: supported
     sandbox: unavailable
@@ -969,7 +969,7 @@ operations:
   transports:
     http:
       name: POST /batch/write
-      source: src/nexus/server/api/v2/routers/async_files.py:1891
+      source: src/nexus/server/api/v2/routers/async_files.py:1902
   profiles:
     lite: supported
     sandbox: unavailable
@@ -988,7 +988,7 @@ operations:
   transports:
     http:
       name: POST /copy
-      source: src/nexus/server/api/v2/routers/async_files.py:2116
+      source: src/nexus/server/api/v2/routers/async_files.py:2127
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1007,7 +1007,7 @@ operations:
   transports:
     http:
       name: POST /copy-bulk
-      source: src/nexus/server/api/v2/routers/async_files.py:2215
+      source: src/nexus/server/api/v2/routers/async_files.py:2226
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1026,7 +1026,7 @@ operations:
   transports:
     http:
       name: DELETE /delete
-      source: src/nexus/server/api/v2/routers/async_files.py:1422
+      source: src/nexus/server/api/v2/routers/async_files.py:1433
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1044,7 +1044,7 @@ operations:
   transports:
     http:
       name: GET /exists
-      source: src/nexus/server/api/v2/routers/async_files.py:1498
+      source: src/nexus/server/api/v2/routers/async_files.py:1509
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1062,7 +1062,7 @@ operations:
   transports:
     http:
       name: GET /glob
-      source: src/nexus/server/api/v2/routers/async_files.py:2292
+      source: src/nexus/server/api/v2/routers/async_files.py:2303
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1080,7 +1080,7 @@ operations:
   transports:
     http:
       name: GET /grep
-      source: src/nexus/server/api/v2/routers/async_files.py:2343
+      source: src/nexus/server/api/v2/routers/async_files.py:2354
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1099,7 +1099,7 @@ operations:
   transports:
     http:
       name: GET /list
-      source: src/nexus/server/api/v2/routers/async_files.py:1527
+      source: src/nexus/server/api/v2/routers/async_files.py:1538
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1117,7 +1117,7 @@ operations:
   transports:
     http:
       name: GET /md-structure
-      source: src/nexus/server/api/v2/routers/async_files.py:1324
+      source: src/nexus/server/api/v2/routers/async_files.py:1335
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1135,7 +1135,7 @@ operations:
   transports:
     http:
       name: GET /metadata
-      source: src/nexus/server/api/v2/routers/async_files.py:1803
+      source: src/nexus/server/api/v2/routers/async_files.py:1814
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1153,7 +1153,7 @@ operations:
   transports:
     http:
       name: POST /mkdir
-      source: src/nexus/server/api/v2/routers/async_files.py:1765
+      source: src/nexus/server/api/v2/routers/async_files.py:1776
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1208,7 +1208,7 @@ operations:
   transports:
     http:
       name: POST /rename
-      source: src/nexus/server/api/v2/routers/async_files.py:2078
+      source: src/nexus/server/api/v2/routers/async_files.py:2089
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1226,7 +1226,7 @@ operations:
   transports:
     http:
       name: POST /rename-batch
-      source: src/nexus/server/api/v2/routers/async_files.py:2173
+      source: src/nexus/server/api/v2/routers/async_files.py:2184
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1244,7 +1244,7 @@ operations:
   transports:
     http:
       name: GET /stream
-      source: src/nexus/server/api/v2/routers/async_files.py:2014
+      source: src/nexus/server/api/v2/routers/async_files.py:2025
   profiles:
     lite: supported
     sandbox: unavailable

--- a/docs/surface-coverage/api-rpc-surface-coverage.yaml
+++ b/docs/surface-coverage/api-rpc-surface-coverage.yaml
@@ -950,7 +950,7 @@ operations:
   transports:
     http:
       name: POST /batch/read
-      source: src/nexus/server/api/v2/routers/async_files.py:1806
+      source: src/nexus/server/api/v2/routers/async_files.py:1868
   profiles:
     lite: supported
     sandbox: unavailable
@@ -969,7 +969,7 @@ operations:
   transports:
     http:
       name: POST /batch/write
-      source: src/nexus/server/api/v2/routers/async_files.py:1757
+      source: src/nexus/server/api/v2/routers/async_files.py:1819
   profiles:
     lite: supported
     sandbox: unavailable
@@ -988,7 +988,7 @@ operations:
   transports:
     http:
       name: POST /copy
-      source: src/nexus/server/api/v2/routers/async_files.py:1982
+      source: src/nexus/server/api/v2/routers/async_files.py:2044
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1007,7 +1007,7 @@ operations:
   transports:
     http:
       name: POST /copy-bulk
-      source: src/nexus/server/api/v2/routers/async_files.py:2081
+      source: src/nexus/server/api/v2/routers/async_files.py:2143
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1026,7 +1026,7 @@ operations:
   transports:
     http:
       name: DELETE /delete
-      source: src/nexus/server/api/v2/routers/async_files.py:1288
+      source: src/nexus/server/api/v2/routers/async_files.py:1350
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1044,7 +1044,7 @@ operations:
   transports:
     http:
       name: GET /exists
-      source: src/nexus/server/api/v2/routers/async_files.py:1364
+      source: src/nexus/server/api/v2/routers/async_files.py:1426
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1062,7 +1062,7 @@ operations:
   transports:
     http:
       name: GET /glob
-      source: src/nexus/server/api/v2/routers/async_files.py:2158
+      source: src/nexus/server/api/v2/routers/async_files.py:2220
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1080,7 +1080,7 @@ operations:
   transports:
     http:
       name: GET /grep
-      source: src/nexus/server/api/v2/routers/async_files.py:2209
+      source: src/nexus/server/api/v2/routers/async_files.py:2271
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1099,7 +1099,7 @@ operations:
   transports:
     http:
       name: GET /list
-      source: src/nexus/server/api/v2/routers/async_files.py:1393
+      source: src/nexus/server/api/v2/routers/async_files.py:1455
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1117,7 +1117,7 @@ operations:
   transports:
     http:
       name: GET /md-structure
-      source: src/nexus/server/api/v2/routers/async_files.py:1190
+      source: src/nexus/server/api/v2/routers/async_files.py:1252
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1135,7 +1135,7 @@ operations:
   transports:
     http:
       name: GET /metadata
-      source: src/nexus/server/api/v2/routers/async_files.py:1669
+      source: src/nexus/server/api/v2/routers/async_files.py:1731
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1153,7 +1153,7 @@ operations:
   transports:
     http:
       name: POST /mkdir
-      source: src/nexus/server/api/v2/routers/async_files.py:1631
+      source: src/nexus/server/api/v2/routers/async_files.py:1693
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1183,13 +1183,31 @@ operations:
   perf_link: tests/benchmarks/bench_read_write_overhead.py::TestRouteOverhead; tests/benchmarks/bench_read_write_overhead.py::TestReadWithMetadata
   gap_issue: 4127
   owning_issue: 4127
+- id: async_files.read_url
+  module: filesystem
+  summary: ''
+  transports:
+    http:
+      name: GET /read-url
+      source: src/nexus/server/api/v2/routers/async_files.py:1190
+  profiles:
+    lite: supported
+    sandbox: supported
+    full: supported
+  usage_example: null
+  correctness_test: src/nexus/server/api/v2/routers/tests/test_read_url.py::test_read_url_s3_mount_returns_presigned_url
+  perf_class: control
+  perf_link: 'Control-plane: ReBAC sys_stat + presigned-URL signing only, no byte transfer (client fetches directly from R2/CDN).
+    Not separately benchmarked.'
+  gap_issue: null
+  owning_issue: 4262
 - id: async_files.rename
   module: filesystem
   summary: HTTP async file/search route exists in non-sandbox profiles, but sandbox filters HTTP to /health and /api/v2/features.
   transports:
     http:
       name: POST /rename
-      source: src/nexus/server/api/v2/routers/async_files.py:1944
+      source: src/nexus/server/api/v2/routers/async_files.py:2006
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1207,7 +1225,7 @@ operations:
   transports:
     http:
       name: POST /rename-batch
-      source: src/nexus/server/api/v2/routers/async_files.py:2039
+      source: src/nexus/server/api/v2/routers/async_files.py:2101
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1225,7 +1243,7 @@ operations:
   transports:
     http:
       name: GET /stream
-      source: src/nexus/server/api/v2/routers/async_files.py:1880
+      source: src/nexus/server/api/v2/routers/async_files.py:1942
   profiles:
     lite: supported
     sandbox: unavailable
@@ -10346,6 +10364,14 @@ parity_warnings:
   - mcp
   - sdk
 - operation_id: async_files.read
+  has:
+  - http
+  missing:
+  - cli
+  - grpc_typed
+  - mcp
+  - sdk
+- operation_id: async_files.read_url
   has:
   - http
   missing:

--- a/docs/surface-coverage/api-rpc-surface-coverage.yaml
+++ b/docs/surface-coverage/api-rpc-surface-coverage.yaml
@@ -950,7 +950,7 @@ operations:
   transports:
     http:
       name: POST /batch/read
-      source: src/nexus/server/api/v2/routers/async_files.py:1868
+      source: src/nexus/server/api/v2/routers/async_files.py:1894
   profiles:
     lite: supported
     sandbox: unavailable
@@ -969,7 +969,7 @@ operations:
   transports:
     http:
       name: POST /batch/write
-      source: src/nexus/server/api/v2/routers/async_files.py:1819
+      source: src/nexus/server/api/v2/routers/async_files.py:1845
   profiles:
     lite: supported
     sandbox: unavailable
@@ -988,7 +988,7 @@ operations:
   transports:
     http:
       name: POST /copy
-      source: src/nexus/server/api/v2/routers/async_files.py:2044
+      source: src/nexus/server/api/v2/routers/async_files.py:2070
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1007,7 +1007,7 @@ operations:
   transports:
     http:
       name: POST /copy-bulk
-      source: src/nexus/server/api/v2/routers/async_files.py:2143
+      source: src/nexus/server/api/v2/routers/async_files.py:2169
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1026,7 +1026,7 @@ operations:
   transports:
     http:
       name: DELETE /delete
-      source: src/nexus/server/api/v2/routers/async_files.py:1350
+      source: src/nexus/server/api/v2/routers/async_files.py:1376
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1044,7 +1044,7 @@ operations:
   transports:
     http:
       name: GET /exists
-      source: src/nexus/server/api/v2/routers/async_files.py:1426
+      source: src/nexus/server/api/v2/routers/async_files.py:1452
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1062,7 +1062,7 @@ operations:
   transports:
     http:
       name: GET /glob
-      source: src/nexus/server/api/v2/routers/async_files.py:2220
+      source: src/nexus/server/api/v2/routers/async_files.py:2246
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1080,7 +1080,7 @@ operations:
   transports:
     http:
       name: GET /grep
-      source: src/nexus/server/api/v2/routers/async_files.py:2271
+      source: src/nexus/server/api/v2/routers/async_files.py:2297
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1099,7 +1099,7 @@ operations:
   transports:
     http:
       name: GET /list
-      source: src/nexus/server/api/v2/routers/async_files.py:1455
+      source: src/nexus/server/api/v2/routers/async_files.py:1481
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1117,7 +1117,7 @@ operations:
   transports:
     http:
       name: GET /md-structure
-      source: src/nexus/server/api/v2/routers/async_files.py:1252
+      source: src/nexus/server/api/v2/routers/async_files.py:1278
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1135,7 +1135,7 @@ operations:
   transports:
     http:
       name: GET /metadata
-      source: src/nexus/server/api/v2/routers/async_files.py:1731
+      source: src/nexus/server/api/v2/routers/async_files.py:1757
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1153,7 +1153,7 @@ operations:
   transports:
     http:
       name: POST /mkdir
-      source: src/nexus/server/api/v2/routers/async_files.py:1693
+      source: src/nexus/server/api/v2/routers/async_files.py:1719
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1171,7 +1171,7 @@ operations:
   transports:
     http:
       name: GET /read
-      source: src/nexus/server/api/v2/routers/async_files.py:821
+      source: src/nexus/server/api/v2/routers/async_files.py:822
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1189,7 +1189,7 @@ operations:
   transports:
     http:
       name: GET /read-url
-      source: src/nexus/server/api/v2/routers/async_files.py:1190
+      source: src/nexus/server/api/v2/routers/async_files.py:1191
   profiles:
     lite: supported
     sandbox: supported
@@ -1207,7 +1207,7 @@ operations:
   transports:
     http:
       name: POST /rename
-      source: src/nexus/server/api/v2/routers/async_files.py:2006
+      source: src/nexus/server/api/v2/routers/async_files.py:2032
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1225,7 +1225,7 @@ operations:
   transports:
     http:
       name: POST /rename-batch
-      source: src/nexus/server/api/v2/routers/async_files.py:2101
+      source: src/nexus/server/api/v2/routers/async_files.py:2127
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1243,7 +1243,7 @@ operations:
   transports:
     http:
       name: GET /stream
-      source: src/nexus/server/api/v2/routers/async_files.py:1942
+      source: src/nexus/server/api/v2/routers/async_files.py:1968
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1261,7 +1261,7 @@ operations:
   transports:
     http:
       name: POST /write
-      source: src/nexus/server/api/v2/routers/async_files.py:621
+      source: src/nexus/server/api/v2/routers/async_files.py:622
   profiles:
     lite: supported
     sandbox: unavailable

--- a/docs/surface-coverage/api-rpc-surface-coverage.yaml
+++ b/docs/surface-coverage/api-rpc-surface-coverage.yaml
@@ -950,7 +950,7 @@ operations:
   transports:
     http:
       name: POST /batch/read
-      source: src/nexus/server/api/v2/routers/async_files.py:1894
+      source: src/nexus/server/api/v2/routers/async_files.py:1917
   profiles:
     lite: supported
     sandbox: unavailable
@@ -969,7 +969,7 @@ operations:
   transports:
     http:
       name: POST /batch/write
-      source: src/nexus/server/api/v2/routers/async_files.py:1845
+      source: src/nexus/server/api/v2/routers/async_files.py:1868
   profiles:
     lite: supported
     sandbox: unavailable
@@ -988,7 +988,7 @@ operations:
   transports:
     http:
       name: POST /copy
-      source: src/nexus/server/api/v2/routers/async_files.py:2070
+      source: src/nexus/server/api/v2/routers/async_files.py:2093
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1007,7 +1007,7 @@ operations:
   transports:
     http:
       name: POST /copy-bulk
-      source: src/nexus/server/api/v2/routers/async_files.py:2169
+      source: src/nexus/server/api/v2/routers/async_files.py:2192
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1026,7 +1026,7 @@ operations:
   transports:
     http:
       name: DELETE /delete
-      source: src/nexus/server/api/v2/routers/async_files.py:1376
+      source: src/nexus/server/api/v2/routers/async_files.py:1399
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1044,7 +1044,7 @@ operations:
   transports:
     http:
       name: GET /exists
-      source: src/nexus/server/api/v2/routers/async_files.py:1452
+      source: src/nexus/server/api/v2/routers/async_files.py:1475
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1062,7 +1062,7 @@ operations:
   transports:
     http:
       name: GET /glob
-      source: src/nexus/server/api/v2/routers/async_files.py:2246
+      source: src/nexus/server/api/v2/routers/async_files.py:2269
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1080,7 +1080,7 @@ operations:
   transports:
     http:
       name: GET /grep
-      source: src/nexus/server/api/v2/routers/async_files.py:2297
+      source: src/nexus/server/api/v2/routers/async_files.py:2320
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1099,7 +1099,7 @@ operations:
   transports:
     http:
       name: GET /list
-      source: src/nexus/server/api/v2/routers/async_files.py:1481
+      source: src/nexus/server/api/v2/routers/async_files.py:1504
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1117,7 +1117,7 @@ operations:
   transports:
     http:
       name: GET /md-structure
-      source: src/nexus/server/api/v2/routers/async_files.py:1278
+      source: src/nexus/server/api/v2/routers/async_files.py:1301
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1135,7 +1135,7 @@ operations:
   transports:
     http:
       name: GET /metadata
-      source: src/nexus/server/api/v2/routers/async_files.py:1757
+      source: src/nexus/server/api/v2/routers/async_files.py:1780
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1153,7 +1153,7 @@ operations:
   transports:
     http:
       name: POST /mkdir
-      source: src/nexus/server/api/v2/routers/async_files.py:1719
+      source: src/nexus/server/api/v2/routers/async_files.py:1742
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1192,14 +1192,15 @@ operations:
       source: src/nexus/server/api/v2/routers/async_files.py:1191
   profiles:
     lite: supported
-    sandbox: supported
+    sandbox: unavailable
     full: supported
-  usage_example: null
+  usage_example: 'Unavailable in sandbox: async file HTTP routes (including /api/v2/files/read-url) return 404 after the sandbox
+    route allowlist; use /zone/local kernel/SDK surfaces instead.'
   correctness_test: src/nexus/server/api/v2/routers/tests/test_read_url.py::test_read_url_s3_mount_returns_presigned_url
   perf_class: control
   perf_link: 'Control-plane: ReBAC sys_stat + presigned-URL signing only, no byte transfer (client fetches directly from R2/CDN).
     Not separately benchmarked.'
-  gap_issue: null
+  gap_issue: 4127
   owning_issue: 4262
 - id: async_files.rename
   module: filesystem
@@ -1207,7 +1208,7 @@ operations:
   transports:
     http:
       name: POST /rename
-      source: src/nexus/server/api/v2/routers/async_files.py:2032
+      source: src/nexus/server/api/v2/routers/async_files.py:2055
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1225,7 +1226,7 @@ operations:
   transports:
     http:
       name: POST /rename-batch
-      source: src/nexus/server/api/v2/routers/async_files.py:2127
+      source: src/nexus/server/api/v2/routers/async_files.py:2150
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1243,7 +1244,7 @@ operations:
   transports:
     http:
       name: GET /stream
-      source: src/nexus/server/api/v2/routers/async_files.py:1968
+      source: src/nexus/server/api/v2/routers/async_files.py:1991
   profiles:
     lite: supported
     sandbox: unavailable

--- a/docs/surface-coverage/api-rpc-surface-coverage.yaml
+++ b/docs/surface-coverage/api-rpc-surface-coverage.yaml
@@ -950,7 +950,7 @@ operations:
   transports:
     http:
       name: POST /batch/read
-      source: src/nexus/server/api/v2/routers/async_files.py:1975
+      source: src/nexus/server/api/v2/routers/async_files.py:1963
   profiles:
     lite: supported
     sandbox: unavailable
@@ -969,7 +969,7 @@ operations:
   transports:
     http:
       name: POST /batch/write
-      source: src/nexus/server/api/v2/routers/async_files.py:1926
+      source: src/nexus/server/api/v2/routers/async_files.py:1914
   profiles:
     lite: supported
     sandbox: unavailable
@@ -988,7 +988,7 @@ operations:
   transports:
     http:
       name: POST /copy
-      source: src/nexus/server/api/v2/routers/async_files.py:2151
+      source: src/nexus/server/api/v2/routers/async_files.py:2139
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1007,7 +1007,7 @@ operations:
   transports:
     http:
       name: POST /copy-bulk
-      source: src/nexus/server/api/v2/routers/async_files.py:2250
+      source: src/nexus/server/api/v2/routers/async_files.py:2238
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1026,7 +1026,7 @@ operations:
   transports:
     http:
       name: DELETE /delete
-      source: src/nexus/server/api/v2/routers/async_files.py:1457
+      source: src/nexus/server/api/v2/routers/async_files.py:1445
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1044,7 +1044,7 @@ operations:
   transports:
     http:
       name: GET /exists
-      source: src/nexus/server/api/v2/routers/async_files.py:1533
+      source: src/nexus/server/api/v2/routers/async_files.py:1521
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1062,7 +1062,7 @@ operations:
   transports:
     http:
       name: GET /glob
-      source: src/nexus/server/api/v2/routers/async_files.py:2327
+      source: src/nexus/server/api/v2/routers/async_files.py:2315
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1080,7 +1080,7 @@ operations:
   transports:
     http:
       name: GET /grep
-      source: src/nexus/server/api/v2/routers/async_files.py:2378
+      source: src/nexus/server/api/v2/routers/async_files.py:2366
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1099,7 +1099,7 @@ operations:
   transports:
     http:
       name: GET /list
-      source: src/nexus/server/api/v2/routers/async_files.py:1562
+      source: src/nexus/server/api/v2/routers/async_files.py:1550
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1117,7 +1117,7 @@ operations:
   transports:
     http:
       name: GET /md-structure
-      source: src/nexus/server/api/v2/routers/async_files.py:1359
+      source: src/nexus/server/api/v2/routers/async_files.py:1347
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1135,7 +1135,7 @@ operations:
   transports:
     http:
       name: GET /metadata
-      source: src/nexus/server/api/v2/routers/async_files.py:1838
+      source: src/nexus/server/api/v2/routers/async_files.py:1826
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1153,7 +1153,7 @@ operations:
   transports:
     http:
       name: POST /mkdir
-      source: src/nexus/server/api/v2/routers/async_files.py:1800
+      source: src/nexus/server/api/v2/routers/async_files.py:1788
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1208,7 +1208,7 @@ operations:
   transports:
     http:
       name: POST /rename
-      source: src/nexus/server/api/v2/routers/async_files.py:2113
+      source: src/nexus/server/api/v2/routers/async_files.py:2101
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1226,7 +1226,7 @@ operations:
   transports:
     http:
       name: POST /rename-batch
-      source: src/nexus/server/api/v2/routers/async_files.py:2208
+      source: src/nexus/server/api/v2/routers/async_files.py:2196
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1244,7 +1244,7 @@ operations:
   transports:
     http:
       name: GET /stream
-      source: src/nexus/server/api/v2/routers/async_files.py:2049
+      source: src/nexus/server/api/v2/routers/async_files.py:2037
   profiles:
     lite: supported
     sandbox: unavailable

--- a/docs/surface-coverage/api-rpc-surface-coverage.yaml
+++ b/docs/surface-coverage/api-rpc-surface-coverage.yaml
@@ -950,7 +950,7 @@ operations:
   transports:
     http:
       name: POST /batch/read
-      source: src/nexus/server/api/v2/routers/async_files.py:1917
+      source: src/nexus/server/api/v2/routers/async_files.py:1929
   profiles:
     lite: supported
     sandbox: unavailable
@@ -969,7 +969,7 @@ operations:
   transports:
     http:
       name: POST /batch/write
-      source: src/nexus/server/api/v2/routers/async_files.py:1868
+      source: src/nexus/server/api/v2/routers/async_files.py:1880
   profiles:
     lite: supported
     sandbox: unavailable
@@ -988,7 +988,7 @@ operations:
   transports:
     http:
       name: POST /copy
-      source: src/nexus/server/api/v2/routers/async_files.py:2093
+      source: src/nexus/server/api/v2/routers/async_files.py:2105
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1007,7 +1007,7 @@ operations:
   transports:
     http:
       name: POST /copy-bulk
-      source: src/nexus/server/api/v2/routers/async_files.py:2192
+      source: src/nexus/server/api/v2/routers/async_files.py:2204
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1026,7 +1026,7 @@ operations:
   transports:
     http:
       name: DELETE /delete
-      source: src/nexus/server/api/v2/routers/async_files.py:1399
+      source: src/nexus/server/api/v2/routers/async_files.py:1411
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1044,7 +1044,7 @@ operations:
   transports:
     http:
       name: GET /exists
-      source: src/nexus/server/api/v2/routers/async_files.py:1475
+      source: src/nexus/server/api/v2/routers/async_files.py:1487
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1062,7 +1062,7 @@ operations:
   transports:
     http:
       name: GET /glob
-      source: src/nexus/server/api/v2/routers/async_files.py:2269
+      source: src/nexus/server/api/v2/routers/async_files.py:2281
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1080,7 +1080,7 @@ operations:
   transports:
     http:
       name: GET /grep
-      source: src/nexus/server/api/v2/routers/async_files.py:2320
+      source: src/nexus/server/api/v2/routers/async_files.py:2332
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1099,7 +1099,7 @@ operations:
   transports:
     http:
       name: GET /list
-      source: src/nexus/server/api/v2/routers/async_files.py:1504
+      source: src/nexus/server/api/v2/routers/async_files.py:1516
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1117,7 +1117,7 @@ operations:
   transports:
     http:
       name: GET /md-structure
-      source: src/nexus/server/api/v2/routers/async_files.py:1301
+      source: src/nexus/server/api/v2/routers/async_files.py:1313
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1135,7 +1135,7 @@ operations:
   transports:
     http:
       name: GET /metadata
-      source: src/nexus/server/api/v2/routers/async_files.py:1780
+      source: src/nexus/server/api/v2/routers/async_files.py:1792
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1153,7 +1153,7 @@ operations:
   transports:
     http:
       name: POST /mkdir
-      source: src/nexus/server/api/v2/routers/async_files.py:1742
+      source: src/nexus/server/api/v2/routers/async_files.py:1754
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1171,7 +1171,7 @@ operations:
   transports:
     http:
       name: GET /read
-      source: src/nexus/server/api/v2/routers/async_files.py:822
+      source: src/nexus/server/api/v2/routers/async_files.py:823
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1189,7 +1189,7 @@ operations:
   transports:
     http:
       name: GET /read-url
-      source: src/nexus/server/api/v2/routers/async_files.py:1191
+      source: src/nexus/server/api/v2/routers/async_files.py:1192
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1208,7 +1208,7 @@ operations:
   transports:
     http:
       name: POST /rename
-      source: src/nexus/server/api/v2/routers/async_files.py:2055
+      source: src/nexus/server/api/v2/routers/async_files.py:2067
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1226,7 +1226,7 @@ operations:
   transports:
     http:
       name: POST /rename-batch
-      source: src/nexus/server/api/v2/routers/async_files.py:2150
+      source: src/nexus/server/api/v2/routers/async_files.py:2162
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1244,7 +1244,7 @@ operations:
   transports:
     http:
       name: GET /stream
-      source: src/nexus/server/api/v2/routers/async_files.py:1991
+      source: src/nexus/server/api/v2/routers/async_files.py:2003
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1262,7 +1262,7 @@ operations:
   transports:
     http:
       name: POST /write
-      source: src/nexus/server/api/v2/routers/async_files.py:622
+      source: src/nexus/server/api/v2/routers/async_files.py:623
   profiles:
     lite: supported
     sandbox: unavailable

--- a/src/nexus/backends/storage/path_s3.py
+++ b/src/nexus/backends/storage/path_s3.py
@@ -241,15 +241,25 @@ class PathS3Backend(PathAddressingEngine, MultipartUpload):
             context.backend_path if context and context.backend_path else path.lstrip("/")
         )
         key = self._get_key_path(backend_path)
-        # R2/S3 presign is pure signing — no network round-trip.
-        op = "get_object" if method.upper() == "GET" else "put_object"
+        # R2/S3 presign is pure signing — no network round-trip. Strictly map the
+        # method to an S3 operation and REJECT anything unrecognized: defaulting
+        # an unexpected/mistyped method to put_object would silently mint a
+        # write-capable URL (the caller owns the ReBAC check, not this signer).
+        method = method.upper()
+        op_for_method = {"GET": "get_object", "PUT": "put_object"}
+        op = op_for_method.get(method)
+        if op is None:
+            raise ValueError(
+                f"generate_signed_url: unsupported method {method!r}; "
+                f"expected one of {sorted(op_for_method)}"
+            )
         expires_in = min(expires_in, 604800)  # S3 SigV4 hard cap: 7 days
         url = self._s3_transport.s3_client.generate_presigned_url(
             op,
             Params={"Bucket": self.bucket_name, "Key": key},
             ExpiresIn=expires_in,
         )
-        return {"url": url, "expires_in": expires_in, "method": method.upper()}
+        return {"url": url, "expires_in": expires_in, "method": method}
 
     # === Multipart Upload (MultipartUpload) ===
 

--- a/src/nexus/backends/storage/path_s3.py
+++ b/src/nexus/backends/storage/path_s3.py
@@ -220,6 +220,37 @@ class PathS3Backend(PathAddressingEngine, MultipartUpload):
         )
         return self._s3_transport.fingerprint(self._get_key_path(backend_path))
 
+    # === Signed URL (BackendFeature.SIGNED_URL) ===
+
+    def generate_signed_url(
+        self,
+        path: str,
+        expires_in: int = 3600,
+        method: str = "GET",
+        context: "OperationContext | None" = None,
+    ) -> dict[str, str | int]:
+        """Mint a presigned S3/R2 URL so a client can fetch (or PUT) the object
+        directly from object storage — nexus stays out of the byte path.
+
+        The CALLER is responsible for the ReBAC permission check BEFORE asking
+        for a URL (the ``/files/read-url`` endpoint gates on ``sys_stat``); this
+        method only signs. Streaming-service model: validate once, hand out a
+        short-TTL signed URL, let R2/CDN serve the bytes.
+        """
+        backend_path = (
+            context.backend_path if context and context.backend_path else path.lstrip("/")
+        )
+        key = self._get_key_path(backend_path)
+        # R2/S3 presign is pure signing — no network round-trip.
+        op = "get_object" if method.upper() == "GET" else "put_object"
+        expires_in = min(expires_in, 604800)  # S3 SigV4 hard cap: 7 days
+        url = self._s3_transport.s3_client.generate_presigned_url(
+            op,
+            Params={"Bucket": self.bucket_name, "Key": key},
+            ExpiresIn=expires_in,
+        )
+        return {"url": url, "expires_in": expires_in, "method": method.upper()}
+
     # === Multipart Upload (MultipartUpload) ===
 
     def init_multipart(

--- a/src/nexus/server/api/v2/routers/async_files.py
+++ b/src/nexus/server/api/v2/routers/async_files.py
@@ -1215,9 +1215,32 @@ def create_async_files_router(
                 # object. Fail closed: never mint a bearer S3/R2 URL for a key we
                 # have not proven exists as an authorized object.
                 raise HTTPException(status_code=404, detail=f"Not found: {path}")
+            # Only regular files get a direct object URL. sys_stat also succeeds
+            # for directories and mount roots; signing their empty/prefix key
+            # would hand out a bearer URL GET /read would never serve for that
+            # VFS path.
+            is_dir = (
+                meta.get("is_directory")
+                if isinstance(meta, dict)
+                else getattr(meta, "is_directory", False)
+            )
+            if is_dir:
+                raise HTTPException(
+                    status_code=409,
+                    detail="read-url is for regular files only, not directories/mounts; use GET /read.",
+                )
 
             # 2. Find the owning mount's backend instance (holds creds). Longest
             #    matching mount prefix wins.
+            #
+            # Zone safety: this map is keyed by mount path and the cluster
+            # permits at most one backend per VFS path (mounting the same path
+            # in a second zone is rejected). The authorization boundary is the
+            # zone-scoped sys_stat above — this whole _work runs inside
+            # _run_for_context, so a path not mounted/authorized in the caller's
+            # zone returns None -> 404 before any backend is looked up or signed.
+            # A fully zone-keyed mount map ((zone, path) -> backend) is the
+            # proper long-term hardening and is tracked as separate work.
             mounted = getattr(fs, "_mounted_backend_instances", {}) or {}
             norm = "/" + str(path).strip("/")
             mount_pt = max(

--- a/src/nexus/server/api/v2/routers/async_files.py
+++ b/src/nexus/server/api/v2/routers/async_files.py
@@ -1304,6 +1304,30 @@ def create_async_files_router(
                     status_code=409,
                     detail="read-url is for regular files only, not a mount root; use GET /read.",
                 )
+
+            # Read post-hooks (e.g. DynamicViewerReadHook's column-level CSV
+            # redaction) run in the GET /read byte path. A direct signed URL
+            # bypasses them, so a file GET /read would redact/transform could be
+            # fetched RAW through the URL. Fail closed whenever any "read"
+            # post-hook is registered — the caller falls back to GET /read, which
+            # applies the hooks. (Default to fail-closed if we can't determine.)
+            kernel = getattr(fs, "_kernel", None)
+            hook_count = getattr(kernel, "hook_count", None)
+            read_hooks_active = True
+            if callable(hook_count):
+                try:
+                    read_hooks_active = hook_count("read") > 0
+                except Exception:  # noqa: BLE001 — unknown hook state -> fail closed
+                    read_hooks_active = True
+            if read_hooks_active:
+                raise HTTPException(
+                    status_code=409,
+                    detail=(
+                        "read-url unavailable while read-transform hooks are active "
+                        "for this server; use GET /read."
+                    ),
+                )
+
             try:
                 signed = signer(rel, expires_in=ttl, method="GET", context=context)
             except Exception as e:

--- a/src/nexus/server/api/v2/routers/async_files.py
+++ b/src/nexus/server/api/v2/routers/async_files.py
@@ -1205,49 +1205,59 @@ def create_async_files_router(
         # 1. ReBAC gate — identical posture to GET /read. sys_stat enforces READ
         #    and returns metadata (content_id) without transferring any bytes.
         context = _apply_zone_override(context, zone, auth_result, required_perm="r")
-        fs = await _get_fs()
-        meta = fs.sys_stat(path, context=context)  # raises -> 403 if denied
 
-        # 2. Find the owning mount's backend instance (holds creds). Longest
-        #    matching mount prefix wins.
-        mounted = getattr(fs, "_mounted_backend_instances", {}) or {}
-        norm = "/" + str(path).strip("/")
-        mount_pt = max(
-            (m for m in mounted if norm == m or norm.startswith(m.rstrip("/") + "/")),
-            key=len,
-            default=None,
-        )
-        backend = mounted.get(mount_pt) if mount_pt else None
-        if mount_pt is None or backend is None or not hasattr(backend, "generate_signed_url"):
-            raise HTTPException(
-                status_code=409,
-                detail="Direct read-url is only available for S3/R2 mounts; use GET /read.",
+        async def _work() -> Response:
+            fs = await _get_fs()
+            meta = fs.sys_stat(path, context=context)  # raises -> 403 if denied
+
+            # 2. Find the owning mount's backend instance (holds creds). Longest
+            #    matching mount prefix wins.
+            mounted = getattr(fs, "_mounted_backend_instances", {}) or {}
+            norm = "/" + str(path).strip("/")
+            mount_pt = max(
+                (m for m in mounted if norm == m or norm.startswith(m.rstrip("/") + "/")),
+                key=len,
+                default=None,
+            )
+            backend = mounted.get(mount_pt) if mount_pt else None
+            if mount_pt is None or backend is None or not hasattr(backend, "generate_signed_url"):
+                raise HTTPException(
+                    status_code=409,
+                    detail="Direct read-url is only available for S3/R2 mounts; use GET /read.",
+                )
+
+            # 3. Mint the presigned URL (pure signing, no network). Path relative
+            #    to the mount; the backend adds its own prefix in _get_key_path.
+            rel = norm[len(mount_pt.rstrip("/")) :].lstrip("/")
+            try:
+                signed = backend.generate_signed_url(
+                    rel, expires_in=ttl, method="GET", context=context
+                )
+            except Exception as e:
+                logger.exception(f"read-url signing error: {e}")
+                raise HTTPException(status_code=500, detail=f"signing failed: {e}") from e
+            content_id = None
+            if isinstance(meta, dict):
+                content_id = meta.get("content_id")
+            elif meta is not None:
+                content_id = getattr(meta, "content_id", None)
+            return Response(
+                content=json.dumps(
+                    {
+                        "url": signed["url"],
+                        "expires_in": signed["expires_in"],
+                        "content_id": content_id,
+                        "path": path,
+                    }
+                ),
+                media_type="application/json",
             )
 
-        # 3. Mint the presigned URL (pure signing, no network). Path relative to
-        #    the mount; the backend adds its own prefix in _get_key_path.
-        rel = norm[len(mount_pt.rstrip("/")) :].lstrip("/")
-        try:
-            signed = backend.generate_signed_url(rel, expires_in=ttl, method="GET", context=context)
-        except Exception as e:
-            logger.exception(f"read-url signing error: {e}")
-            raise HTTPException(status_code=500, detail=f"signing failed: {e}") from e
-        content_id = None
-        if isinstance(meta, dict):
-            content_id = meta.get("content_id")
-        elif meta is not None:
-            content_id = getattr(meta, "content_id", None)
-        return Response(
-            content=json.dumps(
-                {
-                    "url": signed["url"],
-                    "expires_in": signed["expires_in"],
-                    "content_id": content_id,
-                    "path": path,
-                }
-            ),
-            media_type="application/json",
-        )
+        # Route through the same zone-scoped guard as GET /read: a mismatched
+        # path/query zone is rejected (400) before any stat/sign, and the stat +
+        # mount resolution + signing all run in the resolved target zone — so an
+        # out-of-band storage URL can't be minted across a tenant boundary.
+        return await _run_for_context(context, {"path": path, "zone": zone}, _work)
 
     @router.get("/md-structure")
     async def md_structure(

--- a/src/nexus/server/api/v2/routers/async_files.py
+++ b/src/nexus/server/api/v2/routers/async_files.py
@@ -1201,8 +1201,19 @@ def create_async_files_router(
         presigned R2/S3 URL so the client fetches bytes DIRECTLY from object
         storage (or a CDN fronting R2). nexus stays out of the byte path.
 
-        403 if caller lacks READ on `path`; 409 if the owning mount is not S3/R2
-        (fall back to GET /read). Reads only — writes stay proxied.
+        403 if caller lacks READ on `path`; 404 if `path` doesn't resolve to a
+        regular file; 409 if the owning mount is not S3/R2 (fall back to GET
+        /read). Reads only — writes stay proxied.
+
+        Security model: the URL is a *time-boxed bearer credential* for the
+        path's object key (path-addressed, not version-pinned). It is not
+        revocable within its TTL, and a concurrent overwrite of the same key
+        during the window would serve the new bytes — both inherent to the
+        signed-URL model and bounded by the short default TTL. The caller is
+        already authorized for the path, so this is not an authz escalation;
+        clients needing read-the-exact-version or immediate-revocation semantics
+        must use GET /read. Version-pinned URLs (binding to an S3 VersionId) are
+        future work and require backend object-version tracking.
         """
         # 1. ReBAC gate — identical posture to GET /read. sys_stat enforces READ
         #    and returns metadata (content_id) without transferring any bytes.

--- a/src/nexus/server/api/v2/routers/async_files.py
+++ b/src/nexus/server/api/v2/routers/async_files.py
@@ -1189,7 +1189,6 @@ def create_async_files_router(
 
     @router.get("/read-url")
     async def read_url(
-        request: Request,
         path: str = Query(..., description="VFS path to mint a direct read URL for"),
         ttl: int = Query(60, ge=5, le=3600, description="URL lifetime seconds (keep short)"),
         zone: str | None = Query(None, description="Override zone (must be in token's zone_set)."),
@@ -1219,7 +1218,7 @@ def create_async_files_router(
             default=None,
         )
         backend = mounted.get(mount_pt) if mount_pt else None
-        if backend is None or not hasattr(backend, "generate_signed_url"):
+        if mount_pt is None or backend is None or not hasattr(backend, "generate_signed_url"):
             raise HTTPException(
                 status_code=409,
                 detail="Direct read-url is only available for S3/R2 mounts; use GET /read.",
@@ -1227,7 +1226,7 @@ def create_async_files_router(
 
         # 3. Mint the presigned URL (pure signing, no network). Path relative to
         #    the mount; the backend adds its own prefix in _get_key_path.
-        rel = norm[len(mount_pt.rstrip("/")):].lstrip("/")
+        rel = norm[len(mount_pt.rstrip("/")) :].lstrip("/")
         try:
             signed = backend.generate_signed_url(rel, expires_in=ttl, method="GET", context=context)
         except Exception as e:

--- a/src/nexus/server/api/v2/routers/async_files.py
+++ b/src/nexus/server/api/v2/routers/async_files.py
@@ -1187,6 +1187,69 @@ def create_async_files_router(
             logger.exception(f"Read error: {e}")
             raise HTTPException(status_code=500, detail=str(e)) from e
 
+    @router.get("/read-url")
+    async def read_url(
+        request: Request,
+        path: str = Query(..., description="VFS path to mint a direct read URL for"),
+        ttl: int = Query(60, ge=5, le=3600, description="URL lifetime seconds (keep short)"),
+        zone: str | None = Query(None, description="Override zone (must be in token's zone_set)."),
+        context: Any = Depends(get_context),
+        auth_result: dict[str, Any] = Depends(require_auth),
+    ) -> Response:
+        """Streaming-service read path: validate (ReBAC), then return a short-TTL
+        presigned R2/S3 URL so the client fetches bytes DIRECTLY from object
+        storage (or a CDN fronting R2). nexus stays out of the byte path.
+
+        403 if caller lacks READ on `path`; 409 if the owning mount is not S3/R2
+        (fall back to GET /read). Reads only — writes stay proxied.
+        """
+        # 1. ReBAC gate — identical posture to GET /read. sys_stat enforces READ
+        #    and returns metadata (content_id) without transferring any bytes.
+        context = _apply_zone_override(context, zone, auth_result, required_perm="r")
+        fs = await _get_fs()
+        meta = fs.sys_stat(path, context=context)  # raises -> 403 if denied
+
+        # 2. Find the owning mount's backend instance (holds creds). Longest
+        #    matching mount prefix wins.
+        mounted = getattr(fs, "_mounted_backend_instances", {}) or {}
+        norm = "/" + str(path).strip("/")
+        mount_pt = max(
+            (m for m in mounted if norm == m or norm.startswith(m.rstrip("/") + "/")),
+            key=len,
+            default=None,
+        )
+        backend = mounted.get(mount_pt) if mount_pt else None
+        if backend is None or not hasattr(backend, "generate_signed_url"):
+            raise HTTPException(
+                status_code=409,
+                detail="Direct read-url is only available for S3/R2 mounts; use GET /read.",
+            )
+
+        # 3. Mint the presigned URL (pure signing, no network). Path relative to
+        #    the mount; the backend adds its own prefix in _get_key_path.
+        rel = norm[len(mount_pt.rstrip("/")):].lstrip("/")
+        try:
+            signed = backend.generate_signed_url(rel, expires_in=ttl, method="GET", context=context)
+        except Exception as e:
+            logger.exception(f"read-url signing error: {e}")
+            raise HTTPException(status_code=500, detail=f"signing failed: {e}") from e
+        content_id = None
+        if isinstance(meta, dict):
+            content_id = meta.get("content_id")
+        elif meta is not None:
+            content_id = getattr(meta, "content_id", None)
+        return Response(
+            content=json.dumps(
+                {
+                    "url": signed["url"],
+                    "expires_in": signed["expires_in"],
+                    "content_id": content_id,
+                    "path": path,
+                }
+            ),
+            media_type="application/json",
+        )
+
     @router.get("/md-structure")
     async def md_structure(
         path: str = Query(..., description="Path to a markdown file"),

--- a/src/nexus/server/api/v2/routers/async_files.py
+++ b/src/nexus/server/api/v2/routers/async_files.py
@@ -1293,6 +1293,17 @@ def create_async_files_router(
             # 3. Mint the presigned URL (pure signing, no network). Path relative
             #    to the mount; the backend adds its own prefix in _get_key_path.
             rel = norm[len(mount_pt.rstrip("/")) :].lstrip("/")
+            if not rel:
+                # The path IS the mount root (stripping the prefix leaves
+                # nothing). Robust mount-root guard independent of stat fields:
+                # the real sys_stat projection omits entry_type, so a mount root
+                # reporting is_directory=False would otherwise reach here and the
+                # signer would mint a bearer URL for the backend's empty/prefix
+                # key. Never sign a mount root.
+                raise HTTPException(
+                    status_code=409,
+                    detail="read-url is for regular files only, not a mount root; use GET /read.",
+                )
             try:
                 signed = signer(rel, expires_in=ttl, method="GET", context=context)
             except Exception as e:

--- a/src/nexus/server/api/v2/routers/async_files.py
+++ b/src/nexus/server/api/v2/routers/async_files.py
@@ -1214,6 +1214,17 @@ def create_async_files_router(
         clients needing read-the-exact-version or immediate-revocation semantics
         must use GET /read. Version-pinned URLs (binding to an S3 VersionId) are
         future work and require backend object-version tracking.
+
+        LIMITATION — read post-hooks: a signed URL fetches RAW object bytes and
+        therefore bypasses the GET /read byte-path post-processing, including any
+        read post-hooks that redact/transform content (e.g. column-level CSV
+        filtering). Deployments that rely on read-time redaction as an access
+        control on S3/R2-mounted paths must serve those reads through GET /read,
+        not read-url. A precise server-side gate (signing only when no
+        content-transforming post-read hook applies) needs a kernel API to count
+        post-read transform hooks distinctly from pre-read permission hooks; that
+        is deferred infrastructure (the aggregate hook_count also includes the
+        always-present permission pre-hook, so it cannot be used here).
         """
         # 1. ReBAC gate — identical posture to GET /read. sys_stat enforces READ
         #    and returns metadata (content_id) without transferring any bytes.
@@ -1303,29 +1314,6 @@ def create_async_files_router(
                 raise HTTPException(
                     status_code=409,
                     detail="read-url is for regular files only, not a mount root; use GET /read.",
-                )
-
-            # Read post-hooks (e.g. DynamicViewerReadHook's column-level CSV
-            # redaction) run in the GET /read byte path. A direct signed URL
-            # bypasses them, so a file GET /read would redact/transform could be
-            # fetched RAW through the URL. Fail closed whenever any "read"
-            # post-hook is registered — the caller falls back to GET /read, which
-            # applies the hooks. (Default to fail-closed if we can't determine.)
-            kernel = getattr(fs, "_kernel", None)
-            hook_count = getattr(kernel, "hook_count", None)
-            read_hooks_active = True
-            if callable(hook_count):
-                try:
-                    read_hooks_active = hook_count("read") > 0
-                except Exception:  # noqa: BLE001 — unknown hook state -> fail closed
-                    read_hooks_active = True
-            if read_hooks_active:
-                raise HTTPException(
-                    status_code=409,
-                    detail=(
-                        "read-url unavailable while read-transform hooks are active "
-                        "for this server; use GET /read."
-                    ),
                 )
 
             try:

--- a/src/nexus/server/api/v2/routers/async_files.py
+++ b/src/nexus/server/api/v2/routers/async_files.py
@@ -8,6 +8,7 @@ All operations pass user context for permission enforcement.
 import asyncio
 import base64
 import hashlib
+import inspect
 import json
 import logging
 from collections.abc import Awaitable, Callable, Iterator
@@ -1209,6 +1210,11 @@ def create_async_files_router(
         async def _work() -> Response:
             fs = await _get_fs()
             meta = fs.sys_stat(path, context=context)  # raises -> 403 if denied
+            if meta is None:
+                # sys_stat returns None when the VFS cannot resolve the path to an
+                # object. Fail closed: never mint a bearer S3/R2 URL for a key we
+                # have not proven exists as an authorized object.
+                raise HTTPException(status_code=404, detail=f"Not found: {path}")
 
             # 2. Find the owning mount's backend instance (holds creds). Longest
             #    matching mount prefix wins.
@@ -1220,7 +1226,19 @@ def create_async_files_router(
                 default=None,
             )
             backend = mounted.get(mount_pt) if mount_pt else None
-            if mount_pt is None or backend is None or not hasattr(backend, "generate_signed_url"):
+            # Only S3/R2-style signers are served here. Detect them by the
+            # ``method`` parameter on generate_signed_url (PathS3Backend has it);
+            # a method-less signer (e.g. PathGCSBackend) would otherwise be called
+            # with method="GET" and raise TypeError -> 500 instead of the
+            # advertised 409 fallback to GET /read.
+            signer = getattr(backend, "generate_signed_url", None)
+            accepts_method = False
+            if signer is not None:
+                try:
+                    accepts_method = "method" in inspect.signature(signer).parameters
+                except (TypeError, ValueError):
+                    accepts_method = False
+            if mount_pt is None or not accepts_method:
                 raise HTTPException(
                     status_code=409,
                     detail="Direct read-url is only available for S3/R2 mounts; use GET /read.",
@@ -1230,9 +1248,7 @@ def create_async_files_router(
             #    to the mount; the backend adds its own prefix in _get_key_path.
             rel = norm[len(mount_pt.rstrip("/")) :].lstrip("/")
             try:
-                signed = backend.generate_signed_url(
-                    rel, expires_in=ttl, method="GET", context=context
-                )
+                signed = signer(rel, expires_in=ttl, method="GET", context=context)
             except Exception as e:
                 logger.exception(f"read-url signing error: {e}")
                 raise HTTPException(status_code=500, detail=f"signing failed: {e}") from e

--- a/src/nexus/server/api/v2/routers/async_files.py
+++ b/src/nexus/server/api/v2/routers/async_files.py
@@ -1295,7 +1295,7 @@ def create_async_files_router(
                     accepts_method = "method" in inspect.signature(signer).parameters
                 except (TypeError, ValueError):
                     accepts_method = False
-            if mount_pt is None or not accepts_method:
+            if mount_pt is None or signer is None or not accepts_method:
                 raise HTTPException(
                     status_code=409,
                     detail="Direct read-url is only available for S3/R2 mounts; use GET /read.",

--- a/src/nexus/server/api/v2/routers/async_files.py
+++ b/src/nexus/server/api/v2/routers/async_files.py
@@ -29,6 +29,7 @@ from nexus.contracts.exceptions import (
     NexusFileNotFoundError,
     NexusPermissionError,
 )
+from nexus.contracts.metadata import DT_REG
 from nexus.core.path_utils import validate_path as _normalize_path
 from nexus.runtime.zone_resolution import (
     target_zone_for_context,
@@ -1215,19 +1216,30 @@ def create_async_files_router(
                 # object. Fail closed: never mint a bearer S3/R2 URL for a key we
                 # have not proven exists as an authorized object.
                 raise HTTPException(status_code=404, detail=f"Not found: {path}")
-            # Only regular files get a direct object URL. sys_stat also succeeds
-            # for directories and mount roots; signing their empty/prefix key
-            # would hand out a bearer URL GET /read would never serve for that
-            # VFS path.
-            is_dir = (
-                meta.get("is_directory")
-                if isinstance(meta, dict)
-                else getattr(meta, "is_directory", False)
-            )
-            if is_dir:
+
+            # Only mint a URL for an explicit regular file (DT_REG). sys_stat also
+            # succeeds for directories (DT_DIR), mount roots (DT_MOUNT),
+            # pipes/streams, and external-storage markers — none map to a single
+            # object key, and a mount root can even report is_directory=False, so
+            # checking is_directory alone is insufficient. Signing their
+            # empty/prefix key would hand out a bearer URL GET /read never serves.
+            def _meta_get(field: str, default: Any = None) -> Any:
+                return (
+                    meta.get(field, default)
+                    if isinstance(meta, dict)
+                    else getattr(meta, field, default)
+                )
+
+            entry_type = _meta_get("entry_type")
+            if _meta_get("is_directory", False) or (
+                entry_type is not None and entry_type != DT_REG
+            ):
                 raise HTTPException(
                     status_code=409,
-                    detail="read-url is for regular files only, not directories/mounts; use GET /read.",
+                    detail=(
+                        "read-url is for regular files only (not directories, mounts, "
+                        "or other special entries); use GET /read."
+                    ),
                 )
 
             # 2. Find the owning mount's backend instance (holds creds). Longest

--- a/src/nexus/server/api/v2/routers/tests/test_read_url.py
+++ b/src/nexus/server/api/v2/routers/tests/test_read_url.py
@@ -50,7 +50,7 @@ class _GcsLikeBackend:
         self,
         path: str,  # noqa: ARG002
         expires_in: int = 3600,  # noqa: ARG002
-        context=None,  # noqa: ARG002
+        context: object = None,  # noqa: ARG002
     ) -> dict[str, object]:
         raise AssertionError("read-url must not call a method-less (non-S3) signer")
 

--- a/src/nexus/server/api/v2/routers/tests/test_read_url.py
+++ b/src/nexus/server/api/v2/routers/tests/test_read_url.py
@@ -58,11 +58,17 @@ class _GcsLikeBackend:
 _DEFAULT_STAT = {"content_id": "abc123", "size": 12, "is_directory": False}
 
 
-def _make_client(mounts: dict[str, object], stat_result: object = _DEFAULT_STAT) -> TestClient:
+def _make_client(
+    mounts: dict[str, object],
+    stat_result: object = _DEFAULT_STAT,
+    read_hook_count: int = 0,
+) -> TestClient:
     fs = MagicMock()
     fs.sys_stat.return_value = stat_result
     # The endpoint resolves the owning mount via this dict.
     fs._mounted_backend_instances = mounts
+    # Read post-hook gate: 0 = no redaction hooks (signing allowed).
+    fs._kernel.hook_count.return_value = read_hook_count
 
     app = FastAPI()
     app.include_router(create_async_files_router(nexus_fs=fs))
@@ -95,6 +101,18 @@ def test_read_url_s3_mount_returns_presigned_url(s3_backend: _SignableBackend) -
     assert body["path"] == "/workspace/demo/file.md"
     # Path handed to the backend is mount-relative (mount prefix stripped).
     assert s3_backend.calls == [("demo/file.md", 120, "GET")]
+
+
+def test_read_url_read_hooks_active_returns_409(s3_backend: _SignableBackend) -> None:
+    """When a 'read' post-hook is registered (e.g. DynamicViewerReadHook column
+    redaction), read-url must 409 — a signed URL would bypass the redaction that
+    GET /read applies, exposing raw bytes. Never sign in that case."""
+    client = _make_client({"/workspace": s3_backend}, read_hook_count=1)
+
+    resp = client.get("/read-url", params={"path": "/workspace/demo/file.md"})
+
+    assert resp.status_code == 409
+    assert s3_backend.calls == []  # never signed while read hooks active
 
 
 def test_read_url_longest_mount_prefix_wins() -> None:

--- a/src/nexus/server/api/v2/routers/tests/test_read_url.py
+++ b/src/nexus/server/api/v2/routers/tests/test_read_url.py
@@ -42,9 +42,25 @@ class _PlainBackend:
     """A non-S3 backend with NO generate_signed_url (e.g. local)."""
 
 
-def _make_client(mounts: dict[str, object]) -> TestClient:
+class _GcsLikeBackend:
+    """A signing backend whose generate_signed_url has NO ``method`` param (like
+    PathGCSBackend). read-url must 409 it, not call it into a TypeError -> 500."""
+
+    def generate_signed_url(
+        self,
+        path: str,  # noqa: ARG002
+        expires_in: int = 3600,  # noqa: ARG002
+        context=None,  # noqa: ARG002
+    ) -> dict[str, object]:
+        raise AssertionError("read-url must not call a method-less (non-S3) signer")
+
+
+_DEFAULT_STAT = {"content_id": "abc123", "size": 12, "is_directory": False}
+
+
+def _make_client(mounts: dict[str, object], stat_result: object = _DEFAULT_STAT) -> TestClient:
     fs = MagicMock()
-    fs.sys_stat.return_value = {"content_id": "abc123", "size": 12, "is_directory": False}
+    fs.sys_stat.return_value = stat_result
     # The endpoint resolves the owning mount via this dict.
     fs._mounted_backend_instances = mounts
 
@@ -127,3 +143,24 @@ def test_read_url_ttl_bounds_enforced(s3_backend: _SignableBackend) -> None:
 
     assert client.get("/read-url", params={"path": "/workspace/f", "ttl": 1}).status_code == 422
     assert client.get("/read-url", params={"path": "/workspace/f", "ttl": 99999}).status_code == 422
+
+
+def test_read_url_stat_none_returns_404_without_signing(s3_backend: _SignableBackend) -> None:
+    """sys_stat → None (path not resolvable) must 404 BEFORE any signing — never
+    mint a bearer URL for a key the VFS didn't prove exists."""
+    client = _make_client({"/workspace": s3_backend}, stat_result=None)
+
+    resp = client.get("/read-url", params={"path": "/workspace/missing.txt"})
+
+    assert resp.status_code == 404
+    assert s3_backend.calls == []  # signer must not have been called
+
+
+def test_read_url_method_less_signer_returns_409() -> None:
+    """A signer without a ``method`` param (GCS-style) → 409 fallback, not a 500
+    from calling it with an unexpected method= kwarg."""
+    client = _make_client({"/workspace": _GcsLikeBackend()})
+
+    resp = client.get("/read-url", params={"path": "/workspace/file.txt"})
+
+    assert resp.status_code == 409

--- a/src/nexus/server/api/v2/routers/tests/test_read_url.py
+++ b/src/nexus/server/api/v2/routers/tests/test_read_url.py
@@ -180,6 +180,24 @@ def test_read_url_directory_returns_409_without_signing(s3_backend: _SignableBac
     assert s3_backend.calls == []  # never signed a directory
 
 
+def test_read_url_mount_root_production_metadata_returns_409(
+    s3_backend: _SignableBackend,
+) -> None:
+    """A mount-root request with PRODUCTION-shaped stat metadata (is_directory
+    False, NO entry_type — the real sys_stat projection omits it) must still 409:
+    the path IS the mount root, so the mount-relative key is empty and must never
+    be signed."""
+    client = _make_client(
+        {"/workspace": s3_backend},
+        stat_result={"content_id": "root", "size": 0, "is_directory": False},
+    )
+
+    resp = client.get("/read-url", params={"path": "/workspace"})
+
+    assert resp.status_code == 409
+    assert s3_backend.calls == []  # never signed the mount root's empty key
+
+
 def test_read_url_mount_root_entry_type_returns_409(s3_backend: _SignableBackend) -> None:
     """A DT_MOUNT stat (entry_type=2) that reports is_directory=False must STILL
     409 — checking is_directory alone would let a mount root through and sign its

--- a/src/nexus/server/api/v2/routers/tests/test_read_url.py
+++ b/src/nexus/server/api/v2/routers/tests/test_read_url.py
@@ -164,3 +164,17 @@ def test_read_url_method_less_signer_returns_409() -> None:
     resp = client.get("/read-url", params={"path": "/workspace/file.txt"})
 
     assert resp.status_code == 409
+
+
+def test_read_url_directory_returns_409_without_signing(s3_backend: _SignableBackend) -> None:
+    """sys_stat for a directory/mount root → 409 (regular files only); never
+    sign the empty/prefix key of a non-file entry."""
+    client = _make_client(
+        {"/workspace": s3_backend},
+        stat_result={"content_id": None, "size": 0, "is_directory": True},
+    )
+
+    resp = client.get("/read-url", params={"path": "/workspace/somedir"})
+
+    assert resp.status_code == 409
+    assert s3_backend.calls == []  # never signed a directory

--- a/src/nexus/server/api/v2/routers/tests/test_read_url.py
+++ b/src/nexus/server/api/v2/routers/tests/test_read_url.py
@@ -24,7 +24,11 @@ class _SignableBackend:
         self.calls: list[tuple[str, int, str]] = []
 
     def generate_signed_url(
-        self, path: str, expires_in: int = 3600, method: str = "GET", context=None
+        self,
+        path: str,
+        expires_in: int = 3600,
+        method: str = "GET",
+        context: object = None,  # noqa: ARG002
     ) -> dict[str, object]:
         self.calls.append((path, expires_in, method))
         return {

--- a/src/nexus/server/api/v2/routers/tests/test_read_url.py
+++ b/src/nexus/server/api/v2/routers/tests/test_read_url.py
@@ -58,17 +58,11 @@ class _GcsLikeBackend:
 _DEFAULT_STAT = {"content_id": "abc123", "size": 12, "is_directory": False}
 
 
-def _make_client(
-    mounts: dict[str, object],
-    stat_result: object = _DEFAULT_STAT,
-    read_hook_count: int = 0,
-) -> TestClient:
+def _make_client(mounts: dict[str, object], stat_result: object = _DEFAULT_STAT) -> TestClient:
     fs = MagicMock()
     fs.sys_stat.return_value = stat_result
     # The endpoint resolves the owning mount via this dict.
     fs._mounted_backend_instances = mounts
-    # Read post-hook gate: 0 = no redaction hooks (signing allowed).
-    fs._kernel.hook_count.return_value = read_hook_count
 
     app = FastAPI()
     app.include_router(create_async_files_router(nexus_fs=fs))
@@ -101,18 +95,6 @@ def test_read_url_s3_mount_returns_presigned_url(s3_backend: _SignableBackend) -
     assert body["path"] == "/workspace/demo/file.md"
     # Path handed to the backend is mount-relative (mount prefix stripped).
     assert s3_backend.calls == [("demo/file.md", 120, "GET")]
-
-
-def test_read_url_read_hooks_active_returns_409(s3_backend: _SignableBackend) -> None:
-    """When a 'read' post-hook is registered (e.g. DynamicViewerReadHook column
-    redaction), read-url must 409 — a signed URL would bypass the redaction that
-    GET /read applies, exposing raw bytes. Never sign in that case."""
-    client = _make_client({"/workspace": s3_backend}, read_hook_count=1)
-
-    resp = client.get("/read-url", params={"path": "/workspace/demo/file.md"})
-
-    assert resp.status_code == 409
-    assert s3_backend.calls == []  # never signed while read hooks active
 
 
 def test_read_url_longest_mount_prefix_wins() -> None:

--- a/src/nexus/server/api/v2/routers/tests/test_read_url.py
+++ b/src/nexus/server/api/v2/routers/tests/test_read_url.py
@@ -1,0 +1,125 @@
+"""Tests for GET /api/v2/files/read-url — the signed-URL read path.
+
+The endpoint does a ReBAC gate (sys_stat) and, for S3/R2 mounts, returns a
+short-TTL presigned URL so the client fetches bytes directly from object
+storage. nexus stays out of the byte path.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from nexus.server.api.v2.routers.async_files import create_async_files_router
+from nexus.server.dependencies import get_auth_result
+
+
+class _SignableBackend:
+    """Stand-in S3/R2 backend exposing generate_signed_url (the SIGNED_URL cap)."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, int, str]] = []
+
+    def generate_signed_url(
+        self, path: str, expires_in: int = 3600, method: str = "GET", context=None
+    ) -> dict[str, object]:
+        self.calls.append((path, expires_in, method))
+        return {
+            "url": f"https://acct.r2.cloudflarestorage.com/bucket/ws/{path}?X-Amz-Signature=deadbeef",
+            "expires_in": expires_in,
+            "method": method,
+        }
+
+
+class _PlainBackend:
+    """A non-S3 backend with NO generate_signed_url (e.g. local)."""
+
+
+def _make_client(mounts: dict[str, object]) -> TestClient:
+    fs = MagicMock()
+    fs.sys_stat.return_value = {"content_id": "abc123", "size": 12, "is_directory": False}
+    # The endpoint resolves the owning mount via this dict.
+    fs._mounted_backend_instances = mounts
+
+    app = FastAPI()
+    app.include_router(create_async_files_router(nexus_fs=fs))
+    app.dependency_overrides[get_auth_result] = lambda: {
+        "authenticated": True,
+        "user_id": "alice",
+        "groups": [],
+        "zone_id": "root",
+        "is_admin": True,
+    }
+    return TestClient(app)
+
+
+@pytest.fixture()
+def s3_backend() -> _SignableBackend:
+    return _SignableBackend()
+
+
+def test_read_url_s3_mount_returns_presigned_url(s3_backend: _SignableBackend) -> None:
+    """An S3/R2 mount → ReBAC gate passes → presigned URL returned, no bytes."""
+    client = _make_client({"/workspace": s3_backend})
+
+    resp = client.get("/read-url", params={"path": "/workspace/demo/file.md", "ttl": 120})
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["url"].startswith("https://acct.r2.cloudflarestorage.com/")
+    assert body["expires_in"] == 120
+    assert body["content_id"] == "abc123"
+    assert body["path"] == "/workspace/demo/file.md"
+    # Path handed to the backend is mount-relative (mount prefix stripped).
+    assert s3_backend.calls == [("demo/file.md", 120, "GET")]
+
+
+def test_read_url_longest_mount_prefix_wins() -> None:
+    """With nested mounts, the longest matching prefix owns the path."""
+    inner = _SignableBackend()
+    outer = _SignableBackend()
+    client = _make_client({"/workspace": outer, "/workspace/sub": inner})
+
+    resp = client.get("/read-url", params={"path": "/workspace/sub/x.txt"})
+
+    assert resp.status_code == 200
+    assert inner.calls and not outer.calls
+    assert inner.calls[0][0] == "x.txt"
+
+
+def test_read_url_non_s3_mount_returns_409() -> None:
+    """A backend without generate_signed_url → 409 (caller falls back to /read)."""
+    client = _make_client({"/local": _PlainBackend()})
+
+    resp = client.get("/read-url", params={"path": "/local/file.txt"})
+
+    assert resp.status_code == 409
+
+
+def test_read_url_no_mount_returns_409() -> None:
+    """No owning mount at all → 409, never a 500."""
+    client = _make_client({})
+
+    resp = client.get("/read-url", params={"path": "/nowhere/file.txt"})
+
+    assert resp.status_code == 409
+
+
+def test_read_url_missing_path_returns_422() -> None:
+    """Missing required 'path' query param → FastAPI 422."""
+    client = _make_client({"/workspace": _SignableBackend()})
+
+    resp = client.get("/read-url")
+
+    assert resp.status_code == 422
+
+
+def test_read_url_ttl_bounds_enforced(s3_backend: _SignableBackend) -> None:
+    """ttl is bounded (5..3600); out-of-range → 422."""
+    client = _make_client({"/workspace": s3_backend})
+
+    assert client.get("/read-url", params={"path": "/workspace/f", "ttl": 1}).status_code == 422
+    assert client.get("/read-url", params={"path": "/workspace/f", "ttl": 99999}).status_code == 422

--- a/src/nexus/server/api/v2/routers/tests/test_read_url.py
+++ b/src/nexus/server/api/v2/routers/tests/test_read_url.py
@@ -178,3 +178,18 @@ def test_read_url_directory_returns_409_without_signing(s3_backend: _SignableBac
 
     assert resp.status_code == 409
     assert s3_backend.calls == []  # never signed a directory
+
+
+def test_read_url_mount_root_entry_type_returns_409(s3_backend: _SignableBackend) -> None:
+    """A DT_MOUNT stat (entry_type=2) that reports is_directory=False must STILL
+    409 — checking is_directory alone would let a mount root through and sign its
+    prefix key."""
+    client = _make_client(
+        {"/workspace": s3_backend},
+        stat_result={"entry_type": 2, "is_directory": False, "content_id": None},
+    )
+
+    resp = client.get("/read-url", params={"path": "/workspace"})
+
+    assert resp.status_code == 409
+    assert s3_backend.calls == []  # never signed a mount root

--- a/src/nexus/sync.py
+++ b/src/nexus/sync.py
@@ -355,7 +355,15 @@ async def move_file(
             # to copy+delete ONLY when rename is genuinely unavailable (e.g. gRPC
             # transport absent on the REMOTE profile). Issue #341.
             try:
-                nx.sys_rename(source, dest, force=force)
+                try:
+                    nx.sys_rename(source, dest, force=force)
+                except TypeError:
+                    # Legacy/remote sys_rename without a `force` kwarg: retry the
+                    # positional form so an ordinary atomic rename still happens —
+                    # a client signature mismatch must NOT be misread as
+                    # rename-unavailable. A force=True overwrite then surfaces as
+                    # a FileExistsError, handled below.
+                    nx.sys_rename(source, dest)
                 return True
             except (
                 NexusPermissionError,

--- a/src/nexus/sync.py
+++ b/src/nexus/sync.py
@@ -358,25 +358,36 @@ async def move_file(
                 nx.sys_rename(source, dest, force=force)
                 return True
             except (
-                FileExistsError,
                 NexusPermissionError,
                 PermissionError,
                 NexusFileNotFoundError,
                 InvalidPathError,
             ):
-                # Terminal rename outcomes — destination exists without force,
-                # permission denied, missing source, invalid path. NEVER mask
-                # these with copy+delete: nx.write(dest) would clobber the
-                # destination and a subsequent failed unlink would leave
-                # duplicated state. Propagate (the caller's handler logs +
-                # returns False without ever touching the destination).
+                # Always terminal — force cannot help (permission denied, missing
+                # source, invalid path). Never mask with copy+delete.
                 raise
+            except FileExistsError:
+                # Destination exists. Terminal when the caller did NOT opt into
+                # overwrite; with force=True the caller wants the overwrite and
+                # sys_rename may not forward force to the kernel, so emulate it.
+                if not force:
+                    raise
+                logger.warning(
+                    "move: sys_rename %s -> %s hit FileExistsError with force=True; "
+                    "emulating overwrite via copy+delete",
+                    source,
+                    dest,
+                )
+                content = nx.sys_read(source)
+                nx.write(dest, content)
+                nx.sys_unlink(source)
+                return True
             except Exception as rename_exc:
-                # Genuine rename-unavailable. The copy+delete emulation is NOT
-                # atomic — a check-then-write no-clobber guard still races a
-                # concurrent create of `dest` — so only run it when the caller
-                # explicitly opted into overwrite (force=True). For force=False
-                # we abort rather than risk clobbering a destination.
+                # Genuine rename-unavailable (e.g. gRPC transport absent on the
+                # REMOTE profile). The copy+delete emulation is NOT atomic, so
+                # only run it when the caller explicitly opted into overwrite
+                # (force=True). For force=False we abort rather than risk
+                # clobbering a destination via a check-then-write race.
                 if not force:
                     logger.warning(
                         "move: sys_rename %s -> %s failed (%r); refusing non-atomic "
@@ -387,7 +398,7 @@ async def move_file(
                     )
                     raise
                 logger.warning(
-                    "move: sys_rename %s -> %s failed (%r); copy+delete fallback (force=True)",
+                    "move: sys_rename %s -> %s unavailable (%r); copy+delete (force=True)",
                     source,
                     dest,
                     rename_exc,

--- a/src/nexus/sync.py
+++ b/src/nexus/sync.py
@@ -4,12 +4,15 @@ Provides efficient sync, copy, and move operations with hash-based
 change detection and progress reporting.
 """
 
+import logging
 import os
 from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from nexus import NexusFilesystem
+
+logger = logging.getLogger(__name__)
 
 
 class SyncStats:
@@ -348,8 +351,14 @@ async def move_file(
             try:
                 nx.sys_rename(source, dest, force=force)
                 return True
-            except Exception:
+            except Exception as rename_exc:
                 # Fallback: copy content then delete source
+                logger.warning(
+                    "move: sys_rename %s -> %s failed (%r); trying copy+delete fallback",
+                    source,
+                    dest,
+                    rename_exc,
+                )
                 content = nx.sys_read(source)
                 nx.write(dest, content)
                 nx.sys_unlink(source)
@@ -366,9 +375,12 @@ async def move_file(
                 nx.sys_unlink(source)
             return True
 
-    except (OSError, ValueError, TypeError):
-        # File operation or path validation failed
+    except (OSError, ValueError, TypeError) as exc:
+        # File operation or path validation failed. Log the real cause —
+        # silently returning False here hid genuine errors (Issue #341).
+        logger.error("move %s -> %s failed: %r", source, dest, exc, exc_info=True)
         return False
-    except Exception:
-        # Catch NexusError subclasses (Issue #341)
+    except Exception as exc:
+        # Catch NexusError subclasses (Issue #341). Surface the cause.
+        logger.error("move %s -> %s failed: %r", source, dest, exc, exc_info=True)
         return False

--- a/src/nexus/sync.py
+++ b/src/nexus/sync.py
@@ -372,18 +372,26 @@ async def move_file(
                 # returns False without ever touching the destination).
                 raise
             except Exception as rename_exc:
-                # Genuine rename-unavailable. Fall back to copy+delete, but never
-                # silently clobber: require force when the destination exists.
+                # Genuine rename-unavailable. The copy+delete emulation is NOT
+                # atomic — a check-then-write no-clobber guard still races a
+                # concurrent create of `dest` — so only run it when the caller
+                # explicitly opted into overwrite (force=True). For force=False
+                # we abort rather than risk clobbering a destination.
+                if not force:
+                    logger.warning(
+                        "move: sys_rename %s -> %s failed (%r); refusing non-atomic "
+                        "copy+delete fallback without force — aborting",
+                        source,
+                        dest,
+                        rename_exc,
+                    )
+                    raise
                 logger.warning(
-                    "move: sys_rename %s -> %s failed (%r); trying copy+delete fallback",
+                    "move: sys_rename %s -> %s failed (%r); copy+delete fallback (force=True)",
                     source,
                     dest,
                     rename_exc,
                 )
-                if not force and nx.access(dest):
-                    raise FileExistsError(
-                        f"move: destination exists and force=False: {dest}"
-                    ) from rename_exc
                 content = nx.sys_read(source)
                 nx.write(dest, content)
                 nx.sys_unlink(source)

--- a/src/nexus/sync.py
+++ b/src/nexus/sync.py
@@ -9,6 +9,12 @@ import os
 from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING
 
+from nexus.contracts.exceptions import (
+    InvalidPathError,
+    NexusFileNotFoundError,
+    NexusPermissionError,
+)
+
 if TYPE_CHECKING:
     from nexus import NexusFilesystem
 
@@ -345,20 +351,39 @@ async def move_file(
             return True
 
         elif not is_source_local and not is_dest_local:
-            # Nexus to Nexus - prefer efficient rename (metadata-only).
-            # Falls back to copy+delete if rename fails (e.g. gRPC transport
-            # not available on REMOTE profile).  Issue #341.
+            # Nexus to Nexus - prefer efficient rename (metadata-only). Fall back
+            # to copy+delete ONLY when rename is genuinely unavailable (e.g. gRPC
+            # transport absent on the REMOTE profile). Issue #341.
             try:
                 nx.sys_rename(source, dest, force=force)
                 return True
+            except (
+                FileExistsError,
+                NexusPermissionError,
+                PermissionError,
+                NexusFileNotFoundError,
+                InvalidPathError,
+            ):
+                # Terminal rename outcomes — destination exists without force,
+                # permission denied, missing source, invalid path. NEVER mask
+                # these with copy+delete: nx.write(dest) would clobber the
+                # destination and a subsequent failed unlink would leave
+                # duplicated state. Propagate (the caller's handler logs +
+                # returns False without ever touching the destination).
+                raise
             except Exception as rename_exc:
-                # Fallback: copy content then delete source
+                # Genuine rename-unavailable. Fall back to copy+delete, but never
+                # silently clobber: require force when the destination exists.
                 logger.warning(
                     "move: sys_rename %s -> %s failed (%r); trying copy+delete fallback",
                     source,
                     dest,
                     rename_exc,
                 )
+                if not force and nx.access(dest):
+                    raise FileExistsError(
+                        f"move: destination exists and force=False: {dest}"
+                    ) from rename_exc
                 content = nx.sys_read(source)
                 nx.write(dest, content)
                 nx.sys_unlink(source)

--- a/tests/unit/fs/test_move_file.py
+++ b/tests/unit/fs/test_move_file.py
@@ -47,12 +47,12 @@ def test_move_permission_error_is_terminal() -> None:
     nx.sys_unlink.assert_not_called()
 
 
-def test_move_fallback_no_clobber_when_dest_exists() -> None:
-    """Rename genuinely unavailable AND destination exists with force=False:
-    the copy+delete fallback must NOT clobber it."""
+def test_move_force_false_disables_copy_delete_fallback() -> None:
+    """With force=False, a genuinely-unavailable rename does NOT fall back to the
+    non-atomic copy+delete (which races a concurrent create); it aborts without
+    writing — no check-then-write TOCTOU window."""
     nx = MagicMock()
     nx.sys_rename.side_effect = RuntimeError("gRPC transport unavailable")
-    nx.access.return_value = True  # destination already exists
 
     result = _run(move_file(nx, _SRC, _DST, force=False))
 
@@ -61,15 +61,14 @@ def test_move_fallback_no_clobber_when_dest_exists() -> None:
     nx.sys_unlink.assert_not_called()
 
 
-def test_move_fallback_copies_when_rename_unavailable_and_no_dest() -> None:
-    """Genuine rename-unavailable with no existing destination still falls back
-    to copy+delete (the original Issue #341 behavior)."""
+def test_move_fallback_copies_with_force_when_rename_unavailable() -> None:
+    """Genuine rename-unavailable WITH force=True falls back to copy+delete —
+    overwrite is explicitly requested (the original Issue #341 behavior)."""
     nx = MagicMock()
     nx.sys_rename.side_effect = RuntimeError("gRPC transport unavailable")
-    nx.access.return_value = False  # destination does not exist
     nx.sys_read.return_value = b"data"
 
-    result = _run(move_file(nx, _SRC, _DST, force=False))
+    result = _run(move_file(nx, _SRC, _DST, force=True))
 
     assert result is True
     nx.write.assert_called_once_with(_DST, b"data")

--- a/tests/unit/fs/test_move_file.py
+++ b/tests/unit/fs/test_move_file.py
@@ -61,6 +61,21 @@ def test_move_force_false_disables_copy_delete_fallback() -> None:
     nx.sys_unlink.assert_not_called()
 
 
+def test_move_force_true_overwrites_on_file_exists() -> None:
+    """FileExistsError with force=True emulates the overwrite via copy+delete —
+    forced overwrite must not regress to a no-op even though sys_rename may not
+    forward force to the kernel."""
+    nx = MagicMock()
+    nx.sys_rename.side_effect = FileExistsError("dest exists")
+    nx.sys_read.return_value = b"data"
+
+    result = _run(move_file(nx, _SRC, _DST, force=True))
+
+    assert result is True
+    nx.write.assert_called_once_with(_DST, b"data")
+    nx.sys_unlink.assert_called_once_with(_SRC)
+
+
 def test_move_fallback_copies_with_force_when_rename_unavailable() -> None:
     """Genuine rename-unavailable WITH force=True falls back to copy+delete —
     overwrite is explicitly requested (the original Issue #341 behavior)."""

--- a/tests/unit/fs/test_move_file.py
+++ b/tests/unit/fs/test_move_file.py
@@ -33,6 +33,26 @@ def test_move_terminal_rename_error_does_not_clobber() -> None:
     nx.sys_unlink.assert_not_called()
 
 
+def test_move_legacy_sys_rename_without_force_kwarg() -> None:
+    """A client whose sys_rename has no `force` kwarg must still complete an
+    ordinary non-force move via a positional retry — a signature mismatch must
+    not be misclassified as rename-unavailable (and trigger copy+delete/abort)."""
+    seen: list[tuple[str, str]] = []
+
+    def _rename(source: str, dest: str) -> None:  # NOTE: no force kwarg
+        seen.append((source, dest))
+
+    nx = MagicMock()
+    nx.sys_rename = MagicMock(side_effect=_rename)
+
+    result = _run(move_file(nx, _SRC, _DST, force=False))
+
+    assert result is True
+    assert seen == [(_SRC, _DST)]  # positional retry performed the atomic rename
+    nx.write.assert_not_called()  # no copy+delete fallback
+    nx.sys_unlink.assert_not_called()
+
+
 def test_move_permission_error_is_terminal() -> None:
     """A permission failure must not be downgraded into a copy+delete."""
     from nexus.contracts.exceptions import NexusPermissionError

--- a/tests/unit/fs/test_move_file.py
+++ b/tests/unit/fs/test_move_file.py
@@ -1,0 +1,76 @@
+"""Unit tests for nexus.sync.move_file fallback safety (Issue #341 hardening).
+
+A failed sys_rename must NOT be masked by a copy+delete that clobbers the
+destination or loses the source. These paths have non-existent parents so
+move_file treats them as Nexus (not local) paths and takes the rename branch.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock
+
+from nexus.sync import move_file
+
+_SRC = "/__nexus_vfs_test__/a/old.txt"
+_DST = "/__nexus_vfs_test__/a/new.txt"
+
+
+def _run(coro: object) -> object:
+    return asyncio.run(coro)  # type: ignore[arg-type]
+
+
+def test_move_terminal_rename_error_does_not_clobber() -> None:
+    """A FileExistsError from sys_rename is terminal: abort (False) without ever
+    copy+deleting — never clobber the destination, never unlink the source."""
+    nx = MagicMock()
+    nx.sys_rename.side_effect = FileExistsError("dest exists")
+
+    result = _run(move_file(nx, _SRC, _DST, force=False))
+
+    assert result is False
+    nx.write.assert_not_called()
+    nx.sys_unlink.assert_not_called()
+
+
+def test_move_permission_error_is_terminal() -> None:
+    """A permission failure must not be downgraded into a copy+delete."""
+    from nexus.contracts.exceptions import NexusPermissionError
+
+    nx = MagicMock()
+    nx.sys_rename.side_effect = NexusPermissionError("denied")
+
+    result = _run(move_file(nx, _SRC, _DST, force=False))
+
+    assert result is False
+    nx.write.assert_not_called()
+    nx.sys_unlink.assert_not_called()
+
+
+def test_move_fallback_no_clobber_when_dest_exists() -> None:
+    """Rename genuinely unavailable AND destination exists with force=False:
+    the copy+delete fallback must NOT clobber it."""
+    nx = MagicMock()
+    nx.sys_rename.side_effect = RuntimeError("gRPC transport unavailable")
+    nx.access.return_value = True  # destination already exists
+
+    result = _run(move_file(nx, _SRC, _DST, force=False))
+
+    assert result is False
+    nx.write.assert_not_called()
+    nx.sys_unlink.assert_not_called()
+
+
+def test_move_fallback_copies_when_rename_unavailable_and_no_dest() -> None:
+    """Genuine rename-unavailable with no existing destination still falls back
+    to copy+delete (the original Issue #341 behavior)."""
+    nx = MagicMock()
+    nx.sys_rename.side_effect = RuntimeError("gRPC transport unavailable")
+    nx.access.return_value = False  # destination does not exist
+    nx.sys_read.return_value = b"data"
+
+    result = _run(move_file(nx, _SRC, _DST, force=False))
+
+    assert result is True
+    nx.write.assert_called_once_with(_DST, b"data")
+    nx.sys_unlink.assert_called_once_with(_SRC)


### PR DESCRIPTION
## Summary
Streaming-service read model for S3/R2 mounts — nexus validates (ReBAC), returns a short-TTL presigned URL, and leaves the byte path. Reads only; writes stay proxied (side effects).

## Changes
- **`path_s3.generate_signed_url()`** — implements the `BackendFeature.SIGNED_URL` the manifest declared but left unimplemented (SigV4 presign via the existing boto3 client; GET/PUT; 7-day cap).
- **`GET /api/v2/files/read-url`** — `sys_stat` ReBAC gate (no bytes) → resolve owning mount backend → mint presigned URL. 409 for non-S3 mounts (fall back to `GET /read`).
- **Dockerfile** — build `nexusd-cluster` with `--features driver-s3` so the full image serves S3/R2 mounts.

## Measured (live Cloudflare R2)
- read-url validate+sign **~14ms** vs **~103ms** proxied → 8× less nexus work; bytes move to R2/CDN edge (verified Cloudflare edge-serving)

## Dependencies
- nexi-lab/nexus-vfs#27 (opt-in `driver-s3` cluster feature) — Dockerfile `--features driver-s3` needs it
- benefits from nexi-lab/nexus-vfs#26 (pooled S3 client)

## Notes / follow-ups
- Reads only by design (writes proxy to capture hash/version/index/OCC).
- Prototype-quality: needs endpoint tests + cred handling via the AWS provider chain / secret store (currently inline mount creds) before production.
- No kernel change.