### PR TITLE
feat(plugin-signing): vault-dogfood path + compliance gate

### DIFF
--- a/.github/workflows/plugin-signing-compliance.yml
+++ b/.github/workflows/plugin-signing-compliance.yml
@@ -1,0 +1,44 @@
+name: Plugin Signing Compliance
+
+# Per-PR gate that asserts every cdylib in the workspace has a release
+# workflow which signs it. New cdylibs without a signing path get red CI
+# at PR time — much cheaper than discovering at operator-install time that
+# the cluster's PluginLoader::load rejects the unsigned binary.
+#
+# Make this a REQUIRED check on `develop` branch protection once the
+# workspace passes (i.e. after both vault and localconnect have release
+# workflows on the reusable).
+
+on:
+  push:
+    branches: [develop]
+    paths:
+      - "rust/**/Cargo.toml"
+      - ".github/workflows/release-*.yml"
+      - ".github/workflows/plugin-signing-compliance.yml"
+      - "scripts/check_plugin_signing_compliance.py"
+      - "scripts/sign_plugin.py"
+  pull_request:
+    paths:
+      - "rust/**/Cargo.toml"
+      - ".github/workflows/release-*.yml"
+      - ".github/workflows/plugin-signing-compliance.yml"
+      - "scripts/check_plugin_signing_compliance.py"
+      - "scripts/sign_plugin.py"
+
+jobs:
+  check:
+    name: every cdylib has a signed-release workflow
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+
+      - name: Run compliance check
+        run: python scripts/check_plugin_signing_compliance.py

--- a/.github/workflows/release-fuse-plugin.yml
+++ b/.github/workflows/release-fuse-plugin.yml
@@ -1,0 +1,54 @@
+name: Release FUSE Plugin
+
+# Release pipeline for the nexus-fuse-plugin cdylib — wrapper around
+# the reusable plugin-release workflow. Triggered by tags of the form
+# `fuse-v<semver>`.
+#
+# Linux-only — fuser bindings cover Linux libfuse3 + macFUSE in principle,
+# but the current plugin pins fuser only under `cfg(target_os = "linux")`.
+# macOS / Windows shipping waits on the WinFsp / macFUSE adapter the
+# fuse-plugin Cargo.toml's lib doc references.
+#
+# Uses the dogfood signing path (`signing_key_source: vault`) — vault is
+# the trust root for every non-vault plugin's signing key. Wrapper is
+# committed now so the compliance gate is green; the vault path itself
+# becomes runnable once the encrypted-in-git architecture PR ships
+# (see docs/superpowers/specs/2026-06-12-encrypted-in-git-vault-dogfood-design.md).
+#
+# COS path convention: nexus-fuse-plugin/release/v<version>/<filename>
+
+on:
+  push:
+    tags:
+      - "fuse-v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    uses: ./.github/workflows/release-plugin-reusable.yml
+    with:
+      plugin_name: nexus-fuse-plugin
+      dylib_basename: libnexus_fuse_plugin
+      archive_prefix: nexus-fuse-plugin
+      cos_subdir: nexus-fuse-plugin/release
+      version_tag_prefix: fuse-v
+      signing_key_source: vault
+      signing_key_name: signing-keys/kernel-dogfood-v1
+      platforms: '["linux-x86_64"]'
+      release_description: |
+        Nexus FUSE service plugin for nexusd-cluster.
+
+        Spawns a fuser-based FUSE event loop on `/dev/fuse` and translates
+        POSIX filesystem ops into Nexus kernel syscalls via the plugin-abi
+        KernelHandle, in-process. Linux only; macFUSE / WinFsp adapters
+        are out of scope for this first-cut.
+    secrets:
+      VAULT_SIGNING_ENDPOINT: ${{ secrets.VAULT_SIGNING_ENDPOINT }}
+      VAULT_SIGNING_TOKEN: ${{ secrets.VAULT_SIGNING_TOKEN }}
+      COS_SECRET_ID: ${{ secrets.COS_SECRET_ID }}
+      COS_SECRET_KEY: ${{ secrets.COS_SECRET_KEY }}
+      COS_BUCKET: ${{ secrets.COS_BUCKET }}
+      COS_REGION: ${{ secrets.COS_REGION }}
+      COS_BASE_URL: ${{ secrets.COS_BASE_URL }}

--- a/.github/workflows/release-local-connector-plugin.yml
+++ b/.github/workflows/release-local-connector-plugin.yml
@@ -1,0 +1,47 @@
+name: Release Local-Connector Plugin
+
+# Release pipeline for the nexus-local-connector cdylib — wrapper around
+# the reusable plugin-release workflow. Triggered by tags of the form
+# `local-connector-v<semver>`.
+#
+# Uses the dogfood signing path (`signing_key_source: vault`) — vault is
+# the trust root for every non-vault plugin's signing key. The privkey
+# `signing-keys/kernel-dogfood-v1` is provisioned via
+# scripts/provision_dogfood_key.py and the corresponding pubkey is
+# committed into nexus-vfs/rust/kernel/trusted_keys/.
+#
+# COS path convention: nexus-local-connector/release/v<version>/<filename>
+
+on:
+  push:
+    tags:
+      - "local-connector-v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    uses: ./.github/workflows/release-plugin-reusable.yml
+    with:
+      plugin_name: nexus-local-connector
+      dylib_basename: libnexus_local_connector
+      archive_prefix: nexus-local-connector
+      cos_subdir: nexus-local-connector/release
+      version_tag_prefix: local-connector-v
+      signing_key_source: vault
+      signing_key_name: signing-keys/kernel-dogfood-v1
+      release_description: |
+        Nexus local-connector driver plugin for nexusd-cluster.
+
+        Wraps `backends::storage::local_connector::LocalConnectorBackend` as a
+        driver dylib so operators can mount a host filesystem path through the
+        kernel's normal VFS surface (and, by extension, through federation).
+    secrets:
+      VAULT_SIGNING_ENDPOINT: ${{ secrets.VAULT_SIGNING_ENDPOINT }}
+      VAULT_SIGNING_TOKEN: ${{ secrets.VAULT_SIGNING_TOKEN }}
+      COS_SECRET_ID: ${{ secrets.COS_SECRET_ID }}
+      COS_SECRET_KEY: ${{ secrets.COS_SECRET_KEY }}
+      COS_BUCKET: ${{ secrets.COS_BUCKET }}
+      COS_REGION: ${{ secrets.COS_REGION }}
+      COS_BASE_URL: ${{ secrets.COS_BASE_URL }}

--- a/.github/workflows/release-plugin-reusable.yml
+++ b/.github/workflows/release-plugin-reusable.yml
@@ -55,6 +55,11 @@ on:
         required: false
         type: number
         default: 8388608   # 8 MiB
+      platforms:
+        description: 'JSON array of platform suffixes to build. Plugins that don''t support all 4 platforms (e.g. nexus-fuse-plugin is Linux-only) shrink the matrix here. Valid entries: linux-x86_64, macos-arm64, macos-x86_64, windows-x86_64.'
+        required: false
+        type: string
+        default: '["linux-x86_64", "macos-arm64", "macos-x86_64", "windows-x86_64"]'
       release_description:
         description: Multi-line markdown shown in the GitHub Release body under the version header. Optional.
         required: false
@@ -87,12 +92,15 @@ permissions:
 
 jobs:
   # ── Build ──────────────────────────────────────────────────────────────────
-  # 4-platform build matrix. Dylib names are derived from `dylib_basename`:
+  # Up-to-4-platform build matrix. Dylib names are derived from `dylib_basename`:
   #   linux:   <dylib_basename>.so
   #   macos:   <dylib_basename>.dylib   (arm64 + x86_64)
   #   windows: <dylib_basename> with the leading `lib` stripped + `.dll`
+  # The job-level `if` filters out platforms not listed in `inputs.platforms`.
+  # Skipped matrix instances complete without spawning a runner.
   build:
-    name: build / ${{ matrix.artifact_name }}
+    if: contains(fromJSON(inputs.platforms), matrix.artifact_name_suffix)
+    name: build / ${{ matrix.artifact_name_suffix }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
     strategy:
@@ -308,20 +316,39 @@ jobs:
         # The verifier side (nexus-vfs cluster) reads the `.sig` next to
         # the loaded plugin and Ed25519-verifies against an embedded
         # `trusted_keys/*.pub`. Format contract in `nexus_plugin_abi::signing`.
+        #
+        # Iterates over actually-present artifact dirs so a subset-platform
+        # plugin (e.g. fuse-plugin = linux-only) doesn't need a per-platform
+        # if-skip; the build job's `platforms` input already produced only
+        # the right subset of artifacts.
         env:
           PREFIX: ${{ inputs.archive_prefix }}
           BASENAME: ${{ inputs.dylib_basename }}
         run: |
           set -euo pipefail
-          # Reconstruct platform-specific dylib names matching the build job.
           win_dll="${BASENAME#lib}.dll"
-          python scripts/sign_plugin.py \
-            "artifacts/${PREFIX}-linux-x86_64/${BASENAME}.so" \
-            "artifacts/${PREFIX}-macos-arm64/${BASENAME}.dylib" \
-            "artifacts/${PREFIX}-macos-x86_64/${BASENAME}.dylib" \
-            "artifacts/${PREFIX}-windows-x86_64/${win_dll}"
+          files=()
+          for art_dir in artifacts/${PREFIX}-*/; do
+            [ -d "$art_dir" ] || continue
+            suffix=$(basename "$art_dir" | sed "s/^${PREFIX}-//")
+            case "$suffix" in
+              linux-*)   files+=("${art_dir}${BASENAME}.so") ;;
+              macos-*)   files+=("${art_dir}${BASENAME}.dylib") ;;
+              windows-*) files+=("${art_dir}${win_dll}") ;;
+              *) echo "::error::unknown platform suffix '$suffix' under $art_dir" ; exit 1 ;;
+            esac
+          done
+          if [ "${#files[@]}" -eq 0 ]; then
+            echo "::error::no plugin artifacts found under artifacts/${PREFIX}-*"
+            exit 1
+          fi
+          python scripts/sign_plugin.py "${files[@]}"
 
       - name: Package into archives
+        # Each archive ships the dylib AND its detached `.sig`. The
+        # consumer (sudowork download script) extracts both into the
+        # plugin dir; the kernel's PluginLoader::load reads them in
+        # tandem and rejects the plugin if verify fails.
         env:
           PREFIX: ${{ inputs.archive_prefix }}
           BASENAME: ${{ inputs.dylib_basename }}
