### PR TITLE
feat(vault): Ed25519-sign plugin dylibs in release CI

### DIFF
--- a/.github/workflows/release-vault-plugin.yml
+++ b/.github/workflows/release-vault-plugin.yml
@@ -52,30 +52,69 @@ jobs:
           path: artifacts
           pattern: nexus-vault-*
 
+      - name: Set up Python for signing
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+
+      - name: Install signing deps
+        run: pip install --quiet cryptography
+
+      - name: Ed25519-sign each platform dylib
+        # Produces `<dylib>.sig` (64 raw bytes) next to each downloaded
+        # binary so the packaging step picks them both into the archive.
+        # The verifier side (nexus-vfs cluster) reads the `.sig` next to
+        # the loaded plugin and Ed25519-verifies against the embedded
+        # `trusted_keys/nexus-team.pub`. Format contract lives in
+        # `nexus_plugin_abi::signing`.
+        env:
+          PLUGIN_SIGNING_PRIVKEY: ${{ secrets.PLUGIN_SIGNING_PRIVKEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${PLUGIN_SIGNING_PRIVKEY}" ]; then
+            echo "::error::PLUGIN_SIGNING_PRIVKEY repo secret is empty."
+            echo "Set it on nexi-lab/nexus to base64(32 raw Ed25519 private bytes)."
+            exit 1
+          fi
+          python scripts/sign_plugin.py \
+            artifacts/nexus-vault-linux-x86_64/libnexus_vault.so \
+            artifacts/nexus-vault-macos-arm64/libnexus_vault.dylib \
+            artifacts/nexus-vault-macos-x86_64/libnexus_vault.dylib \
+            artifacts/nexus-vault-windows-x86_64/nexus_vault.dll
+
       - name: Package into archives
         run: |
           set -euo pipefail
           mkdir -p release-assets
 
+          # Each archive ships the dylib AND its detached `.sig`. The
+          # consumer (sudowork download script) extracts both into the
+          # plugin dir; the kernel's PluginLoader::load reads them in
+          # tandem and rejects the plugin if verify fails.
+
           # Linux x86_64
           cp artifacts/nexus-vault-linux-x86_64/libnexus_vault.so libnexus_vault.so
-          tar -czf release-assets/nexus-vault-linux-x86_64.tar.gz libnexus_vault.so
-          rm libnexus_vault.so
+          cp artifacts/nexus-vault-linux-x86_64/libnexus_vault.so.sig libnexus_vault.so.sig
+          tar -czf release-assets/nexus-vault-linux-x86_64.tar.gz libnexus_vault.so libnexus_vault.so.sig
+          rm libnexus_vault.so libnexus_vault.so.sig
 
           # macOS arm64
           cp artifacts/nexus-vault-macos-arm64/libnexus_vault.dylib libnexus_vault.dylib
-          tar -czf release-assets/nexus-vault-macos-arm64.tar.gz libnexus_vault.dylib
-          rm libnexus_vault.dylib
+          cp artifacts/nexus-vault-macos-arm64/libnexus_vault.dylib.sig libnexus_vault.dylib.sig
+          tar -czf release-assets/nexus-vault-macos-arm64.tar.gz libnexus_vault.dylib libnexus_vault.dylib.sig
+          rm libnexus_vault.dylib libnexus_vault.dylib.sig
 
           # macOS x86_64
           cp artifacts/nexus-vault-macos-x86_64/libnexus_vault.dylib libnexus_vault.dylib
-          tar -czf release-assets/nexus-vault-macos-x86_64.tar.gz libnexus_vault.dylib
-          rm libnexus_vault.dylib
+          cp artifacts/nexus-vault-macos-x86_64/libnexus_vault.dylib.sig libnexus_vault.dylib.sig
+          tar -czf release-assets/nexus-vault-macos-x86_64.tar.gz libnexus_vault.dylib libnexus_vault.dylib.sig
+          rm libnexus_vault.dylib libnexus_vault.dylib.sig
 
           # Windows x86_64
           cp artifacts/nexus-vault-windows-x86_64/nexus_vault.dll nexus_vault.dll
-          zip release-assets/nexus-vault-windows-x86_64.zip nexus_vault.dll
-          rm nexus_vault.dll
+          cp artifacts/nexus-vault-windows-x86_64/nexus_vault.dll.sig nexus_vault.dll.sig
+          zip release-assets/nexus-vault-windows-x86_64.zip nexus_vault.dll nexus_vault.dll.sig
+          rm nexus_vault.dll nexus_vault.dll.sig
 
           echo "=== release-assets ==="
           ls -lh release-assets/

--- a/scripts/sign_plugin.py
+++ b/scripts/sign_plugin.py
@@ -60,9 +60,7 @@ def load_privkey_from_env() -> Ed25519PrivateKey:
     except (ValueError, base64.binascii.Error) as exc:
         raise SystemExit(f"{PRIVKEY_ENV}: not valid base64: {exc}") from exc
     if len(raw) != PRIVKEY_LENGTH:
-        raise SystemExit(
-            f"{PRIVKEY_ENV}: decoded length {len(raw)} != expected {PRIVKEY_LENGTH}"
-        )
+        raise SystemExit(f"{PRIVKEY_ENV}: decoded length {len(raw)} != expected {PRIVKEY_LENGTH}")
     return Ed25519PrivateKey.from_private_bytes(raw)
 
 
@@ -76,9 +74,7 @@ def sign_one(privkey: Ed25519PrivateKey, plugin: Path) -> Path:
         # Defence in depth: cryptography always returns 64 for Ed25519, but
         # an SSOT mismatch (someone bumped the constant on one side and not
         # the other) would silently emit a sig the verifier can't read.
-        raise SystemExit(
-            f"signature length {len(signature)} != expected {SIGNATURE_LENGTH}"
-        )
+        raise SystemExit(f"signature length {len(signature)} != expected {SIGNATURE_LENGTH}")
 
     sig_path = plugin.with_name(plugin.name + SIGNATURE_FILE_SUFFIX)
     sig_path.write_bytes(signature)
@@ -90,9 +86,7 @@ def sign_one(privkey: Ed25519PrivateKey, plugin: Path) -> Path:
     try:
         pubkey.verify(sig_path.read_bytes(), payload)
     except InvalidSignature as exc:
-        raise SystemExit(
-            f"self-verify failed for {sig_path} — signing pipeline is broken"
-        ) from exc
+        raise SystemExit(f"self-verify failed for {sig_path} — signing pipeline is broken") from exc
 
     return sig_path
 

--- a/scripts/sign_plugin.py
+++ b/scripts/sign_plugin.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Detach-sign a plugin binary with the kernel team's Ed25519 key.
+
+Half 2 of the cross-repo plugin-signing 0->1. The verifier side lives in
+the nexus-vfs repository, at `rust/kernel/src/kernel/plugins/loader.rs`
++ `rust/kernel/trusted_keys/nexus-team.pub`.
+
+Format contract is held by `nexus-plugin-abi`:
+    SIGNATURE_FILE_SUFFIX = ".sig"
+    SIGNATURE_LENGTH      = 64   # raw Ed25519 signature, no header
+    PUBKEY_LENGTH         = 32   # raw Ed25519 pubkey, base64 in .pub file
+Constants here are hardcoded to match. If you ever bump one, bump the
+other side in the same coordinated PR — drift fails verify silently
+across every existing signed plugin.
+
+Private key source: `PLUGIN_SIGNING_PRIVKEY` env var, base64 of exactly
+32 raw bytes. Set as a GitHub Actions secret on `nexi-lab/nexus`. The
+private key is never written to disk or echoed; it stays in process
+memory only for the duration of the sign call.
+
+Output: `<plugin>` is left untouched; `<plugin>.sig` is written
+alongside it with exactly 64 raw bytes (no base64, no PEM, no minisign
+frame). The kernel-side verifier reads `<plugin>` and `<plugin>.sig`
+in tandem and Ed25519-verifies one against the other.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import os
+import sys
+from pathlib import Path
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+    Ed25519PrivateKey,
+    Ed25519PublicKey,
+)
+
+# Pinned format constants — must match `nexus-plugin-abi::signing` in nexus-vfs.
+SIGNATURE_FILE_SUFFIX = ".sig"
+SIGNATURE_LENGTH = 64
+PUBKEY_LENGTH = 32
+PRIVKEY_LENGTH = 32
+
+PRIVKEY_ENV = "PLUGIN_SIGNING_PRIVKEY"
+
+
+def load_privkey_from_env() -> Ed25519PrivateKey:
+    """Pull the signing key from `PLUGIN_SIGNING_PRIVKEY` and validate it."""
+    raw_b64 = os.environ.get(PRIVKEY_ENV)
+    if not raw_b64:
+        raise SystemExit(
+            f"environment variable {PRIVKEY_ENV} is empty or unset — "
+            f"set it to base64 of {PRIVKEY_LENGTH} raw Ed25519 private bytes"
+        )
+    try:
+        raw = base64.b64decode(raw_b64.strip(), validate=True)
+    except (ValueError, base64.binascii.Error) as exc:
+        raise SystemExit(f"{PRIVKEY_ENV}: not valid base64: {exc}") from exc
+    if len(raw) != PRIVKEY_LENGTH:
+        raise SystemExit(
+            f"{PRIVKEY_ENV}: decoded length {len(raw)} != expected {PRIVKEY_LENGTH}"
+        )
+    return Ed25519PrivateKey.from_private_bytes(raw)
+
+
+def sign_one(privkey: Ed25519PrivateKey, plugin: Path) -> Path:
+    """Sign one plugin file in place and return the path of the `.sig` written."""
+    if not plugin.is_file():
+        raise SystemExit(f"plugin not found or not a file: {plugin}")
+    payload = plugin.read_bytes()
+    signature = privkey.sign(payload)
+    if len(signature) != SIGNATURE_LENGTH:
+        # Defence in depth: cryptography always returns 64 for Ed25519, but
+        # an SSOT mismatch (someone bumped the constant on one side and not
+        # the other) would silently emit a sig the verifier can't read.
+        raise SystemExit(
+            f"signature length {len(signature)} != expected {SIGNATURE_LENGTH}"
+        )
+
+    sig_path = plugin.with_name(plugin.name + SIGNATURE_FILE_SUFFIX)
+    sig_path.write_bytes(signature)
+
+    # Self-check the just-written sig against the in-memory pubkey so an IO
+    # truncation, encoding accident, or wrong-keypair pairing is caught
+    # before we ship — much cheaper to fail here than in the cluster log.
+    pubkey: Ed25519PublicKey = privkey.public_key()
+    try:
+        pubkey.verify(sig_path.read_bytes(), payload)
+    except InvalidSignature as exc:
+        raise SystemExit(
+            f"self-verify failed for {sig_path} — signing pipeline is broken"
+        ) from exc
+
+    return sig_path
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(
+        description="Ed25519 detach-sign one or more plugin binaries.",
+    )
+    p.add_argument(
+        "plugins",
+        nargs="+",
+        type=Path,
+        help="plugin binaries to sign (`.so` / `.dylib` / `.dll`)",
+    )
+    args = p.parse_args(argv)
+
+    privkey = load_privkey_from_env()
+    for plugin in args.plugins:
+        sig_path = sign_one(privkey, plugin)
+        sha = base64.b64encode(privkey.public_key().public_bytes_raw()).decode()
+        print(f"signed {plugin} -> {sig_path} (pubkey {sha[:8]}...)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Half 2 of the cross-repo plugin signing 0→1 (kernel-side verify is at https://github.com/nexi-lab/nexus-vfs/pull/52).

## What this PR does

1. **`scripts/sign_plugin.py`** — a tiny Ed25519 detached signer. Reads `PLUGIN_SIGNING_PRIVKEY` (base64 of 32 raw bytes, sourced from a repo secret on `nexi-lab/nexus`), signs each argument file, writes `<arg>.sig` (raw 64 bytes) next to it. Self-verifies the just-written sig against the in-memory pubkey so an IO truncation or wrong-keypair pairing is caught at signing time.
2. **`release-vault-plugin.yml`** — adds a sign step between "Download all build artifacts" and "Package into archives". Each release archive now ships both the dylib AND its `.sig`:
   - `nexus-vault-linux-x86_64.tar.gz` → `libnexus_vault.so` + `libnexus_vault.so.sig`
   - `nexus-vault-macos-arm64.tar.gz` → `libnexus_vault.dylib` + `libnexus_vault.dylib.sig`
   - `nexus-vault-macos-x86_64.tar.gz` → `libnexus_vault.dylib` + `libnexus_vault.dylib.sig`
   - `nexus-vault-windows-x86_64.zip` → `nexus_vault.dll` + `nexus_vault.dll.sig`

## Where the key is

- **Private** — `PLUGIN_SIGNING_PRIVKEY` repo secret on `nexi-lab/nexus`. Already set. Never echoed, never written to disk during CI — stays in process memory for the duration of the sign call.
- **Public** — `nexus-vfs/rust/kernel/trusted_keys/nexus-team.pub` (committed in the matching PR). The pubkey is `include_bytes!`'d into `nexusd-cluster` at compile time so the trust root is part of the binary, not loaded from disk at runtime.

## Format SSOT

Pinned in `nexus_plugin_abi::signing` (in nexus-vfs):
- `SIGNATURE_FILE_SUFFIX = ".sig"`
- `SIGNATURE_LENGTH = 64` (raw Ed25519, no header)
- `PUBKEY_LENGTH = 32` (base64 in `.pub` files)

This script hardcodes the same values with a comment pointing at the SSOT. If either side ever bumps a constant, bump the other side in the same coordinated PR.

## Coordinated rollout (please read before tag)

The verify code in `nexus-vfs#52` rejects unsigned plugins outright — there is no `--allow-unsigned` escape hatch. So:

1. Land nexi-lab/nexus-vfs#52 → next `nexusd-cluster` build includes verify.
2. Merge this PR → cut `vault-v0.1.2` tag → CI publishes signed archives to COS at `nexus-vault/release/v0.1.2/`.
3. In sudowork, bump both runtime versions (cluster + vault) + update `download-nexus-vfs.js` to extract `.sig` alongside the dylib. That sudowork bump is the rollout point — until then, end users keep running the old unsigned-friendly cluster + old unsigned vault.

## Smoke test

Local round-trip verified with a throwaway keypair: sign → write `.sig` (64 bytes) → verify against pubkey passes; tampered plugin rejected by the same pubkey.