### PR TITLE
docs(contributing): promote sccache to recommended for multi-worktree dev

### DIFF
--- a/docs/contributing/build-performance.md
+++ b/docs/contributing/build-performance.md
@@ -1,6 +1,7 @@
 # Build Performance Guide
 
-Tips for faster local builds, especially on macOS.
+Tips for faster local builds, with special attention to multi-worktree
+development setups.
 
 ## Rust Extension Builds
 
@@ -21,6 +22,80 @@ Use `--release` only when you need production-grade performance (benchmarking, p
 The dev profile uses `opt-level = 2` for third-party dependencies via
 `[profile.dev.package."*"]`. These are compiled once and cached in `target/`,
 so subsequent builds after code changes are fast.
+
+## Recommended: sccache (multi-worktree dev)
+
+If you run **multiple git worktrees in parallel** (e.g., several AI agents
+on separate branches), each worktree's `target/` accumulates ~10 GB of Rust
+build artifacts independently — 8 worktrees can sprawl to 40+ GB of largely
+duplicate compiled crates.
+
+[sccache](https://github.com/mozilla/sccache) wraps `rustc` and caches
+compilation results by input hash, so the same crate compiled in any worktree
+hits the shared cache instead of recompiling. Each worktree still keeps its
+own `target/` for link artifacts (no contention with parallel builds), but
+the heavy `rustc` work is deduplicated globally.
+
+This is the single highest-leverage change for multi-worktree setups.
+
+### Install
+
+| Platform | Command |
+|----------|---------|
+| macOS    | `brew install sccache` |
+| Linux (apt)   | `sudo apt install sccache` |
+| Windows (winget) | `winget install Mozilla.sccache` |
+| Any platform (universal fallback, ~3 min) | `cargo install sccache --locked` |
+
+Verify the install:
+
+```bash
+sccache --version
+```
+
+### Enable for cargo
+
+Add this export to your shell profile (`~/.zshrc`, `~/.bashrc`, or
+PowerShell `$PROFILE`) — **once per machine, applies to all worktrees**:
+
+```bash
+# bash / zsh
+export RUSTC_WRAPPER=sccache
+```
+
+```powershell
+# PowerShell
+$env:RUSTC_WRAPPER = "sccache"
+# To persist, add the above line to $PROFILE
+```
+
+Open a new shell after editing the profile. From this point every
+`cargo build` in any worktree consults the shared sccache.
+
+### Verify it's working
+
+After a build, inspect the cache stats:
+
+```bash
+sccache --show-stats
+```
+
+You should see `Cache hits` climb when you rebuild the same crate across
+worktrees. A fresh first build populates the cache; the second worktree's
+first build of the same crate is the one you'll feel — typically **40-70%
+faster** for cold builds of large dependencies.
+
+### Cache configuration (optional)
+
+Default cache location and size (10 GB) are sensible for most setups. To
+customize, set environment variables before any `cargo` invocation — see
+[sccache docs](https://github.com/mozilla/sccache/blob/main/docs/Configuration.md).
+
+Common knob: increase the cache size if you work on many feature branches.
+
+```bash
+export SCCACHE_CACHE_SIZE="40G"
+```
 
 ## macOS-Specific Optimizations
 
@@ -61,22 +136,6 @@ with near-native file system performance.
 
 If Docker builds are slow, switching to OrbStack is the single highest-impact
 change on macOS.
-
-## Optional: sccache
-
-[sccache](https://github.com/mozilla/sccache) caches Rust compilation artifacts
-across projects and machines. It's especially useful if you work on multiple
-branches or frequently `cargo clean`.
-
-```bash
-brew install sccache
-
-# Add to your shell profile:
-export RUSTC_WRAPPER=sccache
-```
-
-sccache wraps `rustc` and caches compilation results. Cache hits skip compilation
-entirely. Works with local disk or remote storage (S3, GCS, Redis).
 
 ## Optional: Faster linker (lld)
 


### PR DESCRIPTION
## Why

The existing `docs/contributing/build-performance.md` had sccache under "Optional", macOS-only (`brew install`), and effectively zero adoption. Meanwhile multi-worktree dev (8 parallel worktrees) is hitting **40+ GB** of duplicate Rust build artifacts — `target/` in each worktree independently re-compiling the same crates.

sccache wraps `rustc` and caches by input hash, so the same crate built in any worktree hits the shared cache instead of recompiling. Each worktree keeps its own `target/` for link artifacts (so parallel builds don't contend), but the heavy `rustc` work deduplicates globally.

This is the single highest-leverage build-perf change for multi-worktree setups.

## What

Pure docs change — no code, no build-system, no `.cargo/config.toml` mutation, no shell-profile auto-edit.

- Promote sccache from "Optional" → "Recommended (multi-worktree dev)"
- Quantify the actual cost (40+ GB across 8 worktrees) so readers understand the leverage
- **Cross-platform install table:** brew / apt / winget / `cargo install sccache --locked` (universal fallback)
- The single critical export line (`RUSTC_WRAPPER=sccache`) for both bash/zsh and PowerShell — once per machine, applies to all worktrees
- Verification recipe via `sccache --show-stats`
- Cache-size knob (`SCCACHE_CACHE_SIZE`) for heavy multi-branch users
- Drops the duplicate "Optional: sccache" section to keep SSOT

Opt-in by design: devs add the export to their own profile. No script auto-edits dotfiles, no checked-in `.cargo/config.toml` change that would break builds for devs without sccache installed.

## Out of scope (intentionally deferred)

These were considered for this PR and **explicitly deferred** until we have post-adoption measurement:

- `just measure-targets` recipe to baseline `target/` steady-state
- `cargo sweep` integration via `just` recipes (post-build conditional sweep, threshold-gated)
- `pre-push` hook as safety net for IDE-driven builds that bypass `just`
- `just clean-stale` manual escape hatch

If post-adoption sweep through worktrees shows 46 GB → 18-22 GB, sweep integration may be unnecessary. Land sccache, measure for a week, decide.

## Verification

Visual: `gh pr diff` — docs only, single file change.

Render check (locally): GitHub markdown preview — install table renders correctly across the 4 platforms.

## Forbidden zones (re-confirmed)

| Zone | This PR |
|---|---|
| Rust kernel code / primitives | Not touched |
| Kernel ABI / syscall / hook ABI | Not touched |
| `nexusd-cluster` (services, drivers) | Not touched |
| `src/nexus/core/` Python kernel-tier | Not touched |
| `.cargo/config.toml` (tracked) | Not touched |
| Pre-commit / CI config | Not touched |