### PR TITLE
docs(runbook): §3 Windows MSYS / Git Bash + doctor reference (paired with nexus-vfs#39)

### DIFF
--- a/docs/architecture/federation-cross-machine-runbook.md
+++ b/docs/architecture/federation-cross-machine-runbook.md
@@ -185,6 +185,7 @@ Key contract rules:
 * **`NEXUS_HOSTNAME` should be the node's Tailscale IP** for unambiguous self-detection across machines.
 * **`NEXUS_DATA_DIR` and `--data-dir` must point to the same directory.**
 * **`--no-tls` is fine for local testing.**  Without it the daemon auto-detects certs in `<data-dir>/tls/`.
+* **Windows MSYS / Git Bash operators**: set `MSYS_NO_PATHCONV=1` in the shell *before* exporting `NEXUS_FEDERATION_MOUNTS`, or single-quote the value (`'NEXUS_FEDERATION_MOUNTS=/shared=sharedzone'`).  Without one of these, the shell rewrites the leading `/shared` into `C:/Program Files/Git/shared` before `nexusd-cluster` ever sees the env var; the daemon then boots with `mount_count=0` and the `/shared` namespace stays un-federated.  Post-nexus-vfs#39 the cluster binary refuses to start in this state and names the workaround in the error; on older binaries the symptom is a silent zero-mount federation that surfaces as downstream raft replication failures hours later.
 
 **3a. Founder (machine A, first boot)**
 
@@ -403,6 +404,17 @@ The choices below are stable invariants of the design.  Each ties back to a spec
 ---
 
 ## Troubleshooting
+
+### One-shot self-check: `nexusd-cluster doctor`
+
+Before grepping logs, ask the binary:
+
+```bash
+pkill -f nexusd-cluster
+target/release/nexusd-cluster doctor --data-dir /tmp/nexus-fed-data
+```
+
+It walks every zone subdirectory, reads ConfState + HardState + log indices directly from redb, and prints a one-screen per-zone summary plus any alarms (`STORAGE_LOCKED`, `STALE_LOG`, …) with operator recovery hints.  Exit code 2 means at least one zone is wedged.  Available post-nexus-vfs#39.
 
 ### Tailscale
 


### PR DESCRIPTION
## Summary

Paired with [nexus-vfs#39](https://github.com/nexi-lab/nexus-vfs/pull/39) (federation operator-experience hardening).  Two operator-experience updates distilled from an 8-hour Mac↔Win L1 manual smoke that wedged on substrate signals downstream of the actual root cause:

* **§3 contract rules** — Windows MSYS / Git Bash silently rewrites `/shared` in `NEXUS_FEDERATION_MOUNTS` into `C:/Program Files/Git/shared` before exec.  The cluster binary then drops the entry and boots with `mount_count=0`.  Add `MSYS_NO_PATHCONV=1` (or single-quoting) as the canonical workaround.  Post-nexus-vfs#39 the cluster binary refuses to start in this state and names the workaround in the error.
* **Troubleshooting** — new "One-shot self-check" subsection introducing `nexusd-cluster doctor --data-dir <dir>` as the first thing to run before grepping logs.  Available post-nexus-vfs#39.

## Test plan

- [x] Doc render visually checks out.
- [ ] Merge after nexus-vfs#39 lands so the cross-reference is valid.