### PR TITLE
feat(plugin-signing): encrypted-in-git impl — vault on the runner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,3 +20,16 @@
 
 # Architecture docs
 /docs/architecture/       @elfenlieds7
+
+# Plugin signing trust chain — kernel team owns every file the cluster's
+# PluginLoader::load implicitly trusts (signing scripts, signing-keys
+# vault DB, the workflows that produce + verify signed dylibs, the
+# compliance gate that keeps unsigned cdylibs out of the workspace).
+/data/vault-signing/                              @elfenlieds7
+/.github/workflows/release-plugin-reusable.yml    @elfenlieds7
+/.github/workflows/plugin-signing-compliance.yml  @elfenlieds7
+/scripts/sign_plugin.py                           @elfenlieds7
+/scripts/vault_get_signing_key.py                 @elfenlieds7
+/scripts/provision_dogfood_key.py                 @elfenlieds7
+/scripts/bootstrap_dogfood_vault.py               @elfenlieds7
+/scripts/check_plugin_signing_compliance.py       @elfenlieds7

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,12 +35,13 @@ jobs:
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
 
-      - name: Create virtual environment
-        run: uv venv --python 3.14
-
       - name: Install dependencies
+        # `uv sync --frozen` installs from the committed uv.lock instead of
+        # re-resolving, so transient registry / cargo-metadata HTTP/2 flakes
+        # in sdist deps (pdf-inspector, etc.) don't surface as lint failures.
+        # `uv sync` also manages the venv, so no separate `uv venv` step.
         run: |
-          uv pip install -e ".[dev]"
+          uv sync --frozen --extra dev
 
       - name: Run ruff linting
         run: |

--- a/.github/workflows/release-fuse-plugin.yml
+++ b/.github/workflows/release-fuse-plugin.yml
@@ -10,10 +10,11 @@ name: Release FUSE Plugin
 # fuse-plugin Cargo.toml's lib doc references.
 #
 # Uses the dogfood signing path (`signing_key_source: vault`) — vault is
-# the trust root for every non-vault plugin's signing key. Wrapper is
-# committed now so the compliance gate is green; the vault path itself
-# becomes runnable once the encrypted-in-git architecture PR ships
-# (see docs/superpowers/specs/2026-06-12-encrypted-in-git-vault-dogfood-design.md).
+# the trust root for every non-vault plugin's signing key. The reusable
+# boots an ephemeral nexusd-cluster + vault.dylib on the runner against
+# data/vault-signing/vault.redb (encrypted-in-git), fetches the privkey,
+# signs, tears down — see
+# docs/superpowers/specs/2026-06-12-encrypted-in-git-vault-dogfood-design.md.
 #
 # COS path convention: nexus-fuse-plugin/release/v<version>/<filename>
 
@@ -45,8 +46,7 @@ jobs:
         KernelHandle, in-process. Linux only; macFUSE / WinFsp adapters
         are out of scope for this first-cut.
     secrets:
-      VAULT_SIGNING_ENDPOINT: ${{ secrets.VAULT_SIGNING_ENDPOINT }}
-      VAULT_SIGNING_TOKEN: ${{ secrets.VAULT_SIGNING_TOKEN }}
+      VAULT_SIGNING_MASTER_KEY: ${{ secrets.VAULT_SIGNING_MASTER_KEY }}
       COS_SECRET_ID: ${{ secrets.COS_SECRET_ID }}
       COS_SECRET_KEY: ${{ secrets.COS_SECRET_KEY }}
       COS_BUCKET: ${{ secrets.COS_BUCKET }}

--- a/.github/workflows/release-local-connector-plugin.yml
+++ b/.github/workflows/release-local-connector-plugin.yml
@@ -38,8 +38,7 @@ jobs:
         driver dylib so operators can mount a host filesystem path through the
         kernel's normal VFS surface (and, by extension, through federation).
     secrets:
-      VAULT_SIGNING_ENDPOINT: ${{ secrets.VAULT_SIGNING_ENDPOINT }}
-      VAULT_SIGNING_TOKEN: ${{ secrets.VAULT_SIGNING_TOKEN }}
+      VAULT_SIGNING_MASTER_KEY: ${{ secrets.VAULT_SIGNING_MASTER_KEY }}
       COS_SECRET_ID: ${{ secrets.COS_SECRET_ID }}
       COS_SECRET_KEY: ${{ secrets.COS_SECRET_KEY }}
       COS_BUCKET: ${{ secrets.COS_BUCKET }}

--- a/.github/workflows/release-plugin-reusable.yml
+++ b/.github/workflows/release-plugin-reusable.yml
@@ -73,12 +73,6 @@ on:
       VAULT_SIGNING_MASTER_KEY:
         description: Base64-encoded 32-byte master key used to decrypt data/vault-signing/vault.redb. Required when signing_key_source=vault. Boots an ephemeral nexusd-cluster + vault.dylib on the runner against the checked-in encrypted DB.
         required: false
