### PR TITLE
[codex] Batch Tiger resource map sync

### DIFF
--- a/src/nexus/bricks/rebac/cache/tiger/resource_map.py
+++ b/src/nexus/bricks/rebac/cache/tiger/resource_map.py
@@ -51,6 +51,10 @@ class TigerResourceMap:
         self._int_to_uuid: dict[int, tuple[str, str]] = {}  # int -> (type, id)
         self._lock = threading.RLock()
 
+    def connection(self) -> "Connection":
+        """Open a database connection for callers that batch resource-map work."""
+        return self._engine.connect()
+
     def get_or_create_int_id(
         self,
         resource_type: str,
@@ -142,6 +146,74 @@ class TigerResourceMap:
             self._int_to_uuid[int_id] = key
 
         return int_id
+
+    def bulk_get_or_create_int_ids(
+        self,
+        resources: list[tuple[str, str]],
+        conn: "Connection | None" = None,
+    ) -> dict[tuple[str, str], int]:
+        """Bulk get or create integer IDs for resources.
+
+        Inserts all cache misses in one conflict-tolerant statement, commits
+        once, then refreshes the in-memory map with a batched SELECT.
+        """
+        if not resources:
+            return {}
+
+        unique_resources: list[tuple[str, str]] = []
+        seen: set[tuple[str, str]] = set()
+        for resource in resources:
+            if resource in seen:
+                continue
+            seen.add(resource)
+            unique_resources.append(resource)
+
+        results: dict[tuple[str, str], int] = {}
+        missing: list[tuple[str, str]] = []
+        with self._lock:
+            for resource in unique_resources:
+                int_id = self._uuid_to_int.get(resource)
+                if int_id is None:
+                    missing.append(resource)
+                else:
+                    results[resource] = int_id
+
+        if not missing:
+            return results
+
+        def execute(connection: "Connection") -> None:
+            created_at = datetime.now(UTC)
+            rows = [
+                {
+                    "resource_type": resource_type,
+                    "resource_id": resource_id,
+                    "created_at": created_at,
+                }
+                for resource_type, resource_id in missing
+            ]
+            if self._is_postgresql:
+                connection.execute(
+                    pg_insert(TRM).on_conflict_do_nothing(
+                        index_elements=["resource_type", "resource_id"],
+                    ),
+                    rows,
+                )
+            else:
+                connection.execute(insert(TRM).prefix_with("OR IGNORE"), rows)
+            connection.commit()
+
+            fetched = self.bulk_get_int_ids(missing, connection)
+            for resource, int_id in fetched.items():
+                if int_id is not None:
+                    results[resource] = int(int_id)
+
+        if conn:
+            execute(conn)
+        else:
+            with self.connection() as new_conn:
+                execute(new_conn)
+
+        return results
 
     def get_resource_id(
         self, int_id: int, conn: "Connection | None" = None

--- a/src/nexus/bricks/rebac/tiger_cache_manager.py
+++ b/src/nexus/bricks/rebac/tiger_cache_manager.py
@@ -9,6 +9,7 @@ import os
 import sys
 import threading
 from collections.abc import Callable
+from contextlib import nullcontext
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -22,6 +23,7 @@ logger = logging.getLogger(__name__)
 # (_PRELOAD_TIMEOUT_SECONDS in bricks/search/daemon.py): boot must not block
 # indefinitely on a perf optimization.
 _DEFAULT_INIT_TIMEOUT_SECONDS = 30.0
+_RESOURCE_MAP_SYNC_CHUNK_SIZE = 500
 
 
 class TigerCacheManager:
@@ -222,29 +224,44 @@ class TigerCacheManager:
         try:
             count = 0
             log_interval = 1000
+            pending: list[tuple[str, str]] = []
 
             from nexus.contracts.types import OperationContext
 
             sys_ctx = OperationContext(user_id="system", groups=[], is_system=True)
-            for entry_path in self._nexus_fs.sys_readdir(
-                "/", recursive=True, details=False, context=sys_ctx
-            ):
-                if self._sync_stop.is_set():
-                    logger.info(
-                        "Tiger resource map sync stopped after %d resources (shutdown)",
-                        count,
-                    )
-                    return count
-                if not entry_path:
-                    continue
-                resource_map.get_or_create_int_id(
-                    resource_type="file",
-                    resource_id=str(entry_path),
-                )
-                count += 1
+            with self._resource_map_connection(resource_map) as conn:
+                for entry_path in self._nexus_fs.sys_readdir(
+                    "/", recursive=True, details=False, context=sys_ctx
+                ):
+                    if self._sync_stop.is_set():
+                        logger.info(
+                            "Tiger resource map sync stopped after %d resources (shutdown)",
+                            count,
+                        )
+                        return count
+                    if not entry_path:
+                        continue
+                    pending.append(("file", str(entry_path)))
+                    if len(pending) < _RESOURCE_MAP_SYNC_CHUNK_SIZE:
+                        continue
 
-                if count % log_interval == 0:
-                    logger.debug(f"Tiger resource map sync progress: {count} resources...")
+                    self._sync_resource_map_batch(resource_map, pending, conn)
+                    count += len(pending)
+                    pending.clear()
+
+                    if count % log_interval == 0:
+                        logger.debug(f"Tiger resource map sync progress: {count} resources...")
+
+                    if self._sync_stop.is_set():
+                        logger.info(
+                            "Tiger resource map sync stopped after %d resources (shutdown)",
+                            count,
+                        )
+                        return count
+
+                if pending and not self._sync_stop.is_set():
+                    self._sync_resource_map_batch(resource_map, pending, conn)
+                    count += len(pending)
 
             logger.info(f"Tiger resource map sync complete: {count} resources")
             return count
@@ -252,6 +269,39 @@ class TigerCacheManager:
         except Exception as e:
             logger.warning(f"Failed to sync resource map from metadata: {e}")
             return 0
+
+    def _resource_map_connection(self, resource_map: Any) -> Any:
+        connection_factory = getattr(resource_map, "connection", None)
+        if callable(connection_factory):
+            return connection_factory()
+        engine = getattr(resource_map, "_engine", None)
+        if engine is not None:
+            return engine.connect()
+        return nullcontext(None)
+
+    def _sync_resource_map_batch(
+        self,
+        resource_map: Any,
+        resources: list[tuple[str, str]],
+        conn: Any,
+    ) -> None:
+        bulk_get_or_create = getattr(resource_map, "bulk_get_or_create_int_ids", None)
+        if callable(bulk_get_or_create):
+            bulk_get_or_create(resources, conn=conn)
+            return
+
+        for resource_type, resource_id in resources:
+            try:
+                resource_map.get_or_create_int_id(
+                    resource_type=resource_type,
+                    resource_id=resource_id,
+                    conn=conn,
+                )
+            except TypeError:
+                resource_map.get_or_create_int_id(
+                    resource_type=resource_type,
+                    resource_id=resource_id,
+                )
 
     def start_worker(self) -> None:
         """Start background thread for Tiger Cache queue processing.

--- a/tests/unit/bricks/rebac/cache/tiger/test_resource_map.py
+++ b/tests/unit/bricks/rebac/cache/tiger/test_resource_map.py
@@ -1,0 +1,29 @@
+from sqlalchemy import create_engine, select
+
+from nexus.bricks.rebac.cache.tiger.resource_map import TigerResourceMap
+from nexus.storage.models import Base
+from nexus.storage.models.permissions import TigerResourceMapModel as TRM
+
+
+def test_bulk_get_or_create_int_ids_inserts_missing_and_returns_existing() -> None:
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    resource_map = TigerResourceMap(engine)
+
+    with engine.connect() as conn:
+        first = resource_map.bulk_get_or_create_int_ids(
+            [("file", "/a.txt"), ("file", "/b.txt")],
+            conn=conn,
+        )
+        second = resource_map.bulk_get_or_create_int_ids(
+            [("file", "/a.txt"), ("file", "/c.txt")],
+            conn=conn,
+        )
+        rows = conn.execute(
+            select(TRM.resource_type, TRM.resource_id).order_by(TRM.resource_int_id)
+        ).all()
+
+    assert set(first) == {("file", "/a.txt"), ("file", "/b.txt")}
+    assert set(second) == {("file", "/a.txt"), ("file", "/c.txt")}
+    assert second[("file", "/a.txt")] == first[("file", "/a.txt")]
+    assert {row.resource_id for row in rows} == {"/a.txt", "/b.txt", "/c.txt"}

--- a/tests/unit/bricks/rebac/test_tiger_cache_manager.py
+++ b/tests/unit/bricks/rebac/test_tiger_cache_manager.py
@@ -16,20 +16,53 @@ from nexus.bricks.rebac.tiger_cache_manager import TigerCacheManager
 
 
 class FakeResourceMap:
-    """Records get_or_create_int_id calls; thread-safe."""
+    """Records resource-map calls; thread-safe."""
 
     def __init__(self) -> None:
         self._lock = threading.Lock()
         self.calls: list[tuple[str, str]] = []
+        self.bulk_calls: list[list[tuple[str, str]]] = []
+        self.connection_entries = 0
+        self.connections_seen: list[object | None] = []
+        self._connection = object()
+        self.on_bulk_call = None
 
     def get_or_create_int_id(self, resource_type: str, resource_id: str) -> int:
         with self._lock:
             self.calls.append((resource_type, resource_id))
             return len(self.calls)
 
+    def connection(self):
+        resource_map = self
+
+        class FakeConnectionContext:
+            def __enter__(self):
+                resource_map.connection_entries += 1
+                return resource_map._connection
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+        return FakeConnectionContext()
+
+    def bulk_get_or_create_int_ids(
+        self,
+        resources: list[tuple[str, str]],
+        conn: object | None = None,
+    ) -> dict[tuple[str, str], int]:
+        with self._lock:
+            self.bulk_calls.append(list(resources))
+            self.connections_seen.append(conn)
+            start = sum(len(call) for call in self.bulk_calls[:-1])
+        if self.on_bulk_call is not None:
+            self.on_bulk_call()
+        return {resource: start + index + 1 for index, resource in enumerate(resources)}
+
     def paths(self) -> list[str]:
         with self._lock:
-            return [rid for _, rid in self.calls]
+            resources = [resource for call in self.bulk_calls for resource in call]
+            resources.extend(self.calls)
+            return [rid for _, rid in resources]
 
 
 class FakeTigerCache:
@@ -102,7 +135,35 @@ def test_initialize_completes_sync_before_returning_when_fast() -> None:
     manager.initialize()
 
     assert resource_map.paths() == ["/a.txt", "/b/c.txt"]
-    assert all(rtype == "file" for rtype, _ in resource_map.calls)
+    assert all(rtype == "file" for rtype, _ in resource_map.bulk_calls[0])
+
+
+def test_sync_resource_map_batches_upserts_on_one_connection() -> None:
+    paths = [f"/doc-{i}.txt" for i in range(501)]
+    resource_map = FakeResourceMap()
+    manager = make_manager(FakeNexusFS(paths), resource_map)
+
+    assert manager.sync_resource_map() == 501
+
+    assert resource_map.calls == []
+    assert [len(call) for call in resource_map.bulk_calls] == [500, 1]
+    assert resource_map.bulk_calls[0][0] == ("file", "/doc-0.txt")
+    assert resource_map.bulk_calls[0][-1] == ("file", "/doc-499.txt")
+    assert resource_map.bulk_calls[1] == [("file", "/doc-500.txt")]
+    assert resource_map.connection_entries == 1
+    assert resource_map.connections_seen == [resource_map._connection, resource_map._connection]
+
+
+def test_sync_resource_map_honors_stop_between_batches() -> None:
+    paths = [f"/doc-{i}.txt" for i in range(501)]
+    resource_map = FakeResourceMap()
+    manager = make_manager(FakeNexusFS(paths), resource_map)
+    resource_map.on_bulk_call = manager._sync_stop.set
+
+    assert manager.sync_resource_map() == 500
+
+    assert resource_map.calls == []
+    assert [len(call) for call in resource_map.bulk_calls] == [500]
 
 
 def test_sync_finishes_in_background_after_boot_timeout(


### PR DESCRIPTION
## Summary

Fixes #4360.

- Adds a bulk `TigerResourceMap.bulk_get_or_create_int_ids()` path that inserts missing resource-map rows in one conflict-tolerant statement, commits once, and refreshes IDs with a batched lookup.
- Updates `TigerCacheManager.sync_resource_map()` to sync filesystem paths in 500-resource chunks over one resource-map connection instead of calling `get_or_create_int_id()` per path.
- Adds unit coverage for chunking, stop handling between batches, connection reuse, and bulk insert/reuse behavior.

## Root Cause

Startup resource-map sync iterated every filesystem path and called `get_or_create_int_id()` individually. Each uncached path could perform its own select/insert/commit sequence and repeatedly use the DB pool, producing an N+1 startup sync pattern for large existing metadata sets.

## Verification

- `.venv/bin/python -m pytest tests/unit/bricks/rebac/test_tiger_cache_manager.py tests/unit/bricks/rebac/cache/tiger/test_resource_map.py -q` -> 15 passed
- `.venv/bin/ruff check src/nexus/bricks/rebac/tiger_cache_manager.py src/nexus/bricks/rebac/cache/tiger/resource_map.py tests/unit/bricks/rebac/test_tiger_cache_manager.py tests/unit/bricks/rebac/cache/tiger/test_resource_map.py` -> passed
- `.venv/bin/ruff format --check src/nexus/bricks/rebac/tiger_cache_manager.py src/nexus/bricks/rebac/cache/tiger/resource_map.py tests/unit/bricks/rebac/test_tiger_cache_manager.py tests/unit/bricks/rebac/cache/tiger/test_resource_map.py` -> passed
- `.venv/bin/pre-commit run mypy --files src/nexus/bricks/rebac/cache/tiger/resource_map.py src/nexus/bricks/rebac/tiger_cache_manager.py` -> passed
- `git diff --check` -> passed
- Commit hook suite on `git commit` -> passed, including ruff, ruff format, mypy, boundary checks
- Full `nexus up --build` Docker proof:
  - booted rebuilt stack with Tiger disabled, uploaded 501 files, confirmed `tiger_resource_map` stayed at 0
  - stopped stack, booted rebuilt stack with Tiger enabled
  - service log showed `Tiger resource map sync complete: 502 resources` and `Synced 502 resources to Tiger resource map`
  - DB showed 501 `/sync-e2e/%` rows from `/sync-e2e/file-000.txt` through `/sync-e2e/file-500.txt`
  - `nexus cat /sync-e2e/file-500.txt` returned `resource-map-sync-e2e 500\n`
