### PR TITLE
fix(search): bounded retries + durable parking for unresolvable mutation events (#4337)

### DIFF
--- a/docs/operations/search-mutation-parking.md
+++ b/docs/operations/search-mutation-parking.md
@@ -1,0 +1,98 @@
+# Runbook: Search Mutation Parking (#4337)
+
+When the search daemon cannot resolve content for a write event, the
+consumer retries the batch (the checkpoint does not advance). Since #4337
+retries are **bounded**: permanent failures (file gone) park after
+~3 passes (~6 s), transient failures (backend outage) after ~30 passes
+(~60 s). A **parked** event is skipped by the live consumer but durably
+recorded for re-drive or discard.
+
+## Symptoms
+
+Log lines from `nexus.bricks.search.daemon`:
+
+- Retrying (bounded):
+  `<consumer> mutation content unresolved for event_id=... path=... kind=... attempt=N/M — refusing to checkpoint so the consumer retries on next pass`
+- Parked (skipped, recorded):
+  `Search mutation PARKED for consumer=... event_id=... path=... kind=... after N attempts ...`
+- Forced skip:
+  `Search mutation checkpoint FORCED for consumer=...: A -> B`
+
+Metrics (Prometheus):
+
+| Metric | Meaning | Suggested alert |
+| --- | --- | --- |
+| `nexus_search_mutation_parked_total{consumer,kind}` | Events parked | Page on any increase |
+| `nexus_search_mutation_parked_current{consumer}` | Currently parked | Warn while > 0 |
+| `nexus_search_mutation_unresolved_retries_total{consumer,kind}` | Retry passes (pre-park) | Warn on sustained rate |
+| `nexus_search_mutation_parked_evicted_total{consumer}` | Cap evictions (parking storm) | Page on any increase |
+
+## Diagnose
+
+```bash
+# Consumer state: parked_count, last_parked, retrying head-of-line blocker
+curl -s "$NEXUS_URL/api/v2/search/stats" | jq '.mutation_consumers'
+
+# Full parked entries (admin)
+curl -s -H "Authorization: Bearer $ADMIN_TOKEN" \
+  "$NEXUS_URL/api/v2/search/parked" | jq
+```
+
+`kind=permanent` → the path's payload is gone (cf. issue #4339 forensics).
+`kind=transient` → the content backend was unreachable; content may exist.
+
+## Decide
+
+- **Payload restored / outage over → retry** (re-drives through the
+  consumer; success removes the record, failure re-parks with the error):
+
+```bash
+curl -s -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"consumer": "embedding", "event_ids": null}' \
+  "$NEXUS_URL/api/v2/search/parked/retry" | jq
+```
+
+(`event_ids: null` retries everything parked for that consumer.)
+
+A response of `{"retried": 0, ...}` means none of the given `event_ids` are
+currently parked for that consumer (typo, already retried, or discarded) —
+check `GET /api/v2/search/parked` for the live list.
+
+- **Content permanently gone, loss accepted → discard:**
+
+```bash
+curl -s -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"consumer": "embedding", "event_ids": ["search:a39822b6-..."]}' \
+  "$NEXUS_URL/api/v2/search/parked/discard" | jq
+```
+
+- **Consumer wedged on something the gate does not handle → force-advance
+  the checkpoint** (skips EVERY event ≤ the new sequence for that
+  consumer — use the smallest sequence that unwedges, typically the
+  blocker's own `sequence_number` from `/stats`):
+
+```bash
+curl -s -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"sequence": 123456}' \
+  "$NEXUS_URL/api/v2/search/consumers/embedding/skip-to" | jq
+```
+
+On a daemon whose consumers have never run, the 400 rejection's "current
+checkpoint" is the live operation-log maximum (the value consumer startup
+would snap to), not 0.
+
+## Notes
+
+- Park records live in the settings store under `search_mutation_parked`
+  (file fallback `mutation-parked.json` next to the checkpoints file).
+  Capped at 200 entries per consumer; evictions log ERROR and bump
+  `..._parked_evicted_total` — an eviction means a parking storm, look for
+  a systemic cause (e.g. #4339-scale payload loss) instead of per-event
+  triage.
+- Restarts reset in-flight retry counters (a poisoned event re-parks within
+  seconds); parked records persist.
+- A parked event whose content later resolves on its own (e.g. the same
+  path is re-written) is auto-unparked by the gate.

--- a/docs/superpowers/plans/2026-06-09-issue-4337-search-mutation-parking.md
+++ b/docs/superpowers/plans/2026-06-09-issue-4337-search-mutation-parking.md
@@ -1,0 +1,2133 @@
+# Search Mutation Parking (#4337) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop one unresolvable mutation event from head-of-line blocking search indexing forever: classify resolution failures, bound retries, park exhausted events durably, and give admins REST endpoints to re-drive/discard parked events or force-advance a consumer checkpoint.
+
+**Architecture:** All four durable consumers (`bm25`, `fts`, `embedding`, `txtai`) funnel through `SearchDaemon._resolve_mutations`; a bounded-retry gate lives there (spec: `docs/superpowers/specs/2026-06-09-issue-4337-search-mutation-parking-design.md`). A new `MutationParkStore` mirrors the checkpoint dual-persistence pattern (settings store primary, JSON file fallback). The `MutationResolver` learns to classify read failures permanent vs transient instead of swallowing them. New admin REST endpoints land in the existing search router.
+
+**Tech Stack:** Python 3.12+, asyncio, pytest + pytest-asyncio, FastAPI + TestClient, prometheus_client, dataclasses. Test runner: `uv run pytest`.
+
+**Worktree gotchas (from prior sessions):** if pre-commit fails oddly in this worktree, `rm -rf .venv` (bare `.venv` dir breaks it). Run `uv sync --all-extras` once if `uv run pytest` can't import the package.
+
+---
+
+## File map
+
+| File | Action | Responsibility |
+| --- | --- | --- |
+| `src/nexus/bricks/search/consumer_metrics.py` | Create | Prometheus metrics (4337), precedent `bricks/auth/consumer_metrics.py` |
+| `src/nexus/bricks/search/mutation_parking.py` | Create | `UnresolvedMutationError`, `ParkedEvent`, `MutationParkStore` (dual persistence, cap, dedupe) |
+| `src/nexus/bricks/search/mutation_resolver.py` | Modify | `failure_kind`/`failure_detail` classification; stop caching unresolved |
+| `src/nexus/bricks/search/daemon.py` | Modify | Config knobs; gate in `_resolve_mutations`; park-store wiring + stats; monotonic checkpoint; `force_checkpoint`/`list_parked`/`retry_parked`/`discard_parked`; delete per-consumer unresolved branches |
+| `src/nexus/server/api/v2/routers/search.py` | Modify | `GET /parked`, `POST /parked/retry`, `POST /parked/discard`, `POST /consumers/{name}/skip-to` (admin) |
+| `docs/operations/search-mutation-parking.md` | Create | Runbook |
+| `tests/unit/bricks/search/test_mutation_parking_store.py` | Create | Store unit tests |
+| `tests/unit/bricks/search/test_mutation_resolver_classification.py` | Create | Resolver classification tests |
+| `tests/unit/bricks/search/test_daemon_parking_gate.py` | Create | Gate + consumer + checkpoint + retry/discard/stats tests |
+| `tests/unit/server/routers/test_search_parked_admin.py` | Create | REST endpoint tests |
+
+Key existing anchors (verified on this branch):
+
+- `DaemonConfig` fields end at `path_context_max_zones: int = 2048` (daemon.py:186).
+- `SearchDaemon.__init__` consumer state block at daemon.py:281-293 (`_consumer_last_sequence`, `_checkpoint_file`, `_checkpoint_lock`).
+- `_save_consumer_checkpoint` at daemon.py:2952.
+- `_run_mutation_consumer` at daemon.py:3071 (handler → `_save_consumer_checkpoint(events[-1].sequence_number)`).
+- `_resolve_mutations` at daemon.py:3116; call sites: `_delete_indexes_for_paths` (legacy, :2442), `_consume_bm25_mutations` (:3148), `_consume_fts_mutations` (:3207), `_consume_embedding_mutations` (:3274), `_consume_txtai_mutations` (:3351).
+- Unresolved-raise branches to delete: bm25 :3161-3167, fts :3209-3218, embedding :3276-3285.
+- `_index_refresh_loop` consumer dict at :2366-2371; reconcile handler dict at :2833-2837.
+- `get_stats` returns `"mutation_consumers": self.stats.mutation_consumers` at :3767.
+- Router deps: `_get_search_daemon` (search.py:61), `require_admin` exists in `nexus.server.dependencies` (used as `Depends(require_admin)` in `routers/path_contexts.py:223`).
+- `SystemSettingDTO` from `get_setting` exposes `.value` (see checkpoint read, daemon.py:2707-2716).
+
+---
+
+### Task 0: Environment sanity check
+
+**Files:** none modified.
+
+- [ ] **Step 0.1: Verify the test environment runs existing search tests**
+
+Run: `uv run pytest tests/unit/bricks/search/test_daemon_bm25_only.py -x -q`
+Expected: all tests pass. If imports fail, run `uv sync --all-extras` and retry. If pre-commit later fails with a venv error, `rm -rf .venv`.
+
+---
+
+### Task 1: Prometheus metrics module
+
+**Files:**
+- Create: `src/nexus/bricks/search/consumer_metrics.py`
+
+- [ ] **Step 1.1: Create the metrics module**
+
+```python
+"""Prometheus metrics for search mutation consumers (#4337).
+
+Low-cardinality labels only:
+  - consumer ∈ {bm25, fts, embedding, txtai}
+  - kind ∈ {permanent, transient}
+
+Split of responsibilities: the parking gate in ``daemon.py`` increments
+``MUTATION_PARKED_TOTAL`` / ``MUTATION_UNRESOLVED_RETRIES_TOTAL``; the
+``MutationParkStore`` owns ``MUTATION_PARKED`` (gauge synced on load /
+park / remove) and ``MUTATION_PARKED_EVICTED_TOTAL``.
+"""
+
+from __future__ import annotations
+
+from prometheus_client import Counter, Gauge
+
+MUTATION_PARKED_TOTAL = Counter(
+    "nexus_search_mutation_parked_total",
+    "Search mutation events parked after exhausting their retry budget",
+    labelnames=("consumer", "kind"),
+)
+
+MUTATION_PARKED = Gauge(
+    # Not "..._parked": prometheus_client strips "_total" from Counter
+    # names, so MUTATION_PARKED_TOTAL above already claims the
+    # "nexus_search_mutation_parked" base name in the registry.
+    "nexus_search_mutation_parked_current",
+    "Search mutation events currently parked",
+    labelnames=("consumer",),
+)
+
+MUTATION_UNRESOLVED_RETRIES_TOTAL = Counter(
+    "nexus_search_mutation_unresolved_retries_total",
+    "Retry passes that observed an unresolved mutation (early warning before parking)",
+    labelnames=("consumer", "kind"),
+)
+
+MUTATION_PARKED_EVICTED_TOTAL = Counter(
+    "nexus_search_mutation_parked_evicted_total",
+    "Parked entries evicted by the per-consumer cap",
+    labelnames=("consumer",),
+)
+```
+
+- [ ] **Step 1.2: Smoke-test the import**
+
+Run: `uv run python -c "from nexus.bricks.search import consumer_metrics as m; m.MUTATION_PARKED.labels(consumer='bm25').set(0); print('ok')"`
+Expected: `ok`
+
+- [ ] **Step 1.3: Commit**
+
+```bash
+git add src/nexus/bricks/search/consumer_metrics.py
+git commit -m "feat(#4337): prometheus metrics for search mutation parking"
+```
+
+---
+
+### Task 2: ParkedEvent + MutationParkStore
+
+**Files:**
+- Create: `src/nexus/bricks/search/mutation_parking.py`
+- Test: `tests/unit/bricks/search/test_mutation_parking_store.py`
+
+- [ ] **Step 2.1: Write the failing tests**
+
+```python
+"""Unit tests for MutationParkStore / ParkedEvent (#4337)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from nexus.bricks.search.mutation_events import SearchMutationEvent, SearchMutationOp
+from nexus.bricks.search.mutation_parking import MutationParkStore, ParkedEvent
+
+
+class FakeSettingsStore:
+    def __init__(self) -> None:
+        self.values: dict[str, str] = {}
+
+    def get_setting(self, key: str) -> Any:
+        value = self.values.get(key)
+        return SimpleNamespace(value=value) if value is not None else None
+
+    def set_setting(self, key: str, value: str, *, description: str | None = None) -> None:
+        self.values[key] = value
+
+
+class BrokenSettingsStore:
+    def get_setting(self, key: str) -> Any:
+        raise RuntimeError("settings store down")
+
+    def set_setting(self, key: str, value: str, *, description: str | None = None) -> None:
+        raise RuntimeError("settings store down")
+
+
+def _entry(consumer: str = "bm25", event_id: str = "search:op-1", seq: int = 7) -> ParkedEvent:
+    return ParkedEvent(
+        consumer=consumer,
+        event_id=event_id,
+        operation_id=event_id.removeprefix("search:"),
+        op="upsert",
+        path="/zone/z1/docs/a.md",
+        zone_id="z1",
+        timestamp="2026-06-09T01:02:03",
+        sequence_number=seq,
+        new_path=None,
+        kind="permanent",
+        detail="FileNotFoundError('/zone/z1/docs/a.md')",
+        attempts=3,
+        parked_at=1750000000.0,
+    )
+
+
+def test_parked_event_roundtrip_dict_and_event() -> None:
+    entry = _entry()
+    rebuilt = ParkedEvent.from_dict(entry.to_dict())
+    assert rebuilt == entry
+    event = rebuilt.to_event()
+    assert isinstance(event, SearchMutationEvent)
+    assert event.op == SearchMutationOp.UPSERT
+    assert event.event_id == "search:op-1"
+    assert event.sequence_number == 7
+    assert event.virtual_path == "/docs/a.md"
+
+
+@pytest.mark.asyncio
+async def test_park_and_load_via_settings_store(tmp_path) -> None:
+    settings = FakeSettingsStore()
+    store = MutationParkStore(
+        settings_store=settings,
+        fallback_file=tmp_path / "mutation-parked.json",
+        max_entries_per_consumer=10,
+    )
+    await store.load()
+    await store.park(_entry())
+    assert store.contains("bm25", "search:op-1")
+    assert store.count("bm25") == 1
+
+    # A fresh store (simulated restart) loads the same state back.
+    store2 = MutationParkStore(
+        settings_store=settings,
+        fallback_file=tmp_path / "mutation-parked.json",
+        max_entries_per_consumer=10,
+    )
+    await store2.load()
+    assert store2.contains("bm25", "search:op-1")
+    assert store2.last("bm25") == _entry()
+
+
+@pytest.mark.asyncio
+async def test_park_falls_back_to_file_when_settings_store_broken(tmp_path) -> None:
+    store = MutationParkStore(
+        settings_store=BrokenSettingsStore(),
+        fallback_file=tmp_path / "mutation-parked.json",
+        max_entries_per_consumer=10,
+    )
+    await store.load()
+    await store.park(_entry())
+    assert (tmp_path / "mutation-parked.json").exists()
+
+    store2 = MutationParkStore(
+        settings_store=None,
+        fallback_file=tmp_path / "mutation-parked.json",
+        max_entries_per_consumer=10,
+    )
+    await store2.load()
+    assert store2.contains("bm25", "search:op-1")
+
+
+@pytest.mark.asyncio
+async def test_park_dedupes_by_consumer_and_event_id(tmp_path) -> None:
+    store = MutationParkStore(
+        settings_store=None,
+        fallback_file=tmp_path / "mutation-parked.json",
+        max_entries_per_consumer=10,
+    )
+    await store.load()
+    await store.park(_entry())
+    replacement = _entry()
+    replacement = ParkedEvent.from_dict({**replacement.to_dict(), "attempts": 9})
+    await store.park(replacement)
+    assert store.count("bm25") == 1
+    assert store.last("bm25").attempts == 9
+
+
+@pytest.mark.asyncio
+async def test_cap_evicts_oldest_first(tmp_path) -> None:
+    store = MutationParkStore(
+        settings_store=None,
+        fallback_file=tmp_path / "mutation-parked.json",
+        max_entries_per_consumer=2,
+    )
+    await store.load()
+    await store.park(_entry(event_id="search:op-1", seq=1))
+    await store.park(_entry(event_id="search:op-2", seq=2))
+    await store.park(_entry(event_id="search:op-3", seq=3))
+    assert store.count("bm25") == 2
+    assert not store.contains("bm25", "search:op-1")
+    assert store.contains("bm25", "search:op-2")
+    assert store.contains("bm25", "search:op-3")
+
+
+@pytest.mark.asyncio
+async def test_remove_returns_removed_entries(tmp_path) -> None:
+    store = MutationParkStore(
+        settings_store=None,
+        fallback_file=tmp_path / "mutation-parked.json",
+        max_entries_per_consumer=10,
+    )
+    await store.load()
+    await store.park(_entry(event_id="search:op-1"))
+    await store.park(_entry(event_id="search:op-2"))
+    removed = await store.remove("bm25", ["search:op-1", "search:missing"])
+    assert [e.event_id for e in removed] == ["search:op-1"]
+    assert store.count("bm25") == 1
+
+
+@pytest.mark.asyncio
+async def test_park_raises_when_both_persistence_paths_fail(tmp_path, monkeypatch) -> None:
+    store = MutationParkStore(
+        settings_store=BrokenSettingsStore(),
+        fallback_file=tmp_path / "nope" / "mutation-parked.json",
+        max_entries_per_consumer=10,
+    )
+    await store.load()
+
+    def _boom(*args: Any, **kwargs: Any) -> None:
+        raise OSError("disk full")
+
+    monkeypatch.setattr("pathlib.Path.write_text", _boom)
+    with pytest.raises(OSError):
+        await store.park(_entry())
+```
+
+- [ ] **Step 2.2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/unit/bricks/search/test_mutation_parking_store.py -q`
+Expected: FAIL — `ModuleNotFoundError: No module named 'nexus.bricks.search.mutation_parking'`
+
+- [ ] **Step 2.3: Implement `mutation_parking.py`**
+
+```python
+"""Parked-event store for search mutation consumers (#4337).
+
+When the bounded-retry gate in ``SearchDaemon._resolve_mutations`` exhausts
+an unresolved mutation's budget, the event is parked here: skipped by the
+live consumer (the checkpoint advances past it) but durably recorded so an
+admin can re-drive or discard it via the REST surface.
+
+Persistence mirrors the mutation-checkpoint pattern: settings store primary
+(key ``search_mutation_parked``), JSON file fallback next to
+``mutation-checkpoints.json``. If BOTH paths fail, ``park`` raises so the
+caller refuses to checkpoint — an event is never skipped without a record.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+from dataclasses import asdict, dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from nexus.bricks.search import consumer_metrics
+from nexus.bricks.search.mutation_events import SearchMutationEvent, SearchMutationOp
+
+logger = logging.getLogger(__name__)
+
+PARKED_SETTINGS_KEY = "search_mutation_parked"
+
+
+class UnresolvedMutationError(RuntimeError):
+    """Unresolved mutation still within its retry budget — batch must retry."""
+
+
+@dataclass(frozen=True)
+class ParkedEvent:
+    """A skipped mutation event plus enough context to re-drive it."""
+
+    consumer: str
+    event_id: str
+    operation_id: str
+    op: str  # SearchMutationOp value
+    path: str
+    zone_id: str
+    timestamp: str  # ISO-8601, naive UTC (matches SearchMutationEvent.timestamp)
+    sequence_number: int
+    new_path: str | None
+    kind: str  # "permanent" | "transient"
+    detail: str
+    attempts: int
+    parked_at: float
+
+    @classmethod
+    def from_mutation(
+        cls,
+        consumer: str,
+        mutation: Any,
+        *,
+        kind: str,
+        detail: str,
+        attempts: int,
+    ) -> "ParkedEvent":
+        event = mutation.event
+        return cls(
+            consumer=consumer,
+            event_id=event.event_id,
+            operation_id=event.operation_id,
+            op=event.op.value,
+            path=event.path,
+            zone_id=event.zone_id,
+            timestamp=event.timestamp.isoformat(),
+            sequence_number=event.sequence_number,
+            new_path=event.new_path,
+            kind=kind,
+            detail=detail,
+            attempts=attempts,
+            parked_at=time.time(),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "ParkedEvent":
+        return cls(
+            consumer=str(data["consumer"]),
+            event_id=str(data["event_id"]),
+            operation_id=str(data["operation_id"]),
+            op=str(data["op"]),
+            path=str(data["path"]),
+            zone_id=str(data["zone_id"]),
+            timestamp=str(data["timestamp"]),
+            sequence_number=int(data["sequence_number"]),
+            new_path=data.get("new_path"),
+            kind=str(data.get("kind", "transient")),
+            detail=str(data.get("detail", "")),
+            attempts=int(data.get("attempts", 0)),
+            parked_at=float(data.get("parked_at", 0.0)),
+        )
+
+    def to_event(self) -> SearchMutationEvent:
+        return SearchMutationEvent(
+            event_id=self.event_id,
+            operation_id=self.operation_id,
+            op=SearchMutationOp(self.op),
+            path=self.path,
+            zone_id=self.zone_id,
+            timestamp=datetime.fromisoformat(self.timestamp),
+            sequence_number=self.sequence_number,
+            new_path=self.new_path,
+        )
+
+
+class MutationParkStore:
+    """Durable per-consumer list of parked mutation events.
+
+    In-memory dict is the source of truth after ``load``; every mutation
+    re-persists the full document (small: capped per consumer).
+    """
+
+    def __init__(
+        self,
+        *,
+        settings_store: Any | None,
+        fallback_file: Path,
+        max_entries_per_consumer: int = 200,
+    ) -> None:
+        self._settings_store = settings_store
+        self._fallback_file = fallback_file
+        self._max_entries = max(1, int(max_entries_per_consumer))
+        self._lock = asyncio.Lock()
+        self._entries: dict[str, list[ParkedEvent]] = {}
+
+    # -- queries (sync, in-memory) -----------------------------------------
+
+    def contains(self, consumer: str, event_id: str) -> bool:
+        return any(e.event_id == event_id for e in self._entries.get(consumer, []))
+
+    def count(self, consumer: str) -> int:
+        return len(self._entries.get(consumer, []))
+
+    def last(self, consumer: str) -> ParkedEvent | None:
+        entries = self._entries.get(consumer, [])
+        return entries[-1] if entries else None
+
+    def list_entries(self, consumer: str | None = None) -> dict[str, list[ParkedEvent]]:
+        if consumer is not None:
+            return {consumer: list(self._entries.get(consumer, []))}
+        return {name: list(entries) for name, entries in self._entries.items()}
+
+    # -- mutations ----------------------------------------------------------
+
+    async def load(self) -> None:
+        """Load persisted state (best-effort) and seed the parked gauge."""
+        async with self._lock:
+            payload: str | None = None
+            if self._settings_store is not None:
+                try:
+                    setting = self._settings_store.get_setting(PARKED_SETTINGS_KEY)
+                    if setting is not None:
+                        payload = getattr(setting, "value", None)
+                except Exception as exc:
+                    logger.warning(
+                        "Parked-event store read falling back to file storage: %s", exc
+                    )
+                    self._settings_store = None
+            if payload is None:
+                payload = await asyncio.to_thread(self._read_file)
+            if payload:
+                try:
+                    raw = json.loads(payload)
+                    self._entries = {
+                        str(consumer): [ParkedEvent.from_dict(item) for item in items]
+                        for consumer, items in raw.items()
+                    }
+                except Exception as exc:
+                    logger.error(
+                        "Parked-event store unreadable; starting empty "
+                        "(previous parked records lost): %s",
+                        exc,
+                    )
+                    self._entries = {}
+            for consumer in self._entries:
+                self._sync_gauge(consumer)
+
+    async def park(self, entry: ParkedEvent) -> None:
+        """Insert/replace an entry; evict oldest beyond the cap; persist.
+
+        Raises if BOTH persistence paths fail — callers must not skip an
+        event that has no durable record.
+        """
+        async with self._lock:
+            entries = [
+                e for e in self._entries.get(entry.consumer, []) if e.event_id != entry.event_id
+            ]
+            entries.append(entry)
+            while len(entries) > self._max_entries:
+                evicted = entries.pop(0)
+                consumer_metrics.MUTATION_PARKED_EVICTED_TOTAL.labels(
+                    consumer=entry.consumer
+                ).inc()
+                logger.error(
+                    "Parked-event cap (%d) exceeded for consumer=%s — evicting "
+                    "oldest entry event_id=%s path=%s (parking storm?)",
+                    self._max_entries,
+                    entry.consumer,
+                    evicted.event_id,
+                    evicted.path,
+                )
+            self._entries[entry.consumer] = entries
+            await self._persist()
+            self._sync_gauge(entry.consumer)
+
+    async def remove(self, consumer: str, event_ids: list[str]) -> list[ParkedEvent]:
+        """Remove entries by id; returns the removed entries."""
+        wanted = set(event_ids)
+        async with self._lock:
+            entries = self._entries.get(consumer, [])
+            removed = [e for e in entries if e.event_id in wanted]
+            if not removed:
+                return []
+            self._entries[consumer] = [e for e in entries if e.event_id not in wanted]
+            await self._persist()
+            self._sync_gauge(consumer)
+            return removed
+
+    # -- internals ----------------------------------------------------------
+
+    def _read_file(self) -> str | None:
+        try:
+            if not self._fallback_file.exists():
+                return None
+            return self._fallback_file.read_text()
+        except OSError as exc:
+            logger.warning("Parked-event fallback file unreadable: %s", exc)
+            return None
+
+    def _sync_gauge(self, consumer: str) -> None:
+        consumer_metrics.MUTATION_PARKED.labels(consumer=consumer).set(
+            len(self._entries.get(consumer, []))
+        )
+
+    async def _persist(self) -> None:
+        payload = json.dumps(
+            {
+                consumer: [e.to_dict() for e in entries]
+                for consumer, entries in self._entries.items()
+                if entries
+            },
+            sort_keys=True,
+        )
+        if self._settings_store is not None:
+            try:
+                self._settings_store.set_setting(
+                    PARKED_SETTINGS_KEY,
+                    payload,
+                    description="Parked search mutation events (#4337)",
+                )
+                return
+            except Exception as exc:
+                logger.warning(
+                    "Parked-event store falling back to file storage: %s", exc
+                )
+                self._settings_store = None
+
+        def _write() -> None:
+            self._fallback_file.parent.mkdir(parents=True, exist_ok=True)
+            self._fallback_file.write_text(payload)
+
+        await asyncio.to_thread(_write)
+```
+
+- [ ] **Step 2.4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/unit/bricks/search/test_mutation_parking_store.py -q`
+Expected: all PASS
+
+- [ ] **Step 2.5: Commit**
+
+```bash
+git add src/nexus/bricks/search/mutation_parking.py tests/unit/bricks/search/test_mutation_parking_store.py
+git commit -m "feat(#4337): MutationParkStore with dual persistence and cap"
+```
+
+---
+
+### Task 3: Resolver failure classification
+
+**Files:**
+- Modify: `src/nexus/bricks/search/mutation_resolver.py`
+- Test: `tests/unit/bricks/search/test_mutation_resolver_classification.py`
+
+- [ ] **Step 3.1: Write the failing tests**
+
+```python
+"""MutationResolver failure-classification tests (#4337)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+
+from nexus.bricks.search.mutation_events import SearchMutationEvent, SearchMutationOp
+from nexus.bricks.search.mutation_resolver import MutationResolver
+from nexus.contracts.exceptions import NexusFileNotFoundError
+
+
+def _event(op: SearchMutationOp = SearchMutationOp.UPSERT, path: str = "/zone/z1/docs/a.md"):
+    return SearchMutationEvent(
+        event_id="search:op-1",
+        operation_id="op-1",
+        op=op,
+        path=path,
+        zone_id="z1",
+        timestamp=datetime(2026, 6, 9, 1, 2, 3),
+        sequence_number=7,
+    )
+
+
+class NotFoundReader:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def read_text(self, path: str) -> str:
+        self.calls += 1
+        raise FileNotFoundError(path)
+
+
+class OutageReader:
+    async def read_text(self, path: str) -> str:
+        raise TimeoutError("backend down")
+
+
+class MixedReader:
+    """NotFound on scoped path, outage on virtual path."""
+
+    async def read_text(self, path: str) -> str:
+        if path.startswith("/zone/"):
+            raise FileNotFoundError(path)
+        raise TimeoutError("backend down")
+
+
+class EmptyReader:
+    async def read_text(self, path: str) -> str:
+        return ""
+
+
+def test_nexus_not_found_is_filenotfound_subclass() -> None:
+    assert issubclass(NexusFileNotFoundError, FileNotFoundError)
+
+
+@pytest.mark.asyncio
+async def test_not_found_on_both_paths_is_permanent() -> None:
+    resolver = MutationResolver(file_reader=NotFoundReader(), async_session_factory=None)
+    [mutation] = await resolver.resolve_batch([_event()])
+    assert mutation.content_resolved is False
+    assert mutation.failure_kind == "permanent"
+    assert mutation.failure_detail
+
+
+@pytest.mark.asyncio
+async def test_non_notfound_failure_is_transient() -> None:
+    resolver = MutationResolver(file_reader=OutageReader(), async_session_factory=None)
+    [mutation] = await resolver.resolve_batch([_event()])
+    assert mutation.content_resolved is False
+    assert mutation.failure_kind == "transient"
+
+
+@pytest.mark.asyncio
+async def test_mixed_failures_are_transient() -> None:
+    resolver = MutationResolver(file_reader=MixedReader(), async_session_factory=None)
+    [mutation] = await resolver.resolve_batch([_event()])
+    assert mutation.failure_kind == "transient"
+
+
+@pytest.mark.asyncio
+async def test_missing_reader_is_transient_boot_window() -> None:
+    resolver = MutationResolver(file_reader=None, async_session_factory=None)
+    [mutation] = await resolver.resolve_batch([_event()])
+    assert mutation.content_resolved is False
+    assert mutation.failure_kind == "transient"
+
+
+@pytest.mark.asyncio
+async def test_empty_string_read_is_resolved_not_failure() -> None:
+    resolver = MutationResolver(file_reader=EmptyReader(), async_session_factory=None)
+    [mutation] = await resolver.resolve_batch([_event()])
+    assert mutation.content_resolved is True
+    assert mutation.content == ""
+    assert mutation.failure_kind is None
+
+
+@pytest.mark.asyncio
+async def test_delete_events_have_no_failure() -> None:
+    resolver = MutationResolver(file_reader=NotFoundReader(), async_session_factory=None)
+    [mutation] = await resolver.resolve_batch([_event(op=SearchMutationOp.DELETE)])
+    assert mutation.content_resolved is True
+    assert mutation.failure_kind is None
+
+
+@pytest.mark.asyncio
+async def test_unresolved_mutations_are_not_cached() -> None:
+    reader = NotFoundReader()
+    resolver = MutationResolver(file_reader=reader, async_session_factory=None)
+    await resolver.resolve_batch([_event()])
+    first_calls = reader.calls
+    assert first_calls > 0
+    assert "search:op-1" not in resolver._cache
+    await resolver.resolve_batch([_event()])
+    assert reader.calls > first_calls  # second pass re-read (no stale cache)
+
+
+@pytest.mark.asyncio
+async def test_resolved_mutations_are_still_cached() -> None:
+    resolver = MutationResolver(file_reader=EmptyReader(), async_session_factory=None)
+    await resolver.resolve_batch([_event()])
+    assert "search:op-1" in resolver._cache
+```
+
+- [ ] **Step 3.2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/unit/bricks/search/test_mutation_resolver_classification.py -q`
+Expected: FAIL — `ResolvedMutation` has no `failure_kind` (AttributeError / assertion errors)
+
+- [ ] **Step 3.3: Add the fields to `ResolvedMutation`**
+
+In `mutation_resolver.py`, extend the dataclass (after `content_resolved: bool = True`) and document:
+
+```python
+    event: SearchMutationEvent
+    zone_id: str
+    virtual_path: str
+    path_id: str
+    doc_id: str
+    content: str | None = None
+    path_id_resolved: bool = True
+    content_resolved: bool = True
+    # #4337: when content_resolved=False, classify WHY so the parking gate
+    # can budget retries: "permanent" (every read raised FileNotFoundError —
+    # the path is gone) vs "transient" (no reader yet, non-NotFound error,
+    # backend outage). None when content_resolved=True.
+    failure_kind: str | None = None
+    failure_detail: str | None = None
+```
+
+- [ ] **Step 3.4: Replace `_read_content` with the classifying version**
+
+Replace the whole `_read_content` method:
+
+```python
+    async def _read_content(
+        self, scoped_path: str, virtual_path: str
+    ) -> tuple[str | None, str | None, str | None]:
+        """Return ``(content, failure_kind, failure_detail)``.
+
+        ``content`` is a str (possibly empty) on success. On failure it is
+        ``None`` and ``failure_kind`` classifies the failure (#4337):
+
+          * ``"permanent"`` — every attempted read raised
+            ``FileNotFoundError`` (incl. ``NexusFileNotFoundError``): the
+            path is gone as far as the reader is concerned.
+          * ``"transient"`` — anything else: no reader attached yet (the
+            server lifespan wires it post-boot), a non-string return, or a
+            non-NotFound exception (backend outage, timeout).
+        """
+        if self._file_reader is None:
+            return None, "transient", "no file_reader attached"
+
+        candidates = [scoped_path]
+        if virtual_path != scoped_path:
+            candidates.append(virtual_path)
+
+        failures: list[tuple[str, BaseException | str]] = []
+        for candidate in candidates:
+            try:
+                content = await self._file_reader.read_text(candidate)
+            except Exception as exc:
+                failures.append((candidate, exc))
+                continue
+            if isinstance(content, str):
+                return content, None, None
+            failures.append((candidate, f"non-string return {type(content).__name__!r}"))
+
+        permanent = all(
+            isinstance(failure, FileNotFoundError) for _, failure in failures
+        )
+        kind = "permanent" if permanent else "transient"
+        detail = "; ".join(f"{path}: {failure!r}" for path, failure in failures)
+        return None, kind, detail
+```
+
+The old version's `with contextlib.suppress(...)` block was the module's only use of `contextlib` — delete the `import contextlib` line at the top of `mutation_resolver.py` (ruff will flag it otherwise).
+
+- [ ] **Step 3.5: Thread failures through `_lookup_content`**
+
+Replace `_lookup_content` so it returns both maps:
+
+```python
+    async def _lookup_content(
+        self,
+        events: list[SearchMutationEvent],
+        unresolved_indices: list[int],
+    ) -> tuple[dict[str, str], dict[str, tuple[str, str]]]:
+        """Resolve UPSERT content for each unresolved event.
+
+        Returns ``(content_map, failure_map)``: an event_id present in
+        ``content_map`` is resolved (possibly to ``""`` — a valid state);
+        an event_id present in ``failure_map`` failed with
+        ``(failure_kind, failure_detail)``. The content_cache DB fallback
+        clears a read failure when it hits.
+        """
+        content_map: dict[str, str] = {}
+        failure_map: dict[str, tuple[str, str]] = {}
+        update_events = [
+            events[idx] for idx in unresolved_indices if events[idx].op.value == "upsert"
+        ]
+        if not update_events:
+            return content_map, failure_map
+
+        missing_events: list[SearchMutationEvent] = []
+        for event in update_events:
+            content, kind, detail = await self._read_content(event.path, event.virtual_path)
+            if isinstance(content, str):
+                content_map[event.event_id] = _strip_null_bytes(content)
+            else:
+                failure_map[event.event_id] = (
+                    kind or "transient",
+                    detail or "unknown read failure",
+                )
+                missing_events.append(event)
+
+        if missing_events and self._async_session_factory is not None:
+            lookup_candidates: list[tuple[str, str, str, int]] = []
+            for event in missing_events:
+                lookup_candidates.extend(self._lookup_candidates(event))
+            db_content = await self._lookup_content_cache(lookup_candidates)
+            for event in missing_events:
+                content = db_content.get(self._path_key(event.zone_id, event.virtual_path))
+                if isinstance(content, str):
+                    content_map[event.event_id] = _strip_null_bytes(content)
+                    failure_map.pop(event.event_id, None)
+
+        return content_map, failure_map
+```
+
+- [ ] **Step 3.6: Use the failure map in `resolve_batch` and stop caching unresolved**
+
+In `resolve_batch`, change the call site:
+
+```python
+        content_map, failure_map = await self._lookup_content(events, unresolved_indices)
+```
+
+and replace the per-event block (the `if event.op == SearchMutationOp.DELETE:` /
+`else:` content section through `resolved[idx] = mutation`) with:
+
+```python
+            if event.op == SearchMutationOp.DELETE:
+                content_resolved = True
+                content_value: str | None = None
+                failure_kind: str | None = None
+                failure_detail: str | None = None
+            else:
+                content_resolved = event.event_id in content_map
+                content_value = content_map.get(event.event_id)
+                if content_resolved:
+                    failure_kind = None
+                    failure_detail = None
+                else:
+                    failure_kind, failure_detail = failure_map.get(
+                        event.event_id, ("transient", "unresolved")
+                    )
+            mutation = ResolvedMutation(
+                event=event,
+                zone_id=zone_id,
+                virtual_path=virtual_path,
+                path_id=path_id,
+                doc_id=doc_id,
+                content=content_value,
+                path_id_resolved=path_id_resolved,
+                content_resolved=content_resolved,
+                failure_kind=failure_kind,
+                failure_detail=failure_detail,
+            )
+            # #4337: do NOT cache unresolved mutations. A cached miss would
+            # be served to every retry pass inside the TTL, making the
+            # gate's attempt budget count cache hits instead of real reads.
+            if mutation.content_resolved:
+                self._cache[event.event_id] = (now, mutation)
+            resolved[idx] = mutation
+```
+
+- [ ] **Step 3.7: Run the new tests and the existing search suite**
+
+Run: `uv run pytest tests/unit/bricks/search/test_mutation_resolver_classification.py tests/unit/bricks/search -q`
+Expected: all PASS (existing daemon tests unaffected — `ResolvedMutation` gained optional fields only)
+
+- [ ] **Step 3.8: Commit**
+
+```bash
+git add src/nexus/bricks/search/mutation_resolver.py tests/unit/bricks/search/test_mutation_resolver_classification.py
+git commit -m "feat(#4337): classify mutation read failures permanent vs transient"
+```
+
+---
+
+### Task 4: Config knobs + parking gate in the daemon
+
+**Files:**
+- Modify: `src/nexus/bricks/search/daemon.py`
+- Test: `tests/unit/bricks/search/test_daemon_parking_gate.py`
+
+- [ ] **Step 4.1: Write the failing tests**
+
+```python
+"""Parking-gate, checkpoint, and admin-method tests for SearchDaemon (#4337)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+import pytest
+
+from nexus.bricks.search.daemon import DaemonConfig, SearchDaemon
+from nexus.bricks.search.mutation_events import SearchMutationEvent, SearchMutationOp
+from nexus.bricks.search.mutation_parking import UnresolvedMutationError
+from nexus.bricks.search.mutation_resolver import ResolvedMutation
+
+
+def _event(event_id: str, seq: int, op: SearchMutationOp = SearchMutationOp.UPSERT):
+    return SearchMutationEvent(
+        event_id=event_id,
+        operation_id=event_id.removeprefix("search:"),
+        op=op,
+        path=f"/zone/z1/docs/{event_id.removeprefix('search:')}.md",
+        zone_id="z1",
+        timestamp=datetime(2026, 6, 9, 1, 2, 3),
+        sequence_number=seq,
+    )
+
+
+def _resolved(event: SearchMutationEvent, *, content: str | None = "body") -> ResolvedMutation:
+    return ResolvedMutation(
+        event=event,
+        zone_id=event.zone_id,
+        virtual_path=event.virtual_path,
+        path_id=f"pid-{event.operation_id}",
+        doc_id=f"{event.zone_id}:{event.virtual_path}",
+        content=content,
+        content_resolved=True,
+    )
+
+
+def _unresolved(event: SearchMutationEvent, *, kind: str = "permanent") -> ResolvedMutation:
+    return ResolvedMutation(
+        event=event,
+        zone_id=event.zone_id,
+        virtual_path=event.virtual_path,
+        path_id=event.virtual_path,
+        doc_id=f"{event.zone_id}:{event.virtual_path}",
+        content=None,
+        path_id_resolved=False,
+        content_resolved=False,
+        failure_kind=kind,
+        failure_detail="FileNotFoundError(...)",
+    )
+
+
+class FakeResolver:
+    """resolve_batch returns canned ResolvedMutations keyed by event_id."""
+
+    def __init__(self, results: dict[str, ResolvedMutation]) -> None:
+        self.results = results
+
+    async def resolve_batch(self, events: list[SearchMutationEvent]):
+        return [self.results[e.event_id] for e in events if e.event_id in self.results]
+
+
+def _daemon(tmp_path, **config_overrides: Any) -> SearchDaemon:
+    config = DaemonConfig(
+        database_url=None,
+        bm25s_index_dir=str(tmp_path / "bm25s"),
+        txtai_model=None,
+        refresh_enabled=False,
+        vector_warmup_enabled=False,
+        mutation_unresolved_permanent_attempts=2,
+        mutation_unresolved_transient_attempts=4,
+        **config_overrides,
+    )
+    return SearchDaemon(config)
+
+
+@pytest.mark.asyncio
+async def test_under_budget_raises_unresolved_error(tmp_path) -> None:
+    daemon = _daemon(tmp_path)
+    poison = _event("search:poison", 10)
+    daemon._mutation_resolver = FakeResolver({"search:poison": _unresolved(poison)})
+    with pytest.raises(UnresolvedMutationError):
+        await daemon._resolve_mutations("bm25", [poison])
+    assert daemon._park_store.count("bm25") == 0
+
+
+@pytest.mark.asyncio
+async def test_budget_exhaustion_parks_and_filters(tmp_path) -> None:
+    daemon = _daemon(tmp_path)
+    poison = _event("search:poison", 10)
+    healthy = _event("search:ok", 11)
+    daemon._mutation_resolver = FakeResolver(
+        {"search:poison": _unresolved(poison), "search:ok": _resolved(healthy)}
+    )
+    events = [poison, healthy]
+    # permanent budget = 2: pass 1 raises, pass 2 parks and yields healthy only
+    with pytest.raises(UnresolvedMutationError):
+        await daemon._resolve_mutations("bm25", events)
+    kept = await daemon._resolve_mutations("bm25", events)
+    assert [m.event.event_id for m in kept] == ["search:ok"]
+    assert daemon._park_store.contains("bm25", "search:poison")
+    assert ("bm25", "search:poison") not in daemon._unresolved_attempts
+
+
+@pytest.mark.asyncio
+async def test_transient_budget_is_larger(tmp_path) -> None:
+    daemon = _daemon(tmp_path)
+    poison = _event("search:flaky", 10)
+    daemon._mutation_resolver = FakeResolver(
+        {"search:flaky": _unresolved(poison, kind="transient")}
+    )
+    for _ in range(3):  # transient budget = 4: passes 1-3 raise
+        with pytest.raises(UnresolvedMutationError):
+            await daemon._resolve_mutations("fts", [poison])
+    kept = await daemon._resolve_mutations("fts", [poison])  # pass 4 parks
+    assert kept == []
+    assert daemon._park_store.contains("fts", "search:flaky")
+
+
+@pytest.mark.asyncio
+async def test_already_parked_event_is_filtered_without_recount(tmp_path) -> None:
+    daemon = _daemon(tmp_path)
+    poison = _event("search:poison", 10)
+    daemon._mutation_resolver = FakeResolver({"search:poison": _unresolved(poison)})
+    with pytest.raises(UnresolvedMutationError):
+        await daemon._resolve_mutations("bm25", [poison])
+    await daemon._resolve_mutations("bm25", [poison])  # parks
+    kept = await daemon._resolve_mutations("bm25", [poison])  # already parked
+    assert kept == []
+    assert ("bm25", "search:poison") not in daemon._unresolved_attempts
+    assert daemon._park_store.count("bm25") == 1
+
+
+@pytest.mark.asyncio
+async def test_recovered_event_auto_unparks(tmp_path) -> None:
+    daemon = _daemon(tmp_path)
+    poison = _event("search:poison", 10)
+    daemon._mutation_resolver = FakeResolver({"search:poison": _unresolved(poison)})
+    with pytest.raises(UnresolvedMutationError):
+        await daemon._resolve_mutations("bm25", [poison])
+    await daemon._resolve_mutations("bm25", [poison])  # parks
+    daemon._mutation_resolver = FakeResolver({"search:poison": _resolved(poison)})
+    kept = await daemon._resolve_mutations("bm25", [poison])
+    assert [m.event.event_id for m in kept] == ["search:poison"]
+    assert not daemon._park_store.contains("bm25", "search:poison")
+
+
+@pytest.mark.asyncio
+async def test_legacy_refresh_bypasses_gate(tmp_path) -> None:
+    daemon = _daemon(tmp_path)
+    poison = _event("search:poison", 10)
+    daemon._mutation_resolver = FakeResolver({"search:poison": _unresolved(poison)})
+    # No raise, no park, unresolved mutation passes through untouched.
+    resolved = await daemon._resolve_mutations("legacy-refresh", [poison])
+    assert len(resolved) == 1
+    assert daemon._park_store.count("legacy-refresh") == 0
+
+
+@pytest.mark.asyncio
+async def test_consumers_are_independent(tmp_path) -> None:
+    daemon = _daemon(tmp_path)
+    poison = _event("search:poison", 10)
+    daemon._mutation_resolver = FakeResolver({"search:poison": _unresolved(poison)})
+    with pytest.raises(UnresolvedMutationError):
+        await daemon._resolve_mutations("bm25", [poison])
+    # fts has its own counter — first pass raises even though bm25 counted one.
+    with pytest.raises(UnresolvedMutationError):
+        await daemon._resolve_mutations("fts", [poison])
+    assert daemon._unresolved_attempts[("bm25", "search:poison")] == 1
+    assert daemon._unresolved_attempts[("fts", "search:poison")] == 1
+```
+
+- [ ] **Step 4.2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/unit/bricks/search/test_daemon_parking_gate.py -q`
+Expected: FAIL — `DaemonConfig` has no `mutation_unresolved_permanent_attempts` (TypeError)
+
+- [ ] **Step 4.3: Add config knobs**
+
+In `daemon.py`, `DaemonConfig`, after `path_context_max_zones: int = 2048` add:
+
+```python
+    # Bounded retries for unresolved-content mutations (#4337). When the
+    # MutationResolver cannot obtain content for an UPSERT, the consumer
+    # retries the batch (refusing to checkpoint) up to this many passes,
+    # then PARKS the event (durable skip record + metric) so one poisoned
+    # event cannot head-of-line block indexing forever.
+    mutation_unresolved_permanent_attempts: int = 3
+    mutation_unresolved_transient_attempts: int = 30
+    mutation_parked_max_entries: int = 200
+```
+
+- [ ] **Step 4.4: Add module constant, imports, and instance state**
+
+Near the existing search-brick imports in `daemon.py` add:
+
+```python
+from nexus.bricks.search import consumer_metrics
+from nexus.bricks.search.mutation_parking import (
+    MutationParkStore,
+    ParkedEvent,
+    UnresolvedMutationError,
+)
+```
+
+Below the module-level `logger` add:
+
+```python
+# Durable mutation consumer names (#4337): single source for the refresh
+# loop, startup reconciliation, parked-event re-drive, and admin skip-to.
+MUTATION_CONSUMER_NAMES: tuple[str, ...] = ("bm25", "fts", "embedding", "txtai")
+LEGACY_REFRESH_CONSUMER = "legacy-refresh"
+```
+
+In `SearchDaemon.__init__`, right after the `self._checkpoint_lock = asyncio.Lock()` line:
+
+```python
+        # #4337: bounded-retry gate state. Attempt counts are in-memory
+        # (restart resets them; a poisoned event re-accumulates to budget in
+        # seconds). The park store is the durable record of skipped events.
+        self._unresolved_attempts: dict[tuple[str, str], int] = {}
+        self._consumer_retrying: dict[str, dict[str, Any] | None] = {}
+        self._park_store = MutationParkStore(
+            settings_store=settings_store,
+            fallback_file=Path(self.config.bm25s_index_dir).parent / "mutation-parked.json",
+            max_entries_per_consumer=self.config.mutation_parked_max_entries,
+        )
+```
+
+- [ ] **Step 4.5: Implement the gate and re-sign `_resolve_mutations`**
+
+Replace the existing `_resolve_mutations` (daemon.py:3116-3122) with:
+
+```python
+    async def _resolve_mutations(
+        self,
+        consumer_name: str,
+        events: list[SearchMutationEvent],
+    ) -> list[ResolvedMutation]:
+        if self._mutation_resolver is None:
+            return []
+        resolved = await self._mutation_resolver.resolve_batch(events)
+        if consumer_name == LEGACY_REFRESH_CONSUMER:
+            # Fallback delete-propagation path: resolves DELETE events only
+            # (always content_resolved) — the gate has nothing to do.
+            return resolved
+        return await self._gate_unresolved(consumer_name, resolved)
+
+    async def _gate_unresolved(
+        self,
+        consumer_name: str,
+        resolved: list[ResolvedMutation],
+    ) -> list[ResolvedMutation]:
+        """Bounded-retry gate for unresolved-content UPSERTs (#4337).
+
+        Per pass over a batch:
+          * already-parked events are filtered out (no recount);
+          * resolved events drop any stale attempt counter and auto-unpark;
+          * unresolved upserts count one attempt against their kind's
+            budget — at/over budget they are parked (durable record +
+            metrics) and filtered, otherwise the lowest-sequence one is
+            reported in a raised ``UnresolvedMutationError`` so the whole
+            batch retries (checkpoint untouched), exactly like the
+            pre-#4337 refuse-to-checkpoint behavior but bounded.
+        """
+        kept: list[ResolvedMutation] = []
+        blocking: ResolvedMutation | None = None
+        blocking_attempts = 0
+        blocking_budget = 0
+        for mutation in resolved:
+            event = mutation.event
+            key = (consumer_name, event.event_id)
+            is_unresolved_upsert = (
+                event.op == SearchMutationOp.UPSERT and not mutation.content_resolved
+            )
+            if not is_unresolved_upsert:
+                self._unresolved_attempts.pop(key, None)
+                if self._park_store.contains(consumer_name, event.event_id):
+                    # Content recovered while parked — heal the record.
+                    await self._park_store.remove(consumer_name, [event.event_id])
+                kept.append(mutation)
+                continue
+            if self._park_store.contains(consumer_name, event.event_id):
+                continue  # already parked: skip without recounting
+            kind = mutation.failure_kind or "transient"
+            attempts = self._unresolved_attempts.get(key, 0) + 1
+            self._unresolved_attempts[key] = attempts
+            budget = (
+                self.config.mutation_unresolved_permanent_attempts
+                if kind == "permanent"
+                else self.config.mutation_unresolved_transient_attempts
+            )
+            consumer_metrics.MUTATION_UNRESOLVED_RETRIES_TOTAL.labels(
+                consumer=consumer_name, kind=kind
+            ).inc()
+            if attempts >= budget:
+                entry = ParkedEvent.from_mutation(
+                    consumer_name,
+                    mutation,
+                    kind=kind,
+                    detail=mutation.failure_detail or "",
+                    attempts=attempts,
+                )
+                # park() raises if it cannot persist a record — in that
+                # case the error propagates, the batch retries, and the
+                # event is NEVER skipped without a durable record.
+                await self._park_store.park(entry)
+                consumer_metrics.MUTATION_PARKED_TOTAL.labels(
+                    consumer=consumer_name, kind=kind
+                ).inc()
+                self._unresolved_attempts.pop(key, None)
+                logger.warning(
+                    "Search mutation PARKED for consumer=%s event_id=%s path=%s "
+                    "kind=%s after %d attempts (checkpoint will advance past it; "
+                    "re-drive or discard via /api/v2/search/parked): %s",
+                    consumer_name,
+                    event.event_id,
+                    event.path,
+                    kind,
+                    attempts,
+                    mutation.failure_detail,
+                )
+                continue
+            if blocking is None or event.sequence_number < blocking.event.sequence_number:
+                blocking = mutation
+                blocking_attempts = attempts
+                blocking_budget = budget
+        if blocking is not None:
+            self._consumer_retrying[consumer_name] = {
+                "event_id": blocking.event.event_id,
+                "path": blocking.event.path,
+                "attempts": blocking_attempts,
+                "budget": blocking_budget,
+                "kind": blocking.failure_kind or "transient",
+            }
+            raise UnresolvedMutationError(
+                f"{consumer_name} mutation content unresolved for "
+                f"event_id={blocking.event.event_id} path={blocking.event.path} "
+                f"kind={blocking.failure_kind or 'transient'} "
+                f"attempt={blocking_attempts}/{blocking_budget} — refusing to "
+                "checkpoint so the consumer retries on next pass"
+            )
+        self._consumer_retrying[consumer_name] = None
+        return kept
+```
+
+- [ ] **Step 4.6: Update the five call sites to pass a consumer name**
+
+- daemon.py:2442 (`_delete_indexes_for_paths`): `resolved = await self._resolve_mutations(LEGACY_REFRESH_CONSUMER, events)`
+- `_consume_bm25_mutations`: `resolved = self._collapse_resolved_mutations(await self._resolve_mutations("bm25", events))`
+- `_consume_fts_mutations`: same with `"fts"`
+- `_consume_embedding_mutations`: same with `"embedding"`
+- `_consume_txtai_mutations`: same with `"txtai"`
+
+- [ ] **Step 4.7: Run gate tests**
+
+Run: `uv run pytest tests/unit/bricks/search/test_daemon_parking_gate.py -q`
+Expected: all PASS
+
+- [ ] **Step 4.8: Commit**
+
+```bash
+git add src/nexus/bricks/search/daemon.py tests/unit/bricks/search/test_daemon_parking_gate.py
+git commit -m "feat(#4337): bounded-retry parking gate in _resolve_mutations"
+```
+
+---
+
+### Task 5: Delete per-consumer unresolved branches (gate owns the policy)
+
+**Files:**
+- Modify: `src/nexus/bricks/search/daemon.py`
+- Test: extend `tests/unit/bricks/search/test_daemon_parking_gate.py`
+
+- [ ] **Step 5.1: Write the failing test (consumer processes healthy events past a parked poison)**
+
+Append to `test_daemon_parking_gate.py`:
+
+```python
+class FakeBM25Index:
+    def __init__(self) -> None:
+        self.indexed: list[str] = []
+
+    async def index_document(self, path_id: str, virtual_path: str, content: str) -> None:
+        self.indexed.append(path_id)
+
+    async def delete_document(self, path_id: str) -> bool:
+        return True
+
+
+@pytest.mark.asyncio
+async def test_bm25_consumer_unwedges_after_parking(tmp_path) -> None:
+    daemon = _daemon(tmp_path)
+    poison = _event("search:poison", 10)
+    healthy = _event("search:ok", 11)
+    daemon._mutation_resolver = FakeResolver(
+        {"search:poison": _unresolved(poison), "search:ok": _resolved(healthy)}
+    )
+    daemon._bm25s_index = FakeBM25Index()
+    events = [poison, healthy]
+    # Pass 1: under budget — handler raises, nothing indexed (no checkpoint).
+    with pytest.raises(UnresolvedMutationError):
+        await daemon._consume_bm25_mutations(events)
+    assert daemon._bm25s_index.indexed == []
+    # Pass 2: budget (=2) hit — poison parks, healthy indexes, handler returns.
+    await daemon._consume_bm25_mutations(events)
+    assert daemon._bm25s_index.indexed == ["pid-ok"]
+    assert daemon._park_store.contains("bm25", "search:poison")
+```
+
+- [ ] **Step 5.2: Run to verify the new test currently passes or fails for the right reason**
+
+Run: `uv run pytest tests/unit/bricks/search/test_daemon_parking_gate.py::test_bm25_consumer_unwedges_after_parking -q`
+Expected: PASS already (the gate filters before the handler loop runs — the old in-handler raise never fires because gated mutations are filtered). If it fails on the old raise, continue: Step 5.3 removes it. Either way proceed — the test pins the behavior.
+
+- [ ] **Step 5.3: Delete the three raise branches**
+
+In `_consume_bm25_mutations` delete:
+
+```python
+            if mutation.event.op == SearchMutationOp.UPSERT and not mutation.content_resolved:
+                raise RuntimeError(
+                    f"BM25 mutation content unresolved for "
+                    f"event_id={mutation.event.event_id} "
+                    f"path={mutation.event.path} — refusing to checkpoint "
+                    "so the consumer retries on next pass"
+                )
+```
+
+and update the preceding comment block (`# Codex review R8 #2 / R9 #1 / R10 #1: ...`) by replacing its bullet `* UPSERT + content_resolved=False → raise (don't checkpoint a transient read failure).` with `* UPSERT + content_resolved=False → never reaches this handler: the #4337 parking gate in _resolve_mutations retries (raise) or parks+filters it.`
+
+In `_consume_fts_mutations` delete:
+
+```python
+            # Codex review R10 #1 (high): refuse to checkpoint
+            # unresolved-content UPSERTs — see ``_consume_bm25_mutations``
+            # for the rationale.
+            if mutation.event.op == SearchMutationOp.UPSERT and not mutation.content_resolved:
+                raise RuntimeError(
+                    f"FTS mutation content unresolved for "
+                    f"event_id={mutation.event.event_id} "
+                    f"path={mutation.event.path} — refusing to checkpoint "
+                    "so the consumer retries on next pass"
+                )
+```
+
+In `_consume_embedding_mutations` delete:
+
+```python
+            # Codex review R10 #1 (high): refuse to checkpoint
+            # unresolved-content UPSERTs — see ``_consume_bm25_mutations``
+            # for the rationale.
+            if mutation.event.op == SearchMutationOp.UPSERT and not mutation.content_resolved:
+                raise RuntimeError(
+                    f"Embedding mutation content unresolved for "
+                    f"event_id={mutation.event.event_id} "
+                    f"path={mutation.event.path} — refusing to checkpoint "
+                    "so the consumer retries on next pass"
+                )
+```
+
+(`_consume_txtai_mutations` has no raise branch — the gate now covers its former silent drop.)
+
+- [ ] **Step 5.4: Run the full search unit suite**
+
+Run: `uv run pytest tests/unit/bricks/search -q`
+Expected: all PASS
+
+- [ ] **Step 5.5: Commit**
+
+```bash
+git add src/nexus/bricks/search/daemon.py tests/unit/bricks/search/test_daemon_parking_gate.py
+git commit -m "refactor(#4337): consumers rely on parking gate for unresolved upserts"
+```
+
+---
+
+### Task 6: Boot wiring, handler map DRY, stats merge
+
+**Files:**
+- Modify: `src/nexus/bricks/search/daemon.py`
+- Test: extend `tests/unit/bricks/search/test_daemon_parking_gate.py`
+
+- [ ] **Step 6.1: Write the failing stats test**
+
+Append to `test_daemon_parking_gate.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_get_stats_exposes_parking_state(tmp_path) -> None:
+    daemon = _daemon(tmp_path)
+    poison = _event("search:poison", 10)
+    daemon._mutation_resolver = FakeResolver({"search:poison": _unresolved(poison)})
+    with pytest.raises(UnresolvedMutationError):
+        await daemon._resolve_mutations("bm25", [poison])
+    stats = daemon.get_stats()
+    bm25 = stats["mutation_consumers"]["bm25"]
+    assert bm25["retrying"]["event_id"] == "search:poison"
+    assert bm25["retrying"]["attempts"] == 1
+    assert bm25["parked_count"] == 0
+    await daemon._resolve_mutations("bm25", [poison])  # parks (budget=2)
+    stats = daemon.get_stats()
+    bm25 = stats["mutation_consumers"]["bm25"]
+    assert bm25["parked_count"] == 1
+    assert bm25["last_parked"]["event_id"] == "search:poison"
+    assert bm25["last_parked"]["kind"] == "permanent"
+    assert bm25["retrying"] is None
+    # Consumers with no activity still report the parking keys.
+    assert stats["mutation_consumers"]["txtai"]["parked_count"] == 0
+```
+
+Run: `uv run pytest tests/unit/bricks/search/test_daemon_parking_gate.py::test_get_stats_exposes_parking_state -q`
+Expected: FAIL — `KeyError: 'bm25'` (stats.mutation_consumers is empty / lacks parking keys)
+
+- [ ] **Step 6.2: Extract `_mutation_handlers()` and reuse it (DRY)**
+
+Add next to `_index_refresh_loop`:
+
+```python
+    def _mutation_handlers(self) -> dict[str, Any]:
+        """Consumer-name → handler map (#4337): single source for the
+        refresh loop, startup reconciliation, and parked-event re-drive."""
+        return {
+            "bm25": self._consume_bm25_mutations,
+            "fts": self._consume_fts_mutations,
+            "embedding": self._consume_embedding_mutations,
+            "txtai": self._consume_txtai_mutations,
+        }
+```
+
+In `_index_refresh_loop` replace the `consumer_specs = { ... }` dict literal with `consumer_specs = self._mutation_handlers()`, and in `_reconcile_unindexed_paths_at_startup` replace its `handlers_by_name: dict[str, Any] = { ... }` literal with `handlers_by_name: dict[str, Any] = self._mutation_handlers()`.
+
+- [ ] **Step 6.3: Load the park store before consumers start**
+
+In `_index_refresh_loop`, immediately before `await self._reconcile_unindexed_paths_at_startup()`:
+
+```python
+        # #4337: load parked records before consumers start so the gauge,
+        # stats, and already-parked filtering reflect prior runs. Best-effort:
+        # a corrupt/unreadable store logs and starts empty.
+        try:
+            await self._park_store.load()
+        except Exception as exc:
+            logger.error("Parked-event store load failed; starting empty: %s", exc)
+```
+
+- [ ] **Step 6.4: Merge parking info into `get_stats`**
+
+Add the helper method near `get_stats`:
+
+```python
+    def _mutation_consumer_stats(self) -> dict[str, dict[str, Any]]:
+        """Per-consumer loop stats merged with parking state (#4337)."""
+        merged: dict[str, dict[str, Any]] = {}
+        names = set(self.stats.mutation_consumers) | set(MUTATION_CONSUMER_NAMES)
+        for name in sorted(names):
+            entry = dict(self.stats.mutation_consumers.get(name, {}))
+            entry["parked_count"] = self._park_store.count(name)
+            last = self._park_store.last(name)
+            entry["last_parked"] = (
+                {
+                    "event_id": last.event_id,
+                    "path": last.path,
+                    "kind": last.kind,
+                    "parked_at": last.parked_at,
+                }
+                if last is not None
+                else None
+            )
+            entry["retrying"] = self._consumer_retrying.get(name)
+            merged[name] = entry
+        return merged
+```
+
+In `get_stats` change `"mutation_consumers": self.stats.mutation_consumers,` to `"mutation_consumers": self._mutation_consumer_stats(),`.
+
+- [ ] **Step 6.5: Run tests**
+
+Run: `uv run pytest tests/unit/bricks/search -q`
+Expected: all PASS
+
+- [ ] **Step 6.6: Commit**
+
+```bash
+git add src/nexus/bricks/search/daemon.py tests/unit/bricks/search/test_daemon_parking_gate.py
+git commit -m "feat(#4337): park-store boot load and parking stats in get_stats"
+```
+
+---
+
+### Task 7: Monotonic checkpoint + `force_checkpoint`
+
+**Files:**
+- Modify: `src/nexus/bricks/search/daemon.py`
+- Test: extend `tests/unit/bricks/search/test_daemon_parking_gate.py`
+
+- [ ] **Step 7.1: Write the failing tests**
+
+Append to `test_daemon_parking_gate.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_force_checkpoint_advances_and_validates(tmp_path) -> None:
+    daemon = _daemon(tmp_path)
+    daemon._consumer_last_sequence["bm25"] = 100
+    result = await daemon.force_checkpoint("bm25", 250)
+    assert result == {"previous": 100, "current": 250}
+    assert daemon._consumer_last_sequence["bm25"] == 250
+
+    with pytest.raises(ValueError, match="greater than current"):
+        await daemon.force_checkpoint("bm25", 250)
+    with pytest.raises(ValueError, match="unknown consumer"):
+        await daemon.force_checkpoint("nope", 999)
+
+
+@pytest.mark.asyncio
+async def test_save_checkpoint_is_monotonic(tmp_path) -> None:
+    daemon = _daemon(tmp_path)
+    daemon._consumer_last_sequence["bm25"] = 100
+    await daemon.force_checkpoint("bm25", 250)
+    # An in-flight stale pass completing with an older batch must not rewind.
+    await daemon._save_consumer_checkpoint("bm25", 120)
+    assert daemon._consumer_last_sequence["bm25"] == 250
+```
+
+Run: `uv run pytest tests/unit/bricks/search/test_daemon_parking_gate.py::test_force_checkpoint_advances_and_validates -q`
+Expected: FAIL — `AttributeError: 'SearchDaemon' object has no attribute 'force_checkpoint'`
+
+- [ ] **Step 7.2: Make `_save_consumer_checkpoint` monotonic**
+
+Replace the method (daemon.py:2952-2954):
+
+```python
+    async def _save_consumer_checkpoint(self, consumer_name: str, sequence_number: int) -> None:
+        current = self._consumer_last_sequence.get(consumer_name)
+        if current is not None and sequence_number < current:
+            # #4337: monotonic guard — an in-flight pass that succeeds with a
+            # stale batch must not rewind an admin force-advance (skip-to).
+            sequence_number = current
+        self._consumer_last_sequence[consumer_name] = sequence_number
+        await self._persist_checkpoint(consumer_name, sequence_number)
+```
+
+- [ ] **Step 7.3: Add `force_checkpoint`**
+
+Add after `_save_consumer_checkpoint`:
+
+```python
+    async def force_checkpoint(self, consumer_name: str, sequence_number: int) -> dict[str, int]:
+        """Force-advance a consumer checkpoint past a poisoned range (#4337).
+
+        Admin escape hatch ("skip event N"): everything with
+        sequence_number <= the new value is permanently skipped for this
+        consumer. Deliberately NOT capped at the current op-log max so an
+        operator can pre-advance past a known-bad range.
+        """
+        if consumer_name not in MUTATION_CONSUMER_NAMES:
+            raise ValueError(
+                f"unknown consumer {consumer_name!r}; expected one of {MUTATION_CONSUMER_NAMES}"
+            )
+        current = self._consumer_last_sequence.get(consumer_name)
+        if current is None:
+            current = await self._initialize_consumer_checkpoint(consumer_name)
+            self._consumer_last_sequence[consumer_name] = current
+        if sequence_number <= current:
+            raise ValueError(
+                f"sequence {sequence_number} must be greater than current checkpoint {current}"
+            )
+        await self._save_consumer_checkpoint(consumer_name, sequence_number)
+        logger.warning(
+            "Search mutation checkpoint FORCED for consumer=%s: %d -> %d "
+            "(events in between are skipped)",
+            consumer_name,
+            current,
+            sequence_number,
+        )
+        return {"previous": current, "current": sequence_number}
+```
+
+- [ ] **Step 7.4: Run tests**
+
+Run: `uv run pytest tests/unit/bricks/search/test_daemon_parking_gate.py -q`
+Expected: all PASS
+
+- [ ] **Step 7.5: Commit**
+
+```bash
+git add src/nexus/bricks/search/daemon.py tests/unit/bricks/search/test_daemon_parking_gate.py
+git commit -m "feat(#4337): monotonic checkpoints and admin force_checkpoint"
+```
+
+---
+
+### Task 8: `list_parked` / `retry_parked` / `discard_parked`
+
+**Files:**
+- Modify: `src/nexus/bricks/search/daemon.py`
+- Test: extend `tests/unit/bricks/search/test_daemon_parking_gate.py`
+
+- [ ] **Step 8.1: Write the failing tests**
+
+Append to `test_daemon_parking_gate.py`:
+
+```python
+async def _park_one(daemon, consumer: str = "bm25", event_id: str = "search:poison"):
+    poison = _event(event_id, 10)
+    daemon._mutation_resolver = FakeResolver({event_id: _unresolved(poison)})
+    with pytest.raises(UnresolvedMutationError):
+        await daemon._resolve_mutations(consumer, [poison])
+    await daemon._resolve_mutations(consumer, [poison])  # budget=2 → parks
+    return poison
+
+
+@pytest.mark.asyncio
+async def test_list_parked_serializes_entries(tmp_path) -> None:
+    daemon = _daemon(tmp_path)
+    await _park_one(daemon)
+    parked = daemon.list_parked()
+    assert list(parked.keys()) == ["bm25"]
+    assert parked["bm25"][0]["event_id"] == "search:poison"
+    assert parked["bm25"][0]["kind"] == "permanent"
+
+
+@pytest.mark.asyncio
+async def test_retry_parked_success_unparks(tmp_path) -> None:
+    daemon = _daemon(tmp_path)
+    poison = await _park_one(daemon)
+    # Content recovered: resolver now resolves the event.
+    daemon._mutation_resolver = FakeResolver({"search:poison": _resolved(poison)})
+    daemon._bm25s_index = FakeBM25Index()
+    result = await daemon.retry_parked("bm25", None)
+    assert result["retried"] == 1
+    assert result["succeeded"] == ["search:poison"]
+    assert result["failed"] == []
+    assert not daemon._park_store.contains("bm25", "search:poison")
+    assert daemon._bm25s_index.indexed == ["pid-poison"]
+
+
+@pytest.mark.asyncio
+async def test_retry_parked_failure_reparks(tmp_path) -> None:
+    daemon = _daemon(tmp_path)
+    await _park_one(daemon)  # leaves resolver returning unresolved
+    daemon._bm25s_index = FakeBM25Index()
+    result = await daemon.retry_parked("bm25", ["search:poison"])
+    assert result["succeeded"] == []
+    assert result["failed"][0]["event_id"] == "search:poison"
+    # Still parked (re-parked after the one-shot failed) — not silently lost.
+    assert daemon._park_store.contains("bm25", "search:poison")
+    # And the one-shot didn't leak a live retry counter.
+    assert ("bm25", "search:poison") not in daemon._unresolved_attempts
+
+
+@pytest.mark.asyncio
+async def test_discard_parked_removes_without_retry(tmp_path) -> None:
+    daemon = _daemon(tmp_path)
+    await _park_one(daemon)
+    result = await daemon.discard_parked("bm25", ["search:poison"])
+    assert result == {"discarded": ["search:poison"]}
+    assert daemon._park_store.count("bm25") == 0
+
+    with pytest.raises(ValueError, match="unknown consumer"):
+        await daemon.discard_parked("nope", ["x"])
+```
+
+Run: `uv run pytest tests/unit/bricks/search/test_daemon_parking_gate.py::test_list_parked_serializes_entries -q`
+Expected: FAIL — `AttributeError: 'SearchDaemon' object has no attribute 'list_parked'`
+
+- [ ] **Step 8.2: Implement the three methods**
+
+Add after `force_checkpoint` (note `from dataclasses import replace` — daemon.py already imports `dataclass, field` from dataclasses; extend that import):
+
+```python
+    def list_parked(self) -> dict[str, list[dict[str, Any]]]:
+        """Parked mutation events per consumer, serialized for the API (#4337)."""
+        return {
+            consumer: [entry.to_dict() for entry in entries]
+            for consumer, entries in self._park_store.list_entries().items()
+            if entries
+        }
+
+    async def retry_parked(
+        self,
+        consumer_name: str,
+        event_ids: list[str] | None = None,
+    ) -> dict[str, Any]:
+        """Re-drive parked events through their consumer handler (#4337).
+
+        One-shot per event: the entry is removed from the store FIRST (so
+        the gate doesn't filter it as already-parked, which would make the
+        handler succeed vacuously), then run through the handler. Success →
+        stays unparked. Failure → re-parked with the new error detail.
+        """
+        if consumer_name not in MUTATION_CONSUMER_NAMES:
+            raise ValueError(
+                f"unknown consumer {consumer_name!r}; expected one of {MUTATION_CONSUMER_NAMES}"
+            )
+        entries = self._park_store.list_entries(consumer_name).get(consumer_name, [])
+        if event_ids is not None:
+            wanted = set(event_ids)
+            entries = [entry for entry in entries if entry.event_id in wanted]
+        handler = self._mutation_handlers()[consumer_name]
+        succeeded: list[str] = []
+        failed: list[dict[str, str]] = []
+        for entry in entries:
+            await self._park_store.remove(consumer_name, [entry.event_id])
+            try:
+                await handler([entry.to_event()])
+                succeeded.append(entry.event_id)
+            except Exception as exc:
+                await self._park_store.park(
+                    replace(entry, detail=str(exc), parked_at=time.time())
+                )
+                failed.append({"event_id": entry.event_id, "error": str(exc)})
+            finally:
+                self._unresolved_attempts.pop((consumer_name, entry.event_id), None)
+        return {"retried": len(entries), "succeeded": succeeded, "failed": failed}
+
+    async def discard_parked(
+        self,
+        consumer_name: str,
+        event_ids: list[str],
+    ) -> dict[str, Any]:
+        """Drop parked events without retrying — operator accepts the loss (#4337)."""
+        if consumer_name not in MUTATION_CONSUMER_NAMES:
+            raise ValueError(
+                f"unknown consumer {consumer_name!r}; expected one of {MUTATION_CONSUMER_NAMES}"
+            )
+        removed = await self._park_store.remove(consumer_name, event_ids)
+        return {"discarded": [entry.event_id for entry in removed]}
+```
+
+- [ ] **Step 8.3: Run tests**
+
+Run: `uv run pytest tests/unit/bricks/search -q`
+Expected: all PASS
+
+- [ ] **Step 8.4: Commit**
+
+```bash
+git add src/nexus/bricks/search/daemon.py tests/unit/bricks/search/test_daemon_parking_gate.py
+git commit -m "feat(#4337): list/retry/discard parked mutation events"
+```
+
+---
+
+### Task 9: REST admin endpoints
+
+**Files:**
+- Modify: `src/nexus/server/api/v2/routers/search.py`
+- Test: `tests/unit/server/routers/test_search_parked_admin.py`
+
+- [ ] **Step 9.1: Write the failing tests**
+
+```python
+"""REST tests for the parked-event admin endpoints (#4337)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from nexus.server.api.v2.routers.search import router
+from nexus.server.dependencies import require_admin
+
+
+class FakeDaemon:
+    def __init__(self) -> None:
+        self.skip_calls: list[tuple[str, int]] = []
+
+    def list_parked(self) -> dict[str, list[dict[str, Any]]]:
+        return {"bm25": [{"event_id": "search:op-1", "kind": "permanent"}]}
+
+    async def retry_parked(self, consumer: str, event_ids: list[str] | None) -> dict[str, Any]:
+        if consumer == "nope":
+            raise ValueError("unknown consumer 'nope'")
+        return {"retried": 1, "succeeded": ["search:op-1"], "failed": []}
+
+    async def discard_parked(self, consumer: str, event_ids: list[str]) -> dict[str, Any]:
+        return {"discarded": event_ids}
+
+    async def force_checkpoint(self, consumer: str, sequence: int) -> dict[str, int]:
+        if sequence <= 100:
+            raise ValueError("sequence 100 must be greater than current checkpoint 100")
+        self.skip_calls.append((consumer, sequence))
+        return {"previous": 100, "current": sequence}
+
+
+def _client(daemon: FakeDaemon | None = None, *, admin: bool = True) -> TestClient:
+    app = FastAPI()
+    app.include_router(router)
+    app.state.search_daemon = daemon or FakeDaemon()
+    if admin:
+        app.dependency_overrides[require_admin] = lambda: {"is_admin": True}
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def test_parked_list_requires_admin() -> None:
+    client = _client(admin=False)
+    response = client.get("/api/v2/search/parked")
+    assert response.status_code in (401, 403)
+
+
+def test_parked_list_returns_entries() -> None:
+    client = _client()
+    response = client.get("/api/v2/search/parked")
+    assert response.status_code == 200
+    assert response.json()["parked"]["bm25"][0]["event_id"] == "search:op-1"
+
+
+def test_parked_retry_happy_path() -> None:
+    client = _client()
+    response = client.post(
+        "/api/v2/search/parked/retry",
+        json={"consumer": "bm25", "event_ids": None},
+    )
+    assert response.status_code == 200
+    assert response.json()["succeeded"] == ["search:op-1"]
+
+
+def test_parked_retry_unknown_consumer_is_400() -> None:
+    client = _client()
+    response = client.post("/api/v2/search/parked/retry", json={"consumer": "nope"})
+    assert response.status_code == 400
+
+
+def test_parked_discard() -> None:
+    client = _client()
+    response = client.post(
+        "/api/v2/search/parked/discard",
+        json={"consumer": "bm25", "event_ids": ["search:op-1"]},
+    )
+    assert response.status_code == 200
+    assert response.json()["discarded"] == ["search:op-1"]
+
+
+def test_skip_to_happy_path_and_validation() -> None:
+    daemon = FakeDaemon()
+    client = _client(daemon)
+    response = client.post("/api/v2/search/consumers/bm25/skip-to", json={"sequence": 250})
+    assert response.status_code == 200
+    assert response.json() == {"previous": 100, "current": 250}
+    assert daemon.skip_calls == [("bm25", 250)]
+
+    response = client.post("/api/v2/search/consumers/bm25/skip-to", json={"sequence": 100})
+    assert response.status_code == 400
+```
+
+- [ ] **Step 9.2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/unit/server/routers/test_search_parked_admin.py -q`
+Expected: FAIL — 404s (routes don't exist)
+
+- [ ] **Step 9.3: Add the endpoints**
+
+In `routers/search.py`: extend the imports —
+
+```python
+from pydantic import BaseModel
+
+from nexus.server.dependencies import require_admin, require_auth
+```
+
+(keep the existing `require_auth` import line if already present; just add `require_admin`). Add request models near the other module-level helpers and the endpoints after `search_daemon_stats`:
+
+```python
+class ParkedRetryRequest(BaseModel):
+    consumer: str
+    event_ids: list[str] | None = None
+
+
+class ParkedDiscardRequest(BaseModel):
+    consumer: str
+    event_ids: list[str]
+
+
+class ConsumerSkipToRequest(BaseModel):
+    sequence: int
+
+
+@router.get("/parked")
+async def search_parked_list(
+    search_daemon: Any = Depends(_get_search_daemon),
+    _admin: dict[str, Any] = Depends(require_admin),
+) -> dict[str, Any]:
+    """List parked (poison) mutation events per consumer (#4337)."""
+    return {"parked": search_daemon.list_parked()}
+
+
+@router.post("/parked/retry")
+async def search_parked_retry(
+    body: ParkedRetryRequest,
+    search_daemon: Any = Depends(_get_search_daemon),
+    _admin: dict[str, Any] = Depends(require_admin),
+) -> dict[str, Any]:
+    """Re-drive parked mutation events through their consumer (#4337)."""
+    try:
+        result: dict[str, Any] = await search_daemon.retry_parked(
+            body.consumer, body.event_ids
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return result
+
+
+@router.post("/parked/discard")
+async def search_parked_discard(
+    body: ParkedDiscardRequest,
+    search_daemon: Any = Depends(_get_search_daemon),
+    _admin: dict[str, Any] = Depends(require_admin),
+) -> dict[str, Any]:
+    """Discard parked mutation events without retrying (#4337)."""
+    try:
+        result: dict[str, Any] = await search_daemon.discard_parked(
+            body.consumer, body.event_ids
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return result
+
+
+@router.post("/consumers/{consumer_name}/skip-to")
+async def search_consumer_skip_to(
+    consumer_name: str,
+    body: ConsumerSkipToRequest,
+    search_daemon: Any = Depends(_get_search_daemon),
+    _admin: dict[str, Any] = Depends(require_admin),
+) -> dict[str, Any]:
+    """Force-advance a mutation consumer checkpoint past a poisoned range (#4337)."""
+    try:
+        result: dict[str, int] = await search_daemon.force_checkpoint(
+            consumer_name, body.sequence
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return result
+```
+
+Also update the module docstring's endpoint list with the four new routes:
+
+```
+- GET  /api/v2/search/parked            -- parked (poison) mutation events (#4337, admin)
+- POST /api/v2/search/parked/retry      -- re-drive parked events (#4337, admin)
+- POST /api/v2/search/parked/discard    -- discard parked events (#4337, admin)
+- POST /api/v2/search/consumers/{name}/skip-to -- force checkpoint advance (#4337, admin)
+```
+
+- [ ] **Step 9.4: Run tests**
+
+Run: `uv run pytest tests/unit/server/routers/test_search_parked_admin.py -q`
+Expected: all PASS. If the no-override test returns 422 instead of 401/403, inspect `require_admin`'s signature and adjust the assertion to the actual unauthorized status — do not weaken the admin gate itself.
+
+- [ ] **Step 9.5: Commit**
+
+```bash
+git add src/nexus/server/api/v2/routers/search.py tests/unit/server/routers/test_search_parked_admin.py
+git commit -m "feat(#4337): admin REST surface for parked events and skip-to"
+```
+
+---
+
+### Task 10: Runbook
+
+**Files:**
+- Create: `docs/operations/search-mutation-parking.md`
+
+- [ ] **Step 10.1: Write the runbook**
+
+```markdown
+# Runbook: Search Mutation Parking (#4337)
+
+When the search daemon cannot resolve content for a write event, the
+consumer retries the batch (the checkpoint does not advance). Since #4337
+retries are **bounded**: permanent failures (file gone) park after
+~3 passes (~6 s), transient failures (backend outage) after ~30 passes
+(~60 s). A **parked** event is skipped by the live consumer but durably
+recorded for re-drive or discard.
+
+## Symptoms
+
+Log lines from `nexus.bricks.search.daemon`:
+
+- Retrying (bounded):
+  `<consumer> mutation content unresolved for event_id=... path=... kind=... attempt=N/M — refusing to checkpoint so the consumer retries on next pass`
+- Parked (skipped, recorded):
+  `Search mutation PARKED for consumer=... event_id=... path=... kind=... after N attempts ...`
+- Forced skip:
+  `Search mutation checkpoint FORCED for consumer=...: A -> B`
+
+Metrics (Prometheus):
+
+| Metric | Meaning | Suggested alert |
+| --- | --- | --- |
+| `nexus_search_mutation_parked_total{consumer,kind}` | Events parked | Page on any increase |
+| `nexus_search_mutation_parked_current{consumer}` | Currently parked | Warn while > 0 |
+| `nexus_search_mutation_unresolved_retries_total{consumer,kind}` | Retry passes (pre-park) | Warn on sustained rate |
+| `nexus_search_mutation_parked_evicted_total{consumer}` | Cap evictions (parking storm) | Page on any increase |
+
+## Diagnose
+
+```bash
+# Consumer state: parked_count, last_parked, retrying head-of-line blocker
+curl -s "$NEXUS_URL/api/v2/search/stats" | jq '.mutation_consumers'
+
+# Full parked entries (admin)
+curl -s -H "Authorization: Bearer $ADMIN_TOKEN" \
+  "$NEXUS_URL/api/v2/search/parked" | jq
+```
+
+`kind=permanent` → the path's payload is gone (cf. issue #4339 forensics).
+`kind=transient` → the content backend was unreachable; content may exist.
+
+## Decide
+
+- **Payload restored / outage over → retry** (re-drives through the
+  consumer; success removes the record, failure re-parks with the error):
+
+```bash
+curl -s -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"consumer": "embedding", "event_ids": null}' \
+  "$NEXUS_URL/api/v2/search/parked/retry" | jq
+```
+
+(`event_ids: null` retries everything parked for that consumer.)
+
+- **Content permanently gone, loss accepted → discard:**
+
+```bash
+curl -s -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"consumer": "embedding", "event_ids": ["search:a39822b6-..."]}' \
+  "$NEXUS_URL/api/v2/search/parked/discard" | jq
+```
+
+- **Consumer wedged on something the gate does not handle → force-advance
+  the checkpoint** (skips EVERY event ≤ the new sequence for that
+  consumer — use the smallest sequence that unwedges, typically the
+  blocker's own `sequence_number` from `/stats`):
+
+```bash
+curl -s -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"sequence": 123456}' \
+  "$NEXUS_URL/api/v2/search/consumers/embedding/skip-to" | jq
+```
+
+## Notes
+
+- Park records live in the settings store under `search_mutation_parked`
+  (file fallback `mutation-parked.json` next to the checkpoints file).
+  Capped at 200 entries per consumer; evictions log ERROR and bump
+  `..._parked_evicted_total` — an eviction means a parking storm, look for
+  a systemic cause (e.g. #4339-scale payload loss) instead of per-event
+  triage.
+- Restarts reset in-flight retry counters (a poisoned event re-parks within
+  seconds); parked records persist.
+- A parked event whose content later resolves on its own (e.g. the same
+  path is re-written) is auto-unparked by the gate.
+```
+
+- [ ] **Step 10.2: Commit**
+
+```bash
+git add docs/operations/search-mutation-parking.md
+git commit -m "docs(#4337): runbook for search mutation parking"
+```
+
+---
+
+### Task 11: Full verification
+
+**Files:** none new.
+
+- [ ] **Step 11.1: Run the affected test suites**
+
+Run: `uv run pytest tests/unit/bricks/search tests/unit/server/routers -q`
+Expected: all PASS
+
+- [ ] **Step 11.2: Lint + types on touched files**
+
+Run: `uv run ruff check src/nexus/bricks/search src/nexus/server/api/v2/routers/search.py && uv run ruff format --check src/nexus/bricks/search src/nexus/server/api/v2/routers/search.py`
+Expected: clean (pre-commit re-runs ruff/mypy on commit; fix anything it flags)
+
+Run: `uv run mypy src/nexus/bricks/search/mutation_parking.py src/nexus/bricks/search/mutation_resolver.py src/nexus/bricks/search/consumer_metrics.py`
+Expected: no new errors (match the repo's existing mypy posture; pre-commit is the gate)
+
+- [ ] **Step 11.3: Wider sanity — server lifespan tests that touch the daemon**
+
+Run: `uv run pytest tests/unit/server/lifespan/test_search_lifespan.py tests/unit/server/lifespan/test_search_runtime_config.py -q`
+Expected: all PASS (lifespan calls `_resolve_mutations` indirectly via daemon wiring; signature change is internal)
+
+- [ ] **Step 11.4: grep for stale call sites**
+
+Run: `grep -rn "_resolve_mutations(" src/nexus tests | grep -v "consumer_name\|\"bm25\"\|\"fts\"\|\"embedding\"\|\"txtai\"\|LEGACY_REFRESH_CONSUMER\|def _resolve_mutations"`
+Expected: no hits (every call passes a consumer name)
+
+- [ ] **Step 11.5: Commit any straggler fixes**
+
+```bash
+git status --short   # should be clean; commit fixes if verification surfaced any
+```

--- a/docs/superpowers/specs/2026-06-09-issue-4337-search-mutation-parking-design.md
+++ b/docs/superpowers/specs/2026-06-09-issue-4337-search-mutation-parking-design.md
@@ -4,6 +4,13 @@
 **Issue:** [#4337](https://github.com/nexi-lab/nexus/issues/4337) — search daemon: unresolvable mutation event blocks checkpoint forever (head-of-line, infinite 2s retry)
 **Companion context:** [#4339](https://github.com/nexi-lab/nexus/issues/4339) — payload integrity loss made a class of paths permanently unreadable; those paths' write events are the observed poison events.
 
+> **Post-#3699 note (2026-06-10):** this spec was written against the
+> four-consumer daemon (`bm25`, `fts`, `embedding`, `txtai`). Issue #3699
+> later removed the txtai/bm25s stack, so the shipped implementation gates
+> the remaining two consumers (`fts`, `embedding`) — see
+> `MUTATION_CONSUMER_NAMES` in `daemon.py`. The design is otherwise
+> unchanged; consumer-count references below are historical.
+
 ## Problem
 
 The four durable search mutation consumers (`bm25`, `fts`, `embedding`, `txtai`) in

--- a/docs/superpowers/specs/2026-06-09-issue-4337-search-mutation-parking-design.md
+++ b/docs/superpowers/specs/2026-06-09-issue-4337-search-mutation-parking-design.md
@@ -1,0 +1,228 @@
+# Search Mutation Consumer Parking — Design (Issue #4337)
+
+**Date:** 2026-06-09
+**Issue:** [#4337](https://github.com/nexi-lab/nexus/issues/4337) — search daemon: unresolvable mutation event blocks checkpoint forever (head-of-line, infinite 2s retry)
+**Companion context:** [#4339](https://github.com/nexi-lab/nexus/issues/4339) — payload integrity loss made a class of paths permanently unreadable; those paths' write events are the observed poison events.
+
+## Problem
+
+The four durable search mutation consumers (`bm25`, `fts`, `embedding`, `txtai`) in
+`src/nexus/bricks/search/daemon.py` each tail the operation log from a persisted
+per-consumer checkpoint. `_run_mutation_consumer` fetches a batch, runs the
+handler, and checkpoints the last sequence number only if the handler returns.
+
+When the `MutationResolver` cannot obtain content for an UPSERT
+(`content_resolved=False`), the bm25/fts/embedding handlers raise, so the
+checkpoint never advances and the same batch is refetched every
+`mutation_poll_seconds` (2s) forever. One permanently unresolvable event
+(e.g. a #4339 victim path) therefore head-of-line blocks **all** subsequent
+search indexing for that consumer. The txtai handler has the opposite defect:
+it silently drops unresolved upserts with no trace.
+
+Two root deficiencies:
+
+1. **No retry bound.** "Refuse to checkpoint" is correct for transient
+   failures but has no escape for permanent ones.
+2. **No failure classification.** `MutationResolver._read_content` swallows
+   every exception and returns `None`, so "file is gone" (permanent) is
+   indistinguishable from "backend timeout" (transient).
+
+## Goals (from issue asks)
+
+1. Bounded retries per event; on exhaustion, **park** the event durably
+   (skip + record + metric) instead of wedging.
+2. Classify resolution failures permanent vs transient; fail fast on
+   permanent.
+3. Admin surface + runbook to unwedge (`skip event N`) and to re-drive or
+   discard parked events — no settings-store surgery.
+
+Non-goals: changing the operation-log schema, reworking checkpoint storage,
+handling non-content handler failures (e.g. backend delete errors — verified
+that `delete_document` on an absent doc returns `True`, so a parked upsert
+followed by a delete cannot re-wedge), or wiring alert rules into a specific
+deployment (runbook documents what to alert on).
+
+## Approach (chosen: resolve-step chokepoint)
+
+All four handlers already funnel through `SearchDaemon._resolve_mutations`.
+The gate lives there, parameterized by consumer name. Alternatives considered
+and rejected: per-consumer gate helper (4 duplicated call sites, txtai needs a
+new branch); loop-level exception protocol in `_run_mutation_consumer`
+(one-park-per-pass convergence, batch prefix re-execution,
+exception-as-control-flow).
+
+## Design
+
+### 1. Resolver failure classification (`mutation_resolver.py`)
+
+- `ResolvedMutation` gains:
+  - `failure_kind: Literal["permanent", "transient"] | None = None`
+  - `failure_detail: str | None = None`
+
+  Set only when `content_resolved=False`.
+- `_read_content` returns content plus classification instead of swallowing
+  exceptions:
+  - `FileNotFoundError` family (includes `NexusFileNotFoundError`) on **both**
+    the scoped-path and virtual-path reads → `permanent`.
+  - Any other exception, or a non-`str` return → `transient`.
+  - `file_reader is None` → `transient`. (The reader is attached after boot by
+    the server lifespan via `set_file_reader`; the boot window must never
+    park events.)
+- The `content_cache` DB fallback clears the failure when it hits. On a miss,
+  the read's classification stands. Errors raised by the DB lookup itself
+  continue to propagate (existing whole-batch retry path, unchanged — the
+  gate never sees them).
+- **Unresolved mutations are no longer cached.** Today the 30s TTL cache
+  would serve a stale unresolved entry to most retry passes, making "N
+  attempts" mean ~N/15 real read attempts. Not caching failures makes
+  attempt budgets honest; the cost (one failed read per 2s pass per poisoned
+  event) is exactly today's steady-state load.
+
+### 2. Parking gate (`daemon.py`, inside `_resolve_mutations`)
+
+- Signature becomes `_resolve_mutations(consumer_name, events)`. The four
+  consumer handlers pass their name; the legacy hook-driven refresh path
+  passes `"legacy-refresh"` and is exempt from the gate (it only resolves
+  DELETE events, which are always resolved).
+- In-memory attempt counts: `dict[(consumer_name, event_id), int]`,
+  incremented once per pass that observes the event unresolved. Restart
+  resets counts; a poisoned event then re-accumulates to its budget within
+  seconds and re-parks. Accepted trade-off for not persisting counters.
+  Hygiene: a counter is dropped when its event parks **or** resolves
+  (recovered transient), so the dict stays bounded by the current batch.
+- Budgets on `SearchDaemonConfig`:
+  - `mutation_unresolved_permanent_attempts: int = 3` (~6s at 2s poll —
+    absorbs cross-process visibility races despite op-log events being
+    post-success)
+  - `mutation_unresolved_transient_attempts: int = 30` (~60s — rides out
+    brief backend blips; longer outages park and are re-driven later)
+- Per pass, over the resolved batch's unresolved UPSERTs:
+  1. Events at/over budget → park (persist record, bump metrics, WARNING
+     log with event_id/path/kind/attempts), remove from the returned list,
+     clear their counters.
+  2. If any unresolved upsert remains under budget → raise
+     `UnresolvedMutationError` (subclass of `RuntimeError`) naming event_id,
+     path, kind, attempt/budget. `_run_mutation_consumer`'s existing except
+     branch logs it and retries the batch — current semantics preserved.
+     With mixed-budget batches this converges in at most
+     `max(budgets)` passes.
+- When the handler finally returns, the checkpoint advances past the parked
+  events naturally.
+- The consumers' four unresolved-content branches (three `raise` sites, one
+  txtai silent drop) are **deleted**; the gate guarantees handlers only see
+  resolved mutations. txtai thereby joins the same policy (its silent data
+  loss becomes a visible parked record).
+- If persisting a park record fails (settings store **and** file fallback),
+  the gate raises instead of filtering: the batch retries and parking is
+  re-attempted next pass. We never skip an event we failed to record.
+
+### 3. Park store (mirrors checkpoint dual persistence)
+
+- Primary: settings store key `search_mutation_parked` (single JSON
+  document `{consumer_name: [entry, ...]}`); fallback file
+  `mutation-parked.json` next to `mutation-checkpoints.json`. Same
+  store-or-file degradation pattern and an `asyncio.Lock` as checkpoints.
+- Entry fields: every field needed to reconstruct the
+  `SearchMutationEvent` (`event_id`, `operation_id`, `op`, `path`,
+  `new_path`, `zone_id`, `timestamp`, `sequence_number`) plus
+  `kind`, `detail`, `attempts`, `parked_at`.
+- Keyed by `(consumer, event_id)`; re-parking the same event replaces its
+  entry.
+- Cap `mutation_parked_max_entries: int = 200` per consumer. Overflow
+  FIFO-evicts the oldest entry with an ERROR log and an eviction counter —
+  a #4339-scale storm (thousands of dead paths) must not bloat the settings
+  row; the storm itself is surfaced by metrics.
+- Loaded at daemon start to seed the gauge and stats.
+
+### 4. Metrics + stats
+
+- New `src/nexus/bricks/search/consumer_metrics.py` (precedent:
+  `src/nexus/bricks/auth/consumer_metrics.py`), direct import of `prometheus_client` (a hard dependency — matches the auth-brick precedent):
+  - `nexus_search_mutation_parked_total{consumer, kind}` (Counter)
+  - `nexus_search_mutation_parked_current{consumer}` (Gauge — set on park,
+    unpark, discard, boot load; not named `..._parked` because
+    prometheus_client strips `_total` from Counter names, so the Counter
+    above already claims the `..._parked` base name in the registry)
+  - `nexus_search_mutation_unresolved_retries_total{consumer, kind}`
+    (Counter — one increment per retry pass; sustained rate is the
+    early-warning signal before anything parks)
+  - `nexus_search_mutation_parked_evicted_total{consumer}` (Counter)
+- `stats.mutation_consumers[<name>]` gains `parked_count`,
+  `last_parked {event_id, path, kind, parked_at}`, and
+  `retrying {event_id, attempts, budget, kind} | None` — the
+  lowest-sequence event currently under retry (the head-of-line blocker)
+  when several are in flight — all surfaced by the existing
+  `GET /api/v2/search/stats`.
+
+### 5. REST admin surface (`src/nexus/server/api/v2/routers/search.py`)
+
+Admin-gated with the same auth dependency as the router's existing
+mutating/admin endpoints.
+
+- `GET /api/v2/search/parked` → `{consumer: [entries]}`.
+- `POST /api/v2/search/parked/retry` body
+  `{"consumer": str, "event_ids": [str] | null}` (null = all for that
+  consumer) → for each entry: reconstruct the event, run it one-shot through
+  that consumer's handler; success → remove from park store; failure → keep
+  entry, report. Response
+  `{"retried": n, "succeeded": [...], "failed": [{"event_id", "error"}]}`.
+  No checkpoint interaction — parked events are already behind the
+  checkpoint. Concurrent live-consumer activity is safe: index upserts are
+  idempotent. (Embedding handler no-ops without a provider, matching live
+  behavior.)
+- `POST /api/v2/search/parked/discard` body
+  `{"consumer": str, "event_ids": [str]}` → remove entries without retrying
+  (operator accepts the loss, e.g. after #4339 forensics).
+- `POST /api/v2/search/consumers/{name}/skip-to` body `{"sequence": int}` →
+  force-advance the persisted checkpoint. Validates the consumer name and
+  `sequence > current`; deliberately does **not** cap at the current op-log
+  max (an admin may pre-advance past a known-bad range) — the runbook warns
+  that everything ≤ the new sequence is skipped for that consumer. Returns
+  `{"previous": int, "current": int}`. This is the issue's "skip event N"
+  escape hatch and also covers any future poison class the gate doesn't
+  classify.
+- Hardening: `_save_consumer_checkpoint` becomes monotonic
+  (`max(current, new)`) so an in-flight consumer pass that succeeds with a
+  stale batch cannot rewind a forced advance.
+
+### 6. Runbook (`docs/operations/search-mutation-parking.md`)
+
+Covers: symptom log lines (the exact "refusing to checkpoint" / parked
+WARNING formats), diagnosis via `GET /api/v2/search/stats` and
+`GET /api/v2/search/parked`, decision guide (retry after payload restore vs
+discard), curl examples for retry/discard/skip-to, and suggested alert rules
+(page on `nexus_search_mutation_parked_total` increase; warn on sustained
+`nexus_search_mutation_unresolved_retries_total` rate).
+
+### 7. Testing
+
+- **Resolver unit tests:** classification matrix (NotFound both reads →
+  permanent; NotFound then non-NotFound → transient; reader None →
+  transient; cache hit clears failure; empty string still resolved),
+  unresolved results not cached.
+- **Gate unit tests:** budget exhaustion parks + filters + clears counter;
+  under-budget raises `UnresolvedMutationError`; mixed batch (one permanent,
+  one transient, one healthy) converges with checkpoint advance; park
+  persistence failure raises instead of skipping; legacy-refresh exemption.
+- **Park store tests:** settings-store and file-fallback round-trips,
+  dedupe/replace, cap eviction order, boot load.
+- **Daemon integration tests:** simulated poison event wedges then
+  auto-unwedges after budget with checkpoint advanced past it; restart
+  re-parks within budget; retry endpoint unparks on success and keeps on
+  failure; skip-to monotonic guard under a concurrent stale checkpoint
+  write.
+- **API tests:** auth required, unknown consumer 4xx, `sequence <= current`
+  4xx, happy paths.
+
+Scope check: single brick (`bricks/search`) + one router + one runbook doc.
+No kernel-internal (`rust/kernel/src/core/`) changes — no ownership concerns.
+
+## Decisions log
+
+| Decision | Choice | Why |
+| --- | --- | --- |
+| DLQ shape | Parked-record + re-drive (settings store/file; no DB migration) | Replayable after payload restore; avoids migration weight; matches checkpoint persistence pattern |
+| Retry budgets | permanent 3 / transient 30 passes, in-memory | Fast unwedge (6s/60s); restart re-accumulates quickly; parked re-drive covers long outages |
+| Admin surface | REST + runbook (CLI deferred) | Host CLI unreliable in some envs; REST is the dependable path |
+| txtai | Unified under the same gate | Silent data loss → visible parked record; one policy for all four consumers |
+| Gate location | `_resolve_mutations` chokepoint | One policy point; deletes four divergent per-consumer branches |

--- a/docs/surface-coverage/api-rpc-surface-coverage.yaml
+++ b/docs/surface-coverage/api-rpc-surface-coverage.yaml
@@ -7619,13 +7619,30 @@ operations:
   perf_link: thin CLI wrapper; underlying grep/query/index paths carry the performance classification
   gap_issue: null
   owning_issue: 4129
+- id: search.consumers_{consumer_name}_skip_to
+  module: search
+  summary: Admin escape hatch that force-advances a mutation consumer checkpoint past a poisoned op-log range (#4337).
+  transports:
+    http:
+      name: POST /api/v2/search/consumers/{consumer_name}/skip-to
+      source: src/nexus/server/api/v2/routers/search.py:272
+  profiles:
+    lite: supported
+    sandbox: supported
+    full: supported
+  usage_example: POST /api/v2/search/consumers/embedding/skip-to {"sequence":123456}
+  correctness_test: tests/unit/server/routers/test_search_parked_admin.py; tests/unit/bricks/search/test_daemon_parking_gate.py
+  perf_class: control
+  perf_link: rare admin operation; one settings-store/file checkpoint write
+  gap_issue: null
+  owning_issue: 4337
 - id: search.expand
   module: search
   summary: HTTP query-expansion endpoint for improving weak search queries through provider-backed expansion.
   transports:
     http:
       name: POST /api/v2/search/expand
-      source: src/nexus/server/api/v2/routers/search.py:1454
+      source: src/nexus/server/api/v2/routers/search.py:1534
   profiles:
     lite: supported
     sandbox: supported
@@ -7649,7 +7666,7 @@ operations:
       source: src/nexus/bricks/search/search_service.py:1791
     http:
       name: POST /api/v2/search/glob
-      source: src/nexus/server/api/v2/routers/search.py:1335
+      source: src/nexus/server/api/v2/routers/search.py:1415
     mcp:
       name: nexus_glob
       source: src/nexus/config/tool_profiles.yaml:1
@@ -7676,7 +7693,7 @@ operations:
       source: src/nexus/bricks/search/search_service.py:2101
     http:
       name: POST /api/v2/search/grep
-      source: src/nexus/server/api/v2/routers/search.py:1212
+      source: src/nexus/server/api/v2/routers/search.py:1292
     mcp:
       name: nexus_grep
       source: src/nexus/config/tool_profiles.yaml:1
@@ -7712,7 +7729,7 @@ operations:
   transports:
     http:
       name: GET /api/v2/search/health
-      source: src/nexus/server/api/v2/routers/search.py:186
+      source: src/nexus/server/api/v2/routers/search.py:191
   profiles:
     lite: supported
     sandbox: supported
@@ -7729,7 +7746,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/index
-      source: src/nexus/server/api/v2/routers/search.py:1397
+      source: src/nexus/server/api/v2/routers/search.py:1477
   profiles:
     lite: supported
     sandbox: supported
@@ -7747,7 +7764,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/index-directory
-      source: src/nexus/server/api/v2/routers/search.py:1596
+      source: src/nexus/server/api/v2/routers/search.py:1676
   profiles:
     lite: supported
     sandbox: supported
@@ -7764,7 +7781,7 @@ operations:
   transports:
     http:
       name: GET /api/v2/search/indexed-dirs
-      source: src/nexus/server/api/v2/routers/search.py:1814
+      source: src/nexus/server/api/v2/routers/search.py:1894
   profiles:
     lite: supported
     sandbox: supported
@@ -7781,7 +7798,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/indexing-mode
-      source: src/nexus/server/api/v2/routers/search.py:1851
+      source: src/nexus/server/api/v2/routers/search.py:1931
   profiles:
     lite: supported
     sandbox: supported
@@ -7798,7 +7815,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/locate
-      source: src/nexus/server/api/v2/routers/search.py:2032
+      source: src/nexus/server/api/v2/routers/search.py:2112
   profiles:
     lite: supported
     sandbox: supported
@@ -7809,13 +7826,65 @@ operations:
   perf_link: tests/benchmarks/test_search_protocol_benchmark.py; docs/benchmarks/2026-04-18-sandbox-vs-gbrain.md; tests/e2e/self_contained/test_search_surface_live_e2e.py
   gap_issue: null
   owning_issue: 4135
+- id: search.parked
+  module: search
+  summary: Lists parked (poison) search mutation events per consumer with kind/attempts/detail for admin triage (#4337).
+  transports:
+    http:
+      name: GET /api/v2/search/parked
+      source: src/nexus/server/api/v2/routers/search.py:229
+  profiles:
+    lite: supported
+    sandbox: supported
+    full: supported
+  usage_example: GET /api/v2/search/parked
+  correctness_test: tests/unit/server/routers/test_search_parked_admin.py; tests/unit/bricks/search/test_daemon_parking_gate.py
+  perf_class: control
+  perf_link: in-memory park-store read; bounded at 200 entries per consumer
+  gap_issue: null
+  owning_issue: 4337
+- id: search.parked_discard
+  module: search
+  summary: "Discards parked search mutation events without retrying \u2014 operator accepts the index loss (#4337)."
+  transports:
+    http:
+      name: POST /api/v2/search/parked/discard
+      source: src/nexus/server/api/v2/routers/search.py:255
+  profiles:
+    lite: supported
+    sandbox: supported
+    full: supported
+  usage_example: POST /api/v2/search/parked/discard {"consumer":"embedding","event_ids":["search:..."]}
+  correctness_test: tests/unit/server/routers/test_search_parked_admin.py; tests/unit/bricks/search/test_daemon_parking_gate.py
+  perf_class: control
+  perf_link: rare admin operation; one park-store document write
+  gap_issue: null
+  owning_issue: 4337
+- id: search.parked_retry
+  module: search
+  summary: Re-drives parked search mutation events through their consumer one-shot; success unparks, failure re-parks with
+    the new error (#4337).
+  transports:
+    http:
+      name: POST /api/v2/search/parked/retry
+      source: src/nexus/server/api/v2/routers/search.py:238
+  profiles:
+    lite: supported
+    sandbox: supported
+    full: supported
+  usage_example: POST /api/v2/search/parked/retry {"consumer":"embedding","event_ids":null}
+  correctness_test: tests/unit/server/routers/test_search_parked_admin.py; tests/unit/bricks/search/test_daemon_parking_gate.py
+  perf_class: control
+  perf_link: rare admin operation; bounded by parked entries (cap 200/consumer), idempotent index upserts
+  gap_issue: null
+  owning_issue: 4337
 - id: search.purge_unscoped
   module: search
   summary: Remove unscoped vector chunks after switching a zone to scoped indexing.
   transports:
     http:
       name: POST /api/v2/search/purge-unscoped
-      source: src/nexus/server/api/v2/routers/search.py:1978
+      source: src/nexus/server/api/v2/routers/search.py:2058
   profiles:
     lite: supported
     sandbox: supported
@@ -7833,7 +7902,7 @@ operations:
   transports:
     http:
       name: GET /api/v2/search/query
-      source: src/nexus/server/api/v2/routers/search.py:210
+      source: src/nexus/server/api/v2/routers/search.py:290
   profiles:
     lite: supported
     sandbox: supported
@@ -7851,7 +7920,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/query/batch
-      source: src/nexus/server/api/v2/routers/search.py:642
+      source: src/nexus/server/api/v2/routers/search.py:722
   profiles:
     lite: supported
     sandbox: supported
@@ -7868,7 +7937,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/refresh
-      source: src/nexus/server/api/v2/routers/search.py:1433
+      source: src/nexus/server/api/v2/routers/search.py:1513
   profiles:
     lite: supported
     sandbox: supported
@@ -7903,7 +7972,7 @@ operations:
   transports:
     http:
       name: GET /api/v2/search/stats
-      source: src/nexus/server/api/v2/routers/search.py:201
+      source: src/nexus/server/api/v2/routers/search.py:206
   profiles:
     lite: supported
     sandbox: supported
@@ -12210,6 +12279,14 @@ parity_warnings:
   - http
   - mcp
   - sdk
+- operation_id: search.consumers_{consumer_name}_skip_to
+  has:
+  - http
+  missing:
+  - cli
+  - grpc_typed
+  - mcp
+  - sdk
 - operation_id: search.expand
   has:
   - http
@@ -12275,6 +12352,30 @@ parity_warnings:
   - mcp
   - sdk
 - operation_id: search.locate
+  has:
+  - http
+  missing:
+  - cli
+  - grpc_typed
+  - mcp
+  - sdk
+- operation_id: search.parked
+  has:
+  - http
+  missing:
+  - cli
+  - grpc_typed
+  - mcp
+  - sdk
+- operation_id: search.parked_discard
+  has:
+  - http
+  missing:
+  - cli
+  - grpc_typed
+  - mcp
+  - sdk
+- operation_id: search.parked_retry
   has:
   - http
   missing:

--- a/src/nexus/bricks/search/consumer_metrics.py
+++ b/src/nexus/bricks/search/consumer_metrics.py
@@ -1,0 +1,39 @@
+"""Prometheus metrics for search mutation consumers (#4337).
+
+Low-cardinality labels only:
+  - consumer ∈ {bm25, fts, embedding, txtai}
+  - kind ∈ {permanent, transient}
+
+Split of responsibilities: the parking gate in ``daemon.py`` increments
+``MUTATION_PARKED_TOTAL`` / ``MUTATION_UNRESOLVED_RETRIES_TOTAL``; the
+``MutationParkStore`` owns ``MUTATION_PARKED`` (gauge synced on load /
+park / remove) and ``MUTATION_PARKED_EVICTED_TOTAL``.
+"""
+
+from __future__ import annotations
+
+from prometheus_client import Counter, Gauge
+
+MUTATION_PARKED_TOTAL = Counter(
+    "nexus_search_mutation_parked_total",
+    "Search mutation events parked after exhausting their retry budget",
+    labelnames=("consumer", "kind"),
+)
+
+MUTATION_PARKED = Gauge(
+    "nexus_search_mutation_parked_current",
+    "Search mutation events currently parked",
+    labelnames=("consumer",),
+)
+
+MUTATION_UNRESOLVED_RETRIES_TOTAL = Counter(
+    "nexus_search_mutation_unresolved_retries_total",
+    "Retry passes that observed an unresolved mutation (early warning before parking)",
+    labelnames=("consumer", "kind"),
+)
+
+MUTATION_PARKED_EVICTED_TOTAL = Counter(
+    "nexus_search_mutation_parked_evicted_total",
+    "Parked entries evicted by the per-consumer cap",
+    labelnames=("consumer",),
+)

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -38,19 +38,25 @@ import os
 import time
 from collections.abc import Awaitable, Callable, Iterable
 from contextvars import ContextVar
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, TypeVar
 
 from sqlalchemy import text as sa_text
 
+from nexus.bricks.search import consumer_metrics
 from nexus.bricks.search.chunk_store import ChunkRecord, ChunkStore
 from nexus.bricks.search.mutation_events import (
     SearchMutationEvent,
     SearchMutationOp,
     extract_zone_id,
     strip_zone_prefix,
+)
+from nexus.bricks.search.mutation_parking import (
+    MutationParkStore,
+    ParkedEvent,
+    UnresolvedMutationError,
 )
 from nexus.bricks.search.mutation_resolver import MutationResolver, ResolvedMutation
 from nexus.bricks.search.results import BaseSearchResult
@@ -68,6 +74,11 @@ if TYPE_CHECKING:
     from nexus.bricks.search.path_context import PathContextCache
 
 logger = logging.getLogger(__name__)
+
+# Durable mutation consumer names (#4337): single source for the refresh
+# loop, startup reconciliation, parked-event re-drive, and admin skip-to.
+MUTATION_CONSUMER_NAMES: tuple[str, ...] = ("fts", "embedding")
+LEGACY_REFRESH_CONSUMER = "legacy-refresh"
 
 _BACKEND_LEG_TIMING_KEYS = (
     "backend_ms",
@@ -264,6 +275,18 @@ class DaemonConfig:
     # as config so operators can tune without a code change.
     path_context_max_zones: int = 2048
 
+    # Bounded retries for unresolved-content mutations (#4337). When the
+    # MutationResolver cannot obtain content for an UPSERT, the consumer
+    # retries the batch (refusing to checkpoint) up to this many passes,
+    # then PARKS the event (durable skip record + metric) so one poisoned
+    # event cannot head-of-line block indexing forever.
+    # NOTE: budgets must be >= 2 — startup reconciliation drives each handler
+    # exactly once through the gate (possibly before the file_reader is
+    # attached), so a budget of 1 would park live files during boot.
+    mutation_unresolved_permanent_attempts: int = 3
+    mutation_unresolved_transient_attempts: int = 30
+    mutation_parked_max_entries: int = 200
+
 
 class SearchDaemon:
     """Long-running search service with pre-warmed indexes.
@@ -396,6 +419,16 @@ class SearchDaemon:
         self._consumer_last_sequence: dict[str, int] = {}
         self._checkpoint_file = Path(".nexus-data") / "mutation-checkpoints.json"
         self._checkpoint_lock = asyncio.Lock()
+        # #4337: bounded-retry gate state. Attempt counts are in-memory
+        # (restart resets them; a poisoned event re-accumulates to budget in
+        # seconds). The park store is the durable record of skipped events.
+        self._unresolved_attempts: dict[tuple[str, str], int] = {}
+        self._consumer_retrying: dict[str, dict[str, Any] | None] = {}
+        self._park_store = MutationParkStore(
+            settings_store=settings_store,
+            fallback_file=self._checkpoint_file.parent / "mutation-parked.json",
+            max_entries_per_consumer=self.config.mutation_parked_max_entries,
+        )
         self._shared_mutation_lock = asyncio.Lock()
         self._shared_mutation_events: list[SearchMutationEvent] = []
         self._shared_mutation_floor_sequence = 0
@@ -2854,14 +2887,26 @@ class SearchDaemon:
             self._pending_delete_paths.discard(path)
         self._mutation_wakeup.set()
 
-    async def _index_refresh_loop(self) -> None:
-        """Background task to drive durable per-indexer mutation consumers."""
-        consumer_specs = {
+    def _mutation_handlers(self) -> dict[str, Any]:
+        """Consumer-name → handler map (#4337): single source for the
+        refresh loop, startup reconciliation, and parked-event re-drive."""
+        return {
             "fts": self._consume_fts_mutations,
             "embedding": self._consume_embedding_mutations,
         }
+
+    async def _index_refresh_loop(self) -> None:
+        """Background task to drive durable per-indexer mutation consumers."""
+        consumer_specs = self._mutation_handlers()
         all_consumer_names = tuple(consumer_specs.keys())
         self._consumer_names = all_consumer_names
+        # #4337: load parked records before consumers start so the gauge,
+        # stats, and already-parked filtering reflect prior runs. Best-effort:
+        # a corrupt/unreadable store logs and starts empty.
+        try:
+            await self._park_store.load()
+        except Exception as exc:
+            logger.error("Parked-event store load failed; starting empty: %s", exc)
         # #4016: reconcile pre-existing unindexed files BEFORE consumers
         # snap their checkpoints to MAX(sequence_number). Skipped on warm
         # restarts (any consumer already has a persisted checkpoint).
@@ -2948,7 +2993,7 @@ class SearchDaemon:
             )
             for path in paths
         ]
-        resolved = await self._resolve_mutations(events)
+        resolved = await self._resolve_mutations(LEGACY_REFRESH_CONSUMER, events)
         logger.debug(
             "delete-propagation: resolved=%d (resolved_path_id=%d)",
             len(resolved),
@@ -3327,10 +3372,7 @@ class SearchDaemon:
         if self._async_session is None or not self._consumer_names:
             return
 
-        handlers_by_name: dict[str, Any] = {
-            "fts": self._consume_fts_mutations,
-            "embedding": self._consume_embedding_mutations,
-        }
+        handlers_by_name: dict[str, Any] = self._mutation_handlers()
         pending: list[tuple[str, Any]] = []
         for name in self._consumer_names:
             handler = handlers_by_name.get(name)
@@ -3441,8 +3483,115 @@ class SearchDaemon:
         return events
 
     async def _save_consumer_checkpoint(self, consumer_name: str, sequence_number: int) -> None:
+        current = self._consumer_last_sequence.get(consumer_name)
+        if current is not None and sequence_number < current:
+            # #4337: monotonic guard — an in-flight pass that succeeds with a
+            # stale batch must not rewind an admin force-advance (skip-to).
+            sequence_number = current
         self._consumer_last_sequence[consumer_name] = sequence_number
         await self._persist_checkpoint(consumer_name, sequence_number)
+
+    async def force_checkpoint(self, consumer_name: str, sequence_number: int) -> dict[str, int]:
+        """Force-advance a consumer checkpoint past a poisoned range (#4337).
+
+        Admin escape hatch ("skip event N"): everything with
+        sequence_number <= the new value is permanently skipped for this
+        consumer. Deliberately NOT capped at the current op-log max so an
+        operator can pre-advance past a known-bad range.
+        """
+        if consumer_name not in MUTATION_CONSUMER_NAMES:
+            raise ValueError(
+                f"unknown consumer {consumer_name!r}; expected one of {MUTATION_CONSUMER_NAMES}"
+            )
+        current = self._consumer_last_sequence.get(consumer_name)
+        if current is None:
+            current = await self._initialize_consumer_checkpoint(consumer_name)
+            self._consumer_last_sequence[consumer_name] = current
+        if sequence_number <= current:
+            raise ValueError(
+                f"sequence {sequence_number} must be greater than current checkpoint {current}"
+            )
+        await self._save_consumer_checkpoint(consumer_name, sequence_number)
+        # #4337 review: events skipped by the force-advance can never resolve
+        # or park — drop their in-flight retry counters so the dict stays tidy.
+        self._unresolved_attempts = {
+            key: value
+            for key, value in self._unresolved_attempts.items()
+            if key[0] != consumer_name
+        }
+        logger.warning(
+            "Search mutation checkpoint FORCED for consumer=%s: %d -> %d "
+            "(events in between are skipped)",
+            consumer_name,
+            current,
+            sequence_number,
+        )
+        return {"previous": current, "current": sequence_number}
+
+    def list_parked(self) -> dict[str, list[dict[str, Any]]]:
+        """Parked mutation events per consumer, serialized for the API (#4337)."""
+        return {
+            consumer: [entry.to_dict() for entry in entries]
+            for consumer, entries in self._park_store.list_entries().items()
+            if entries
+        }
+
+    async def retry_parked(
+        self,
+        consumer_name: str,
+        event_ids: list[str] | None = None,
+    ) -> dict[str, Any]:
+        """Re-drive parked events through their consumer handler (#4337).
+
+        One-shot per event: the entry is removed from the store FIRST (so
+        the gate doesn't filter it as already-parked, which would make the
+        handler succeed vacuously), then run through the handler. Success →
+        stays unparked. Failure → re-parked with the new error detail.
+        """
+        if consumer_name not in MUTATION_CONSUMER_NAMES:
+            raise ValueError(
+                f"unknown consumer {consumer_name!r}; expected one of {MUTATION_CONSUMER_NAMES}"
+            )
+        entries = self._park_store.list_entries(consumer_name).get(consumer_name, [])
+        if event_ids is not None:
+            wanted = set(event_ids)
+            entries = [entry for entry in entries if entry.event_id in wanted]
+        handler = self._mutation_handlers()[consumer_name]
+        succeeded: list[str] = []
+        failed: list[dict[str, str]] = []
+        for entry in entries:
+            await self._park_store.remove(consumer_name, [entry.event_id])
+            # #4337 review: one-shot semantics — start from a clean counter so
+            # a live pass's accumulated attempts can't make the in-handler gate
+            # park (and double-count) before our own failure handling re-parks.
+            self._unresolved_attempts.pop((consumer_name, entry.event_id), None)
+            # #4337 final review: the one-shot's gate pass writes
+            # _consumer_retrying — snapshot/restore so an admin re-drive
+            # never clobbers (or fabricates) the live loop's blocker stats.
+            retrying_snapshot = self._consumer_retrying.get(consumer_name)
+            try:
+                await handler([entry.to_event()])
+                succeeded.append(entry.event_id)
+            except Exception as exc:
+                await self._park_store.park(replace(entry, detail=str(exc), parked_at=time.time()))
+                failed.append({"event_id": entry.event_id, "error": str(exc)})
+            finally:
+                self._unresolved_attempts.pop((consumer_name, entry.event_id), None)
+                self._consumer_retrying[consumer_name] = retrying_snapshot
+        return {"retried": len(entries), "succeeded": succeeded, "failed": failed}
+
+    async def discard_parked(
+        self,
+        consumer_name: str,
+        event_ids: list[str],
+    ) -> dict[str, Any]:
+        """Drop parked events without retrying — operator accepts the loss (#4337)."""
+        if consumer_name not in MUTATION_CONSUMER_NAMES:
+            raise ValueError(
+                f"unknown consumer {consumer_name!r}; expected one of {MUTATION_CONSUMER_NAMES}"
+            )
+        removed = await self._park_store.remove(consumer_name, event_ids)
+        return {"discarded": [entry.event_id for entry in removed]}
 
     async def _fetch_operation_log_events(
         self,
@@ -3606,11 +3755,116 @@ class SearchDaemon:
 
     async def _resolve_mutations(
         self,
+        consumer_name: str,
         events: list[SearchMutationEvent],
     ) -> list[ResolvedMutation]:
         if self._mutation_resolver is None:
             return []
-        return await self._mutation_resolver.resolve_batch(events)
+        resolved = await self._mutation_resolver.resolve_batch(events)
+        if consumer_name == LEGACY_REFRESH_CONSUMER:
+            # Fallback delete-propagation path: resolves DELETE events only
+            # (always content_resolved) — the gate has nothing to do.
+            return resolved
+        return await self._gate_unresolved(consumer_name, resolved)
+
+    async def _gate_unresolved(
+        self,
+        consumer_name: str,
+        resolved: list[ResolvedMutation],
+    ) -> list[ResolvedMutation]:
+        """Bounded-retry gate for unresolved-content UPSERTs (#4337).
+
+        Per pass over a batch:
+          * already-parked events are filtered out (no recount);
+          * resolved events drop any stale attempt counter and auto-unpark;
+          * unresolved upserts count one attempt against their kind's
+            budget — at/over budget they are parked (durable record +
+            metrics) and filtered, otherwise the lowest-sequence one is
+            reported in a raised ``UnresolvedMutationError`` so the whole
+            batch retries (checkpoint untouched), exactly like the
+            pre-#4337 refuse-to-checkpoint behavior but bounded.
+        """
+        # #4337 review: reset per-pass so a stale blocker from a previous
+        # pass never survives an early return or a mid-batch park failure.
+        self._consumer_retrying[consumer_name] = None
+        kept: list[ResolvedMutation] = []
+        blocking: ResolvedMutation | None = None
+        blocking_attempts = 0
+        blocking_budget = 0
+        for mutation in resolved:
+            event = mutation.event
+            key = (consumer_name, event.event_id)
+            is_unresolved_upsert = (
+                event.op == SearchMutationOp.UPSERT and not mutation.content_resolved
+            )
+            if not is_unresolved_upsert:
+                self._unresolved_attempts.pop(key, None)
+                if self._park_store.contains(consumer_name, event.event_id):
+                    # Content recovered while parked — heal the record.
+                    await self._park_store.remove(consumer_name, [event.event_id])
+                kept.append(mutation)
+                continue
+            if self._park_store.contains(consumer_name, event.event_id):
+                continue  # already parked: skip without recounting
+            kind = mutation.failure_kind or "transient"
+            attempts = self._unresolved_attempts.get(key, 0) + 1
+            self._unresolved_attempts[key] = attempts
+            budget = (
+                self.config.mutation_unresolved_permanent_attempts
+                if kind == "permanent"
+                else self.config.mutation_unresolved_transient_attempts
+            )
+            consumer_metrics.MUTATION_UNRESOLVED_RETRIES_TOTAL.labels(
+                consumer=consumer_name, kind=kind
+            ).inc()
+            if attempts >= budget:
+                entry = ParkedEvent.from_mutation(
+                    consumer_name,
+                    mutation,
+                    kind=kind,
+                    detail=mutation.failure_detail or "",
+                    attempts=attempts,
+                )
+                # park() raises if it cannot persist a record — in that
+                # case the error propagates, the batch retries, and the
+                # event is NEVER skipped without a durable record.
+                await self._park_store.park(entry)
+                consumer_metrics.MUTATION_PARKED_TOTAL.labels(
+                    consumer=consumer_name, kind=kind
+                ).inc()
+                self._unresolved_attempts.pop(key, None)
+                logger.warning(
+                    "Search mutation PARKED for consumer=%s event_id=%s path=%s "
+                    "kind=%s after %d attempts (checkpoint will advance past it; "
+                    "re-drive or discard via /api/v2/search/parked): %s",
+                    consumer_name,
+                    event.event_id,
+                    event.path,
+                    kind,
+                    attempts,
+                    mutation.failure_detail,
+                )
+                continue
+            if blocking is None or event.sequence_number < blocking.event.sequence_number:
+                blocking = mutation
+                blocking_attempts = attempts
+                blocking_budget = budget
+        if blocking is not None:
+            self._consumer_retrying[consumer_name] = {
+                "event_id": blocking.event.event_id,
+                "path": blocking.event.path,
+                "attempts": blocking_attempts,
+                "budget": blocking_budget,
+                "kind": blocking.failure_kind or "transient",
+            }
+            raise UnresolvedMutationError(
+                f"{consumer_name} mutation content unresolved for "
+                f"event_id={blocking.event.event_id} path={blocking.event.path} "
+                f"kind={blocking.failure_kind or 'transient'} "
+                f"attempt={blocking_attempts}/{blocking_budget} — refusing to "
+                "checkpoint so the consumer retries on next pass"
+            )
+        return kept
 
     def _collapse_resolved_mutations(
         self,
@@ -3639,18 +3893,8 @@ class SearchDaemon:
         embedding_active = (
             self._indexing_pipeline is not None and self._embedding_provider is not None
         )
-        resolved = self._collapse_resolved_mutations(await self._resolve_mutations(events))
+        resolved = self._collapse_resolved_mutations(await self._resolve_mutations("fts", events))
         for mutation in resolved:
-            # Codex review R10 #1 (high): refuse to checkpoint
-            # unresolved-content UPSERTs — see commit history for rationale
-            # for the rationale.
-            if mutation.event.op == SearchMutationOp.UPSERT and not mutation.content_resolved:
-                raise RuntimeError(
-                    f"FTS mutation content unresolved for "
-                    f"event_id={mutation.event.event_id} "
-                    f"path={mutation.event.path} — refusing to checkpoint "
-                    "so the consumer retries on next pass"
-                )
             is_delete_shaped = mutation.event.op == SearchMutationOp.DELETE or (
                 mutation.event.op == SearchMutationOp.UPSERT and mutation.content == ""
             )
@@ -3706,18 +3950,10 @@ class SearchDaemon:
     async def _consume_embedding_mutations(self, events: list[SearchMutationEvent]) -> None:
         if self._indexing_pipeline is None or self._embedding_provider is None:
             return
-        resolved = self._collapse_resolved_mutations(await self._resolve_mutations(events))
+        resolved = self._collapse_resolved_mutations(
+            await self._resolve_mutations("embedding", events)
+        )
         for mutation in resolved:
-            # Codex review R10 #1 (high): refuse to checkpoint
-            # unresolved-content UPSERTs — see commit history for rationale
-            # for the rationale.
-            if mutation.event.op == SearchMutationOp.UPSERT and not mutation.content_resolved:
-                raise RuntimeError(
-                    f"Embedding mutation content unresolved for "
-                    f"event_id={mutation.event.event_id} "
-                    f"path={mutation.event.path} — refusing to checkpoint "
-                    "so the consumer retries on next pass"
-                )
             # Codex review R10 #1 (high): treat resolved-empty UPSERTs
             # as DELETEs (real truncation). Combined with the explicit
             # DELETE op below.
@@ -3956,6 +4192,28 @@ class SearchDaemon:
             p99_idx = int(len(sorted_latencies) * 0.99)
             self.stats.p99_latency_ms = sorted_latencies[p99_idx] if sorted_latencies else 0
 
+    def _mutation_consumer_stats(self) -> dict[str, dict[str, Any]]:
+        """Per-consumer loop stats merged with parking state (#4337)."""
+        merged: dict[str, dict[str, Any]] = {}
+        names = set(self.stats.mutation_consumers) | set(MUTATION_CONSUMER_NAMES)
+        for name in sorted(names):
+            entry = dict(self.stats.mutation_consumers.get(name, {}))
+            entry["parked_count"] = self._park_store.count(name)
+            last = self._park_store.last(name)
+            entry["last_parked"] = (
+                {
+                    "event_id": last.event_id,
+                    "path": last.path,
+                    "kind": last.kind,
+                    "parked_at": last.parked_at,
+                }
+                if last is not None
+                else None
+            )
+            entry["retrying"] = self._consumer_retrying.get(name)
+            merged[name] = entry
+        return merged
+
     def get_stats(self) -> dict[str, Any]:
         """Get current daemon statistics.
 
@@ -4003,7 +4261,7 @@ class SearchDaemon:
             "txtai_model": self.config.txtai_model,
             "txtai_reranker": self.config.txtai_reranker,
             "txtai_graph": self.config.txtai_graph,
-            "mutation_consumers": self.stats.mutation_consumers,
+            "mutation_consumers": self._mutation_consumer_stats(),
             # Issue #3773: path-context attach runs fail-soft so search is
             # never broken by a context-lookup bug. Expose the counts so
             # operators can spot persistent failures via /search/stats.

--- a/src/nexus/bricks/search/mutation_parking.py
+++ b/src/nexus/bricks/search/mutation_parking.py
@@ -1,0 +1,279 @@
+"""Parked-event store for search mutation consumers (#4337).
+
+When the bounded-retry gate in ``SearchDaemon._resolve_mutations`` exhausts
+an unresolved mutation's budget, the event is parked here: skipped by the
+live consumer (the checkpoint advances past it) but durably recorded so an
+admin can re-drive or discard it via the REST surface.
+
+Persistence mirrors the mutation-checkpoint pattern: settings store primary
+(key ``search_mutation_parked``), JSON file fallback next to
+``mutation-checkpoints.json``. If BOTH paths fail, ``park`` raises so the
+caller refuses to checkpoint — an event is never skipped without a record.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+from dataclasses import asdict, dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from nexus.bricks.search import consumer_metrics
+from nexus.bricks.search.mutation_events import SearchMutationEvent, SearchMutationOp
+
+logger = logging.getLogger(__name__)
+
+PARKED_SETTINGS_KEY = "search_mutation_parked"
+
+
+class UnresolvedMutationError(RuntimeError):
+    """Unresolved mutation still within its retry budget — batch must retry."""
+
+
+@dataclass(frozen=True)
+class ParkedEvent:
+    """A skipped mutation event plus enough context to re-drive it."""
+
+    consumer: str
+    event_id: str
+    operation_id: str
+    op: str  # SearchMutationOp value
+    path: str
+    zone_id: str
+    timestamp: str  # ISO-8601, naive UTC (matches SearchMutationEvent.timestamp)
+    sequence_number: int
+    new_path: str | None
+    kind: str  # "permanent" | "transient"
+    detail: str
+    attempts: int
+    parked_at: float
+
+    @classmethod
+    def from_mutation(
+        cls,
+        consumer: str,
+        mutation: Any,
+        *,
+        kind: str,
+        detail: str,
+        attempts: int,
+    ) -> "ParkedEvent":
+        event = mutation.event
+        return cls(
+            consumer=consumer,
+            event_id=event.event_id,
+            operation_id=event.operation_id,
+            op=event.op.value,
+            path=event.path,
+            zone_id=event.zone_id,
+            timestamp=event.timestamp.isoformat(),
+            sequence_number=event.sequence_number,
+            new_path=event.new_path,
+            kind=kind,
+            detail=detail,
+            attempts=attempts,
+            parked_at=time.time(),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "ParkedEvent":
+        return cls(
+            consumer=str(data["consumer"]),
+            event_id=str(data["event_id"]),
+            operation_id=str(data["operation_id"]),
+            op=str(data["op"]),
+            path=str(data["path"]),
+            zone_id=str(data["zone_id"]),
+            timestamp=str(data["timestamp"]),
+            sequence_number=int(data["sequence_number"]),
+            new_path=data.get("new_path"),
+            kind=str(data.get("kind", "transient")),
+            detail=str(data.get("detail", "")),
+            attempts=int(data.get("attempts", 0)),
+            parked_at=float(data.get("parked_at", 0.0)),
+        )
+
+    def to_event(self) -> SearchMutationEvent:
+        return SearchMutationEvent(
+            event_id=self.event_id,
+            operation_id=self.operation_id,
+            op=SearchMutationOp(self.op),
+            path=self.path,
+            zone_id=self.zone_id,
+            timestamp=datetime.fromisoformat(self.timestamp),
+            sequence_number=self.sequence_number,
+            new_path=self.new_path,
+        )
+
+
+class MutationParkStore:
+    """Durable per-consumer list of parked mutation events.
+
+    In-memory dict is the source of truth after ``load``; every mutation
+    re-persists the full document (small: capped per consumer).
+    """
+
+    def __init__(
+        self,
+        *,
+        settings_store: Any | None,
+        fallback_file: Path,
+        max_entries_per_consumer: int = 200,
+    ) -> None:
+        self._settings_store = settings_store
+        self._fallback_file = fallback_file
+        self._max_entries = max(1, int(max_entries_per_consumer))
+        self._lock = asyncio.Lock()
+        self._entries: dict[str, list[ParkedEvent]] = {}
+
+    # -- queries (sync, in-memory) -----------------------------------------
+
+    def contains(self, consumer: str, event_id: str) -> bool:
+        return any(e.event_id == event_id for e in self._entries.get(consumer, []))
+
+    def count(self, consumer: str) -> int:
+        return len(self._entries.get(consumer, []))
+
+    def last(self, consumer: str) -> ParkedEvent | None:
+        entries = self._entries.get(consumer, [])
+        return entries[-1] if entries else None
+
+    def list_entries(self, consumer: str | None = None) -> dict[str, list[ParkedEvent]]:
+        if consumer is not None:
+            return {consumer: list(self._entries.get(consumer, []))}
+        return {name: list(entries) for name, entries in self._entries.items()}
+
+    # -- mutations ----------------------------------------------------------
+
+    async def load(self) -> None:
+        """Load persisted state (best-effort) and seed the parked gauge."""
+        async with self._lock:
+            payload: str | None = None
+            if self._settings_store is not None:
+                try:
+                    setting = self._settings_store.get_setting(PARKED_SETTINGS_KEY)
+                    if setting is not None:
+                        payload = getattr(setting, "value", None)
+                except Exception as exc:
+                    logger.warning("Parked-event store read falling back to file storage: %s", exc)
+                    self._settings_store = None
+            if payload is None:
+                payload = await asyncio.to_thread(self._read_file)
+            if payload:
+                try:
+                    raw = json.loads(payload)
+                    self._entries = {
+                        str(consumer): [ParkedEvent.from_dict(item) for item in items]
+                        for consumer, items in raw.items()
+                    }
+                except Exception as exc:
+                    logger.error(
+                        "Parked-event store unreadable; starting empty "
+                        "(previous parked records lost): %s",
+                        exc,
+                    )
+                    self._entries = {}
+            for consumer in self._entries:
+                self._sync_gauge(consumer)
+
+    async def park(self, entry: ParkedEvent) -> None:
+        """Insert/replace an entry; evict oldest beyond the cap; persist.
+
+        Persist-then-commit: ``self._entries`` is only updated after the
+        document is durably written. If BOTH persistence paths fail this
+        raises and in-memory state is untouched, so ``contains`` never
+        reports a phantom park — callers must not skip an event that has
+        no durable record.
+        """
+        async with self._lock:
+            entries = [
+                e for e in self._entries.get(entry.consumer, []) if e.event_id != entry.event_id
+            ]
+            entries.append(entry)
+            evicted: list[ParkedEvent] = []
+            while len(entries) > self._max_entries:
+                evicted.append(entries.pop(0))
+            candidate = {**self._entries, entry.consumer: entries}
+            await self._persist(candidate)
+            self._entries = candidate
+            for old in evicted:
+                consumer_metrics.MUTATION_PARKED_EVICTED_TOTAL.labels(consumer=entry.consumer).inc()
+                logger.error(
+                    "Parked-event cap (%d) exceeded for consumer=%s — evicting "
+                    "oldest entry event_id=%s path=%s (parking storm?)",
+                    self._max_entries,
+                    entry.consumer,
+                    old.event_id,
+                    old.path,
+                )
+            self._sync_gauge(entry.consumer)
+
+    async def remove(self, consumer: str, event_ids: list[str]) -> list[ParkedEvent]:
+        """Remove entries by id; returns the removed entries.
+
+        Persist-then-commit, same contract as ``park``.
+        """
+        wanted = set(event_ids)
+        async with self._lock:
+            entries = self._entries.get(consumer, [])
+            removed = [e for e in entries if e.event_id in wanted]
+            if not removed:
+                return []
+            candidate = {
+                **self._entries,
+                consumer: [e for e in entries if e.event_id not in wanted],
+            }
+            await self._persist(candidate)
+            self._entries = candidate
+            self._sync_gauge(consumer)
+            return removed
+
+    # -- internals ----------------------------------------------------------
+
+    def _read_file(self) -> str | None:
+        try:
+            if not self._fallback_file.exists():
+                return None
+            return self._fallback_file.read_text()
+        except Exception as exc:
+            logger.warning("Parked-event fallback file unreadable: %s", exc)
+            return None
+
+    def _sync_gauge(self, consumer: str) -> None:
+        consumer_metrics.MUTATION_PARKED.labels(consumer=consumer).set(
+            len(self._entries.get(consumer, []))
+        )
+
+    async def _persist(self, document: dict[str, list[ParkedEvent]]) -> None:
+        payload = json.dumps(
+            {
+                consumer: [e.to_dict() for e in entries]
+                for consumer, entries in document.items()
+                if entries
+            },
+            sort_keys=True,
+        )
+        if self._settings_store is not None:
+            try:
+                self._settings_store.set_setting(
+                    PARKED_SETTINGS_KEY,
+                    payload,
+                    description="Parked search mutation events (#4337)",
+                )
+                return
+            except Exception as exc:
+                logger.warning("Parked-event store falling back to file storage: %s", exc)
+                self._settings_store = None
+
+        def _write() -> None:
+            self._fallback_file.parent.mkdir(parents=True, exist_ok=True)
+            self._fallback_file.write_text(payload)
+
+        await asyncio.to_thread(_write)

--- a/src/nexus/bricks/search/mutation_resolver.py
+++ b/src/nexus/bricks/search/mutation_resolver.py
@@ -7,7 +7,6 @@ and path lookup within a worker cycle.
 
 from __future__ import annotations
 
-import contextlib
 import logging
 import time
 from dataclasses import dataclass
@@ -20,6 +19,10 @@ from nexus.bricks.search.mutation_events import SearchMutationEvent, SearchMutat
 from nexus.contracts.constants import ROOT_ZONE_ID
 
 logger = logging.getLogger(__name__)
+
+# #4337: failure_detail flows into durable park records and WARNING logs;
+# bound it so a fat backend exception repr can't bloat either sink.
+FAILURE_DETAIL_MAX_CHARS = 512
 
 
 def _strip_null_bytes(value: str) -> str:
@@ -47,8 +50,9 @@ class ResolvedMutation:
       * ``content_resolved=True``  + ``content=""`` → confirmed empty;
         consumers should treat as a delete-shaped operation.
       * ``content_resolved=True``  + ``content=text`` → indexable.
-      * ``content_resolved=False``                → unresolved; consumers
-        MUST refuse to checkpoint (raise) so the next batch retries.
+      * ``content_resolved=False`` → unresolved; the #4337 parking gate in
+        SearchDaemon._resolve_mutations refuses to checkpoint (bounded
+        retries) or parks the event.
 
     DELETE events are always resolved (they don't need content).
     """
@@ -61,6 +65,12 @@ class ResolvedMutation:
     content: str | None = None
     path_id_resolved: bool = True
     content_resolved: bool = True
+    # #4337: when content_resolved=False, classify WHY so the parking gate
+    # can budget retries: "permanent" (every read raised FileNotFoundError —
+    # the path is gone) vs "transient" (no reader yet, non-NotFound error,
+    # backend outage). None when content_resolved=True.
+    failure_kind: str | None = None
+    failure_detail: str | None = None
 
 
 class MutationResolver:
@@ -132,7 +142,7 @@ class MutationResolver:
         path_id_map = await self._lookup_path_ids(
             lookup_candidates, include_deleted=include_deleted
         )
-        content_map = await self._lookup_content(events, unresolved_indices)
+        content_map, failure_map = await self._lookup_content(events, unresolved_indices)
 
         for idx in unresolved_indices:
             event = events[idx]
@@ -152,9 +162,18 @@ class MutationResolver:
             if event.op == SearchMutationOp.DELETE:
                 content_resolved = True
                 content_value: str | None = None
+                failure_kind: str | None = None
+                failure_detail: str | None = None
             else:
                 content_resolved = event.event_id in content_map
                 content_value = content_map.get(event.event_id)
+                if content_resolved:
+                    failure_kind = None
+                    failure_detail = None
+                else:
+                    failure_kind, failure_detail = failure_map.get(
+                        event.event_id, ("transient", "unresolved")
+                    )
             mutation = ResolvedMutation(
                 event=event,
                 zone_id=zone_id,
@@ -164,8 +183,14 @@ class MutationResolver:
                 content=content_value,
                 path_id_resolved=path_id_resolved,
                 content_resolved=content_resolved,
+                failure_kind=failure_kind,
+                failure_detail=failure_detail,
             )
-            self._cache[event.event_id] = (now, mutation)
+            # #4337: do NOT cache unresolved mutations. A cached miss would
+            # be served to every retry pass inside the TTL, making the
+            # gate's attempt budget count cache hits instead of real reads.
+            if mutation.content_resolved:
+                self._cache[event.event_id] = (now, mutation)
             resolved[idx] = mutation
 
         return [item for item in resolved if item is not None]
@@ -233,29 +258,35 @@ class MutationResolver:
         self,
         events: list[SearchMutationEvent],
         unresolved_indices: list[int],
-    ) -> dict[str, str]:
+    ) -> tuple[dict[str, str], dict[str, tuple[str, str]]]:
         """Resolve UPSERT content for each unresolved event.
 
-        Codex review R10 #1 (high): the caller treats absence-from-map
-        as "couldn't resolve" (unresolved → consumer raises). An empty
-        string IS a valid resolution state and MUST be recorded.
-        Previously the ``if content:`` truthy filter dropped empty
-        strings on the floor, conflating them with read failures.
+        Returns ``(content_map, failure_map)``: an event_id present in
+        ``content_map`` is resolved (possibly to ``""`` — a valid state,
+        per Codex review R10 #1: empty string IS a valid resolution and
+        MUST be recorded so consumers don't conflate it with a read
+        failure); an event_id present in ``failure_map`` failed with
+        ``(failure_kind, failure_detail)``. The content_cache DB fallback
+        clears a read failure when it hits.
         """
         content_map: dict[str, str] = {}
+        failure_map: dict[str, tuple[str, str]] = {}
         update_events = [
             events[idx] for idx in unresolved_indices if events[idx].op.value == "upsert"
         ]
         if not update_events:
-            return content_map
+            return content_map, failure_map
 
         missing_events: list[SearchMutationEvent] = []
         for event in update_events:
-            content = await self._read_content(event.path, event.virtual_path)
+            content, kind, detail = await self._read_content(event.path, event.virtual_path)
             if isinstance(content, str):
-                # Resolved (could be empty string).
                 content_map[event.event_id] = _strip_null_bytes(content)
             else:
+                failure_map[event.event_id] = (
+                    kind or "transient",
+                    detail or "unknown read failure",
+                )
                 missing_events.append(event)
 
         if missing_events and self._async_session_factory is not None:
@@ -267,31 +298,49 @@ class MutationResolver:
                 content = db_content.get(self._path_key(event.zone_id, event.virtual_path))
                 if isinstance(content, str):
                     content_map[event.event_id] = _strip_null_bytes(content)
+                    failure_map.pop(event.event_id, None)
 
-        return content_map
+        return content_map, failure_map
 
-    async def _read_content(self, scoped_path: str, virtual_path: str) -> str | None:
-        """Return resolved content (possibly empty) or ``None`` on read failure.
+    async def _read_content(
+        self, scoped_path: str, virtual_path: str
+    ) -> tuple[str | None, str | None, str | None]:
+        """Return ``(content, failure_kind, failure_detail)``.
 
-        Codex review R10 #1 (high): an empty file is a valid read
-        outcome (caller distinguishes via isinstance) — only
-        exceptions / non-string returns map to ``None`` so the caller
-        can detect transient failures and retry instead of treating
-        them as truncations.
+        ``content`` is a str (possibly empty) on success. On failure it is
+        ``None`` and ``failure_kind`` classifies the failure (#4337):
+
+          * ``"permanent"`` — every attempted read raised
+            ``FileNotFoundError`` (incl. ``NexusFileNotFoundError``): the
+            path is gone as far as the reader is concerned.
+          * ``"transient"`` — anything else: no reader attached yet (the
+            server lifespan wires it post-boot), a non-string return, or a
+            non-NotFound exception (backend outage, timeout).
         """
         if self._file_reader is None:
-            return None
+            return None, "transient", "no file_reader attached"
 
-        try:
-            scoped_content = await self._file_reader.read_text(scoped_path)
-            if isinstance(scoped_content, str):
-                return scoped_content
-        except Exception:
-            with contextlib.suppress(OSError, ValueError, Exception):
-                virtual_content = await self._file_reader.read_text(virtual_path)
-                if isinstance(virtual_content, str):
-                    return virtual_content
-        return None
+        candidates = [scoped_path]
+        if virtual_path != scoped_path:
+            candidates.append(virtual_path)
+
+        failures: list[tuple[str, BaseException | str]] = []
+        for candidate in candidates:
+            try:
+                content = await self._file_reader.read_text(candidate)
+            except Exception as exc:
+                failures.append((candidate, exc))
+                continue
+            if isinstance(content, str):
+                return content, None, None
+            failures.append((candidate, f"non-string return {type(content).__name__!r}"))
+
+        permanent = all(isinstance(failure, FileNotFoundError) for _, failure in failures)
+        kind = "permanent" if permanent else "transient"
+        detail = "; ".join(f"{path}: {failure!r}" for path, failure in failures)
+        if len(detail) > FAILURE_DETAIL_MAX_CHARS:
+            detail = detail[:FAILURE_DETAIL_MAX_CHARS] + "…[truncated]"
+        return None, kind, detail
 
     async def _lookup_content_cache(
         self,

--- a/src/nexus/server/api/v2/routers/search.py
+++ b/src/nexus/server/api/v2/routers/search.py
@@ -11,6 +11,10 @@ Provides search daemon endpoints:
 - POST /api/v2/search/index    -- explicit document indexing
 - POST /api/v2/search/refresh  -- notify daemon of file change
 - POST /api/v2/search/expand   -- LLM-based query expansion
+- GET  /api/v2/search/parked            -- parked (poison) mutation events (#4337, admin)
+- POST /api/v2/search/parked/retry      -- re-drive parked events (#4337, admin)
+- POST /api/v2/search/parked/discard    -- discard parked events (#4337, admin)
+- POST /api/v2/search/consumers/{name}/skip-to -- force checkpoint advance (#4337, admin)
 
 Rewritten for txtai backend (#2663):
 - txtai handles hybrid BM25+dense fusion internally
@@ -31,6 +35,7 @@ from typing import Any
 
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from pydantic import BaseModel
 
 from nexus.bricks.search.daemon import _BACKEND_LEG_TIMING_KEYS
 from nexus.lib.pagination import build_paginated_list_response
@@ -38,7 +43,7 @@ from nexus.lib.rebac_filter import apply_rebac_filter as _apply_rebac_filter
 from nexus.lib.rebac_filter import compute_rebac_fetch_limit as _compute_rebac_fetch_limit
 from nexus.lib.rebac_filter import rebac_denial_stats as _rebac_denial_stats
 from nexus.runtime.zone_resolution import target_zone_for_context
-from nexus.server.dependencies import get_operation_context, require_auth
+from nexus.server.dependencies import get_operation_context, require_admin, require_auth
 from nexus.server.zone_execution import run_zone_scoped
 
 logger = logging.getLogger(__name__)
@@ -205,6 +210,81 @@ async def search_daemon_stats(
     """Get search daemon statistics."""
     stats: dict[str, Any] = search_daemon.get_stats()
     return stats
+
+
+class ParkedRetryRequest(BaseModel):
+    consumer: str
+    event_ids: list[str] | None = None
+
+
+class ParkedDiscardRequest(BaseModel):
+    consumer: str
+    event_ids: list[str]
+
+
+class ConsumerSkipToRequest(BaseModel):
+    sequence: int
+
+
+@router.get("/parked")
+async def search_parked_list(
+    _admin: dict[str, Any] = Depends(require_admin),
+    search_daemon: Any = Depends(_get_search_daemon),
+) -> dict[str, Any]:
+    """List parked (poison) mutation events per consumer (#4337)."""
+    return {"parked": search_daemon.list_parked()}
+
+
+@router.post("/parked/retry")
+async def search_parked_retry(
+    body: ParkedRetryRequest,
+    _admin: dict[str, Any] = Depends(require_admin),
+    search_daemon: Any = Depends(_get_search_daemon),
+) -> dict[str, Any]:
+    """Re-drive parked mutation events through their consumer (#4337)."""
+    try:
+        result: dict[str, Any] = await search_daemon.retry_parked(body.consumer, body.event_ids)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except Exception as exc:
+        logger.error("Parked-event retry failed: %s", exc, exc_info=True)
+        raise HTTPException(status_code=500, detail="Parked-event retry failed") from exc
+    return result
+
+
+@router.post("/parked/discard")
+async def search_parked_discard(
+    body: ParkedDiscardRequest,
+    _admin: dict[str, Any] = Depends(require_admin),
+    search_daemon: Any = Depends(_get_search_daemon),
+) -> dict[str, Any]:
+    """Discard parked mutation events without retrying (#4337)."""
+    try:
+        result: dict[str, Any] = await search_daemon.discard_parked(body.consumer, body.event_ids)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except Exception as exc:
+        logger.error("Parked-event discard failed: %s", exc, exc_info=True)
+        raise HTTPException(status_code=500, detail="Parked-event discard failed") from exc
+    return result
+
+
+@router.post("/consumers/{consumer_name}/skip-to")
+async def search_consumer_skip_to(
+    consumer_name: str,
+    body: ConsumerSkipToRequest,
+    _admin: dict[str, Any] = Depends(require_admin),
+    search_daemon: Any = Depends(_get_search_daemon),
+) -> dict[str, Any]:
+    """Force-advance a mutation consumer checkpoint past a poisoned range (#4337)."""
+    try:
+        result: dict[str, int] = await search_daemon.force_checkpoint(consumer_name, body.sequence)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except Exception as exc:
+        logger.error("Checkpoint skip-to failed: %s", exc, exc_info=True)
+        raise HTTPException(status_code=500, detail="Checkpoint skip-to failed") from exc
+    return result
 
 
 @router.get("/query")

--- a/src/nexus/server/api/v2/versioning.py
+++ b/src/nexus/server/api/v2/versioning.py
@@ -387,7 +387,8 @@ def build_v2_registry(
         from nexus.server.api.v2.routers.search import router as search_router
 
         # +4 for Issue #3698: index-directory (POST/DELETE), indexed-dirs, purge-unscoped
-        registry.add(RouterEntry(router=search_router, name="search", endpoint_count=9))
+        # +4 for Issue #4337 (parked admin)
+        registry.add(RouterEntry(router=search_router, name="search", endpoint_count=13))
     except ImportError as e:
         logger.warning("Failed to import Search routes: %s", e)
 

--- a/tests/unit/bricks/search/test_daemon_parking_gate.py
+++ b/tests/unit/bricks/search/test_daemon_parking_gate.py
@@ -1,0 +1,334 @@
+"""Parking-gate, checkpoint, and admin-method tests for SearchDaemon (#4337)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+import pytest
+
+from nexus.bricks.search.daemon import DaemonConfig, SearchDaemon
+from nexus.bricks.search.mutation_events import SearchMutationEvent, SearchMutationOp
+from nexus.bricks.search.mutation_parking import MutationParkStore, UnresolvedMutationError
+from nexus.bricks.search.mutation_resolver import ResolvedMutation
+
+
+def _event(event_id: str, seq: int, op: SearchMutationOp = SearchMutationOp.UPSERT):
+    return SearchMutationEvent(
+        event_id=event_id,
+        operation_id=event_id.removeprefix("search:"),
+        op=op,
+        path=f"/zone/z1/docs/{event_id.removeprefix('search:')}.md",
+        zone_id="z1",
+        timestamp=datetime(2026, 6, 9, 1, 2, 3),
+        sequence_number=seq,
+    )
+
+
+def _resolved(event: SearchMutationEvent, *, content: str | None = "body") -> ResolvedMutation:
+    return ResolvedMutation(
+        event=event,
+        zone_id=event.zone_id,
+        virtual_path=event.virtual_path,
+        path_id=f"pid-{event.operation_id}",
+        doc_id=f"{event.zone_id}:{event.virtual_path}",
+        content=content,
+        content_resolved=True,
+    )
+
+
+def _unresolved(event: SearchMutationEvent, *, kind: str = "permanent") -> ResolvedMutation:
+    return ResolvedMutation(
+        event=event,
+        zone_id=event.zone_id,
+        virtual_path=event.virtual_path,
+        path_id=event.virtual_path,
+        doc_id=f"{event.zone_id}:{event.virtual_path}",
+        content=None,
+        path_id_resolved=False,
+        content_resolved=False,
+        failure_kind=kind,
+        failure_detail="FileNotFoundError(...)",
+    )
+
+
+class FakeResolver:
+    """resolve_batch returns canned ResolvedMutations keyed by event_id."""
+
+    def __init__(self, results: dict[str, ResolvedMutation]) -> None:
+        self.results = results
+
+    async def resolve_batch(self, events: list[SearchMutationEvent]):
+        return [self.results[e.event_id] for e in events if e.event_id in self.results]
+
+
+class FakeChunkStore:
+    """Records document writes from the fts consumer."""
+
+    def __init__(self) -> None:
+        self.replaced: list[str] = []
+
+    async def replace_document_chunks(self, path_id: str, records: Any) -> None:
+        self.replaced.append(path_id)
+
+    async def delete_document_chunks(self, path_id: str) -> None:
+        pass
+
+
+def _daemon(tmp_path, **config_overrides: Any) -> SearchDaemon:
+    config = DaemonConfig(
+        database_url=None,
+        txtai_model=None,
+        refresh_enabled=False,
+        vector_warmup_enabled=False,
+        mutation_unresolved_permanent_attempts=2,
+        mutation_unresolved_transient_attempts=4,
+        **config_overrides,
+    )
+    daemon = SearchDaemon(config)
+    # The checkpoint file is anchored at .nexus-data in CWD — redirect both
+    # it and the park store into tmp_path so tests never touch the repo dir.
+    daemon._checkpoint_file = tmp_path / "mutation-checkpoints.json"
+    daemon._park_store = MutationParkStore(
+        settings_store=None,
+        fallback_file=tmp_path / "mutation-parked.json",
+        max_entries_per_consumer=config.mutation_parked_max_entries,
+    )
+    return daemon
+
+
+@pytest.mark.asyncio
+async def test_under_budget_raises_unresolved_error(tmp_path) -> None:
+    daemon = _daemon(tmp_path)
+    poison = _event("search:poison", 10)
+    daemon._mutation_resolver = FakeResolver({"search:poison": _unresolved(poison)})
+    with pytest.raises(UnresolvedMutationError):
+        await daemon._resolve_mutations("fts", [poison])
+    assert daemon._park_store.count("fts") == 0
+
+
+@pytest.mark.asyncio
+async def test_budget_exhaustion_parks_and_filters(tmp_path) -> None:
+    daemon = _daemon(tmp_path)
+    poison = _event("search:poison", 10)
+    healthy = _event("search:ok", 11)
+    daemon._mutation_resolver = FakeResolver(
+        {"search:poison": _unresolved(poison), "search:ok": _resolved(healthy)}
+    )
+    events = [poison, healthy]
+    # permanent budget = 2: pass 1 raises, pass 2 parks and yields healthy only
+    with pytest.raises(UnresolvedMutationError):
+        await daemon._resolve_mutations("fts", events)
+    kept = await daemon._resolve_mutations("fts", events)
+    assert [m.event.event_id for m in kept] == ["search:ok"]
+    assert daemon._park_store.contains("fts", "search:poison")
+    assert ("fts", "search:poison") not in daemon._unresolved_attempts
+
+
+@pytest.mark.asyncio
+async def test_transient_budget_is_larger(tmp_path) -> None:
+    daemon = _daemon(tmp_path)
+    poison = _event("search:flaky", 10)
+    daemon._mutation_resolver = FakeResolver(
+        {"search:flaky": _unresolved(poison, kind="transient")}
+    )
+    for _ in range(3):  # transient budget = 4: passes 1-3 raise
+        with pytest.raises(UnresolvedMutationError):
+            await daemon._resolve_mutations("embedding", [poison])
+    kept = await daemon._resolve_mutations("embedding", [poison])  # pass 4 parks
+    assert kept == []
+    assert daemon._park_store.contains("embedding", "search:flaky")
+
+
+@pytest.mark.asyncio
+async def test_already_parked_event_is_filtered_without_recount(tmp_path) -> None:
+    daemon = _daemon(tmp_path)
+    poison = _event("search:poison", 10)
+    daemon._mutation_resolver = FakeResolver({"search:poison": _unresolved(poison)})
+    with pytest.raises(UnresolvedMutationError):
+        await daemon._resolve_mutations("fts", [poison])
+    await daemon._resolve_mutations("fts", [poison])  # parks
+    kept = await daemon._resolve_mutations("fts", [poison])  # already parked
+    assert kept == []
+    assert ("fts", "search:poison") not in daemon._unresolved_attempts
+    assert daemon._park_store.count("fts") == 1
+
+
+@pytest.mark.asyncio
+async def test_recovered_event_auto_unparks(tmp_path) -> None:
+    daemon = _daemon(tmp_path)
+    poison = _event("search:poison", 10)
+    daemon._mutation_resolver = FakeResolver({"search:poison": _unresolved(poison)})
+    with pytest.raises(UnresolvedMutationError):
+        await daemon._resolve_mutations("fts", [poison])
+    await daemon._resolve_mutations("fts", [poison])  # parks
+    daemon._mutation_resolver = FakeResolver({"search:poison": _resolved(poison)})
+    kept = await daemon._resolve_mutations("fts", [poison])
+    assert [m.event.event_id for m in kept] == ["search:poison"]
+    assert not daemon._park_store.contains("fts", "search:poison")
+
+
+@pytest.mark.asyncio
+async def test_legacy_refresh_bypasses_gate(tmp_path) -> None:
+    daemon = _daemon(tmp_path)
+    poison = _event("search:poison", 10)
+    daemon._mutation_resolver = FakeResolver({"search:poison": _unresolved(poison)})
+    # No raise, no park, unresolved mutation passes through untouched.
+    resolved = await daemon._resolve_mutations("legacy-refresh", [poison])
+    assert len(resolved) == 1
+    assert daemon._park_store.count("legacy-refresh") == 0
+
+
+@pytest.mark.asyncio
+async def test_consumers_are_independent(tmp_path) -> None:
+    daemon = _daemon(tmp_path)
+    poison = _event("search:poison", 10)
+    daemon._mutation_resolver = FakeResolver({"search:poison": _unresolved(poison)})
+    with pytest.raises(UnresolvedMutationError):
+        await daemon._resolve_mutations("fts", [poison])
+    # embedding has its own counter — first pass raises even though fts counted one.
+    with pytest.raises(UnresolvedMutationError):
+        await daemon._resolve_mutations("embedding", [poison])
+    assert daemon._unresolved_attempts[("fts", "search:poison")] == 1
+    assert daemon._unresolved_attempts[("embedding", "search:poison")] == 1
+
+
+@pytest.mark.asyncio
+async def test_fts_consumer_unwedges_after_parking(tmp_path) -> None:
+    daemon = _daemon(tmp_path)
+    poison = _event("search:poison", 10)
+    healthy = _event("search:ok", 11)
+    daemon._mutation_resolver = FakeResolver(
+        {"search:poison": _unresolved(poison), "search:ok": _resolved(healthy)}
+    )
+    daemon._chunk_store = FakeChunkStore()
+    events = [poison, healthy]
+    # Pass 1: under budget — handler raises, nothing indexed (no checkpoint).
+    with pytest.raises(UnresolvedMutationError):
+        await daemon._consume_fts_mutations(events)
+    assert daemon._chunk_store.replaced == []
+    # Pass 2: budget (=2) hit — poison parks, healthy indexes, handler returns.
+    await daemon._consume_fts_mutations(events)
+    assert daemon._chunk_store.replaced == ["pid-ok"]
+    assert daemon._park_store.contains("fts", "search:poison")
+
+
+@pytest.mark.asyncio
+async def test_get_stats_exposes_parking_state(tmp_path) -> None:
+    daemon = _daemon(tmp_path)
+    poison = _event("search:poison", 10)
+    daemon._mutation_resolver = FakeResolver({"search:poison": _unresolved(poison)})
+    with pytest.raises(UnresolvedMutationError):
+        await daemon._resolve_mutations("fts", [poison])
+    stats = daemon.get_stats()
+    fts = stats["mutation_consumers"]["fts"]
+    assert fts["retrying"]["event_id"] == "search:poison"
+    assert fts["retrying"]["attempts"] == 1
+    assert fts["parked_count"] == 0
+    await daemon._resolve_mutations("fts", [poison])  # parks (budget=2)
+    stats = daemon.get_stats()
+    fts = stats["mutation_consumers"]["fts"]
+    assert fts["parked_count"] == 1
+    assert fts["last_parked"]["event_id"] == "search:poison"
+    assert fts["last_parked"]["kind"] == "permanent"
+    assert fts["retrying"] is None
+    # Consumers with no activity still report the parking keys.
+    assert stats["mutation_consumers"]["embedding"]["parked_count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_force_checkpoint_advances_and_validates(tmp_path) -> None:
+    daemon = _daemon(tmp_path)
+    daemon._consumer_last_sequence["fts"] = 100
+    result = await daemon.force_checkpoint("fts", 250)
+    assert result == {"previous": 100, "current": 250}
+    assert daemon._consumer_last_sequence["fts"] == 250
+
+    with pytest.raises(ValueError, match="greater than current"):
+        await daemon.force_checkpoint("fts", 250)
+    with pytest.raises(ValueError, match="unknown consumer"):
+        await daemon.force_checkpoint("nope", 999)
+
+
+@pytest.mark.asyncio
+async def test_save_checkpoint_is_monotonic(tmp_path) -> None:
+    daemon = _daemon(tmp_path)
+    daemon._consumer_last_sequence["fts"] = 100
+    await daemon.force_checkpoint("fts", 250)
+    # An in-flight stale pass completing with an older batch must not rewind.
+    await daemon._save_consumer_checkpoint("fts", 120)
+    assert daemon._consumer_last_sequence["fts"] == 250
+
+
+@pytest.mark.asyncio
+async def test_force_checkpoint_prunes_retry_counters(tmp_path) -> None:
+    daemon = _daemon(tmp_path)
+    poison = _event("search:poison", 10)
+    daemon._mutation_resolver = FakeResolver({"search:poison": _unresolved(poison)})
+    daemon._consumer_last_sequence["fts"] = 5
+    with pytest.raises(UnresolvedMutationError):
+        await daemon._resolve_mutations("fts", [poison])
+    assert ("fts", "search:poison") in daemon._unresolved_attempts
+    await daemon.force_checkpoint("fts", 50)
+    # Skipped-past events must not leak attempt counters.
+    assert ("fts", "search:poison") not in daemon._unresolved_attempts
+
+
+async def _park_one(daemon, consumer: str = "fts", event_id: str = "search:poison"):
+    poison = _event(event_id, 10)
+    daemon._mutation_resolver = FakeResolver({event_id: _unresolved(poison)})
+    with pytest.raises(UnresolvedMutationError):
+        await daemon._resolve_mutations(consumer, [poison])
+    await daemon._resolve_mutations(consumer, [poison])  # budget=2 → parks
+    return poison
+
+
+@pytest.mark.asyncio
+async def test_list_parked_serializes_entries(tmp_path) -> None:
+    daemon = _daemon(tmp_path)
+    await _park_one(daemon)
+    parked = daemon.list_parked()
+    assert list(parked.keys()) == ["fts"]
+    assert parked["fts"][0]["event_id"] == "search:poison"
+    assert parked["fts"][0]["kind"] == "permanent"
+
+
+@pytest.mark.asyncio
+async def test_retry_parked_success_unparks(tmp_path) -> None:
+    daemon = _daemon(tmp_path)
+    poison = await _park_one(daemon)
+    # Content recovered: resolver now resolves the event.
+    daemon._mutation_resolver = FakeResolver({"search:poison": _resolved(poison)})
+    daemon._chunk_store = FakeChunkStore()
+    result = await daemon.retry_parked("fts", None)
+    assert result["retried"] == 1
+    assert result["succeeded"] == ["search:poison"]
+    assert result["failed"] == []
+    assert not daemon._park_store.contains("fts", "search:poison")
+    assert daemon._chunk_store.replaced == ["pid-poison"]
+
+
+@pytest.mark.asyncio
+async def test_retry_parked_failure_reparks(tmp_path) -> None:
+    daemon = _daemon(tmp_path)
+    await _park_one(daemon)  # leaves resolver returning unresolved
+    daemon._chunk_store = FakeChunkStore()
+    result = await daemon.retry_parked("fts", ["search:poison"])
+    assert result["succeeded"] == []
+    assert result["failed"][0]["event_id"] == "search:poison"
+    # Still parked (re-parked after the one-shot failed) — not silently lost.
+    assert daemon._park_store.contains("fts", "search:poison")
+    # And the one-shot didn't leak a live retry counter.
+    assert ("fts", "search:poison") not in daemon._unresolved_attempts
+
+
+@pytest.mark.asyncio
+async def test_discard_parked_removes_without_retry(tmp_path) -> None:
+    daemon = _daemon(tmp_path)
+    await _park_one(daemon)
+    result = await daemon.discard_parked("fts", ["search:poison"])
+    assert result == {"discarded": ["search:poison"]}
+    assert daemon._park_store.count("fts") == 0
+
+    with pytest.raises(ValueError, match="unknown consumer"):
+        await daemon.discard_parked("nope", ["x"])

--- a/tests/unit/bricks/search/test_daemon_sqlite_vec_wiring.py
+++ b/tests/unit/bricks/search/test_daemon_sqlite_vec_wiring.py
@@ -158,7 +158,7 @@ async def test_delete_mutation_prunes_sqlite_vec(
         virtual_path="/gone.md",
     )
 
-    async def _resolve(_events: Any) -> list[Any]:
+    async def _resolve(_consumer: Any, _events: Any) -> list[Any]:
         return [delete_mut]
 
     # Method-stub injection on a SearchDaemon instance — setattr to
@@ -207,7 +207,7 @@ async def test_fts_consumer_prunes_vec_on_delete_when_no_embedder(
         virtual_path="/old.md",
     )
 
-    async def _resolve(_events: Any) -> list[Any]:
+    async def _resolve(_consumer: Any, _events: Any) -> list[Any]:
         return [delete_mut]
 
     setattr(daemon, "_resolve_mutations", _resolve)  # noqa: B010
@@ -349,7 +349,7 @@ async def test_legacy_refresh_prunes_sqlite_vec(monkeypatch: pytest.MonkeyPatch)
         ),
     ]
 
-    async def _resolve(_events: Any) -> list[Any]:
+    async def _resolve(_consumer: Any, _events: Any) -> list[Any]:
         return resolved
 
     setattr(daemon, "_resolve_mutations", _resolve)  # noqa: B010
@@ -403,7 +403,7 @@ async def test_legacy_refresh_vec_failure_does_not_block_other_lanes() -> None:
         zone_id: str
         virtual_path: str
 
-    async def _resolve(_events: Any) -> list[Any]:
+    async def _resolve(_consumer: Any, _events: Any) -> list[Any]:
         return [
             _R(
                 event=_FakeMutEvent(path="/zone/zX/g.md", op=None),
@@ -453,7 +453,7 @@ async def test_fts_consumer_propagates_vec_delete_failure_on_delete() -> None:
         virtual_path="/v.md",
     )
 
-    async def _resolve(_events: Any) -> list[Any]:
+    async def _resolve(_consumer: Any, _events: Any) -> list[Any]:
         return [delete_mut]
 
     setattr(daemon, "_resolve_mutations", _resolve)  # noqa: B010
@@ -491,7 +491,7 @@ async def test_embedding_consumer_propagates_vec_delete_failure_on_delete() -> N
         virtual_path="/e.md",
     )
 
-    async def _resolve(_events: Any) -> list[Any]:
+    async def _resolve(_consumer: Any, _events: Any) -> list[Any]:
         return [delete_mut]
 
     setattr(daemon, "_resolve_mutations", _resolve)  # noqa: B010
@@ -503,10 +503,13 @@ async def test_embedding_consumer_propagates_vec_delete_failure_on_delete() -> N
 
 
 @pytest.mark.asyncio
-async def test_fts_consumer_raises_on_unresolved_upsert() -> None:
-    """Codex review R10 #1 (high): the FTS consumer must also refuse
-    to checkpoint unresolved-content UPSERTs (transient resolver
-    failures), or the lane stays broken until the next mutation."""
+async def test_fts_consumer_skips_unresolved_upsert_without_raise() -> None:
+    """#4337: refuse-to-checkpoint now lives in the parking gate inside
+    ``_resolve_mutations``. If an unresolved UPSERT somehow reaches the
+    handler (gate stubbed out here), it must be skipped defensively —
+    never indexed with ``None`` content and never treated as a delete."""
+    from unittest.mock import AsyncMock
+
     from nexus.bricks.search.daemon import SearchDaemon
     from nexus.bricks.search.mutation_events import SearchMutationOp
 
@@ -514,7 +517,9 @@ async def test_fts_consumer_raises_on_unresolved_upsert() -> None:
     daemon._sqlite_vec_backend = None
     daemon._embedding_provider = None
     daemon._indexing_pipeline = None
-    daemon._chunk_store = MagicMock()
+    daemon._chunk_store = MagicMock(
+        replace_document_chunks=AsyncMock(), delete_document_chunks=AsyncMock()
+    )
 
     upsert_event = _FakeMutEvent(path="/zone/zU/u.md", op=SearchMutationOp.UPSERT)
     unresolved = _FakeResolvedMutation(
@@ -526,12 +531,13 @@ async def test_fts_consumer_raises_on_unresolved_upsert() -> None:
         content_resolved=False,
     )
 
-    async def _resolve(_events: Any) -> list[Any]:
+    async def _resolve(_consumer: Any, _events: Any) -> list[Any]:
         return [unresolved]
 
     setattr(daemon, "_resolve_mutations", _resolve)  # noqa: B010
     setattr(daemon, "_collapse_resolved_mutations", lambda items: items)  # noqa: B010
     setattr(daemon, "_has_resolved_path_id", lambda m: True)  # noqa: B010
 
-    with pytest.raises(RuntimeError, match="content unresolved"):
-        await daemon._consume_fts_mutations([MagicMock()])
+    await daemon._consume_fts_mutations([MagicMock()])
+    daemon._chunk_store.replace_document_chunks.assert_not_awaited()
+    daemon._chunk_store.delete_document_chunks.assert_not_awaited()

--- a/tests/unit/bricks/search/test_mutation_parking_store.py
+++ b/tests/unit/bricks/search/test_mutation_parking_store.py
@@ -1,0 +1,194 @@
+"""Unit tests for MutationParkStore / ParkedEvent (#4337)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from nexus.bricks.search.mutation_events import SearchMutationEvent, SearchMutationOp
+from nexus.bricks.search.mutation_parking import MutationParkStore, ParkedEvent
+
+
+class FakeSettingsStore:
+    def __init__(self) -> None:
+        self.values: dict[str, str] = {}
+
+    def get_setting(self, key: str) -> Any:
+        value = self.values.get(key)
+        return SimpleNamespace(value=value) if value is not None else None
+
+    def set_setting(self, key: str, value: str, *, description: str | None = None) -> None:
+        self.values[key] = value
+
+
+class BrokenSettingsStore:
+    def get_setting(self, key: str) -> Any:
+        raise RuntimeError("settings store down")
+
+    def set_setting(self, key: str, value: str, *, description: str | None = None) -> None:
+        raise RuntimeError("settings store down")
+
+
+def _entry(consumer: str = "bm25", event_id: str = "search:op-1", seq: int = 7) -> ParkedEvent:
+    return ParkedEvent(
+        consumer=consumer,
+        event_id=event_id,
+        operation_id=event_id.removeprefix("search:"),
+        op="upsert",
+        path="/zone/z1/docs/a.md",
+        zone_id="z1",
+        timestamp="2026-06-09T01:02:03",
+        sequence_number=seq,
+        new_path=None,
+        kind="permanent",
+        detail="FileNotFoundError('/zone/z1/docs/a.md')",
+        attempts=3,
+        parked_at=1750000000.0,
+    )
+
+
+def test_parked_event_roundtrip_dict_and_event() -> None:
+    entry = _entry()
+    rebuilt = ParkedEvent.from_dict(entry.to_dict())
+    assert rebuilt == entry
+    event = rebuilt.to_event()
+    assert isinstance(event, SearchMutationEvent)
+    assert event.op == SearchMutationOp.UPSERT
+    assert event.event_id == "search:op-1"
+    assert event.sequence_number == 7
+    assert event.virtual_path == "/docs/a.md"
+
+
+@pytest.mark.asyncio
+async def test_park_and_load_via_settings_store(tmp_path) -> None:
+    settings = FakeSettingsStore()
+    store = MutationParkStore(
+        settings_store=settings,
+        fallback_file=tmp_path / "mutation-parked.json",
+        max_entries_per_consumer=10,
+    )
+    await store.load()
+    await store.park(_entry())
+    assert store.contains("bm25", "search:op-1")
+    assert store.count("bm25") == 1
+
+    # A fresh store (simulated restart) loads the same state back.
+    store2 = MutationParkStore(
+        settings_store=settings,
+        fallback_file=tmp_path / "mutation-parked.json",
+        max_entries_per_consumer=10,
+    )
+    await store2.load()
+    assert store2.contains("bm25", "search:op-1")
+    assert store2.last("bm25") == _entry()
+
+
+@pytest.mark.asyncio
+async def test_park_falls_back_to_file_when_settings_store_broken(tmp_path) -> None:
+    store = MutationParkStore(
+        settings_store=BrokenSettingsStore(),
+        fallback_file=tmp_path / "mutation-parked.json",
+        max_entries_per_consumer=10,
+    )
+    await store.load()
+    await store.park(_entry())
+    assert (tmp_path / "mutation-parked.json").exists()
+
+    store2 = MutationParkStore(
+        settings_store=None,
+        fallback_file=tmp_path / "mutation-parked.json",
+        max_entries_per_consumer=10,
+    )
+    await store2.load()
+    assert store2.contains("bm25", "search:op-1")
+
+
+@pytest.mark.asyncio
+async def test_park_dedupes_by_consumer_and_event_id(tmp_path) -> None:
+    store = MutationParkStore(
+        settings_store=None,
+        fallback_file=tmp_path / "mutation-parked.json",
+        max_entries_per_consumer=10,
+    )
+    await store.load()
+    await store.park(_entry())
+    replacement = _entry()
+    replacement = ParkedEvent.from_dict({**replacement.to_dict(), "attempts": 9})
+    await store.park(replacement)
+    assert store.count("bm25") == 1
+    assert store.last("bm25").attempts == 9
+
+
+@pytest.mark.asyncio
+async def test_cap_evicts_oldest_first(tmp_path) -> None:
+    store = MutationParkStore(
+        settings_store=None,
+        fallback_file=tmp_path / "mutation-parked.json",
+        max_entries_per_consumer=2,
+    )
+    await store.load()
+    await store.park(_entry(event_id="search:op-1", seq=1))
+    await store.park(_entry(event_id="search:op-2", seq=2))
+    await store.park(_entry(event_id="search:op-3", seq=3))
+    assert store.count("bm25") == 2
+    assert not store.contains("bm25", "search:op-1")
+    assert store.contains("bm25", "search:op-2")
+    assert store.contains("bm25", "search:op-3")
+
+
+@pytest.mark.asyncio
+async def test_remove_returns_removed_entries(tmp_path) -> None:
+    store = MutationParkStore(
+        settings_store=None,
+        fallback_file=tmp_path / "mutation-parked.json",
+        max_entries_per_consumer=10,
+    )
+    await store.load()
+    await store.park(_entry(event_id="search:op-1"))
+    await store.park(_entry(event_id="search:op-2"))
+    removed = await store.remove("bm25", ["search:op-1", "search:missing"])
+    assert [e.event_id for e in removed] == ["search:op-1"]
+    assert store.count("bm25") == 1
+
+
+@pytest.mark.asyncio
+async def test_park_raises_when_both_persistence_paths_fail(tmp_path, monkeypatch) -> None:
+    store = MutationParkStore(
+        settings_store=BrokenSettingsStore(),
+        fallback_file=tmp_path / "nope" / "mutation-parked.json",
+        max_entries_per_consumer=10,
+    )
+    await store.load()
+
+    def _boom(*args: Any, **kwargs: Any) -> None:
+        raise OSError("disk full")
+
+    monkeypatch.setattr("pathlib.Path.write_text", _boom)
+    with pytest.raises(OSError):
+        await store.park(_entry())
+    # Persist-then-commit: the failed park must not leave a phantom record.
+    assert not store.contains("bm25", "search:op-1")
+    assert store.count("bm25") == 0
+
+
+@pytest.mark.asyncio
+async def test_remove_rolls_back_when_persistence_fails(tmp_path, monkeypatch) -> None:
+    store = MutationParkStore(
+        settings_store=None,
+        fallback_file=tmp_path / "mutation-parked.json",
+        max_entries_per_consumer=10,
+    )
+    await store.load()
+    await store.park(_entry())
+
+    def _boom(*args: Any, **kwargs: Any) -> None:
+        raise OSError("disk full")
+
+    monkeypatch.setattr("pathlib.Path.write_text", _boom)
+    with pytest.raises(OSError):
+        await store.remove("bm25", ["search:op-1"])
+    # Entry must still be present — a failed remove must not vanish records.
+    assert store.contains("bm25", "search:op-1")
+    assert store.count("bm25") == 1

--- a/tests/unit/bricks/search/test_mutation_resolver_classification.py
+++ b/tests/unit/bricks/search/test_mutation_resolver_classification.py
@@ -1,0 +1,138 @@
+"""MutationResolver failure-classification tests (#4337)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+
+from nexus.bricks.search.mutation_events import SearchMutationEvent, SearchMutationOp
+from nexus.bricks.search.mutation_resolver import MutationResolver
+from nexus.contracts.exceptions import NexusFileNotFoundError
+
+
+def _event(op: SearchMutationOp = SearchMutationOp.UPSERT, path: str = "/zone/z1/docs/a.md"):
+    return SearchMutationEvent(
+        event_id="search:op-1",
+        operation_id="op-1",
+        op=op,
+        path=path,
+        zone_id="z1",
+        timestamp=datetime(2026, 6, 9, 1, 2, 3),
+        sequence_number=7,
+    )
+
+
+class NotFoundReader:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def read_text(self, path: str) -> str:
+        self.calls += 1
+        raise FileNotFoundError(path)
+
+
+class OutageReader:
+    async def read_text(self, path: str) -> str:
+        raise TimeoutError("backend down")
+
+
+class MixedReader:
+    """NotFound on scoped path, outage on virtual path."""
+
+    async def read_text(self, path: str) -> str:
+        if path.startswith("/zone/"):
+            raise FileNotFoundError(path)
+        raise TimeoutError("backend down")
+
+
+class EmptyReader:
+    async def read_text(self, path: str) -> str:
+        return ""
+
+
+def test_nexus_not_found_is_filenotfound_subclass() -> None:
+    assert issubclass(NexusFileNotFoundError, FileNotFoundError)
+
+
+@pytest.mark.asyncio
+async def test_not_found_on_both_paths_is_permanent() -> None:
+    resolver = MutationResolver(file_reader=NotFoundReader(), async_session_factory=None)
+    [mutation] = await resolver.resolve_batch([_event()])
+    assert mutation.content_resolved is False
+    assert mutation.failure_kind == "permanent"
+    assert mutation.failure_detail
+
+
+@pytest.mark.asyncio
+async def test_non_notfound_failure_is_transient() -> None:
+    resolver = MutationResolver(file_reader=OutageReader(), async_session_factory=None)
+    [mutation] = await resolver.resolve_batch([_event()])
+    assert mutation.content_resolved is False
+    assert mutation.failure_kind == "transient"
+
+
+@pytest.mark.asyncio
+async def test_mixed_failures_are_transient() -> None:
+    resolver = MutationResolver(file_reader=MixedReader(), async_session_factory=None)
+    [mutation] = await resolver.resolve_batch([_event()])
+    assert mutation.failure_kind == "transient"
+
+
+@pytest.mark.asyncio
+async def test_missing_reader_is_transient_boot_window() -> None:
+    resolver = MutationResolver(file_reader=None, async_session_factory=None)
+    [mutation] = await resolver.resolve_batch([_event()])
+    assert mutation.content_resolved is False
+    assert mutation.failure_kind == "transient"
+
+
+@pytest.mark.asyncio
+async def test_empty_string_read_is_resolved_not_failure() -> None:
+    resolver = MutationResolver(file_reader=EmptyReader(), async_session_factory=None)
+    [mutation] = await resolver.resolve_batch([_event()])
+    assert mutation.content_resolved is True
+    assert mutation.content == ""
+    assert mutation.failure_kind is None
+
+
+@pytest.mark.asyncio
+async def test_delete_events_have_no_failure() -> None:
+    resolver = MutationResolver(file_reader=NotFoundReader(), async_session_factory=None)
+    [mutation] = await resolver.resolve_batch([_event(op=SearchMutationOp.DELETE)])
+    assert mutation.content_resolved is True
+    assert mutation.failure_kind is None
+
+
+@pytest.mark.asyncio
+async def test_unresolved_mutations_are_not_cached() -> None:
+    reader = NotFoundReader()
+    resolver = MutationResolver(file_reader=reader, async_session_factory=None)
+    await resolver.resolve_batch([_event()])
+    first_calls = reader.calls
+    assert first_calls > 0
+    assert "search:op-1" not in resolver._cache
+    await resolver.resolve_batch([_event()])
+    assert reader.calls > first_calls  # second pass re-read (no stale cache)
+
+
+@pytest.mark.asyncio
+async def test_resolved_mutations_are_still_cached() -> None:
+    resolver = MutationResolver(file_reader=EmptyReader(), async_session_factory=None)
+    await resolver.resolve_batch([_event()])
+    assert "search:op-1" in resolver._cache
+
+
+class HugeErrorReader:
+    async def read_text(self, path: str) -> str:
+        raise RuntimeError("x" * 10_000)
+
+
+@pytest.mark.asyncio
+async def test_failure_detail_is_bounded() -> None:
+    resolver = MutationResolver(file_reader=HugeErrorReader(), async_session_factory=None)
+    [mutation] = await resolver.resolve_batch([_event()])
+    assert mutation.content_resolved is False
+    assert mutation.failure_detail is not None
+    assert len(mutation.failure_detail) < 600
+    assert mutation.failure_detail.endswith("…[truncated]")

--- a/tests/unit/server/routers/test_search_parked_admin.py
+++ b/tests/unit/server/routers/test_search_parked_admin.py
@@ -1,0 +1,104 @@
+"""REST tests for the parked-event admin endpoints (#4337)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from nexus.server.api.v2.routers.search import router
+from nexus.server.dependencies import require_admin
+
+
+class FakeDaemon:
+    def __init__(self) -> None:
+        self.skip_calls: list[tuple[str, int]] = []
+
+    def list_parked(self) -> dict[str, list[dict[str, Any]]]:
+        return {"bm25": [{"event_id": "search:op-1", "kind": "permanent"}]}
+
+    async def retry_parked(self, consumer: str, event_ids: list[str] | None) -> dict[str, Any]:
+        if consumer == "nope":
+            raise ValueError("unknown consumer 'nope'")
+        return {"retried": 1, "succeeded": ["search:op-1"], "failed": []}
+
+    async def discard_parked(self, consumer: str, event_ids: list[str]) -> dict[str, Any]:
+        if consumer == "nope":
+            raise ValueError("unknown consumer 'nope'")
+        return {"discarded": event_ids}
+
+    async def force_checkpoint(self, consumer: str, sequence: int) -> dict[str, int]:
+        if sequence <= 100:
+            raise ValueError("sequence 100 must be greater than current checkpoint 100")
+        self.skip_calls.append((consumer, sequence))
+        return {"previous": 100, "current": sequence}
+
+
+def _client(daemon: FakeDaemon | None = None, *, admin: bool = True) -> TestClient:
+    app = FastAPI()
+    app.include_router(router)
+    app.state.search_daemon = daemon or FakeDaemon()
+    if admin:
+        app.dependency_overrides[require_admin] = lambda: {"is_admin": True}
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def test_parked_list_requires_admin() -> None:
+    client = _client(admin=False)
+    response = client.get("/api/v2/search/parked")
+    assert response.status_code in (401, 403)
+
+
+def test_parked_list_returns_entries() -> None:
+    client = _client()
+    response = client.get("/api/v2/search/parked")
+    assert response.status_code == 200
+    assert response.json()["parked"]["bm25"][0]["event_id"] == "search:op-1"
+
+
+def test_parked_retry_happy_path() -> None:
+    client = _client()
+    response = client.post(
+        "/api/v2/search/parked/retry",
+        json={"consumer": "bm25", "event_ids": None},
+    )
+    assert response.status_code == 200
+    assert response.json()["succeeded"] == ["search:op-1"]
+
+
+def test_parked_retry_unknown_consumer_is_400() -> None:
+    client = _client()
+    response = client.post("/api/v2/search/parked/retry", json={"consumer": "nope"})
+    assert response.status_code == 400
+
+
+def test_parked_discard() -> None:
+    client = _client()
+    response = client.post(
+        "/api/v2/search/parked/discard",
+        json={"consumer": "bm25", "event_ids": ["search:op-1"]},
+    )
+    assert response.status_code == 200
+    assert response.json()["discarded"] == ["search:op-1"]
+
+
+def test_skip_to_happy_path_and_validation() -> None:
+    daemon = FakeDaemon()
+    client = _client(daemon)
+    response = client.post("/api/v2/search/consumers/bm25/skip-to", json={"sequence": 250})
+    assert response.status_code == 200
+    assert response.json() == {"previous": 100, "current": 250}
+    assert daemon.skip_calls == [("bm25", 250)]
+
+    response = client.post("/api/v2/search/consumers/bm25/skip-to", json={"sequence": 100})
+    assert response.status_code == 400
+
+
+def test_parked_discard_unknown_consumer_is_400() -> None:
+    client = _client()
+    response = client.post(
+        "/api/v2/search/parked/discard",
+        json={"consumer": "nope", "event_ids": ["x"]},
+    )
+    assert response.status_code == 400


### PR DESCRIPTION
Closes #4337.

> **Rebased onto develop post-#3699** (txtai/bm25s removal): the daemon now runs two durable consumers (`fts`, `embedding`) and the parking gate covers both. The design docs were written against the earlier four-consumer daemon and carry a note to that effect.

## Summary

One permanently unresolvable mutation event (e.g. a #4339 victim path) used to head-of-line block **all** search indexing forever: the consumer refused to checkpoint and retried the same batch every 2s. This PR bounds those retries and makes the failure operable:

- **Failure classification** (`mutation_resolver.py`): reads now classify `permanent` (FileNotFoundError family on every attempted path, incl. `NexusFileNotFoundError`) vs `transient` (backend outage, timeout, boot window before the file_reader attaches). `failure_detail` is bounded at 512 chars. Unresolved results are no longer TTL-cached, so retry budgets count real reads.
- **Parking gate** (`daemon.py`, chokepoint in `_resolve_mutations`): unresolved upserts retry the batch (refusing to checkpoint, exactly as before) up to `mutation_unresolved_permanent_attempts=3` / `mutation_unresolved_transient_attempts=30` passes, then are **parked** — durably recorded, filtered out, checkpoint advances. Both consumers (`fts`, `embedding`) share the policy; recovered events auto-unpark.
- **Durable park store** (`mutation_parking.py`): settings-store primary + JSON file fallback (mirrors checkpoint persistence), persist-then-commit, dedupe by (consumer, event_id), 200/consumer cap with eviction metric. An event is never skipped without a durable record — if persistence fails, the gate keeps refusing to checkpoint.
- **Metrics** (`consumer_metrics.py`): `nexus_search_mutation_parked_total{consumer,kind}`, `nexus_search_mutation_parked_current{consumer}`, `nexus_search_mutation_unresolved_retries_total{consumer,kind}`, `nexus_search_mutation_parked_evicted_total{consumer}`. (Gauge is `_current` because prometheus_client strips `_total` from Counter names — the Counter already claims the `_parked` base name.)
- **Admin REST surface** (`routers/search.py`, admin-gated): `GET /api/v2/search/parked`, `POST /parked/retry` (one-shot re-drive), `POST /parked/discard`, `POST /consumers/{name}/skip-to` (force checkpoint advance — the issue's "skip event N" escape hatch). Checkpoint saves are now monotonic so an in-flight stale pass can't rewind a forced advance. `/stats` exposes per-consumer `parked_count` / `last_parked` / `retrying`.
- **Runbook**: `docs/operations/search-mutation-parking.md` (symptoms, diagnosis, retry-vs-discard-vs-skip-to decision guide, alert suggestions).
- Design spec + implementation plan under `docs/superpowers/`.

## Known follow-up (pre-existing, not regressed)

Startup reconciliation (`_reconcile_unindexed_paths_at_startup`) drives handlers once per boot and is deliberately under-budget, so a permanently unreadable *unindexed* path still blocks that consumer's backfill each boot — same disease in a sibling path, surfaced during final review. Will be filed as a separate issue (fix sketch: park-on-permanent during reconcile).

## Test Plan

- [x] 41 new unit tests: park store persistence/rollback/cap (8), resolver classification matrix (10), gate budgets/convergence/auto-unpark/stats/checkpoint/re-drive (16), admin endpoints incl. auth ordering (7)
- [x] Full `tests/unit/bricks/search` + `tests/unit/server/routers` + `tests/unit/server/lifespan` suites green after the rebase (only env-gated Postgres/sqlite_vec skips)
- [x] Multi-stage review: per-slice spec + quality reviews, final whole-implementation review; re-verified after the post-#3699 port