### PR TITLE
feat(fuse-plugin): in-process FUSE service plugin scaffolding (Phase B-1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,6 +75,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -216,12 +266,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "base64ct"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
-
-[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -341,6 +385,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -362,16 +412,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
 name = "compare"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea0095f6103c2a8b44acd6fd15960c801dafebf02e21940360833e0673f48ba7"
-
-[[package]]
-name = "const-oid"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "const-oid"
@@ -518,33 +608,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "curve25519-dalek"
-version = "4.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "curve25519-dalek-derive",
- "digest 0.10.7",
- "fiat-crypto",
- "rustc_version",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "curve25519-dalek-derive"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "dashmap"
 version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -556,16 +619,6 @@ dependencies = [
  "lock_api",
  "once_cell",
  "parking_lot_core",
-]
-
-[[package]]
-name = "der"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
-dependencies = [
- "const-oid 0.9.6",
- "zeroize",
 ]
 
 [[package]]
@@ -597,30 +650,6 @@ dependencies = [
  "block-buffer 0.12.1",
  "const-oid",
  "crypto-common 0.2.2",
-]
-
-[[package]]
-name = "ed25519"
-version = "2.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
-dependencies = [
- "pkcs8",
- "signature",
-]
-
-[[package]]
-name = "ed25519-dalek"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
-dependencies = [
- "curve25519-dalek",
- "ed25519",
- "serde",
- "sha2 0.10.9",
- "subtle",
- "zeroize",
 ]
 
 [[package]]
@@ -677,12 +706,6 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
-
-[[package]]
-name = "fiat-crypto"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "find-msvc-tools"
@@ -747,6 +770,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fuser"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80a5eca878900c2e39e9e52fd797954b7fc39eeefc8558257114bfea6a698fcf"
+dependencies = [
+ "bitflags",
+ "libc",
+ "log",
+ "memchr",
+ "nix",
+ "num_enum",
+ "page_size",
+ "parking_lot",
+ "pkg-config",
+ "ref-cast",
+ "smallvec",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1137,6 +1180,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1176,7 +1225,6 @@ dependencies = [
  "contracts",
  "crc32fast",
  "dashmap",
- "ed25519-dalek",
  "fastcdc",
  "futures",
  "globset",
@@ -1208,6 +1256,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1234,7 +1288,7 @@ dependencies = [
  "roaring",
  "serde",
  "serde_json",
- "sha2 0.11.0",
+ "sha2",
  "string-interner",
  "thiserror",
  "time",
@@ -1342,6 +1396,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1365,6 +1428,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
+name = "nexus-fuse-plugin"
+version = "0.1.0"
+dependencies = [
+ "fuser",
+ "libc",
+ "nexus-plugin-abi",
+ "tracing",
+]
+
+[[package]]
 name = "nexus-local-connector"
 version = "0.1.0"
 dependencies = [
@@ -1386,6 +1459,7 @@ name = "nexus-vault"
 version = "0.1.2"
 dependencies = [
  "backends",
+ "clap",
  "kernel",
  "libloading",
  "nexus-plugin-abi",
@@ -1395,6 +1469,29 @@ dependencies = [
  "tokio",
  "tonic",
  "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1413,16 +1510,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
 name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "parking_lot"
@@ -1501,14 +1636,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pkcs8"
-version = "0.10.2"
+name = "pkg-config"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
-dependencies = [
- "der",
- "spki",
-]
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "polyval"
@@ -1536,6 +1667,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
 ]
 
 [[package]]
@@ -1757,6 +1897,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1814,15 +1974,6 @@ name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
-
-[[package]]
-name = "rustc_version"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
-dependencies = [
- "semver",
-]
 
 [[package]]
 name = "rustix"
@@ -2027,17 +2178,6 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "digest 0.10.7",
-]
-
-[[package]]
-name = "sha2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
@@ -2045,6 +2185,15 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
  "digest 0.11.3",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -2061,15 +2210,6 @@ checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
  "errno",
  "libc",
-]
-
-[[package]]
-name = "signature"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
-dependencies = [
- "rand_core",
 ]
 
 [[package]]
@@ -2116,16 +2256,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "spki"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
-dependencies = [
- "base64ct",
- "der",
-]
-
-[[package]]
 name = "string-interner"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2134,6 +2264,12 @@ dependencies = [
  "hashbrown 0.16.1",
  "serde",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
@@ -2189,6 +2325,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -2290,6 +2435,36 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
 ]
 
 [[package]]
@@ -2421,6 +2596,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -2476,6 +2677,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "uuid"
 version = "1.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2485,6 +2692,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "varint-rs"
@@ -2609,6 +2822,28 @@ dependencies = [
  "indexmap",
  "semver",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
@@ -2750,6 +2985,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,19 @@ members = [
     # nexusd-cluster via --plugin-dir; mounted via
     # `--mount-driver local-connector:<vfs-path>:<config-json>`.
     "rust/backends/local-connector",
+    # nexus-fuse-plugin — cdylib service plugin that mounts the Nexus
+    # VFS at an operator-named host path via libfuse3 (Linux).  Spawns
+    # a fuser-based FUSE event loop in a background thread on
+    # `nexus_service_create`; FUSE ops translate in-process to kernel
+    # syscalls via the plugin-abi KernelHandle.  Loaded by
+    # nexusd-cluster via --plugin-dir alongside nexus-vault.
+    "rust/services/fuse-plugin",
 ]
 # nexus-fuse excluded: standalone FUSE daemon with different dependency versions
+# from the workspace.  Distinct from nexus-fuse-plugin (the new
+# in-process service plugin above) — the legacy daemon talks to a
+# Python FastAPI server over HTTPS REST and is being phased out as
+# the plugin matures.
 exclude = ["nexus-fuse"]
 
 [workspace.dependencies]

--- a/rust/services/fuse-plugin/Cargo.toml
+++ b/rust/services/fuse-plugin/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "nexus-fuse-plugin"
+version = "0.1.0"
+edition = "2021"
+description = "Nexus FUSE service plugin — cdylib loaded by `nexusd-cluster` via `--plugin-dir`. Spawns a fuser-based FUSE event loop on /dev/fuse and translates POSIX filesystem ops into Nexus kernel syscalls via the plugin-abi KernelHandle, in-process. Mirrors the `nexus-vault` shape so signing/release pipelines apply identically."
+authors = ["Nexus Team"]
+publish = false
+
+[lib]
+# cdylib for the loader to dlopen at startup.  rlib so unit tests can
+# link the plugin's internal Rust APIs without going through the C ABI.
+name = "nexus_fuse_plugin"
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+# Plugin ABI — stable C ABI contract for dylib plugins.
+# The `declare_service_plugin!` macro + KernelHandle live here.
+nexus-plugin-abi = { workspace = true }
+
+# `fuser` is the production-quality Rust wrapper around libfuse3 on
+# Linux / macFUSE on macOS.  We pin against the same version that
+# `nexus-fuse` (the legacy standalone daemon) used so familiar
+# semantics carry over.  Windows support is via a separate WinFsp
+# adapter — out of scope for this first-cut plugin.
+[target.'cfg(target_os = "linux")'.dependencies]
+fuser = "0.17"
+# Errno constants for translating kernel-callback failures into POSIX
+# errors that FUSE clients understand.  Linux-only — macFUSE/WinFsp
+# adapters will pull in their own equivalents.
+libc = "0.2"
+
+# tracing for diagnostic logs.  Kept opt-in via the cluster binary's
+# RUST_LOG so the plugin is silent by default.
+tracing = "0.1"

--- a/rust/services/fuse-plugin/src/fs.rs
+++ b/rust/services/fuse-plugin/src/fs.rs
@@ -86,11 +86,9 @@ fn errno_nosys() -> Errno {
 
 pub struct NexusFs {
     kernel: KernelHandle,
-    /// VFS-path prefix that maps to the FUSE root inode.  Joined with
-    /// child names to produce kernel-side paths.
-    vfs_root: String,
-    /// `inode -> VFS path` registry.  Path lookups populate this; we
-    /// never evict.
+    /// `inode -> VFS path` registry.  Root inode (FUSE_ROOT_RAW) is
+    /// seeded with the operator-supplied `vfs_root` prefix; child
+    /// lookups join from there.  We never evict.
     inodes: Mutex<HashMap<u64, String>>,
     next_inode: AtomicU64,
 }
@@ -98,10 +96,9 @@ pub struct NexusFs {
 impl NexusFs {
     pub fn new(kernel: KernelHandle, vfs_root: String) -> Self {
         let mut inodes = HashMap::new();
-        inodes.insert(FUSE_ROOT_RAW, vfs_root.clone());
+        inodes.insert(FUSE_ROOT_RAW, vfs_root);
         Self {
             kernel,
-            vfs_root,
             inodes: Mutex::new(inodes),
             // First allocated inode = root + 1; the root inode itself
             // is reserved (fuser INodeNo::ROOT == 1).

--- a/rust/services/fuse-plugin/src/fs.rs
+++ b/rust/services/fuse-plugin/src/fs.rs
@@ -63,6 +63,11 @@ const ENTRY_TTL: Duration = Duration::from_secs(1);
 /// the inode map can use plain `u64` keys.
 const FUSE_ROOT_RAW: u64 = INodeNo::ROOT.0;
 
+/// Raw i32 EIO used by the internal sys_*() C-ABI wrappers (which
+/// return `Result<_, i32>` mirroring the C-side rc).  Trait-level
+/// methods wrap it into the typed `Errno` via `errno_io()`.
+const ERRNO_IO_RAW: i32 = libc::EIO;
+
 /// `EIO` errno wrapper used as the catch-all for "kernel callback
 /// returned a non-zero status."  Refined later if we want to map
 /// specific kernel errors to ENOENT / EACCES / etc.
@@ -119,7 +124,7 @@ impl NexusFs {
     fn sys_stat(&self, path: &str) -> Result<String, i32> {
         let c_path = match CString::new(path) {
             Ok(s) => s,
-            Err(_) => return Err(ERRNO_IO),
+            Err(_) => return Err(ERRNO_IO_RAW),
         };
         let mut out_buf: *mut u8 = std::ptr::null_mut();
         let mut out_len: usize = 0;
@@ -138,7 +143,7 @@ impl NexusFs {
             let slice = std::slice::from_raw_parts(out_buf, out_len);
             let s = std::str::from_utf8(slice)
                 .map(|s| s.to_string())
-                .map_err(|_| ERRNO_IO);
+                .map_err(|_| ERRNO_IO_RAW);
             nexus_free(out_buf, out_len);
             s?
         };
@@ -150,7 +155,7 @@ impl NexusFs {
     fn sys_read(&self, path: &str) -> Result<Vec<u8>, i32> {
         let c_path = match CString::new(path) {
             Ok(s) => s,
-            Err(_) => return Err(ERRNO_IO),
+            Err(_) => return Err(ERRNO_IO_RAW),
         };
         let mut out_buf: *mut u8 = std::ptr::null_mut();
         let mut out_len: usize = 0;
@@ -178,7 +183,7 @@ impl NexusFs {
     fn sys_write(&self, path: &str, data: &[u8]) -> Result<(), i32> {
         let c_path = match CString::new(path) {
             Ok(s) => s,
-            Err(_) => return Err(ERRNO_IO),
+            Err(_) => return Err(ERRNO_IO_RAW),
         };
         let rc = unsafe {
             (self.kernel.sys_write)(

--- a/rust/services/fuse-plugin/src/fs.rs
+++ b/rust/services/fuse-plugin/src/fs.rs
@@ -321,7 +321,7 @@ impl Filesystem for NexusFs {
         _fh: FileHandle,
         offset: u64,
         size: u32,
-        _flags: fuser::AccessFlags,
+        _flags: fuser::OpenFlags,
         _lock_owner: Option<fuser::LockOwner>,
         reply: ReplyData,
     ) {
@@ -360,7 +360,7 @@ impl Filesystem for NexusFs {
         offset: u64,
         data: &[u8],
         _write_flags: fuser::WriteFlags,
-        _flags: fuser::AccessFlags,
+        _flags: fuser::OpenFlags,
         _lock_owner: Option<fuser::LockOwner>,
         reply: ReplyWrite,
     ) {

--- a/rust/services/fuse-plugin/src/fs.rs
+++ b/rust/services/fuse-plugin/src/fs.rs
@@ -43,11 +43,11 @@ use std::collections::HashMap;
 use std::ffi::CString;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Mutex;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime};
 
 use fuser::{
-    FileAttr, FileType, Filesystem, ReplyAttr, ReplyData, ReplyEmpty, ReplyEntry, ReplyOpen,
-    ReplyWrite, Request, FUSE_ROOT_ID,
+    Errno, FileAttr, FileHandle, FileType, Filesystem, Generation, INodeNo, ReplyAttr, ReplyData,
+    ReplyEmpty, ReplyEntry, ReplyOpen, ReplyWrite, Request,
 };
 
 use nexus_plugin_abi::{nexus_free, KernelHandle};
@@ -58,13 +58,26 @@ use nexus_plugin_abi::{nexus_free, KernelHandle};
 const ATTR_TTL: Duration = Duration::from_secs(1);
 const ENTRY_TTL: Duration = Duration::from_secs(1);
 
-/// `EIO` — best-fit POSIX errno for "kernel callback returned a
-/// non-zero status."  Refined later if we want to map specific kernel
-/// errors to ENOENT / EACCES / etc.
-const ERRNO_IO: i32 = libc::EIO;
-/// `ENOSYS` — surfaced for ops that depend on `KernelHandle` syscalls
-/// not yet exposed (readdir / unlink / mkdir / rmdir / rename).
-const ERRNO_NOSYS: i32 = libc::ENOSYS;
+/// Raw inode value for the FUSE root.  fuser 0.17 exposes a typed
+/// `INodeNo::ROOT` constant (the `u64` 1), which we unwrap here so
+/// the inode map can use plain `u64` keys.
+const FUSE_ROOT_RAW: u64 = INodeNo::ROOT.0;
+
+/// `EIO` errno wrapper used as the catch-all for "kernel callback
+/// returned a non-zero status."  Refined later if we want to map
+/// specific kernel errors to ENOENT / EACCES / etc.
+fn errno_io() -> Errno {
+    Errno::from_i32(libc::EIO)
+}
+fn errno_enoent() -> Errno {
+    Errno::from_i32(libc::ENOENT)
+}
+fn errno_einval() -> Errno {
+    Errno::from_i32(libc::EINVAL)
+}
+fn errno_nosys() -> Errno {
+    Errno::from_i32(libc::ENOSYS)
+}
 
 pub struct NexusFs {
     kernel: KernelHandle,
@@ -80,19 +93,19 @@ pub struct NexusFs {
 impl NexusFs {
     pub fn new(kernel: KernelHandle, vfs_root: String) -> Self {
         let mut inodes = HashMap::new();
-        inodes.insert(FUSE_ROOT_ID, vfs_root.clone());
+        inodes.insert(FUSE_ROOT_RAW, vfs_root.clone());
         Self {
             kernel,
             vfs_root,
             inodes: Mutex::new(inodes),
-            // First allocated inode = root + 1; FUSE_ROOT_ID itself is
-            // reserved.
-            next_inode: AtomicU64::new(FUSE_ROOT_ID + 1),
+            // First allocated inode = root + 1; the root inode itself
+            // is reserved (fuser INodeNo::ROOT == 1).
+            next_inode: AtomicU64::new(FUSE_ROOT_RAW + 1),
         }
     }
 
-    fn path_for(&self, ino: u64) -> Option<String> {
-        self.inodes.lock().unwrap().get(&ino).cloned()
+    fn path_for(&self, ino: INodeNo) -> Option<String> {
+        self.inodes.lock().unwrap().get(&ino.0).cloned()
     }
 
     fn alloc_inode(&self, path: String) -> u64 {
@@ -187,7 +200,7 @@ impl NexusFs {
     /// in `kernel/src/kernel/plugins/mod.rs kernel_cb_sys_stat`);
     /// we hand-roll a tiny parser to avoid pulling `serde_json` into
     /// the cdylib's dependency closure for two fields.
-    fn parse_stat(&self, ino: u64, json: &str) -> Option<FileAttr> {
+    fn parse_stat(&self, ino: INodeNo, json: &str) -> Option<FileAttr> {
         // Kernel callback exports `entry_type` (the SSOT for "what
         // kind of inode this is") rather than a precomputed
         // `is_directory` flag, so dispatch by entry_type instead.
@@ -229,6 +242,14 @@ impl NexusFs {
             flags: 0,
         })
     }
+
+    /// Same sys_stat wrapper but returning a populated FileAttr on
+    /// success.  Centralises the path → callback → parse pipeline so
+    /// lookup / getattr / readdir share one error mapping.
+    fn stat_attr(&self, ino: INodeNo, path: &str) -> Result<FileAttr, Errno> {
+        let json = self.sys_stat(path).map_err(|_| errno_enoent())?;
+        self.parse_stat(ino, &json).ok_or_else(errno_io)
+    }
 }
 
 /// Extract a `u64` from `json` by scanning for `key` and parsing the
@@ -243,99 +264,80 @@ fn json_u64(json: &str, key: &str) -> Option<u64> {
 }
 
 impl Filesystem for NexusFs {
-    fn lookup(&mut self, _req: &Request, parent: u64, name: &std::ffi::OsStr, reply: ReplyEntry) {
+    fn lookup(&self, _req: &Request, parent: INodeNo, name: &std::ffi::OsStr, reply: ReplyEntry) {
         let parent_path = match self.path_for(parent) {
             Some(p) => p,
             None => {
-                reply.error(libc::ENOENT);
+                reply.error(errno_enoent());
                 return;
             }
         };
         let name_str = match name.to_str() {
             Some(s) => s,
             None => {
-                reply.error(libc::EINVAL);
+                reply.error(errno_einval());
                 return;
             }
         };
         let path = join_path(&parent_path, name_str);
-        let json = match self.sys_stat(&path) {
-            Ok(j) => j,
-            Err(_) => {
-                reply.error(libc::ENOENT);
-                return;
-            }
-        };
-        let ino = self.alloc_inode(path.clone());
-        let attr = match self.parse_stat(ino, &json) {
-            Some(a) => a,
-            None => {
-                reply.error(ERRNO_IO);
-                return;
-            }
-        };
-        reply.entry(&ENTRY_TTL, &attr, /* generation */ 0);
+        let ino_raw = self.alloc_inode(path.clone());
+        let ino = INodeNo(ino_raw);
+        match self.stat_attr(ino, &path) {
+            Ok(attr) => reply.entry(&ENTRY_TTL, &attr, Generation(0)),
+            Err(e) => reply.error(e),
+        }
     }
 
-    fn getattr(&mut self, _req: &Request, ino: u64, _fh: Option<u64>, reply: ReplyAttr) {
+    fn getattr(&self, _req: &Request, ino: INodeNo, _fh: Option<FileHandle>, reply: ReplyAttr) {
         let path = match self.path_for(ino) {
             Some(p) => p,
             None => {
-                reply.error(libc::ENOENT);
+                reply.error(errno_enoent());
                 return;
             }
         };
-        let json = match self.sys_stat(&path) {
-            Ok(j) => j,
-            Err(_) => {
-                reply.error(libc::ENOENT);
-                return;
-            }
-        };
-        let attr = match self.parse_stat(ino, &json) {
-            Some(a) => a,
-            None => {
-                reply.error(ERRNO_IO);
-                return;
-            }
-        };
-        reply.attr(&ATTR_TTL, &attr);
+        match self.stat_attr(ino, &path) {
+            Ok(attr) => reply.attr(&ATTR_TTL, &attr),
+            Err(e) => reply.error(e),
+        }
     }
 
-    fn open(&mut self, _req: &Request, _ino: u64, _flags: i32, reply: ReplyOpen) {
-        // No per-fd state.  fh=0, flags=0 keeps it stateless.
-        reply.opened(0, 0);
+    fn open(&self, _req: &Request, _ino: INodeNo, _flags: fuser::OpenFlags, reply: ReplyOpen) {
+        // Stateless: no per-fd context.  fuser accepts FileHandle(0)
+        // as the "no handle" sentinel; FopenFlags::empty() opts out
+        // of fuser's caching hints.
+        reply.opened(FileHandle(0), fuser::FopenFlags::empty());
     }
 
     fn read(
-        &mut self,
+        &self,
         _req: &Request,
-        ino: u64,
-        _fh: u64,
+        ino: INodeNo,
+        _fh: FileHandle,
         offset: i64,
         size: u32,
-        _flags: i32,
-        _lock_owner: Option<u64>,
+        _flags: fuser::AccessFlags,
+        _lock_owner: Option<fuser::LockOwner>,
         reply: ReplyData,
     ) {
         let path = match self.path_for(ino) {
             Some(p) => p,
             None => {
-                reply.error(libc::ENOENT);
+                reply.error(errno_enoent());
                 return;
             }
         };
         let full = match self.sys_read(&path) {
             Ok(d) => d,
             Err(_) => {
-                reply.error(libc::ENOENT);
+                reply.error(errno_enoent());
                 return;
             }
         };
         // Slice by offset/size.  Once the offset-aware `sys_read`
         // extension lands in KernelHandle, this becomes a direct
-        // callback pass-through and stops reading the whole file
-        // for every page-sized FUSE read.
+        // callback pass-through and stops reading the whole file for
+        // every page-sized FUSE read.
         let start = offset as usize;
         if start >= full.len() {
             reply.data(&[]);
@@ -346,15 +348,15 @@ impl Filesystem for NexusFs {
     }
 
     fn write(
-        &mut self,
+        &self,
         _req: &Request,
-        ino: u64,
-        _fh: u64,
+        ino: INodeNo,
+        _fh: FileHandle,
         offset: i64,
         data: &[u8],
-        _write_flags: u32,
-        _flags: i32,
-        _lock_owner: Option<u64>,
+        _write_flags: fuser::WriteFlags,
+        _flags: fuser::AccessFlags,
+        _lock_owner: Option<fuser::LockOwner>,
         reply: ReplyWrite,
     ) {
         // First cut: O_TRUNC semantics only.  An offset != 0 write
@@ -363,33 +365,40 @@ impl Filesystem for NexusFs {
         // dropping bytes; CC's task-file workflow always rewrites
         // the whole JSON document so offset==0 is the common path.
         if offset != 0 {
-            reply.error(libc::EIO);
+            reply.error(errno_io());
             return;
         }
         let path = match self.path_for(ino) {
             Some(p) => p,
             None => {
-                reply.error(libc::ENOENT);
+                reply.error(errno_enoent());
                 return;
             }
         };
         match self.sys_write(&path, data) {
             Ok(()) => reply.written(data.len() as u32),
-            Err(_) => reply.error(ERRNO_IO),
+            Err(_) => reply.error(errno_io()),
         }
     }
 
-    fn flush(&mut self, _req: &Request, _ino: u64, _fh: u64, _lock_owner: u64, reply: ReplyEmpty) {
+    fn flush(
+        &self,
+        _req: &Request,
+        _ino: INodeNo,
+        _fh: FileHandle,
+        _lock_owner: fuser::LockOwner,
+        reply: ReplyEmpty,
+    ) {
         reply.ok();
     }
 
     fn release(
-        &mut self,
+        &self,
         _req: &Request,
-        _ino: u64,
-        _fh: u64,
-        _flags: i32,
-        _lock_owner: Option<u64>,
+        _ino: INodeNo,
+        _fh: FileHandle,
+        _flags: fuser::AccessFlags,
+        _lock_owner: Option<fuser::LockOwner>,
         _flush: bool,
         reply: ReplyEmpty,
     ) {
@@ -403,66 +412,66 @@ impl Filesystem for NexusFs {
     // crate's docstring as the follow-up nexus-vfs PR.
 
     fn readdir(
-        &mut self,
+        &self,
         _req: &Request,
-        _ino: u64,
-        _fh: u64,
+        _ino: INodeNo,
+        _fh: FileHandle,
         _offset: i64,
         reply: fuser::ReplyDirectory,
     ) {
-        reply.error(ERRNO_NOSYS);
+        reply.error(errno_nosys());
     }
 
     fn mkdir(
-        &mut self,
+        &self,
         _req: &Request,
-        _parent: u64,
+        _parent: INodeNo,
         _name: &std::ffi::OsStr,
         _mode: u32,
         _umask: u32,
         reply: ReplyEntry,
     ) {
-        reply.error(ERRNO_NOSYS);
+        reply.error(errno_nosys());
     }
 
-    fn unlink(&mut self, _req: &Request, _parent: u64, _name: &std::ffi::OsStr, reply: ReplyEmpty) {
-        reply.error(ERRNO_NOSYS);
+    fn unlink(&self, _req: &Request, _parent: INodeNo, _name: &std::ffi::OsStr, reply: ReplyEmpty) {
+        reply.error(errno_nosys());
     }
 
-    fn rmdir(&mut self, _req: &Request, _parent: u64, _name: &std::ffi::OsStr, reply: ReplyEmpty) {
-        reply.error(ERRNO_NOSYS);
+    fn rmdir(&self, _req: &Request, _parent: INodeNo, _name: &std::ffi::OsStr, reply: ReplyEmpty) {
+        reply.error(errno_nosys());
     }
 
     fn rename(
-        &mut self,
+        &self,
         _req: &Request,
-        _parent: u64,
+        _parent: INodeNo,
         _name: &std::ffi::OsStr,
-        _newparent: u64,
+        _newparent: INodeNo,
         _newname: &std::ffi::OsStr,
-        _flags: u32,
+        _flags: fuser::RenameFlags,
         reply: ReplyEmpty,
     ) {
-        reply.error(ERRNO_NOSYS);
+        reply.error(errno_nosys());
     }
 
     fn create(
-        &mut self,
+        &self,
         _req: &Request,
-        _parent: u64,
+        _parent: INodeNo,
         _name: &std::ffi::OsStr,
         _mode: u32,
         _umask: u32,
-        _flags: i32,
+        _flags: fuser::AccessFlags,
         reply: fuser::ReplyCreate,
     ) {
-        reply.error(ERRNO_NOSYS);
+        reply.error(errno_nosys());
     }
 
     fn setattr(
-        &mut self,
+        &self,
         _req: &Request,
-        _ino: u64,
+        _ino: INodeNo,
         _mode: Option<u32>,
         _uid: Option<u32>,
         _gid: Option<u32>,
@@ -470,14 +479,14 @@ impl Filesystem for NexusFs {
         _atime: Option<fuser::TimeOrNow>,
         _mtime: Option<fuser::TimeOrNow>,
         _ctime: Option<SystemTime>,
-        _fh: Option<u64>,
+        _fh: Option<FileHandle>,
         _crtime: Option<SystemTime>,
         _chgtime: Option<SystemTime>,
         _bkuptime: Option<SystemTime>,
         _flags: Option<u32>,
         reply: ReplyAttr,
     ) {
-        reply.error(ERRNO_NOSYS);
+        reply.error(errno_nosys());
     }
 }
 

--- a/rust/services/fuse-plugin/src/fs.rs
+++ b/rust/services/fuse-plugin/src/fs.rs
@@ -183,20 +183,31 @@ impl NexusFs {
 
     /// Parse the JSON payload `sys_stat` returns into a `FileAttr`.
     /// The kernel-side shape is `StatResult` (see
-    /// `kernel/src/kernel/mod.rs StatResult`); we hand-roll a tiny
-    /// parser to avoid pulling `serde_json` into the cdylib's
-    /// dependency closure for one path.
+    /// `kernel/src/kernel/mod.rs StatResult` and the JSON serializer
+    /// in `kernel/src/kernel/plugins/mod.rs kernel_cb_sys_stat`);
+    /// we hand-roll a tiny parser to avoid pulling `serde_json` into
+    /// the cdylib's dependency closure for two fields.
     fn parse_stat(&self, ino: u64, json: &str) -> Option<FileAttr> {
-        // Crude key-value scan — kernel-side JSON is well-formed by
-        // construction, and we only need three fields.  When stat
-        // grows more shape (gen, mode bits), promote to serde_json.
+        // Kernel callback exports `entry_type` (the SSOT for "what
+        // kind of inode this is") rather than a precomputed
+        // `is_directory` flag, so dispatch by entry_type instead.
+        // DT_DIR (1) is the only directory variant; everything else
+        // (DT_REG / DT_MOUNT / DT_PIPE / DT_STREAM /
+        // DT_EXTERNAL_STORAGE / DT_LINK) maps to a regular-file
+        // surface for FUSE callers.  DT_MOUNT would deserve a
+        // directory surface here once the FUSE layer learns how to
+        // traverse mount points; for now treating it as a regular
+        // file is consistent with the kernel returning miss on
+        // readdir against a mount root.
         let size = json_u64(json, "\"size\":")?;
-        let is_dir = json_bool(json, "\"is_directory\":")?;
-        let kind = if is_dir {
+        let entry_type = json_u64(json, "\"entry_type\":")?;
+        const DT_DIR: u64 = 1;
+        let kind = if entry_type == DT_DIR {
             FileType::Directory
         } else {
             FileType::RegularFile
         };
+        let is_dir = entry_type == DT_DIR;
         // FUSE wants a complete FileAttr; fields we don't pull from
         // sys_stat default to zero / now / 0644.
         let now = SystemTime::now();
@@ -229,18 +240,6 @@ fn json_u64(json: &str, key: &str) -> Option<u64> {
         .find(|c: char| !c.is_ascii_digit())
         .unwrap_or(after.len());
     after[..end].parse().ok()
-}
-
-/// Extract a JSON `true` / `false` from `json` after `key`.
-fn json_bool(json: &str, key: &str) -> Option<bool> {
-    let after = json.split_once(key)?.1.trim_start();
-    if after.starts_with("true") {
-        Some(true)
-    } else if after.starts_with("false") {
-        Some(false)
-    } else {
-        None
-    }
 }
 
 impl Filesystem for NexusFs {
@@ -514,22 +513,24 @@ mod tests {
     }
 
     #[test]
-    fn json_u64_extracts() {
+    fn json_u64_extracts_size() {
         assert_eq!(
-            json_u64(r#"{"size":12345,"is_directory":false}"#, "\"size\":"),
+            json_u64(r#"{"size":12345,"entry_type":0}"#, "\"size\":"),
             Some(12345)
         );
     }
 
     #[test]
-    fn json_bool_extracts() {
+    fn json_u64_extracts_entry_type() {
+        // Directory entry — kernel reports entry_type=1 (DT_DIR).
         assert_eq!(
-            json_bool(r#"{"is_directory":true}"#, "\"is_directory\":"),
-            Some(true)
+            json_u64(r#"{"size":4096,"entry_type":1}"#, "\"entry_type\":"),
+            Some(1)
         );
+        // Regular file — entry_type=0 (DT_REG).
         assert_eq!(
-            json_bool(r#"{"is_directory":false}"#, "\"is_directory\":"),
-            Some(false)
+            json_u64(r#"{"size":12,"entry_type":0}"#, "\"entry_type\":"),
+            Some(0)
         );
     }
 }

--- a/rust/services/fuse-plugin/src/fs.rs
+++ b/rust/services/fuse-plugin/src/fs.rs
@@ -1,0 +1,541 @@
+//! `NexusFs` — `fuser::Filesystem` impl that translates FUSE ops
+//! into Nexus kernel syscalls via the `KernelHandle` callback table.
+//!
+//! ## Inode model
+//!
+//! FUSE addresses files by `u64` inode numbers; Nexus VFS addresses
+//! them by path strings.  We maintain a `HashMap<u64, String>` —
+//! built incrementally on every `lookup` — that lets the FUSE ops
+//! translate an inode back into the path the kernel-side callbacks
+//! expect.  The root inode (`fuser::FUSE_ROOT_ID == 1`) maps to the
+//! configured VFS root prefix (`/` by default).  New inodes are
+//! allocated monotonically from a counter; we never recycle, which
+//! keeps the implementation lock-free in the common read path at the
+//! cost of unbounded growth on long-running mounts.  Replacing the
+//! counter with a path-cache eviction policy is a follow-up.
+//!
+//! ## What works in the first cut
+//!
+//! * `lookup` / `getattr` — both route through `sys_stat` on the path
+//!   resolved from inode mapping.  `getattr` returns a `FileAttr`
+//!   synthesised from the stat result.
+//! * `read` — reads the **entire** file via `sys_read` and slices the
+//!   returned buffer by offset / size.  This is correct but wasteful
+//!   for large files; an offset-aware `sys_read` is one of the
+//!   `KernelHandle` extensions tracked for a follow-up nexus-vfs PR.
+//! * `write` — writes the full payload at offset 0 only (effectively
+//!   `O_TRUNC` semantics).  Real offset-aware writes need the same
+//!   `KernelHandle` extension.
+//! * `open` / `release` / `flush` — no-ops; the kernel doesn't carry
+//!   per-fd state.
+//!
+//! ## What surfaces as `ENOSYS` until KernelHandle grows
+//!
+//! `readdir`, `create`, `mkdir`, `unlink`, `rmdir`, `rename`,
+//! `setattr` — every directory-mutating op and any read that depends
+//! on enumeration.  These are tracked in the parent crate's docstring
+//! as the upcoming `nexus-vfs` PR.  Reporting `ENOSYS` rather than a
+//! best-effort fake keeps the operator-visible surface honest: `ls`
+//! over the mount fails loudly until the extension lands, instead of
+//! silently returning an empty directory.
+
+use std::collections::HashMap;
+use std::ffi::CString;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Mutex;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use fuser::{
+    FileAttr, FileType, Filesystem, ReplyAttr, ReplyData, ReplyEmpty, ReplyEntry, ReplyOpen,
+    ReplyWrite, Request, FUSE_ROOT_ID,
+};
+
+use nexus_plugin_abi::{nexus_free, KernelHandle};
+
+/// Cache TTL for kernel-attributes returned to FUSE.  Set to 1 second
+/// to mirror typical NFS defaults; the kernel-side metastore is the
+/// SSOT, so stale entries self-correct within a tick.
+const ATTR_TTL: Duration = Duration::from_secs(1);
+const ENTRY_TTL: Duration = Duration::from_secs(1);
+
+/// `EIO` — best-fit POSIX errno for "kernel callback returned a
+/// non-zero status."  Refined later if we want to map specific kernel
+/// errors to ENOENT / EACCES / etc.
+const ERRNO_IO: i32 = libc::EIO;
+/// `ENOSYS` — surfaced for ops that depend on `KernelHandle` syscalls
+/// not yet exposed (readdir / unlink / mkdir / rmdir / rename).
+const ERRNO_NOSYS: i32 = libc::ENOSYS;
+
+pub struct NexusFs {
+    kernel: KernelHandle,
+    /// VFS-path prefix that maps to the FUSE root inode.  Joined with
+    /// child names to produce kernel-side paths.
+    vfs_root: String,
+    /// `inode -> VFS path` registry.  Path lookups populate this; we
+    /// never evict.
+    inodes: Mutex<HashMap<u64, String>>,
+    next_inode: AtomicU64,
+}
+
+impl NexusFs {
+    pub fn new(kernel: KernelHandle, vfs_root: String) -> Self {
+        let mut inodes = HashMap::new();
+        inodes.insert(FUSE_ROOT_ID, vfs_root.clone());
+        Self {
+            kernel,
+            vfs_root,
+            inodes: Mutex::new(inodes),
+            // First allocated inode = root + 1; FUSE_ROOT_ID itself is
+            // reserved.
+            next_inode: AtomicU64::new(FUSE_ROOT_ID + 1),
+        }
+    }
+
+    fn path_for(&self, ino: u64) -> Option<String> {
+        self.inodes.lock().unwrap().get(&ino).cloned()
+    }
+
+    fn alloc_inode(&self, path: String) -> u64 {
+        let ino = self.next_inode.fetch_add(1, Ordering::Relaxed);
+        self.inodes.lock().unwrap().insert(ino, path);
+        ino
+    }
+
+    /// Wrapper around the C `sys_stat` callback.  Returns the JSON
+    /// payload as a `String` on success.
+    fn sys_stat(&self, path: &str) -> Result<String, i32> {
+        let c_path = match CString::new(path) {
+            Ok(s) => s,
+            Err(_) => return Err(ERRNO_IO),
+        };
+        let mut out_buf: *mut u8 = std::ptr::null_mut();
+        let mut out_len: usize = 0;
+        let rc = unsafe {
+            (self.kernel.sys_stat)(
+                self.kernel.kernel_ptr,
+                c_path.as_ptr(),
+                &mut out_buf,
+                &mut out_len,
+            )
+        };
+        if rc != 0 {
+            return Err(rc);
+        }
+        let json = unsafe {
+            let slice = std::slice::from_raw_parts(out_buf, out_len);
+            let s = std::str::from_utf8(slice)
+                .map(|s| s.to_string())
+                .map_err(|_| ERRNO_IO);
+            nexus_free(out_buf, out_len);
+            s?
+        };
+        Ok(json)
+    }
+
+    /// Wrapper around the C `sys_read` callback.  Returns the full
+    /// file content as a `Vec<u8>`; callers slice for offset/size.
+    fn sys_read(&self, path: &str) -> Result<Vec<u8>, i32> {
+        let c_path = match CString::new(path) {
+            Ok(s) => s,
+            Err(_) => return Err(ERRNO_IO),
+        };
+        let mut out_buf: *mut u8 = std::ptr::null_mut();
+        let mut out_len: usize = 0;
+        let rc = unsafe {
+            (self.kernel.sys_read)(
+                self.kernel.kernel_ptr,
+                c_path.as_ptr(),
+                &mut out_buf,
+                &mut out_len,
+            )
+        };
+        if rc != 0 {
+            return Err(rc);
+        }
+        let data = unsafe {
+            let slice = std::slice::from_raw_parts(out_buf, out_len);
+            let v = slice.to_vec();
+            nexus_free(out_buf, out_len);
+            v
+        };
+        Ok(data)
+    }
+
+    /// Wrapper around the C `sys_write` callback.
+    fn sys_write(&self, path: &str, data: &[u8]) -> Result<(), i32> {
+        let c_path = match CString::new(path) {
+            Ok(s) => s,
+            Err(_) => return Err(ERRNO_IO),
+        };
+        let rc = unsafe {
+            (self.kernel.sys_write)(
+                self.kernel.kernel_ptr,
+                c_path.as_ptr(),
+                data.as_ptr(),
+                data.len(),
+            )
+        };
+        if rc != 0 {
+            return Err(rc);
+        }
+        Ok(())
+    }
+
+    /// Parse the JSON payload `sys_stat` returns into a `FileAttr`.
+    /// The kernel-side shape is `StatResult` (see
+    /// `kernel/src/kernel/mod.rs StatResult`); we hand-roll a tiny
+    /// parser to avoid pulling `serde_json` into the cdylib's
+    /// dependency closure for one path.
+    fn parse_stat(&self, ino: u64, json: &str) -> Option<FileAttr> {
+        // Crude key-value scan — kernel-side JSON is well-formed by
+        // construction, and we only need three fields.  When stat
+        // grows more shape (gen, mode bits), promote to serde_json.
+        let size = json_u64(json, "\"size\":")?;
+        let is_dir = json_bool(json, "\"is_directory\":")?;
+        let kind = if is_dir {
+            FileType::Directory
+        } else {
+            FileType::RegularFile
+        };
+        // FUSE wants a complete FileAttr; fields we don't pull from
+        // sys_stat default to zero / now / 0644.
+        let now = SystemTime::now();
+        Some(FileAttr {
+            ino,
+            size,
+            blocks: size.div_ceil(512),
+            atime: now,
+            mtime: now,
+            ctime: now,
+            crtime: now,
+            kind,
+            perm: if is_dir { 0o755 } else { 0o644 },
+            nlink: if is_dir { 2 } else { 1 },
+            uid: unsafe { libc::getuid() },
+            gid: unsafe { libc::getgid() },
+            rdev: 0,
+            blksize: 4096,
+            flags: 0,
+        })
+    }
+}
+
+/// Extract a `u64` from `json` by scanning for `key` and parsing the
+/// digits that follow.  Returns `None` if the key isn't present or
+/// the value isn't a non-negative integer.
+fn json_u64(json: &str, key: &str) -> Option<u64> {
+    let after = json.split_once(key)?.1.trim_start();
+    let end = after
+        .find(|c: char| !c.is_ascii_digit())
+        .unwrap_or(after.len());
+    after[..end].parse().ok()
+}
+
+/// Extract a JSON `true` / `false` from `json` after `key`.
+fn json_bool(json: &str, key: &str) -> Option<bool> {
+    let after = json.split_once(key)?.1.trim_start();
+    if after.starts_with("true") {
+        Some(true)
+    } else if after.starts_with("false") {
+        Some(false)
+    } else {
+        None
+    }
+}
+
+impl Filesystem for NexusFs {
+    fn lookup(&mut self, _req: &Request, parent: u64, name: &std::ffi::OsStr, reply: ReplyEntry) {
+        let parent_path = match self.path_for(parent) {
+            Some(p) => p,
+            None => {
+                reply.error(libc::ENOENT);
+                return;
+            }
+        };
+        let name_str = match name.to_str() {
+            Some(s) => s,
+            None => {
+                reply.error(libc::EINVAL);
+                return;
+            }
+        };
+        let path = join_path(&parent_path, name_str);
+        let json = match self.sys_stat(&path) {
+            Ok(j) => j,
+            Err(_) => {
+                reply.error(libc::ENOENT);
+                return;
+            }
+        };
+        let ino = self.alloc_inode(path.clone());
+        let attr = match self.parse_stat(ino, &json) {
+            Some(a) => a,
+            None => {
+                reply.error(ERRNO_IO);
+                return;
+            }
+        };
+        reply.entry(&ENTRY_TTL, &attr, /* generation */ 0);
+    }
+
+    fn getattr(&mut self, _req: &Request, ino: u64, _fh: Option<u64>, reply: ReplyAttr) {
+        let path = match self.path_for(ino) {
+            Some(p) => p,
+            None => {
+                reply.error(libc::ENOENT);
+                return;
+            }
+        };
+        let json = match self.sys_stat(&path) {
+            Ok(j) => j,
+            Err(_) => {
+                reply.error(libc::ENOENT);
+                return;
+            }
+        };
+        let attr = match self.parse_stat(ino, &json) {
+            Some(a) => a,
+            None => {
+                reply.error(ERRNO_IO);
+                return;
+            }
+        };
+        reply.attr(&ATTR_TTL, &attr);
+    }
+
+    fn open(&mut self, _req: &Request, _ino: u64, _flags: i32, reply: ReplyOpen) {
+        // No per-fd state.  fh=0, flags=0 keeps it stateless.
+        reply.opened(0, 0);
+    }
+
+    fn read(
+        &mut self,
+        _req: &Request,
+        ino: u64,
+        _fh: u64,
+        offset: i64,
+        size: u32,
+        _flags: i32,
+        _lock_owner: Option<u64>,
+        reply: ReplyData,
+    ) {
+        let path = match self.path_for(ino) {
+            Some(p) => p,
+            None => {
+                reply.error(libc::ENOENT);
+                return;
+            }
+        };
+        let full = match self.sys_read(&path) {
+            Ok(d) => d,
+            Err(_) => {
+                reply.error(libc::ENOENT);
+                return;
+            }
+        };
+        // Slice by offset/size.  Once the offset-aware `sys_read`
+        // extension lands in KernelHandle, this becomes a direct
+        // callback pass-through and stops reading the whole file
+        // for every page-sized FUSE read.
+        let start = offset as usize;
+        if start >= full.len() {
+            reply.data(&[]);
+            return;
+        }
+        let end = (start + size as usize).min(full.len());
+        reply.data(&full[start..end]);
+    }
+
+    fn write(
+        &mut self,
+        _req: &Request,
+        ino: u64,
+        _fh: u64,
+        offset: i64,
+        data: &[u8],
+        _write_flags: u32,
+        _flags: i32,
+        _lock_owner: Option<u64>,
+        reply: ReplyWrite,
+    ) {
+        // First cut: O_TRUNC semantics only.  An offset != 0 write
+        // surfaces as EIO until the offset-aware kernel callback
+        // lands.  This is honest about the gap rather than silently
+        // dropping bytes; CC's task-file workflow always rewrites
+        // the whole JSON document so offset==0 is the common path.
+        if offset != 0 {
+            reply.error(libc::EIO);
+            return;
+        }
+        let path = match self.path_for(ino) {
+            Some(p) => p,
+            None => {
+                reply.error(libc::ENOENT);
+                return;
+            }
+        };
+        match self.sys_write(&path, data) {
+            Ok(()) => reply.written(data.len() as u32),
+            Err(_) => reply.error(ERRNO_IO),
+        }
+    }
+
+    fn flush(&mut self, _req: &Request, _ino: u64, _fh: u64, _lock_owner: u64, reply: ReplyEmpty) {
+        reply.ok();
+    }
+
+    fn release(
+        &mut self,
+        _req: &Request,
+        _ino: u64,
+        _fh: u64,
+        _flags: i32,
+        _lock_owner: Option<u64>,
+        _flush: bool,
+        reply: ReplyEmpty,
+    ) {
+        reply.ok();
+    }
+
+    // ── Ops that need KernelHandle to grow ───────────────────────────
+    //
+    // Surface as ENOSYS until the matching syscall is added to the
+    // plugin ABI's KernelHandle struct.  Tracked in the parent
+    // crate's docstring as the follow-up nexus-vfs PR.
+
+    fn readdir(
+        &mut self,
+        _req: &Request,
+        _ino: u64,
+        _fh: u64,
+        _offset: i64,
+        reply: fuser::ReplyDirectory,
+    ) {
+        reply.error(ERRNO_NOSYS);
+    }
+
+    fn mkdir(
+        &mut self,
+        _req: &Request,
+        _parent: u64,
+        _name: &std::ffi::OsStr,
+        _mode: u32,
+        _umask: u32,
+        reply: ReplyEntry,
+    ) {
+        reply.error(ERRNO_NOSYS);
+    }
+
+    fn unlink(
+        &mut self,
+        _req: &Request,
+        _parent: u64,
+        _name: &std::ffi::OsStr,
+        reply: ReplyEmpty,
+    ) {
+        reply.error(ERRNO_NOSYS);
+    }
+
+    fn rmdir(&mut self, _req: &Request, _parent: u64, _name: &std::ffi::OsStr, reply: ReplyEmpty) {
+        reply.error(ERRNO_NOSYS);
+    }
+
+    fn rename(
+        &mut self,
+        _req: &Request,
+        _parent: u64,
+        _name: &std::ffi::OsStr,
+        _newparent: u64,
+        _newname: &std::ffi::OsStr,
+        _flags: u32,
+        reply: ReplyEmpty,
+    ) {
+        reply.error(ERRNO_NOSYS);
+    }
+
+    fn create(
+        &mut self,
+        _req: &Request,
+        _parent: u64,
+        _name: &std::ffi::OsStr,
+        _mode: u32,
+        _umask: u32,
+        _flags: i32,
+        reply: fuser::ReplyCreate,
+    ) {
+        reply.error(ERRNO_NOSYS);
+    }
+
+    fn setattr(
+        &mut self,
+        _req: &Request,
+        _ino: u64,
+        _mode: Option<u32>,
+        _uid: Option<u32>,
+        _gid: Option<u32>,
+        _size: Option<u64>,
+        _atime: Option<fuser::TimeOrNow>,
+        _mtime: Option<fuser::TimeOrNow>,
+        _ctime: Option<SystemTime>,
+        _fh: Option<u64>,
+        _crtime: Option<SystemTime>,
+        _chgtime: Option<SystemTime>,
+        _bkuptime: Option<SystemTime>,
+        _flags: Option<u32>,
+        reply: ReplyAttr,
+    ) {
+        reply.error(ERRNO_NOSYS);
+    }
+}
+
+/// Join a parent VFS path and a child file name into the canonical
+/// `parent/child` form the kernel expects.  Strips trailing slashes
+/// from `parent` so `/` + `foo` == `/foo` (not `//foo`).
+fn join_path(parent: &str, name: &str) -> String {
+    if parent == "/" {
+        format!("/{name}")
+    } else {
+        let p = parent.trim_end_matches('/');
+        format!("{p}/{name}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn join_path_root() {
+        assert_eq!(join_path("/", "foo"), "/foo");
+    }
+
+    #[test]
+    fn join_path_nested() {
+        assert_eq!(join_path("/a/b", "c"), "/a/b/c");
+    }
+
+    #[test]
+    fn join_path_strips_trailing_slash() {
+        assert_eq!(join_path("/a/b/", "c"), "/a/b/c");
+    }
+
+    #[test]
+    fn json_u64_extracts() {
+        assert_eq!(
+            json_u64(r#"{"size":12345,"is_directory":false}"#, "\"size\":"),
+            Some(12345)
+        );
+    }
+
+    #[test]
+    fn json_bool_extracts() {
+        assert_eq!(
+            json_bool(r#"{"is_directory":true}"#, "\"is_directory\":"),
+            Some(true)
+        );
+        assert_eq!(
+            json_bool(r#"{"is_directory":false}"#, "\"is_directory\":"),
+            Some(false)
+        );
+    }
+}

--- a/rust/services/fuse-plugin/src/fs.rs
+++ b/rust/services/fuse-plugin/src/fs.rs
@@ -426,13 +426,7 @@ impl Filesystem for NexusFs {
         reply.error(ERRNO_NOSYS);
     }
 
-    fn unlink(
-        &mut self,
-        _req: &Request,
-        _parent: u64,
-        _name: &std::ffi::OsStr,
-        reply: ReplyEmpty,
-    ) {
+    fn unlink(&mut self, _req: &Request, _parent: u64, _name: &std::ffi::OsStr, reply: ReplyEmpty) {
         reply.error(ERRNO_NOSYS);
     }
 

--- a/rust/services/fuse-plugin/src/fs.rs
+++ b/rust/services/fuse-plugin/src/fs.rs
@@ -319,7 +319,7 @@ impl Filesystem for NexusFs {
         _req: &Request,
         ino: INodeNo,
         _fh: FileHandle,
-        offset: i64,
+        offset: u64,
         size: u32,
         _flags: fuser::AccessFlags,
         _lock_owner: Option<fuser::LockOwner>,
@@ -357,7 +357,7 @@ impl Filesystem for NexusFs {
         _req: &Request,
         ino: INodeNo,
         _fh: FileHandle,
-        offset: i64,
+        offset: u64,
         data: &[u8],
         _write_flags: fuser::WriteFlags,
         _flags: fuser::AccessFlags,
@@ -402,7 +402,7 @@ impl Filesystem for NexusFs {
         _req: &Request,
         _ino: INodeNo,
         _fh: FileHandle,
-        _flags: fuser::AccessFlags,
+        _flags: fuser::OpenFlags,
         _lock_owner: Option<fuser::LockOwner>,
         _flush: bool,
         reply: ReplyEmpty,
@@ -421,7 +421,7 @@ impl Filesystem for NexusFs {
         _req: &Request,
         _ino: INodeNo,
         _fh: FileHandle,
-        _offset: i64,
+        _offset: u64,
         reply: fuser::ReplyDirectory,
     ) {
         reply.error(errno_nosys());
@@ -467,7 +467,7 @@ impl Filesystem for NexusFs {
         _name: &std::ffi::OsStr,
         _mode: u32,
         _umask: u32,
-        _flags: fuser::AccessFlags,
+        _flags: i32,
         reply: fuser::ReplyCreate,
     ) {
         reply.error(errno_nosys());
@@ -488,7 +488,7 @@ impl Filesystem for NexusFs {
         _crtime: Option<SystemTime>,
         _chgtime: Option<SystemTime>,
         _bkuptime: Option<SystemTime>,
-        _flags: Option<u32>,
+        _flags: Option<fuser::BsdFileFlags>,
         reply: ReplyAttr,
     ) {
         reply.error(errno_nosys());

--- a/rust/services/fuse-plugin/src/lib.rs
+++ b/rust/services/fuse-plugin/src/lib.rs
@@ -1,0 +1,211 @@
+//! `nexus-fuse-plugin` — FUSE service-plugin dylib.
+//!
+//! Loaded by `nexusd-cluster` at startup via `--plugin-dir`.  Registers
+//! as a service plugin named `"fuse"` through the plugin ABI's
+//! `declare_service_plugin!` macro.  On `create`, spawns a fuser-based
+//! FUSE event loop in a background thread that mounts the Nexus VFS at
+//! an operator-named host path.  POSIX filesystem ops landing on that
+//! mount point translate **in-process** to Nexus kernel syscalls via
+//! the same `KernelHandle` callback table the loader handed to
+//! `nexus_service_create` — no gRPC, no client process, no socket.
+//!
+//! ## Why a service plugin (and not a separate daemon)
+//!
+//! The legacy `nexus-fuse` crate is a standalone process that talks to
+//! a Python FastAPI server over HTTPS REST.  Every filesystem syscall
+//! crosses two process boundaries plus a serialization round-trip;
+//! latency on the hot path is dominated by transport, not by the
+//! filesystem itself.  The service-plugin model puts the FUSE event
+//! loop in the same process as the kernel.  Each filesystem op is one
+//! C-ABI function call into kernel-resident code — same cost as a
+//! direct `kernel.sys_read(path)`.  The architecture matches what
+//! `nexus-vault` does for password ops: bridge a service-tier surface
+//! (gRPC / FUSE / whatever) into kernel syscalls without leaving the
+//! process.
+//!
+//! ## Operator surface
+//!
+//! Mount point + VFS path prefix come from environment variables read
+//! at `nexus_service_create` time:
+//!
+//!   * `NEXUS_FUSE_MOUNT_POINT` — host path where Nexus VFS will be
+//!     mounted (e.g. `/mnt/nexus`).  Must exist and be empty.
+//!   * `NEXUS_FUSE_VFS_ROOT` — VFS path prefix to expose at the mount
+//!     point's root (defaults to `/`).
+//!
+//! Both default to placeholder values when the env vars are absent, so
+//! `--plugin-dir` scans don't fail on hosts that load the dylib for
+//! ABI introspection only.  The plugin no-ops in that case (event loop
+//! exits immediately, no mount happens).  Production deployments
+//! always set these env vars in the daemon's launch environment.
+//!
+//! ## Platform support
+//!
+//! Linux first (`libfuse3` via the `fuser` crate).  macOS support
+//! piggybacks on `fuser`'s macFUSE backend the moment we add the
+//! `target_os = "macos"` cfg gate.  Windows requires a separate
+//! WinFsp adapter — out of scope for this first cut.
+
+#[cfg(target_os = "linux")]
+mod fs;
+
+#[cfg(target_os = "linux")]
+use std::sync::Mutex;
+
+use nexus_plugin_abi::{declare_service_plugin, KernelHandle};
+
+/// Plugin state held between `create` and `destroy`.
+///
+/// On Linux, owns the `fuser::BackgroundSession` driving the FUSE
+/// event loop — dropping it sends an unmount + joins the worker
+/// thread.  On non-Linux targets, holds nothing; the plugin is
+/// effectively a no-op.
+struct FusePlugin {
+    #[cfg(target_os = "linux")]
+    session: Mutex<Option<fuser::BackgroundSession>>,
+    #[cfg(not(target_os = "linux"))]
+    _phantom: (),
+}
+
+impl FusePlugin {
+    fn new() -> Self {
+        Self {
+            #[cfg(target_os = "linux")]
+            session: Mutex::new(None),
+            #[cfg(not(target_os = "linux"))]
+            _phantom: (),
+        }
+    }
+}
+
+/// Plugin-lifecycle `create`: read operator config from env, build the
+/// FUSE filesystem instance, and spawn the event loop in a background
+/// thread.  Returns the boxed `FusePlugin` even when the mount fails —
+/// the dispatch surface exposes a `"status"` method that operators can
+/// poll to see whether the event loop is actually running.  The
+/// alternative (returning null from `create`) would block the
+/// nexusd-cluster boot path on a recoverable mount failure, which
+/// over-couples plugin lifecycle to operator-environment correctness.
+#[allow(unused_variables)] // _kernel unused on non-Linux until those targets land
+fn create_fuse_plugin(_kernel: &KernelHandle) -> Box<FusePlugin> {
+    let plugin = FusePlugin::new();
+
+    #[cfg(target_os = "linux")]
+    {
+        let mount_point = std::env::var("NEXUS_FUSE_MOUNT_POINT").ok();
+        if let Some(mount_point) = mount_point {
+            let vfs_root = std::env::var("NEXUS_FUSE_VFS_ROOT").unwrap_or_else(|_| "/".to_string());
+
+            // SAFETY: KernelHandle's function pointers and `kernel_ptr`
+            // are documented to remain valid for the plugin's lifetime.
+            // The fuser background session keeps `NexusFs` alive only
+            // while the FUSE event loop runs, which can't outlive the
+            // plugin instance (destroy joins the worker thread before
+            // dropping the box).
+            let kernel_clone = unsafe { kernel_handle_clone(_kernel) };
+            let fs = fs::NexusFs::new(kernel_clone, vfs_root);
+
+            match fuser::spawn_mount2(fs, &mount_point, &fuser::MountOption::default_options()) {
+                Ok(session) => {
+                    tracing::info!(
+                        target: "nexus::fuse",
+                        mount_point = %mount_point,
+                        "FUSE event loop spawned"
+                    );
+                    *plugin.session.lock().unwrap() = Some(session);
+                }
+                Err(e) => {
+                    tracing::error!(
+                        target: "nexus::fuse",
+                        mount_point = %mount_point,
+                        error = %e,
+                        "FUSE mount failed; plugin will report status=unmounted"
+                    );
+                }
+            }
+        } else {
+            tracing::warn!(
+                target: "nexus::fuse",
+                "NEXUS_FUSE_MOUNT_POINT not set — plugin loaded but no mount performed"
+            );
+        }
+    }
+
+    Box::new(plugin)
+}
+
+/// Clone the kernel handle so the FUSE thread owns its own copy.
+/// `KernelHandle` is a `#[repr(C)]` bag of function pointers + an
+/// opaque kernel pointer; cloning is just a field-by-field copy.  The
+/// kernel guarantees the underlying state lives at least as long as
+/// any plugin holding a clone (loader holds the `Arc<Kernel>` via the
+/// `DylibRustService` it stores).
+#[cfg(target_os = "linux")]
+unsafe fn kernel_handle_clone(src: &KernelHandle) -> KernelHandle {
+    KernelHandle {
+        sys_read: src.sys_read,
+        sys_write: src.sys_write,
+        sys_stat: src.sys_stat,
+        kernel_ptr: src.kernel_ptr,
+    }
+}
+
+/// Plugin-lifecycle `dispatch` — admin-method surface invoked by the
+/// service registry.  This is the **gRPC-style** path; the FUSE event
+/// loop itself doesn't ride dispatch (it runs continuously in a
+/// background thread and serves FUSE ops via the kernel handle
+/// directly).  Methods here are operator pokes: `status` for a health
+/// probe, `unmount` for shutdown without dropping the whole plugin.
+///
+/// Payload encoding: plain UTF-8 strings on input and output for the
+/// first-cut admin surface.  When more structured methods land
+/// (`stat-one-path`, `walk-tree`), graduate to prost-encoded protobuf
+/// to match vault's payload shape.
+fn dispatch_fuse(svc: &FusePlugin, method: &str, _payload: &[u8]) -> Result<Vec<u8>, i32> {
+    match method {
+        "status" => {
+            #[cfg(target_os = "linux")]
+            {
+                let mounted = svc.session.lock().unwrap().is_some();
+                Ok(if mounted {
+                    b"mounted".to_vec()
+                } else {
+                    b"unmounted".to_vec()
+                })
+            }
+            #[cfg(not(target_os = "linux"))]
+            {
+                let _ = svc;
+                Ok(b"unsupported-platform".to_vec())
+            }
+        }
+        "unmount" => {
+            #[cfg(target_os = "linux")]
+            {
+                let session = svc.session.lock().unwrap().take();
+                if session.is_some() {
+                    // Dropping the BackgroundSession sends the unmount
+                    // ioctl and joins the worker thread.
+                    drop(session);
+                    Ok(b"ok".to_vec())
+                } else {
+                    Ok(b"not-mounted".to_vec())
+                }
+            }
+            #[cfg(not(target_os = "linux"))]
+            {
+                let _ = svc;
+                Ok(b"unsupported-platform".to_vec())
+            }
+        }
+        _ => {
+            // -1 maps to PluginResult::NotFound on the loader side.
+            Err(-1)
+        }
+    }
+}
+
+declare_service_plugin!("fuse", FusePlugin, {
+    create: create_fuse_plugin,
+    dispatch: dispatch_fuse,
+});

--- a/rust/services/fuse-plugin/src/lib.rs
+++ b/rust/services/fuse-plugin/src/lib.rs
@@ -105,7 +105,12 @@ fn create_fuse_plugin(_kernel: &KernelHandle) -> Box<FusePlugin> {
             let kernel_clone = unsafe { kernel_handle_clone(_kernel) };
             let fs = fs::NexusFs::new(kernel_clone, vfs_root);
 
-            match fuser::spawn_mount2(fs, &mount_point, &fuser::MountOption::default_options()) {
+            // Minimal MountOption set — defaults are sufficient for
+            // cc-tasks-share's flat-file read/write workflow.  Operators
+            // who need uid/gid mapping or read-only mounts set them via
+            // the OS-level FUSE mount wrapper, not the plugin.
+            let mount_opts: &[fuser::MountOption] = &[];
+            match fuser::spawn_mount2(fs, &mount_point, mount_opts) {
                 Ok(session) => {
                     tracing::info!(
                         target: "nexus::fuse",

--- a/rust/services/fuse-plugin/src/lib.rs
+++ b/rust/services/fuse-plugin/src/lib.rs
@@ -105,12 +105,12 @@ fn create_fuse_plugin(_kernel: &KernelHandle) -> Box<FusePlugin> {
             let kernel_clone = unsafe { kernel_handle_clone(_kernel) };
             let fs = fs::NexusFs::new(kernel_clone, vfs_root);
 
-            // Minimal MountOption set — defaults are sufficient for
-            // cc-tasks-share's flat-file read/write workflow.  Operators
-            // who need uid/gid mapping or read-only mounts set them via
-            // the OS-level FUSE mount wrapper, not the plugin.
-            let mount_opts: &[fuser::MountOption] = &[];
-            match fuser::spawn_mount2(fs, &mount_point, mount_opts) {
+            // Default fuser::Config is sufficient for cc-tasks-share's
+            // flat-file read/write workflow.  Operators who need uid/gid
+            // mapping or read-only mounts set them via the OS-level FUSE
+            // mount wrapper, not the plugin.
+            let mount_config = fuser::Config::default();
+            match fuser::spawn_mount2(fs, &mount_point, &mount_config) {
                 Ok(session) => {
                     tracing::info!(
                         target: "nexus::fuse",


### PR DESCRIPTION
## Why

Closes the FUSE gap on the Mac↔Win `cc tasks list` milestone path.  cc-tasks-share Docker E2E (nexus#4362, merged) pinned the substrate at the **gRPC API** layer — bytes flow across federated Nexus nodes, byte-exact in both directions.  But CC reads/writes its task files as **POSIX filesystem** ops (`~/.claude/tasks/<session>/<n>.json`); it doesn't speak gRPC.  We need a FUSE mount that translates POSIX → Nexus syscalls, in the same process as the kernel, so the substrate is reachable to anything that opens a file.

The plan-of-record (see nexi-lab/nexus-vfs#46 commit chain) calls for FUSE to be a **service plugin** alongside vault — `declare_service_plugin!` + `cdylib`, loaded by `nexusd-cluster` via `--plugin-dir` — not a separate daemon.  Same shape, different transport (FUSE opcodes vs gRPC methods).

## What's in this PR

* New `rust/services/fuse-plugin/` crate, cdylib + rlib.
* `declare_service_plugin!("fuse", FusePlugin, { create, dispatch })` with the canonical 3-symbol C ABI surface.
* `create` reads `NEXUS_FUSE_MOUNT_POINT` + `NEXUS_FUSE_VFS_ROOT` from env and spawns a `fuser::BackgroundSession` driving `/dev/fuse`.  Missing-env path is a no-op (the dylib still loads cleanly so `--plugin-dir` ABI scans work on hosts without a configured mount).
* `dispatch` exposes `status` and `unmount` as admin pokes.
* `NexusFs` impls `fuser::Filesystem` and translates FUSE ops to Nexus kernel syscalls via the plugin-abi `KernelHandle`'s three callbacks (`sys_read` / `sys_write` / `sys_stat`), **in-process** — every filesystem op is one C-ABI function call into kernel-resident code.

## What's **not** in this PR

### Plugin signing

This plugin ships unsigned in this PR.  Tracked alongside the same gap that left `libnexus_local_connector.so` unsigned post-substrate-merge (see nexus#4374).  The signing-tooling AI's work covers both: once the Ed25519 `.sig` pipeline lands for vault → local-connector, this plugin's release Dockerfile (a follow-up PR, not in this scaffolding cut) gets the same one-line signing helper call.

### Directory ops + offset-aware read/write

The current `KernelHandle` (in `nexus-plugin-abi`) exposes only `sys_read` / `sys_write` / `sys_stat`.  That's enough for `cat` / `echo > file` / `stat` workflows but leaves `readdir` / `create` / `mkdir` / `unlink` / `rmdir` / `rename` / `setattr` with no callback to call.  Those FUSE ops surface as **`ENOSYS`** — failing loudly is better than silently faking an empty directory.

The follow-up nexus-vfs PR extends `KernelHandle` (bumping `PLUGIN_API_VERSION`) with:
* `sys_readdir(kernel, path) → Vec<(String, EntryType)>`
* `sys_unlink(kernel, path) → ()`
* `sys_mkdir(kernel, path, mode) → ()`
* `sys_rmdir(kernel, path) → ()`
* `sys_rename(kernel, old, new) → ()`
* offset-aware `sys_read(kernel, path, offset, len)` + `sys_write(kernel, path, offset, data)`

Once it lands, the `ENOSYS` stubs swap to the real callbacks in a one-commit follow-up here and `ls /mnt/nexus` + large-file streaming starts working.

### macFUSE + WinFsp

Linux-only (`#[cfg(target_os = "linux")]`).  fuser's macFUSE backend is one cfg gate away; WinFsp is a different crate (`confuse` or `winfsp-rs`) so it gets its own adapter PR.

## Test plan

- [x] `cargo check -p nexus-fuse-plugin` on Windows (non-target-os path) — clean
- [ ] `cargo build -p nexus-fuse-plugin` on Linux CI — fuser pulls in libfuse3 headers via build dep
- [ ] Unit tests: `json_u64` / `json_bool` / `join_path`
- [ ] Manual smoke once kernel-extension PR lands: `docker run` with `--plugin-dir`, `NEXUS_FUSE_MOUNT_POINT=/mnt/nexus`, `echo hello > /mnt/nexus/foo.txt`, `cat /mnt/nexus/foo.txt`, `ls /mnt/nexus` (the last one is the readdir/ENOSYS regression boundary)
- [ ] CI e2e once readdir lands — same compose shape as cc-tasks-share, swap in FUSE mount point

## Coordination

* Signing AI — nexus#4374 (LocalConnector regression) + this plugin (both unsigned, both unblock once their pipeline ships)
* Kernel-extension follow-up — separate PR I'll open in nexus-vfs once I know if anyone else is touching plugin-abi (will check before authoring)