### PR TITLE
fix(#4342): bound TigerCacheManager.initialize() boot wait

### DIFF
--- a/docs/operations/tiger-cache-boot.md
+++ b/docs/operations/tiger-cache-boot.md
@@ -57,3 +57,9 @@ when the database unwedges, the sync finishes on its own — no restart needed.
   `NEXUS_DISABLE_PERF_OPTIMIZATIONS=true`.
 - The `tiger-init-sync` thread is named, so it is visible in
   `PYTHONFAULTHANDLER=1` dumps if you need to see where it is blocked.
+- **Shutdown caveat**: graceful stop signals the sync between per-path
+  upserts, but the initial `sys_readdir` listing is materialized in one call
+  (Rust-side, see Issue #3706) and a single wedged DB statement cannot be
+  interrupted from Python. In that case shutdown logs
+  `tiger-init-sync still running ... abandoning daemon thread` and proceeds;
+  the daemon thread cannot block process exit.

--- a/docs/operations/tiger-cache-boot.md
+++ b/docs/operations/tiger-cache-boot.md
@@ -1,0 +1,59 @@
+# Tiger Cache Boot Behavior
+
+Issue #4342 bounds the Tiger Cache resource-map sync at boot. Before the fix,
+`TigerCacheManager.initialize()` ran the sync synchronously on the boot thread
+with no deadline — a wedged metastore/DB call blocked instead of raising, so
+nexusd never bound its port and never logged again after the WIRED tier began.
+
+## What runs at boot
+
+When `NEXUS_ENABLE_TIGER_CACHE=true` (and the record store is PostgreSQL),
+the WIRED tier starts a `tiger-init-sync` daemon thread that:
+
+1. Syncs `tiger_resource_map` from existing metadata (full recursive listing,
+   one upsert per path), gated by `NEXUS_SYNC_TIGER_RESOURCE_MAP`.
+2. Optionally warms the Tiger Cache (`NEXUS_WARM_TIGER_CACHE`).
+
+Boot waits for that thread at most `NEXUS_TIGER_INIT_TIMEOUT_SECONDS`, then
+proceeds. On a healthy database the sync finishes inside the window and the
+log order is unchanged:
+
+```
+Synced 155 resources to Tiger resource map
+[BOOT:WIRED] 12/13 services ready (0.904s)
+```
+
+If the sync is still running when the window closes, boot continues and logs:
+
+```
+[WARNING] Tiger resource map sync still running after 30s; continuing boot
+without it — permission checks use the slow path until the background sync
+completes (Issue #4342)
+```
+
+Permission checks fall back to the slow path (same behavior as
+`NEXUS_DISABLE_PERF_OPTIMIZATIONS=true`) until the background sync completes;
+when the database unwedges, the sync finishes on its own — no restart needed.
+
+## Environment knobs
+
+| Variable | Default | Effect |
+|----------|---------|--------|
+| `NEXUS_ENABLE_TIGER_CACHE` | `false` in the stack template, `true` in-code | Construct the Tiger Cache at all (requires PostgreSQL) |
+| `NEXUS_TIGER_INIT_TIMEOUT_SECONDS` | `30` | Max time boot waits for the resource-map sync; `0` = don't wait (pure background) |
+| `NEXUS_SYNC_TIGER_RESOURCE_MAP` | `true` | Run the resource-map sync at boot |
+| `NEXUS_WARM_TIGER_CACHE` | `false` | Also warm the cache during the sync thread |
+| `NEXUS_DISABLE_PERF_OPTIMIZATIONS` | `false` | Skip sync, warm, and worker entirely (permanent slow path) |
+| `NEXUS_ENABLE_TIGER_WORKER` | `false` | Start the legacy queue-processing worker |
+
+## Troubleshooting
+
+- **Boot warns "sync still running"** on every start: the metastore listing or
+  the per-path upserts are slow or blocked. Check PostgreSQL for lock waiters
+  on `tiger_resource_map` and for dead client connections. The server is fully
+  functional meanwhile; only permission-check latency is degraded.
+- **Symptom of the original bug** (pre-fix images): silence after the
+  ShareLinkService init line, port never bound. Workaround on old images:
+  `NEXUS_DISABLE_PERF_OPTIMIZATIONS=true`.
+- The `tiger-init-sync` thread is named, so it is visible in
+  `PYTHONFAULTHANDLER=1` dumps if you need to see where it is blocked.

--- a/nexus-stack.yml
+++ b/nexus-stack.yml
@@ -187,6 +187,7 @@ services:
       NEXUS_APPROVALS_ENABLED: "${NEXUS_APPROVALS_ENABLED:-false}"
       NEXUS_APPROVALS_ADMIN_TOKEN: "${NEXUS_APPROVALS_ADMIN_TOKEN:-}"
       NEXUS_APPROVALS_GRPC_PORT: "${NEXUS_APPROVALS_GRPC_PORT:-2029}"
+      NEXUS_TIGER_INIT_TIMEOUT_SECONDS: "${NEXUS_TIGER_INIT_TIMEOUT_SECONDS:-}"
       NEXUS_APPROVALS_GRPC_BIND_ALL: "${NEXUS_APPROVALS_GRPC_BIND_ALL:-1}"
       # Federation/Raft — forwarded from host only when set (null-value form skips unset vars).
       # Empty strings override Rust fallbacks, so these are absent in single-node mode.

--- a/src/nexus/bricks/rebac/tiger_cache_manager.py
+++ b/src/nexus/bricks/rebac/tiger_cache_manager.py
@@ -51,6 +51,10 @@ class TigerCacheManager:
         self._tiger_worker_thread: threading.Thread | None = None
         self._sync_thread: threading.Thread | None = None
         self._sync_stop = threading.Event()
+        # Serializes initialize() vs stop_worker() so a manual refresh cannot
+        # clear a stop event an in-flight shutdown just set, and sync stays
+        # single-flight (Codex review, Issue #4342).
+        self._lifecycle_lock = threading.Lock()
 
     def initialize(self) -> None:
         """Initialize performance optimizations for permission checks.
@@ -86,14 +90,24 @@ class TigerCacheManager:
                 )
                 timeout = _DEFAULT_INIT_TIMEOUT_SECONDS
 
-            self._sync_stop.clear()  # support manual re-initialize after stop
-            sync_thread = threading.Thread(
-                target=self._sync_and_warm,
-                name="tiger-init-sync",
-                daemon=True,
-            )
-            self._sync_thread = sync_thread
-            sync_thread.start()
+            with self._lifecycle_lock:
+                # Single-flight: a manual refresh while the previous sync is
+                # still running would orphan that thread and (via a cleared
+                # stop event) could undo a concurrent shutdown signal.
+                if self._sync_thread is not None and self._sync_thread.is_alive():
+                    logger.info("Tiger resource map sync already running; skipping re-initialize")
+                    self.start_worker()
+                    return
+                # Fresh event per run (never clear()) so an older thread that
+                # was told to stop keeps seeing its own event as set.
+                self._sync_stop = threading.Event()
+                sync_thread = threading.Thread(
+                    target=self._sync_and_warm,
+                    name="tiger-init-sync",
+                    daemon=True,
+                )
+                self._sync_thread = sync_thread
+                sync_thread.start()
             if timeout > 0:
                 sync_thread.join(timeout=timeout)
             if sync_thread.is_alive():
@@ -283,10 +297,23 @@ class TigerCacheManager:
         """
         is_test = "pytest" in sys.modules
         timeout = 15.0 if is_test else 5.0
-        self._sync_stop.set()
-        if self._sync_thread is not None:
-            self._sync_thread.join(timeout=timeout)
-        if self._tiger_worker_stop is not None:
-            self._tiger_worker_stop.set()
-        if self._tiger_worker_thread is not None:
-            self._tiger_worker_thread.join(timeout=timeout)
+        with self._lifecycle_lock:
+            self._sync_stop.set()
+            if self._sync_thread is not None:
+                self._sync_thread.join(timeout=timeout)
+                if self._sync_thread.is_alive():
+                    # The sync observes the stop event between per-path
+                    # upserts, but a call wedged inside sys_readdir or a
+                    # single DB statement cannot be interrupted from Python.
+                    # The thread is a daemon, so it cannot block process
+                    # exit; it may log fail-soft warnings if it touches
+                    # closed resources afterwards.
+                    logger.warning(
+                        "tiger-init-sync still running %.0fs after shutdown "
+                        "request; abandoning daemon thread (Issue #4342)",
+                        timeout,
+                    )
+            if self._tiger_worker_stop is not None:
+                self._tiger_worker_stop.set()
+            if self._tiger_worker_thread is not None:
+                self._tiger_worker_thread.join(timeout=timeout)

--- a/src/nexus/bricks/rebac/tiger_cache_manager.py
+++ b/src/nexus/bricks/rebac/tiger_cache_manager.py
@@ -17,6 +17,12 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Issue #4342: bound on how long initialize() may hold the boot thread while
+# the resource-map sync runs. Mirrors the search daemon's startup preload
+# (_PRELOAD_TIMEOUT_SECONDS in bricks/search/daemon.py): boot must not block
+# indefinitely on a perf optimization.
+_DEFAULT_INIT_TIMEOUT_SECONDS = 30.0
+
 
 class TigerCacheManager:
     """Manages Tiger Cache performance optimizations.
@@ -43,6 +49,8 @@ class TigerCacheManager:
 
         self._tiger_worker_stop: threading.Event | None = None
         self._tiger_worker_thread: threading.Thread | None = None
+        self._sync_thread: threading.Thread | None = None
+        self._sync_stop = threading.Event()
 
     def initialize(self) -> None:
         """Initialize performance optimizations for permission checks.
@@ -53,11 +61,63 @@ class TigerCacheManager:
         3. Starts background worker for Tiger Cache queue processing
 
         Called automatically during startup. Can be called manually to refresh.
+
+        Issue #4342: steps 1-2 are DB-bound and used to run unbounded on the
+        boot thread — a wedged metastore/DB call blocks instead of raising,
+        so the except below never fires and the port is never bound. They now
+        run on a daemon thread; boot waits at most
+        NEXUS_TIGER_INIT_TIMEOUT_SECONDS (default 30, 0 = don't wait) and
+        then proceeds, leaving the sync to finish in the background.
+        Permission checks fall back to the slow path until it completes.
         """
         if os.getenv("NEXUS_DISABLE_PERF_OPTIMIZATIONS", "false").lower() in ("true", "1", "yes"):
             logger.debug("Performance optimizations disabled via environment variable")
             return
 
+        try:
+            timeout_raw = os.getenv("NEXUS_TIGER_INIT_TIMEOUT_SECONDS", "")
+            try:
+                timeout = float(timeout_raw) if timeout_raw else _DEFAULT_INIT_TIMEOUT_SECONDS
+            except ValueError:
+                logger.warning(
+                    "Invalid NEXUS_TIGER_INIT_TIMEOUT_SECONDS=%r; using %.0fs",
+                    timeout_raw,
+                    _DEFAULT_INIT_TIMEOUT_SECONDS,
+                )
+                timeout = _DEFAULT_INIT_TIMEOUT_SECONDS
+
+            self._sync_stop.clear()  # support manual re-initialize after stop
+            sync_thread = threading.Thread(
+                target=self._sync_and_warm,
+                name="tiger-init-sync",
+                daemon=True,
+            )
+            self._sync_thread = sync_thread
+            sync_thread.start()
+            if timeout > 0:
+                sync_thread.join(timeout=timeout)
+            if sync_thread.is_alive():
+                logger.warning(
+                    "Tiger resource map sync still running after %.0fs; continuing "
+                    "boot without it — permission checks use the slow path until "
+                    "the background sync completes (Issue #4342)",
+                    timeout,
+                )
+
+            # Start Tiger Cache background worker (thread spawn only — safe
+            # on the boot thread, independent of the sync above)
+            self.start_worker()
+
+        except Exception as e:
+            # Don't fail initialization if optimizations fail
+            logger.warning(f"Failed to initialize performance optimizations: {e}")
+
+    def _sync_and_warm(self) -> None:
+        """Resource-map sync + optional cache warm (runs on tiger-init-sync).
+
+        Everything here is fail-soft: failures only mean permission checks
+        keep paying the slow-path cost they would pay anyway.
+        """
         try:
             # 1. Sync tiger_resource_map from existing metadata (Issue #934)
             # This MUST happen BEFORE cache warming so Tiger Cache can find resources
@@ -79,12 +139,7 @@ class TigerCacheManager:
                 entries = self._warm_cache_fn(zone_id=self._default_zone_id)
                 if entries > 0:
                     logger.info(f"Warmed Tiger Cache with {entries} entries")
-
-            # 3. Start Tiger Cache background worker
-            self.start_worker()
-
         except Exception as e:
-            # Don't fail initialization if optimizations fail
             logger.warning(f"Failed to initialize performance optimizations: {e}")
 
     def sync_resource_map(self) -> int:
@@ -135,6 +190,12 @@ class TigerCacheManager:
             for entry_path in self._nexus_fs.sys_readdir(
                 "/", recursive=True, details=False, context=sys_ctx
             ):
+                if self._sync_stop.is_set():
+                    logger.info(
+                        "Tiger resource map sync stopped after %d resources (shutdown)",
+                        count,
+                    )
+                    return count
                 if not entry_path:
                     continue
                 resource_map.get_or_create_int_id(
@@ -216,13 +277,16 @@ class TigerCacheManager:
         logger.debug(f"Tiger Cache worker started (interval={interval}s)")
 
     def stop_worker(self) -> None:
-        """Stop the Tiger Cache background worker.
+        """Stop the Tiger Cache background worker and any in-progress sync.
 
         Call this during graceful shutdown to stop the worker thread.
         """
+        is_test = "pytest" in sys.modules
+        timeout = 15.0 if is_test else 5.0
+        self._sync_stop.set()
+        if self._sync_thread is not None:
+            self._sync_thread.join(timeout=timeout)
         if self._tiger_worker_stop is not None:
             self._tiger_worker_stop.set()
         if self._tiger_worker_thread is not None:
-            is_test = "pytest" in sys.modules
-            timeout = 15.0 if is_test else 5.0
             self._tiger_worker_thread.join(timeout=timeout)

--- a/src/nexus/bricks/rebac/tiger_cache_manager.py
+++ b/src/nexus/bricks/rebac/tiger_cache_manager.py
@@ -56,6 +56,10 @@ class TigerCacheManager:
         # and sync stays single-flight (Codex review, Issue #4342). RLock:
         # initialize() calls start_worker() while holding it.
         self._lifecycle_lock = threading.RLock()
+        # Terminal once stop_worker() ran: a boot thread resuming from its
+        # bounded join (held outside the lock) must not start the worker,
+        # and a manual initialize() must not spawn a new sync.
+        self._stopped = False
 
     def initialize(self) -> None:
         """Initialize performance optimizations for permission checks.
@@ -100,6 +104,9 @@ class TigerCacheManager:
             timeout = min(timeout, threading.TIMEOUT_MAX)
 
             with self._lifecycle_lock:
+                if self._stopped:
+                    logger.info("TigerCacheManager stopped; skipping initialize")
+                    return
                 # Single-flight: a manual refresh while the previous sync is
                 # still running would orphan that thread and (via a cleared
                 # stop event) could undo a concurrent shutdown signal.
@@ -265,6 +272,12 @@ class TigerCacheManager:
             return
 
         with self._lifecycle_lock:
+            # Terminal stop: a boot thread that resumed from its bounded
+            # join after stop_worker() completed lands here — don't revive
+            # background work after shutdown began.
+            if self._stopped:
+                logger.debug("TigerCacheManager stopped; not starting worker")
+                return
             # Don't start if already running
             if self._tiger_worker_thread is not None and self._tiger_worker_thread.is_alive():
                 return
@@ -319,6 +332,7 @@ class TigerCacheManager:
         is_test = "pytest" in sys.modules
         timeout = 15.0 if is_test else 5.0
         with self._lifecycle_lock:
+            self._stopped = True
             # Signal BOTH threads before joining either, so the worker does
             # not keep running for the duration of the sync join.
             self._sync_stop.set()

--- a/src/nexus/bricks/rebac/tiger_cache_manager.py
+++ b/src/nexus/bricks/rebac/tiger_cache_manager.py
@@ -51,10 +51,11 @@ class TigerCacheManager:
         self._tiger_worker_thread: threading.Thread | None = None
         self._sync_thread: threading.Thread | None = None
         self._sync_stop = threading.Event()
-        # Serializes initialize() vs stop_worker() so a manual refresh cannot
-        # clear a stop event an in-flight shutdown just set, and sync stays
-        # single-flight (Codex review, Issue #4342).
-        self._lifecycle_lock = threading.Lock()
+        # Serializes initialize()/start_worker()/stop_worker() so a manual
+        # refresh cannot clear a stop event an in-flight shutdown just set,
+        # and sync stays single-flight (Codex review, Issue #4342). RLock:
+        # initialize() calls start_worker() while holding it.
+        self._lifecycle_lock = threading.RLock()
 
     def initialize(self) -> None:
         """Initialize performance optimizations for permission checks.
@@ -79,16 +80,24 @@ class TigerCacheManager:
             return
 
         try:
+            import math
+
             timeout_raw = os.getenv("NEXUS_TIGER_INIT_TIMEOUT_SECONDS", "")
             try:
                 timeout = float(timeout_raw) if timeout_raw else _DEFAULT_INIT_TIMEOUT_SECONDS
             except ValueError:
+                timeout = math.nan  # rejected below
+            # Contract: finite seconds >= 0 (0 = don't wait). inf raises
+            # OverflowError inside Thread.join (aborting initialize via the
+            # outer except); nan/negative silently skip the join.
+            if not math.isfinite(timeout) or timeout < 0:
                 logger.warning(
                     "Invalid NEXUS_TIGER_INIT_TIMEOUT_SECONDS=%r; using %.0fs",
                     timeout_raw,
                     _DEFAULT_INIT_TIMEOUT_SECONDS,
                 )
                 timeout = _DEFAULT_INIT_TIMEOUT_SECONDS
+            timeout = min(timeout, threading.TIMEOUT_MAX)
 
             with self._lifecycle_lock:
                 # Single-flight: a manual refresh while the previous sync is
@@ -100,9 +109,11 @@ class TigerCacheManager:
                     return
                 # Fresh event per run (never clear()) so an older thread that
                 # was told to stop keeps seeing its own event as set.
-                self._sync_stop = threading.Event()
+                stop_event = threading.Event()
+                self._sync_stop = stop_event
                 sync_thread = threading.Thread(
                     target=self._sync_and_warm,
+                    args=(stop_event,),
                     name="tiger-init-sync",
                     daemon=True,
                 )
@@ -126,11 +137,13 @@ class TigerCacheManager:
             # Don't fail initialization if optimizations fail
             logger.warning(f"Failed to initialize performance optimizations: {e}")
 
-    def _sync_and_warm(self) -> None:
+    def _sync_and_warm(self, stop_event: threading.Event) -> None:
         """Resource-map sync + optional cache warm (runs on tiger-init-sync).
 
         Everything here is fail-soft: failures only mean permission checks
-        keep paying the slow-path cost they would pay anyway.
+        keep paying the slow-path cost they would pay anyway. ``stop_event``
+        is this run's own event (captured, not read from self) so a later
+        re-initialize cannot detach this thread from its shutdown signal.
         """
         try:
             # 1. Sync tiger_resource_map from existing metadata (Issue #934)
@@ -141,8 +154,13 @@ class TigerCacheManager:
                 "yes",
             ):
                 synced = self.sync_resource_map()
-                if synced > 0:
+                if synced > 0 and not stop_event.is_set():
                     logger.info(f"Synced {synced} resources to Tiger resource map")
+
+            # A stop request that ended the sync early must not fall through
+            # into another DB-bound phase (Codex round 2).
+            if stop_event.is_set():
+                return
 
             # 2. Warm Tiger Cache (optional, can be slow for large systems)
             # Only warm if explicitly enabled via environment variable
@@ -246,49 +264,52 @@ class TigerCacheManager:
             logger.debug("Tiger Cache queue worker disabled (write-through handles grants)")
             return
 
-        # Don't start if already running
-        if self._tiger_worker_thread is not None and self._tiger_worker_thread.is_alive():
-            return
+        with self._lifecycle_lock:
+            # Don't start if already running
+            if self._tiger_worker_thread is not None and self._tiger_worker_thread.is_alive():
+                return
 
-        # Worker interval in seconds (default: 1 second)
-        interval = float(os.getenv("NEXUS_TIGER_WORKER_INTERVAL", "1.0"))
+            # Worker interval in seconds (default: 1 second)
+            interval = float(os.getenv("NEXUS_TIGER_WORKER_INTERVAL", "1.0"))
 
-        # Shutdown flag
-        self._tiger_worker_stop = threading.Event()
+            # Per-run shutdown flag, captured by the closure (never read from
+            # self) so a later start_worker() cannot detach a still-running
+            # loop from the stop signal it was given (Codex round 2).
+            worker_stop = threading.Event()
+            self._tiger_worker_stop = worker_stop
 
-        # Capture callback reference for the closure
-        process_queue_fn = self._process_queue_fn
+            # Capture callback reference for the closure
+            process_queue_fn = self._process_queue_fn
 
-        def worker_loop() -> None:
-            """Background worker loop for Tiger Cache queue processing.
+            def worker_loop() -> None:
+                """Background worker loop for Tiger Cache queue processing.
 
-            NOTE: With write-through implemented, this worker is mainly for legacy
-            queue entries. New permission grants are handled immediately by
-            persist_single_grant() in rebac_write.
-            """
-            assert self._tiger_worker_stop is not None
-            while not self._tiger_worker_stop.is_set():
-                try:
-                    if process_queue_fn is not None:
-                        processed = process_queue_fn(batch_size=1)
-                        if processed > 0:
-                            logger.debug(f"Tiger Cache worker processed {processed} updates")
-                except Exception as e:
-                    logger.warning(f"Tiger Cache worker error: {e}")
+                NOTE: With write-through implemented, this worker is mainly for legacy
+                queue entries. New permission grants are handled immediately by
+                persist_single_grant() in rebac_write.
+                """
+                while not worker_stop.is_set():
+                    try:
+                        if process_queue_fn is not None:
+                            processed = process_queue_fn(batch_size=1)
+                            if processed > 0:
+                                logger.debug(f"Tiger Cache worker processed {processed} updates")
+                    except Exception as e:
+                        logger.warning(f"Tiger Cache worker error: {e}")
 
-                # Sleep longer since write-through handles new grants
-                # This worker is just for legacy queue cleanup
-                self._tiger_worker_stop.wait(timeout=interval * 10)
+                    # Sleep longer since write-through handles new grants
+                    # This worker is just for legacy queue cleanup
+                    worker_stop.wait(timeout=interval * 10)
 
-            logger.debug("Tiger Cache worker stopped")
+                logger.debug("Tiger Cache worker stopped")
 
-        self._tiger_worker_thread = threading.Thread(
-            target=worker_loop,
-            name="tiger-cache-worker",
-            daemon=True,
-        )
-        self._tiger_worker_thread.start()
-        logger.debug(f"Tiger Cache worker started (interval={interval}s)")
+            self._tiger_worker_thread = threading.Thread(
+                target=worker_loop,
+                name="tiger-cache-worker",
+                daemon=True,
+            )
+            self._tiger_worker_thread.start()
+            logger.debug(f"Tiger Cache worker started (interval={interval}s)")
 
     def stop_worker(self) -> None:
         """Stop the Tiger Cache background worker and any in-progress sync.
@@ -298,7 +319,11 @@ class TigerCacheManager:
         is_test = "pytest" in sys.modules
         timeout = 15.0 if is_test else 5.0
         with self._lifecycle_lock:
+            # Signal BOTH threads before joining either, so the worker does
+            # not keep running for the duration of the sync join.
             self._sync_stop.set()
+            if self._tiger_worker_stop is not None:
+                self._tiger_worker_stop.set()
             if self._sync_thread is not None:
                 self._sync_thread.join(timeout=timeout)
                 if self._sync_thread.is_alive():
@@ -313,7 +338,5 @@ class TigerCacheManager:
                         "request; abandoning daemon thread (Issue #4342)",
                         timeout,
                     )
-            if self._tiger_worker_stop is not None:
-                self._tiger_worker_stop.set()
             if self._tiger_worker_thread is not None:
                 self._tiger_worker_thread.join(timeout=timeout)

--- a/src/nexus/factory/_wired.py
+++ b/src/nexus/factory/_wired.py
@@ -392,12 +392,15 @@ def _boot_post_kernel_services(
             nexus_fs=nx,
             default_zone_id=getattr(_nx_init_cred, "zone_id", None) or ROOT_ZONE_ID,
         )
-        _tiger_cache_manager.initialize()
         # Issue #4342: initialize() may leave a tiger-init-sync daemon thread
         # (and optionally the queue worker) running past boot; stop both at
         # NexusFS.close() like the other factory-spawned workers
-        # (_lifecycle.py write observer / delivery worker).
+        # (_lifecycle.py write observer / delivery worker). Registered BEFORE
+        # initialize() so a close() racing the bounded boot wait still owns
+        # the sync thread (stop_worker is terminal — a resumed initialize
+        # cannot restart background work afterwards).
         nx._close_callbacks.append(_tiger_cache_manager.stop_worker)
+        _tiger_cache_manager.initialize()
         logger.debug("[BOOT:WIRED] TigerCacheManager created")
     except Exception as exc:
         logger.warning("[BOOT:WIRED] TigerCacheManager unavailable: %s", exc)

--- a/src/nexus/factory/_wired.py
+++ b/src/nexus/factory/_wired.py
@@ -393,6 +393,11 @@ def _boot_post_kernel_services(
             default_zone_id=getattr(_nx_init_cred, "zone_id", None) or ROOT_ZONE_ID,
         )
         _tiger_cache_manager.initialize()
+        # Issue #4342: initialize() may leave a tiger-init-sync daemon thread
+        # (and optionally the queue worker) running past boot; stop both at
+        # NexusFS.close() like the other factory-spawned workers
+        # (_lifecycle.py write observer / delivery worker).
+        nx._close_callbacks.append(_tiger_cache_manager.stop_worker)
         logger.debug("[BOOT:WIRED] TigerCacheManager created")
     except Exception as exc:
         logger.warning("[BOOT:WIRED] TigerCacheManager unavailable: %s", exc)

--- a/tests/unit/bricks/rebac/test_tiger_cache_manager.py
+++ b/tests/unit/bricks/rebac/test_tiger_cache_manager.py
@@ -165,3 +165,16 @@ def test_stop_worker_halts_in_progress_background_sync(
     manager.stop_worker()
     sync_thread.join(timeout=5.0)
     assert not sync_thread.is_alive(), "stop_worker() must end the sync loop"
+
+
+def test_stop_worker_is_safe_without_initialize_and_idempotent() -> None:
+    """stop_worker() is wired as a NexusFS close callback (Issue #4342), so it
+    must be a no-op when initialize() never ran and safe to call twice."""
+    resource_map = FakeResourceMap()
+    manager = make_manager(FakeNexusFS(["/a.txt"]), resource_map)
+
+    manager.stop_worker()  # never initialized — must not raise
+
+    manager.initialize()
+    manager.stop_worker()
+    manager.stop_worker()  # second call must not raise

--- a/tests/unit/bricks/rebac/test_tiger_cache_manager.py
+++ b/tests/unit/bricks/rebac/test_tiger_cache_manager.py
@@ -167,6 +167,62 @@ def test_stop_worker_halts_in_progress_background_sync(
     assert not sync_thread.is_alive(), "stop_worker() must end the sync loop"
 
 
+def test_initialize_is_single_flight_while_sync_running(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Re-initialize while a sync is still running must not spawn a second
+    sync thread (orphaning the first) nor clear its stop event."""
+    monkeypatch.setenv("NEXUS_TIGER_INIT_TIMEOUT_SECONDS", "0.05")
+    resource_map = FakeResourceMap()
+    manager = TigerCacheManager(
+        rebac_manager=FakeRebacManager(resource_map),
+        nexus_fs=EndlessNexusFS(),
+        default_zone_id="root",
+    )
+
+    manager.initialize()  # returns after timeout; sync grinds in background
+    first_thread = manager._sync_thread
+    assert first_thread is not None and first_thread.is_alive()
+
+    manager.initialize()  # manual refresh while sync still running
+    assert manager._sync_thread is first_thread, (
+        "re-initialize while a sync is alive must be single-flight"
+    )
+
+    manager.stop_worker()
+    first_thread.join(timeout=5.0)
+    assert not first_thread.is_alive()
+
+
+def test_blocked_materialized_listing_still_bounds_boot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Production sys_readdir returns a fully materialized list — a wedged
+    listing blocks inside the call itself. Boot must still be bounded."""
+    monkeypatch.setenv("NEXUS_TIGER_INIT_TIMEOUT_SECONDS", "0.2")
+    gate = threading.Event()
+
+    class BlockingListNexusFS:
+        def sys_readdir(self, path, recursive=False, details=False, context=None):
+            gate.wait()  # block before returning, like a wedged metastore
+            return ["/a.txt"]  # materialized list, not a generator
+
+    resource_map = FakeResourceMap()
+    manager = TigerCacheManager(
+        rebac_manager=FakeRebacManager(resource_map),
+        nexus_fs=BlockingListNexusFS(),
+        default_zone_id="root",
+    )
+
+    boot = threading.Thread(target=manager.initialize, daemon=True)
+    boot.start()
+    boot.join(timeout=5.0)
+    try:
+        assert not boot.is_alive(), "boot must proceed while the listing is wedged"
+    finally:
+        gate.set()
+
+
 def test_stop_worker_is_safe_without_initialize_and_idempotent() -> None:
     """stop_worker() is wired as a NexusFS close callback (Issue #4342), so it
     must be a no-op when initialize() never ran and safe to call twice."""

--- a/tests/unit/bricks/rebac/test_tiger_cache_manager.py
+++ b/tests/unit/bricks/rebac/test_tiger_cache_manager.py
@@ -1,0 +1,167 @@
+"""TigerCacheManager boot-path tests (Issue #4342).
+
+nexusd boot hung indefinitely because ``initialize()`` runs
+``sync_resource_map()`` synchronously on the boot thread with no deadline:
+a wedged metastore/DB call blocks instead of raising, so the fail-soft
+try/except never fires and the port is never bound. These tests pin the
+bounded/fail-soft contract: boot must proceed even when the sync hangs.
+"""
+
+import threading
+import time
+
+import pytest
+
+from nexus.bricks.rebac.tiger_cache_manager import TigerCacheManager
+
+
+class FakeResourceMap:
+    """Records get_or_create_int_id calls; thread-safe."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self.calls: list[tuple[str, str]] = []
+
+    def get_or_create_int_id(self, resource_type: str, resource_id: str) -> int:
+        with self._lock:
+            self.calls.append((resource_type, resource_id))
+            return len(self.calls)
+
+    def paths(self) -> list[str]:
+        with self._lock:
+            return [rid for _, rid in self.calls]
+
+
+class FakeTigerCache:
+    def __init__(self, resource_map: FakeResourceMap) -> None:
+        self._resource_map = resource_map
+
+
+class FakeRebacManager:
+    def __init__(self, resource_map: FakeResourceMap) -> None:
+        self._tiger_cache = FakeTigerCache(resource_map)
+
+
+class FakeNexusFS:
+    """sys_readdir yields ``before`` entries, then blocks on ``gate`` (if
+    given), then yields ``after`` entries — emulating a wedged metastore
+    listing mid-iteration."""
+
+    def __init__(
+        self,
+        before: list[str],
+        gate: threading.Event | None = None,
+        after: list[str] | None = None,
+    ) -> None:
+        self._before = before
+        self._gate = gate
+        self._after = after or []
+
+    def sys_readdir(self, path, recursive=False, details=False, context=None):
+        yield from self._before
+        if self._gate is not None:
+            self._gate.wait()
+        yield from self._after
+
+
+def make_manager(nexus_fs: FakeNexusFS, resource_map: FakeResourceMap) -> TigerCacheManager:
+    return TigerCacheManager(
+        rebac_manager=FakeRebacManager(resource_map),
+        nexus_fs=nexus_fs,
+        default_zone_id="root",
+    )
+
+
+def test_initialize_returns_when_readdir_blocks(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Boot must not block indefinitely on a wedged resource-map sync."""
+    monkeypatch.setenv("NEXUS_TIGER_INIT_TIMEOUT_SECONDS", "0.2")
+    gate = threading.Event()  # never set before the assertion: sync is wedged
+    resource_map = FakeResourceMap()
+    manager = make_manager(FakeNexusFS(["/a.txt"], gate=gate), resource_map)
+
+    boot = threading.Thread(target=manager.initialize, daemon=True)
+    start = time.monotonic()
+    boot.start()
+    boot.join(timeout=5.0)
+    elapsed = time.monotonic() - start
+
+    try:
+        assert not boot.is_alive(), (
+            f"initialize() still blocked after {elapsed:.1f}s with a wedged "
+            "sys_readdir; boot must proceed (Issue #4342)"
+        )
+    finally:
+        gate.set()  # let the background sync thread finish
+
+
+def test_initialize_completes_sync_before_returning_when_fast() -> None:
+    """Healthy case keeps today's semantics: map is populated synchronously."""
+    resource_map = FakeResourceMap()
+    manager = make_manager(FakeNexusFS(["/a.txt", "/b/c.txt"]), resource_map)
+
+    manager.initialize()
+
+    assert resource_map.paths() == ["/a.txt", "/b/c.txt"]
+    assert all(rtype == "file" for rtype, _ in resource_map.calls)
+
+
+def test_sync_finishes_in_background_after_boot_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A sync that outlives the boot timeout still completes in background."""
+    monkeypatch.setenv("NEXUS_TIGER_INIT_TIMEOUT_SECONDS", "0.1")
+    gate = threading.Event()
+    resource_map = FakeResourceMap()
+    manager = make_manager(FakeNexusFS(["/a.txt"], gate=gate, after=["/b.txt"]), resource_map)
+
+    manager.initialize()  # returns after ~0.1s, sync wedged on gate
+    assert "/b.txt" not in resource_map.paths()
+
+    gate.set()
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline:
+        if "/b.txt" in resource_map.paths():
+            break
+        time.sleep(0.01)
+    assert "/b.txt" in resource_map.paths(), "background sync never completed"
+
+
+def test_disable_env_skips_sync_entirely(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("NEXUS_DISABLE_PERF_OPTIMIZATIONS", "true")
+    resource_map = FakeResourceMap()
+    manager = make_manager(FakeNexusFS(["/a.txt"]), resource_map)
+
+    manager.initialize()
+
+    assert resource_map.calls == []
+
+
+class EndlessNexusFS:
+    """sys_readdir yields entries forever — a grinding, never-finishing sync."""
+
+    def sys_readdir(self, path, recursive=False, details=False, context=None):
+        i = 0
+        while True:
+            yield f"/grind/{i}.txt"
+            i += 1
+            time.sleep(0.005)
+
+
+def test_stop_worker_halts_in_progress_background_sync(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("NEXUS_TIGER_INIT_TIMEOUT_SECONDS", "0.05")
+    resource_map = FakeResourceMap()
+    manager = TigerCacheManager(
+        rebac_manager=FakeRebacManager(resource_map),
+        nexus_fs=EndlessNexusFS(),
+        default_zone_id="root",
+    )
+
+    manager.initialize()  # returns after timeout; sync grinds in background
+    sync_thread = manager._sync_thread
+    assert sync_thread is not None and sync_thread.is_alive()
+
+    manager.stop_worker()
+    sync_thread.join(timeout=5.0)
+    assert not sync_thread.is_alive(), "stop_worker() must end the sync loop"

--- a/tests/unit/bricks/rebac/test_tiger_cache_manager.py
+++ b/tests/unit/bricks/rebac/test_tiger_cache_manager.py
@@ -268,6 +268,47 @@ def test_invalid_timeout_values_fall_back_to_default(
         )
 
 
+def test_stop_is_terminal_against_in_flight_initialize(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A boot thread resuming from its bounded join after stop_worker()
+    completed must not start the queue worker (Codex round 3)."""
+    monkeypatch.setenv("NEXUS_TIGER_INIT_TIMEOUT_SECONDS", "5")
+    monkeypatch.setenv("NEXUS_ENABLE_TIGER_WORKER", "true")
+    resource_map = FakeResourceMap()
+    manager = TigerCacheManager(
+        rebac_manager=FakeRebacManager(resource_map),
+        nexus_fs=EndlessNexusFS(),
+        default_zone_id="root",
+    )
+
+    boot = threading.Thread(target=manager.initialize, daemon=True)
+    boot.start()
+    deadline = time.monotonic() + 2.0  # wait until the sync is grinding
+    while time.monotonic() < deadline:
+        if manager._sync_thread is not None and manager._sync_thread.is_alive():
+            break
+        time.sleep(0.01)
+
+    manager.stop_worker()  # shutdown while boot is inside its bounded join
+    boot.join(timeout=10.0)
+    assert not boot.is_alive()
+    assert manager._tiger_worker_thread is None or not manager._tiger_worker_thread.is_alive(), (
+        "start_worker() after stop_worker() must not revive the queue worker"
+    )
+
+
+def test_initialize_after_stop_is_a_noop() -> None:
+    """Manual initialize() after shutdown must not spawn a new sync."""
+    resource_map = FakeResourceMap()
+    manager = make_manager(FakeNexusFS(["/a.txt"]), resource_map)
+    manager.stop_worker()
+
+    manager.initialize()
+
+    assert resource_map.calls == [], "no sync may run after the manager stopped"
+
+
 def test_stop_worker_is_safe_without_initialize_and_idempotent() -> None:
     """stop_worker() is wired as a NexusFS close callback (Issue #4342), so it
     must be a no-op when initialize() never ran and safe to call twice."""

--- a/tests/unit/bricks/rebac/test_tiger_cache_manager.py
+++ b/tests/unit/bricks/rebac/test_tiger_cache_manager.py
@@ -223,6 +223,51 @@ def test_blocked_materialized_listing_still_bounds_boot(
         gate.set()
 
 
+def test_stop_skips_cache_warm(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A shutdown that stops the sync must not fall through into the
+    DB-bound warm phase (Codex round 2)."""
+    monkeypatch.setenv("NEXUS_TIGER_INIT_TIMEOUT_SECONDS", "0.05")
+    monkeypatch.setenv("NEXUS_WARM_TIGER_CACHE", "true")
+    warm_calls: list[str] = []
+    resource_map = FakeResourceMap()
+    manager = TigerCacheManager(
+        rebac_manager=FakeRebacManager(resource_map),
+        nexus_fs=EndlessNexusFS(),
+        default_zone_id="root",
+        warm_cache_fn=lambda zone_id: warm_calls.append(zone_id) or 0,
+    )
+
+    manager.initialize()  # returns after timeout; sync grinds in background
+    manager.stop_worker()  # stops the sync between entries
+    sync_thread = manager._sync_thread
+    assert sync_thread is not None
+    sync_thread.join(timeout=5.0)
+    assert not sync_thread.is_alive()
+    assert warm_calls == [], "warm phase must be skipped after a stop request"
+
+
+def test_invalid_timeout_values_fall_back_to_default(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """inf raises from Thread.join (aborting initialize), nan/negative skip
+    the join silently — all must fall back to the default instead."""
+    for bad in ("inf", "nan", "-5"):
+        monkeypatch.setenv("NEXUS_TIGER_INIT_TIMEOUT_SECONDS", bad)
+        resource_map = FakeResourceMap()
+        manager = make_manager(FakeNexusFS(["/a.txt"]), resource_map)
+        caplog.clear()
+        with caplog.at_level("WARNING"):
+            manager.initialize()  # fast sync: default join returns immediately
+        messages = [r.getMessage() for r in caplog.records]
+        assert any("Invalid NEXUS_TIGER_INIT_TIMEOUT_SECONDS" in m for m in messages), (
+            f"{bad!r} must be rejected with a warning"
+        )
+        assert not any("Failed to initialize" in m for m in messages), (
+            f"{bad!r} must not abort initialize()"
+        )
+
+
 def test_stop_worker_is_safe_without_initialize_and_idempotent() -> None:
     """stop_worker() is wired as a NexusFS close callback (Issue #4342), so it
     must be a no-op when initialize() never ran and safe to call twice."""


### PR DESCRIPTION
Fixes #4342.

## Problem

nexusd boot hung indefinitely in the WIRED tier: `TigerCacheManager.initialize()` runs `sync_resource_map()` synchronously on the boot thread with no deadline. With `recursive=True`, `sys_readdir` bypasses the kernel fast path and hits the metastore DB, then every file pays SELECT + INSERT-ON-CONFLICT + COMMIT on a fresh pooled connection. A wedged DB call **blocks instead of raising**, so the fail-soft `try/except` never fires, the `[BOOT:WIRED]` summary is never reached, and the port is never bound (prod: 2/2 boots, 15+ min silence after ShareLinkService init).

## Fix

Mirrors the search daemon's `_PRELOAD_TIMEOUT_SECONDS` startup contract (`bricks/search/daemon.py`: boot must not block indefinitely on a perf optimization):

- Resource-map sync + optional cache warm now run on a `tiger-init-sync` **daemon thread**; boot joins it for at most `NEXUS_TIGER_INIT_TIMEOUT_SECONDS` (default 30, `0` = don't wait), then logs a warning and proceeds. Permission checks fall back to the slow path until the background sync completes — same degraded mode `NEXUS_DISABLE_PERF_OPTIMIZATIONS=true` produces permanently.
- Healthy boots keep today's semantics: the sync finishes within the window and the resource map is populated before `initialize()` returns.
- `stop_worker()` now also stops an in-progress sync between entries (`_sync_stop` event checked per readdir entry) and joins the sync thread.
- The named thread also makes the sync visible in `PYTHONFAULTHANDLER` dumps if the underlying DB wedge recurs.

## Testing

New `tests/unit/bricks/rebac/test_tiger_cache_manager.py` (5 tests), TDD red-green verified — with the src change stashed, the three new-behavior tests fail (initialize blocks on a wedged readdir, sync not stoppable); with it, 5/5 pass:

- `initialize()` returns even when `sys_readdir` blocks forever
- healthy case populates the map before returning (existing semantics)
- a sync outliving the boot timeout still completes in background
- `NEXUS_DISABLE_PERF_OPTIMIZATIONS=true` still skips entirely
- `stop_worker()` halts a grinding background sync

Broader `tests/unit/bricks/rebac/` + `tests/unit/core/test_rebac.py`: 42 passed. All pre-commit hooks (ruff, ruff-format, mypy, boundary checks) pass.