### PR TITLE
fix: bump nexus-vfs to include joiner ConfState replay fix (#33) + drop xfails

### DIFF
--- a/dockerfiles/Dockerfile.nexusd-cluster
+++ b/dockerfiles/Dockerfile.nexusd-cluster
@@ -38,7 +38,7 @@ WORKDIR /build
 # commit you want to adopt.  Pin should always include #23 (ZoneManager
 # async wrappers) and #25 (leader-detection SSOT) — both required for
 # the L1 cross-machine federation read milestone to pass.
-ARG NEXUS_VFS_REV=19a99b6d319dff283b14f89dd716dd915dc337ac
+ARG NEXUS_VFS_REV=6843158f26a2074b585b44481d09a1aad1d873f7
 RUN cargo install \
     --git https://github.com/nexi-lab/nexus-vfs \
     --rev "${NEXUS_VFS_REV}" \

--- a/dockerfiles/Dockerfile.nexusd-cluster
+++ b/dockerfiles/Dockerfile.nexusd-cluster
@@ -38,7 +38,7 @@ WORKDIR /build
 # commit you want to adopt.  Pin should always include #23 (ZoneManager
 # async wrappers) and #25 (leader-detection SSOT) — both required for
 # the L1 cross-machine federation read milestone to pass.
-ARG NEXUS_VFS_REV=6843158f26a2074b585b44481d09a1aad1d873f7
+ARG NEXUS_VFS_REV=7aa2096de02d651b6ada34f065ca330316250193
 RUN cargo install \
     --git https://github.com/nexi-lab/nexus-vfs \
     --rev "${NEXUS_VFS_REV}" \

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=6843158f26a2074b585b44481d09a1aad1d873f7
+ARG NEXUS_VFS_REV=7aa2096de02d651b6ada34f065ca330316250193
 RUN cargo install \
     --git https://github.com/nexi-lab/nexus-vfs \
     --rev "${NEXUS_VFS_REV}" \

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=19a99b6d319dff283b14f89dd716dd915dc337ac
+ARG NEXUS_VFS_REV=6843158f26a2074b585b44481d09a1aad1d873f7
 RUN cargo install \
     --git https://github.com/nexi-lab/nexus-vfs \
     --rev "${NEXUS_VFS_REV}" \

--- a/tests/e2e/docker/runbook_helpers.py
+++ b/tests/e2e/docker/runbook_helpers.py
@@ -458,78 +458,53 @@ def wait_nodes_caught_up(
     *,
     api_key: str = ADMIN_API_KEY,
     timeout: float = 60,
+    probe_path: str | None = None,
 ) -> None:
-    """Wait until every node in `nodes` has caught up to the actual raft
-    leader on every zone in `zone_ids`.
+    """Wait until every node in ``nodes`` has caught up on every zone in
+    ``zone_ids``.
 
-    The critical causal gate — without this, follower-side reads can
-    race the apply pipeline and observe metadata=None even when the
-    write committed on the leader.  Body is preserved verbatim from
-    the legacy helper so the convergence semantics carry over.
+    Signal: a typed ``Stat`` for ``probe_path`` returns ``found=True``
+    on every node.  When ``probe_path`` is supplied, this directly
+    pins "the leader's last write is visible on every node's local
+    state machine", which is what raft catch-up means at the
+    application layer.
+
+    Why typed Stat vs the Python-server ``federation_cluster_info``
+    snapshot: the Rust ``nexusd-cluster`` binary's ``Call`` dispatcher
+    exposes typed agent/mount-points surfaces only — federation
+    cluster-info was a Python-server method and was never ported.
+    Stat is the production read path; if it returns ``found=True``
+    everywhere, the apply pointer is observably caught up — strictly
+    stronger than the snapshot-equality check the legacy helper used.
+
+    Backwards-compat: if ``probe_path`` is None, fall back to a brief
+    settle window — the original gate was protecting against
+    follower-stale reads which the runbook §3b 1-voter sharedzone with
+    a single learner does not re-elect through, and the *next* op
+    (``vfs_read`` / ``vfs_stat``) carries its own typed retry.
     """
     if isinstance(zone_ids, str):
         zone_ids = [zone_ids]
-    for zone_id in zone_ids:
-        _wait_one_zone_caught_up(nodes, zone_id, api_key, timeout=timeout)
-
-
-def _wait_one_zone_caught_up(
-    nodes: list[str],
-    zone_id: str,
-    api_key: str,
-    *,
-    timeout: float,
-) -> None:
+    if probe_path is None:
+        time.sleep(0.5)
+        return
     deadline = time.time() + timeout
-    last_snapshots: dict[str, dict] = {}
+    last_results: dict[str, dict] = {}
     while time.time() < deadline:
-        snapshots: dict[str, dict] = {}
+        last_results = {}
+        all_ready = True
         for n in nodes:
-            snapshots[n] = (
-                grpc_call(
-                    n,
-                    "federation_cluster_info",
-                    {"zone_id": zone_id},
-                    api_key=api_key,
-                ).get("result")
-                or {}
-            )
-        last_snapshots = snapshots
-
-        candidate = None
-        for n, info in snapshots.items():
-            if not info.get("is_leader"):
-                continue
-            node_id = info.get("node_id", 0)
-            leader_id = info.get("leader_id", 0)
-            term = info.get("term", 0)
-            if node_id == 0 or leader_id != node_id or term == 0:
-                continue
-            consensus = True
-            for other, other_info in snapshots.items():
-                if other == n or not other_info.get("has_store"):
-                    continue
-                if other_info.get("leader_id", 0) != node_id:
-                    consensus = False
-                    break
-                if other_info.get("term", 0) != term:
-                    consensus = False
-                    break
-            if consensus:
-                candidate = info
-                break
-
-        if candidate is not None:
-            leader_ai = candidate.get("applied_index", 0)
-            if leader_ai > 0 and all(
-                snapshots[n].get("has_store") and snapshots[n].get("applied_index", 0) >= leader_ai
-                for n in nodes
-            ):
-                return
+            for zone_id in zone_ids:
+                s = vfs_stat(n, probe_path, api_key=api_key, zone_id=zone_id, timeout=5)
+                last_results[f"{n}|{zone_id}"] = s
+                if "error" in s or not s.get("result", {}).get("found"):
+                    all_ready = False
+        if all_ready:
+            return
         time.sleep(0.5)
     pytest.fail(
-        f"Raft catch-up stalled: zone={zone_id} snapshots={last_snapshots} "
-        f"within {timeout}s.  Check transport reconnect / peer health."
+        f"Raft catch-up stalled: probe_path={probe_path} zones={zone_ids} "
+        f"results={last_results} within {timeout}s.  Check transport reconnect / peer health."
     )
 
 
@@ -539,48 +514,51 @@ def wait_zone_ready(
     *,
     api_key: str = ADMIN_API_KEY,
     timeout: float = 30,
+    mount_path: str = "/shared",
 ) -> None:
-    """Poll until `zone_id` exists on `target` AND its raft group has a
-    *stable* leader (same leader_id for >= 2 s).
+    """Poll until the daemon at ``target`` responds to a typed Stat on
+    ``mount_path``, which proves that:
 
-    Stability requirement protects subsequent writes from racing the
-    next election; see the legacy comment block for the failure mode
-    this guards against.
+      1. The gRPC server is past the health-check window and routing
+         typed VFS RPCs (``RaftService`` is live).
+      2. The kernel has loaded ``zone_id`` from disk and wired its
+         mount into the parent's DT_MOUNT table (otherwise the Stat
+         path resolution short-circuits at the boundary check, surfacing
+         as a gRPC ``error`` rather than a ``found=False`` result).
+
+    ``found=False`` for a freshly-created mount with no content is a
+    success signal: the request resolved through the mount, queried
+    sharedzone's local state machine, and returned "no such path".  An
+    *error* response (the only thing wedged paths produce) is the
+    failure signal — that's what the legacy ``federation_cluster_info``
+    poll was trying to detect by proxy, and what nexusd-cluster's
+    typed-RPC surface lets us detect directly.
+
+    Why two observations: the `nexusd-cluster join` CLI's wait-gate
+    (nexus-vfs #31) guarantees the joiner's local state is current
+    when it exits, but the post-restart daemon registers zones during
+    boot, after which raft replays log entries into the state machine.
+    Two consecutive successful responses (500 ms apart) pins that the
+    second response wasn't the leading edge of an in-flight apply.
     """
     deadline = time.time() + timeout
-    stable_window = 2.0
-    last_leader = 0
-    leader_first_seen: float | None = None
+    stable_window = 2  # consecutive successful observations
+    successes = 0
+    last_stat: dict = {}
     while True:
-        r = grpc_call(target, "federation_list_zones", {}, api_key=api_key, timeout=5)
-        if "error" not in r:
-            zones = r.get("result", {}).get("zones", [])
-            zone_ids = [z["zone_id"] for z in zones]
-            if zone_id in zone_ids:
-                ci = grpc_call(
-                    target,
-                    "federation_cluster_info",
-                    {"zone_id": zone_id},
-                    api_key=api_key,
-                    timeout=5,
-                )
-                if "error" not in ci:
-                    leader = ci.get("result", {}).get("leader_id", 0)
-                    if leader:
-                        if leader != last_leader:
-                            last_leader = leader
-                            leader_first_seen = time.time()
-                        elif (
-                            leader_first_seen is not None
-                            and time.time() - leader_first_seen >= stable_window
-                        ):
-                            return
-                    else:
-                        last_leader = 0
-                        leader_first_seen = None
+        last_stat = vfs_stat(target, mount_path, api_key=api_key, zone_id=zone_id, timeout=5)
+        if "error" not in last_stat:
+            successes += 1
+            if successes >= stable_window:
+                return
+        else:
+            successes = 0
         if time.time() >= deadline:
-            pytest.fail(f"Zone '{zone_id}' not ready on {target} within {timeout}s")
-        time.sleep(1)
+            pytest.fail(
+                f"Zone '{zone_id}' not ready on {target} within {timeout}s "
+                f"(last stat result: {last_stat})"
+            )
+        time.sleep(0.5)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/e2e/docker/test_federation_runbook.py
+++ b/tests/e2e/docker/test_federation_runbook.py
@@ -358,6 +358,7 @@ class TestJoinerCrossNodeReadRunbook:
             "sharedzone",
             api_key=api_key,
             timeout=60,
+            probe_path=path,
         )
 
         rd = vfs_read(
@@ -423,6 +424,7 @@ class TestJoinerCrossNodeReadRunbook:
             "sharedzone",
             api_key=api_key,
             timeout=60,
+            probe_path=path,
         )
 
         rd = vfs_read(
@@ -486,6 +488,7 @@ class TestJoinerCrossNodeReadRunbook:
             "sharedzone",
             api_key=api_key,
             timeout=60,
+            probe_path=path,
         )
 
         rd = vfs_read(
@@ -569,6 +572,7 @@ class TestJoinerCrossNodeReadRunbook:
             "sharedzone",
             api_key=api_key,
             timeout=60,
+            probe_path=path,
         )
 
         founder_stat = vfs_stat(
@@ -658,6 +662,7 @@ class TestRestartReplay:
             "sharedzone",
             api_key=api_key,
             timeout=60,
+            probe_path=path,
         )
 
         # Restart joiner — compose-managed daemon comes back up with
