### PR TITLE
chore(deps): bump nexus-vfs to d78e4ae — durable kernel metastore (#4343)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,7 +168,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=32c47310e48d449bb5c3f02e48ef12455bf0e8fa#32c47310e48d449bb5c3f02e48ef12455bf0e8fa"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=d78e4ae83de68b6d024f1561674622650089640c#d78e4ae83de68b6d024f1561674622650089640c"
 dependencies = [
  "ahash",
  "base64",
@@ -214,6 +214,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bincode"
@@ -363,6 +369,12 @@ checksum = "ea0095f6103c2a8b44acd6fd15960c801dafebf02e21940360833e0673f48ba7"
 
 [[package]]
 name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
@@ -396,7 +408,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=32c47310e48d449bb5c3f02e48ef12455bf0e8fa#32c47310e48d449bb5c3f02e48ef12455bf0e8fa"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=d78e4ae83de68b6d024f1561674622650089640c#d78e4ae83de68b6d024f1561674622650089640c"
 dependencies = [
  "parking_lot",
  "serde",
@@ -506,6 +518,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "digest 0.10.7",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "dashmap"
 version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -517,6 +556,16 @@ dependencies = [
  "lock_api",
  "once_cell",
  "parking_lot_core",
+]
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid 0.9.6",
+ "zeroize",
 ]
 
 [[package]]
@@ -546,8 +595,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.0",
- "const-oid",
+ "const-oid 0.10.2",
  "crypto-common 0.2.2",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "serde",
+ "sha2 0.10.9",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -604,6 +677,12 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "find-msvc-tools"
@@ -1087,7 +1166,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=32c47310e48d449bb5c3f02e48ef12455bf0e8fa#32c47310e48d449bb5c3f02e48ef12455bf0e8fa"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=d78e4ae83de68b6d024f1561674622650089640c#d78e4ae83de68b6d024f1561674622650089640c"
 dependencies = [
  "ahash",
  "base64",
@@ -1098,6 +1177,7 @@ dependencies = [
  "contracts",
  "crc32fast",
  "dashmap",
+ "ed25519-dalek",
  "fastcdc",
  "futures",
  "globset",
@@ -1137,7 +1217,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=32c47310e48d449bb5c3f02e48ef12455bf0e8fa#32c47310e48d449bb5c3f02e48ef12455bf0e8fa"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=d78e4ae83de68b6d024f1561674622650089640c#d78e4ae83de68b6d024f1561674622650089640c"
 dependencies = [
  "ahash",
  "base64",
@@ -1155,7 +1235,7 @@ dependencies = [
  "roaring",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "string-interner",
  "thiserror",
  "time",
@@ -1300,7 +1380,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=32c47310e48d449bb5c3f02e48ef12455bf0e8fa#32c47310e48d449bb5c3f02e48ef12455bf0e8fa"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=d78e4ae83de68b6d024f1561674622650089640c#d78e4ae83de68b6d024f1561674622650089640c"
 
 [[package]]
 name = "nexus-vault"
@@ -1420,6 +1500,16 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
 
 [[package]]
 name = "polyval"
@@ -1727,6 +1817,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1929,6 +2028,17 @@ dependencies = [
 
 [[package]]
 name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
@@ -1952,6 +2062,15 @@ checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
  "errno",
  "libc",
+]
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "rand_core",
 ]
 
 [[package]]
@@ -1995,6 +2114,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,7 +168,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=d78e4ae83de68b6d024f1561674622650089640c#d78e4ae83de68b6d024f1561674622650089640c"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=67ac07f04e509d00eb462b984ef17883eb376211#67ac07f04e509d00eb462b984ef17883eb376211"
 dependencies = [
  "ahash",
  "base64",
@@ -408,7 +408,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=d78e4ae83de68b6d024f1561674622650089640c#d78e4ae83de68b6d024f1561674622650089640c"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=67ac07f04e509d00eb462b984ef17883eb376211#67ac07f04e509d00eb462b984ef17883eb376211"
 dependencies = [
  "parking_lot",
  "serde",
@@ -1166,7 +1166,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=d78e4ae83de68b6d024f1561674622650089640c#d78e4ae83de68b6d024f1561674622650089640c"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=67ac07f04e509d00eb462b984ef17883eb376211#67ac07f04e509d00eb462b984ef17883eb376211"
 dependencies = [
  "ahash",
  "base64",
@@ -1217,7 +1217,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=d78e4ae83de68b6d024f1561674622650089640c#d78e4ae83de68b6d024f1561674622650089640c"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=67ac07f04e509d00eb462b984ef17883eb376211#67ac07f04e509d00eb462b984ef17883eb376211"
 dependencies = [
  "ahash",
  "base64",
@@ -1380,7 +1380,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=d78e4ae83de68b6d024f1561674622650089640c#d78e4ae83de68b6d024f1561674622650089640c"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=67ac07f04e509d00eb462b984ef17883eb376211#67ac07f04e509d00eb462b984ef17883eb376211"
 
 [[package]]
 name = "nexus-vault"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,13 +26,13 @@ exclude = ["nexus-fuse"]
 # restart's cross-zone routes are always re-wired).  Bump alongside
 # the rest of nexus-vfs updates when a downstream change needs newer
 # kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "32c47310e48d449bb5c3f02e48ef12455bf0e8fa" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "32c47310e48d449bb5c3f02e48ef12455bf0e8fa" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "32c47310e48d449bb5c3f02e48ef12455bf0e8fa" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "32c47310e48d449bb5c3f02e48ef12455bf0e8fa", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "32c47310e48d449bb5c3f02e48ef12455bf0e8fa", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "32c47310e48d449bb5c3f02e48ef12455bf0e8fa", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "32c47310e48d449bb5c3f02e48ef12455bf0e8fa" }
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "d78e4ae83de68b6d024f1561674622650089640c" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "d78e4ae83de68b6d024f1561674622650089640c" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "d78e4ae83de68b6d024f1561674622650089640c" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "d78e4ae83de68b6d024f1561674622650089640c", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "d78e4ae83de68b6d024f1561674622650089640c", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "d78e4ae83de68b6d024f1561674622650089640c", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "d78e4ae83de68b6d024f1561674622650089640c" }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,13 +26,13 @@ exclude = ["nexus-fuse"]
 # restart's cross-zone routes are always re-wired).  Bump alongside
 # the rest of nexus-vfs updates when a downstream change needs newer
 # kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "d78e4ae83de68b6d024f1561674622650089640c" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "d78e4ae83de68b6d024f1561674622650089640c" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "d78e4ae83de68b6d024f1561674622650089640c" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "d78e4ae83de68b6d024f1561674622650089640c", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "d78e4ae83de68b6d024f1561674622650089640c", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "d78e4ae83de68b6d024f1561674622650089640c", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "d78e4ae83de68b6d024f1561674622650089640c" }
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "67ac07f04e509d00eb462b984ef17883eb376211" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "67ac07f04e509d00eb462b984ef17883eb376211" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "67ac07f04e509d00eb462b984ef17883eb376211" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "67ac07f04e509d00eb462b984ef17883eb376211", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "67ac07f04e509d00eb462b984ef17883eb376211", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "67ac07f04e509d00eb462b984ef17883eb376211", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "67ac07f04e509d00eb462b984ef17883eb376211" }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ENV CARGO_NET_RETRY=10 \
     CARGO_HTTP_TIMEOUT=120
 # Override for edge/CI or a different pin: --build-arg NEXUS_VFS_REV=<sha|tag>
-ARG NEXUS_VFS_REV=f4227a21bc8a7546477bc3851bd9407f3579f925
+ARG NEXUS_VFS_REV=d78e4ae83de68b6d024f1561674622650089640c
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,id=cargo-install-${TARGETARCH},target=/root/.cargo/target \

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ENV CARGO_NET_RETRY=10 \
     CARGO_HTTP_TIMEOUT=120
 # Override for edge/CI or a different pin: --build-arg NEXUS_VFS_REV=<sha|tag>
-ARG NEXUS_VFS_REV=d78e4ae83de68b6d024f1561674622650089640c
+ARG NEXUS_VFS_REV=67ac07f04e509d00eb462b984ef17883eb376211
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,id=cargo-install-${TARGETARCH},target=/root/.cargo/target \


### PR DESCRIPTION
Carries [nexus-vfs#42](https://github.com/nexi-lab/nexus-vfs/pull/42) (merged as `d78e4ae`) into the product: the cluster kernel finally persists its VFS namespace across restarts — fixes #4343, the failure mode that wiped all file visibility on koodle prod twice on 2026-06-09.

**Changes**
- `Cargo.toml`: all 7 `nexus-vfs` workspace rev pins `32c4731` → `d78e4ae` (+ `Cargo.lock` regenerated — picks up the ed25519 chain from plugin-signing #52, also in range).
- `Dockerfile`: `ARG NEXUS_VFS_REV` → `d78e4ae` so image builds compile the fixed `nexusd-full`.

**Validation**
- `cargo check --workspace` green at the new rev (235 crates).
- The kernel change itself was E2E-validated downstream against a docker stack built at this rev's predecessor head: write → container restart → `exists` stays true; `ephemeral` opt-out reproduces the old amnesia; empty env refuses to boot (evidence: DeepBuildAI/koodle#1302).

**Operator note**: the metastore override env is `NEXUS_KERNEL_METASTORE_PATH` — deliberately not `NEXUS_METASTORE_PATH`, which the Python server sets for its own legacy metadata path and copies into the kernel subprocess (details in the arg docs / nexus-vfs#42 discussion).

Close #4343 once this merges; the remaining nice-to-have from that issue (an upstream walk-import admin command for already-bitten instances) is split out separately.