### PR TITLE
fix(ci): add --locked to cargo install in Dockerfiles

### DIFF
--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -38,7 +38,7 @@ COPY src/ ./src/
 RUN pip install --no-cache-dir --no-deps --prefix=/install .
 
 # Install nexusd-cluster from nexus-vfs
-RUN cargo install --git https://github.com/nexi-lab/nexus-vfs --bin nexusd-cluster nexus-cluster
+RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --bin nexusd-cluster nexus-cluster
 
 # -- Runtime stage --
 FROM python:3.14-slim

--- a/dockerfiles/Dockerfile.nexusd-cluster
+++ b/dockerfiles/Dockerfile.nexusd-cluster
@@ -39,7 +39,7 @@ WORKDIR /build
 # async wrappers) and #25 (leader-detection SSOT) — both required for
 # the L1 cross-machine federation read milestone to pass.
 ARG NEXUS_VFS_REV=32c47310e48d449bb5c3f02e48ef12455bf0e8fa
-RUN cargo install \
+RUN cargo install --locked \
     --git https://github.com/nexi-lab/nexus-vfs \
     --rev "${NEXUS_VFS_REV}" \
     --bin nexusd-cluster \

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -21,7 +21,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /build
 
-RUN cargo install --git https://github.com/nexi-lab/nexus-vfs --bin nexus-raft-server raft
+RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --bin nexus-raft-server raft
 
 # ---------- Production image ----------
 FROM debian:bookworm-slim

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -28,7 +28,7 @@ WORKDIR /build
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
 ARG NEXUS_VFS_REV=7aa2096de02d651b6ada34f065ca330316250193
-RUN cargo install \
+RUN cargo install --locked \
     --git https://github.com/nexi-lab/nexus-vfs \
     --rev "${NEXUS_VFS_REV}" \
     --bin nexus-witness \


### PR DESCRIPTION
## Summary
- Adds `--locked` flag to all `cargo install --git nexus-vfs` commands in 4 Dockerfiles
- Completes the fix from #4372 which covered CI workflows but missed Docker builds
- Root cause: `time` 0.3.48 + `rcgen` 0.14.8 have conflicting `From<HourBase>` trait impls; the committed Cargo.lock pins compatible versions (time 0.3.47 + rcgen 0.14.7)

## Test plan
- [x] Federation E2E (Docker) — the check that was failing on #4372

🤖 Generated with [Claude Code](https://claude.com/claude-code)