### PR TITLE
fix(#4338): self-heal rebac durable consumer on NOGROUP after cache flush

### DIFF
--- a/src/nexus/bricks/rebac/cache/durable_stream.py
+++ b/src/nexus/bricks/rebac/cache/durable_stream.py
@@ -19,7 +19,32 @@ The sync publish preserves the synchronous invalidate_for_write() contract.
 The small window between queue-append and XADD is covered by the read fence
 (cached results are compared against the watermark, not the stream directly).
 
-Related: Issue #3396 (decisions 1A, 6A, 14A, 15A, 16A)
+Cache-flush semantics (Issue #4338):
+    The stream lives in the cache tier, often a volumeless Redis/Dragonfly
+    whose restart legitimately wipes the stream, consumer groups, PEL, and
+    DLQ.  An empty cache is treated as normal:
+
+    - start() creates the group via XGROUP CREATE ... MKSTREAM (BUSYGROUP
+      means it already exists — fine).
+    - The consumer self-heals mid-run: when XREADGROUP fails with NOGROUP,
+      the group is re-created at id="0" (consume everything still in the
+      stream) and reading resumes.  Tracked by the ``group_recreates`` stat.
+
+    What a flush loses — and why no backfill/replay is needed:
+
+    - ReBAC relationship tuples are unaffected.  The relational store is
+      the source of truth; the stream only carries cache-invalidation
+      hints.
+    - Invalidation events not yet consumed (including PEL retries and DLQ
+      entries) are lost.  Remote zones may serve stale cached decisions
+      until their caches expire — bounded by the L1 result-cache TTL
+      (default 300s grants / 60s denials) and the permission-lease TTL
+      (default 30s) — after which decisions are re-derived from the source
+      of truth.  Correctness converges without replay.
+    - Consumer-group offsets are lost, but they referenced wiped entries;
+      the re-created group starts at the head of the new stream.
+
+Related: Issue #3396 (decisions 1A, 6A, 14A, 15A, 16A), Issue #4338
 """
 
 from __future__ import annotations
@@ -127,6 +152,7 @@ class DurableInvalidationStream:
         self._consumed = 0
         self._consume_errors = 0
         self._queue_drops = 0
+        self._group_recreates = 0
 
     # -- lifecycle ------------------------------------------------------------
 
@@ -308,7 +334,33 @@ class DurableInvalidationStream:
 
             except asyncio.CancelledError:
                 return
-            except Exception:
+            except Exception as exc:
+                # NOGROUP: the cache tier lost the stream and/or group — normal
+                # for a volumeless Redis/Dragonfly that restarted empty.  XADD
+                # from publishers re-creates the stream but never the group, so
+                # re-create it here and resume instead of erroring forever
+                # (Issue #4338).  Redis prefixes the error code, so startswith
+                # avoids false positives on payloads that merely contain the
+                # token.  What a flush loses is documented in the module
+                # docstring ("Cache-flush semantics").
+                if str(exc).startswith("NOGROUP"):
+                    logger.warning(
+                        "[DurableStream] Stream/group %s missing (cache flush?) — "
+                        "re-creating (see module docstring for cache-flush semantics)",
+                        self._group_name,
+                    )
+                    try:
+                        await self._ensure_consumer_groups()
+                        self._group_recreates += 1
+                        continue
+                    except asyncio.CancelledError:
+                        # stop() may cancel us mid-re-create — must propagate.
+                        raise
+                    except Exception:
+                        logger.warning(
+                            "[DurableStream] Group re-create failed — will retry",
+                            exc_info=True,
+                        )
                 self._consume_errors += 1
                 logger.warning("[DurableStream] Consumer error", exc_info=True)
                 await asyncio.sleep(1.0)
@@ -506,6 +558,7 @@ class DurableInvalidationStream:
             "queue_drops": self._queue_drops,
             "queue_size": len(self._queue),
             "handler_count": len(self._handlers),
+            "group_recreates": self._group_recreates,
         }
 
     async def health_check(self) -> dict[str, Any]:

--- a/tests/unit/core/test_durable_stream_flush_recovery.py
+++ b/tests/unit/core/test_durable_stream_flush_recovery.py
@@ -1,0 +1,243 @@
+"""Regression tests for Issue #4338 — durable consumer vs. cache flush.
+
+Prod incident: the ReBAC durable stream lives in a volumeless Dragonfly.
+A Railway region move restarted it empty; publishers' XADD re-created the
+stream but never the consumer group, so the consumer crash-looped on
+NOGROUP forever instead of re-creating the group.
+
+These tests pin the recovery contract with a purpose-built fake that
+mirrors real Redis error semantics (NOGROUP / BUSYGROUP / MKSTREAM):
+
+1. start() on an empty cache creates stream+group (XGROUP CREATE MKSTREAM)
+2. group creation is idempotent across restarts (BUSYGROUP swallowed)
+3. a mid-run flush self-heals: the consumer re-creates the group and
+   resumes delivery
+
+Related: Issue #4338, Issue #3396 (original stream design)
+"""
+
+import asyncio
+import json
+
+import pytest
+
+from nexus.bricks.rebac.cache.channel_codec import encode_channel
+from nexus.bricks.rebac.cache.durable_stream import DurableInvalidationStream
+from nexus.bricks.rebac.cache.read_fence import ReadFence
+
+
+class FakeResponseError(Exception):
+    """Stands in for redis.exceptions.ResponseError (string-matched by prod code)."""
+
+
+class FakeRedisStreams:
+    """Minimal async Redis Streams fake with real error semantics.
+
+    - XREADGROUP raises NOGROUP when the stream key or consumer group is
+      missing (exact prod error shape)
+    - XGROUP CREATE raises BUSYGROUP when the group exists, and ERR when
+      the key is missing without MKSTREAM
+    - flush() simulates a volumeless Dragonfly restart
+    """
+
+    def __init__(self):
+        self._streams: dict[str, list[tuple[str, dict]]] = {}
+        self._groups: dict[str, str] = {}  # "stream:group" -> last delivered id
+        self._seq = 0
+
+    def flush(self):
+        """Simulate a volumeless Dragonfly restart: every key is gone."""
+        self._streams.clear()
+        self._groups.clear()
+
+    async def xadd(self, name, fields, maxlen=None, approximate=False):
+        self._seq += 1
+        msg_id = f"{self._seq}-0"
+        self._streams.setdefault(name, []).append((msg_id, fields))
+        return msg_id
+
+    async def xreadgroup(self, groupname, consumername, streams, count=1, block=0):
+        results = []
+        for stream_key, _last_id in streams.items():
+            group_key = f"{stream_key}:{groupname}"
+            if group_key not in self._groups:
+                raise FakeResponseError(
+                    f"NOGROUP No such key '{stream_key}' or consumer group "
+                    f"'{groupname}' in XREADGROUP with GROUP option"
+                )
+            if stream_key not in self._streams:
+                continue
+            offset = int(self._groups[group_key].split("-")[0])
+            messages = [
+                (mid, fields)
+                for mid, fields in self._streams[stream_key]
+                if int(mid.split("-")[0]) > offset
+            ][:count]
+            if messages:
+                results.append((stream_key, messages))
+                self._groups[group_key] = messages[-1][0]
+        if results:
+            return results
+        if block:
+            # Real XREADGROUP BLOCK suspends; yield so the consumer task
+            # doesn't starve the test event loop.
+            await asyncio.sleep(0.01)
+        return None
+
+    async def xack(self, name, groupname, *ids):
+        return len(ids)
+
+    async def xgroup_create(self, name, groupname, id="0", mkstream=False):
+        group_key = f"{name}:{groupname}"
+        if group_key in self._groups:
+            raise FakeResponseError("BUSYGROUP Consumer Group name already exists")
+        if name not in self._streams:
+            if not mkstream:
+                raise FakeResponseError(
+                    "ERR The XGROUP subcommand requires the key to exist. Note that "
+                    "for CREATE you may want to use the MKSTREAM option to create "
+                    "an empty stream automatically."
+                )
+            self._streams[name] = []
+        self._groups[group_key] = id
+
+    async def xautoclaim(
+        self, name, groupname, consumername, min_idle_time=0, start_id="0-0", count=10
+    ):
+        group_key = f"{name}:{groupname}"
+        if group_key not in self._groups:
+            raise FakeResponseError(f"NOGROUP No such key '{name}' or consumer group '{groupname}'")
+        return ["0-0", [], []]
+
+
+@pytest.fixture
+def fake_redis():
+    return FakeRedisStreams()
+
+
+@pytest.mark.asyncio
+async def test_start_on_empty_cache_creates_stream_and_group(fake_redis):
+    """Empty cache at boot is normal: start() runs XGROUP CREATE MKSTREAM."""
+    stream = DurableInvalidationStream(redis_client=fake_redis, zone_id="zone-b")
+    await stream.start()
+    try:
+        stream_key = encode_channel("rebac:durable", "zone-b", "all")
+        assert stream_key in fake_redis._streams
+        assert f"{stream_key}:zone:zone-b" in fake_redis._groups
+    finally:
+        await stream.stop()
+
+
+@pytest.mark.asyncio
+async def test_group_create_idempotent_on_restart(fake_redis):
+    """BUSYGROUP from an existing group is swallowed (normal restart path)."""
+    stream = DurableInvalidationStream(redis_client=fake_redis, zone_id="zone-b")
+    await stream._ensure_consumer_groups()
+    # Second create must not raise despite BUSYGROUP from the server
+    await stream._ensure_consumer_groups()
+
+
+@pytest.mark.asyncio
+async def test_consumer_self_heals_after_cache_flush(fake_redis):
+    """Mid-run cache flush: consumer re-creates the group and resumes.
+
+    Reproduces the #4338 crash loop: group exists at start(), Dragonfly
+    restarts empty, a publisher's XADD re-creates the stream but not the
+    group, and every XREADGROUP fails with NOGROUP until the consumer
+    re-creates the group itself.
+    """
+    fence = ReadFence()
+    stream = DurableInvalidationStream(
+        redis_client=fake_redis,
+        zone_id="zone-b",
+        read_fence=fence,
+        consumer_block_ms=50,
+    )
+
+    received = asyncio.Event()
+
+    async def handler(zone_id, payload):
+        received.set()
+
+    stream.register_handler("test", handler)
+    await stream.start()
+    try:
+        # Let the consumer complete at least one healthy read cycle
+        await asyncio.sleep(0.05)
+
+        # Volumeless Dragonfly restarts empty
+        fake_redis.flush()
+
+        # A publisher in another zone keeps writing — XADD re-creates the
+        # stream but never the consumer group
+        stream_key = encode_channel("rebac:durable", "zone-b", "all")
+        await fake_redis.xadd(
+            stream_key,
+            {"data": json.dumps({"source_zone": "zone-a", "subject_id": "alice"})},
+        )
+
+        # Consumer must re-create the group and deliver the event
+        await asyncio.wait_for(received.wait(), timeout=3.0)
+
+        assert stream.stats()["group_recreates"] >= 1
+        assert fence.watermark("zone-a") == 1
+    finally:
+        await stream.stop()
+
+
+@pytest.mark.asyncio
+async def test_recreate_failure_backs_off_then_recovers(fake_redis):
+    """Half-up Redis: failed re-create takes the 1s backoff path, then heals.
+
+    If XGROUP CREATE itself fails after a flush (e.g. Redis still coming
+    up), the consumer must fall back to the error backoff instead of
+    hot-looping, and recover once the server accepts the create.
+    """
+    fence = ReadFence()
+    stream = DurableInvalidationStream(
+        redis_client=fake_redis,
+        zone_id="zone-b",
+        read_fence=fence,
+        consumer_block_ms=50,
+    )
+
+    received = asyncio.Event()
+
+    async def handler(zone_id, payload):
+        received.set()
+
+    stream.register_handler("test", handler)
+    await stream.start()
+    try:
+        await asyncio.sleep(0.05)
+        fake_redis.flush()
+
+        real_create = fake_redis.xgroup_create
+        fail_remaining = 2
+
+        async def flaky_create(*args, **kwargs):
+            nonlocal fail_remaining
+            if fail_remaining > 0:
+                fail_remaining -= 1
+                raise FakeResponseError("connection refused")
+            return await real_create(*args, **kwargs)
+
+        fake_redis.xgroup_create = flaky_create
+
+        stream_key = encode_channel("rebac:durable", "zone-b", "all")
+        await fake_redis.xadd(
+            stream_key,
+            {"data": json.dumps({"source_zone": "zone-a", "subject_id": "alice"})},
+        )
+
+        # Two failed re-creates (~1s backoff each), then success + delivery
+        await asyncio.wait_for(received.wait(), timeout=8.0)
+
+        stats = stream.stats()
+        assert stats["group_recreates"] >= 1
+        assert stats["consume_errors"] >= 2  # the failed re-creates backed off
+    finally:
+        # Restore before stop() so a consumer mid-recreate at teardown
+        # can't hit the flaky raise path and log spurious warnings.
+        fake_redis.xgroup_create = real_create
+        await stream.stop()


### PR DESCRIPTION
## Summary

Fixes the `NOGROUP` crash loop from #4338: the ReBAC durable consumer created its stream + consumer group only in `start()`. When the volumeless Dragonfly cache restarted empty mid-run (Railway region move, 2026-06-02), publishers' `XADD` re-created the stream but never the group, so every `XREADGROUP` failed with `NOGROUP`, was swallowed by the generic error handler, and retried identically forever.

- **Self-heal (ask 1):** `_consume_loop` now detects `NOGROUP`, re-runs the idempotent `XGROUP CREATE ... MKSTREAM` (`id=0`, so anything still in the stream is consumed), and resumes immediately. Re-create failures fall back to the existing 1s-backoff error path, so a half-up Redis can't hot-loop it. New `group_recreates` counter in `stats()` for observability. Boot-time creation already existed (since #3462) and is now pinned by tests.
- **Flush semantics doc (ask 2):** module docstring documents what a cache flush loses and why **no backfill/replay is needed**: relationship tuples live in the relational source of truth — the stream only carries cache-invalidation hints. Lost events mean remote zones can serve stale cached decisions only until TTL expiry (L1 result cache 300s grants / 60s denials, permission leases 30s), after which decisions re-derive from the source of truth.

## Tests

Batch 8 test pruning (5b38629f9) removed the mock-heavy cross-zone suite, leaving `DurableInvalidationStream` with no functional coverage, so the regression tests live in a new focused file `tests/unit/core/test_durable_stream_flush_recovery.py` with a purpose-built fake that mirrors real Redis error semantics (raises `NOGROUP`/`BUSYGROUP`/`ERR` like the server does).

- [x] `test_consumer_self_heals_after_cache_flush` reproduces the prod loop (verified red against unfixed source — fails in the NOGROUP loop with the prod-identical error — and green with the fix)
- [x] Pin tests: `start()` on an empty cache creates stream+group via MKSTREAM; `BUSYGROUP` on restart is swallowed
- [x] ruff check/format clean; mypy clean on changed source; pre-commit hooks pass

Closes #4338