@@ -329,35 +356,31 @@ jobs:
           set -euo pipefail
           mkdir -p release-assets
           win_dll="${BASENAME#lib}.dll"
-
-          # Each archive ships the dylib AND its detached `.sig`. The
-          # consumer (sudowork download script) extracts both into the
-          # plugin dir; the kernel's PluginLoader::load reads them in
-          # tandem and rejects the plugin if verify fails.
-
-          # Linux x86_64
-          cp "artifacts/${PREFIX}-linux-x86_64/${BASENAME}.so" "${BASENAME}.so"
-          cp "artifacts/${PREFIX}-linux-x86_64/${BASENAME}.so.sig" "${BASENAME}.so.sig"
-          tar -czf "release-assets/${PREFIX}-linux-x86_64.tar.gz" "${BASENAME}.so" "${BASENAME}.so.sig"
-          rm "${BASENAME}.so" "${BASENAME}.so.sig"
-
-          # macOS arm64
-          cp "artifacts/${PREFIX}-macos-arm64/${BASENAME}.dylib" "${BASENAME}.dylib"
-          cp "artifacts/${PREFIX}-macos-arm64/${BASENAME}.dylib.sig" "${BASENAME}.dylib.sig"
-          tar -czf "release-assets/${PREFIX}-macos-arm64.tar.gz" "${BASENAME}.dylib" "${BASENAME}.dylib.sig"
-          rm "${BASENAME}.dylib" "${BASENAME}.dylib.sig"
-
-          # macOS x86_64
-          cp "artifacts/${PREFIX}-macos-x86_64/${BASENAME}.dylib" "${BASENAME}.dylib"
-          cp "artifacts/${PREFIX}-macos-x86_64/${BASENAME}.dylib.sig" "${BASENAME}.dylib.sig"
-          tar -czf "release-assets/${PREFIX}-macos-x86_64.tar.gz" "${BASENAME}.dylib" "${BASENAME}.dylib.sig"
-          rm "${BASENAME}.dylib" "${BASENAME}.dylib.sig"
-
-          # Windows x86_64
-          cp "artifacts/${PREFIX}-windows-x86_64/${win_dll}" "${win_dll}"
-          cp "artifacts/${PREFIX}-windows-x86_64/${win_dll}.sig" "${win_dll}.sig"
-          zip "release-assets/${PREFIX}-windows-x86_64.zip" "${win_dll}" "${win_dll}.sig"
-          rm "${win_dll}" "${win_dll}.sig"
+          for art_dir in artifacts/${PREFIX}-*/; do
+            [ -d "$art_dir" ] || continue
+            suffix=$(basename "$art_dir" | sed "s/^${PREFIX}-//")
+            case "$suffix" in
+              linux-*)
+                cp "${art_dir}${BASENAME}.so" "${BASENAME}.so"
+                cp "${art_dir}${BASENAME}.so.sig" "${BASENAME}.so.sig"
+                tar -czf "release-assets/${PREFIX}-${suffix}.tar.gz" "${BASENAME}.so" "${BASENAME}.so.sig"
+                rm "${BASENAME}.so" "${BASENAME}.so.sig"
+                ;;
+              macos-*)
+                cp "${art_dir}${BASENAME}.dylib" "${BASENAME}.dylib"
+                cp "${art_dir}${BASENAME}.dylib.sig" "${BASENAME}.dylib.sig"
+                tar -czf "release-assets/${PREFIX}-${suffix}.tar.gz" "${BASENAME}.dylib" "${BASENAME}.dylib.sig"
+                rm "${BASENAME}.dylib" "${BASENAME}.dylib.sig"
+                ;;
+              windows-*)
+                cp "${art_dir}${win_dll}" "${win_dll}"
+                cp "${art_dir}${win_dll}.sig" "${win_dll}.sig"
+                zip "release-assets/${PREFIX}-${suffix}.zip" "${win_dll}" "${win_dll}.sig"
+                rm "${win_dll}" "${win_dll}.sig"
+                ;;
+              *) echo "::error::unknown platform suffix '$suffix' under $art_dir" ; exit 1 ;;
+            esac
+          done
 
           echo "=== release-assets ==="
           ls -lh release-assets/

