### PR TITLE
docs(runbook) + test(e2e): align bootstrap-mode contract with validator

### DIFF
--- a/docs/architecture/federation-cross-machine-runbook.md
+++ b/docs/architecture/federation-cross-machine-runbook.md
@@ -178,7 +178,7 @@ Windows extra: open a Developer Command Prompt for VS Build Tools first so `cl.e
 
 Key contract rules:
 
-* **`--bootstrap-mode` is required when federation is in play** (PR #4028).  Pass `static` for first boot, `restart` for resuming persisted state, `dynamic` only for runtime-API-driven setups.
+* **`--bootstrap-mode` is required when federation is in play** (PR #4028).  Pass `static` for env-driven topology (`NEXUS_FEDERATION_*` carry the cluster shape, used across first boot and subsequent container restarts), `restart` for operator-managed resume where persisted ConfState is the source of truth (no env needed), `dynamic` for runtime-API-driven setups.
 * **`--peers` lists only the *other* machines.**  Self-listed peers are rejected at parse (PR #4014).
 * **`NEXUS_HOSTNAME` should be the node's Tailscale IP** for unambiguous self-detection across machines.
 * **`NEXUS_DATA_DIR` and `--data-dir` must point to the same directory.**
@@ -354,7 +354,7 @@ The choices below are stable invariants of the design.  Each ties back to a spec
 
 * **Node IDs are opaque random `u64`.**  Minted on first boot, persisted to `<data-dir>/.node_id` (PR #3996).  Wipe-rejoin mints a fresh ID; the old ID stays in ConfState as a ghost.  Hostname is *not* part of the identity — that's what lets a single host re-register cleanly after disk wipe.
 * **`--peers` lists only the *other* nodes** (PR #4014).  Self-in-peers is a parse error.  Self enters the cluster through `create_zone` (founder path) or AddNode-on-leader (joiner path), never via env.
-* **Bootstrap mode is explicit** (PR #4028).  Operator must declare `static` / `restart` / `dynamic` at boot.  A validator runs at startup and rejects state × flag combinations that don't match the declared mode (e.g. `restart` on an empty data dir, `static` on a non-empty one).
+* **Bootstrap mode is explicit** (PR #4028).  Operator declares `static` / `restart` / `dynamic` at boot.  A validator at startup rejects state × flag combinations that contradict the declared mode (e.g. `restart` on an empty data dir, or `dynamic` on a non-empty one); `static` accepts any data-dir state by design so the same env safely covers both first boot and container restart, with `bootstrap_or_join_zone` resuming from persisted ConfState when it finds one.
 * **DT_MOUNT entries live in the *parent* zone's raft state.**  Both `share --mount-at` and `join` write DT_MOUNT via `propose_set_metadata` on the parent zone (PR #4293).  Each node has its own local root zone with its own DT_MOUNT entries — symmetric semantics either side; nodes don't need to share root-zone membership.
 * **Federation cross-node read uses a two-Arc round-trip** (PR #4294).
   1. Write side records `last_writer_address = <self_address>` on every entry's metadata.
@@ -389,8 +389,8 @@ The choices below are stable invariants of the design.  Each ties back to a spec
 | Symptom | Cause | Fix |
 |---|---|---|
 | `NEXUS_BOOTSTRAP_MODE is required when bootstrapping federation` | Missing `--bootstrap-mode` flag | Pass `static`, `restart`, or `dynamic` |
-| `bootstrap mode = static, but data dir already holds a 'root' zone` | Re-bootstrapping a non-empty data dir | Pass `--bootstrap-mode restart`, or wipe the data dir |
-| `bootstrap mode = dynamic forbids NEXUS_BOOTSTRAP_NEW / NEXUS_PEERS` | Mode mismatch | Drop the env/flag or switch to `static` |
+| `bootstrap mode = dynamic, but data dir already holds a 'root' zone` | Dynamic mode requires a fresh data dir; persisted state is reserved for static or restart | Pass `--bootstrap-mode restart` to resume persisted state, or wipe the data dir to start over |
+| `bootstrap mode = dynamic forbids NEXUS_BOOTSTRAP_NEW / NEXUS_PEERS` | Dynamic mode is runtime-API driven; cluster shape arrives via `share` / `join` RPCs, not env | Drop the env/flag, or switch to `--bootstrap-mode static` |
 | `bootstrap mode = restart, but data dir is empty` | First-time boot with `restart` | Use `static` for the first boot |
 | `bootstrap mode = restart forbids NEXUS_PEERS / --peers` | Passing peers under `restart` | Drop the flag — persisted ConfState carries the address book |
 

--- a/tests/e2e/docker/test_federation_runbook.py
+++ b/tests/e2e/docker/test_federation_runbook.py
@@ -969,42 +969,29 @@ class TestRunbookOperatorErgonomics:
             f"\nstdout/stderr: {combined[-2000:]}"
         )
 
-    def test_static_mode_rejects_existing_data_dir(
+    def test_dynamic_mode_rejects_existing_data_dir(
         self,
         topology: RunbookTopology,
     ) -> None:
-        """`--bootstrap-mode static` + NEXUS_BOOTSTRAP_NEW=1 on a data
-        dir that already holds a `root` zone must fail with the
-        documented validator error.
+        """`--bootstrap-mode dynamic` on a data dir that already holds
+        a `root` zone must fail with the documented validator error.
 
-        Pins the PR #4028 validator state-x-flag rejection.  Runbook
-        troubleshooting:
-          `bootstrap mode = static, but data dir already holds a
-          'root' zone` | Re-bootstrapping a non-empty data dir | …
-        NEXUS_BOOTSTRAP_NEW=1 + `--bootstrap-mode static` on a
-        non-empty dir IS exactly the "re-bootstrap a fresh cluster on
-        live state" scenario the runbook says the validator must
-        reject.
+        Pins PR #4028's dynamic-mode state-x-flag rejection.  Dynamic
+        mode is runtime-API driven (cluster shape arrives via
+        `share` / `join` RPCs), so persisted state would conflict
+        with the model.  The validator emits
+        `bootstrap mode = dynamic, but data dir already holds a
+        'root' zone` and the binary exits before opening any port.
 
-        CI shows the validator currently LOGS "validated" for this
-        combination instead of rejecting it (verified output:
-        `bootstrap mode validated mode="static" bootstrap_new=true
-        peers_non_empty=false data_dir_has_root=true`).  The daemon
-        then proceeds to mount host-fs and load node_id, never
-        emitting the documented error.  Upstream bug in PR #4028's
-        validator on nexus-vfs main HEAD.
-
-        xfail until upstream lands a fix.  When the validator
-        correctly rejects, this test XPASSes and prompts removal of
-        the xfail.
+        Probes against the joiner's existing /app/data, which has a
+        root zone from the joiner's first-boot static topology — no
+        joined_cluster fixture needed.
         """
         from tests.e2e.docker.runbook_helpers import docker_exec
 
         result = docker_exec(
             topology.joiner_container,
             [
-                "env",
-                "NEXUS_BOOTSTRAP_NEW=1",
                 "timeout",
                 "5",
                 "nexusd-cluster",
@@ -1016,7 +1003,7 @@ class TestRunbookOperatorErgonomics:
                 "/app/data",
                 "--no-tls",
                 "--bootstrap-mode",
-                "static",
+                "dynamic",
             ],
             timeout=20,
         )
@@ -1024,37 +1011,19 @@ class TestRunbookOperatorErgonomics:
 
         # tracing's structured fields embed ANSI escape codes between
         # every key/value when stdout is a tty (which `docker exec`
-        # makes it).  Strip them before substring checks so the
-        # validator-bypass signature ("mode=\"static\" bootstrap_new=true
-        # data_dir_has_root=true") actually matches as written.
+        # makes it).  Strip them before substring checks.
         combined = re.sub(r"\x1b\[[0-9;]*m", "", result.stdout + result.stderr)
         lowered = combined.lower()
-        validator_accepted = (
-            "bootstrap mode validated" in combined
-            and 'mode="static"' in combined
-            and "bootstrap_new=true" in combined
-            and "data_dir_has_root=true" in combined
-        )
-        if validator_accepted:
-            pytest.xfail(
-                "nexus-vfs PR #4028 validator upstream regression: "
-                '`bootstrap mode validated mode="static" bootstrap_new=true '
-                "data_dir_has_root=true` — should reject per runbook but "
-                "logs 'validated' and proceeds.  Operator-error path is "
-                "structurally unprotected until upstream fixes the "
-                "validator's state-x-flag matrix.\n"
-                f"stdout/stderr: {combined[-2000:]}"
-            )
         assert result.rc != 0, (
-            "`nexusd-cluster --bootstrap-mode static` + NEXUS_BOOTSTRAP_NEW=1 "
-            "on a non-empty data dir did NOT fail — PR #4028 state-x-flag "
-            f"validator was bypassed.\nstdout/stderr: {combined[-2000:]}"
+            "`nexusd-cluster --bootstrap-mode dynamic` on a non-empty data dir "
+            "did NOT fail — PR #4028 state-x-flag validator was bypassed."
+            f"\nstdout/stderr: {combined[-2000:]}"
         )
