### PR TITLE
ci(dockerfiles): bump NEXUS_VFS_REV to post-#31 SHA

### DIFF
--- a/dockerfiles/Dockerfile.nexusd-cluster
+++ b/dockerfiles/Dockerfile.nexusd-cluster
@@ -38,7 +38,7 @@ WORKDIR /build
 # commit you want to adopt.  Pin should always include #23 (ZoneManager
 # async wrappers) and #25 (leader-detection SSOT) — both required for
 # the L1 cross-machine federation read milestone to pass.
-ARG NEXUS_VFS_REV=621c5c02b783270b1b3bca7376cbb3a77b750776
+ARG NEXUS_VFS_REV=19a99b6d319dff283b14f89dd716dd915dc337ac
 RUN cargo install \
     --git https://github.com/nexi-lab/nexus-vfs \
     --rev "${NEXUS_VFS_REV}" \

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=621c5c02b783270b1b3bca7376cbb3a77b750776
+ARG NEXUS_VFS_REV=19a99b6d319dff283b14f89dd716dd915dc337ac
 RUN cargo install \
     --git https://github.com/nexi-lab/nexus-vfs \
     --rev "${NEXUS_VFS_REV}" \

--- a/tests/e2e/docker/test_federation_runbook.py
+++ b/tests/e2e/docker/test_federation_runbook.py
@@ -238,6 +238,36 @@ class TestFounderBootstrap:
 # ===========================================================================
 # TestJoinerCrossNodeReadRunbook — runbook §3b + §4 (THE MILESTONE)
 # ===========================================================================
+# UPSTREAM BUG TRACKER — joined_cluster fixture
+#
+# Symptom: after `nexusd-cluster join` returns rc=0, the joiner's restart
+# shows `Zone 'sharedzone' registered (..., peers=0)` and raft floods
+# `raft step error: raft: cannot step as peer not found`.  Founder's
+# ConfState IS correct ([voter: founder, learner: joiner]); the joiner's
+# persisted view is `solo cluster of self`.
+#
+# Root cause: nexus-vfs offline `nexusd-cluster join` does not durably
+# persist the post-`JoinZone` ConfState (founder added as peer) to the
+# joiner's redb before the CLI exits.  On daemon restart the joiner
+# reloads pre-snapshot state and never recovers because the leader's
+# AppendEntries are rejected.
+#
+# Scope: the offline-CLI path is what runbook §3b documents; this PR's
+# whole point is to lock it in CI.  The bug is in the upstream nexus-vfs
+# main HEAD we pin (621c5c02b...), reproduced reliably in CI.  Cannot be
+# fixed from this repo.
+#
+# What we do until upstream lands a fix:
+#   * `joined_cluster` raises `pytest.xfail()` when the offline-join
+#     produces an invalid joiner state.  Tests depending on it are
+#     marked XFAIL — non-strict, so the moment upstream lands a fix the
+#     tests will XPASS and prompt removal of this xfail.
+#   * TestFounderBootstrap (4 tests) continues passing — those validate
+#     the founder-side static-topology bootstrap which is fully working.
+#   * TestRunbookOperatorErgonomics (4 tests) is decoupled from
+#     joined_cluster — those validators run on a clean joiner and
+#     don't need a successful offline join.
+# ===========================================================================
 @pytest.fixture(scope="class")
 def joined_cluster(topology: RunbookTopology, api_key: str) -> dict:
     """Execute the runbook §3b joiner-side CLI flow (offline join + restart).
@@ -252,12 +282,14 @@ def joined_cluster(topology: RunbookTopology, api_key: str) -> dict:
       B-4: `docker start` joiner — auto-detect entrypoint picks
            `--bootstrap-mode restart` from `.node_id` presence.
       B-5: gate on the joiner observing sharedzone with a stable leader.
-           Backed by nexus-vfs #31's wait gate inside
-           `attempt_join_zone_round`, which blocks the offline CLI
-           until the joiner's ConfState has the founder as a peer —
-           so this readiness-gate poll converges on the first try.
+
+    Raises pytest.xfail with an upstream-bug tracker message when B-5
+    times out due to the offline-join state-sync bug (peers=0 on
+    joiner's sharedzone ConfState).
     """
     import os
+
+    from _pytest.outcomes import Failed
 
     from tests.e2e.docker.runbook_helpers import (
         docker_start,
@@ -284,15 +316,35 @@ def joined_cluster(topology: RunbookTopology, api_key: str) -> dict:
         data_dir="/app/data",
         timeout=120,
     )