-      VAULT_SIGNING_TOKEN:
-        description: (Deprecated, removed in D5.) Bearer token for an external vault. Kept temporarily for wrapper-call compatibility during the transition.
-        required: false
-      VAULT_SIGNING_ENDPOINT:
-        description: (Deprecated, removed in D5.) gRPC endpoint of an external vault. Kept temporarily for wrapper-call compatibility during the transition.
-        required: false
       COS_SECRET_ID:
         required: false
       COS_SECRET_KEY:

--- a/.github/workflows/release-plugin-reusable.yml
+++ b/.github/workflows/release-plugin-reusable.yml
@@ -70,11 +70,14 @@ on:
       PLUGIN_SIGNING_PRIVKEY:
         description: Bootstrap signing privkey (base64 of 32 raw Ed25519 priv bytes). Required when signing_key_source=github-secret.
         required: false
+      VAULT_SIGNING_MASTER_KEY:
+        description: Base64-encoded 32-byte master key used to decrypt data/vault-signing/vault.redb. Required when signing_key_source=vault. Boots an ephemeral nexusd-cluster + vault.dylib on the runner against the checked-in encrypted DB.
+        required: false
       VAULT_SIGNING_TOKEN:
-        description: Bearer token for the vault plugin's auth surface. Required when signing_key_source=vault.
+        description: (Deprecated, removed in D5.) Bearer token for an external vault. Kept temporarily for wrapper-call compatibility during the transition.
         required: false
       VAULT_SIGNING_ENDPOINT:
-        description: gRPC endpoint of the cluster running vault.dylib. Required when signing_key_source=vault.
+        description: (Deprecated, removed in D5.) gRPC endpoint of an external vault. Kept temporarily for wrapper-call compatibility during the transition.
         required: false
       COS_SECRET_ID:
         required: false
@@ -270,6 +273,108 @@ jobs:
         if: inputs.signing_key_source == 'vault'
         run: pip install --quiet grpcio grpcio-tools
 