-        assert "static" in lowered and (
-            "already" in lowered or "non-empty" in lowered or "exist" in lowered
+        assert "dynamic" in lowered and (
+            "already" in lowered or "fresh" in lowered or "wipe" in lowered
         ), (
-            "validator error message did not match runbook's documented "
-            "shape (`bootstrap mode = static, but data dir already holds a "
+            "validator error message did not match the documented shape "
+            "(`bootstrap mode = dynamic, but data dir already holds a "
             f"'root' zone`).\nstdout/stderr: {combined[-2000:]}"
         )
 


### PR DESCRIPTION
## Summary

Investigation of nexus-vfs's `validate_bootstrap_mode` (followup to PR #4327) revealed three documentation drifts in the cross-machine federation runbook and one over-strict E2E test. The validator's `Static` branch deliberately accepts any data-dir state to support container-restart UX (env-driven topology that the same compose env covers across boot and restart cycles); the existing nexus-vfs unit test `validate_static_allows_existing_state_for_container_restart` pins this as the desired behaviour. Our runbook + test were documenting a stricter contract that doesn't (and shouldn't) exist.

## Changes

* **`docs/architecture/federation-cross-machine-runbook.md`** —
  * Operator-flow callout: reframes `static` as "env-driven topology across first boot AND container restart" instead of "first boot only".
  * Key design decisions: removes the wrong `static`-on-non-empty rejection example; adds a positive statement of what static guarantees.
  * Troubleshooting table: removes the non-existent `bootstrap mode = static, but data dir already holds a 'root' zone` error row; replaces it with the actually-emitted `bootstrap mode = dynamic, but data dir already holds a 'root' zone` row.

* **`tests/e2e/docker/test_federation_runbook.py`** — renames `test_static_mode_rejects_existing_data_dir` to `test_dynamic_mode_rejects_existing_data_dir`. The repurposed test now probes the validator's actual rejection path (`dynamic + non-empty`); no xfail dance needed — that path works correctly upstream.

## Why these are the right edits

* **Positive framing** (per docs principles): every statement says what each mode IS, not what it isn't.
* **SSOT alignment**: runbook now mirrors nexus-vfs's `validate_bootstrap_mode` source of truth rather than describing an aspirational contract.
* **Related content together**: bootstrap-mode semantics live in the troubleshooting/key-design sections; nothing new added elsewhere.
* **No transient state**: documentation describes steady-state behaviour only.

## Test plan

- [ ] `Federation E2E (Docker)` workflow goes green — `test_dynamic_mode_rejects_existing_data_dir` is no longer xfailed and validates the real dynamic-mode rejection path.
- [ ] No other test classes affected (founder + joiner CLI + restart replay tests stay xfailed against the pending upstream fix in nexi-lab/nexus-vfs#31).

## Related

* nexi-lab/nexus-vfs#31 — fixes the offline-join ConfState-install bug; will unblock the remaining xfails in this suite.