### PR TITLE
fix(vault): Windows compatibility - zip path and NTFS namespace encoding

### DIFF
--- a/.github/workflows/release-vault-plugin.yml
+++ b/.github/workflows/release-vault-plugin.yml
@@ -74,7 +74,7 @@ jobs:
 
           # Windows x86_64
           cp artifacts/nexus-vault-windows-x86_64/nexus_vault.dll nexus_vault.dll
-          cd release-assets && zip nexus-vault-windows-x86_64.zip ../nexus_vault.dll && cd ..
+          zip release-assets/nexus-vault-windows-x86_64.zip nexus_vault.dll
           rm nexus_vault.dll
 
           echo "=== release-assets ==="

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1304,7 +1304,7 @@ source = "git+https://github.com/nexi-lab/nexus-vfs?rev=32c47310e48d449bb5c3f02e
 
 [[package]]
 name = "nexus-vault"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "backends",
  "kernel",

--- a/rust/services/src/generic_secrets/mod.rs
+++ b/rust/services/src/generic_secrets/mod.rs
@@ -73,6 +73,14 @@ impl GenericSecretsServiceImpl {
         master_key: crypto::MasterKey,
     ) -> Result<Self, PasswordVaultError> {
         let storage = SecretStorage::new_on_existing_mount(kernel, root)?;
+        // Bring any pre-v0.1.2 on-disk files (literal NTFS-illegal segments
+        // surviving from when v0.1.1 wrote raw `:` paths on Linux/macOS) onto
+        // the canonical percent-encoded layout. Called explicitly here rather
+        // than from `SecretStorage::new_*` so the constructor stays
+        // side-effect-free; storage's read/write contract then only ever
+        // targets the canonical layout (one SSOT, no fallback paths).
+        // Idempotent on a clean tree.
+        storage.migrate_legacy_layout()?;
         Ok(Self {
             inner: Arc::new(Inner {
                 storage,

--- a/rust/services/src/generic_secrets/storage.rs
+++ b/rust/services/src/generic_secrets/storage.rs
@@ -305,9 +305,7 @@ impl SecretStorage {
                 self.kernel
                     .sys_readdir(&dir, "root", true)
                     .into_iter()
-                    .filter_map(|(path, _)| {
-                        path.rsplit('/').next().map(unescape_path_component)
-                    })
+                    .filter_map(|(path, _)| path.rsplit('/').next().map(unescape_path_component))
                     .filter(|s| !s.is_empty())
                     .collect()
             }
@@ -536,7 +534,11 @@ mod tests {
             let input = (b as char).to_string();
             let got = escape_path_component(&input);
             let want = format!("%{:02X}", b);
-            assert_eq!(got, want, "control char 0x{:02X} did not encode to {}", b, want);
+            assert_eq!(
+                got, want,
+                "control char 0x{:02X} did not encode to {}",
+                b, want
+            );
         }
     }
 
@@ -567,7 +569,12 @@ mod tests {
         // Documents the invariant that encoding overhead is paid only when
         // namespaces actually contain illegal chars.
         for s in &["abc123", "service-x", "X-API-Key", "passwords", "auth_jwt"] {
-            assert_eq!(escape_path_component(s), *s, "non-identity for safe {:?}", s);
+            assert_eq!(
+                escape_path_component(s),
+                *s,
+                "non-identity for safe {:?}",
+                s
+            );
         }
     }
 

--- a/rust/services/src/generic_secrets/storage.rs
+++ b/rust/services/src/generic_secrets/storage.rs
@@ -20,7 +20,16 @@ const DT_DIR: i32 = 1;
 /// Percent-encode characters that are illegal in Windows NTFS path components
 /// (and the leading `%` to keep the round-trip unambiguous).
 ///
-/// Encoded set: `% : / \ < > " | ? *` + ASCII control chars 0x00..=0x1F.
+/// Encoded set:
+/// - `% : / \ < > " | ? *` (NTFS-illegal + `%` self-encoding)
+/// - ASCII control chars `0x00..=0x1F`
+/// - **All non-ASCII bytes `0x80..=0xFF`** so multi-byte UTF-8 sequences in
+///   namespace/key inputs are preserved byte-for-byte across the round-trip.
+///   Without this, `b as char` on a high byte would yield `U+0080..U+00FF`
+///   and `String` would re-encode it as 2-byte UTF-8, breaking
+///   `unescape(escape(s)) == s` for any non-ASCII input (e.g. `"café"`
+///   would land on disk as `"cafÃ©"`).
+///
 /// Output uses uppercase `%HH` (matches URL percent-encoding convention).
 ///
 /// Applied uniformly across all platforms — there is no `cfg(windows)` branch:
@@ -31,7 +40,9 @@ fn escape_path_component(s: &str) -> String {
     for b in s.bytes() {
         let needs_encode = matches!(
             b,
-            b'%' | b':' | b'/' | b'\\' | b'<' | b'>' | b'"' | b'|' | b'?' | b'*' | 0x00..=0x1F
+            b'%' | b':' | b'/' | b'\\' | b'<' | b'>' | b'"' | b'|' | b'?' | b'*'
+            | 0x00..=0x1F
+            | 0x80..=0xFF
         );
         if needs_encode {
             out.push('%');
@@ -287,6 +298,190 @@ impl SecretStorage {
         }
         out.sort_by_key(|e| e.version);
         Ok(out)
+    }
+
+    /// Migrate any pre-v0.1.2 files whose path segments were stored
+    /// literally (e.g. `service:shareone` written by v0.1.1 on Linux/macOS
+    /// where NTFS-illegal chars survived the trip to disk) onto the
+    /// canonical percent-encoded layout. Idempotent — on a clean canonical
+    /// tree this performs two readdir scans and returns.
+    ///
+    /// Called explicitly by `GenericSecretsServiceImpl::new_on_existing_mount`
+    /// after the storage is constructed so the read/write contract stays
+    /// SSOT (every other method here targets canonical paths only — there
+    /// is no fallback / dual-layout logic to maintain).
+    pub(crate) fn migrate_legacy_layout(&self) -> Result<(), PasswordVaultError> {
+        self.migrate_subtree_entries()?;
+        self.migrate_subtree_versions()?;
+        Ok(())
+    }
+
+    fn migrate_subtree_entries(&self) -> Result<(), PasswordVaultError> {
+        // depth-2: /entries/{ns}/{key}
+        let root = format!("{}/entries", self.root);
+        let ns_paths: Vec<String> = self
+            .kernel
+            .sys_readdir(&root, "root", true)
+            .into_iter()
+            .map(|(p, _)| p)
+            .collect();
+
+        for ns_path in ns_paths {
+            let ns_segment = match ns_path.rsplit('/').next() {
+                Some(s) if !s.is_empty() => s.to_string(),
+                _ => continue,
+            };
+            let ns_logical = unescape_path_component(&ns_segment);
+            let canonical_ns_segment = escape_path_component(&ns_logical);
+            let ns_needs_rename = ns_segment != canonical_ns_segment;
+
+            let key_paths: Vec<String> = self
+                .kernel
+                .sys_readdir(&ns_path, "root", true)
+                .into_iter()
+                .map(|(p, _)| p)
+                .collect();
+            for key_path in key_paths {
+                let key_segment = match key_path.rsplit('/').next() {
+                    Some(s) if !s.is_empty() => s.to_string(),
+                    _ => continue,
+                };
+                let key_logical = unescape_path_component(&key_segment);
+                let canonical = self.entries_path(&ns_logical, &key_logical);
+                if key_path == canonical {
+                    continue; // already canonical
+                }
+                self.move_kernel_file(&key_path, &canonical)?;
+            }
+
+            if ns_needs_rename {
+                // Try to reap the now-empty legacy ns dir. Best-effort —
+                // a non-empty dir (un-migrated leftover) just stays.
+                let _ = self.kernel.sys_unlink(
+                    &[kernel::kernel::UnlinkRequest {
+                        path: ns_path,
+                        recursive: false,
+                    }],
+                    &self.ctx,
+                );
+            }
+        }
+        Ok(())
+    }
+
+    fn migrate_subtree_versions(&self) -> Result<(), PasswordVaultError> {
+        // depth-3: /versions/{ns}/{key}/{version}
+        let root = format!("{}/versions", self.root);
+        let ns_paths: Vec<String> = self
+            .kernel
+            .sys_readdir(&root, "root", true)
+            .into_iter()
+            .map(|(p, _)| p)
+            .collect();
+
+        for ns_path in ns_paths {
+            let ns_segment = match ns_path.rsplit('/').next() {
+                Some(s) if !s.is_empty() => s.to_string(),
+                _ => continue,
+            };
+            let ns_logical = unescape_path_component(&ns_segment);
+            let canonical_ns_segment = escape_path_component(&ns_logical);
+            let ns_needs_rename = ns_segment != canonical_ns_segment;
+
+            let key_paths: Vec<String> = self
+                .kernel
+                .sys_readdir(&ns_path, "root", true)
+                .into_iter()
+                .map(|(p, _)| p)
+                .collect();
+            for key_path in key_paths {
+                let key_segment = match key_path.rsplit('/').next() {
+                    Some(s) if !s.is_empty() => s.to_string(),
+                    _ => continue,
+                };
+                let key_logical = unescape_path_component(&key_segment);
+                let canonical_key_dir = self.versions_dir(&ns_logical, &key_logical);
+                let key_needs_rename = key_path != canonical_key_dir;
+
+                let version_paths: Vec<String> = self
+                    .kernel
+                    .sys_readdir(&key_path, "root", true)
+                    .into_iter()
+                    .map(|(p, _)| p)
+                    .collect();
+                for version_path in version_paths {
+                    let version_segment = match version_path.rsplit('/').next() {
+                        Some(s) if !s.is_empty() => s.to_string(),
+                        _ => continue,
+                    };
+                    // Version segments are zero-padded digits — encode-identity.
+                    let canonical = format!("{canonical_key_dir}/{version_segment}");
+                    if version_path == canonical {
+                        continue;
+                    }
+                    self.move_kernel_file(&version_path, &canonical)?;
+                }
+
+                if key_needs_rename {
+                    let _ = self.kernel.sys_unlink(
+                        &[kernel::kernel::UnlinkRequest {
+                            path: key_path,
+                            recursive: false,
+                        }],
+                        &self.ctx,
+                    );
+                }
+            }
+
+            if ns_needs_rename {
+                let _ = self.kernel.sys_unlink(
+                    &[kernel::kernel::UnlinkRequest {
+                        path: ns_path,
+                        recursive: false,
+                    }],
+                    &self.ctx,
+                );
+            }
+        }
+        Ok(())
+    }
+
+    /// Read `src` and write its content to `dst`, then unlink `src`.
+    /// If `dst` already exists, leave `src` alone — defensive against a
+    /// prior partial migration that left both copies on disk; an operator
+    /// can investigate / drop the stale legacy file manually.
+    fn move_kernel_file(&self, src: &str, dst: &str) -> Result<(), PasswordVaultError> {
+        if KernelConvenience::read(&*self.kernel, dst, &self.ctx, 0, 0).is_ok() {
+            return Ok(());
+        }
+
+        let data = match KernelConvenience::read(&*self.kernel, src, &self.ctx, 0, 0) {
+            Ok(result) => result.data.unwrap_or_default(),
+            Err(KernelError::FileNotFound(_)) => return Ok(()),
+            Err(e) => {
+                return Err(PasswordVaultError::Storage(format!(
+                    "migrate read {src}: {e:?}"
+                )));
+            }
+        };
+
+        if let Some((parent, _)) = dst.rsplit_once('/') {
+            self.ensure_dir(parent)?;
+        }
+
+        self.kernel
+            .write(dst, &self.ctx, &data, 0)
+            .map_err(|e| PasswordVaultError::Storage(format!("migrate write {dst}: {e:?}")))?;
+
+        let _ = self.kernel.sys_unlink(
+            &[kernel::kernel::UnlinkRequest {
+                path: src.to_string(),
+                recursive: false,
+            }],
+            &self.ctx,
+        );
+
+        Ok(())
     }
 
     /// List all secret indexes, optionally filtered by namespace.
@@ -589,5 +784,183 @@ mod tests {
         assert_eq!(unescape_path_component("a%2Gb"), "a%2Gb");
         // Sanity: valid mixed with invalid still decodes the valid part.
         assert_eq!(unescape_path_component("a%3Ab%ZZc"), "a:b%ZZc");
+    }
+
+    #[test]
+    fn escape_unescape_handles_non_ascii_round_trip() {
+        // Pre-fix, a UTF-8 multi-byte input (`café` = 5 bytes) was reinterpreted
+        // byte-by-byte through `b as char`, expanding to 7 bytes on the way
+        // out and breaking the round-trip. With 0x80..=0xFF in the encode
+        // set every UTF-8 sequence survives as `%C3%A9` etc.
+        let cases: &[&str] = &[
+            "café",
+            "密码",
+            "🔑emoji",
+            "服务:shareone",   // mixed UTF-8 + NTFS-illegal
+            "naïve\x00ctrl",   // UTF-8 + control char
+            "λ→μ",             // multi-byte non-Latin1
+        ];
+        for s in cases {
+            let round = unescape_path_component(&escape_path_component(s));
+            assert_eq!(&round, s, "round-trip failed for {:?}", s);
+        }
+        // And explicit byte-level: `é` (U+00E9) is `0xC3 0xA9` in UTF-8.
+        // Each high byte must encode to `%HH` independently.
+        assert_eq!(escape_path_component("é"), "%C3%A9");
+    }
+
+    // ── Migration tests for v0.1.1 → v0.1.2 layout ───────────────────
+    //
+    // v0.1.1 wrote raw namespace/key segments to disk (no encoding), so
+    // Linux/macOS users have on-disk paths like
+    // `/vault/entries/service:shareone/X-API-Key`. `migrate_legacy_layout`
+    // must move that data onto `/vault/entries/service%3Ashareone/X-API-Key`
+    // (the canonical v0.1.2 layout) so every subsequent read/write through
+    // the encoded helpers finds it.
+
+    /// Build a kernel with a MemBackend mounted at /vault, then write a
+    /// v0.1.1-style file at the given literal path. Returns the kernel +
+    /// a test OperationContext so the caller can wire up more files
+    /// before constructing SecretStorage.
+    fn mount_with_legacy_data() -> (Arc<Kernel>, OperationContext) {
+        let kernel = Arc::new(Kernel::new());
+        let backend: Arc<dyn ObjectStore> = Arc::new(MemBackend::new());
+        let backend_name = backend.name().to_string();
+        kernel
+            .sys_setattr(
+                "/vault",
+                2, /* DT_MOUNT */
+                &backend_name,
+                Some(backend),
+                None,
+                None,
+                "memory",
+                "root",
+                false,
+                0,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+            .unwrap();
+        let ctx =
+            OperationContext::new("vault-storage", "root", true, Some("vault-storage"), true);
+        (kernel, ctx)
+    }
+
+    fn mkdir_raw(kernel: &Arc<Kernel>, path: &str) {
+        kernel
+            .sys_setattr(
+                path, DT_DIR, "", None, None, None, "memory", "root", false, 0, None, None, None,
+                None, None, None, None, None, None, None, None,
+            )
+            .unwrap();
+    }
+
+    #[test]
+    fn migrate_legacy_layout_moves_v011_entries_and_versions_to_canonical() {
+        let (kernel, ctx) = mount_with_legacy_data();
+
+        // Pre-create v0.1.1 layout WITHOUT running through storage's
+        // encoding helpers. Literal `:` survives in the dir name.
+        mkdir_raw(&kernel, "/vault/entries");
+        mkdir_raw(&kernel, "/vault/entries/service:shareone");
+        let idx_bytes = bincode::serialize(&index(1, false)).unwrap();
+        kernel
+            .write(
+                "/vault/entries/service:shareone/X-API-Key",
+                &ctx,
+                &idx_bytes,
+                0,
+            )
+            .unwrap();
+
+        mkdir_raw(&kernel, "/vault/versions");
+        mkdir_raw(&kernel, "/vault/versions/service:shareone");
+        mkdir_raw(&kernel, "/vault/versions/service:shareone/X-API-Key");
+        let entry_bytes = bincode::serialize(&entry(1, b"secret")).unwrap();
+        kernel
+            .write(
+                "/vault/versions/service:shareone/X-API-Key/0000000001",
+                &ctx,
+                &entry_bytes,
+                0,
+            )
+            .unwrap();
+
+        // Storage construction does not migrate (constructor stays clean).
+        // Reads through canonical paths therefore miss the legacy data.
+        let storage = SecretStorage::new_on_existing_mount(kernel.clone(), "/vault").unwrap();
+        assert!(
+            storage
+                .get_index("service:shareone", "X-API-Key")
+                .unwrap()
+                .is_none(),
+            "pre-migration get_index must miss the legacy literal layout"
+        );
+
+        // Explicit migration brings the data onto the canonical layout.
+        storage.migrate_legacy_layout().unwrap();
+
+        let got = storage
+            .get_index("service:shareone", "X-API-Key")
+            .unwrap()
+            .expect("post-migration get_index must hit canonical layout");
+        assert_eq!(got.current_version, 1);
+
+        let listed = storage.list_indexes(None).unwrap();
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].0, "service:shareone", "namespace echoes literal");
+        assert_eq!(listed[0].1, "X-API-Key");
+
+        let versions = storage
+            .list_versions("service:shareone", "X-API-Key")
+            .unwrap();
+        assert_eq!(versions.len(), 1);
+        assert_eq!(versions[0].version, 1);
+        assert_eq!(versions[0].ciphertext, b"secret");
+    }
+
+    #[test]
+    fn migrate_legacy_layout_is_idempotent_on_canonical_tree() {
+        // Setup via the normal storage API — all writes already canonical.
+        let storage = mount_and_create();
+        storage
+            .set_index("service:shareone", "X-API-Key", &index(1, false))
+            .unwrap();
+        storage
+            .put_version("service:shareone", "X-API-Key", 1, &entry(1, b"v1"))
+            .unwrap();
+
+        // Migration on already-canonical layout must be a no-op (no reads
+        // observable through the API change).
+        storage.migrate_legacy_layout().unwrap();
+
+        let got = storage
+            .get_index("service:shareone", "X-API-Key")
+            .unwrap()
+            .unwrap();
+        assert_eq!(got.current_version, 1);
+        let versions = storage
+            .list_versions("service:shareone", "X-API-Key")
+            .unwrap();
+        assert_eq!(versions.len(), 1);
+
+        // And calling migration a second time must also be safe.
+        storage.migrate_legacy_layout().unwrap();
+        assert!(
+            storage
+                .get_index("service:shareone", "X-API-Key")
+                .unwrap()
+                .is_some()
+        );
     }
 }

--- a/rust/services/src/generic_secrets/storage.rs
+++ b/rust/services/src/generic_secrets/storage.rs
@@ -796,9 +796,9 @@ mod tests {
             "café",
             "密码",
             "🔑emoji",
-            "服务:shareone",   // mixed UTF-8 + NTFS-illegal
-            "naïve\x00ctrl",   // UTF-8 + control char
-            "λ→μ",             // multi-byte non-Latin1
+            "服务:shareone", // mixed UTF-8 + NTFS-illegal
+            "naïve\x00ctrl", // UTF-8 + control char
+            "λ→μ",           // multi-byte non-Latin1
         ];
         for s in cases {
             let round = unescape_path_component(&escape_path_component(s));
@@ -851,8 +851,7 @@ mod tests {
                 None,
             )
             .unwrap();
-        let ctx =
-            OperationContext::new("vault-storage", "root", true, Some("vault-storage"), true);
+        let ctx = OperationContext::new("vault-storage", "root", true, Some("vault-storage"), true);
         (kernel, ctx)
     }
 
@@ -956,11 +955,9 @@ mod tests {
 
         // And calling migration a second time must also be safe.
         storage.migrate_legacy_layout().unwrap();
-        assert!(
-            storage
-                .get_index("service:shareone", "X-API-Key")
-                .unwrap()
-                .is_some()
-        );
+        assert!(storage
+            .get_index("service:shareone", "X-API-Key")
+            .unwrap()
+            .is_some());
     }
 }

--- a/rust/services/src/generic_secrets/storage.rs
+++ b/rust/services/src/generic_secrets/storage.rs
@@ -17,6 +17,61 @@ use crate::password_vault::types::{PasswordVaultError, SecretIndex, StoredEntry}
 
 const DT_DIR: i32 = 1;
 
+/// Percent-encode characters that are illegal in Windows NTFS path components
+/// (and the leading `%` to keep the round-trip unambiguous).
+///
+/// Encoded set: `% : / \ < > " | ? *` + ASCII control chars 0x00..=0x1F.
+/// Output uses uppercase `%HH` (matches URL percent-encoding convention).
+///
+/// Applied uniformly across all platforms — there is no `cfg(windows)` branch:
+/// on-disk layout must round-trip between Linux/macOS/Windows. See
+/// `zazzy-chasing-pizza.md` "头号约束" for the rationale.
+fn escape_path_component(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for b in s.bytes() {
+        let needs_encode = matches!(
+            b,
+            b'%' | b':' | b'/' | b'\\' | b'<' | b'>' | b'"' | b'|' | b'?' | b'*' | 0x00..=0x1F
+        );
+        if needs_encode {
+            out.push('%');
+            out.push_str(&format!("{:02X}", b));
+        } else {
+            out.push(b as char);
+        }
+    }
+    out
+}
+
+/// Inverse of `escape_path_component`. Decodes `%HH` (two hex digits, either
+/// case) back to the original byte. Tolerant of malformed input: a `%` not
+/// followed by two hex digits (e.g. `%ZZ`, `%A`, trailing `%`) is passed
+/// through verbatim rather than panicking or returning a `Result`. Rationale:
+/// readdir may surface foreign directories (manual `mv`, future tooling) and
+/// `list` must not crash on them.
+fn unescape_path_component(s: &str) -> String {
+    let bytes = s.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' && i + 2 < bytes.len() {
+            let h1 = (bytes[i + 1] as char).to_digit(16);
+            let h2 = (bytes[i + 2] as char).to_digit(16);
+            if let (Some(h1), Some(h2)) = (h1, h2) {
+                out.push((h1 * 16 + h2) as u8);
+                i += 3;
+                continue;
+            }
+        }
+        out.push(bytes[i]);
+        i += 1;
+    }
+    // Encoded bytes are always valid UTF-8 since we only encode ASCII-range
+    // bytes and pass others through. So from_utf8_lossy is a safety net,
+    // not load-bearing.
+    String::from_utf8_lossy(&out).into_owned()
+}
+
 pub(crate) struct SecretStorage {
     kernel: Arc<Kernel>,
     ctx: OperationContext,
@@ -50,26 +105,43 @@ impl SecretStorage {
     }
 
     fn entries_path(&self, namespace: &str, key: &str) -> String {
-        format!("{}/entries/{}/{}", self.root, namespace, key)
+        format!(
+            "{}/entries/{}/{}",
+            self.root,
+            escape_path_component(namespace),
+            escape_path_component(key)
+        )
     }
 
     fn ns_dir_path(&self, namespace: &str) -> String {
-        format!("{}/entries/{}", self.root, namespace)
+        format!("{}/entries/{}", self.root, escape_path_component(namespace))
     }
 
     fn version_path(&self, namespace: &str, key: &str, version: u32) -> String {
         format!(
             "{}/versions/{}/{}/{:010}",
-            self.root, namespace, key, version
+            self.root,
+            escape_path_component(namespace),
+            escape_path_component(key),
+            version
         )
     }
 
     fn versions_dir(&self, namespace: &str, key: &str) -> String {
-        format!("{}/versions/{}/{}", self.root, namespace, key)
+        format!(
+            "{}/versions/{}/{}",
+            self.root,
+            escape_path_component(namespace),
+            escape_path_component(key)
+        )
     }
 
     fn ns_version_dir(&self, namespace: &str) -> String {
-        format!("{}/versions/{}", self.root, namespace)
+        format!(
+            "{}/versions/{}",
+            self.root,
+            escape_path_component(namespace)
+        )
     }
 
     pub(crate) fn get_index(
@@ -233,7 +305,9 @@ impl SecretStorage {
                 self.kernel
                     .sys_readdir(&dir, "root", true)
                     .into_iter()
-                    .filter_map(|(path, _)| path.rsplit('/').next().map(|s| s.to_string()))
+                    .filter_map(|(path, _)| {
+                        path.rsplit('/').next().map(unescape_path_component)
+                    })
                     .filter(|s| !s.is_empty())
                     .collect()
             }
@@ -244,7 +318,7 @@ impl SecretStorage {
             let entries = self.kernel.sys_readdir(&ns_dir, "root", true);
             for (child_path, _etype) in entries {
                 let key = match child_path.rsplit('/').next() {
-                    Some(k) if !k.is_empty() => k.to_string(),
+                    Some(k) if !k.is_empty() => unescape_path_component(k),
                     _ => continue,
                 };
                 match KernelConvenience::read(&*self.kernel, &child_path, &self.ctx, 0, 0) {
@@ -432,5 +506,81 @@ mod tests {
         let vers = s.list_versions("ns", "k").unwrap();
         let nums: Vec<u32> = vers.iter().map(|e| e.version).collect();
         assert_eq!(nums, vec![1, 2, 3]);
+    }
+
+    // ── Percent-encoding tests for path-component escape/unescape ─────
+    //
+    // These tests target the pure string-transform functions defined at
+    // the top of this module. They must stay platform-agnostic — there is
+    // intentionally no `cfg(target_os = ...)` anywhere in the encoder.
+
+    #[test]
+    fn escape_l1_character_set_explicit_assertions() {
+        // L1 character set (Windows NTFS-illegal + `%` self-encoding).
+        // Each character listed in zazzy-chasing-pizza.md is asserted
+        // individually so the test fails loudly if any one is dropped
+        // from the encoder match arm.
+        assert_eq!(escape_path_component("%"), "%25");
+        assert_eq!(escape_path_component(":"), "%3A");
+        assert_eq!(escape_path_component("/"), "%2F");
+        assert_eq!(escape_path_component("\\"), "%5C");
+        assert_eq!(escape_path_component("<"), "%3C");
+        assert_eq!(escape_path_component(">"), "%3E");
+        assert_eq!(escape_path_component("\""), "%22");
+        assert_eq!(escape_path_component("|"), "%7C");
+        assert_eq!(escape_path_component("?"), "%3F");
+        assert_eq!(escape_path_component("*"), "%2A");
+
+        // ASCII control chars 0x00..=0x1F — loop instead of enumerating.
+        for b in 0x00u8..=0x1F {
+            let input = (b as char).to_string();
+            let got = escape_path_component(&input);
+            let want = format!("%{:02X}", b);
+            assert_eq!(got, want, "control char 0x{:02X} did not encode to {}", b, want);
+        }
+    }
+
+    #[test]
+    fn escape_unescape_round_trip() {
+        let cases: &[&str] = &[
+            "service:shareone",
+            "channel:lark:456",
+            "path/with/slash",
+            "mix:and/match",
+            "percent%inline",
+            "back\\slash",
+            "",
+            "abc123",
+            "no-special",
+            "control\x00\x1Fbytes",
+            "quote\"and|pipe?star*<lt>gt",
+        ];
+        for s in cases {
+            let round = unescape_path_component(&escape_path_component(s));
+            assert_eq!(&round, s, "round-trip failed for {:?}", s);
+        }
+    }
+
+    #[test]
+    fn escape_is_identity_on_safe_alphanumeric() {
+        // Pure alphanumeric / safe-ASCII inputs must pass through unchanged.
+        // Documents the invariant that encoding overhead is paid only when
+        // namespaces actually contain illegal chars.
+        for s in &["abc123", "service-x", "X-API-Key", "passwords", "auth_jwt"] {
+            assert_eq!(escape_path_component(s), *s, "non-identity for safe {:?}", s);
+        }
+    }
+
+    #[test]
+    fn unescape_tolerates_invalid_percent_sequences() {
+        // Malformed inputs must pass through verbatim, not panic, not
+        // return Result. This protects `list_indexes` from crashing on
+        // foreign / hand-placed directories.
+        assert_eq!(unescape_path_component("%ZZ"), "%ZZ");
+        assert_eq!(unescape_path_component("%A"), "%A");
+        assert_eq!(unescape_path_component("100%"), "100%");
+        assert_eq!(unescape_path_component("a%2Gb"), "a%2Gb");
+        // Sanity: valid mixed with invalid still decodes the valid part.
+        assert_eq!(unescape_path_component("a%3Ab%ZZc"), "a:b%ZZc");
     }
 }

--- a/rust/services/vault/Cargo.toml
+++ b/rust/services/vault/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nexus-vault"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 description = "Nexus vault plugin — cdylib loaded by `nexusd-cluster` via `--plugin-dir`. Hosts PasswordVaultService as a dylib plugin with C ABI dispatch."
 authors = ["Nexus Team"]

--- a/rust/services/vault/src/lib.rs
+++ b/rust/services/vault/src/lib.rs
@@ -1092,7 +1092,11 @@ mod dispatch_e2e {
         let resp = dispatch_vault(&plugin, "put_entry", &payload).unwrap();
         let pw_title = PutEntryResponse::decode(resp.as_slice()).unwrap().title;
 
-        // Step 2: Store generic secret — capture returned namespace:key
+        // Step 2: Store generic secret. Uses `provider:openai` (with a
+        // colon — an NTFS-illegal char) on purpose, to make this test
+        // also assert the post-encoding contract: namespace/key segments
+        // on disk are percent-encoded, while the wire-level API echoes
+        // back the original literal.
         let payload = encode(&secrets_proto::PutSecretRequest {
             namespace: "provider:openai".into(),
             key: "api_key".into(),
@@ -1104,10 +1108,18 @@ mod dispatch_e2e {
             .unwrap()
             .metadata
             .unwrap();
-        let secret_ns = meta.namespace;
-        let secret_key = meta.key;
+        // API contract: returned namespace/key are the original strings,
+        // NOT the on-disk encoded form.
+        assert_eq!(meta.namespace, "provider:openai");
+        assert_eq!(meta.key, "api_key");
+        let secret_ns_api = meta.namespace; // logical (API) value
+        // Physical layout contract: disk segments are percent-encoded.
+        // `:` is encoded as `%3A`; `api_key` is safe → identity.
+        let secret_ns_disk = "provider%3Aopenai";
+        let secret_key_disk = "api_key";
 
-        // Step 3: Verify /vault/entries/ has namespace dirs from steps 1-2
+        // Step 3: Verify /vault/entries/ shows the ENCODED namespace dir
+        // (not the API literal). This is what readdir actually returns.
         let entries_root = kernel.sys_readdir("/vault/entries", "root", true);
         let ns_names: Vec<&str> = entries_root
             .iter()
@@ -1115,11 +1127,16 @@ mod dispatch_e2e {
             .collect();
         assert!(
             ns_names.contains(&"passwords"),
-            "passwords namespace dir exists"
+            "passwords namespace dir exists (no encoding — ASCII-safe)"
         );
         assert!(
-            ns_names.contains(&secret_ns.as_str()),
-            "secret namespace dir exists"
+            ns_names.contains(&secret_ns_disk),
+            "secret namespace dir exists IN ENCODED FORM ({secret_ns_disk}), not as API literal {secret_ns_api}"
+        );
+        // Explicitly assert the API literal is NOT what shows up on disk.
+        assert!(
+            !ns_names.contains(&secret_ns_api.as_str()),
+            "raw colon must not survive on disk — it would break NTFS"
         );
 
         // Step 4: Verify password entry path uses title from step 1
@@ -1130,13 +1147,18 @@ mod dispatch_e2e {
             "password entry filename matches put title"
         );
 
-        // Step 5: Verify generic secret entry path uses ns:key from step 2
-        let secret_entries =
-            kernel.sys_readdir(&format!("/vault/entries/{secret_ns}"), "root", true);
+        // Step 5: Verify generic secret entry path. Direct readdir into
+        // the storage layout MUST use the encoded namespace segment;
+        // walking via the API literal would simply not exist on disk.
+        let secret_entries = kernel.sys_readdir(
+            &format!("/vault/entries/{secret_ns_disk}"),
+            "root",
+            true,
+        );
         assert_eq!(secret_entries.len(), 1);
         assert!(
-            secret_entries[0].0.ends_with(&format!("/{secret_key}")),
-            "secret entry filename matches put key"
+            secret_entries[0].0.ends_with(&format!("/{secret_key_disk}")),
+            "secret entry filename matches put key (encoded)"
         );
 
         // Step 6: Verify version files exist under unified versions/ tree
@@ -1148,7 +1170,7 @@ mod dispatch_e2e {
         assert_eq!(pw_vers.len(), 1, "1 version for password");
 
         let secret_vers = kernel.sys_readdir(
-            &format!("/vault/versions/{secret_ns}/{secret_key}"),
+            &format!("/vault/versions/{secret_ns_disk}/{secret_key_disk}"),
             "root",
             true,
         );
@@ -1221,5 +1243,250 @@ mod dispatch_e2e {
         let resp = dispatch_vault(&plugin, "list_versions", &lv).unwrap();
         let lv_resp = ListVersionsResponse::decode(resp.as_slice()).unwrap();
         assert_eq!(lv_resp.count, 2);
+    }
+
+    // ── Scenario 15: Real-disk PathLocalBackend accepts `%` in path
+    //                segments (the namespace percent-encoding "head
+    //                constraint" turned into executable evidence).
+    //
+    // Background: `zazzy-chasing-pizza.md` assumes the kernel + backend
+    // write path does not reject `%` characters. Source of that claim is
+    // the external `nexus-vfs` crate (pinned by commit in workspace
+    // Cargo.toml) — its source is not vendored, so this test exists to
+    // make the assumption fail loudly under CI three-platform matrix if
+    // a future bump rejects `%`.
+    //
+    // Crucially this test uses `fresh_plugin` (PathLocalBackend on a
+    // TempDir), not `mount_and_create` from storage.rs which is
+    // MemBackend-backed and bypasses real filesystem rules.
+
+    #[test]
+    fn pathlocal_backend_accepts_percent_in_namespace() {
+        let (_dir, plugin) = fresh_plugin();
+
+        let put_payload = encode(&secrets_proto::PutSecretRequest {
+            namespace: "ns%test".into(),
+            key: "k".into(),
+            value: "v".into(),
+            description: None,
+        });
+        // The whole point: this must not error on Windows / Linux / macOS.
+        dispatch_vault(&plugin, "secret_put", &put_payload).unwrap();
+
+        let get_payload = encode(&secrets_proto::GetSecretRequest {
+            namespace: "ns%test".into(),
+            key: "k".into(),
+            version: None,
+        });
+        let resp = dispatch_vault(&plugin, "secret_get", &get_payload).unwrap();
+        let got = secrets_proto::GetSecretResponse::decode(resp.as_slice()).unwrap();
+        assert_eq!(got.value, "v");
+        assert_eq!(got.namespace, "ns%test", "namespace returned unencoded");
+    }
+
+    // ── Scenario 16: Verification step 2 — colon namespace round-trip on
+    //                real disk, value + namespace echo identity.
+    //
+    // Maps to zazzy verification step 2: secret_put with namespace
+    // "service:shareone" key "X-API-Key" must round-trip on PathLocalBackend
+    // and the list must echo namespace unencoded.
+
+    #[test]
+    fn colon_namespace_round_trip_on_real_disk() {
+        let (_dir, plugin) = fresh_plugin();
+
+        let put_payload = encode(&secrets_proto::PutSecretRequest {
+            namespace: "service:shareone".into(),
+            key: "X-API-Key".into(),
+            value: "sk-prod-123".into(),
+            description: Some("AI Platform key".into()),
+        });
+        dispatch_vault(&plugin, "secret_put", &put_payload).unwrap();
+
+        let get_payload = encode(&secrets_proto::GetSecretRequest {
+            namespace: "service:shareone".into(),
+            key: "X-API-Key".into(),
+            version: None,
+        });
+        let got_resp = dispatch_vault(&plugin, "secret_get", &get_payload).unwrap();
+        let got = secrets_proto::GetSecretResponse::decode(got_resp.as_slice()).unwrap();
+        assert_eq!(got.value, "sk-prod-123");
+
+        let list_payload = encode(&secrets_proto::ListSecretsRequest {
+            namespace: Some("service:shareone".into()),
+            include_deleted: false,
+        });
+        let list_resp = dispatch_vault(&plugin, "secret_list", &list_payload).unwrap();
+        let list = secrets_proto::ListSecretsResponse::decode(list_resp.as_slice()).unwrap();
+        assert_eq!(list.count, 1);
+        assert_eq!(
+            list.secrets[0].namespace, "service:shareone",
+            "namespace must echo original, NOT percent-encoded"
+        );
+        assert!(
+            !list.secrets[0].namespace.contains('%'),
+            "no encoded form must leak through API"
+        );
+    }
+
+    // ── Scenario 17: Verification step 3 — slash in namespace does NOT
+    //                split into directory levels on real disk.
+
+    #[test]
+    fn slash_namespace_does_not_split_directories_on_real_disk() {
+        let (_dir, plugin) = fresh_plugin();
+
+        let put_payload = encode(&secrets_proto::PutSecretRequest {
+            namespace: "a/b/c".into(),
+            key: "k".into(),
+            value: "v".into(),
+            description: None,
+        });
+        dispatch_vault(&plugin, "secret_put", &put_payload).unwrap();
+
+        let list_payload = encode(&secrets_proto::ListSecretsRequest {
+            namespace: None,
+            include_deleted: false,
+        });
+        let list_resp = dispatch_vault(&plugin, "secret_list", &list_payload).unwrap();
+        let list = secrets_proto::ListSecretsResponse::decode(list_resp.as_slice()).unwrap();
+        // Exactly one secret, with the original namespace "a/b/c" intact.
+        assert_eq!(list.count, 1);
+        assert_eq!(list.secrets[0].namespace, "a/b/c");
+        assert_eq!(list.secrets[0].key, "k");
+    }
+
+    // ── Scenario 18: Verification step 4 — multi-character combination
+    //                (`:` and `/`) on real disk.
+
+    #[test]
+    fn mixed_special_chars_namespace_round_trip_on_real_disk() {
+        let (_dir, plugin) = fresh_plugin();
+
+        let ns = "service:shareone/v2";
+        let put_payload = encode(&secrets_proto::PutSecretRequest {
+            namespace: ns.into(),
+            key: "k".into(),
+            value: "v".into(),
+            description: None,
+        });
+        dispatch_vault(&plugin, "secret_put", &put_payload).unwrap();
+
+        let get_payload = encode(&secrets_proto::GetSecretRequest {
+            namespace: ns.into(),
+            key: "k".into(),
+            version: None,
+        });
+        let resp = dispatch_vault(&plugin, "secret_get", &get_payload).unwrap();
+        let got = secrets_proto::GetSecretResponse::decode(resp.as_slice()).unwrap();
+        assert_eq!(got.value, "v");
+
+        let list_payload = encode(&secrets_proto::ListSecretsRequest {
+            namespace: Some(ns.into()),
+            include_deleted: false,
+        });
+        let list_resp = dispatch_vault(&plugin, "secret_list", &list_payload).unwrap();
+        let list = secrets_proto::ListSecretsResponse::decode(list_resp.as_slice()).unwrap();
+        assert_eq!(list.count, 1);
+        assert_eq!(list.secrets[0].namespace, ns);
+    }
+
+    // ── Scenario 19: Verification step 5 — full lifecycle of a secret
+    //                whose namespace contains `:`, exercising all 6
+    //                outward operations (put / get / list / delete /
+    //                restore / list_versions) plus delete_secret_version.
+    //
+    // This is the documented regression net for ns_version_dir-class
+    // omissions: if any path helper failed to escape, one of these steps
+    // would fail on Windows even when the simpler put/get test passed.
+
+    #[test]
+    fn full_lifecycle_with_colon_namespace_on_real_disk() {
+        let (_dir, plugin) = fresh_plugin();
+        let ns = "service:shareone";
+        let key = "X-API-Key";
+
+        // Step 1: put twice — version 1, then version 2 (rotation).
+        for val in ["v1", "v2"] {
+            let payload = encode(&secrets_proto::PutSecretRequest {
+                namespace: ns.into(),
+                key: key.into(),
+                value: val.to_string(),
+                description: None,
+            });
+            dispatch_vault(&plugin, "secret_put", &payload).unwrap();
+        }
+
+        // Step 2: get latest — must be v2.
+        let get_payload = encode(&secrets_proto::GetSecretRequest {
+            namespace: ns.into(),
+            key: key.into(),
+            version: None,
+        });
+        let resp = dispatch_vault(&plugin, "secret_get", &get_payload).unwrap();
+        let got = secrets_proto::GetSecretResponse::decode(resp.as_slice()).unwrap();
+        assert_eq!(got.value, "v2");
+
+        // Step 3: list_versions — must see both v1 and v2.
+        let lv_payload = encode(&secrets_proto::ListSecretVersionsRequest {
+            namespace: ns.into(),
+            key: key.into(),
+        });
+        let resp = dispatch_vault(&plugin, "secret_list_versions", &lv_payload).unwrap();
+        let lv = secrets_proto::ListSecretVersionsResponse::decode(resp.as_slice()).unwrap();
+        assert_eq!(lv.count, 2);
+        let vers: Vec<i32> = lv.versions.iter().map(|v| v.version).collect();
+        assert_eq!(vers, vec![1, 2]);
+
+        // Step 4: delete (tombstone).
+        let del_payload = encode(&secrets_proto::DeleteSecretRequest {
+            namespace: ns.into(),
+            key: key.into(),
+        });
+        let resp = dispatch_vault(&plugin, "secret_delete", &del_payload).unwrap();
+        let del = secrets_proto::DeleteSecretResponse::decode(resp.as_slice()).unwrap();
+        assert!(del.deleted);
+
+        // Step 5: list with include_deleted=true — must surface the entry,
+        // and the listed namespace must round-trip to the original string.
+        let list_payload = encode(&secrets_proto::ListSecretsRequest {
+            namespace: Some(ns.into()),
+            include_deleted: true,
+        });
+        let resp = dispatch_vault(&plugin, "secret_list", &list_payload).unwrap();
+        let list = secrets_proto::ListSecretsResponse::decode(resp.as_slice()).unwrap();
+        assert_eq!(list.count, 1);
+        assert_eq!(list.secrets[0].namespace, ns);
+        assert!(list.secrets[0].deleted);
+
+        // Step 6: restore — must clear the tombstone.
+        let restore_payload = encode(&secrets_proto::RestoreSecretRequest {
+            namespace: ns.into(),
+            key: key.into(),
+        });
+        let resp = dispatch_vault(&plugin, "secret_restore", &restore_payload).unwrap();
+        let restored = secrets_proto::RestoreSecretResponse::decode(resp.as_slice()).unwrap();
+        assert!(restored.restored);
+
+        // Step 7: get post-restore — must return v2 again.
+        let resp = dispatch_vault(&plugin, "secret_get", &get_payload).unwrap();
+        let got = secrets_proto::GetSecretResponse::decode(resp.as_slice()).unwrap();
+        assert_eq!(got.value, "v2");
+
+        // Step 8: delete_secret_version on a non-current version (v1).
+        let dv_payload = encode(&secrets_proto::DeleteSecretVersionRequest {
+            namespace: ns.into(),
+            key: key.into(),
+            version: 1,
+        });
+        let resp = dispatch_vault(&plugin, "secret_delete_version", &dv_payload).unwrap();
+        let dv = secrets_proto::DeleteSecretVersionResponse::decode(resp.as_slice()).unwrap();
+        assert!(dv.deleted);
+
+        // Step 9: list_versions — only v2 should remain.
+        let resp = dispatch_vault(&plugin, "secret_list_versions", &lv_payload).unwrap();
+        let lv = secrets_proto::ListSecretVersionsResponse::decode(resp.as_slice()).unwrap();
+        assert_eq!(lv.count, 1);
+        assert_eq!(lv.versions[0].version, 2);
     }
 }

--- a/rust/services/vault/src/lib.rs
+++ b/rust/services/vault/src/lib.rs
@@ -1112,7 +1112,8 @@ mod dispatch_e2e {
         // NOT the on-disk encoded form.
         assert_eq!(meta.namespace, "provider:openai");
         assert_eq!(meta.key, "api_key");
-        let secret_ns_api = meta.namespace; // logical (API) value
+        // logical (API) value — returned verbatim by the wire layer
+        let secret_ns_api = meta.namespace;
         // Physical layout contract: disk segments are percent-encoded.
         // `:` is encoded as `%3A`; `api_key` is safe → identity.
         let secret_ns_disk = "provider%3Aopenai";
@@ -1150,14 +1151,13 @@ mod dispatch_e2e {
         // Step 5: Verify generic secret entry path. Direct readdir into
         // the storage layout MUST use the encoded namespace segment;
         // walking via the API literal would simply not exist on disk.
-        let secret_entries = kernel.sys_readdir(
-            &format!("/vault/entries/{secret_ns_disk}"),
-            "root",
-            true,
-        );
+        let secret_entries =
+            kernel.sys_readdir(&format!("/vault/entries/{secret_ns_disk}"), "root", true);
         assert_eq!(secret_entries.len(), 1);
         assert!(
-            secret_entries[0].0.ends_with(&format!("/{secret_key_disk}")),
+            secret_entries[0]
+                .0
+                .ends_with(&format!("/{secret_key_disk}")),
             "secret entry filename matches put key (encoded)"
         );
 


### PR DESCRIPTION
Two independent Windows bugs in nexus-vault v0.1.1:

1. Release zip contained '..' in entry names so Expand-Archive
   refused to extract. Switch the workflow's Windows packaging step
   to the cp->zip->rm pattern matching Linux/macOS.

2. namespace containing ':' (e.g. service:shareone) failed secret_put
   with plugin error -3 because NTFS rejects ':' in path segments.
   Storage layer now percent-encodes all path components uniformly
   (no cfg(target_os)) so the on-disk format is cross-platform.

Changes:
- add escape/unescape_path_component (L1 charset; malformed %XX
  passes through verbatim)
- encode in 5 path helpers + decode in list_indexes (2 sites)
- new tests: 4 storage unit tests + 5 dispatch_e2e PathLocalBackend
  tests covering colon/slash/mixed/full-lifecycle on real disk
- adjust unified_vfs_layout test to honestly assert the new disk
  contract (encoded segments) vs API contract (literal echo)
- bump nexus-vault to 0.1.2

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
