### PR TITLE
fix(#4352): surface create-key zone-guard ValueError as structured 400

### DIFF
--- a/docs/surface-coverage/api-rpc-surface-coverage.yaml
+++ b/docs/surface-coverage/api-rpc-surface-coverage.yaml
@@ -1501,7 +1501,7 @@ operations:
   transports:
     http:
       name: GET /api/v2/auth/keys/{key_id}
-      source: src/nexus/server/api/v2/routers/auth_keys.py:351
+      source: src/nexus/server/api/v2/routers/auth_keys.py:358
   profiles:
     lite: supported
     sandbox: supported

--- a/src/nexus/bricks/auth/providers/database_key.py
+++ b/src/nexus/bricks/auth/providers/database_key.py
@@ -24,6 +24,8 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+VALID_SUBJECT_TYPES = ["user", "agent", "service"]
+
 
 class DatabaseAPIKeyAuth(AuthProvider):
     """Database-backed API key authentication with expiry and revocation.
@@ -266,18 +268,20 @@ class DatabaseAPIKeyAuth(AuthProvider):
         return hmac.new(secret.encode("utf-8"), key.encode("utf-8"), hashlib.sha256).hexdigest()
 
     @classmethod
-    def validate_zone_for_key(
+    def validate_key_params(
         cls,
         session: Session,
         *,
         zone_id: str | None,
         is_admin: bool,
+        subject_type: str = "user",
     ) -> None:
-        """Validate zone constraints for key issuance (#3871).
+        """Validate subject/zone constraints for key issuance.
 
-        Raises ValueError when the request is for a zoneless non-admin key
-        (round 4) or when the target zone is missing, not Active, or
-        soft-deleted (rounds 3+6). Surfaces a controlled ValueError instead
+        Raises ValueError when the subject_type is outside the allow-list,
+        when the request is for a zoneless non-admin key (#3871 round 4),
+        or when the target zone is missing, not Active, or soft-deleted
+        (#3871 rounds 3+6). Surfaces a controlled ValueError instead
         of (a) an opaque IntegrityError from the junction FK constraint or
         (b) a returned raw key that the lifecycle gate immediately rejects
         at first authentication (already persisted/displayed once).
@@ -286,6 +290,11 @@ class DatabaseAPIKeyAuth(AuthProvider):
         registration in handle_admin_create_key) must run this first so a
         rejected request leaves no side effects (#4352 review).
         """
+        if subject_type not in VALID_SUBJECT_TYPES:
+            raise ValueError(
+                f"subject_type must be one of {VALID_SUBJECT_TYPES}, got {subject_type}"
+            )
+
         # Zoneless non-admin: the token would have no zone access at auth
         # time (and downstream routes would coerce the missing zone to
         # ROOT_ZONE_ID, silently granting root).
@@ -326,13 +335,11 @@ class DatabaseAPIKeyAuth(AuthProvider):
         """
         from nexus.storage.models import APIKeyModel
 
-        final_subject_id = subject_id or user_id
-        valid_subject_types = ["user", "agent", "service"]
-        if subject_type not in valid_subject_types:
-            raise ValueError(
-                f"subject_type must be one of {valid_subject_types}, got {subject_type}"
-            )
+        cls.validate_key_params(
+            session, zone_id=zone_id, is_admin=is_admin, subject_type=subject_type
+        )
 
+        final_subject_id = subject_id or user_id
         zone_prefix = f"{zone_id[:8]}_" if zone_id else ""
         subject_prefix = final_subject_id[:12] if subject_type == "agent" else user_id[:8]
         random_suffix = secrets.token_hex(16)
@@ -340,8 +347,6 @@ class DatabaseAPIKeyAuth(AuthProvider):
 
         raw_key = f"{API_KEY_PREFIX}{zone_prefix}{subject_prefix}_{key_id_part}_{random_suffix}"
         key_hash = cls._hash_key(raw_key)
-
-        cls.validate_zone_for_key(session, zone_id=zone_id, is_admin=is_admin)
 
         api_key = APIKeyModel(
             key_hash=key_hash,

--- a/src/nexus/bricks/auth/providers/database_key.py
+++ b/src/nexus/bricks/auth/providers/database_key.py
@@ -307,7 +307,13 @@ class DatabaseAPIKeyAuth(AuthProvider):
         if zone_id:
             from nexus.storage.models import ZoneModel
 
-            zone = session.scalar(select(ZoneModel).where(ZoneModel.zone_id == zone_id))
+            # with_for_update: hold the zone row through the caller's
+            # transaction so a concurrent terminate/soft-delete serializes
+            # with key issuance instead of racing the select→commit window
+            # (no-op on SQLite, row lock on Postgres). #4352 review.
+            zone = session.scalar(
+                select(ZoneModel).where(ZoneModel.zone_id == zone_id).with_for_update()
+            )
             if zone is None or zone.phase != ZonePhase.ACTIVE or zone.deleted_at is not None:
                 raise ValueError(
                     f"DatabaseAPIKeyAuth.create_key: zone {zone_id!r} is not active "

--- a/src/nexus/bricks/auth/providers/database_key.py
+++ b/src/nexus/bricks/auth/providers/database_key.py
@@ -266,6 +266,47 @@ class DatabaseAPIKeyAuth(AuthProvider):
         return hmac.new(secret.encode("utf-8"), key.encode("utf-8"), hashlib.sha256).hexdigest()
 
     @classmethod
+    def validate_zone_for_key(
+        cls,
+        session: Session,
+        *,
+        zone_id: str | None,
+        is_admin: bool,
+    ) -> None:
+        """Validate zone constraints for key issuance (#3871).
+
+        Raises ValueError when the request is for a zoneless non-admin key
+        (round 4) or when the target zone is missing, not Active, or
+        soft-deleted (rounds 3+6). Surfaces a controlled ValueError instead
+        of (a) an opaque IntegrityError from the junction FK constraint or
+        (b) a returned raw key that the lifecycle gate immediately rejects
+        at first authentication (already persisted/displayed once).
+
+        Callers that mutate other state before create_key (e.g. entity
+        registration in handle_admin_create_key) must run this first so a
+        rejected request leaves no side effects (#4352 review).
+        """
+        # Zoneless non-admin: the token would have no zone access at auth
+        # time (and downstream routes would coerce the missing zone to
+        # ROOT_ZONE_ID, silently granting root).
+        if not zone_id and not is_admin:
+            raise ValueError(
+                "DatabaseAPIKeyAuth.create_key: non-admin keys must specify a zone_id "
+                "(zoneless tokens are reserved for global admins, #3871)"
+            )
+
+        if zone_id:
+            from nexus.storage.models import ZoneModel
+
+            zone = session.scalar(select(ZoneModel).where(ZoneModel.zone_id == zone_id))
+            if zone is None or zone.phase != ZonePhase.ACTIVE or zone.deleted_at is not None:
+                raise ValueError(
+                    f"DatabaseAPIKeyAuth.create_key: zone {zone_id!r} is not active "
+                    "(missing, Terminating, or soft-deleted); create or restore "
+                    "the zone before issuing keys against it"
+                )
+
+    @classmethod
     def create_key(
         cls,
         session: Session,
@@ -300,31 +341,7 @@ class DatabaseAPIKeyAuth(AuthProvider):
         raw_key = f"{API_KEY_PREFIX}{zone_prefix}{subject_prefix}_{key_id_part}_{random_suffix}"
         key_hash = cls._hash_key(raw_key)
 
-        # #3871 round 4: non-admin keys must have a zone. Otherwise the token
-        # has no zone access at auth time (and downstream routes would coerce
-        # the missing zone to ROOT_ZONE_ID, silently granting root). Zoneless
-        # is reserved for explicit global admins.
-        if not zone_id and not is_admin:
-            raise ValueError(
-                "DatabaseAPIKeyAuth.create_key: non-admin keys must specify a zone_id "
-                "(zoneless tokens are reserved for global admins, #3871)"
-            )
-
-        # #3871 round 3+6: validate zone exists, is Active, and not deleted
-        # before inserting junction row. Surfaces a controlled ValueError
-        # instead of (a) an opaque IntegrityError from the FK constraint or
-        # (b) a returned raw key that the lifecycle gate immediately rejects
-        # at first authentication (already persisted/displayed once).
-        if zone_id:
-            from nexus.storage.models import ZoneModel
-
-            zone = session.scalar(select(ZoneModel).where(ZoneModel.zone_id == zone_id))
-            if zone is None or zone.phase != ZonePhase.ACTIVE or zone.deleted_at is not None:
-                raise ValueError(
-                    f"DatabaseAPIKeyAuth.create_key: zone {zone_id!r} is not active "
-                    "(missing, Terminating, or soft-deleted); create or restore "
-                    "the zone before issuing keys against it"
-                )
+        cls.validate_zone_for_key(session, zone_id=zone_id, is_admin=is_admin)
 
         api_key = APIKeyModel(
             key_hash=key_hash,

--- a/src/nexus/bricks/rebac/entity_registry.py
+++ b/src/nexus/bricks/rebac/entity_registry.py
@@ -100,15 +100,42 @@ class EntityRegistry:
             f"[ENTITY-REG] register_entity called: {entity_type}:{entity_id}, parent={parent_type}:{parent_id}"
         )
 
+        entity, _created = self.register_entity_if_absent(
+            entity_type=entity_type,
+            entity_id=entity_id,
+            parent_type=parent_type,
+            parent_id=parent_id,
+            entity_metadata=entity_metadata,
+        )
+        return entity
+
+    def register_entity_if_absent(
+        self,
+        entity_type: str,
+        entity_id: str,
+        parent_type: str | None = None,
+        parent_id: str | None = None,
+        entity_metadata: dict | None = None,
+    ) -> tuple[EntityRegistryModel, bool]:
+        """Register an entity, reporting whether THIS call inserted the row.
+
+        Returns (entity, created). ``created`` is True only when this call
+        won the insert; a concurrent insert that beats us between the
+        existence check and our flush resolves via the PK conflict to
+        (existing row, False). Callers that compensate failed multi-step
+        flows must delete only rows they created (#4352 review).
+        """
         # Check if entity already exists
         existing = self.get_entity(entity_type, entity_id)
         if existing:
             logger.debug(f"[ENTITY-REG] Entity already exists: {entity_type}:{entity_id}")
-            return existing
+            return existing, False
 
         # Create new entity
         with self._get_session() as session:
             import json
+
+            from sqlalchemy.exc import IntegrityError
 
             # Serialize metadata to JSON string if provided
             metadata_json = json.dumps(entity_metadata) if entity_metadata else None
@@ -126,12 +153,21 @@ class EntityRegistry:
             entity.validate()
 
             session.add(entity)
+            try:
+                session.flush()
+            except IntegrityError:
+                # Concurrent insert won the PK race — ours is the duplicate.
+                session.rollback()
+                winner = self.get_entity(entity_type, entity_id)
+                if winner is not None:
+                    return winner, False
+                raise
             session.commit()
 
             # Refresh to ensure we have the committed state
             session.refresh(entity)
             logger.debug(f"[ENTITY-REG] Entity registered successfully: {entity_type}:{entity_id}")
-            return entity
+            return entity, True
 
     def get_entity(self, entity_type: str, entity_id: str) -> EntityRegistryModel | None:
         """Get an entity from the registry.

--- a/src/nexus/server/api/v2/routers/auth_keys.py
+++ b/src/nexus/server/api/v2/routers/auth_keys.py
@@ -252,7 +252,14 @@ async def create_key(
     # Build a minimal context with is_admin=True (already verified by require_admin)
     context = SimpleNamespace(is_admin=True)
 
-    result = handle_admin_create_key(db_provider, params, context)
+    # Domain validation failures (zone missing/not-Active per #3871, invalid
+    # subject_type, zoneless non-admin key) surface as ValueError from
+    # DatabaseAPIKeyAuth.create_key — translate to a structured 400 instead of
+    # letting them escape as an unstructured plain-text 500 (#4352).
+    try:
+        result = handle_admin_create_key(db_provider, params, context)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     from nexus.storage.api_key_ops import get_primary_zone
 

--- a/src/nexus/server/rpc/handlers/admin.py
+++ b/src/nexus/server/rpc/handlers/admin.py
@@ -266,18 +266,20 @@ def handle_admin_create_key(auth_provider: Any, params: Any, context: Any) -> di
         entity_registry = EntityRegistry(_record_store)
         subject_type = params.subject_type or "user"
         entity_id = params.subject_id or user_id if subject_type == "agent" else user_id
-        # Track newly-created registrations so a create_key rejection in the
-        # precheck→create_key window (zone terminated mid-request) can
+        # Track registrations THIS request inserted so a create_key rejection
+        # in the precheck→create_key window (zone terminated mid-request) can
         # compensate instead of leaving a row parented to an invalid zone.
-        if entity_registry.get_entity(subject_type, entity_id) is None:
-            created_entity = (subject_type, entity_id)
-        entity_registry.register_entity(
+        # Insert provenance comes from the registry's PK-conflict resolution,
+        # so a row inserted by a concurrent request is never ours to delete.
+        _entity, _created = entity_registry.register_entity_if_absent(
             entity_type=subject_type,
             entity_id=entity_id,
             parent_type="zone",
             parent_id=params.zone_id,
             entity_metadata={"name": params.name} if params.name else None,
         )
+        if _created:
+            created_entity = (subject_type, entity_id)
 
     expires_at = None
     if params.expires_days:
@@ -298,7 +300,9 @@ def handle_admin_create_key(auth_provider: Any, params: Any, context: Any) -> di
         except ValueError:
             if entity_registry is not None and created_entity is not None:
                 try:
-                    entity_registry.delete_entity(*created_entity)
+                    # cascade=False: this row was inserted moments ago by this
+                    # request; never sweep children that may have raced in.
+                    entity_registry.delete_entity(*created_entity, cascade=False)
                 except Exception:
                     logger.exception(
                         "Failed to compensate entity registration %s after rejected key create",

--- a/src/nexus/server/rpc/handlers/admin.py
+++ b/src/nexus/server/rpc/handlers/admin.py
@@ -286,6 +286,10 @@ def handle_admin_create_key(auth_provider: Any, params: Any, context: Any) -> di
         expires_at = datetime.now(UTC) + timedelta(days=params.expires_days)
 
     with auth_provider.session_factory() as session:
+        # Compensation covers ANY failure up to and including the key commit
+        # (validation ValueError, driver errors, commit failures) — but not
+        # the post-commit steps (grants): once the key exists the entity
+        # registration is legitimate state and must stay.
         try:
             key_id, raw_key = DatabaseAPIKeyAuth.create_key(
                 session,
@@ -297,7 +301,8 @@ def handle_admin_create_key(auth_provider: Any, params: Any, context: Any) -> di
                 is_admin=params.is_admin,
                 expires_at=expires_at,
             )
-        except ValueError:
+            session.commit()
+        except Exception:
             if entity_registry is not None and created_entity is not None:
                 try:
                     # cascade=False: this row was inserted moments ago by this
@@ -309,7 +314,6 @@ def handle_admin_create_key(auth_provider: Any, params: Any, context: Any) -> di
                         created_entity,
                     )
             raise
-        session.commit()
 
         result: dict[str, Any] = {
             "key_id": key_id,

--- a/src/nexus/server/rpc/handlers/admin.py
+++ b/src/nexus/server/rpc/handlers/admin.py
@@ -273,7 +273,10 @@ def handle_admin_create_key(auth_provider: Any, params: Any, context: Any) -> di
         _record_store = _resolve_record_store(auth_provider)
         subject_type = params.subject_type or "user"
         if _record_store is not None and subject_type in ("user", "agent"):
-            entity_id = params.subject_id or user_id if subject_type == "agent" else user_id
+            # Mirror create_key's effective subject: `subject_id or user_id`
+            # for every subject_type — the registry must describe the same
+            # principal the key authenticates as (#4352 review).
+            entity_id = params.subject_id or user_id
             try:
                 EntityRegistry(_record_store).register_entity_if_absent(
                     entity_type=subject_type,

--- a/src/nexus/server/rpc/handlers/admin.py
+++ b/src/nexus/server/rpc/handlers/admin.py
@@ -246,74 +246,50 @@ def handle_admin_create_key(auth_provider: Any, params: Any, context: Any) -> di
     if not user_id:
         user_id = f"user_{uuid.uuid4().hex[:12]}"
 
-    # Fail-fast before register_entity: a request rejected by create_key
-    # after registration would leave a committed entity_registry row
-    # parented to the bad zone, and the early-return on existing entities
-    # would keep that wrong parent on every later valid create (#4352
-    # review). Mirrors the exact checks create_key re-runs in-transaction.
-    with auth_provider.session_factory() as session:
-        DatabaseAPIKeyAuth.validate_key_params(
-            session,
-            zone_id=params.zone_id,
-            is_admin=params.is_admin,
-            subject_type=params.subject_type,
-        )
-
-    _record_store = _resolve_record_store(auth_provider)
-    entity_registry = None
-    created_entity: tuple[str, str] | None = None
-    if _record_store is not None:
-        entity_registry = EntityRegistry(_record_store)
-        subject_type = params.subject_type or "user"
-        entity_id = params.subject_id or user_id if subject_type == "agent" else user_id
-        # Track registrations THIS request inserted so a create_key rejection
-        # in the precheck→create_key window (zone terminated mid-request) can
-        # compensate instead of leaving a row parented to an invalid zone.
-        # Insert provenance comes from the registry's PK-conflict resolution,
-        # so a row inserted by a concurrent request is never ours to delete.
-        _entity, _created = entity_registry.register_entity_if_absent(
-            entity_type=subject_type,
-            entity_id=entity_id,
-            parent_type="zone",
-            parent_id=params.zone_id,
-            entity_metadata={"name": params.name} if params.name else None,
-        )
-        if _created:
-            created_entity = (subject_type, entity_id)
-
     expires_at = None
     if params.expires_days:
         expires_at = datetime.now(UTC) + timedelta(days=params.expires_days)
 
     with auth_provider.session_factory() as session:
-        # Compensation covers ANY failure up to and including the key commit
-        # (validation ValueError, driver errors, commit failures) — but not
-        # the post-commit steps (grants): once the key exists the entity
-        # registration is legitimate state and must stay.
-        try:
-            key_id, raw_key = DatabaseAPIKeyAuth.create_key(
-                session,
-                user_id=user_id,
-                name=params.name,
-                subject_type=params.subject_type,
-                subject_id=params.subject_id,
-                zone_id=params.zone_id,
-                is_admin=params.is_admin,
-                expires_at=expires_at,
-            )
-            session.commit()
-        except Exception:
-            if entity_registry is not None and created_entity is not None:
-                try:
-                    # cascade=False: this row was inserted moments ago by this
-                    # request; never sweep children that may have raced in.
-                    entity_registry.delete_entity(*created_entity, cascade=False)
-                except Exception:
-                    logger.exception(
-                        "Failed to compensate entity registration %s after rejected key create",
-                        created_entity,
-                    )
-            raise
+        key_id, raw_key = DatabaseAPIKeyAuth.create_key(
+            session,
+            user_id=user_id,
+            name=params.name,
+            subject_type=params.subject_type,
+            subject_id=params.subject_id,
+            zone_id=params.zone_id,
+            is_admin=params.is_admin,
+            expires_at=expires_at,
+        )
+        session.commit()
+
+        # Register the subject only AFTER the key commit (#4352 review): a
+        # row published before the key exists turns every create_key failure
+        # into a stale-row leak, and a compensating delete can erase a row a
+        # concurrent request has already adopted. Post-commit the row is
+        # legitimate state; a registration failure here is benign (the
+        # registry is best-effort ID disambiguation, junction rows are the
+        # access SSOT per #3871) and self-heals on the next create.
+        _record_store = _resolve_record_store(auth_provider)
+        subject_type = params.subject_type or "user"
+        if _record_store is not None and subject_type in ("user", "agent"):
+            entity_id = params.subject_id or user_id if subject_type == "agent" else user_id
+            try:
+                EntityRegistry(_record_store).register_entity_if_absent(
+                    entity_type=subject_type,
+                    entity_id=entity_id,
+                    parent_type="zone",
+                    parent_id=params.zone_id,
+                    entity_metadata={"name": params.name} if params.name else None,
+                )
+            except Exception:
+                logger.exception(
+                    "Entity registration failed for created key %s (subject %s:%s); "
+                    "registry row will be retried on the next key create",
+                    key_id,
+                    subject_type,
+                    entity_id,
+                )
 
         result: dict[str, Any] = {
             "key_id": key_id,

--- a/src/nexus/server/rpc/handlers/admin.py
+++ b/src/nexus/server/rpc/handlers/admin.py
@@ -246,6 +246,15 @@ def handle_admin_create_key(auth_provider: Any, params: Any, context: Any) -> di
     if not user_id:
         user_id = f"user_{uuid.uuid4().hex[:12]}"
 
+    # Fail-fast before register_entity: a zone rejected by create_key after
+    # registration would leave a committed entity_registry row parented to
+    # the bad zone, and the early-return on existing entities would keep
+    # that wrong parent on every later valid create (#4352 review).
+    with auth_provider.session_factory() as session:
+        DatabaseAPIKeyAuth.validate_zone_for_key(
+            session, zone_id=params.zone_id, is_admin=params.is_admin
+        )
+
     _record_store = _resolve_record_store(auth_provider)
     if _record_store is not None:
         entity_registry = EntityRegistry(_record_store)

--- a/src/nexus/server/rpc/handlers/admin.py
+++ b/src/nexus/server/rpc/handlers/admin.py
@@ -246,20 +246,31 @@ def handle_admin_create_key(auth_provider: Any, params: Any, context: Any) -> di
     if not user_id:
         user_id = f"user_{uuid.uuid4().hex[:12]}"
 
-    # Fail-fast before register_entity: a zone rejected by create_key after
-    # registration would leave a committed entity_registry row parented to
-    # the bad zone, and the early-return on existing entities would keep
-    # that wrong parent on every later valid create (#4352 review).
+    # Fail-fast before register_entity: a request rejected by create_key
+    # after registration would leave a committed entity_registry row
+    # parented to the bad zone, and the early-return on existing entities
+    # would keep that wrong parent on every later valid create (#4352
+    # review). Mirrors the exact checks create_key re-runs in-transaction.
     with auth_provider.session_factory() as session:
-        DatabaseAPIKeyAuth.validate_zone_for_key(
-            session, zone_id=params.zone_id, is_admin=params.is_admin
+        DatabaseAPIKeyAuth.validate_key_params(
+            session,
+            zone_id=params.zone_id,
+            is_admin=params.is_admin,
+            subject_type=params.subject_type,
         )
 
     _record_store = _resolve_record_store(auth_provider)
+    entity_registry = None
+    created_entity: tuple[str, str] | None = None
     if _record_store is not None:
         entity_registry = EntityRegistry(_record_store)
         subject_type = params.subject_type or "user"
         entity_id = params.subject_id or user_id if subject_type == "agent" else user_id
+        # Track newly-created registrations so a create_key rejection in the
+        # precheck→create_key window (zone terminated mid-request) can
+        # compensate instead of leaving a row parented to an invalid zone.
+        if entity_registry.get_entity(subject_type, entity_id) is None:
+            created_entity = (subject_type, entity_id)
         entity_registry.register_entity(
             entity_type=subject_type,
             entity_id=entity_id,
@@ -273,16 +284,27 @@ def handle_admin_create_key(auth_provider: Any, params: Any, context: Any) -> di
         expires_at = datetime.now(UTC) + timedelta(days=params.expires_days)
 
     with auth_provider.session_factory() as session:
-        key_id, raw_key = DatabaseAPIKeyAuth.create_key(
-            session,
-            user_id=user_id,
-            name=params.name,
-            subject_type=params.subject_type,
-            subject_id=params.subject_id,
-            zone_id=params.zone_id,
-            is_admin=params.is_admin,
-            expires_at=expires_at,
-        )
+        try:
+            key_id, raw_key = DatabaseAPIKeyAuth.create_key(
+                session,
+                user_id=user_id,
+                name=params.name,
+                subject_type=params.subject_type,
+                subject_id=params.subject_id,
+                zone_id=params.zone_id,
+                is_admin=params.is_admin,
+                expires_at=expires_at,
+            )
+        except ValueError:
+            if entity_registry is not None and created_entity is not None:
+                try:
+                    entity_registry.delete_entity(*created_entity)
+                except Exception:
+                    logger.exception(
+                        "Failed to compensate entity registration %s after rejected key create",
+                        created_entity,
+                    )
+            raise
         session.commit()
 
         result: dict[str, Any] = {

--- a/tests/integration/server/api/v2/routers/test_auth_keys_grants.py
+++ b/tests/integration/server/api/v2/routers/test_auth_keys_grants.py
@@ -49,6 +49,14 @@ def record_store():
             )
         )
         conn.commit()
+    # create_key validates the target zone exists and is Active (#3871);
+    # keys here use the default ROOT_ZONE_ID, so seed that zone.
+    from nexus.contracts.constants import ROOT_ZONE_ID
+    from nexus.storage.models.auth import ZoneModel
+
+    with store.session_factory() as session:
+        session.add(ZoneModel(zone_id=ROOT_ZONE_ID, name=ROOT_ZONE_ID, phase="Active"))
+        session.commit()
     yield store
     store.close()
 

--- a/tests/unit/core/test_entity_registry.py
+++ b/tests/unit/core/test_entity_registry.py
@@ -184,3 +184,46 @@ def test_get_children_returns_direct_children_only(registry):
     # Agent has no children
     agent_children = registry.get_children("agent", "agent_1")
     assert len(agent_children) == 0
+
+
+# ---------------------------------------------------------------------------
+# register_entity_if_absent — insert provenance (#4352 review round 3)
+# ---------------------------------------------------------------------------
+
+
+def test_register_if_absent_reports_created(registry):
+    entity, created = registry.register_entity_if_absent("zone", "acme")
+    assert created is True
+    assert entity.entity_id == "acme"
+
+
+def test_register_if_absent_reports_existing(registry):
+    registry.register_entity("zone", "acme")
+    entity, created = registry.register_entity_if_absent("zone", "acme")
+    assert created is False
+    assert entity.entity_id == "acme"
+
+
+def test_register_if_absent_lost_insert_race_reports_existing(registry, monkeypatch):
+    """If a concurrent request inserts the row between our existence check and
+    our insert, the PK conflict must resolve to (existing row, created=False) —
+    not an exception, and never created=True (which would let a compensation
+    path delete the other request's row)."""
+    registry.register_entity("zone", "acme")
+
+    # Simulate the stale pre-read: the existence check misses the
+    # concurrently-inserted row exactly once.
+    orig_get = EntityRegistry.get_entity
+    calls = {"n": 0}
+
+    def stale_first_read(self, entity_type, entity_id):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return None
+        return orig_get(self, entity_type, entity_id)
+
+    monkeypatch.setattr(EntityRegistry, "get_entity", stale_first_read)
+
+    entity, created = registry.register_entity_if_absent("zone", "acme")
+    assert created is False
+    assert entity.entity_id == "acme"

--- a/tests/unit/server/api/v2/routers/test_auth_keys_create_zone_guard.py
+++ b/tests/unit/server/api/v2/routers/test_auth_keys_create_zone_guard.py
@@ -150,3 +150,52 @@ def test_failed_create_leaves_no_entity_registry_row(record_store_client):
             select(EntityRegistryModel).where(EntityRegistryModel.entity_id == "team-agent")
         ).one()
         assert entity.parent_id == "zone_active"
+
+
+def test_invalid_subject_type_leaves_no_entity_registry_row(record_store_client):
+    """'zone' is a valid entity_registry type but not a valid key subject_type;
+    the rejection must come before the entity row is committed."""
+    from sqlalchemy import select
+
+    from nexus.storage.models.memory import EntityRegistryModel
+
+    client, store = record_store_client
+
+    resp = client.post("/api/v2/auth/keys", json=_create_body("zone_active", subject_type="zone"))
+    assert resp.status_code == 400, resp.text
+    assert "subject_type" in resp.json()["detail"]
+
+    with store.session_factory() as s:
+        rows = s.scalars(select(EntityRegistryModel)).all()
+        assert rows == [], f"stale entity rows after rejected subject_type: {rows}"
+
+
+def test_zone_terminated_mid_request_compensates_entity_row(record_store_client, monkeypatch):
+    """TOCTOU: zone passes the precheck but is terminated before create_key's
+    in-transaction recheck. The 400 must compensate the just-registered entity."""
+    from sqlalchemy import select
+
+    from nexus.bricks.rebac.entity_registry import EntityRegistry
+    from nexus.storage.models.memory import EntityRegistryModel
+
+    client, store = record_store_client
+
+    orig_register = EntityRegistry.register_entity
+
+    def register_then_terminate_zone(self, *args, **kwargs):
+        result = orig_register(self, *args, **kwargs)
+        with store.session_factory() as s:
+            zone = s.scalars(select(ZoneModel).where(ZoneModel.zone_id == "zone_active")).one()
+            zone.phase = "Terminated"
+            s.commit()
+        return result
+
+    monkeypatch.setattr(EntityRegistry, "register_entity", register_then_terminate_zone)
+
+    resp = client.post("/api/v2/auth/keys", json=_create_body("zone_active"))
+    assert resp.status_code == 400, resp.text
+    assert "is not active" in resp.json()["detail"]
+
+    with store.session_factory() as s:
+        rows = s.scalars(select(EntityRegistryModel)).all()
+        assert rows == [], f"stale entity rows after mid-request zone flip: {rows}"

--- a/tests/unit/server/api/v2/routers/test_auth_keys_create_zone_guard.py
+++ b/tests/unit/server/api/v2/routers/test_auth_keys_create_zone_guard.py
@@ -170,41 +170,27 @@ def test_invalid_subject_type_leaves_no_entity_registry_row(record_store_client)
         assert rows == [], f"stale entity rows after rejected subject_type: {rows}"
 
 
-def test_zone_terminated_mid_request_compensates_entity_row(record_store_client, monkeypatch):
-    """TOCTOU: zone passes the precheck but is terminated before create_key's
-    in-transaction recheck. The 400 must compensate the just-registered entity."""
-    from sqlalchemy import select
-
+def test_registration_failure_does_not_fail_created_key(record_store_client, monkeypatch):
+    """Registration runs only after the key commit and is best-effort: a
+    registry failure must not turn an already-issued key into an error
+    response (the row self-heals on the next create)."""
     from nexus.bricks.rebac.entity_registry import EntityRegistry
-    from nexus.storage.models.memory import EntityRegistryModel
 
-    client, store = record_store_client
+    client, _store = record_store_client
 
-    orig_register = EntityRegistry.register_entity_if_absent
+    def boom(self, *args, **kwargs):
+        raise RuntimeError("simulated registry failure")
 
-    def register_then_terminate_zone(self, *args, **kwargs):
-        result = orig_register(self, *args, **kwargs)
-        with store.session_factory() as s:
-            zone = s.scalars(select(ZoneModel).where(ZoneModel.zone_id == "zone_active")).one()
-            zone.phase = "Terminated"
-            s.commit()
-        return result
-
-    monkeypatch.setattr(EntityRegistry, "register_entity_if_absent", register_then_terminate_zone)
+    monkeypatch.setattr(EntityRegistry, "register_entity_if_absent", boom)
 
     resp = client.post("/api/v2/auth/keys", json=_create_body("zone_active"))
-    assert resp.status_code == 400, resp.text
-    assert "is not active" in resp.json()["detail"]
-
-    with store.session_factory() as s:
-        rows = s.scalars(select(EntityRegistryModel)).all()
-        assert rows == [], f"stale entity rows after mid-request zone flip: {rows}"
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["key"].startswith("sk-")
 
 
-def test_non_valueerror_create_failure_also_compensates(record_store_client, monkeypatch):
-    """Compensation must cover any key-creation failure, not just the
-    ValueError guards — a driver error after registration must not leak the
-    just-inserted entity row either."""
+def test_non_valueerror_create_failure_leaves_no_entity_row(record_store_client, monkeypatch):
+    """Any key-creation failure — not just the ValueError guards — must leave
+    no entity row behind (registration only runs after a successful commit)."""
     from sqlalchemy import select
 
     from nexus.bricks.auth.providers.database_key import DatabaseAPIKeyAuth
@@ -225,10 +211,9 @@ def test_non_valueerror_create_failure_also_compensates(record_store_client, mon
         assert rows == [], f"stale entity rows after non-ValueError failure: {rows}"
 
 
-def test_compensation_never_deletes_preexisting_entity(record_store_client, monkeypatch):
-    """Ownership: a row registered by an earlier/concurrent request must
-    survive this request's 400 — compensation may only delete rows this
-    request inserted."""
+def test_failed_create_never_deletes_preexisting_entity(record_store_client):
+    """Ownership: a row registered by an earlier request must survive this
+    request's failure — failed creates never touch the registry."""
     from sqlalchemy import select
 
     from nexus.bricks.rebac.entity_registry import EntityRegistry
@@ -241,24 +226,12 @@ def test_compensation_never_deletes_preexisting_entity(record_store_client, monk
         "agent", "team-agent", parent_type="zone", parent_id="zone_active"
     )
 
-    orig_register = EntityRegistry.register_entity_if_absent
-
-    def register_then_terminate_zone(self, *args, **kwargs):
-        result = orig_register(self, *args, **kwargs)
-        with store.session_factory() as s:
-            zone = s.scalars(select(ZoneModel).where(ZoneModel.zone_id == "zone_active")).one()
-            zone.phase = "Terminated"
-            s.commit()
-        return result
-
-    monkeypatch.setattr(EntityRegistry, "register_entity_if_absent", register_then_terminate_zone)
-
-    resp = client.post("/api/v2/auth/keys", json=_create_body("zone_active"))
+    resp = client.post("/api/v2/auth/keys", json=_create_body("zone_ghost"))
     assert resp.status_code == 400, resp.text
 
     with store.session_factory() as s:
         entity = s.scalars(
             select(EntityRegistryModel).where(EntityRegistryModel.entity_id == "team-agent")
         ).one_or_none()
-        assert entity is not None, "compensation deleted another request's entity row"
+        assert entity is not None, "failed create deleted another request's entity row"
         assert entity.parent_id == "zone_active"

--- a/tests/unit/server/api/v2/routers/test_auth_keys_create_zone_guard.py
+++ b/tests/unit/server/api/v2/routers/test_auth_keys_create_zone_guard.py
@@ -97,3 +97,56 @@ def test_create_key_active_zone_still_succeeds(client):
     body = resp.json()
     assert body["zone_id"] == "zone_active"
     assert body["key"].startswith("sk-")
+
+
+@pytest.fixture
+def record_store_client(monkeypatch):
+    """Client backed by a real record store so the entity-registry path runs."""
+    from tests.testkit.records import InMemoryRecordStore
+
+    store = InMemoryRecordStore()
+    with store.session_factory() as s:
+        s.add(ZoneModel(zone_id="zone_active", name="zone_active", phase="Active"))
+        s.commit()
+
+    provider = SimpleNamespace(session_factory=store.session_factory, _record_store=store)
+
+    from nexus.server.api.v2.routers import auth_keys as auth_keys_module
+
+    monkeypatch.setattr(auth_keys_module, "_resolve_db_auth", lambda request: provider)
+
+    app = FastAPI()
+    app.include_router(auth_keys_module.router)
+    app.dependency_overrides[require_admin] = lambda: SimpleNamespace(is_admin=True)
+    app.add_exception_handler(NexusError, nexus_error_handler)
+
+    yield TestClient(app, raise_server_exceptions=False), store
+    store.close()
+
+
+def test_failed_create_leaves_no_entity_registry_row(record_store_client):
+    """A 400 from the zone guard must not commit identity state: a stale
+    entity_registry row parented to the bad zone would make a later valid
+    create skip registration and keep the wrong parent forever."""
+    from sqlalchemy import select
+
+    from nexus.storage.models.memory import EntityRegistryModel
+
+    client, store = record_store_client
+
+    resp = client.post("/api/v2/auth/keys", json=_create_body("zone_ghost"))
+    assert resp.status_code == 400, resp.text
+
+    with store.session_factory() as s:
+        rows = s.scalars(select(EntityRegistryModel)).all()
+        assert rows == [], f"stale entity rows after failed create: {rows}"
+
+    # Subsequent valid create must register the entity under the active zone
+    resp = client.post("/api/v2/auth/keys", json=_create_body("zone_active"))
+    assert resp.status_code == 201, resp.text
+
+    with store.session_factory() as s:
+        entity = s.scalars(
+            select(EntityRegistryModel).where(EntityRegistryModel.entity_id == "team-agent")
+        ).one()
+        assert entity.parent_id == "zone_active"

--- a/tests/unit/server/api/v2/routers/test_auth_keys_create_zone_guard.py
+++ b/tests/unit/server/api/v2/routers/test_auth_keys_create_zone_guard.py
@@ -180,7 +180,7 @@ def test_zone_terminated_mid_request_compensates_entity_row(record_store_client,
 
     client, store = record_store_client
 
-    orig_register = EntityRegistry.register_entity
+    orig_register = EntityRegistry.register_entity_if_absent
 
     def register_then_terminate_zone(self, *args, **kwargs):
         result = orig_register(self, *args, **kwargs)
@@ -190,7 +190,7 @@ def test_zone_terminated_mid_request_compensates_entity_row(record_store_client,
             s.commit()
         return result
 
-    monkeypatch.setattr(EntityRegistry, "register_entity", register_then_terminate_zone)
+    monkeypatch.setattr(EntityRegistry, "register_entity_if_absent", register_then_terminate_zone)
 
     resp = client.post("/api/v2/auth/keys", json=_create_body("zone_active"))
     assert resp.status_code == 400, resp.text
@@ -199,3 +199,42 @@ def test_zone_terminated_mid_request_compensates_entity_row(record_store_client,
     with store.session_factory() as s:
         rows = s.scalars(select(EntityRegistryModel)).all()
         assert rows == [], f"stale entity rows after mid-request zone flip: {rows}"
+
+
+def test_compensation_never_deletes_preexisting_entity(record_store_client, monkeypatch):
+    """Ownership: a row registered by an earlier/concurrent request must
+    survive this request's 400 — compensation may only delete rows this
+    request inserted."""
+    from sqlalchemy import select
+
+    from nexus.bricks.rebac.entity_registry import EntityRegistry
+    from nexus.storage.models.memory import EntityRegistryModel
+
+    client, store = record_store_client
+
+    # Another request already registered the subject under the active zone.
+    EntityRegistry(store).register_entity(
+        "agent", "team-agent", parent_type="zone", parent_id="zone_active"
+    )
+
+    orig_register = EntityRegistry.register_entity_if_absent
+
+    def register_then_terminate_zone(self, *args, **kwargs):
+        result = orig_register(self, *args, **kwargs)
+        with store.session_factory() as s:
+            zone = s.scalars(select(ZoneModel).where(ZoneModel.zone_id == "zone_active")).one()
+            zone.phase = "Terminated"
+            s.commit()
+        return result
+
+    monkeypatch.setattr(EntityRegistry, "register_entity_if_absent", register_then_terminate_zone)
+
+    resp = client.post("/api/v2/auth/keys", json=_create_body("zone_active"))
+    assert resp.status_code == 400, resp.text
+
+    with store.session_factory() as s:
+        entity = s.scalars(
+            select(EntityRegistryModel).where(EntityRegistryModel.entity_id == "team-agent")
+        ).one_or_none()
+        assert entity is not None, "compensation deleted another request's entity row"
+        assert entity.parent_id == "zone_active"

--- a/tests/unit/server/api/v2/routers/test_auth_keys_create_zone_guard.py
+++ b/tests/unit/server/api/v2/routers/test_auth_keys_create_zone_guard.py
@@ -201,6 +201,30 @@ def test_zone_terminated_mid_request_compensates_entity_row(record_store_client,
         assert rows == [], f"stale entity rows after mid-request zone flip: {rows}"
 
 
+def test_non_valueerror_create_failure_also_compensates(record_store_client, monkeypatch):
+    """Compensation must cover any key-creation failure, not just the
+    ValueError guards — a driver error after registration must not leak the
+    just-inserted entity row either."""
+    from sqlalchemy import select
+
+    from nexus.bricks.auth.providers.database_key import DatabaseAPIKeyAuth
+    from nexus.storage.models.memory import EntityRegistryModel
+
+    client, store = record_store_client
+
+    def boom(cls_session, *args, **kwargs):
+        raise RuntimeError("simulated driver failure")
+
+    monkeypatch.setattr(DatabaseAPIKeyAuth, "create_key", classmethod(boom))
+
+    resp = client.post("/api/v2/auth/keys", json=_create_body("zone_active"))
+    assert resp.status_code == 500
+
+    with store.session_factory() as s:
+        rows = s.scalars(select(EntityRegistryModel)).all()
+        assert rows == [], f"stale entity rows after non-ValueError failure: {rows}"
+
+
 def test_compensation_never_deletes_preexisting_entity(record_store_client, monkeypatch):
     """Ownership: a row registered by an earlier/concurrent request must
     survive this request's 400 — compensation may only delete rows this

--- a/tests/unit/server/api/v2/routers/test_auth_keys_create_zone_guard.py
+++ b/tests/unit/server/api/v2/routers/test_auth_keys_create_zone_guard.py
@@ -170,6 +170,31 @@ def test_invalid_subject_type_leaves_no_entity_registry_row(record_store_client)
         assert rows == [], f"stale entity rows after rejected subject_type: {rows}"
 
 
+def test_user_subject_registers_effective_subject_id(record_store_client):
+    """The registry must register the same principal the key authenticates
+    as: create_key's effective subject is `subject_id or user_id` for every
+    subject_type, not just agents."""
+    from sqlalchemy import select
+
+    from nexus.storage.models.memory import EntityRegistryModel
+
+    client, store = record_store_client
+
+    resp = client.post(
+        "/api/v2/auth/keys",
+        json=_create_body(
+            "zone_active", subject_type="user", user_id="owner", subject_id="delegated"
+        ),
+    )
+    assert resp.status_code == 201, resp.text
+
+    with store.session_factory() as s:
+        rows = s.scalars(select(EntityRegistryModel)).all()
+        ids = {(r.entity_type, r.entity_id) for r in rows}
+        assert ("user", "delegated") in ids, f"effective subject not registered: {ids}"
+        assert ("user", "owner") not in ids, f"wrong identity registered: {ids}"
+
+
 def test_registration_failure_does_not_fail_created_key(record_store_client, monkeypatch):
     """Registration runs only after the key commit and is best-effort: a
     registry failure must not turn an already-issued key into an error

--- a/tests/unit/server/api/v2/routers/test_auth_keys_create_zone_guard.py
+++ b/tests/unit/server/api/v2/routers/test_auth_keys_create_zone_guard.py
@@ -1,0 +1,99 @@
+"""REST create_key surfaces zone-lifecycle guard failures as structured 400s (#4352).
+
+The #3871 guard in DatabaseAPIKeyAuth.create_key raises ValueError when the
+target zone is missing, Terminating/Terminated, or soft-deleted. The REST
+route must translate that into an HTTPException(400) with the cause in
+``detail`` — not let it escape as an unstructured plain-text 500.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from nexus.contracts.exceptions import NexusError
+from nexus.server.dependencies import require_admin
+from nexus.server.error_handlers import nexus_error_handler
+from nexus.storage.models._base import Base
+from nexus.storage.models.auth import ZoneModel
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    db_path = tmp_path / "test.db"
+    engine = create_engine(f"sqlite:///{db_path}")
+    Base.metadata.create_all(engine)
+    SessionLocal = sessionmaker(bind=engine)
+
+    with SessionLocal() as s:
+        s.add(ZoneModel(zone_id="zone_active", name="zone_active", phase="Active"))
+        s.add(ZoneModel(zone_id="zone_terminated", name="zone_terminated", phase="Terminated"))
+        s.commit()
+
+    @contextmanager
+    def _factory():
+        s = SessionLocal()
+        try:
+            yield s
+        finally:
+            s.close()
+
+    fake_db_provider = SimpleNamespace(session_factory=_factory)
+
+    # _resolve_db_auth is a plain function called inside the handler (not a Depends),
+    # so we monkeypatch the symbol on the router module rather than using
+    # app.dependency_overrides.
+    from nexus.server.api.v2.routers import auth_keys as auth_keys_module
+
+    monkeypatch.setattr(auth_keys_module, "_resolve_db_auth", lambda request: fake_db_provider)
+
+    app = FastAPI()
+    app.include_router(auth_keys_module.router)
+    app.dependency_overrides[require_admin] = lambda: SimpleNamespace(is_admin=True)
+    app.add_exception_handler(NexusError, nexus_error_handler)
+
+    # raise_server_exceptions=False mirrors prod: an uncaught exception becomes
+    # Starlette's plain-text 500 instead of re-raising into the test.
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def _create_body(zone_id: str | None, **overrides) -> dict:
+    body = {
+        "label": "koodle team key",
+        "user_id": "team-user",
+        "subject_type": "agent",
+        "subject_id": "team-agent",
+        "is_admin": False,
+    }
+    if zone_id is not None:
+        body["zone_id"] = zone_id
+    body.update(overrides)
+    return body
+
+
+def test_create_key_missing_zone_returns_structured_400(client):
+    resp = client.post("/api/v2/auth/keys", json=_create_body("zone_ghost"))
+    assert resp.status_code == 400, resp.text
+    detail = resp.json()["detail"]
+    assert "zone_ghost" in detail
+    assert "is not active" in detail
+
+
+def test_create_key_terminated_zone_returns_structured_400(client):
+    resp = client.post("/api/v2/auth/keys", json=_create_body("zone_terminated"))
+    assert resp.status_code == 400, resp.text
+    assert "is not active" in resp.json()["detail"]
+
+
+def test_create_key_active_zone_still_succeeds(client):
+    resp = client.post("/api/v2/auth/keys", json=_create_body("zone_active"))
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["zone_id"] == "zone_active"
+    assert body["key"].startswith("sk-")


### PR DESCRIPTION
## Summary

Fixes #4352: `POST /api/v2/auth/keys` returned an unstructured plain-text `500 Internal Server Error` when the target zone was missing/not-Active from the server's DB view. Hardened through a 7-round adversarial review loop (Codex, approved round 7).

### Root cause

The #3871 zone-lifecycle guard in `DatabaseAPIKeyAuth.create_key` raises `ValueError` when the target zone is missing, Terminating/Terminated, or soft-deleted. The REST route never caught it (only `NexusError`/`NexusExchangeError` have app handlers), so Starlette's `ServerErrorMiddleware` emitted the plain-text 500 Koodle observed.

### Changes

**REST (`auth_keys.py`)**
- `handle_admin_create_key` domain `ValueError`s → `HTTPException(400, detail)`, matching sibling v2 routers.

**Validation (`database_key.py`)**
- Guards extracted to `DatabaseAPIKeyAuth.validate_key_params` (subject_type allow-list + zoneless-non-admin + zone-active), called inside `create_key`.
- Zone select takes `with_for_update` so concurrent terminate serializes with issuance (no-op SQLite, row lock Postgres).

**Side-effect safety (`admin.py` + `entity_registry.py`) — review-loop findings**
- Entity registration moved **after** the key commit: failed creates never touch the registry. Previously a rejected request committed an `entity_registry` row parented to the bad zone, and first-parent-wins kept the wrong parent forever.
- Registration is best-effort (registry is ID disambiguation; junction rows are the access SSOT per #3871), registers create_key's effective subject (`subject_id or user_id`), user/agent only.
- New `EntityRegistry.register_entity_if_absent` → `(entity, created)` with PK-conflict resolution (concurrent insert resolves to the winner, never raises).
- Behavior change: service-subject keys no longer 400 on record-store deployments (registration skipped instead of failing the request).

**Tests**
- 10 new tests: structured-400 guards, no-stale-row invariants (ValueError + non-ValueError failures), pre-existing-row survival, effective-subject registration, best-effort registration, registry provenance semantics incl. lost-insert race.
- `test_auth_keys_grants.py` fixture seeds `root` zone — file had been failing on develop since the guard landed (e74b719dd).
- Surface matrix regenerated (line drift).

### Verification

- 105 tests passing across zone-guard/registry/grants/junction/admin-handler/CLI suites.
- E2E on live `nexus up --build` stacks, before AND after (see comments): unfixed `:edge` reproduces the exact prod plain-text 500; this branch returns structured 400s, 201 for direct-SQL-inserted Active zones (Koodle's fallback path), issued keys authenticate, and failed creates leave zero registry rows.

### Accepted residuals (documented in review comment)

Zone-teardown-side lock ordering (teardown subsystem; keys fail closed at auth) · REST grants-failure-after-commit leaves a benign self-healing registry row (proper fix = grants-flow unification, follow-up).

### Note for the Koodle prod symptom

The guard firing means nexus-rpc's database does not see zone `015769dc…` as Active even though Koodle's direct-DB probes do — check that Koodle's `NEXUS_DATABASE_URL` and nexus-rpc point at the same database (ParadeDB vs rollback Postgres). After deploy, the 400 detail confirms/denies this directly.

Closes #4352