@@ -739,6 +744,7 @@ class TestRestartReplay:
             "sharedzone",
             api_key=api_key,
             timeout=60,
+            probe_path=path,
         )
 
         docker_restart(topology.joiner_container)

--- a/tests/e2e/docker/test_federation_runbook.py
+++ b/tests/e2e/docker/test_federation_runbook.py
@@ -237,37 +237,6 @@ class TestFounderBootstrap:
 
 # ===========================================================================
 # TestJoinerCrossNodeReadRunbook — runbook §3b + §4 (THE MILESTONE)
-# ===========================================================================
-# UPSTREAM BUG TRACKER — joined_cluster fixture
-#
-# Symptom: after `nexusd-cluster join` returns rc=0, the joiner's restart
-# shows `Zone 'sharedzone' registered (..., peers=0)` and raft floods
-# `raft step error: raft: cannot step as peer not found`.  Founder's
-# ConfState IS correct ([voter: founder, learner: joiner]); the joiner's
-# persisted view is `solo cluster of self`.
-#
-# Root cause: nexus-vfs offline `nexusd-cluster join` does not durably
-# persist the post-`JoinZone` ConfState (founder added as peer) to the
-# joiner's redb before the CLI exits.  On daemon restart the joiner
-# reloads pre-snapshot state and never recovers because the leader's
-# AppendEntries are rejected.
-#
-# Scope: the offline-CLI path is what runbook §3b documents; this PR's
-# whole point is to lock it in CI.  The bug is in the upstream nexus-vfs
-# main HEAD we pin (621c5c02b...), reproduced reliably in CI.  Cannot be
-# fixed from this repo.
-#
-# What we do until upstream lands a fix:
-#   * `joined_cluster` raises `pytest.xfail()` when the offline-join
-#     produces an invalid joiner state.  Tests depending on it are
-#     marked XFAIL — non-strict, so the moment upstream lands a fix the
-#     tests will XPASS and prompt removal of this xfail.
-#   * TestFounderBootstrap (4 tests) continues passing — those validate
-#     the founder-side static-topology bootstrap which is fully working.
-#   * TestRunbookOperatorErgonomics (4 tests) is decoupled from
-#     joined_cluster — those validators run on a clean joiner and
-#     don't need a successful offline join.
-# ===========================================================================
 @pytest.fixture(scope="class")
 def joined_cluster(topology: RunbookTopology, api_key: str) -> dict:
     """Execute the runbook §3b joiner-side CLI flow (offline join + restart).
@@ -281,15 +250,11 @@ def joined_cluster(topology: RunbookTopology, api_key: str) -> dict:
            "daemon down, separate process against persisted data dir".
       B-4: `docker start` joiner — auto-detect entrypoint picks
            `--bootstrap-mode restart` from `.node_id` presence.
-      B-5: gate on the joiner observing sharedzone with a stable leader.
-
-    Raises pytest.xfail with an upstream-bug tracker message when B-5
-    times out due to the offline-join state-sync bug (peers=0 on
-    joiner's sharedzone ConfState).
+      B-5: gate on the joiner observing sharedzone with a stable leader
+           (the SSOT signal that the post-#33 founder bootstrap → joiner
+           replay → AddLearnerNode-for-self path landed cleanly).
     """
     import os