+      # ── Ephemeral vault on runner (signing_key_source: vault) ──────────────
+      # When the signing key lives in the encrypted-in-git vault DB, we boot
+      # a throwaway nexusd-cluster + vault.dylib on the runner pointed at
+      # data/vault-signing/vault.redb, fetch the privkey over localhost
+      # gRPC, sign, then tear down. The cluster never persists to the
+      # runner outside the job — keys never leave the workflow.
+      #
+      # Pinned nexus-vfs rev: refresh quarterly via PR. The rev controls
+      # which TRUSTED_KEY_FILES the ephemeral cluster ships; bumping it
+      # too aggressively risks the cluster not yet embedding a key that
+      # signs vault.dylib downloaded from GH Releases.
+      - name: Install nexusd-cluster for ephemeral vault
+        if: inputs.signing_key_source == 'vault'
+        env:
+          # TODO(kernel-team): replace with a real pinned nexus-vfs rev
+          # before the first vault-source release tag is pushed. CI flags
+          # this with a clear cargo install failure otherwise.
+          NEXUS_VFS_REV: REPLACE_WITH_PINNED_NEXUS_VFS_REV
+        run: |
+          set -euo pipefail
+          if [ "${NEXUS_VFS_REV}" = "REPLACE_WITH_PINNED_NEXUS_VFS_REV" ]; then
+            echo "::error::nexus-vfs rev is not pinned in release-plugin-reusable.yml; update the workflow before pushing a vault-source release tag."
+            exit 1
+          fi
+          cargo install \
+            --git https://github.com/nexi-lab/nexus-vfs \
+            --rev "${NEXUS_VFS_REV}" \
+            --locked \
+            --bin nexusd-cluster \
+            nexus-cluster
+
+      - name: Download latest signed vault.dylib from GH Release
+        if: inputs.signing_key_source == 'vault'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/vault-plugins
+          # Latest release matching the asset pattern. Vault releases via
+          # release-vault-plugin.yml (github-secret path) so a signed
+          # archive is always available before any vault-source plugin
+          # ships.
+          gh release download \
+            --repo nexi-lab/nexus \
+            --pattern 'nexus-vault-linux-x86_64.tar.gz' \
+            --dir /tmp
+          tar -xzf /tmp/nexus-vault-linux-x86_64.tar.gz -C /tmp/vault-plugins/
+          ls -l /tmp/vault-plugins/
+          # Both files must be present — PluginLoader::load Ed25519-verifies
+          # libnexus_vault.so against its TRUSTED_KEY_FILES before dlopen,
+          # using the sibling .sig.
+          test -f /tmp/vault-plugins/libnexus_vault.so
+          test -f /tmp/vault-plugins/libnexus_vault.so.sig
+
+      - name: Stage encrypted vault DB
+        if: inputs.signing_key_source == 'vault'
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/vault-data
+          if [ ! -f data/vault-signing/vault.redb ]; then
+            echo "::error::data/vault-signing/vault.redb is missing — run scripts/bootstrap_dogfood_vault.py and commit the DB before pushing a vault-source release tag."
+            exit 1
+          fi
+          cp data/vault-signing/vault.redb /tmp/vault-data/
+
+      - name: Start ephemeral nexusd-cluster
+        if: inputs.signing_key_source == 'vault'
+        env:
+          VAULT_MASTER_KEY: ${{ secrets.VAULT_SIGNING_MASTER_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${VAULT_MASTER_KEY:-}" ]; then
+            echo "::error::signing_key_source=vault requires VAULT_SIGNING_MASTER_KEY secret on the caller."
+            exit 1
+          fi
+          nexusd-cluster \
+            --no-tls \
+            --data-dir /tmp/vault-data \
+            --plugin-dir /tmp/vault-plugins \
+            --bootstrap-mode static \
+            > /tmp/cluster.log 2>&1 &
+          CLUSTER_PID=$!
+          echo "CLUSTER_PID=${CLUSTER_PID}" >> "$GITHUB_ENV"
+          # Block until the cluster's ready marker appears. The fallback
+          # heuristic (process exited) catches a crash so we fail fast
+          # instead of hitting the 60s timeout.
+          for i in $(seq 1 60); do
+            if [ -f /tmp/vault-data/cluster.ready ]; then
+              echo "cluster ready after ${i}s"
+              exit 0
+            fi
+            if ! kill -0 "${CLUSTER_PID}" 2>/dev/null; then
+              echo "::error::nexusd-cluster exited before ready marker — log:"
+              cat /tmp/cluster.log
+              exit 1
+            fi
+            sleep 1
+          done
+          echo "::error::timed out after 60s waiting for /tmp/vault-data/cluster.ready"
+          cat /tmp/cluster.log
+          exit 1
+
       - name: Fetch signing privkey from vault
         # Pulls the privkey out of the running vault cluster and pipes it
         # into $GITHUB_ENV so the next step's sign_plugin.py call reads
@@ -278,15 +383,12 @@ jobs:
         # log line containing it gets redacted.
         if: inputs.signing_key_source == 'vault'
         env:
-          VAULT_ENDPOINT: ${{ secrets.VAULT_SIGNING_ENDPOINT }}
-          VAULT_TOKEN: ${{ secrets.VAULT_SIGNING_TOKEN }}
+          VAULT_ENDPOINT: localhost:2126
+          VAULT_TOKEN: bootstrap-local
+          VAULT_INSECURE: "1"
           SIGNING_KEY_NAME: ${{ inputs.signing_key_name }}
         run: |
           set -euo pipefail
-          if [ -z "${VAULT_ENDPOINT}" ] || [ -z "${VAULT_TOKEN}" ]; then
-            echo "::error::signing_key_source=vault requires VAULT_SIGNING_ENDPOINT + VAULT_SIGNING_TOKEN secrets on the caller."
-            exit 1
-          fi
           if [ -z "${SIGNING_KEY_NAME}" ]; then
             echo "::error::signing_key_source=vault requires inputs.signing_key_name (e.g. signing-keys/kernel-dogfood-v1)."
             exit 1
@@ -460,6 +562,23 @@ jobs:
           name: release-assets
           path: release-assets/*
           retention-days: 1
+
+      # Tear-down runs `if: always()` so a failure in sign/package/upload
+      # still kills the cluster and wipes the staged DB + plugin dir. The
+      # privkey only exists in $GITHUB_ENV for this job and is masked.
+      - name: Tear down ephemeral vault cluster
+        if: always() && inputs.signing_key_source == 'vault'
+        run: |
+          set +e
+          if [ -n "${CLUSTER_PID:-}" ]; then
+            kill "${CLUSTER_PID}" 2>/dev/null
+            for i in $(seq 1 10); do
+              kill -0 "${CLUSTER_PID}" 2>/dev/null || break
+              sleep 1
+            done
+            kill -9 "${CLUSTER_PID}" 2>/dev/null
+          fi
+          rm -rf /tmp/vault-data /tmp/vault-plugins /tmp/nexus-vault-linux-x86_64.tar.gz /tmp/cluster.log
 
   # ── Create GitHub Release ──────────────────────────────────────────────────
   create-release:

--- a/.github/workflows/release-plugin-reusable.yml
+++ b/.github/workflows/release-plugin-reusable.yml
@@ -281,16 +281,16 @@ jobs:
       - name: Install nexusd-cluster for ephemeral vault
         if: inputs.signing_key_source == 'vault'
         env:
-          # TODO(kernel-team): replace with a real pinned nexus-vfs rev
-          # before the first vault-source release tag is pushed. CI flags
-          # this with a clear cargo install failure otherwise.
-          NEXUS_VFS_REV: REPLACE_WITH_PINNED_NEXUS_VFS_REV
+          # Pinned nexus-vfs rev. Refresh quarterly via PR. At pin time:
+          #   - TRUSTED_KEY_FILES embeds the bootstrap pubkey (nexus-team.pub),
+          #     which signs every vault.dylib download we'll Ed25519-verify.
+          #   - rust/profiles/cluster's nexus-cluster package exposes the
+          #     nexusd-cluster bin with --no-tls / --data-dir / --plugin-dir
+          #     / --bootstrap-mode flags this job depends on.
+          # When refreshing, re-verify both invariants before bumping.
+          NEXUS_VFS_REV: 02ef41f46436cfa56e5e3b043aac4bd90bd1cd2f
         run: |
           set -euo pipefail
-          if [ "${NEXUS_VFS_REV}" = "REPLACE_WITH_PINNED_NEXUS_VFS_REV" ]; then
-            echo "::error::nexus-vfs rev is not pinned in release-plugin-reusable.yml; update the workflow before pushing a vault-source release tag."
-            exit 1
-          fi
           cargo install \
             --git https://github.com/nexi-lab/nexus-vfs \
             --rev "${NEXUS_VFS_REV}" \

--- a/.gitignore
+++ b/.gitignore
@@ -139,11 +139,15 @@ my-data/
 # `nexus serve` from the repo root without setting NEXUS_DATA_DIR drops
 # raft state + redb + CAS into data/, which then bakes into the next
 # `docker compose build` and silently pollutes federation bootstrap.
-# Allow only `data/skills/` to be tracked; everything else under data/
-# is runtime detritus.
+# Allow only `data/skills/` and `data/vault-signing/` to be tracked;
+# everything else under data/ is runtime detritus.
+# `data/vault-signing/` holds the encrypted-in-git plugin signing vault DB
+# (per docs/superpowers/specs/2026-06-12-encrypted-in-git-vault-dogfood-design.md).
 /data/*
 !/data/skills
 !/data/skills/**
+!/data/vault-signing
+!/data/vault-signing/**
 # Runtime state + credentials that can land anywhere `data_dir:` points to.
 .admin-api-key
 .state.json

--- a/data/vault-signing/README.md
+++ b/data/vault-signing/README.md
@@ -1,0 +1,116 @@
+# Vault signing keys — encrypted-in-git dogfood
+
+This directory is the persistent home of the dogfood vault DB that holds
+every non-vault plugin's signing privkey. The DB is committed in binary
+form; vault's AES-256-GCM per-entry encryption hides the privkey values.
+The repo is public; values are unreadable without the master key.
+
+Architecture SSOT: `docs/superpowers/specs/2026-06-12-encrypted-in-git-vault-dogfood-design.md`.
+Kernel team owns this directory (see `CODEOWNERS`).
+
+## Layout
+
+```
+data/vault-signing/
+  README.md                  # this file
+  vault.redb                 # the redb file vault writes to; encrypted values
+  pubkeys/                   # base64 Ed25519 pubkey alongside each privkey
+    <key-name>.pub
+```
+
+`vault.redb` is generated once by the kernel-team lead via
+`scripts/bootstrap_dogfood_vault.py` and never overwritten by routine
+edits — only key adds and rotations touch it.
+
+## Bootstrap (one-time, kernel-team lead only)
+
+Required only once per master key. Run on a kernel-team machine with a
+local `nexusd-cluster` binary and a built (or downloaded + verified)
+`libnexus_vault.so` + `.sig`.
+
+```bash
+python scripts/bootstrap_dogfood_vault.py \
+  --nexusd-cluster <path-to-nexusd-cluster> \
+  --vault-plugin-dir <dir-with-libnexus_vault.so-and-.sig>
+```
+
+Output: an initialized empty `data/vault-signing/vault.redb` + the master
+key printed to stderr. Then:
+
+1. Register the master key as the GH org secret:
+   ```bash
+   gh secret set VAULT_SIGNING_MASTER_KEY --org nexi-lab --body '<master-key>'
+   ```
+2. Stage and commit the DB:
+   ```bash
+   git add data/vault-signing/vault.redb
+   git commit -m 'feat(vault-signing): initial encrypted DB'
+   ```
+
+The script refuses to clobber an existing `vault.redb`. Rotation is a
+distinct procedure (below).
+
+## Adding a plugin signing key
+
+Each new signing root is one PR. Run locally against the checked-out DB:
+
+```bash
+export VAULT_MASTER_KEY=$(gh secret get VAULT_SIGNING_MASTER_KEY --org nexi-lab)
+mkdir -p /tmp/local-vault-data
+cp data/vault-signing/vault.redb /tmp/local-vault-data/
+nexusd-cluster --no-tls --data-dir /tmp/local-vault-data \
+  --plugin-dir <local-vault-plugin-dir> &
+LOCAL_PID=$!
+# Wait for /tmp/local-vault-data/cluster.ready (or sleep ~5s)
+
+python scripts/provision_dogfood_key.py \
+  --vault-endpoint localhost:2126 \
+  --vault-token bootstrap-local \
+  --insecure \
+  --key-name <new-key-name>
+
+kill $LOCAL_PID
+cp /tmp/local-vault-data/vault.redb data/vault-signing/vault.redb
+mv <new-key-name>.pub data/vault-signing/pubkeys/
+```
+
+Stage `data/vault-signing/vault.redb` + `data/vault-signing/pubkeys/<new-key-name>.pub`,
+open the PR. CODEOWNERS gates kernel-team approval.
+
+After this PR merges, ship a sibling nexus-vfs PR adding
+`rust/kernel/trusted_keys/<new-key-name>.pub` + an `include_bytes!` entry
+in `TRUSTED_KEY_FILES` (`rust/kernel/src/kernel/plugins/loader.rs`). Merge
+nexus-vfs **before** any plugin signed with the new key reaches a
+consumer cluster.
+
+## Rotation (master key)
+
+Rotation breaks every committed value's decryption. Procedure:
+
+1. Locally export the current master key from the GH secret and decrypt
+   every secret in memory (one-off script — TBD in a follow-up).
+2. Generate a new master key via CSPRNG.
+3. Re-encrypt all secrets, write a fresh `vault.redb`.
+4. PR the new DB. CODEOWNERS gates review.
+5. Update the GH org secret in lock-step with the merge — between merge
+   and secret update CI release jobs will fail loudly (decrypt error).
+   Coordinate; don't bunch with a release.
+6. Lost master key = every committed secret is unrecoverable. Plugin
+   signing privkeys are designed to be rotatable: re-provision via fresh
+   `<key-name>-v<n+1>`, ship the new pubkey through the nexus-vfs trust
+   root, re-tag releases.
+
+## Concurrency
+
+Two PRs adding keys race on `vault.redb`. The second PR's redb reflects
+state without the first PR's key; merge produces a binary file conflict
+git refuses to auto-resolve. The second PR's author re-runs provisioning
+against the merged-in first PR's DB. Acceptable friction at our
+key-add cadence.
+
+## Threat model
+
+See the design doc — the short version: read access to this repo reveals
+the encrypted DB and pubkeys but not privkey values; master-key
+compromise = full disclosure of every committed signing privkey, requires
+rotating every plugin signing root + shipping cluster trust-root updates.

--- a/scripts/bootstrap_dogfood_vault.py
+++ b/scripts/bootstrap_dogfood_vault.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""One-time tool to create an empty encrypted vault DB for the dogfood path.
+
+Run once per master key, by the kernel-team lead. Boots an ephemeral
+`nexusd-cluster + vault.dylib` against a tempdir with a freshly generated
+master key in env, waits until vault initializes its redb file, stops the
+cluster, and moves the empty initialized DB into
+`data/vault-signing/vault.redb`.
+
+After this script returns:
+
+  1. Register the printed master key as the `VAULT_SIGNING_MASTER_KEY` GH
+     org secret:
+       gh secret set VAULT_SIGNING_MASTER_KEY --org nexi-lab --body '<key>'
+  2. Stage + commit the new `data/vault-signing/vault.redb` and push the PR.
+  3. Provision keys via `scripts/provision_dogfood_key.py` (one-per-PR).
+
+Refuses to run if `data/vault-signing/vault.redb` already exists —
+overwriting would obliterate every committed signing key. Rotation has a
+separate procedure (see design doc).
+
+The generated key prints to stderr, NOT stdout, so piping the script's
+stdout into a file doesn't accidentally land the master key on disk. The
+master key is shredded from process memory before exit on a best-effort
+basis (same `ctypes.memset` pattern as `provision_dogfood_key.py`).
+
+CLI:
+  bootstrap_dogfood_vault.py \
+    --nexusd-cluster <path-to-nexusd-cluster-binary> \
+    --vault-plugin-dir <dir-with-libnexus_vault.so + .sig>
+
+See `docs/superpowers/specs/2026-06-12-encrypted-in-git-vault-dogfood-design.md`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import contextlib
+import ctypes
+import os
+import shutil
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+DEFAULT_READY_MARKER = "cluster.ready"
+DEFAULT_READY_TIMEOUT_SEC = 60
+DEFAULT_VAULT_PORT = 2126
+MASTER_KEY_BYTES = 32
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parent.parent
+
+
+def _target_db_path(root: Path) -> Path:
+    return root / "data" / "vault-signing" / "vault.redb"
+
+
+def _shred_bytes(buf: bytes) -> None:
+    """Best-effort in-place zero of a bytes buffer's backing memory.
+
+    Mirrors the pattern in `provision_dogfood_key.py`. Reduces the window
+    the master key sits live in process RSS.
+    """
+    if not buf:
+        return
+    addr = ctypes.cast(ctypes.c_char_p(buf), ctypes.c_void_p).value
+    if addr:
+        ctypes.memset(addr, 0, len(buf))
+
+
+def _wait_for_ready(
+    data_dir: Path,
+    ready_marker: str,
+    timeout_sec: int,
+    proc: subprocess.Popen[bytes],
+) -> None:
+    deadline = time.monotonic() + timeout_sec
+    marker_path = data_dir / ready_marker
+    redb_path = data_dir / "vault.redb"
+    while time.monotonic() < deadline:
+        if proc.poll() is not None:
+            raise SystemExit(
+                f"nexusd-cluster exited prematurely with code {proc.returncode} "
+                f"before ready marker appeared"
+            )
+        if marker_path.is_file():
+            return
+        # Fallback: vault has flushed an initialized redb file. Use a
+        # non-zero size as a heuristic for "init complete enough to copy".
+        if redb_path.is_file() and redb_path.stat().st_size > 0:
+            # Give vault a moment to finish post-init bookkeeping if it's
+            # going to write the ready marker later.
+            time.sleep(1)
+            return
+        time.sleep(0.5)
+    raise SystemExit(f"timed out after {timeout_sec}s waiting for {marker_path} or {redb_path}")
+
+
+def _stop_cluster(proc: subprocess.Popen[bytes]) -> None:
+    if proc.poll() is not None:
+        return
+    if os.name == "posix":
+        # start_new_session=True put it in its own process group; signal the
+        # whole group so raft / plugin loader subprocesses tear down too.
+        try:
+            os.killpg(proc.pid, signal.SIGTERM)
+        except ProcessLookupError:
+            return
+    else:
+        proc.terminate()
+    try:
+        proc.wait(timeout=15)
+    except subprocess.TimeoutExpired:
+        if os.name == "posix":
+            with contextlib.suppress(ProcessLookupError):
+                os.killpg(proc.pid, signal.SIGKILL)
+        else:
+            proc.kill()
+        proc.wait(timeout=5)
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(
+        description="Initialize the encrypted-in-git vault DB for plugin signing.",
+    )
+    p.add_argument(
+        "--nexusd-cluster",
+        default="nexusd-cluster",
+        help="Path to the nexusd-cluster binary (default: 'nexusd-cluster' on PATH).",
+    )
+    p.add_argument(
+        "--vault-plugin-dir",
+        type=Path,
+        required=True,
+        help="Directory containing libnexus_vault.<ext> + .sig. Passed as --plugin-dir.",
+    )
+    p.add_argument(
+        "--ready-marker",
+        default=DEFAULT_READY_MARKER,
+        help=f"Filename under data-dir vault writes when ready (default: {DEFAULT_READY_MARKER}).",
+    )
+    p.add_argument(
+        "--ready-timeout-sec",
+        type=int,
+        default=DEFAULT_READY_TIMEOUT_SEC,
+        help=f"Seconds to wait for ready marker (default: {DEFAULT_READY_TIMEOUT_SEC}).",
+    )
+    args = p.parse_args(argv)
+
+    root = _repo_root()
+    target = _target_db_path(root)
+    if target.exists():
+        raise SystemExit(
+            f"refusing to clobber existing vault DB: {target.relative_to(root)}\n"
+            f"This script is one-time. Rotation has a separate procedure — see "
+            f"docs/superpowers/specs/2026-06-12-encrypted-in-git-vault-dogfood-design.md."
+        )
+
+    plugin_dir = args.vault_plugin_dir.resolve()
+    if not plugin_dir.is_dir():
+        raise SystemExit(f"vault plugin dir does not exist: {plugin_dir}")
+    dylib_candidates = (
+        plugin_dir / "libnexus_vault.so",
+        plugin_dir / "libnexus_vault.dylib",
+        plugin_dir / "nexus_vault.dll",
+    )
+    if not any(c.is_file() for c in dylib_candidates):
+        raise SystemExit(
+            f"vault plugin dir has no libnexus_vault.{{so,dylib}} or nexus_vault.dll: {plugin_dir}"
+        )
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+
+    raw_master = os.urandom(MASTER_KEY_BYTES)
+    master_b64 = base64.b64encode(raw_master).decode("ascii")
+
+    with tempfile.TemporaryDirectory(prefix="bootstrap-dogfood-vault-") as td:
+        data_dir = Path(td)
+
+        env = os.environ.copy()
+        env["VAULT_MASTER_KEY"] = master_b64
+
+        popen_kwargs: dict[str, object] = {
+            "env": env,
+            "stdout": subprocess.DEVNULL,
+            "stderr": subprocess.PIPE,
+        }
+        if os.name == "posix":
+            popen_kwargs["start_new_session"] = True
+
+        proc = subprocess.Popen(
+            [
+                args.nexusd_cluster,
+                "--no-tls",
+                "--data-dir",
+                str(data_dir),
+                "--plugin-dir",
+                str(plugin_dir),
+                "--bootstrap-mode",
+                "static",
+            ],
+            **popen_kwargs,
+        )
+        try:
+            _wait_for_ready(data_dir, args.ready_marker, args.ready_timeout_sec, proc)
+        finally:
+            _stop_cluster(proc)
+
+        produced = data_dir / "vault.redb"
+        if not produced.is_file():
+            raise SystemExit(f"vault did not produce {produced} — check cluster stderr above")
+        if produced.stat().st_size == 0:
+            raise SystemExit(f"vault produced zero-byte {produced}")
+
+        shutil.move(str(produced), str(target))
+
+    print(
+        f"\nWrote initialized vault DB: {target.relative_to(root)}\n"
+        f"\nNext steps:\n"
+        f"  1. Register the master key as a GH org secret:\n"
+        f"       gh secret set VAULT_SIGNING_MASTER_KEY --org nexi-lab --body '<master-key-below>'\n"
+        f"  2. Stage and commit the DB:\n"
+        f"       git add {target.relative_to(root)}\n"
+        f"       git commit -m 'feat(vault-signing): initial encrypted DB'\n"
+        f"  3. Push and open a PR; CODEOWNERS gates kernel-team review.\n"
+        f"\nMASTER KEY (base64, 32 raw bytes) — save this NOW, it is NOT recoverable:\n"
+        f"{master_b64}\n",
+        file=sys.stderr,
+    )
+
+    _shred_bytes(raw_master)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/provision_dogfood_key.py
+++ b/scripts/provision_dogfood_key.py
@@ -125,6 +125,15 @@ def main(argv: list[str] | None = None) -> int:
         default="",
         help="Optional description recorded with the vault secret metadata.",
     )
+    p.add_argument(
+        "--insecure",
+        action="store_true",
+        help=(
+            "Use grpc.insecure_channel instead of TLS. Required for the kernel-team "
+            "local-provisioning workflow against an ephemeral localhost vault "
+            "(--no-tls cluster). Never use against a network endpoint."
+        ),
+    )
     args = p.parse_args(argv)
 
     from cryptography.exceptions import InvalidSignature
@@ -157,7 +166,10 @@ def main(argv: list[str] | None = None) -> int:
 
         from nexus.secrets.v1 import secrets_pb2, secrets_pb2_grpc
 
-        channel = grpc.secure_channel(args.vault_endpoint, grpc.ssl_channel_credentials())
+        if args.insecure:
+            channel = grpc.insecure_channel(args.vault_endpoint)
+        else:
+            channel = grpc.secure_channel(args.vault_endpoint, grpc.ssl_channel_credentials())
         stub = secrets_pb2_grpc.GenericSecretsServiceStub(channel)
         metadata = (("authorization", f"Bearer {args.vault_token}"),)
 

--- a/scripts/vault_get_signing_key.py
+++ b/scripts/vault_get_signing_key.py
@@ -13,6 +13,10 @@ Env contract:
   VAULT_ENDPOINT   gRPC endpoint of the cluster running vault.dylib
                    (e.g. "vault-signing.internal:2126").
   VAULT_TOKEN      Bearer token for the vault plugin's auth surface.
+  VAULT_INSECURE   When "1", use grpc.insecure_channel instead of TLS.
+                   Required for the ephemeral-vault-on-runner path (no TLS,
+                   localhost only) and the kernel-team local-provisioning
+                   workflow. Unset / "0" in any prod / network path.
 
 CLI:
   vault_get_signing_key.py <namespace>/<key>
@@ -37,6 +41,7 @@ from pathlib import Path
 
 ENDPOINT_ENV = "VAULT_ENDPOINT"
 TOKEN_ENV = "VAULT_TOKEN"
+INSECURE_ENV = "VAULT_INSECURE"
 
 # Repo-relative path to the secrets proto SSOT.
 PROTO_REL = Path("rust/services/proto/nexus/secrets/v1/secrets.proto")
@@ -100,6 +105,7 @@ def main(argv: list[str] | None = None) -> int:
     namespace, key = _parse_key(argv[0])
     endpoint = _require_env(ENDPOINT_ENV)
     token = _require_env(TOKEN_ENV)
+    insecure = os.environ.get(INSECURE_ENV, "").strip() == "1"
 
     with tempfile.TemporaryDirectory(prefix="vault-get-signing-key-") as td:
         out_dir = Path(td)
@@ -110,7 +116,10 @@ def main(argv: list[str] | None = None) -> int:
 
         from nexus.secrets.v1 import secrets_pb2, secrets_pb2_grpc
 
-        channel = grpc.secure_channel(endpoint, grpc.ssl_channel_credentials())
+        if insecure:
+            channel = grpc.insecure_channel(endpoint)
+        else:
+            channel = grpc.secure_channel(endpoint, grpc.ssl_channel_credentials())
         stub = secrets_pb2_grpc.GenericSecretsServiceStub(channel)
         req = secrets_pb2.GetSecretRequest(namespace=namespace, key=key)
         metadata = (("authorization", f"Bearer {token}"),)


### PR DESCRIPTION
## Summary

Phase D of the plugin signing dogfood plan. Turns the `signing_key_source: vault` path on `release-plugin-reusable.yml` from "committed but not runnable" into runnable: each release CI job that needs a dogfood-signed plugin boots an ephemeral `nexusd-cluster + vault.dylib` on the runner against `data/vault-signing/vault.redb` (AES-256-GCM-encrypted with `VAULT_SIGNING_MASTER_KEY`), fetches the privkey over localhost gRPC, signs, tears down. No external vault server, no Feishu coordination.

Architecture SSOT: `docs/superpowers/specs/2026-06-12-encrypted-in-git-vault-dogfood-design.md`.

## Commits

One commit per concern, intentionally not squashed — each is a self-explanatory rollback checkpoint:

1. `feat(scripts): bootstrap_dogfood_vault.py` — one-time DB initializer.
2. `feat(vault-signing): data/vault-signing/ skeleton + README` — placeholder structure + `.gitignore` allow-list.
3. `feat(scripts): VAULT_INSECURE / --insecure` — both Python vault clients can talk to localhost no-TLS.
4. `feat(ci): release-plugin-reusable - ephemeral vault cluster for vault-source` — the 5 new steps + tear-down.
5. `feat(ci): drop external-vault secrets, plumb VAULT_SIGNING_MASTER_KEY` — wrappers + reusable secrets cleanup.
6. `feat(codeowners): kernel-team gates the plugin signing trust chain` — every signing-trust path requires kernel-team review.

## Required operator actions before merge

The compliance gate stays green on this PR as-is, but the vault-source path is not actually exercisable until:

1. **Pin a real nexus-vfs rev.** The reusable workflow's cargo-install step uses placeholder `REPLACE_WITH_PINNED_NEXUS_VFS_REV` and fails the step early with a clear error otherwise. Pick the latest stable rev of `nexi-lab/nexus-vfs` whose `TRUSTED_KEY_FILES` already embeds at least the bootstrap pubkey (so the ephemeral cluster can verify the downloaded `vault.dylib`). Update via a follow-up commit on this PR.
2. **Run the bootstrap script locally** to produce `data/vault-signing/vault.redb`:
   ```bash
   python scripts/bootstrap_dogfood_vault.py \
     --nexusd-cluster <path-to-nexusd-cluster> \
     --vault-plugin-dir <dir-with-libnexus_vault.so-and-.sig>
   ```
3. **Register the printed master key as a GH org secret:**
   ```bash
   gh secret set VAULT_SIGNING_MASTER_KEY --org nexi-lab --body '<printed-key>'
   ```
4. **Commit the generated `data/vault-signing/vault.redb`** to this PR (CODEOWNERS gates kernel-team review).

After all four are done, Phase B2a (provisioning `signing-keys/kernel-dogfood-v1`) and Phase B2b (nexus-vfs trust-root PR) can follow.

## Follow-ups (out of scope, separate PRs)

- nexus-vfs: verify `services::password_vault::auth` accepts the `bootstrap-local` token when `--no-tls` + 127.0.0.1; if not, add `--admin-token` on `nexusd-cluster` or an insecure-local auth bypass.
- Cross-repo mirror check in `check_plugin_signing_compliance.py` (B2c): every `data/vault-signing/pubkeys/*.pub` should have a matching `TRUSTED_KEY_FILES` entry in nexus-vfs. Prefer a soft `gh api` check; don't gate on flaky external fetch.
- `test.yml` should switch to `uv sync --frozen` (backlog item from the plan; orthogonal to this work).

## Test plan

- [x] `python scripts/check_plugin_signing_compliance.py` green locally.
- [x] All 3 modified workflow YAMLs parse with PyYAML.
- [x] Both vault clients (`vault_get_signing_key.py`, `provision_dogfood_key.py`) `--help` still works after the insecure flag edit.
- [ ] CI green on this PR (lint, compliance, no vault-path execution since no release tag).
- [ ] Operator runs `bootstrap_dogfood_vault.py` against a local cluster + vault.dylib, commits `vault.redb`.
- [ ] Operator pins nexus-vfs rev in `release-plugin-reusable.yml`.
- [ ] After merge + Phase B2a + B2b: tag `local-connector-v0.1.1`, watch the full ephemeral-vault path execute end-to-end.