-    assert join_result.returncode == 0, (
-        f"`nexusd-cluster join` on joiner failed: rc={join_result.returncode}\n"
-        f"stdout={join_result.stdout}\nstderr={join_result.stderr}"
-    )
+    if join_result.returncode != 0:
+        pytest.xfail(
+            "nexus-vfs `nexusd-cluster join` upstream regression — "
+            "offline-join CLI returned non-zero.  Tracks upstream bug; "
+            f"the L1 milestone substrate is broken until it lands.\n"
+            f"rc={join_result.returncode}\n"
+            f"stdout={join_result.stdout}\nstderr={join_result.stderr}"
+        )
 
     docker_start(topology.joiner_container)
     wait_healthy([topology.joiner_grpc])
 
-    wait_zone_ready(topology.joiner_grpc, "sharedzone", api_key=api_key, timeout=60)
+    # B-5 readiness gate — also the canary for the ConfState-sync bug.
+    # If sharedzone never reaches a stable leader on the joiner, we hit
+    # the documented upstream bug (peers=0 in the joiner's ConfState
+    # after offline join; `raft step error: peer not found` in joiner
+    # logs).  xfail the dependents until upstream lands a fix.
+    try:
+        wait_zone_ready(topology.joiner_grpc, "sharedzone", api_key=api_key, timeout=60)
+    except Failed as exc:
+        pytest.xfail(
+            "nexus-vfs offline `nexusd-cluster join` upstream regression: "
+            "joiner's persisted sharedzone ConfState has peers=0 after "
+            "successful CLI return (rc=0).  Joiner logs flood `raft step "
+            "error: peer not found` because founder isn't in joiner's "
+            "Progress map.  L1 cross-node read is structurally blocked "
+            "until upstream nexus-vfs fixes offline-join state persistence.\n"
+            f"Underlying readiness-gate failure: {exc}"
+        )
 
     return {
         "founder_node_id": founder_node_id,

--- a/tests/e2e/docker/test_federation_runbook.py
+++ b/tests/e2e/docker/test_federation_runbook.py
@@ -238,36 +238,6 @@ class TestFounderBootstrap:
 # ===========================================================================
 # TestJoinerCrossNodeReadRunbook — runbook §3b + §4 (THE MILESTONE)
 # ===========================================================================
-# UPSTREAM BUG TRACKER — joined_cluster fixture
-#
-# Symptom: after `nexusd-cluster join` returns rc=0, the joiner's restart
-# shows `Zone 'sharedzone' registered (..., peers=0)` and raft floods
-# `raft step error: raft: cannot step as peer not found`.  Founder's
-# ConfState IS correct ([voter: founder, learner: joiner]); the joiner's
-# persisted view is `solo cluster of self`.
-#
-# Root cause: nexus-vfs offline `nexusd-cluster join` does not durably
-# persist the post-`JoinZone` ConfState (founder added as peer) to the
-# joiner's redb before the CLI exits.  On daemon restart the joiner
-# reloads pre-snapshot state and never recovers because the leader's
-# AppendEntries are rejected.
-#
-# Scope: the offline-CLI path is what runbook §3b documents; this PR's
-# whole point is to lock it in CI.  The bug is in the upstream nexus-vfs
-# main HEAD we pin (621c5c02b...), reproduced reliably in CI.  Cannot be
-# fixed from this repo.
-#
-# What we do until upstream lands a fix:
-#   * `joined_cluster` raises `pytest.xfail()` when the offline-join
-#     produces an invalid joiner state.  Tests depending on it are
-#     marked XFAIL — non-strict, so the moment upstream lands a fix the
-#     tests will XPASS and prompt removal of this xfail.
-#   * TestFounderBootstrap (4 tests) continues passing — those validate
-#     the founder-side static-topology bootstrap which is fully working.
-#   * TestRunbookOperatorErgonomics (4 tests) is decoupled from
-#     joined_cluster — those validators run on a clean joiner and
-#     don't need a successful offline join.
-# ===========================================================================
 @pytest.fixture(scope="class")
 def joined_cluster(topology: RunbookTopology, api_key: str) -> dict:
     """Execute the runbook §3b joiner-side CLI flow (offline join + restart).
@@ -282,14 +252,12 @@ def joined_cluster(topology: RunbookTopology, api_key: str) -> dict:
       B-4: `docker start` joiner — auto-detect entrypoint picks
            `--bootstrap-mode restart` from `.node_id` presence.
       B-5: gate on the joiner observing sharedzone with a stable leader.
-
-    Raises pytest.xfail with an upstream-bug tracker message when B-5
-    times out due to the offline-join state-sync bug (peers=0 on
-    joiner's sharedzone ConfState).
+           Backed by nexus-vfs #31's wait gate inside
+           `attempt_join_zone_round`, which blocks the offline CLI
+           until the joiner's ConfState has the founder as a peer —
+           so this readiness-gate poll converges on the first try.
     """
     import os
-
-    from _pytest.outcomes import Failed
 
     from tests.e2e.docker.runbook_helpers import (
         docker_start,
@@ -316,35 +284,15 @@ def joined_cluster(topology: RunbookTopology, api_key: str) -> dict:
         data_dir="/app/data",
         timeout=120,
     )
-    if join_result.returncode != 0:
-        pytest.xfail(
-            "nexus-vfs `nexusd-cluster join` upstream regression — "
-            "offline-join CLI returned non-zero.  Tracks upstream bug; "
-            f"the L1 milestone substrate is broken until it lands.\n"
-            f"rc={join_result.returncode}\n"
-            f"stdout={join_result.stdout}\nstderr={join_result.stderr}"
-        )
+    assert join_result.returncode == 0, (
+        f"`nexusd-cluster join` on joiner failed: rc={join_result.returncode}\n"
+        f"stdout={join_result.stdout}\nstderr={join_result.stderr}"
+    )
 
     docker_start(topology.joiner_container)
     wait_healthy([topology.joiner_grpc])
 
-    # B-5 readiness gate — also the canary for the ConfState-sync bug.
-    # If sharedzone never reaches a stable leader on the joiner, we hit
-    # the documented upstream bug (peers=0 in the joiner's ConfState
-    # after offline join; `raft step error: peer not found` in joiner
-    # logs).  xfail the dependents until upstream lands a fix.
-    try:
-        wait_zone_ready(topology.joiner_grpc, "sharedzone", api_key=api_key, timeout=60)
-    except Failed as exc:
-        pytest.xfail(
-            "nexus-vfs offline `nexusd-cluster join` upstream regression: "
-            "joiner's persisted sharedzone ConfState has peers=0 after "
-            "successful CLI return (rc=0).  Joiner logs flood `raft step "
-            "error: peer not found` because founder isn't in joiner's "
-            "Progress map.  L1 cross-node read is structurally blocked "
-            "until upstream nexus-vfs fixes offline-join state persistence.\n"
-            f"Underlying readiness-gate failure: {exc}"
-        )
+    wait_zone_ready(topology.joiner_grpc, "sharedzone", api_key=api_key, timeout=60)
 
     return {
         "founder_node_id": founder_node_id,


### PR DESCRIPTION
## Summary

Bumps both \`Dockerfile.nexusd-cluster\` and \`Dockerfile.raft-witness\` to nexus-vfs main \`19a99b6d319dff283b14f89dd716dd915dc337ac\` (post-#31). PR #31 added the \`wait_for_join_to_apply\` gate inside \`attempt_join_zone_round\` — verified to fix the offline-join ConfState persistence regression in the in-process integration test.

## Scope

Pure SHA-pin bump. The xfail removal attempted in commits 2/3 is reverted in commit 3 — a Docker-specific issue (joiner's persistent volume still showing \`peers=0\` after the transient join container exits, despite the upstream wait gate succeeding in memory) needs separate diagnosis. Filed as a followup; not blocking this bump.

## Commits

1. \`ci(dockerfiles): bump NEXUS_VFS_REV to ...\` — the actual pin update
2. \`test(e2e): drop joiner-CLI xfails ...\` — speculative removal (reverted)
3. \`Revert "test(e2e): drop joiner-CLI xfails ..."\` — restores xfails until Docker-side issue is diagnosed

Per repo principle "preserve all commit history", the speculative attempt and its revert are kept as bisectable checkpoints.

## Test plan

- [ ] CI runs against the updated pin — substrate improvement gets picked up by all federation paths even though the joiner-CLI xfail tests stay marked as expected-fail until the Docker issue is fixed.
- [ ] Followup: Docker-side state-persistence diagnosis + remove xfails.