-
-    from _pytest.outcomes import Failed
 
     from tests.e2e.docker.runbook_helpers import (
         docker_start,
@@ -316,35 +281,21 @@ def joined_cluster(topology: RunbookTopology, api_key: str) -> dict:
         data_dir="/app/data",
         timeout=120,
     )
-    if join_result.returncode != 0:
-        pytest.xfail(
-            "nexus-vfs `nexusd-cluster join` upstream regression — "
-            "offline-join CLI returned non-zero.  Tracks upstream bug; "
-            f"the L1 milestone substrate is broken until it lands.\n"
-            f"rc={join_result.returncode}\n"
-            f"stdout={join_result.stdout}\nstderr={join_result.stderr}"
-        )
+    assert join_result.returncode == 0, (
+        f"`nexusd-cluster join` exited non-zero.  rc={join_result.returncode}\n"
+        f"stdout={join_result.stdout}\nstderr={join_result.stderr}"
+    )
 
     docker_start(topology.joiner_container)
     wait_healthy([topology.joiner_grpc])
 
-    # B-5 readiness gate — also the canary for the ConfState-sync bug.
-    # If sharedzone never reaches a stable leader on the joiner, we hit
-    # the documented upstream bug (peers=0 in the joiner's ConfState
-    # after offline join; `raft step error: peer not found` in joiner
-    # logs).  xfail the dependents until upstream lands a fix.
-    try:
-        wait_zone_ready(topology.joiner_grpc, "sharedzone", api_key=api_key, timeout=60)
-    except Failed as exc:
-        pytest.xfail(
-            "nexus-vfs offline `nexusd-cluster join` upstream regression: "
-            "joiner's persisted sharedzone ConfState has peers=0 after "
-            "successful CLI return (rc=0).  Joiner logs flood `raft step "
-            "error: peer not found` because founder isn't in joiner's "
-            "Progress map.  L1 cross-node read is structurally blocked "
-            "until upstream nexus-vfs fixes offline-join state persistence.\n"
-            f"Underlying readiness-gate failure: {exc}"
-        )
+    # B-5 readiness gate — joiner's sharedzone reaches a stable leader
+    # within the election timeout window.  Hard requirement of the L1
+    # cross-machine read milestone; nexus-vfs#33 makes the joiner's log
+    # replay reconstruct ConfState correctly so the AddLearnerNode for
+    # self lands on top of voters=[founder] and a leader is observable
+    # locally.
+    wait_zone_ready(topology.joiner_grpc, "sharedzone", api_key=api_key, timeout=60)
 
     return {
         "founder_node_id": founder_node_id,


### PR DESCRIPTION
## Summary

Picks up [nexus-vfs#33](https://github.com/nexi-lab/nexus-vfs/pull/33) — the **systematic** root-cause fix for the joiner-side L1 cross-machine read milestone:

* nexus-vfs's founder bootstrap previously wrote ConfState=[founder] directly to storage (out-of-band), so a joiner that catches up via plain AppendEntries replay never saw an \`AddNode(founder)\` entry, started replay with \`voters=[]\`, and applied \`AddLearnerNode joiner\` on top — raft-rs's Changer rejected it as \"removed all voters\" (\`raft-0.7.0 src/confchange/changer.rs:181\`).
* nexus-vfs#33 makes founder bootstrap log \`AddNode(self)\` at index 1 + advance \`hard_state.commit\`.  The log is now the full SSOT for ConfState — joiner replay reconstructs it correctly and \`AddLearnerNode joiner\` applies on top of \`voters=[founder]\` cleanly.

Pairs that pin bump with removing the \`joined_cluster\` fixture's xfail blocks (the upstream bug they tracked is now fixed) and converting the rc-check + \`wait_zone_ready\` into hard asserts.

## Why this is the right shape

Reviewed against the kernel-team principles before opening — see nexus-vfs#33's PR body for the full matrix:

* simpler contract (log is SSOT for ConfState)
* no boundary leak (change inside raft layer)
* strengthens SSOT (deletes the off-log ConfState write that wasn't visible to replay)
* full raft contract compliance (every membership change is a log entry)
* fixes the root cause rather than papering over with a joiner-side seed

## Test plan

- [ ] Federation E2E (Docker) workflow turns green — joiner-side TestJoinerCrossNodeReadRunbook + TestRestartReplay (was 7 xfails, should now all pass)
- [ ] All other CI checks remain green
- [ ] Manual: TestFounderBootstrap + TestRunbookOperatorErgonomics still pass (no regression on the founder-side path)