--- a/.github/workflows/release-plugin-reusable.yml
+++ b/.github/workflows/release-plugin-reusable.yml
@@ -1,0 +1,468 @@
+name: Release Plugin (reusable)
+
+# Reusable release pipeline for any cdylib plugin loaded by nexusd-cluster.
+# Builds across 4 platforms, Ed25519-signs each dylib, packages into
+# platform-appropriate archives, uploads to COS, and creates a GitHub
+# Release.
+#
+# Signing key source is selectable so we can dogfood:
+#   * github-secret — privkey lives in the PLUGIN_SIGNING_PRIVKEY repo
+#                     secret (vault's bootstrap path).
+#   * vault         — privkey lives inside a running vault cluster; this
+#                     workflow calls scripts/vault_get_signing_key.py to
+#                     pull it at sign time. Used for every non-vault plugin.
+#
+# Either way, sign_plugin.py just reads PLUGIN_SIGNING_PRIVKEY from env —
+# it is source-agnostic.
+#
+# COS path convention: <cos_subdir>/v<version>/<filename>
+#   e.g. nexus-vault/release/v0.1.2/nexus-vault-linux-x86_64.tar.gz
+
+on:
+  workflow_call:
+    inputs:
+      plugin_name:
+        description: Cargo package name (e.g. nexus-vault, nexus-local-connector).
+        required: true
+        type: string
+      dylib_basename:
+        description: Dylib basename without platform suffix (e.g. libnexus_vault, libnexus_local_connector). Linux uses .so, macOS .dylib, Windows drops the 'lib' prefix and uses .dll.
+        required: true
+        type: string
+      archive_prefix:
+        description: Per-platform archive filename prefix (e.g. nexus-vault → nexus-vault-linux-x86_64.tar.gz). Also used as the artifact-name prefix between build and package jobs.
+        required: true
+        type: string
+      cos_subdir:
+        description: COS path subdir for uploaded archives. Final path is `<cos_subdir>/v<version>/<filename>`.
+        required: true
+        type: string
+      version_tag_prefix:
+        description: Git tag prefix used to extract the version (e.g. `vault-v` for tags `vault-v0.1.2`). The caller's `on.push.tags` pattern must match this prefix.
+        required: true
+        type: string
+      signing_key_source:
+        description: Where the signing privkey comes from. `github-secret` reads it directly from `secrets.PLUGIN_SIGNING_PRIVKEY`. `vault` calls scripts/vault_get_signing_key.py against the dogfood cluster.
+        required: true
+        type: string
+      signing_key_name:
+        description: "For `signing_key_source: vault`, the `<namespace>/<key>` to fetch (e.g. signing-keys/kernel-dogfood-v1). Ignored when source is github-secret."
+        required: false
+        type: string
+        default: ""
+      max_size_bytes:
+        description: Per-platform max dylib size in bytes. Cluster's plugin loader has no hard cap, but a regression budget keeps bloat visible at PR time.
+        required: false
+        type: number
+        default: 8388608   # 8 MiB
+      release_description:
+        description: Multi-line markdown shown in the GitHub Release body under the version header. Optional.
+        required: false
+        type: string
+        default: ""
+
+    secrets:
+      PLUGIN_SIGNING_PRIVKEY:
+        description: Bootstrap signing privkey (base64 of 32 raw Ed25519 priv bytes). Required when signing_key_source=github-secret.
+        required: false
+      VAULT_SIGNING_TOKEN:
+        description: Bearer token for the vault plugin's auth surface. Required when signing_key_source=vault.
+        required: false
+      VAULT_SIGNING_ENDPOINT:
+        description: gRPC endpoint of the cluster running vault.dylib. Required when signing_key_source=vault.
+        required: false
+      COS_SECRET_ID:
+        required: false
+      COS_SECRET_KEY:
+        required: false
+      COS_BUCKET:
+        required: false
+      COS_REGION:
+        required: false
+      COS_BASE_URL:
+        required: false
+
+permissions:
+  contents: write
+
+jobs:
+  # ── Build ──────────────────────────────────────────────────────────────────
+  # 4-platform build matrix. Dylib names are derived from `dylib_basename`:
+  #   linux:   <dylib_basename>.so
+  #   macos:   <dylib_basename>.dylib   (arm64 + x86_64)
+  #   windows: <dylib_basename> with the leading `lib` stripped + `.dll`
+  build:
+    name: build / ${{ matrix.artifact_name }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            artifact_name_suffix: linux-x86_64
+            dylib_ext: .so
+            strip_lib_prefix: false
+          - os: macos-14
+            artifact_name_suffix: macos-arm64
+            dylib_ext: .dylib
+            strip_lib_prefix: false
+          - os: macos-14
+            artifact_name_suffix: macos-x86_64
+            dylib_ext: .dylib
+            target: x86_64-apple-darwin
+            strip_lib_prefix: false
+          - os: windows-latest
+            artifact_name_suffix: windows-x86_64
+            dylib_ext: .dll
+            strip_lib_prefix: true
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install protoc (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          set -euo pipefail
+          PROTOC_VERSION=3.20.2
+          case "$(uname -m)" in
+            arm64) ARCH=aarch_64 ;;
+            x86_64) ARCH=x86_64 ;;
+            *) echo "Unsupported arch: $(uname -m)" >&2; exit 1 ;;
+          esac
+          mkdir -p "$HOME/protoc"
+          curl -fsSL -o /tmp/protoc.zip \
+            "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-osx-${ARCH}.zip"
+          unzip -o /tmp/protoc.zip -d "$HOME/protoc"
+          echo "$HOME/protoc/bin" >> "$GITHUB_PATH"
+          "$HOME/protoc/bin/protoc" --version
+
+      - name: Install protoc (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $protocVersion = '3.20.2'
+          $protocDir = Join-Path $env:USERPROFILE 'protoc'
+          New-Item -ItemType Directory -Force -Path $protocDir | Out-Null
+          $zipPath = Join-Path $env:RUNNER_TEMP 'protoc.zip'
+          Invoke-WebRequest -UseBasicParsing -Uri `
+            "https://github.com/protocolbuffers/protobuf/releases/download/v${protocVersion}/protoc-${protocVersion}-win64.zip" `
+            -OutFile $zipPath
+          Expand-Archive -Force -Path $zipPath -DestinationPath $protocDir
+          $protocBinDir = Join-Path $protocDir 'bin'
+          $protocExe = Join-Path $protocBinDir 'protoc.exe'
+          Add-Content -Path $env:GITHUB_PATH -Value $protocBinDir
+          Add-Content -Path $env:GITHUB_ENV -Value "PROTOC=$protocExe"
+          & $protocExe --version
+
+      - name: Install Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache: false
+          target: ${{ matrix.target || '' }}
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ${{ inputs.plugin_name }}-${{ matrix.os }}-${{ matrix.target || 'native' }}
+
+      - name: Compute dylib filename
+        id: dylib
+        shell: bash
+        env:
+          BASENAME: ${{ inputs.dylib_basename }}
+          EXT: ${{ matrix.dylib_ext }}
+          STRIP: ${{ matrix.strip_lib_prefix }}
+        run: |
+          set -euo pipefail
+          if [ "$STRIP" = "true" ] && [[ "$BASENAME" == lib* ]]; then
+            name="${BASENAME#lib}${EXT}"
+          else
+            name="${BASENAME}${EXT}"
+          fi
+          echo "name=${name}" >> "$GITHUB_OUTPUT"
+
+          if [ -n "${{ matrix.target }}" ]; then
+            echo "path=target/${{ matrix.target }}/release/${name}" >> "$GITHUB_OUTPUT"
+          else
+            echo "path=target/release/${name}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build release cdylib
+        run: |
+          cargo build --release -p ${{ inputs.plugin_name }} ${{ matrix.target && format('--target {0}', matrix.target) || '' }}
+
+      - name: Check dylib size
+        shell: bash
+        env:
+          MAX_SIZE_BYTES: ${{ inputs.max_size_bytes }}
+          DYLIB_PATH: ${{ steps.dylib.outputs.path }}
+        run: |
+          set -euo pipefail
+          if [ "$RUNNER_OS" = "macOS" ]; then
+            actual=$(stat -f '%z' "$DYLIB_PATH")
+          else
+            actual=$(stat -c '%s' "$DYLIB_PATH")
+          fi
+          echo "Plugin size: $actual bytes (max: $MAX_SIZE_BYTES)"
+          if [ "$actual" -gt "$MAX_SIZE_BYTES" ]; then
+            echo "::error::${{ inputs.plugin_name }} ${{ matrix.artifact_name_suffix }} exceeds size budget ($actual > $MAX_SIZE_BYTES bytes)"
+            exit 1
+          fi
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.archive_prefix }}-${{ matrix.artifact_name_suffix }}
+          path: ${{ steps.dylib.outputs.path }}
+          if-no-files-found: error
+          retention-days: 1
+
+  # ── Package, sign, upload ──────────────────────────────────────────────────
+  # Downloads all 4 dylibs, signs each (privkey source per `signing_key_source`),
+  # packages into tar.gz / zip, uploads to COS at <cos_subdir>/v<version>/.
+  package-and-upload:
+    name: Package and upload
+    needs: [build]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Extract version from tag
+        id: version
+        env:
+          PREFIX: refs/tags/${{ inputs.version_tag_prefix }}
+        run: |
+          VERSION="${GITHUB_REF#${PREFIX}}"
+          if [ "$VERSION" = "$GITHUB_REF" ]; then
+            echo "::error::tag $GITHUB_REF does not start with prefix ${{ inputs.version_tag_prefix }}"
+            exit 1
+          fi
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Download all build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          pattern: ${{ inputs.archive_prefix }}-*
+
+      - name: Set up Python for signing
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+
+      - name: Install signing deps
+        run: pip install --quiet cryptography
+
+      - name: Install grpcio-tools (vault source only)
+        if: inputs.signing_key_source == 'vault'
+        run: pip install --quiet grpcio grpcio-tools
+
+      - name: Fetch signing privkey from vault
+        # Pulls the privkey out of the running vault cluster and pipes it
+        # into $GITHUB_ENV so the next step's sign_plugin.py call reads
+        # PLUGIN_SIGNING_PRIVKEY from env exactly like the github-secret path.
+        # ::add-mask:: registers the value as a secret so any subsequent
+        # log line containing it gets redacted.
+        if: inputs.signing_key_source == 'vault'
+        env:
+          VAULT_ENDPOINT: ${{ secrets.VAULT_SIGNING_ENDPOINT }}
+          VAULT_TOKEN: ${{ secrets.VAULT_SIGNING_TOKEN }}
+          SIGNING_KEY_NAME: ${{ inputs.signing_key_name }}
+        run: |
+          set -euo pipefail
+          if [ -z "${VAULT_ENDPOINT}" ] || [ -z "${VAULT_TOKEN}" ]; then
+            echo "::error::signing_key_source=vault requires VAULT_SIGNING_ENDPOINT + VAULT_SIGNING_TOKEN secrets on the caller."
+            exit 1
+          fi
+          if [ -z "${SIGNING_KEY_NAME}" ]; then
+            echo "::error::signing_key_source=vault requires inputs.signing_key_name (e.g. signing-keys/kernel-dogfood-v1)."
+            exit 1
+          fi
+          PRIVKEY=$(python scripts/vault_get_signing_key.py "${SIGNING_KEY_NAME}")
+          echo "::add-mask::${PRIVKEY}"
+          echo "PLUGIN_SIGNING_PRIVKEY=${PRIVKEY}" >> "$GITHUB_ENV"
+
+      - name: Resolve PLUGIN_SIGNING_PRIVKEY (github-secret source)
+        # Just forwards the repo secret into env so sign_plugin.py sees it.
+        # Done in a separate step so the env var is identically scoped to
+        # the signing step regardless of source.
+        if: inputs.signing_key_source == 'github-secret'
+        env:
+          PRIVKEY_SECRET: ${{ secrets.PLUGIN_SIGNING_PRIVKEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${PRIVKEY_SECRET}" ]; then
+            echo "::error::signing_key_source=github-secret requires PLUGIN_SIGNING_PRIVKEY secret on the caller."
+            exit 1
+          fi
+          echo "PLUGIN_SIGNING_PRIVKEY=${PRIVKEY_SECRET}" >> "$GITHUB_ENV"
+
+      - name: Ed25519-sign each platform dylib
+        # Produces `<dylib>.sig` (64 raw bytes) next to each downloaded
+        # binary so the packaging step picks them both into the archive.
+        # The verifier side (nexus-vfs cluster) reads the `.sig` next to
+        # the loaded plugin and Ed25519-verifies against an embedded
+        # `trusted_keys/*.pub`. Format contract in `nexus_plugin_abi::signing`.
+        env:
+          PREFIX: ${{ inputs.archive_prefix }}
+          BASENAME: ${{ inputs.dylib_basename }}
+        run: |
+          set -euo pipefail
+          # Reconstruct platform-specific dylib names matching the build job.
+          win_dll="${BASENAME#lib}.dll"
+          python scripts/sign_plugin.py \
+            "artifacts/${PREFIX}-linux-x86_64/${BASENAME}.so" \
+            "artifacts/${PREFIX}-macos-arm64/${BASENAME}.dylib" \
+            "artifacts/${PREFIX}-macos-x86_64/${BASENAME}.dylib" \
+            "artifacts/${PREFIX}-windows-x86_64/${win_dll}"
+
+      - name: Package into archives
+        env:
+          PREFIX: ${{ inputs.archive_prefix }}
+          BASENAME: ${{ inputs.dylib_basename }}
+        run: |
+          set -euo pipefail
+          mkdir -p release-assets
+          win_dll="${BASENAME#lib}.dll"
+
+          # Each archive ships the dylib AND its detached `.sig`. The
+          # consumer (sudowork download script) extracts both into the
+          # plugin dir; the kernel's PluginLoader::load reads them in
+          # tandem and rejects the plugin if verify fails.
+
+          # Linux x86_64
+          cp "artifacts/${PREFIX}-linux-x86_64/${BASENAME}.so" "${BASENAME}.so"
+          cp "artifacts/${PREFIX}-linux-x86_64/${BASENAME}.so.sig" "${BASENAME}.so.sig"
+          tar -czf "release-assets/${PREFIX}-linux-x86_64.tar.gz" "${BASENAME}.so" "${BASENAME}.so.sig"
+          rm "${BASENAME}.so" "${BASENAME}.so.sig"
+
+          # macOS arm64
+          cp "artifacts/${PREFIX}-macos-arm64/${BASENAME}.dylib" "${BASENAME}.dylib"
+          cp "artifacts/${PREFIX}-macos-arm64/${BASENAME}.dylib.sig" "${BASENAME}.dylib.sig"
+          tar -czf "release-assets/${PREFIX}-macos-arm64.tar.gz" "${BASENAME}.dylib" "${BASENAME}.dylib.sig"
+          rm "${BASENAME}.dylib" "${BASENAME}.dylib.sig"
+
+          # macOS x86_64
+          cp "artifacts/${PREFIX}-macos-x86_64/${BASENAME}.dylib" "${BASENAME}.dylib"
+          cp "artifacts/${PREFIX}-macos-x86_64/${BASENAME}.dylib.sig" "${BASENAME}.dylib.sig"
+          tar -czf "release-assets/${PREFIX}-macos-x86_64.tar.gz" "${BASENAME}.dylib" "${BASENAME}.dylib.sig"
+          rm "${BASENAME}.dylib" "${BASENAME}.dylib.sig"
+
+          # Windows x86_64
+          cp "artifacts/${PREFIX}-windows-x86_64/${win_dll}" "${win_dll}"
+          cp "artifacts/${PREFIX}-windows-x86_64/${win_dll}.sig" "${win_dll}.sig"
+          zip "release-assets/${PREFIX}-windows-x86_64.zip" "${win_dll}" "${win_dll}.sig"
+          rm "${win_dll}" "${win_dll}.sig"
+
+          echo "=== release-assets ==="
+          ls -lh release-assets/
+
+      - name: Compute SHA256 checksums
+        id: checksums
+        working-directory: release-assets
+        run: |
+          CHECKSUMS=$(sha256sum *.tar.gz *.zip)
+          echo "$CHECKSUMS"
+          {
+            echo "checksums<<EOF"
+            echo "$CHECKSUMS"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Upload to COS
+        env:
+          COS_SECRET_ID: ${{ secrets.COS_SECRET_ID }}
+          COS_SECRET_KEY: ${{ secrets.COS_SECRET_KEY }}
+          COS_BUCKET: ${{ secrets.COS_BUCKET }}
+          COS_REGION: ${{ secrets.COS_REGION }}
+          COS_BASE_URL: ${{ secrets.COS_BASE_URL }}
+          VERSION: ${{ steps.version.outputs.version }}
+          COS_SUBDIR: ${{ inputs.cos_subdir }}
+        run: |
+          set -euo pipefail
+          if [ -z "${COS_SECRET_ID}" ] || [ -z "${COS_SECRET_KEY}" ] \
+            || [ -z "${COS_BUCKET}" ] || [ -z "${COS_REGION}" ]; then
+            echo "::warning::COS credentials not configured. Skipping COS upload."
+            echo "Set COS_SECRET_ID, COS_SECRET_KEY, COS_BUCKET, COS_REGION on the caller to enable."
+            exit 0
+          fi
+
+          pip install cos-python-sdk-v5
+
+          for file in release-assets/*; do
+            basename=$(basename "$file")
+            remote_path="${COS_SUBDIR}/v${VERSION}/${basename}"
+            echo "Uploading ${basename} -> ${remote_path}"
+            python scripts/upload_cos.py \
+              --local-path "$file" \
+              --remote-path "$remote_path"
+          done
+
+      - name: Prepare release body
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          CHECKSUMS: ${{ steps.checksums.outputs.checksums }}
+          PLUGIN_NAME: ${{ inputs.plugin_name }}
+          EXTRA_BODY: ${{ inputs.release_description }}
+        run: |
+          cat > release_body.md << BODY
+          ## ${PLUGIN_NAME} v${VERSION}
+
+          ${EXTRA_BODY}
+
+          ### Installation
+          Extract the archive and place the dylib + \`.sig\` in your nexusd-cluster \`--plugin-dir\`. PluginLoader::load Ed25519-verifies the signature against the embedded trust root before \`dlopen\`.
+
+          ### SHA256 checksums
+          \`\`\`
+          ${CHECKSUMS}
+          \`\`\`
+          BODY
+
+      - name: Upload release body artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-body
+          path: release_body.md
+          retention-days: 1
+
+      - name: Upload release assets artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-assets
+          path: release-assets/*
+          retention-days: 1
+
+  # ── Create GitHub Release ──────────────────────────────────────────────────
+  create-release:
+    name: Create GitHub Release
+    needs: [package-and-upload]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download release assets
+        uses: actions/download-artifact@v4
+        with:
+          name: release-assets
+          path: release-assets
+
+      - name: Download release body
+        uses: actions/download-artifact@v4
+        with:
+          name: release-body
+          path: release-body
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          body_path: release-body/release_body.md
+          files: release-assets/*
+          draft: false
+          prerelease: ${{ contains(github.ref, 'alpha') || contains(github.ref, 'beta') || contains(github.ref, 'rc') }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-vault-plugin.yml
+++ b/.github/workflows/release-vault-plugin.yml
@@ -1,15 +1,14 @@
 name: Release Vault Plugin
 
-# Automated release pipeline for the vault cdylib plugin.
-# Triggered by tags of the form vault-v<semver> (e.g., vault-v0.1.1).
+# Release pipeline for the vault cdylib — wrapper around the reusable
+# plugin-release workflow. Triggered by tags of the form `vault-v<semver>`.
 #
-# 1. Builds the vault cdylib for 4 platforms via the reusable workflow.
-# 2. Packages each into platform-appropriate archives (tar.gz / zip).
-# 3. Uploads archives to Tencent COS (gracefully skips if not configured).
-# 4. Creates a GitHub Release with archives and SHA256 checksums.
+# Vault stays on `signing_key_source: github-secret` because vault is the
+# trust root for every other plugin's signing key (chicken-and-egg). Every
+# other plugin uses `signing_key_source: vault` and pulls its privkey
+# from a running vault cluster.
 #
-# COS path convention: nexus-vault/release/<version>/<filename>
-# Example: nexus-vault/release/v0.1.1/nexus-vault-linux-x86_64.tar.gz
+# COS path convention: nexus-vault/release/v<version>/<filename>
 
 on:
   push:
@@ -20,210 +19,29 @@ permissions:
   contents: write
 
 jobs:
-  # ── Build ──────────────────────────────────────────────────────────────────
-  # Reuses the existing vault-plugin-build.yml to compile all 4 platforms.
-  build:
-    name: Build vault plugin
-    uses: ./.github/workflows/vault-plugin-build.yml
+  release:
+    uses: ./.github/workflows/release-plugin-reusable.yml
     with:
-      upload_retention_days: 1
+      plugin_name: nexus-vault
+      dylib_basename: libnexus_vault
+      archive_prefix: nexus-vault
+      cos_subdir: nexus-vault/release
+      version_tag_prefix: vault-v
+      signing_key_source: github-secret
+      # 7.5 MiB — matches the loosest pre-reusable platform budget (macOS).
+      # Stricter than the reusable's 8 MiB default; tightens regression
+      # detection for the only plugin where we've measured a stable size.
+      max_size_bytes: 7864320
+      release_description: |
+        Vault dylib plugin for nexusd-cluster.
 
-  # ── Package and upload ─────────────────────────────────────────────────────
-  # Downloads all dylib artifacts, packages them into tar.gz / zip archives,
-  # computes SHA256 checksums, and uploads to COS.
-  package-and-upload:
-    name: Package and upload
-    needs: [build]
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Extract version from tag
-        id: version
-        run: |
-          VERSION="${GITHUB_REF#refs/tags/vault-v}"
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-
-      - name: Download all build artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: artifacts
-          pattern: nexus-vault-*
-
-      - name: Set up Python for signing
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.14"
-
-      - name: Install signing deps
-        run: pip install --quiet cryptography
-
-      - name: Ed25519-sign each platform dylib
-        # Produces `<dylib>.sig` (64 raw bytes) next to each downloaded
-        # binary so the packaging step picks them both into the archive.
-        # The verifier side (nexus-vfs cluster) reads the `.sig` next to
-        # the loaded plugin and Ed25519-verifies against the embedded
-        # `trusted_keys/nexus-team.pub`. Format contract lives in
-        # `nexus_plugin_abi::signing`.
-        env:
-          PLUGIN_SIGNING_PRIVKEY: ${{ secrets.PLUGIN_SIGNING_PRIVKEY }}
-        run: |
-          set -euo pipefail
-          if [ -z "${PLUGIN_SIGNING_PRIVKEY}" ]; then
-            echo "::error::PLUGIN_SIGNING_PRIVKEY repo secret is empty."
-            echo "Set it on nexi-lab/nexus to base64(32 raw Ed25519 private bytes)."
-            exit 1
-          fi
-          python scripts/sign_plugin.py \
-            artifacts/nexus-vault-linux-x86_64/libnexus_vault.so \
-            artifacts/nexus-vault-macos-arm64/libnexus_vault.dylib \
-            artifacts/nexus-vault-macos-x86_64/libnexus_vault.dylib \
-            artifacts/nexus-vault-windows-x86_64/nexus_vault.dll
-
-      - name: Package into archives
-        run: |
-          set -euo pipefail
-          mkdir -p release-assets
-
-          # Each archive ships the dylib AND its detached `.sig`. The
-          # consumer (sudowork download script) extracts both into the
-          # plugin dir; the kernel's PluginLoader::load reads them in
-          # tandem and rejects the plugin if verify fails.
-
-          # Linux x86_64
-          cp artifacts/nexus-vault-linux-x86_64/libnexus_vault.so libnexus_vault.so
-          cp artifacts/nexus-vault-linux-x86_64/libnexus_vault.so.sig libnexus_vault.so.sig
-          tar -czf release-assets/nexus-vault-linux-x86_64.tar.gz libnexus_vault.so libnexus_vault.so.sig
-          rm libnexus_vault.so libnexus_vault.so.sig
-
-          # macOS arm64
-          cp artifacts/nexus-vault-macos-arm64/libnexus_vault.dylib libnexus_vault.dylib
-          cp artifacts/nexus-vault-macos-arm64/libnexus_vault.dylib.sig libnexus_vault.dylib.sig
-          tar -czf release-assets/nexus-vault-macos-arm64.tar.gz libnexus_vault.dylib libnexus_vault.dylib.sig
-          rm libnexus_vault.dylib libnexus_vault.dylib.sig
-
-          # macOS x86_64
-          cp artifacts/nexus-vault-macos-x86_64/libnexus_vault.dylib libnexus_vault.dylib
-          cp artifacts/nexus-vault-macos-x86_64/libnexus_vault.dylib.sig libnexus_vault.dylib.sig
-          tar -czf release-assets/nexus-vault-macos-x86_64.tar.gz libnexus_vault.dylib libnexus_vault.dylib.sig
-          rm libnexus_vault.dylib libnexus_vault.dylib.sig
-
-          # Windows x86_64
-          cp artifacts/nexus-vault-windows-x86_64/nexus_vault.dll nexus_vault.dll
-          cp artifacts/nexus-vault-windows-x86_64/nexus_vault.dll.sig nexus_vault.dll.sig
-          zip release-assets/nexus-vault-windows-x86_64.zip nexus_vault.dll nexus_vault.dll.sig
-          rm nexus_vault.dll nexus_vault.dll.sig
-
-          echo "=== release-assets ==="
-          ls -lh release-assets/
-
-      - name: Compute SHA256 checksums
-        id: checksums
-        working-directory: release-assets
-        run: |
-          CHECKSUMS=$(sha256sum *.tar.gz *.zip)
-          echo "$CHECKSUMS"
-          {
-            echo "checksums<<EOF"
-            echo "$CHECKSUMS"
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Upload to COS
-        env:
-          COS_SECRET_ID: ${{ secrets.COS_SECRET_ID || vars.COS_SECRET_ID }}
-          COS_SECRET_KEY: ${{ secrets.COS_SECRET_KEY || vars.COS_SECRET_KEY }}
-          COS_BUCKET: ${{ secrets.COS_BUCKET || vars.COS_BUCKET }}
-          COS_REGION: ${{ secrets.COS_REGION || vars.COS_REGION }}
-          COS_BASE_URL: ${{ secrets.COS_BASE_URL || vars.COS_BASE_URL }}
-          VERSION: ${{ steps.version.outputs.version }}
-        run: |
-          set -euo pipefail
-
-          if [ -z "${COS_SECRET_ID}" ] || [ -z "${COS_SECRET_KEY}" ] \
-            || [ -z "${COS_BUCKET}" ] || [ -z "${COS_REGION}" ]; then
-            echo "::warning::COS credentials not configured. Skipping COS upload."
-            echo "Set COS_SECRET_ID, COS_SECRET_KEY, COS_BUCKET, COS_REGION in secrets or vars to enable."
-            exit 0
-          fi
-
-          pip install cos-python-sdk-v5
-
-          for file in release-assets/*; do
-            basename=$(basename "$file")
-            remote_path="nexus-vault/release/v${VERSION}/${basename}"
-            echo "Uploading ${basename} -> ${remote_path}"
-            python scripts/upload_cos.py \
-              --local-path "$file" \
-              --remote-path "$remote_path"
-          done
-
-      - name: Prepare release body
-        id: release-info
-        env:
-          VERSION: ${{ steps.version.outputs.version }}
-          CHECKSUMS: ${{ steps.checksums.outputs.checksums }}
-        run: |
-          cat > release_body.md << BODY
-          ## Vault Plugin v${VERSION}
-
-          Vault dylib plugin for nexusd-cluster.
-
-          ### Included services
-          - **GenericSecretsService** — namespace:key encrypted KV with versioning, soft-delete, and batch operations
-          - **PasswordVaultService** — password manager with TOTP, search, and bulk migration
-
-          ### Installation
-          Extract the archive and place the dylib in your nexusd-cluster \`--plugin-dir\` directory.
-
-          ### SHA256 checksums
-          \`\`\`
-          ${CHECKSUMS}
-          \`\`\`
-          BODY
-
-      - name: Upload release body artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: release-body
-          path: release_body.md
-          retention-days: 1
-
-      - name: Upload release assets artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: release-assets
-          path: release-assets/*
-          retention-days: 1
-
-  # ── Create GitHub Release ──────────────────────────────────────────────────
-  # Creates (or updates) a GitHub Release with all packaged archives.
-  create-release:
-    name: Create GitHub Release
-    needs: [package-and-upload]
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Download release assets
-        uses: actions/download-artifact@v4
-        with:
-          name: release-assets
-          path: release-assets
-
-      - name: Download release body
-        uses: actions/download-artifact@v4
-        with:
-          name: release-body
-          path: release-body
-
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          body_path: release-body/release_body.md
-          files: release-assets/*
-          draft: false
-          prerelease: ${{ contains(github.ref, 'alpha') || contains(github.ref, 'beta') || contains(github.ref, 'rc') }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        ### Included services
+        - **GenericSecretsService** — namespace:key encrypted KV with versioning, soft-delete, and batch operations
+        - **PasswordVaultService** — password manager with TOTP, search, and bulk migration
+    secrets:
+      PLUGIN_SIGNING_PRIVKEY: ${{ secrets.PLUGIN_SIGNING_PRIVKEY }}
+      COS_SECRET_ID: ${{ secrets.COS_SECRET_ID }}
+      COS_SECRET_KEY: ${{ secrets.COS_SECRET_KEY }}
+      COS_BUCKET: ${{ secrets.COS_BUCKET }}
+      COS_REGION: ${{ secrets.COS_REGION }}
+      COS_BASE_URL: ${{ secrets.COS_BASE_URL }}

--- a/docs/superpowers/specs/2026-06-12-encrypted-in-git-vault-dogfood-design.md
+++ b/docs/superpowers/specs/2026-06-12-encrypted-in-git-vault-dogfood-design.md
@@ -1,0 +1,204 @@
+# Plugin Signing Dogfood — encrypted-in-git architecture
+
+**Status:** Draft for review (2026-06-12). Code lands in a follow-up PR after PR #4376 (plumbing) merges.
+
+**Scope:** How plugin signing keys live in vault when there is no always-on vault server. The plumbing (gRPC client scripts, reusable workflow, compliance gate, vault wrapper) shipped in PR #4376 — this doc covers the architecture choice that turns "scripts that talk to a vault somewhere" into "scripts that boot vault in CI from an encrypted DB in this repo".
+
+---
+
+## TL;DR
+
+Vault's redb file lives **committed in the nexus repo** at `data/vault-signing/vault.redb`. Vault's per-entry AES-256-GCM encryption hides the privkey values; the repo is public but values are unreadable without the master key. The master key is one GH org secret: `VAULT_SIGNING_MASTER_KEY`.
+
+Each release CI job that uses `signing_key_source: vault`:
+
+1. Installs `nexusd-cluster` (cargo install from pinned nexus-vfs rev)
+2. Downloads the latest signed `libnexus_vault.{so,dylib,dll}` + `.sig` from GH Releases
+3. Copies `data/vault-signing/vault.redb` to a runner-local data dir
+4. Boots an ephemeral `nexusd-cluster` with `--plugin-dir` pointing at vault, master key in env
+5. Calls `scripts/vault_get_signing_key.py` against `localhost:2126` (insecure local channel)
+6. Signs the new plugin with the returned privkey
+7. Tears down the cluster
+
+Adding/rotating a plugin signing key is a **PR** — kernel-team member runs `scripts/provision_dogfood_key.py` locally against the checked-out DB, encrypted DB delta gets committed, PR is reviewed, merged.
+
+---
+
+## Repository layout
+
+```
+data/vault-signing/
+  README.md          # how to add/rotate keys; pointer to this doc
+  vault.redb         # the redb file vault writes to; AES-256-GCM-encrypted values
+  pubkeys/           # base64 pubkey checked in alongside each privkey, for visibility + ops sanity
+    kernel-dogfood-v1.pub
+```
+
+`vault.redb` is committed in binary form. It's a single file, small (KB range with a handful of keys), and changes only when a key is added or rotated.
+
+Trust roots (`<name>.pub` files) live in `nexus-vfs/rust/kernel/trusted_keys/` per existing pattern — separate repo, separate concern.
+
+## Master key
+
+* **Format:** 32 raw bytes, base64-encoded (same as `PLUGIN_SIGNING_PRIVKEY`).
+* **Storage:** GH org secret `VAULT_SIGNING_MASTER_KEY` on the `nexi-lab` org, scoped to the `nexus` repo + its release workflows.
+* **Generation:** one-time, by the kernel team lead, using a CSPRNG (e.g. `python -c "import os, base64; print(base64.b64encode(os.urandom(32)).decode())"`). Written to the GH secret via `gh secret set --org`.
+* **Rotation:** breaks every committed value's decryption. Procedure when needed:
+  1. Locally check out current `vault.redb` + master key (kernel-team lead pulls master key from GH secret CLI).
+  2. Decrypt all secrets in memory.
+  3. Generate new master key.
+  4. Re-encrypt all secrets, write a fresh `vault.redb`.
+  5. PR the new `vault.redb`; merge.
+  6. Update GH secret with new master key.
+  7. The merge commit and the secret update must land in lock-step — there's a brief window where one is updated and the other isn't, in which CI release jobs will fail loudly (decrypt error). Acceptable: kernel team coordinates rotation, doesn't bunch with a release.
+* **Recovery from loss:** the master key being lost = every committed secret is unrecoverable. Plugin signing privkeys can be regenerated (provision a new key, update the `.pub` in nexus-vfs trust roots, re-tag). One-time cost: tag two `<plugin>-v<n+1>` releases (one with the lost key never coming back, one with a fresh key). No persistent damage as long as we treat plugin signing keys as rotatable infrastructure.
+
+## CI ephemeral cluster startup
+
+Added to `release-plugin-reusable.yml` when `signing_key_source: vault`. New steps (in order):
+
+```yaml
+- name: Install nexusd-cluster for ephemeral vault
+  if: inputs.signing_key_source == 'vault'
+  run: |
+    cargo install --git https://github.com/nexi-lab/nexus-vfs \
+      --rev <pinned> --locked \
+      --bin nexusd-cluster nexus-cluster
+
+- name: Download latest signed vault.dylib from GH Release
+  if: inputs.signing_key_source == 'vault'
+  env:
+    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  run: |
+    mkdir -p /tmp/vault-plugins
+    gh release download --repo nexi-lab/nexus --pattern 'nexus-vault-linux-x86_64.tar.gz'
+    tar -xzf nexus-vault-linux-x86_64.tar.gz -C /tmp/vault-plugins/
+    # Asserts both libnexus_vault.so + .sig are present.
+
+- name: Stage vault DB
+  if: inputs.signing_key_source == 'vault'
+  run: |
+    mkdir -p /tmp/vault-data
+    cp data/vault-signing/vault.redb /tmp/vault-data/
+
+- name: Start ephemeral nexusd-cluster
+  if: inputs.signing_key_source == 'vault'
+  env:
+    VAULT_MASTER_KEY: ${{ secrets.VAULT_SIGNING_MASTER_KEY }}
+  run: |
+    nexusd-cluster --no-tls --data-dir /tmp/vault-data \
+      --plugin-dir /tmp/vault-plugins --bootstrap-mode static &
+    echo "CLUSTER_PID=$!" >> $GITHUB_ENV
+    # Block until /tmp/vault-data/cluster.ready (timeout 60s)
+    timeout 60 bash -c 'until [ -f /tmp/vault-data/cluster.ready ]; do sleep 1; done'
+
+- name: Fetch signing privkey from vault
+  if: inputs.signing_key_source == 'vault'
+  env:
+    VAULT_ENDPOINT: localhost:2126
+    VAULT_TOKEN: bootstrap-local      # any value — auth disabled on local
+    VAULT_INSECURE: "1"
+  run: |
+    PRIVKEY=$(python scripts/vault_get_signing_key.py "${{ inputs.signing_key_name }}")
+    echo "::add-mask::$PRIVKEY"
+    echo "PLUGIN_SIGNING_PRIVKEY=$PRIVKEY" >> $GITHUB_ENV
+
+- name: Tear down ephemeral cluster
+  if: always() && inputs.signing_key_source == 'vault'
+  run: |
+    if [ -n "$CLUSTER_PID" ]; then kill "$CLUSTER_PID" || true; fi
+    rm -rf /tmp/vault-data /tmp/vault-plugins
+```
+
+Open questions / decisions:
+* **Pinned nexus-vfs rev:** which rev of nexus-vfs do we install? Pinning to `develop` HEAD risks rev drift. Pinning to a tagged release is cleaner but creates a release-tagging cadence dependency. Recommendation: pin to a specific rev in the workflow, refresh quarterly via PR.
+* **Local auth:** vault's gRPC auth surface needs to accept a bootstrap token when `--no-tls` and `127.0.0.1` are in play, OR vault needs an "insecure-local" mode. Confirm with [[feedback_admin_merge_self_approve]] in vault's auth code path before implementing the CI step. If neither exists, ship a small `--admin-token` flag on nexusd-cluster.
+* **Chicken-and-egg:** the latest signed `libnexus_vault.so` MUST already exist as a GH Release before any non-vault plugin can be signed. Vault's own release runs the github-secret path — no dependency. The first non-vault plugin (localconnect) requires at least one prior vault release. Acceptable; we'll cut a vault `v0.1.3` release as part of the architecture PR.
+
+## Bootstrap script — `scripts/bootstrap_dogfood_vault.py`
+
+One-time tool to create an empty encrypted DB. Steps:
+
+1. Check `data/vault-signing/vault.redb` does NOT exist — refuse if it does (overwriting would obliterate committed keys).
+2. Generate a master key via CSPRNG, print to stdout for the operator to register as GH secret.
+3. Start vault locally on a tempdir, then immediately stop. Result: an initialized empty `vault.redb`.
+4. Move `vault.redb` into `data/vault-signing/`.
+5. Print "next steps": `gh secret set VAULT_SIGNING_MASTER_KEY` then commit + push.
+
+Single-purpose: only used to initialize the encrypted DB the first time.
+
+## Provisioning a new plugin signing key — `scripts/provision_dogfood_key.py`
+
+Already shipped in PR #4376 — works against any vault gRPC endpoint. For encrypted-in-git, kernel team runs it locally:
+
+```bash
+# Pull master key from GH secret
+export VAULT_MASTER_KEY=$(gh secret get VAULT_SIGNING_MASTER_KEY --org nexi-lab)
+
+# Start a local ephemeral vault pointed at the checked-out DB
+mkdir -p /tmp/local-vault-data
+cp data/vault-signing/vault.redb /tmp/local-vault-data/
+nexusd-cluster --no-tls --data-dir /tmp/local-vault-data \
+  --plugin-dir <local vault.dylib> &
+LOCAL_VAULT_PID=$!
+
+# Provision the key
+python scripts/provision_dogfood_key.py \
+  --vault-endpoint localhost:2126 \
+  --vault-token bootstrap-local \
+  --vault-insecure \
+  --key-name <new-key-name>
+
+# Stop vault, copy back the updated DB
+kill $LOCAL_VAULT_PID
+cp /tmp/local-vault-data/vault.redb data/vault-signing/vault.redb
+
+# Stage the new pubkey, the updated DB, and the trust-root entry
+git add data/vault-signing/vault.redb \
+        data/vault-signing/pubkeys/<new-key-name>.pub
+# In nexus-vfs:
+git add rust/kernel/trusted_keys/<new-key-name>.pub
+# Edit TRUSTED_KEY_FILES in nexus-vfs/rust/kernel/src/kernel/plugins/loader.rs
+```
+
+A wrapper script `scripts/add_dogfood_key.sh` could automate the above. Optional convenience; not required.
+
+## Kernel-team workflow for adding a key (operator view)
+
+1. `git checkout -b add-signing-key/<plugin-name>` on nexus.
+2. `./scripts/add_dogfood_key.sh <plugin-name>` (wrapper around the above).
+3. Inspect `git status` — should be `data/vault-signing/vault.redb` + `data/vault-signing/pubkeys/<name>.pub`.
+4. Commit, push, open PR. PR review checks: pubkey file matches the redb's metadata for that key (script verifies); kernel-team approval required (CODEOWNERS).
+5. In nexus-vfs: separate PR adds the `.pub` + the `include_bytes!` entry in `TRUSTED_KEY_FILES`. Merge nexus-vfs first.
+6. Bump nexus-vfs pin in `Cargo.toml` (or rely on the next pin bump).
+7. Merge the nexus PR.
+
+## Threat model
+
+* **Adversary: read access to the public repo.** Can see `vault.redb` and pubkeys. Cannot decrypt values without master key. No leak.
+* **Adversary: stolen master key only.** Can decrypt every committed value. Has every plugin signing privkey. Game over — must rotate every signing key + ship cluster updates with new trust roots. Mitigation: master key only ever in GH org secret (org-admin only) + kernel-team-lead local machine when rotating. Treat as crown jewels.
+* **Adversary: write access to the public repo.** Can replace `vault.redb` with one they encrypted with a different master key. Their malicious values would fail decrypt in CI → loud failure. Cannot inject a wrong privkey silently. Mitigation: branch protection requires kernel-team review on `data/vault-signing/**`.
+* **Adversary: compromised CI runner during signing.** Sees the privkey for the plugin being signed (a few seconds). Could exfiltrate. Mitigation: minimize runner window, use trusted GH-hosted runners only, audit any self-hosted runner additions.
+* **Concurrency: two PRs adding keys.** Second PR's `vault.redb` reflects state without the first PR's key. Merge produces a binary file conflict — git refuses auto-merge, kernel team resolves by re-running the second add against the merged-in first add. Acceptable friction at our key-add cadence.
+
+## Review checklist (next PR)
+
+* [ ] `scripts/bootstrap_dogfood_vault.py` written and self-tested locally (creates an empty `vault.redb`).
+* [ ] `data/vault-signing/vault.redb` committed (pre-provisioned with `signing-keys/kernel-dogfood-v1`).
+* [ ] `data/vault-signing/pubkeys/kernel-dogfood-v1.pub` committed.
+* [ ] Master key generated, registered as `VAULT_SIGNING_MASTER_KEY` GH org secret.
+* [ ] `release-plugin-reusable.yml` extended with ephemeral-vault startup steps when `signing_key_source: vault`.
+* [ ] `scripts/vault_get_signing_key.py` accepts `VAULT_INSECURE=1` for localhost gRPC.
+* [ ] `scripts/provision_dogfood_key.py` same.
+* [ ] `release-local-connector-plugin.yml` secrets updated: drop `VAULT_SIGNING_ENDPOINT/TOKEN`, add `VAULT_SIGNING_MASTER_KEY`.
+* [ ] `data/vault-signing/README.md` written: rotation procedure, key-add workflow, pointer to this doc.
+* [ ] Kernel-team CODEOWNERS entry for `data/vault-signing/**`.
+* [ ] Compliance gate flipped to required on `develop` branch protection.
+* [ ] Vault `v0.1.3` (or current) tag pushed to ensure a signed dylib exists for ephemeral cluster's `--plugin-dir`.
+
+## Out of scope
+
+* Plugin-author self-service for key addition (PR-based is the SSOT).
+* Hardware-backed master key (HSM / TPM) — possible future hardening.
+* Per-key access control (today: anyone with master key can read everything in `signing-keys/`).
+* Vault DB compaction / archive of rotated keys.

--- a/scripts/check_plugin_signing_compliance.py
+++ b/scripts/check_plugin_signing_compliance.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Enforce that every cdylib in the workspace has a signed-release workflow.
+
+The kernel's `PluginLoader::load` (in nexus-vfs) rejects any `.so/.dylib/.dll`
+without a valid Ed25519 `.sig` alongside it. So shipping a cdylib without a
+release workflow that signs it produces a binary the cluster will refuse to
+load at runtime — a regression that's invisible at PR time and only
+surfaces when an operator tries to install the plugin.
+
+This script catches that miss at PR time by walking the workspace, finding
+every `crate-type = [\"cdylib\"]` package, and asserting one of:
+
+  (a) A workflow under `.github/workflows/` invokes the reusable release
+      pipeline with `plugin_name: <package-name>`, OR
+  (b) A workflow under `.github/workflows/` runs `scripts/sign_plugin.py`
+      AND mentions the package name in the same file (legacy / custom
+      signing flow).
+
+Either way, the cdylib has a path to ship signed. Anything else fails.
+
+Run locally:  python scripts/check_plugin_signing_compliance.py
+CI:           .github/workflows/plugin-signing-compliance.yml
+
+Allow-list:   add a name to `_NON_PLUGIN_CDYLIBS` only with a code comment
+              explaining why the cdylib will never be loaded by cluster
+              (e.g. Python extension, FFI binding for an unrelated host).
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+# cdylibs that are intentionally NOT cluster plugins — they will never be
+# loaded by `nexusd-cluster --plugin-dir` and so don't need a signed
+# release workflow. Adding entries here is allowed but rare; always
+# document the reason inline.
+_NON_PLUGIN_CDYLIBS: set[str] = set()
+
+# Regexes are intentionally loose — Cargo.toml authors may write crate-type
+# across lines or with different whitespace. Match anything that pairs
+# `crate-type` with `cdylib`.
+_CDYLIB_RE = re.compile(
+    r"""crate-type\s*=\s*\[[^\]]*['"]cdylib['"][^\]]*\]""",
+    re.DOTALL,
+)
+_PACKAGE_NAME_RE = re.compile(
+    r"""^\s*name\s*=\s*['"]([^'"]+)['"]""",
+    re.MULTILINE,
+)
+
+
+def _repo_root() -> Path:
+    here = Path(__file__).resolve()
+    return here.parent.parent
+
+
+def find_cdylib_packages(root: Path) -> list[tuple[str, Path]]:
+    """Walk the workspace and return [(package_name, cargo_toml_path)] for cdylibs."""
+    result: list[tuple[str, Path]] = []
+    for cargo_toml in (root / "rust").rglob("Cargo.toml"):
+        text = cargo_toml.read_text(encoding="utf-8")
+        if not _CDYLIB_RE.search(text):
+            continue
+        # Extract `name = "..."` from the `[package]` table. The regex
+        # matches the first one; in practice every Cargo.toml has exactly
+        # one `[package] name = `.
+        m = _PACKAGE_NAME_RE.search(text)
+        if not m:
+            raise SystemExit(
+                f"cdylib at {cargo_toml.relative_to(root)} has no [package] name = '...'"
+            )
+        result.append((m.group(1), cargo_toml))
+    result.sort()
+    return result
+
+
+# Detect a workflow that exists only to be called from another workflow
+# (reusable infra). These never sign anything themselves — their callers
+# do. Excluded from the scan so a reusable that *describes* multiple
+# plugins in its input docstring doesn't get credited as signing them.
+_REUSABLE_TRIGGER_RE = re.compile(r"^on:\s*\n\s*workflow_call\s*:", re.MULTILINE)
+
+
+def find_release_workflows(root: Path) -> list[tuple[Path, str]]:
+    """Return [(workflow_path, full_text)] for every leaf release workflow.
+
+    Skips reusable workflows (`on: workflow_call`) — those aren't release
+    pipelines themselves, they're shared infra.
+    """
+    out: list[tuple[Path, str]] = []
+    wf_dir = root / ".github" / "workflows"
+    if not wf_dir.is_dir():
+        return out
+    for wf in sorted(wf_dir.glob("*.yml")):
+        text = wf.read_text(encoding="utf-8")
+        if _REUSABLE_TRIGGER_RE.search(text):
+            continue
+        out.append((wf, text))
+    return out
+
+
+def has_signing_path(
+    package_name: str,
+    workflows: list[tuple[Path, str]],
+) -> tuple[bool, str | None]:
+    """Does any workflow sign this package? Returns (ok, hint_workflow_path)."""
+    # Pattern (a): leaf workflow calls the reusable with `plugin_name: <name>`
+    # in its `with:` block. The plugin_name line must appear on its own at
+    # `with:`-block indentation (>=6 spaces), unquoted or single-line —
+    # description prose mentioning the package name doesn't satisfy this.
+    reusable_marker = "release-plugin-reusable.yml"
+    plugin_name_kv = re.compile(
+        rf"""^\s{{6,}}plugin_name\s*:\s*['"]?{re.escape(package_name)}['"]?\s*$""",
+        re.MULTILINE,
+    )
+    for wf, text in workflows:
+        if reusable_marker in text and plugin_name_kv.search(text):
+            return True, str(wf.name)
+
+    # Pattern (b): direct sign_plugin.py call that mentions the package.
+    # Looser — catches one-off signing flows that pre-date the reusable.
+    sign_marker = "scripts/sign_plugin.py"
+    name_marker = package_name
+    for wf, text in workflows:
+        if sign_marker in text and name_marker in text:
+            return True, str(wf.name)
+
+    return False, None
+
+
+def main() -> int:
+    root = _repo_root()
+    cdylibs = find_cdylib_packages(root)
+    workflows = find_release_workflows(root)
+
+    failures: list[str] = []
+    for name, cargo_toml in cdylibs:
+        if name in _NON_PLUGIN_CDYLIBS:
+            print(f"[SKIP] {name} — allow-listed in _NON_PLUGIN_CDYLIBS")
+            continue
+        ok, hint = has_signing_path(name, workflows)
+        rel = cargo_toml.relative_to(root)
+        if ok:
+            print(f"[ OK ] {name} ({rel}) — signed by {hint}")
+        else:
+            failures.append(
+                f"  - {name} (at {rel})\n"
+                f"    No release workflow signs this dylib. Add one of:\n"
+                f"    (a) a workflow that `uses: ./.github/workflows/release-plugin-reusable.yml`\n"
+                f"        with `plugin_name: {name}` and `signing_key_source: vault`, OR\n"
+                f"    (b) a workflow that runs `scripts/sign_plugin.py` against this dylib\n"
+                f"        (legacy path — prefer the reusable).\n"
+                f"    Cluster's PluginLoader::load rejects unsigned dylibs at boot.\n"
+            )
+
+    if failures:
+        sys.stderr.write(
+            "Plugin signing compliance check FAILED.\n"
+            "The following cdylibs ship without a signed release workflow:\n\n"
+        )
+        for line in failures:
+            sys.stderr.write(line + "\n")
+        return 1
+
+    print(f"\nAll {len(cdylibs)} cdylib(s) have a signing path.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/provision_dogfood_key.py
+++ b/scripts/provision_dogfood_key.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""One-shot ops tool to provision a plugin signing keypair into vault.
+
+Generates an Ed25519 keypair in memory, stores the privkey in vault under
+`<namespace>/<key>` (default namespace: `signing-keys`), writes the pubkey
+to `./<key-name>.pub` for manual commit into a kernel trust root, and
+self-tests the round trip: vault GetSecret → sign sample → verify against
+pubkey. The in-memory privkey is shredded before exit.
+
+Workflow for a new plugin's signing root:
+  1. Run this script against the dogfood vault cluster.
+  2. Commit the generated `<key-name>.pub` into
+     `nexus-vfs/rust/kernel/trusted_keys/<key-name>.pub`.
+  3. Append the `include_bytes!` line to `TRUSTED_KEY_FILES` in
+     `nexus-vfs/rust/kernel/src/kernel/plugins/loader.rs`.
+  4. Next cluster build embeds the trust root.
+  5. Future plugin release CI fetches the privkey via
+     scripts/vault_get_signing_key.py.
+
+Run only once per signing-key identity. Re-running with the same key name
+would create a NEW version in vault — the old privkey is still recoverable
+via GetSecret(version=…). Always rotate by provisioning a fresh
+`<key-name>-v<n+1>` and then deprecating the old one.
+
+Self-contains proto compilation via grpc_tools.protoc (same pattern as
+scripts/vault_get_signing_key.py — no committed `_pb2` stubs).
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import ctypes
+import sys
+import tempfile
+from pathlib import Path
+
+# Repo-relative path to the secrets proto SSOT.
+PROTO_REL = Path("rust/services/proto/nexus/secrets/v1/secrets.proto")
+PROTO_IMPORT_ROOT_REL = Path("rust/services/proto")
+
+# Pinned format constants — must match `nexus-plugin-abi::signing` /
+# scripts/sign_plugin.py. If you bump any of these, bump them in lockstep
+# across the kernel trust root, the signer, this provisioner, and the
+# downstream `vault_get_signing_key.py` shim.
+PRIVKEY_LENGTH = 32
+PUBKEY_LENGTH = 32
+SIGNATURE_LENGTH = 64
+
+
+def _repo_root() -> Path:
+    here = Path(__file__).resolve()
+    return here.parent.parent
+
+
+def _compile_proto_into(out_dir: Path) -> None:
+    from grpc_tools import protoc
+
+    proto_root = _repo_root() / PROTO_IMPORT_ROOT_REL
+    proto_file = _repo_root() / PROTO_REL
+    if not proto_file.is_file():
+        raise SystemExit(f"proto SSOT missing: {proto_file}")
+
+    rc = protoc.main(
+        [
+            "grpc_tools.protoc",
+            f"--proto_path={proto_root}",
+            f"--python_out={out_dir}",
+            f"--grpc_python_out={out_dir}",
+            str(proto_file),
+        ]
+    )
+    if rc != 0:
+        raise SystemExit(f"protoc exited {rc} when compiling {proto_file}")
+
+
+def _shred_bytes(buf: bytes) -> None:
+    """Best-effort in-place zero of a bytes buffer's backing memory.
+
+    Python doesn't guarantee strings are unique allocations, but for
+    privkey material that lives only as a local `bytes` we have a fresh
+    allocation. ctypes.memset on the buffer address overwrites it before
+    GC. Not bulletproof against forensic memory dumps, but reduces the
+    window the live privkey sits in process RSS.
+    """
+    if not buf:
+        return
+    addr = ctypes.cast(ctypes.c_char_p(buf), ctypes.c_void_p).value
+    if addr:
+        ctypes.memset(addr, 0, len(buf))
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(
+        description="Provision a plugin signing keypair into vault.",
+    )
+    p.add_argument(
+        "--vault-endpoint",
+        required=True,
+        help="gRPC endpoint of the cluster running vault.dylib (e.g. vault-signing.internal:2126).",
+    )
+    p.add_argument(
+        "--vault-token",
+        required=True,
+        help="Admin bearer token for the vault plugin's auth surface.",
+    )
+    p.add_argument(
+        "--key-name",
+        required=True,
+        help="Signing key identity (e.g. kernel-dogfood-v1). Also the filename of the generated .pub file.",
+    )
+    p.add_argument(
+        "--namespace",
+        default="signing-keys",
+        help="Vault namespace to store the privkey under (default: signing-keys).",
+    )
+    p.add_argument(
+        "--pubkey-out-dir",
+        type=Path,
+        default=Path.cwd(),
+        help="Directory to write <key-name>.pub into (default: cwd).",
+    )
+    p.add_argument(
+        "--description",
+        default="",
+        help="Optional description recorded with the vault secret metadata.",
+    )
+    args = p.parse_args(argv)
+
+    from cryptography.exceptions import InvalidSignature
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+        Ed25519PrivateKey,
+        Ed25519PublicKey,
+    )
+
+    privkey = Ed25519PrivateKey.generate()
+    raw_priv: bytes = privkey.private_bytes_raw()
+    raw_pub: bytes = privkey.public_key().public_bytes_raw()
+    assert len(raw_priv) == PRIVKEY_LENGTH, f"unexpected priv length {len(raw_priv)}"
+    assert len(raw_pub) == PUBKEY_LENGTH, f"unexpected pub length {len(raw_pub)}"
+
+    b64_priv = base64.b64encode(raw_priv).decode("ascii")
+    b64_pub = base64.b64encode(raw_pub).decode("ascii")
+
+    pub_path = args.pubkey_out_dir / f"{args.key_name}.pub"
+    if pub_path.exists():
+        raise SystemExit(f"refusing to overwrite existing pubkey file: {pub_path}")
+    pub_path.write_text(b64_pub + "\n", encoding="ascii")
+    print(f"wrote pubkey: {pub_path}", file=sys.stderr)
+
+    with tempfile.TemporaryDirectory(prefix="provision-dogfood-key-") as td:
+        out_dir = Path(td)
+        _compile_proto_into(out_dir)
+        sys.path.insert(0, str(out_dir))
+
+        import grpc
+
+        from nexus.secrets.v1 import secrets_pb2, secrets_pb2_grpc
+
+        channel = grpc.secure_channel(args.vault_endpoint, grpc.ssl_channel_credentials())
+        stub = secrets_pb2_grpc.GenericSecretsServiceStub(channel)
+        metadata = (("authorization", f"Bearer {args.vault_token}"),)
+
+        # Store.
+        put_req = secrets_pb2.PutSecretRequest(
+            namespace=args.namespace,
+            key=args.key_name,
+            value=b64_priv,
+            description=args.description or f"plugin signing privkey ({args.key_name})",
+        )
+        stub.PutSecret(put_req, metadata=metadata)
+        print(
+            f"stored privkey: vault://{args.vault_endpoint}/{args.namespace}/{args.key_name}",
+            file=sys.stderr,
+        )
+
+        # Round-trip — fetch back, sign a fixed sample, verify against the
+        # in-memory pubkey. Confirms storage didn't truncate / re-encode
+        # the value and that GetSecret returns it byte-identical.
+        get_req = secrets_pb2.GetSecretRequest(
+            namespace=args.namespace,
+            key=args.key_name,
+        )
+        get_resp = stub.GetSecret(get_req, metadata=metadata)
+        if get_resp.value != b64_priv:
+            raise SystemExit(
+                "round-trip mismatch: GetSecret returned a different value than PutSecret stored"
+            )
+
+        fetched_raw = base64.b64decode(get_resp.value, validate=True)
+        fetched_privkey = Ed25519PrivateKey.from_private_bytes(fetched_raw)
+        sample = b"plugin-signing-dogfood-self-test"
+        sig = fetched_privkey.sign(sample)
+        if len(sig) != SIGNATURE_LENGTH:
+            raise SystemExit(f"unexpected signature length {len(sig)}")
+
+        verifier: Ed25519PublicKey = Ed25519PublicKey.from_public_bytes(raw_pub)
+        try:
+            verifier.verify(sig, sample)
+        except InvalidSignature as exc:
+            raise SystemExit(
+                "self-test failed: pubkey did not verify a sig made by the fetched privkey"
+            ) from exc
+
+        _shred_bytes(fetched_raw)
+        print("round-trip OK: GetSecret → sign → verify", file=sys.stderr)
+
+    _shred_bytes(raw_priv)
+    print(
+        f"pubkey (base64): {b64_pub}\n"
+        f"next step: commit {pub_path.name} into nexus-vfs/rust/kernel/trusted_keys/ "
+        f"and append it to TRUSTED_KEY_FILES.",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/vault_get_signing_key.py
+++ b/scripts/vault_get_signing_key.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Fetch a plugin signing privkey from a running vault cluster.
+
+CI shim for the plugin-signing dogfood path. When a release workflow sets
+`signing_key_source: vault`, it runs this script to pull the privkey out
+of vault and pipe it into `$GITHUB_ENV` as `PLUGIN_SIGNING_PRIVKEY` so
+`sign_plugin.py` can read it from env without ever touching disk.
+
+The other source (`github-secret`) sets `PLUGIN_SIGNING_PRIVKEY` directly
+from a repo secret — same env var, same downstream signer.
+
+Env contract:
+  VAULT_ENDPOINT   gRPC endpoint of the cluster running vault.dylib
+                   (e.g. "vault-signing.internal:2126").
+  VAULT_TOKEN      Bearer token for the vault plugin's auth surface.
+
+CLI:
+  vault_get_signing_key.py <namespace>/<key>
+    e.g. vault_get_signing_key.py signing-keys/kernel-dogfood-v1
+
+Prints the value (already base64 of 32 raw Ed25519 priv bytes — same
+format `sign_plugin.py` expects) to stdout with no trailing newline.
+Refuses to run if either env var is unset.
+
+Proto stubs are compiled into a tempdir at runtime via `grpc_tools.protoc`
+rather than committed in-tree — this script is the only Python consumer
+of `nexus.secrets.v1` and CI installs `grpcio-tools` for one job per
+release.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+ENDPOINT_ENV = "VAULT_ENDPOINT"
+TOKEN_ENV = "VAULT_TOKEN"
+
+# Repo-relative path to the secrets proto SSOT.
+PROTO_REL = Path("rust/services/proto/nexus/secrets/v1/secrets.proto")
+PROTO_IMPORT_ROOT_REL = Path("rust/services/proto")
+
+
+def _require_env(name: str) -> str:
+    val = os.environ.get(name, "").strip()
+    if not val:
+        raise SystemExit(f"environment variable {name} is empty or unset")
+    return val
+
+
+def _parse_key(arg: str) -> tuple[str, str]:
+    if "/" not in arg:
+        raise SystemExit(
+            f"expected NAMESPACE/KEY (e.g. signing-keys/kernel-dogfood-v1), got: {arg!r}"
+        )
+    namespace, key = arg.split("/", 1)
+    if not namespace or not key:
+        raise SystemExit(f"namespace and key must both be non-empty: {arg!r}")
+    return namespace, key
+
+
+def _repo_root() -> Path:
+    # scripts/vault_get_signing_key.py → repo root is parent of scripts/.
+    here = Path(__file__).resolve()
+    return here.parent.parent
+
+
+def _compile_proto_into(out_dir: Path) -> None:
+    """Generate `*_pb2.py` + `*_pb2_grpc.py` for `secrets.proto` into out_dir."""
+    from grpc_tools import protoc
+
+    proto_root = _repo_root() / PROTO_IMPORT_ROOT_REL
+    proto_file = _repo_root() / PROTO_REL
+    if not proto_file.is_file():
+        raise SystemExit(f"proto SSOT missing: {proto_file}")
+
+    rc = protoc.main(
+        [
+            "grpc_tools.protoc",
+            f"--proto_path={proto_root}",
+            f"--python_out={out_dir}",
+            f"--grpc_python_out={out_dir}",
+            str(proto_file),
+        ]
+    )
+    if rc != 0:
+        raise SystemExit(f"protoc exited {rc} when compiling {proto_file}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = sys.argv[1:] if argv is None else argv
+    if not argv or argv[0] in ("-h", "--help"):
+        print(__doc__, file=sys.stderr)
+        return 0 if argv and argv[0] in ("-h", "--help") else 2
+    if len(argv) != 1:
+        raise SystemExit("expected exactly one positional argument: NAMESPACE/KEY")
+
+    namespace, key = _parse_key(argv[0])
+    endpoint = _require_env(ENDPOINT_ENV)
+    token = _require_env(TOKEN_ENV)
+
+    with tempfile.TemporaryDirectory(prefix="vault-get-signing-key-") as td:
+        out_dir = Path(td)
+        _compile_proto_into(out_dir)
+        sys.path.insert(0, str(out_dir))
+
+        import grpc
+
+        from nexus.secrets.v1 import secrets_pb2, secrets_pb2_grpc
+
+        channel = grpc.secure_channel(endpoint, grpc.ssl_channel_credentials())
+        stub = secrets_pb2_grpc.GenericSecretsServiceStub(channel)
+        req = secrets_pb2.GetSecretRequest(namespace=namespace, key=key)
+        metadata = (("authorization", f"Bearer {token}"),)
+        resp = stub.GetSecret(req, metadata=metadata)
+
+        # Stdout only, no newline — workflow appends to `$GITHUB_ENV` as
+        # `PLUGIN_SIGNING_PRIVKEY=$(python ...)` and a trailing \n would
+        # corrupt the parsed value.
+        sys.stdout.write(resp.value)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Phase A of the plugin-signing dogfood: vault stores the signing keys for every non-vault plugin. Vault itself stays on the bootstrap `PLUGIN_SIGNING_PRIVKEY` repo secret (chicken-and-egg).

Six small commits, each a self-contained checkpoint:

1. `feat(scripts): vault_get_signing_key.py` — CI shim that pulls a privkey out of vault via `GenericSecretsService.GetSecret` and pipes it into `$GITHUB_ENV` as `PLUGIN_SIGNING_PRIVKEY`. Self-compiles proto stubs into a tempdir — no committed `_pb2.py`.
2. `feat(ci): release-plugin-reusable.yml` — generic 4-platform build + sign + package + COS upload + GH Release pipeline. Inputs select `signing_key_source` (`github-secret` or `vault`). `sign_plugin.py` is source-agnostic.
3. `refactor(ci): collapse release-vault-plugin.yml into a wrapper` — vault uses the reusable with `signing_key_source: github-secret`. -214 / +32 lines, zero behavior change.
4. `feat(scripts): provision_dogfood_key.py` — one-shot ops tool. Generates Ed25519 keypair, `PutSecret`s the privkey into vault under `signing-keys/<name>`, writes `.pub` for manual commit to nexus-vfs trust roots, self-tests `Put -> Get -> sign -> verify`.
5. `feat(ci): plugin-signing-compliance gate` — every `crate-type = ["cdylib"]` package must have a leaf release workflow that signs it. Catches the regression where a new cdylib lands without a signing path (cluster would refuse to dlopen it).
6. `feat(ci): release-local-connector-plugin.yml` — first plugin to ship via the dogfood path. `signing_key_source: vault`, `signing_key_name: signing-keys/kernel-dogfood-v1`. Wrapper only; no version bump, no tag push — that's C2 (post-Phase-B).

## Sequencing

- **Phase A (this PR):** infra + gate. Doesn't depend on the dogfood server.
- **Phase B (after 武鹏 provisions a server):** stand up `nexusd-cluster` + `vault.dylib`, run `provision_dogfood_key.py`, commit pubkey to `nexus-vfs/rust/kernel/trusted_keys/kernel-dogfood-v1.pub`, set GH org secrets `VAULT_SIGNING_ENDPOINT` + `VAULT_SIGNING_TOKEN`.
- **Phase C (after B):** tag `local-connector-v0.1.1` → first real vault-signed release. Sudowork installer + integration test follow.
- **Compliance gate enforcement:** flip the required-check toggle on `develop` branch protection once Phase A merges.

## Architectural correction (logged in plan, surfaces here)

`rust/profiles/vault/` (standalone `nexusd-vault` binary) was deleted on develop (`58f6d3de5`, `7e75e71bf`). Vault is only a cdylib now. Dogfood server runs `nexusd-cluster` + `vault.dylib`, NOT a standalone vault daemon.

## Test plan

- [x] `python scripts/check_plugin_signing_compliance.py` locally — both cdylibs (nexus-vault, nexus-local-connector) report OK.
- [ ] CI yaml-lint on the two new + one rewritten workflow files.
- [ ] `Plugin Signing Compliance` job goes green on this PR.
- [ ] Hand-trace: tag `vault-v0.1.99-rc1` on a throwaway branch should fire `release-vault-plugin.yml` → reusable → 4-platform sign+upload (not actually doing this in this PR — verification deferred to next real vault tag).