### PR TITLE
[codex] Add ReBAC path-pattern tuple support

### DIFF
--- a/docs/guides/user-guide.md
+++ b/docs/guides/user-guide.md
@@ -659,6 +659,15 @@ nexus rebac explain agent alice write file /zone/local/notes/todo.txt \
   --zone-id sandbox-agent-1 --verbose
 ```
 
+Path-style `file` tuple object IDs also support two explicit suffixes for bulk
+grants:
+
+- `/prefix/**` grants the relation on `/prefix` and every descendant below it.
+- `/prefix/*` grants the relation on direct children of `/prefix` only.
+
+No other glob syntax is expanded. Values such as `/prefix/*.md` or interior
+`*` characters are stored literally.
+
 MCP tool grants use named profiles from `src/nexus/config/tool_profiles.yaml`.
 The profile CLI materializes those profiles into the same `/tools/...` ReBAC
 namespace used by MCP `tools/list` and `tools/call` filtering:

--- a/docs/superpowers/plans/2026-06-12-issue-4239-rebac-path-prefix-tuples.md
+++ b/docs/superpowers/plans/2026-06-12-issue-4239-rebac-path-prefix-tuples.md
@@ -1,0 +1,987 @@
+# Issue #4239 ReBAC Path Prefix Tuples Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add explicit `/**` and `/*` file path-pattern tuple semantics to ReBAC checks, bulk filtering, and cache invalidation.
+
+**Architecture:** Keep tuple storage unchanged and make pattern matching a bounded lookup problem. Generate finite candidate object IDs for each requested file path, query those candidates with indexed `IN` predicates, evaluate exact matches before broader pattern matches, and skip Rust bulk acceleration when fetched tuples contain path patterns until the Rust engine learns the same semantics.
+
+**Tech Stack:** Python 3.14, SQLAlchemy, pytest, existing ReBAC manager/enforcer tests, `uv run --no-sync`, Ruff.
+
+---
+
+## File Structure
+
+- Create `src/nexus/bricks/rebac/path_patterns.py`: pure helper for file path-pattern detection, prefix extraction, candidate generation, and match checks.
+- Create `tests/unit/bricks/rebac/test_path_patterns.py`: unit tests for helper semantics.
+- Create `tests/unit/bricks/rebac/test_path_pattern_permissions.py`: manager, bulk, enforcer, userset, ABAC, and cache invalidation coverage.
+- Modify `src/nexus/bricks/rebac/graph/traversal.py`: single-check direct tuple lookup uses candidate object IDs for direct, wildcard, and userset-as-subject rows.
+- Modify `src/nexus/bricks/rebac/batch/bulk_checker.py`: bulk tuple fetch includes path-pattern candidate object IDs.
+- Modify `src/nexus/bricks/rebac/graph/bulk_evaluator.py`: in-memory direct relation evaluation recognizes fetched path-pattern tuples.
+- Modify `src/nexus/bricks/rebac/utils/fast.py`: skip Rust bulk acceleration when tuple graphs contain path-pattern tuples.
+- Modify `src/nexus/bricks/rebac/cache/coordinator.py`: invalidate cached descendant permission results when a pattern tuple changes.
+- Modify `docs/guides/user-guide.md`: document the supported suffixes in the ReBAC user guide section.
+
+## Task 1: Path Pattern Helper
+
+**Files:**
+- Create: `tests/unit/bricks/rebac/test_path_patterns.py`
+- Create: `src/nexus/bricks/rebac/path_patterns.py`
+
+- [ ] **Step 1: Write failing helper tests**
+
+Create `tests/unit/bricks/rebac/test_path_patterns.py`:
+
+```python
+"""Path-pattern tuple helper tests for ReBAC issue #4239."""
+
+from nexus.bricks.rebac.path_patterns import (
+    is_path_pattern,
+    path_pattern_candidates,
+    path_pattern_matches,
+    path_pattern_prefix,
+)
+
+
+def test_recursive_root_pattern_matches_all_absolute_paths() -> None:
+    assert is_path_pattern("file", "/**")
+    assert path_pattern_prefix("file", "/**") == "/"
+    assert path_pattern_matches("/**", "/")
+    assert path_pattern_matches("/**", "/a")
+    assert path_pattern_matches("/**", "/a/b.txt")
+
+
+def test_recursive_prefix_matches_prefix_and_descendants_only() -> None:
+    assert is_path_pattern("file", "/workspaces/**")
+    assert path_pattern_prefix("file", "/workspaces/**") == "/workspaces"
+    assert path_pattern_matches("/workspaces/**", "/workspaces")
+    assert path_pattern_matches("/workspaces/**", "/workspaces/ws1/a.md")
+    assert not path_pattern_matches("/workspaces/**", "/workspaces2/a.md")
+
+
+def test_single_level_pattern_matches_direct_children_only() -> None:
+    assert is_path_pattern("file", "/workspaces/*")
+    assert path_pattern_prefix("file", "/workspaces/*") == "/workspaces"
+    assert path_pattern_matches("/workspaces/*", "/workspaces/a.md")
+    assert not path_pattern_matches("/workspaces/*", "/workspaces")
+    assert not path_pattern_matches("/workspaces/*", "/workspaces/a/b.md")
+    assert not path_pattern_matches("/workspaces/*", "/workspaces2/a.md")
+
+
+def test_root_single_level_pattern_matches_one_root_child() -> None:
+    assert is_path_pattern("file", "/*")
+    assert path_pattern_prefix("file", "/*") == "/"
+    assert path_pattern_matches("/*", "/a.md")
+    assert not path_pattern_matches("/*", "/")
+    assert not path_pattern_matches("/*", "/a/b.md")
+
+
+def test_non_file_and_relative_ids_are_not_patterns() -> None:
+    assert not is_path_pattern("group", "/workspaces/**")
+    assert not is_path_pattern("file", "workspaces/**")
+    assert path_pattern_prefix("group", "/workspaces/**") is None
+    assert path_pattern_candidates("group", "/workspaces/a.md") == ["/workspaces/a.md"]
+    assert path_pattern_candidates("file", "workspaces/a.md") == ["workspaces/a.md"]
+
+
+def test_candidates_are_bounded_and_ordered_from_exact_to_broad() -> None:
+    assert path_pattern_candidates("file", "/workspaces/ws1/a.md") == [
+        "/workspaces/ws1/a.md",
+        "/workspaces/ws1/a.md/**",
+        "/workspaces/ws1/*",
+        "/workspaces/ws1/**",
+        "/workspaces/**",
+        "/**",
+    ]
+    assert path_pattern_candidates("file", "/a.md") == ["/a.md", "/a.md/**", "/*", "/**"]
+    assert path_pattern_candidates("file", "/") == ["/", "/**"]
+```
+
+- [ ] **Step 2: Run helper tests to verify they fail**
+
+Run:
+
+```bash
+uv run --no-sync pytest tests/unit/bricks/rebac/test_path_patterns.py -o "addopts=" -q
+```
+
+Expected: collection fails with `ModuleNotFoundError: No module named 'nexus.bricks.rebac.path_patterns'`.
+
+- [ ] **Step 3: Add the helper implementation**
+
+Create `src/nexus/bricks/rebac/path_patterns.py`:
+
+```python
+"""Helpers for explicit ReBAC file path-pattern tuple object IDs."""
+
+from __future__ import annotations
+
+RECURSIVE_SUFFIX = "/**"
+SINGLE_LEVEL_SUFFIX = "/*"
+
+
+def _is_absolute_file_path(object_type: str, object_id: str) -> bool:
+    return object_type == "file" and object_id.startswith("/")
+
+
+def _dedupe_preserving_order(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        if value in seen:
+            continue
+        seen.add(value)
+        result.append(value)
+    return result
+
+
+def _ancestors_inclusive(path: str) -> list[str]:
+    if path == "/":
+        return ["/"]
+    parts = [part for part in path.strip("/").split("/") if part]
+    ancestors = ["/" + "/".join(parts[:idx]) for idx in range(len(parts), 0, -1)]
+    ancestors.append("/")
+    return ancestors
+
+
+def _parent(path: str) -> str | None:
+    if path == "/":
+        return None
+    parts = [part for part in path.strip("/").split("/") if part]
+    if len(parts) <= 1:
+        return "/"
+    return "/" + "/".join(parts[:-1])
+
+
+def is_path_pattern(object_type: str, object_id: str) -> bool:
+    """Return whether an object id is a supported file path pattern."""
+    if not _is_absolute_file_path(object_type, object_id):
+        return False
+    return object_id in (RECURSIVE_SUFFIX, SINGLE_LEVEL_SUFFIX) or object_id.endswith(
+        (RECURSIVE_SUFFIX, SINGLE_LEVEL_SUFFIX)
+    )
+
+
+def path_pattern_prefix(object_type: str, object_id: str) -> str | None:
+    """Return the concrete prefix for a supported path pattern."""
+    if not is_path_pattern(object_type, object_id):
+        return None
+    if object_id in (RECURSIVE_SUFFIX, SINGLE_LEVEL_SUFFIX):
+        return "/"
+    if object_id.endswith(RECURSIVE_SUFFIX):
+        return object_id[: -len(RECURSIVE_SUFFIX)] or "/"
+    return object_id[: -len(SINGLE_LEVEL_SUFFIX)] or "/"
+
+
+def path_pattern_matches(pattern_object_id: str, requested_object_id: str) -> bool:
+    """Return whether a pattern object id grants access to a requested path."""
+    if not requested_object_id.startswith("/"):
+        return pattern_object_id == requested_object_id
+    if pattern_object_id == requested_object_id:
+        return True
+    if pattern_object_id.endswith(RECURSIVE_SUFFIX):
+        prefix = (
+            "/"
+            if pattern_object_id == RECURSIVE_SUFFIX
+            else pattern_object_id[: -len(RECURSIVE_SUFFIX)]
+        )
+        return prefix == "/" or requested_object_id == prefix or requested_object_id.startswith(
+            prefix + "/"
+        )
+    if pattern_object_id.endswith(SINGLE_LEVEL_SUFFIX):
+        prefix = (
+            "/"
+            if pattern_object_id == SINGLE_LEVEL_SUFFIX
+            else pattern_object_id[: -len(SINGLE_LEVEL_SUFFIX)]
+        )
+        if prefix == "/":
+            remainder = requested_object_id.strip("/")
+        elif requested_object_id.startswith(prefix + "/"):
+            remainder = requested_object_id[len(prefix) + 1 :]
+        else:
+            return False
+        return bool(remainder) and "/" not in remainder
+    return False
+
+
+def path_pattern_candidates(object_type: str, object_id: str) -> list[str]:
+    """Return exact and pattern object IDs that can match a requested object."""
+    if not _is_absolute_file_path(object_type, object_id):
+        return [object_id]
+
+    candidates = [object_id]
+    if object_id != "/":
+        candidates.append(object_id.rstrip("/") + RECURSIVE_SUFFIX)
+
+    parent = _parent(object_id)
+    if parent is not None:
+        candidates.append(SINGLE_LEVEL_SUFFIX if parent == "/" else parent + SINGLE_LEVEL_SUFFIX)
+
+    for ancestor in _ancestors_inclusive(object_id):
+        recursive = RECURSIVE_SUFFIX if ancestor == "/" else ancestor + RECURSIVE_SUFFIX
+        candidates.append(recursive)
+
+    return _dedupe_preserving_order(candidates)
+```
+
+- [ ] **Step 4: Run helper tests to verify green**
+
+Run:
+
+```bash
+uv run --no-sync pytest tests/unit/bricks/rebac/test_path_patterns.py -o "addopts=" -q
+```
+
+Expected: all helper tests pass.
+
+- [ ] **Step 5: Commit Task 1**
+
+Run:
+
+```bash
+git add tests/unit/bricks/rebac/test_path_patterns.py src/nexus/bricks/rebac/path_patterns.py
+git commit -m "feat(rebac): add path pattern helpers"
+```
+
+Expected: commit succeeds after hooks.
+
+## Task 2: Single ReBAC Check Pattern Lookup
+
+**Files:**
+- Create: `tests/unit/bricks/rebac/test_path_pattern_permissions.py`
+- Modify: `src/nexus/bricks/rebac/graph/traversal.py`
+
+- [ ] **Step 1: Write failing direct-check tests**
+
+Create `tests/unit/bricks/rebac/test_path_pattern_permissions.py`:
+
+```python
+"""ReBAC path-pattern tuple behavior for issue #4239."""
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+pytest.importorskip("pyroaring")
+
+from sqlalchemy import create_engine
+
+from nexus.bricks.rebac.consistency.metastore_namespace_store import MetastoreNamespaceStore
+from nexus.bricks.rebac.manager import ReBACManager
+from nexus.storage.models import Base
+from tests.testkit.metadata import InMemoryNexusFS
+
+
+@pytest.fixture
+def rebac_manager():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    manager = ReBACManager(
+        engine=engine,
+        cache_ttl_seconds=300,
+        max_depth=10,
+        namespace_store=MetastoreNamespaceStore(InMemoryNexusFS()),
+    )
+    try:
+        yield manager
+    finally:
+        manager.close()
+
+
+def test_recursive_path_pattern_grants_descendant_read(rebac_manager) -> None:
+    rebac_manager.rebac_write(
+        subject=("user", "admin"),
+        relation="read",
+        object=("file", "/workspaces/**"),
+        zone_id="root",
+    )
+
+    assert rebac_manager.rebac_check(
+        subject=("user", "admin"),
+        permission="read",
+        object=("file", "/workspaces/ws1/a.md"),
+        zone_id="root",
+    )
+
+
+def test_recursive_path_pattern_grants_prefix_path(rebac_manager) -> None:
+    rebac_manager.rebac_write(
+        subject=("user", "admin"),
+        relation="read",
+        object=("file", "/workspaces/**"),
+        zone_id="root",
+    )
+
+    assert rebac_manager.rebac_check(
+        subject=("user", "admin"),
+        permission="read",
+        object=("file", "/workspaces"),
+        zone_id="root",
+    )
+
+
+def test_single_level_path_pattern_grants_child_but_not_grandchild(rebac_manager) -> None:
+    rebac_manager.rebac_write(
+        subject=("user", "admin"),
+        relation="read",
+        object=("file", "/workspaces/*"),
+        zone_id="root",
+    )
+
+    assert rebac_manager.rebac_check(
+        subject=("user", "admin"),
+        permission="read",
+        object=("file", "/workspaces/a.md"),
+        zone_id="root",
+    )
+    assert not rebac_manager.rebac_check(
+        subject=("user", "admin"),
+        permission="read",
+        object=("file", "/workspaces/ws1/a.md"),
+        zone_id="root",
+    )
+
+
+def test_path_pattern_does_not_partial_prefix_match(rebac_manager) -> None:
+    rebac_manager.rebac_write(
+        subject=("user", "admin"),
+        relation="read",
+        object=("file", "/workspaces/**"),
+        zone_id="root",
+    )
+
+    assert not rebac_manager.rebac_check(
+        subject=("user", "admin"),
+        permission="read",
+        object=("file", "/workspaces2/a.md"),
+        zone_id="root",
+    )
+
+
+def test_wildcard_subject_path_pattern_grants_public_read(rebac_manager) -> None:
+    rebac_manager.rebac_write(
+        subject=("*", "*"),
+        relation="read",
+        object=("file", "/public/**"),
+        zone_id="root",
+    )
+
+    assert rebac_manager.rebac_check(
+        subject=("user", "anonymous"),
+        permission="read",
+        object=("file", "/public/a.md"),
+        zone_id="root",
+    )
+
+
+def test_userset_subject_path_pattern_grants_member_read(rebac_manager) -> None:
+    rebac_manager.rebac_write(
+        subject=("user", "alice"),
+        relation="member",
+        object=("group", "eng"),
+        zone_id="root",
+    )
+    rebac_manager.rebac_write(
+        subject=("group", "eng", "member"),
+        relation="read",
+        object=("file", "/team/**"),
+        zone_id="root",
+    )
+
+    assert rebac_manager.rebac_check(
+        subject=("user", "alice"),
+        permission="read",
+        object=("file", "/team/spec.md"),
+        zone_id="root",
+    )
+    assert not rebac_manager.rebac_check(
+        subject=("user", "bob"),
+        permission="read",
+        object=("file", "/team/spec.md"),
+        zone_id="root",
+    )
+
+
+def test_path_pattern_conditions_are_evaluated(rebac_manager) -> None:
+    rebac_manager.rebac_write(
+        subject=("user", "alice"),
+        relation="read",
+        object=("file", "/secure/**"),
+        zone_id="root",
+        conditions={"department": "eng"},
+        expires_at=datetime.now(UTC) + timedelta(hours=1),
+    )
+
+    assert rebac_manager.rebac_check(
+        subject=("user", "alice"),
+        permission="read",
+        object=("file", "/secure/plan.md"),
+        zone_id="root",
+        context={"department": "eng"},
+    )
+    assert not rebac_manager.rebac_check(
+        subject=("user", "alice"),
+        permission="read",
+        object=("file", "/secure/plan.md"),
+        zone_id="root",
+        context={"department": "sales"},
+    )
+```
+
+- [ ] **Step 2: Run direct-check tests to verify they fail**
+
+Run:
+
+```bash
+uv run --no-sync pytest tests/unit/bricks/rebac/test_path_pattern_permissions.py -k "not bulk and not filter_list and not cache" -o "addopts=" -q
+```
+
+Expected: pattern grant tests fail because direct lookup still uses `object_id = ?`.
+
+- [ ] **Step 3: Update direct tuple lookup queries**
+
+In `src/nexus/bricks/rebac/graph/traversal.py`, add this import near the existing imports:
+
+```python
+from nexus.bricks.rebac.path_patterns import path_pattern_candidates
+```
+
+Add these methods inside `PermissionComputer` before `_query_direct_tuple()`:
+
+```python
+    @staticmethod
+    def _candidate_object_ids(obj: Entity) -> list[str]:
+        return path_pattern_candidates(obj.entity_type, obj.entity_id)
+
+    @staticmethod
+    def _ordered_matching_rows(rows: list[dict[str, Any]], candidates: list[str]) -> list[dict[str, Any]]:
+        ordered: list[dict[str, Any]] = []
+        for candidate in candidates:
+            ordered.extend(row for row in rows if row["object_id"] == candidate)
+        return ordered
+```
+
+Replace `_query_direct_tuple()` with:
+
+```python
+    def _query_direct_tuple(
+        self,
+        cursor: Any,
+        subject: Entity,
+        relation: str,
+        obj: Entity,
+        zone_id: str | None,
+    ) -> dict[str, Any] | None:
+        """Query for a direct concrete subject tuple."""
+        now_iso = datetime.now(UTC).isoformat()
+        fix = self._repo.fix_sql_placeholders
+        candidates = self._candidate_object_ids(obj)
+        bind_slots = ", ".join("?" for _ in candidates)
+
+        if zone_id is None:
+            cursor.execute(
+                fix(
+                    f"""
+                    SELECT tuple_id, subject_type, subject_id, subject_relation,
+                           relation, object_type, object_id, conditions, expires_at
+                    FROM rebac_tuples
+                    WHERE subject_type = ? AND subject_id = ?
+                      AND subject_relation IS NULL
+                      AND relation = ?
+                      AND object_type = ? AND object_id IN ({bind_slots})
+                      AND (expires_at IS NULL OR expires_at >= ?)
+                      AND zone_id IS NULL
+                    """
+                ),
+                (
+                    subject.entity_type,
+                    subject.entity_id,
+                    relation,
+                    obj.entity_type,
+                    *candidates,
+                    now_iso,
+                ),
+            )
+        else:
+            cursor.execute(
+                fix(
+                    f"""
+                    SELECT tuple_id, subject_type, subject_id, subject_relation,
+                           relation, object_type, object_id, conditions, expires_at
+                    FROM rebac_tuples
+                    WHERE subject_type = ? AND subject_id = ?
+                      AND subject_relation IS NULL
+                      AND relation = ?
+                      AND object_type = ? AND object_id IN ({bind_slots})
+                      AND (expires_at IS NULL OR expires_at >= ?)
+                      AND zone_id = ?
+                    """
+                ),
+                (
+                    subject.entity_type,
+                    subject.entity_id,
+                    relation,
+                    obj.entity_type,
+                    *candidates,
+                    now_iso,
+                    zone_id,
+                ),
+            )
+
+        rows = [dict(row) for row in cursor.fetchall()]
+        ordered_rows = self._ordered_matching_rows(rows, candidates)
+        return ordered_rows[0] if ordered_rows else None
+```
+
+Update `_check_wildcard_access()` and `_check_userset_grants()` the same way:
+
+- Compute `candidates = self._candidate_object_ids(obj)`.
+- Use `object_id IN ({bind_slots})`.
+- Expand params with `*candidates`.
+- Iterate rows through `self._ordered_matching_rows(rows, candidates)` before evaluating conditions.
+
+For `_check_wildcard_access()`, return the first row whose conditions pass. For `_check_userset_grants()`, preserve the existing recursive `has_direct_relation()` membership check, but iterate ordered candidate rows.
+
+- [ ] **Step 4: Run direct-check tests to verify green**
+
+Run:
+
+```bash
+uv run --no-sync pytest tests/unit/bricks/rebac/test_path_pattern_permissions.py -k "not bulk and not filter_list and not cache" -o "addopts=" -q
+```
+
+Expected: direct, wildcard, userset, and ABAC tests pass.
+
+- [ ] **Step 5: Commit Task 2**
+
+Run:
+
+```bash
+git add tests/unit/bricks/rebac/test_path_pattern_permissions.py src/nexus/bricks/rebac/graph/traversal.py
+git commit -m "feat(rebac): match path patterns in direct checks"
+```
+
+Expected: commit succeeds after hooks.
+
+## Task 3: Bulk Check and Filter List Pattern Matching
+
+**Files:**
+- Modify: `tests/unit/bricks/rebac/test_path_pattern_permissions.py`
+- Modify: `src/nexus/bricks/rebac/batch/bulk_checker.py`
+- Modify: `src/nexus/bricks/rebac/graph/bulk_evaluator.py`
+- Modify: `src/nexus/bricks/rebac/utils/fast.py`
+
+- [ ] **Step 1: Add failing bulk and filter-list tests**
+
+Append these imports to `tests/unit/bricks/rebac/test_path_pattern_permissions.py`:
+
+```python
+from nexus.bricks.rebac.enforcer import PermissionEnforcer
+from nexus.contracts.types import OperationContext
+```
+
+Append these tests:
+
+```python
+def test_rebac_check_bulk_matches_recursive_path_pattern(rebac_manager) -> None:
+    rebac_manager.rebac_write(
+        subject=("user", "admin"),
+        relation="read",
+        object=("file", "/workspaces/**"),
+        zone_id="root",
+    )
+
+    checks = [
+        (("user", "admin"), "read", ("file", "/workspaces/ws1/a.md")),
+        (("user", "admin"), "read", ("file", "/private/a.md")),
+    ]
+
+    assert rebac_manager.rebac_check_bulk(checks, zone_id="root") == {
+        checks[0]: True,
+        checks[1]: False,
+    }
+
+
+def test_filter_list_matches_recursive_path_pattern(rebac_manager) -> None:
+    rebac_manager.rebac_write(
+        subject=("user", "admin"),
+        relation="read",
+        object=("file", "/workspaces/**"),
+        zone_id="root",
+    )
+    enforcer = PermissionEnforcer(rebac_manager=rebac_manager)
+    context = OperationContext(
+        user_id="admin",
+        groups=[],
+        subject_type="user",
+        subject_id="admin",
+        zone_id="root",
+    )
+
+    assert enforcer.filter_list(
+        ["/workspaces/ws1/a.md", "/workspaces/ws2/b.md", "/private/c.md"],
+        context,
+    ) == ["/workspaces/ws1/a.md", "/workspaces/ws2/b.md"]
+```
+
+- [ ] **Step 2: Run bulk tests to verify they fail**
+
+Run:
+
+```bash
+uv run --no-sync pytest tests/unit/bricks/rebac/test_path_pattern_permissions.py -k "bulk or filter_list" -o "addopts=" -q
+```
+
+Expected: bulk and filter-list tests fail because the bulk fetch/evaluator path still sees only exact object IDs.
+
+- [ ] **Step 3: Add pattern candidates to bulk tuple fetch**
+
+In `src/nexus/bricks/rebac/batch/bulk_checker.py`, add this import near the other imports:
+
+```python
+from nexus.bricks.rebac.path_patterns import path_pattern_candidates
+```
+
+In `_phase_fetch_tuples()`, after the loop that fills `file_paths`, add:
+
+```python
+        for file_path in file_paths:
+            for candidate in path_pattern_candidates("file", file_path):
+                all_objects.add(("file", candidate))
+```
+
+This expands the `entity_list` so SQL fetches exact rows plus pattern rows such as `/workspaces/**`.
+
+- [ ] **Step 4: Update the in-memory bulk evaluator**
+
+In `src/nexus/bricks/rebac/graph/bulk_evaluator.py`, add imports near the top:
+
+```python
+from dataclasses import dataclass
+
+from nexus.bricks.rebac.path_patterns import is_path_pattern, path_pattern_matches
+```
+
+Add this dataclass before `build_direct_index()`:
+
+```python
+@dataclass(frozen=True)
+class DirectRelationIndex:
+    exact: frozenset[tuple[str, str, str, str, str]]
+    patterns: tuple[dict[str, Any], ...]
+```
+
+Replace `build_direct_index()` with:
+
+```python
+def build_direct_index(
+    tuples_graph: list[dict[str, Any]],
+) -> DirectRelationIndex:
+    """Build exact and path-pattern direct relation indexes."""
+    exact: set[tuple[str, str, str, str, str]] = set()
+    patterns: list[dict[str, Any]] = []
+
+    for tuple_data in tuples_graph:
+        if tuple_data.get("conditions") or tuple_data.get("subject_relation") is not None:
+            continue
+        if is_path_pattern(tuple_data["object_type"], tuple_data["object_id"]):
+            patterns.append(tuple_data)
+            continue
+        exact.add(
+            (
+                tuple_data["subject_type"],
+                tuple_data["subject_id"],
+                tuple_data["relation"],
+                tuple_data["object_type"],
+                tuple_data["object_id"],
+            )
+        )
+
+    return DirectRelationIndex(exact=frozenset(exact), patterns=tuple(patterns))
+```
+
+Update the `direct_index` type hints in `compute_permission()` and `check_direct_relation()` from `frozenset[...] | None` to `DirectRelationIndex | None`.
+
+Replace the `direct_index` block in `check_direct_relation()` with:
+
+```python
+    if direct_index is not None:
+        key = (subject.entity_type, subject.entity_id, permission, obj.entity_type, obj.entity_id)
+        if key in direct_index.exact:
+            return True
+        wildcard_key = ("*", "*", permission, obj.entity_type, obj.entity_id)
+        if wildcard_key in direct_index.exact:
+            return True
+
+        for tuple_data in direct_index.patterns:
+            if (
+                tuple_data["relation"] != permission
+                or tuple_data["object_type"] != obj.entity_type
+                or not path_pattern_matches(tuple_data["object_id"], obj.entity_id)
+            ):
+                continue
+            if (
+                tuple_data["subject_type"] == subject.entity_type
+                and tuple_data["subject_id"] == subject.entity_id
+            ) or (tuple_data["subject_type"] == "*" and tuple_data["subject_id"] == "*"):
+                return True
+        return False
+```
+
+In the linear fallback loop, replace `tuple_data["object_id"] != obj.entity_id` with:
+
+```python
+            or not (
+                tuple_data["object_id"] == obj.entity_id
+                or path_pattern_matches(tuple_data["object_id"], obj.entity_id)
+            )
+```
+
+- [ ] **Step 5: Skip Rust when path-pattern tuples are present**
+
+In `src/nexus/bricks/rebac/utils/fast.py`, add this import near the existing imports:
+
+```python
+from nexus.bricks.rebac.path_patterns import is_path_pattern
+```
+
+In `check_permissions_bulk_with_fallback()`, before the `if RUST_AVAILABLE and not force_python:` block, add:
+
+```python
+    has_path_pattern_tuple = any(
+        is_path_pattern(str(t.get("object_type", "")), str(t.get("object_id", "")))
+        for t in tuples
+    )
+    if has_path_pattern_tuple:
+        logger.debug("Skipping Rust ReBAC bulk path because path-pattern tuples are present")
+        return _check_permissions_bulk_python(checks, tuples, namespace_configs)
+```
+
+This keeps the Python evaluator authoritative for this feature.
+
+- [ ] **Step 6: Run bulk tests to verify green**
+
+Run:
+
+```bash
+uv run --no-sync pytest tests/unit/bricks/rebac/test_path_pattern_permissions.py -k "bulk or filter_list" -o "addopts=" -q
+```
+
+Expected: bulk and filter-list tests pass.
+
+- [ ] **Step 7: Commit Task 3**
+
+Run:
+
+```bash
+git add tests/unit/bricks/rebac/test_path_pattern_permissions.py src/nexus/bricks/rebac/batch/bulk_checker.py src/nexus/bricks/rebac/graph/bulk_evaluator.py src/nexus/bricks/rebac/utils/fast.py
+git commit -m "feat(rebac): apply path patterns in bulk checks"
+```
+
+Expected: commit succeeds after hooks.
+
+## Task 4: Pattern Tuple Cache Invalidation
+
+**Files:**
+- Modify: `tests/unit/bricks/rebac/test_path_pattern_permissions.py`
+- Modify: `src/nexus/bricks/rebac/cache/coordinator.py`
+- Modify: `src/nexus/bricks/rebac/path_patterns.py`
+
+- [ ] **Step 1: Add a failing cached-denial invalidation test**
+
+Append this test to `tests/unit/bricks/rebac/test_path_pattern_permissions.py`:
+
+```python
+def test_path_pattern_write_invalidates_cached_descendant_denial(rebac_manager) -> None:
+    target = ("file", "/workspaces/ws1/a.md")
+
+    assert not rebac_manager.rebac_check(
+        subject=("user", "admin"),
+        permission="read",
+        object=target,
+        zone_id="root",
+    )
+
+    rebac_manager.rebac_write(
+        subject=("user", "admin"),
+        relation="read",
+        object=("file", "/workspaces/**"),
+        zone_id="root",
+    )
+
+    assert rebac_manager.rebac_check(
+        subject=("user", "admin"),
+        permission="read",
+        object=target,
+        zone_id="root",
+    )
+```
+
+- [ ] **Step 2: Run invalidation test to verify it fails**
+
+Run:
+
+```bash
+uv run --no-sync pytest tests/unit/bricks/rebac/test_path_pattern_permissions.py::test_path_pattern_write_invalidates_cached_descendant_denial -o "addopts=" -q
+```
+
+Expected: the final assertion fails because the cached denial for `/workspaces/ws1/a.md` was not invalidated by writing `/workspaces/**`.
+
+- [ ] **Step 3: Make prefix extraction reusable**
+
+In `src/nexus/bricks/rebac/path_patterns.py`, keep the existing `path_pattern_prefix()` function from Task 1 unchanged. The cache coordinator will use it to translate `/prefix/**` and `/prefix/*` into `/prefix`.
+
+- [ ] **Step 4: Invalidate descendant cache entries for pattern tuples**
+
+In `src/nexus/bricks/rebac/cache/coordinator.py`, add this import near the existing imports:
+
+```python
+from nexus.bricks.rebac.path_patterns import path_pattern_prefix
+```
+
+In `invalidate_for_tuple_change()`, after the direct `invalidate_subject_object_pair()` block and before eager recompute, add:
+
+```python
+            pattern_prefix = path_pattern_prefix(obj.entity_type, obj.entity_id)
+            if pattern_prefix is not None:
+                if self._l1_cache:
+                    self._l1_cache.invalidate_object_prefix(
+                        obj.entity_type,
+                        pattern_prefix,
+                        zone_id,
+                    )
+                if self._boundary_cache and obj.entity_type == "file":
+                    self._boundary_cache.invalidate_path_prefix(effective_zone_id, pattern_prefix)
+                should_eager_recompute = False
+```
+
+This invalidates descendant L1 entries and boundary-cache entries for both recursive and single-level patterns. It also disables eager recompute for pattern tuples because the changed object ID is not the concrete leaf path being checked.
+
+- [ ] **Step 5: Run invalidation test to verify green**
+
+Run:
+
+```bash
+uv run --no-sync pytest tests/unit/bricks/rebac/test_path_pattern_permissions.py::test_path_pattern_write_invalidates_cached_descendant_denial -o "addopts=" -q
+```
+
+Expected: the cached-denial invalidation test passes.
+
+- [ ] **Step 6: Commit Task 4**
+
+Run:
+
+```bash
+git add tests/unit/bricks/rebac/test_path_pattern_permissions.py src/nexus/bricks/rebac/cache/coordinator.py src/nexus/bricks/rebac/path_patterns.py
+git commit -m "fix(rebac): invalidate cached descendants for path patterns"
+```
+
+Expected: commit succeeds after hooks.
+
+## Task 5: Documentation
+
+**Files:**
+- Modify: `docs/guides/user-guide.md`
+
+- [ ] **Step 1: Update the ReBAC guide text**
+
+In `docs/guides/user-guide.md`, find the "Sandbox ReBAC, hub-zone, and MCP tool boundaries" section. After the tuple CLI examples around `nexus rebac create agent alice direct_owner file /zone/local/notes/todo.txt`, add:
+
+```markdown
+Path-style `file` tuple object IDs also support two explicit suffixes for bulk
+grants:
+
+- `/prefix/**` grants the relation on `/prefix` and every descendant below it.
+- `/prefix/*` grants the relation on direct children of `/prefix` only.
+
+No other glob syntax is expanded. Values such as `/prefix/*.md` or interior
+`*` characters are stored literally.
+```
+
+- [ ] **Step 2: Review the rendered context in plain text**
+
+Run:
+
+```bash
+sed -n '640,670p' docs/guides/user-guide.md
+```
+
+Expected: the new paragraph sits after the ReBAC CLI examples and does not interrupt a fenced code block.
+
+- [ ] **Step 3: Commit Task 5**
+
+Run:
+
+```bash
+git add docs/guides/user-guide.md
+git commit -m "docs(rebac): document path pattern tuple suffixes"
+```
+
+Expected: commit succeeds after hooks.
+
+## Task 6: Focused Verification
+
+**Files:**
+- No file edits.
+
+- [ ] **Step 1: Run all new path-pattern tests**
+
+Run:
+
+```bash
+uv run --no-sync pytest tests/unit/bricks/rebac/test_path_patterns.py tests/unit/bricks/rebac/test_path_pattern_permissions.py -o "addopts=" -q
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 2: Run existing filter-chain regression tests**
+
+Run:
+
+```bash
+uv run --no-sync pytest tests/unit/bricks/rebac/test_permission_filter_chain.py -o "addopts=" -q
+```
+
+Expected: all existing filter-chain tests pass.
+
+- [ ] **Step 3: Run targeted Ruff checks**
+
+Run:
+
+```bash
+uv run --no-sync ruff check src/nexus/bricks/rebac/path_patterns.py src/nexus/bricks/rebac/graph/traversal.py src/nexus/bricks/rebac/batch/bulk_checker.py src/nexus/bricks/rebac/graph/bulk_evaluator.py src/nexus/bricks/rebac/utils/fast.py src/nexus/bricks/rebac/cache/coordinator.py tests/unit/bricks/rebac/test_path_patterns.py tests/unit/bricks/rebac/test_path_pattern_permissions.py
+```
+
+Expected: Ruff reports no issues.
+
+- [ ] **Step 4: Run targeted format checks**
+
+Run:
+
+```bash
+uv run --no-sync ruff format --check src/nexus/bricks/rebac/path_patterns.py src/nexus/bricks/rebac/graph/traversal.py src/nexus/bricks/rebac/batch/bulk_checker.py src/nexus/bricks/rebac/graph/bulk_evaluator.py src/nexus/bricks/rebac/utils/fast.py src/nexus/bricks/rebac/cache/coordinator.py tests/unit/bricks/rebac/test_path_patterns.py tests/unit/bricks/rebac/test_path_pattern_permissions.py
+```
+
+Expected: Ruff format reports no changes needed.
+
+- [ ] **Step 5: Check whitespace**
+
+Run:
+
+```bash
+git diff --check
+```
+
+Expected: no output.
+
+- [ ] **Step 6: Commit verification-only fixes if hooks changed files**
+
+Run this only when a formatter or hook modified tracked files:
+
+```bash
+git status --short
+git add src/nexus/bricks/rebac tests/unit/bricks/rebac docs/guides/user-guide.md
+git commit -m "chore(rebac): apply path pattern verification cleanup"
+```
+
+Expected: either there is nothing to commit, or the cleanup commit contains only formatter/hook changes from this task.

--- a/docs/superpowers/specs/2026-06-12-issue-4239-rebac-path-prefix-tuples-design.md
+++ b/docs/superpowers/specs/2026-06-12-issue-4239-rebac-path-prefix-tuples-design.md
@@ -1,0 +1,225 @@
+# Design: Issue #4239 - ReBAC Path Prefix Tuples
+
+- **Status:** Approved design, awaiting spec review
+- **Date:** 2026-06-12
+- **Owner:** windoliver
+- **Issue:** https://github.com/nexi-lab/nexus/issues/4239
+- **Base branch:** `origin/develop`
+
+## Problem
+
+`POST /api/v2/rebac/tuples` accepts any string as a tuple `object_id`, but
+runtime authorization treats that value as an exact object identifier. Operators
+can write tuples such as `/workspaces/**`, `/workspaces/*`, or `/**`, but those
+tuples do not authorize any file unless the requested file path is exactly the
+same string.
+
+That blocks common static-auth and service-principal setups where file paths are
+created dynamically under a workspace, agent filesystem, or tenant bucket. The
+operator cannot grant blanket read access to a path tree without pre-creating a
+tuple for every file or running a reconciler that mints tuples after every write.
+
+## Context From Code Inspection
+
+The active search/list authorization path checks exact file paths and their
+ancestor directories:
+
+- `src/nexus/bricks/rebac/permission_filter_chain.py` builds `read` checks for
+  the requested path and ancestors only.
+- `src/nexus/bricks/rebac/enforcer.py` does the same for sequential and batched
+  filesystem permission checks.
+- `src/nexus/bricks/rebac/graph/traversal.py` queries direct tuples with
+  `object_id = ?`.
+- `src/nexus/bricks/rebac/batch/bulk_checker.py` fetches tuples for exact entity
+  IDs only, then computes permissions in memory.
+- `src/nexus/bricks/rebac/graph/bulk_evaluator.py` indexes direct tuples by
+  exact `(subject, relation, object_type, object_id)`.
+
+Existing prefix helper work in `src/nexus/lib/prefix_helpers.py` covers path
+visibility and descendant scans, but it does not change ReBAC tuple semantics.
+
+## Goal
+
+Support explicit file path pattern tuples for direct ReBAC grants:
+
+- `object_id` ending in `/**` grants the same relation on the prefix path and all
+  descendants.
+- `object_id` ending in `/*` grants the same relation on direct children one
+  path segment below the prefix.
+- Exact `object_id` values keep their current behavior.
+- Matching is limited to `object_type="file"` path-like object IDs.
+- Search, list, and file permission checks all see the same semantics.
+
+## Non-Goals
+
+- Do not implement folder-object inheritance or a new parent-of relation model in
+  this issue.
+- Do not materialize one tuple per file on write.
+- Do not change tuple storage schema.
+- Do not treat interior `*` characters as glob syntax.
+- Do not add negative or deny tuples.
+- Do not change static-auth subject resolution or API-key grant creation.
+
+## Design
+
+### 1. Path Pattern Helper
+
+Add a small helper module in the ReBAC brick, for example
+`src/nexus/bricks/rebac/path_patterns.py`, with pure functions:
+
+```text
+is_path_pattern(object_type, object_id) -> bool
+path_pattern_candidates(object_type, object_id) -> list[str]
+path_pattern_matches(pattern_object_id, requested_object_id) -> bool
+```
+
+Semantics:
+
+- A pattern is valid only when `object_type == "file"` and `object_id` starts
+  with `/`.
+- `/**` is a special root recursive pattern and matches every absolute file path,
+  including `/`.
+- `/prefix/**` matches `/prefix` and any descendant such as `/prefix/a.txt` or
+  `/prefix/a/b.txt`.
+- `/prefix/*` matches exactly one segment below `/prefix`, such as
+  `/prefix/a.txt`, but not `/prefix/a/b.txt` and not `/prefix`.
+- Anything else is exact and handled by existing code.
+
+For a requested object ID, `path_pattern_candidates()` should return the finite
+set of pattern IDs that could match it. Example for
+`/workspaces/ws1/a.md`:
+
+```text
+/workspaces/ws1/a.md
+/workspaces/ws1/*
+/workspaces/ws1/**
+/workspaces/*
+/workspaces/**
+/*
+/**
+```
+
+The exact path remains first so existing direct grants keep priority and cache
+behavior.
+
+### 2. Single Check Direct Tuple Lookup
+
+Update `PermissionComputer` direct tuple lookup in
+`src/nexus/bricks/rebac/graph/traversal.py` so direct concrete, wildcard, and
+userset-as-subject tuple queries can match the requested exact object ID plus
+the finite candidate pattern object IDs.
+
+The SQL should remain indexed and bounded by using `object_id IN (...)`, not a
+database `LIKE` scan. Candidate generation is deterministic and depends only on
+the requested path depth. Existing non-file object IDs keep the current
+`object_id = ?` path.
+
+Condition evaluation stays unchanged: if a matching pattern tuple has ABAC
+conditions, the same condition evaluation path runs before allowing access.
+
+### 3. Bulk Check Fetch and Evaluation
+
+Update `BulkPermissionChecker` in
+`src/nexus/bricks/rebac/batch/bulk_checker.py` to include pattern candidates for
+file object IDs when building the `entity_list`. This lets the bulk SQL fetch
+pattern tuples together with exact and ancestor tuples.
+
+Update `src/nexus/bricks/rebac/graph/bulk_evaluator.py` direct-relation matching
+so a fetched pattern tuple can satisfy an exact requested file object. Exact
+matches should still use the existing direct index; pattern checks can use a
+separate prefix-pattern index or a small helper over pattern tuples. The key
+requirement is that bulk `filter_list()` and single `rebac_check()` make the same
+allow/deny decision.
+
+### 4. Cache Invalidation
+
+Existing tuple writes already invalidate the exact object ID in L1 and related
+permission caches. Pattern tuple writes need descendant invalidation:
+
+- When writing or deleting `/prefix/**`, invalidate cached file permission
+  results under `/prefix`.
+- When writing or deleting `/prefix/*`, use the same descendant invalidation
+  scope for correctness, even though the match is only one level. Broader
+  invalidation is acceptable here because tuple writes are less frequent than
+  reads and stale allows/denies are security-sensitive.
+- Exact tuple invalidation remains unchanged.
+
+The existing `invalidate_object_prefix()` and boundary-cache prefix invalidation
+paths should be reused where possible rather than introducing a new cache layer.
+
+### 5. API and Documentation Behavior
+
+The tuple write API continues to store the supplied `object_id` string. The
+behavioral change is in authorization semantics, not in request validation or
+storage. API docs and upgrade notes should describe the supported suffixes:
+
+- `/**` for recursive path-tree grants.
+- `/*` for single-level child grants.
+- No other glob syntax is supported.
+
+## Alternatives Considered
+
+### Recommended: Explicit Pattern Tuples
+
+This is the approved approach. It solves the operator pain with no schema
+change, no per-file tuple fanout, and a bounded candidate set for lookup.
+
+### Materialize Per-File Tuples
+
+This would preserve exact-match semantics but doubles write work and creates
+race windows between file creation and tuple reconciliation. It also does not
+help paths created by external backends unless every write path participates.
+
+### Folder Object Inheritance
+
+This is a cleaner long-term authorization model, but it is larger than this
+issue. It requires clearer folder entity semantics, parent relation lifecycle,
+and cross-cache invalidation rules. This is out of scope for #4239 and requires
+a separate design.
+
+## Tests
+
+Follow TDD for implementation.
+
+Add helper tests for:
+
+- `/**` matches `/`, `/a`, and `/a/b.txt`.
+- `/workspaces/**` matches `/workspaces`, `/workspaces/ws1/a.md`, and deeper
+  descendants.
+- `/workspaces/*` matches `/workspaces/a.md` but not `/workspaces/a/b.md` and not
+  `/workspaces`.
+- Partial prefixes do not match, for example `/workspaces/**` does not match
+  `/workspaces2/a.md`.
+- Non-file object types and relative object IDs are not treated as path
+  patterns.
+
+Add manager/enforcer tests for:
+
+- Direct `rebac_check()` allows a descendant from a `/**` tuple.
+- Direct `rebac_check()` allows a single child from a `/*` tuple and denies a
+  grandchild.
+- `rebac_check_bulk()` returns the same decisions as direct checks.
+- `PermissionEnforcer.filter_list()` returns only paths covered by the pattern
+  tuple.
+- Wildcard subject `("*", "*")` plus path pattern still behaves as public access.
+- Userset-as-subject path pattern grants work when the caller is a member of the
+  userset.
+- ABAC conditions on a pattern tuple are evaluated.
+- Cache invalidation after a pattern tuple write changes a previously cached
+  denial to allow.
+
+## Verification
+
+Targeted verification should include:
+
+```bash
+uv run --no-sync pytest tests/unit/bricks/rebac/test_path_patterns.py -o "addopts="
+uv run --no-sync pytest tests/unit/core/test_rebac.py -k "path_pattern or prefix" -o "addopts="
+uv run --no-sync pytest tests/unit/bricks/rebac/test_permission_filter_chain.py -o "addopts="
+uv run --no-sync ruff check src/nexus/bricks/rebac/path_patterns.py src/nexus/bricks/rebac/graph/traversal.py src/nexus/bricks/rebac/batch/bulk_checker.py src/nexus/bricks/rebac/graph/bulk_evaluator.py
+uv run --no-sync ruff format --check src/nexus/bricks/rebac/path_patterns.py src/nexus/bricks/rebac/graph/traversal.py src/nexus/bricks/rebac/batch/bulk_checker.py src/nexus/bricks/rebac/graph/bulk_evaluator.py
+git diff --check
+```
+
+If implementation touches API docs or upgrade notes, include those files in the
+ruff or markdown checks used by the repo.

--- a/docs/superpowers/specs/2026-06-12-issue-4239-rebac-path-prefix-tuples-design.md
+++ b/docs/superpowers/specs/2026-06-12-issue-4239-rebac-path-prefix-tuples-design.md
@@ -91,11 +91,10 @@ set of pattern IDs that could match it. Example for
 
 ```text
 /workspaces/ws1/a.md
+/workspaces/ws1/a.md/**
 /workspaces/ws1/*
 /workspaces/ws1/**
-/workspaces/*
 /workspaces/**
-/*
 /**
 ```
 

--- a/docs/surface-coverage/api-rpc-surface-coverage.yaml
+++ b/docs/surface-coverage/api-rpc-surface-coverage.yaml
@@ -4273,7 +4273,7 @@ operations:
   transports:
     grpc_expose:
       name: get_dynamic_viewer_config
-      source: src/nexus/bricks/rebac/rebac_service.py:1587
+      source: src/nexus/bricks/rebac/rebac_service.py:1597
   profiles:
     lite: supported
     sandbox: supported
@@ -4341,7 +4341,7 @@ operations:
   transports:
     grpc_expose:
       name: get_namespace
-      source: src/nexus/bricks/rebac/rebac_service.py:1073
+      source: src/nexus/bricks/rebac/rebac_service.py:1083
   profiles:
     lite: supported
     sandbox: supported
@@ -4392,7 +4392,7 @@ operations:
   transports:
     grpc_expose:
       name: get_rebac_option
-      source: src/nexus/bricks/rebac/rebac_service.py:981
+      source: src/nexus/bricks/rebac/rebac_service.py:991
   profiles:
     lite: supported
     sandbox: supported
@@ -4601,7 +4601,7 @@ operations:
   transports:
     grpc_expose:
       name: grant_consent
-      source: src/nexus/bricks/rebac/rebac_service.py:1200
+      source: src/nexus/bricks/rebac/rebac_service.py:1210
   profiles:
     lite: supported
     sandbox: supported
@@ -5157,7 +5157,7 @@ operations:
   transports:
     grpc_expose:
       name: list_incoming_shares
-      source: src/nexus/bricks/rebac/rebac_service.py:1529
+      source: src/nexus/bricks/rebac/rebac_service.py:1539
   profiles:
     lite: supported
     sandbox: supported
@@ -5212,7 +5212,7 @@ operations:
   transports:
     grpc_expose:
       name: list_outgoing_shares
-      source: src/nexus/bricks/rebac/rebac_service.py:1479
+      source: src/nexus/bricks/rebac/rebac_service.py:1489
   profiles:
     lite: supported
     sandbox: supported
@@ -5420,7 +5420,7 @@ operations:
   transports:
     grpc_expose:
       name: make_private
-      source: src/nexus/bricks/rebac/rebac_service.py:1282
+      source: src/nexus/bricks/rebac/rebac_service.py:1292
   profiles:
     lite: supported
     sandbox: supported
@@ -5437,7 +5437,7 @@ operations:
   transports:
     grpc_expose:
       name: make_public
-      source: src/nexus/bricks/rebac/rebac_service.py:1263
+      source: src/nexus/bricks/rebac/rebac_service.py:1273
   profiles:
     lite: supported
     sandbox: supported
@@ -5837,7 +5837,7 @@ operations:
   transports:
     grpc_expose:
       name: namespace_delete
-      source: src/nexus/bricks/rebac/rebac_service.py:1118
+      source: src/nexus/bricks/rebac/rebac_service.py:1128
   profiles:
     lite: supported
     sandbox: supported
@@ -5854,7 +5854,7 @@ operations:
   transports:
     grpc_expose:
       name: namespace_list
-      source: src/nexus/bricks/rebac/rebac_service.py:1094
+      source: src/nexus/bricks/rebac/rebac_service.py:1104
   profiles:
     lite: supported
     sandbox: supported
@@ -6905,7 +6905,7 @@ operations:
   transports:
     grpc_expose:
       name: read_with_dynamic_viewer
-      source: src/nexus/bricks/rebac/rebac_service.py:1678
+      source: src/nexus/bricks/rebac/rebac_service.py:1688
   profiles:
     lite: supported
     sandbox: supported
@@ -6958,7 +6958,7 @@ operations:
   transports:
     grpc_expose:
       name: rebac_check
-      source: src/nexus/bricks/rebac/rebac_service.py:408
+      source: src/nexus/bricks/rebac/rebac_service.py:427
   profiles:
     lite: supported
     sandbox: supported
@@ -6975,7 +6975,7 @@ operations:
   transports:
     grpc_expose:
       name: rebac_check_batch
-      source: src/nexus/bricks/rebac/rebac_service.py:631
+      source: src/nexus/bricks/rebac/rebac_service.py:650
   profiles:
     lite: supported
     sandbox: supported
@@ -7009,7 +7009,7 @@ operations:
   transports:
     grpc_expose:
       name: rebac_create
-      source: src/nexus/bricks/rebac/rebac_service.py:193
+      source: src/nexus/bricks/rebac/rebac_service.py:212
   profiles:
     lite: supported
     sandbox: supported
@@ -7026,7 +7026,7 @@ operations:
   transports:
     grpc_expose:
       name: rebac_delete
-      source: src/nexus/bricks/rebac/rebac_service.py:746
+      source: src/nexus/bricks/rebac/rebac_service.py:756
   profiles:
     lite: supported
     sandbox: supported
@@ -7043,7 +7043,7 @@ operations:
   transports:
     grpc_expose:
       name: rebac_expand
-      source: src/nexus/bricks/rebac/rebac_service.py:495
+      source: src/nexus/bricks/rebac/rebac_service.py:514
   profiles:
     lite: supported
     sandbox: supported
@@ -7060,7 +7060,7 @@ operations:
   transports:
     grpc_expose:
       name: rebac_expand_with_privacy
-      source: src/nexus/bricks/rebac/rebac_service.py:1153
+      source: src/nexus/bricks/rebac/rebac_service.py:1163
   profiles:
     lite: supported
     sandbox: supported
@@ -7078,7 +7078,7 @@ operations:
   transports:
     grpc_expose:
       name: rebac_explain
-      source: src/nexus/bricks/rebac/rebac_service.py:551
+      source: src/nexus/bricks/rebac/rebac_service.py:570
   profiles:
     lite: supported
     sandbox: supported
@@ -7095,7 +7095,7 @@ operations:
   transports:
     grpc_expose:
       name: rebac_list_objects
-      source: src/nexus/bricks/rebac/rebac_service.py:889
+      source: src/nexus/bricks/rebac/rebac_service.py:899
   profiles:
     lite: supported
     sandbox: supported
@@ -7112,7 +7112,7 @@ operations:
   transports:
     grpc_expose:
       name: rebac_list_tuples
-      source: src/nexus/bricks/rebac/rebac_service.py:788
+      source: src/nexus/bricks/rebac/rebac_service.py:798
   profiles:
     lite: supported
     sandbox: supported
@@ -7129,7 +7129,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/rebac/tuples
-      source: src/nexus/server/api/v2/routers/rebac.py:167
+      source: src/nexus/server/api/v2/routers/rebac.py:119
   profiles:
     lite: supported
     sandbox: supported
@@ -7198,7 +7198,7 @@ operations:
   transports:
     grpc_expose:
       name: register_namespace
-      source: src/nexus/bricks/rebac/rebac_service.py:1012
+      source: src/nexus/bricks/rebac/rebac_service.py:1022
   profiles:
     lite: supported
     sandbox: supported
@@ -7289,7 +7289,7 @@ operations:
   transports:
     grpc_expose:
       name: revoke_consent
-      source: src/nexus/bricks/rebac/rebac_service.py:1228
+      source: src/nexus/bricks/rebac/rebac_service.py:1238
   profiles:
     lite: supported
     sandbox: supported
@@ -7340,7 +7340,7 @@ operations:
   transports:
     grpc_expose:
       name: revoke_share
-      source: src/nexus/bricks/rebac/rebac_service.py:1391
+      source: src/nexus/bricks/rebac/rebac_service.py:1401
   profiles:
     lite: supported
     sandbox: supported
@@ -7357,7 +7357,7 @@ operations:
   transports:
     grpc_expose:
       name: revoke_share_by_id
-      source: src/nexus/bricks/rebac/rebac_service.py:1455
+      source: src/nexus/bricks/rebac/rebac_service.py:1465
   profiles:
     lite: supported
     sandbox: supported
@@ -8266,7 +8266,7 @@ operations:
   transports:
     grpc_expose:
       name: set_rebac_option
-      source: src/nexus/bricks/rebac/rebac_service.py:944
+      source: src/nexus/bricks/rebac/rebac_service.py:954
   profiles:
     lite: supported
     sandbox: supported
@@ -8317,7 +8317,7 @@ operations:
   transports:
     grpc_expose:
       name: share_with_group
-      source: src/nexus/bricks/rebac/rebac_service.py:1354
+      source: src/nexus/bricks/rebac/rebac_service.py:1364
   profiles:
     lite: supported
     sandbox: supported
@@ -8334,7 +8334,7 @@ operations:
   transports:
     grpc_expose:
       name: share_with_user
-      source: src/nexus/bricks/rebac/rebac_service.py:1317
+      source: src/nexus/bricks/rebac/rebac_service.py:1327
   profiles:
     lite: supported
     sandbox: supported

--- a/src/nexus/bricks/rebac/batch/bulk_checker.py
+++ b/src/nexus/bricks/rebac/batch/bulk_checker.py
@@ -650,6 +650,7 @@ class BulkPermissionChecker:
                 FROM rebac_tuples t
                 WHERE t.subject_type = :wildcard_type
                   AND t.subject_id = :wildcard_id
+                  AND t.subject_relation IS NULL
                   AND t.zone_id != :zone_id
                   AND (t.expires_at IS NULL OR t.expires_at >= :now_iso)
                   AND EXISTS (
@@ -687,6 +688,7 @@ class BulkPermissionChecker:
                 FROM rebac_tuples t
                 WHERE t.subject_type = :wildcard_type
                   AND t.subject_id = :wildcard_id
+                  AND t.subject_relation IS NULL
                   AND t.zone_id != :zone_id
                   AND (t.expires_at IS NULL OR t.expires_at >= :now_iso)
                   AND EXISTS (

--- a/src/nexus/bricks/rebac/batch/bulk_checker.py
+++ b/src/nexus/bricks/rebac/batch/bulk_checker.py
@@ -23,6 +23,7 @@ from sqlalchemy.exc import OperationalError
 
 from nexus.bricks.rebac.domain import Entity
 from nexus.bricks.rebac.graph._operators import parent_path_of
+from nexus.bricks.rebac.path_patterns import path_pattern_candidates
 from nexus.contracts.constants import ROOT_ZONE_ID
 from nexus.contracts.rebac_types import CROSS_ZONE_ALLOWED_RELATIONS
 
@@ -329,6 +330,10 @@ class BulkPermissionChecker:
         for obj_type, obj_id in all_objects:
             if obj_type == "file" and "/" in obj_id:
                 file_paths.append(obj_id)
+
+        for file_path in file_paths:
+            for candidate in path_pattern_candidates("file", file_path):
+                all_objects.add(("file", candidate))
 
         ancestor_paths: set[str] = set()
         for file_path in file_paths:

--- a/src/nexus/bricks/rebac/batch/bulk_checker.py
+++ b/src/nexus/bricks/rebac/batch/bulk_checker.py
@@ -21,7 +21,7 @@ from typing import TYPE_CHECKING, Any
 from sqlalchemy import text
 from sqlalchemy.exc import OperationalError
 
-from nexus.bricks.rebac.domain import Entity
+from nexus.bricks.rebac.domain import WILDCARD_SUBJECT, Entity
 from nexus.bricks.rebac.graph._operators import parent_path_of
 from nexus.bricks.rebac.path_patterns import path_pattern_candidates
 from nexus.contracts.constants import ROOT_ZONE_ID
@@ -375,6 +375,9 @@ class BulkPermissionChecker:
                 cross_zone_count = self._fetch_cross_zone_tuples(
                     conn, all_subjects_list, tuples_graph, now_iso
                 )
+                cross_zone_count += self._fetch_cross_zone_wildcard_tuples(
+                    conn, all_objects_list, tuples_graph, zone_id, now_iso
+                )
                 if cross_zone_count > 0:
                     logger.debug(
                         f"[BULK-UNNEST] Fetched {cross_zone_count} cross-zone tuples in single query"
@@ -606,6 +609,99 @@ class BulkPermissionChecker:
             cross_zone_count += 1
 
         return cross_zone_count
+
+    def _fetch_cross_zone_wildcard_tuples(
+        self,
+        conn: Any,
+        all_objects_list: list[tuple[str, str]],
+        tuples_graph: list[dict[str, Any]],
+        zone_id: str,
+        now_iso: str,
+    ) -> int:
+        """Fetch bounded cross-zone wildcard tuples for candidate objects."""
+        if not all_objects_list:
+            return 0
+
+        is_postgresql = self._engine.dialect.name == "postgresql"
+        if not is_postgresql and len(all_objects_list) > SQLITE_ENTITY_CHUNK_SIZE:
+            wildcard_count = 0
+            for object_chunk in self._chunked(all_objects_list, SQLITE_ENTITY_CHUNK_SIZE):
+                wildcard_count += self._fetch_cross_zone_wildcard_tuples(
+                    conn,
+                    object_chunk,
+                    tuples_graph,
+                    zone_id,
+                    now_iso,
+                )
+            return wildcard_count
+
+        object_types = [o[0] for o in all_objects_list]
+        object_ids = [o[1] for o in all_objects_list]
+
+        if is_postgresql:
+            stmt = text("""
+                WITH object_list AS (
+                    SELECT unnest(CAST(:object_types AS text[])) AS object_type,
+                           unnest(CAST(:object_ids AS text[])) AS object_id
+                )
+                SELECT DISTINCT
+                    t.subject_type, t.subject_id, t.subject_relation,
+                    t.relation, t.object_type, t.object_id, t.conditions, t.expires_at
+                FROM rebac_tuples t
+                WHERE t.subject_type = :wildcard_type
+                  AND t.subject_id = :wildcard_id
+                  AND t.zone_id != :zone_id
+                  AND (t.expires_at IS NULL OR t.expires_at >= :now_iso)
+                  AND EXISTS (
+                      SELECT 1 FROM object_list o
+                      WHERE t.object_type = o.object_type AND t.object_id = o.object_id
+                  )
+            """)
+            params: dict[str, Any] = {
+                "object_types": object_types,
+                "object_ids": object_ids,
+                "wildcard_type": WILDCARD_SUBJECT[0],
+                "wildcard_id": WILDCARD_SUBJECT[1],
+                "zone_id": zone_id,
+                "now_iso": now_iso,
+            }
+        else:
+            values_parts = [f"(:otype_{i}, :oid_{i})" for i in range(len(all_objects_list))]
+            values_str = ", ".join(values_parts)
+            params = {}
+            for i, (otype, oid) in enumerate(all_objects_list):
+                params[f"otype_{i}"] = otype
+                params[f"oid_{i}"] = oid
+            params["wildcard_type"] = WILDCARD_SUBJECT[0]
+            params["wildcard_id"] = WILDCARD_SUBJECT[1]
+            params["zone_id"] = zone_id
+            params["now_iso"] = now_iso
+
+            stmt = text(f"""
+                WITH object_list(object_type, object_id) AS (
+                    VALUES {values_str}
+                )
+                SELECT DISTINCT
+                    t.subject_type, t.subject_id, t.subject_relation,
+                    t.relation, t.object_type, t.object_id, t.conditions, t.expires_at
+                FROM rebac_tuples t
+                WHERE t.subject_type = :wildcard_type
+                  AND t.subject_id = :wildcard_id
+                  AND t.zone_id != :zone_id
+                  AND (t.expires_at IS NULL OR t.expires_at >= :now_iso)
+                  AND EXISTS (
+                      SELECT 1 FROM object_list o
+                      WHERE t.object_type = o.object_type AND t.object_id = o.object_id
+                  )
+            """)
+
+        result = conn.execute(stmt, params)
+        wildcard_count = 0
+        for row in result:
+            tuples_graph.append(self._row_to_tuple_dict(row))
+            wildcard_count += 1
+
+        return wildcard_count
 
     @staticmethod
     def _chunked(items: list[tuple[str, str]], chunk_size: int) -> Iterator[list[tuple[str, str]]]:

--- a/src/nexus/bricks/rebac/batch/bulk_checker.py
+++ b/src/nexus/bricks/rebac/batch/bulk_checker.py
@@ -23,7 +23,7 @@ from sqlalchemy.exc import OperationalError
 
 from nexus.bricks.rebac.domain import WILDCARD_SUBJECT, Entity
 from nexus.bricks.rebac.graph._operators import parent_path_of
-from nexus.bricks.rebac.path_patterns import path_pattern_candidates
+from nexus.bricks.rebac.path_patterns import is_path_pattern, path_pattern_candidates
 from nexus.contracts.constants import ROOT_ZONE_ID
 from nexus.contracts.rebac_types import CROSS_ZONE_ALLOWED_RELATIONS
 
@@ -895,13 +895,14 @@ class BulkPermissionChecker:
                 logger.debug(f"[RUST-PERF] Wrote {l1_cache_writes} results to L1 in-memory cache")
 
             # Write-through to Tiger Cache (Issue #935)
-            self._write_through_tiger_cache(
-                cache_misses,
-                zone_id,
-                lambda check: rust_results_dict.get(
-                    (check[0][0], check[0][1], check[1], check[2][0], check[2][1]), False
-                ),
-            )
+            if not self._has_path_pattern_tuple(tuples_graph):
+                self._write_through_tiger_cache(
+                    cache_misses,
+                    zone_id,
+                    lambda check: rust_results_dict.get(
+                        (check[0][0], check[0][1], check[1], check[2][0], check[2][1]), False
+                    ),
+                )
 
             logger.debug(
                 "[BULK] Rust acceleration successful for %d checks",
@@ -951,11 +952,12 @@ class BulkPermissionChecker:
             self._cache_result(subject_entity, permission, obj_entity, result, zone_id)
 
         # Write-through to Tiger Cache after Python fallback
-        self._write_through_tiger_cache(
-            cache_misses,
-            zone_id,
-            lambda check: results.get(check, False),
-        )
+        if not self._has_path_pattern_tuple(tuples_graph):
+            self._write_through_tiger_cache(
+                cache_misses,
+                zone_id,
+                lambda check: results.get(check, False),
+            )
 
     def _write_through_tiger_cache(
         self,
@@ -1043,6 +1045,17 @@ class BulkPermissionChecker:
                 f"[TIGER] Write-through: {tiger_writes} positive results "
                 f"to {len(tiger_updates)} Tiger Cache bitmaps (async persist started)"
             )
+
+    @staticmethod
+    def _has_path_pattern_tuple(tuples_graph: list[dict[str, Any]]) -> bool:
+        """Return whether the graph contains tuples Tiger cannot materialize safely."""
+        return any(
+            is_path_pattern(
+                str(tuple_data.get("object_type", "")),
+                str(tuple_data.get("object_id", "")),
+            )
+            for tuple_data in tuples_graph
+        )
 
     def _log_bulk_stats(
         self,

--- a/src/nexus/bricks/rebac/cache/boundary.py
+++ b/src/nexus/bricks/rebac/cache/boundary.py
@@ -103,6 +103,11 @@ class PermissionBoundaryCache:
             return "/"
         return path.rstrip("/")
 
+    @staticmethod
+    def _path_matches_prefix(path: str, prefix: str) -> bool:
+        """Return whether path is the prefix itself or below it."""
+        return path == prefix or prefix == "/" or path.startswith(prefix + "/")
+
     def get_boundary(
         self,
         zone_id: str,
@@ -308,12 +313,9 @@ class PermissionBoundaryCache:
                     # 2. boundary starts with prefix (pointing to changed location)
                     # 3. cached_path equals prefix
                     # 4. boundary equals prefix
-                    should_remove = (
-                        cached_path.startswith(normalized_prefix + "/")
-                        or cached_path == normalized_prefix
-                        or boundary.startswith(normalized_prefix + "/")
-                        or boundary == normalized_prefix
-                    )
+                    should_remove = self._path_matches_prefix(
+                        cached_path, normalized_prefix
+                    ) or self._path_matches_prefix(boundary, normalized_prefix)
                     if should_remove:
                         paths_to_remove.append(cached_path)
 
@@ -374,12 +376,9 @@ class PermissionBoundaryCache:
                 # Invalidate if:
                 # 1. The cached path is under the changed path
                 # 2. The boundary points to or under the changed path
-                should_remove = (
-                    cached_path.startswith(normalized_path + "/")
-                    or cached_path == normalized_path
-                    or boundary.startswith(normalized_path + "/")
-                    or boundary == normalized_path
-                )
+                should_remove = self._path_matches_prefix(
+                    cached_path, normalized_path
+                ) or self._path_matches_prefix(boundary, normalized_path)
                 if should_remove:
                     paths_to_remove.append(cached_path)
 

--- a/src/nexus/bricks/rebac/cache/coordinator.py
+++ b/src/nexus/bricks/rebac/cache/coordinator.py
@@ -45,6 +45,7 @@ from nexus.bricks.rebac.cache.invalidation_stream import (
 )
 from nexus.bricks.rebac.cache.pubsub_invalidation import PubSubInvalidation
 from nexus.bricks.rebac.domain import RELATION_TO_PERMISSIONS
+from nexus.bricks.rebac.path_patterns import path_pattern_prefix
 from nexus.contracts.constants import ROOT_ZONE_ID
 
 if TYPE_CHECKING:
@@ -609,6 +610,21 @@ class CacheCoordinator:
                     obj.entity_id,
                     zone_id,
                 )
+
+            pattern_prefix = path_pattern_prefix(obj.entity_type, obj.entity_id)
+            if pattern_prefix is not None:
+                if self._l1_cache:
+                    self._l1_cache.invalidate_object_prefix(
+                        obj.entity_type,
+                        pattern_prefix,
+                        zone_id,
+                    )
+                if self._boundary_cache and obj.entity_type == "file":
+                    self._boundary_cache.invalidate_path_prefix(
+                        effective_zone_id,
+                        pattern_prefix,
+                    )
+                should_eager_recompute = False
 
             # L2 SQL cache (rebac_check_cache) removed — table no longer exists.
             # Invalidation is now handled entirely by L1 in-memory cache above.

--- a/src/nexus/bricks/rebac/cache/coordinator.py
+++ b/src/nexus/bricks/rebac/cache/coordinator.py
@@ -1176,10 +1176,11 @@ class CacheCoordinator:
 
         # Map relation to permissions
         permissions = RELATION_TO_PERMISSIONS.get(relation, [relation])
+        invalidation_object_id = path_pattern_prefix(object_type, object_id) or object_id
 
         def _invoke_boundary(cb: "Callable[..., None]") -> None:
             for permission in permissions:
-                cb(zone_id, subject_type, subject_id, permission, object_id)
+                cb(zone_id, subject_type, subject_id, permission, invalidation_object_id)
 
         self._dispatch_to_layer(
             InvalidationEventType.BOUNDARY,
@@ -1191,7 +1192,7 @@ class CacheCoordinator:
                 "subject_id": subject_id,
                 "relation": relation,
                 "object_type": object_type,
-                "object_id": object_id,
+                "object_id": invalidation_object_id,
                 "permissions": permissions,
             },
             metric_attr="_boundary_invalidations",

--- a/src/nexus/bricks/rebac/graph/bulk_evaluator.py
+++ b/src/nexus/bricks/rebac/graph/bulk_evaluator.py
@@ -12,12 +12,14 @@ Related: Issue #1459 Phase 11, Performance optimization
 """
 
 import logging
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from nexus.bricks.rebac.graph._operators import (
     dispatch_permission_operators,
     dispatch_relation_operators,
 )
+from nexus.bricks.rebac.path_patterns import is_path_pattern, path_pattern_matches
 
 if TYPE_CHECKING:
     from nexus.bricks.rebac.domain import Entity
@@ -26,6 +28,12 @@ logger = logging.getLogger(__name__)
 
 # Maximum traversal depth to prevent infinite recursion
 MAX_DEPTH = 50
+
+
+@dataclass(frozen=True)
+class DirectRelationIndex:
+    exact: frozenset[tuple[str, str, str, str, str]]
+    patterns: tuple[dict[str, Any], ...]
 
 
 def compute_permission(
@@ -39,7 +47,7 @@ def compute_permission(
     visited: set[tuple[str, str, str, str, str]] | None = None,
     bulk_memo_cache: dict[tuple[str, str, str, str, str], bool] | None = None,
     memo_stats: dict[str, int] | None = None,
-    direct_index: frozenset[tuple[str, str, str, str, str]] | None = None,
+    direct_index: DirectRelationIndex | None = None,
 ) -> bool:
     """Compute permission using pre-fetched tuples graph with full in-memory traversal.
 
@@ -270,27 +278,57 @@ def compute_permission(
 
 def build_direct_index(
     tuples_graph: list[dict[str, Any]],
-) -> frozenset[tuple[str, str, str, str, str]]:
+) -> DirectRelationIndex:
     """Build an O(1) lookup index for direct relation checks.
 
-    The index is a frozenset of (subject_type, subject_id, relation,
-    object_type, object_id) tuples for unconditional, direct relations.
-    Built once per bulk call, used O(1) per check_direct_relation().
+    The exact index is a frozenset of (subject_type, subject_id,
+    relation, object_type, object_id) tuples for unconditional, direct
+    relations. File path-pattern tuples are kept separately because they
+    need match evaluation against the requested object id.
 
     Returns:
-        frozenset of 5-tuples for O(1) ``in`` membership tests.
+        DirectRelationIndex for O(1) exact membership tests plus a small
+        pattern scan.
     """
-    return frozenset(
-        (
-            t["subject_type"],
-            t["subject_id"],
-            t["relation"],
-            t["object_type"],
-            t["object_id"],
+    exact: set[tuple[str, str, str, str, str]] = set()
+    patterns: list[dict[str, Any]] = []
+
+    for t in tuples_graph:
+        if _has_conditions(t) or t.get("subject_relation") is not None:
+            continue
+
+        if is_path_pattern(t["object_type"], t["object_id"]):
+            patterns.append(t)
+            continue
+
+        exact.add(
+            (
+                t["subject_type"],
+                t["subject_id"],
+                t["relation"],
+                t["object_type"],
+                t["object_id"],
+            )
         )
-        for t in tuples_graph
-        if not t.get("conditions") and t.get("subject_relation") is None
+
+    return DirectRelationIndex(exact=frozenset(exact), patterns=tuple(patterns))
+
+
+def _tuple_object_matches(tuple_data: dict[str, Any], obj: "Entity") -> bool:
+    if tuple_data["object_id"] == obj.entity_id:
+        return True
+    return is_path_pattern(tuple_data["object_type"], tuple_data["object_id"]) and (
+        path_pattern_matches(tuple_data["object_id"], obj.entity_id)
     )
+
+
+def _tuple_subject_matches(tuple_data: dict[str, Any], subject: "Entity") -> bool:
+    if (
+        tuple_data["subject_type"] == subject.entity_type
+        and tuple_data["subject_id"] == subject.entity_id
+    ):
+        return True
+    return bool(tuple_data["subject_type"] == "*" and tuple_data["subject_id"] == "*")
 
 
 def check_direct_relation(
@@ -298,7 +336,7 @@ def check_direct_relation(
     permission: str,
     obj: "Entity",
     tuples_graph: list[dict[str, Any]],
-    direct_index: frozenset[tuple[str, str, str, str, str]] | None = None,
+    direct_index: DirectRelationIndex | None = None,
 ) -> bool:
     """Check if a direct relation tuple exists in the pre-fetched graph.
 
@@ -314,11 +352,23 @@ def check_direct_relation(
     """
     if direct_index is not None:
         key = (subject.entity_type, subject.entity_id, permission, obj.entity_type, obj.entity_id)
-        if key in direct_index:
+        if key in direct_index.exact:
             return True
         # Round-10: wildcard ``("*", "*")`` matches any subject.
         wildcard_key = ("*", "*", permission, obj.entity_type, obj.entity_id)
-        return wildcard_key in direct_index
+        if wildcard_key in direct_index.exact:
+            return True
+
+        for tuple_data in direct_index.patterns:
+            if (
+                tuple_data["relation"] == permission
+                and tuple_data["object_type"] == obj.entity_type
+                and path_pattern_matches(tuple_data["object_id"], obj.entity_id)
+                and _tuple_subject_matches(tuple_data, subject)
+            ):
+                return True
+
+        return False
 
     # Fallback: O(T) linear scan (for callers without an index).
     for tuple_data in tuples_graph:
@@ -327,16 +377,10 @@ def check_direct_relation(
         if (
             tuple_data["relation"] != permission
             or tuple_data["object_type"] != obj.entity_type
-            or tuple_data["object_id"] != obj.entity_id
             or tuple_data["subject_relation"] is not None
         ):
             continue
-        if (
-            tuple_data["subject_type"] == subject.entity_type
-            and tuple_data["subject_id"] == subject.entity_id
-        ):
-            return True
-        if tuple_data["subject_type"] == "*" and tuple_data["subject_id"] == "*":
+        if _tuple_object_matches(tuple_data, obj) and _tuple_subject_matches(tuple_data, subject):
             return True
     return False
 

--- a/src/nexus/bricks/rebac/graph/bulk_evaluator.py
+++ b/src/nexus/bricks/rebac/graph/bulk_evaluator.py
@@ -12,6 +12,7 @@ Related: Issue #1459 Phase 11, Performance optimization
 """
 
 import logging
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -34,6 +35,7 @@ MAX_DEPTH = 50
 class DirectRelationIndex:
     exact: frozenset[tuple[str, str, str, str, str]]
     patterns: tuple[dict[str, Any], ...]
+    usersets: tuple[dict[str, Any], ...]
 
 
 def compute_permission(
@@ -129,11 +131,6 @@ def compute_permission(
     if direct_index is None and depth == 0:
         direct_index = build_direct_index(tuples_graph)
 
-    # Get namespace config
-    namespace = get_namespace(obj.entity_type)
-    if not namespace:
-        return check_direct_relation(subject, permission, obj, tuples_graph, direct_index)
-
     # Helper to store and return a result.
     # Round-4 fix: only memoize negatives when no cycle was observed
     # during the computation. Positives are always memoizable (the
@@ -142,6 +139,25 @@ def compute_permission(
         if bulk_memo_cache is not None and (result or not cycle_observed[0]):
             bulk_memo_cache[memo_key] = result
         return result
+
+    def _check_direct() -> bool:
+        from nexus.bricks.rebac.domain import Entity as _Entity
+
+        def _check_userset(tuple_data: dict[str, Any]) -> bool:
+            userset_relation = tuple_data.get("subject_relation")
+            if userset_relation is None:
+                return False
+            userset = _Entity(tuple_data["subject_type"], tuple_data["subject_id"])
+            return _recurse(subject, userset_relation, userset)
+
+        return check_direct_relation(
+            subject,
+            permission,
+            obj,
+            tuples_graph,
+            direct_index,
+            userset_relation_checker=_check_userset,
+        )
 
     # Recurse helper. Round-4: detect cycles seen in any subtree by
     # comparing the visited set before/after — if the recursive call
@@ -172,6 +188,11 @@ def compute_permission(
                     cycle_observed[0] = True
                     break
         return result
+
+    # Get namespace config
+    namespace = get_namespace(obj.entity_type)
+    if not namespace:
+        return _store(_check_direct())
 
     # P0-1: Permission -> usersets (e.g., "read" -> ["viewer", "editor", "owner"]).
     # Shared dispatch handles union/intersection/exclusion with fail-closed
@@ -273,7 +294,7 @@ def compute_permission(
         return False
 
     # Direct relation check (base case)
-    return _store(check_direct_relation(subject, permission, obj, tuples_graph, direct_index))
+    return _store(_check_direct())
 
 
 def build_direct_index(
@@ -292,9 +313,14 @@ def build_direct_index(
     """
     exact: set[tuple[str, str, str, str, str]] = set()
     patterns: list[dict[str, Any]] = []
+    usersets: list[dict[str, Any]] = []
 
     for t in tuples_graph:
-        if _has_conditions(t) or t.get("subject_relation") is not None:
+        if _has_conditions(t):
+            continue
+
+        if t.get("subject_relation") is not None:
+            usersets.append(t)
             continue
 
         if is_path_pattern(t["object_type"], t["object_id"]):
@@ -311,7 +337,11 @@ def build_direct_index(
             )
         )
 
-    return DirectRelationIndex(exact=frozenset(exact), patterns=tuple(patterns))
+    return DirectRelationIndex(
+        exact=frozenset(exact),
+        patterns=tuple(patterns),
+        usersets=tuple(usersets),
+    )
 
 
 def _tuple_object_matches(tuple_data: dict[str, Any], obj: "Entity") -> bool:
@@ -337,6 +367,7 @@ def check_direct_relation(
     obj: "Entity",
     tuples_graph: list[dict[str, Any]],
     direct_index: DirectRelationIndex | None = None,
+    userset_relation_checker: Callable[[dict[str, Any]], bool] | None = None,
 ) -> bool:
     """Check if a direct relation tuple exists in the pre-fetched graph.
 
@@ -368,19 +399,31 @@ def check_direct_relation(
             ):
                 return True
 
+        if userset_relation_checker is not None:
+            for tuple_data in direct_index.usersets:
+                if (
+                    tuple_data["relation"] == permission
+                    and tuple_data["object_type"] == obj.entity_type
+                    and _tuple_object_matches(tuple_data, obj)
+                    and userset_relation_checker(tuple_data)
+                ):
+                    return True
+
         return False
 
     # Fallback: O(T) linear scan (for callers without an index).
     for tuple_data in tuples_graph:
         if _has_conditions(tuple_data):
             continue
-        if (
-            tuple_data["relation"] != permission
-            or tuple_data["object_type"] != obj.entity_type
-            or tuple_data["subject_relation"] is not None
-        ):
+        if tuple_data["relation"] != permission or tuple_data["object_type"] != obj.entity_type:
             continue
-        if _tuple_object_matches(tuple_data, obj) and _tuple_subject_matches(tuple_data, subject):
+        if not _tuple_object_matches(tuple_data, obj):
+            continue
+        if tuple_data["subject_relation"] is not None:
+            if userset_relation_checker is not None and userset_relation_checker(tuple_data):
+                return True
+            continue
+        if _tuple_subject_matches(tuple_data, subject):
             return True
     return False
 

--- a/src/nexus/bricks/rebac/graph/bulk_evaluator.py
+++ b/src/nexus/bricks/rebac/graph/bulk_evaluator.py
@@ -473,9 +473,15 @@ def find_subjects(
     for tuple_data in tuples_graph:
         if _has_conditions(tuple_data):
             continue
+        object_matches = tuple_data["object_id"] == obj.entity_id
+        if not object_matches and is_path_pattern(
+            tuple_data["object_type"],
+            tuple_data["object_id"],
+        ):
+            object_matches = path_pattern_matches(tuple_data["object_id"], obj.entity_id)
         if (
             tuple_data["object_type"] == obj.entity_type
-            and tuple_data["object_id"] == obj.entity_id
+            and object_matches
             and tuple_data["relation"] == tupleset_relation
         ):
             subjects.append(_Entity(tuple_data["subject_type"], tuple_data["subject_id"]))

--- a/src/nexus/bricks/rebac/graph/traversal.py
+++ b/src/nexus/bricks/rebac/graph/traversal.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING, Any
 
 from nexus.bricks.rebac.domain import WILDCARD_SUBJECT, Entity
 from nexus.bricks.rebac.graph._operators import dispatch_relation_operators
+from nexus.bricks.rebac.path_patterns import path_pattern_candidates
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -512,8 +513,8 @@ class PermissionComputer:
             cursor = self._repo.create_cursor(conn)
 
             # Check 1: Direct concrete subject (subject_relation IS NULL)
-            row = self._query_direct_tuple(cursor, subject, relation, obj, zone_id)
-            if row:
+            rows = self._query_direct_tuple(cursor, subject, relation, obj, zone_id)
+            for row in rows:
                 if logger.isEnabledFor(logging.DEBUG):
                     logger.debug(
                         "    Found direct tuple for %s -> %s -> %s", subject, relation, obj
@@ -534,6 +535,25 @@ class PermissionComputer:
             # Check 3: Userset-as-subject grants
             return self._check_userset_grants(cursor, subject, relation, obj, context, zone_id)
 
+    def _object_id_candidates(
+        self,
+        obj: Entity,
+    ) -> tuple[str, tuple[str, ...], dict[str, int]]:
+        candidates = tuple(path_pattern_candidates(obj.entity_type, obj.entity_id))
+        placeholders = ", ".join("?" for _ in candidates)
+        candidate_index = {candidate: idx for idx, candidate in enumerate(candidates)}
+        return placeholders, candidates, candidate_index
+
+    def _rows_by_candidate_priority(
+        self,
+        rows: list[dict[str, Any]],
+        candidate_index: dict[str, int],
+    ) -> list[dict[str, Any]]:
+        return sorted(
+            rows,
+            key=lambda row: candidate_index.get(row["object_id"], len(candidate_index)),
+        )
+
     def _query_direct_tuple(
         self,
         cursor: Any,
@@ -541,25 +561,25 @@ class PermissionComputer:
         relation: str,
         obj: Entity,
         zone_id: str | None,
-    ) -> dict[str, Any] | None:
-        """Query for a direct concrete subject tuple."""
+    ) -> list[dict[str, Any]]:
+        """Query for direct concrete subject tuples."""
         now_iso = datetime.now(UTC).isoformat()
         fix = self._repo.fix_sql_placeholders
+        placeholders, candidates, candidate_index = self._object_id_candidates(obj)
 
         if zone_id is None:
             cursor.execute(
                 fix(
-                    """
+                    f"""
                     SELECT tuple_id, subject_type, subject_id, subject_relation,
                            relation, object_type, object_id, conditions, expires_at
                     FROM rebac_tuples
                     WHERE subject_type = ? AND subject_id = ?
                       AND subject_relation IS NULL
                       AND relation = ?
-                      AND object_type = ? AND object_id = ?
+                      AND object_type = ? AND object_id IN ({placeholders})
                       AND (expires_at IS NULL OR expires_at >= ?)
                       AND zone_id IS NULL
-                    LIMIT 1
                     """
                 ),
                 (
@@ -567,24 +587,23 @@ class PermissionComputer:
                     subject.entity_id,
                     relation,
                     obj.entity_type,
-                    obj.entity_id,
+                    *candidates,
                     now_iso,
                 ),
             )
         else:
             cursor.execute(
                 fix(
-                    """
+                    f"""
                     SELECT tuple_id, subject_type, subject_id, subject_relation,
                            relation, object_type, object_id, conditions, expires_at
                     FROM rebac_tuples
                     WHERE subject_type = ? AND subject_id = ?
                       AND subject_relation IS NULL
                       AND relation = ?
-                      AND object_type = ? AND object_id = ?
+                      AND object_type = ? AND object_id IN ({placeholders})
                       AND (expires_at IS NULL OR expires_at >= ?)
                       AND zone_id = ?
-                    LIMIT 1
                     """
                 ),
                 (
@@ -592,14 +611,14 @@ class PermissionComputer:
                     subject.entity_id,
                     relation,
                     obj.entity_type,
-                    obj.entity_id,
+                    *candidates,
                     now_iso,
                     zone_id,
                 ),
             )
 
-        row = cursor.fetchone()
-        return dict(row) if row else None
+        rows = [dict(row) for row in cursor.fetchall()]
+        return self._rows_by_candidate_priority(rows, candidate_index)
 
     def _evaluate_tuple_conditions(
         self,
@@ -642,18 +661,19 @@ class PermissionComputer:
         wildcard_entity = Entity(WILDCARD_SUBJECT[0], WILDCARD_SUBJECT[1])
         now_iso = datetime.now(UTC).isoformat()
         fix = self._repo.fix_sql_placeholders
+        placeholders, candidates, candidate_index = self._object_id_candidates(obj)
 
         if zone_id is None:
             cursor.execute(
                 fix(
-                    """
+                    f"""
                     SELECT tuple_id, subject_type, subject_id, subject_relation,
                            relation, object_type, object_id, conditions, expires_at
                     FROM rebac_tuples
                     WHERE subject_type = ? AND subject_id = ?
                       AND subject_relation IS NULL
                       AND relation = ?
-                      AND object_type = ? AND object_id = ?
+                      AND object_type = ? AND object_id IN ({placeholders})
                       AND (expires_at IS NULL OR expires_at >= ?)
                       AND zone_id IS NULL
                     """
@@ -663,21 +683,21 @@ class PermissionComputer:
                     wildcard_entity.entity_id,
                     relation,
                     obj.entity_type,
-                    obj.entity_id,
+                    *candidates,
                     now_iso,
                 ),
             )
         else:
             cursor.execute(
                 fix(
-                    """
+                    f"""
                     SELECT tuple_id, subject_type, subject_id, subject_relation,
                            relation, object_type, object_id, conditions, expires_at
                     FROM rebac_tuples
                     WHERE subject_type = ? AND subject_id = ?
                       AND subject_relation IS NULL
                       AND relation = ?
-                      AND object_type = ? AND object_id = ?
+                      AND object_type = ? AND object_id IN ({placeholders})
                       AND (expires_at IS NULL OR expires_at >= ?)
                       AND zone_id = ?
                     """
@@ -687,14 +707,15 @@ class PermissionComputer:
                     wildcard_entity.entity_id,
                     relation,
                     obj.entity_type,
-                    obj.entity_id,
+                    *candidates,
                     now_iso,
                     zone_id,
                 ),
             )
 
-        for row in cursor.fetchall():
-            result = self._evaluate_tuple_conditions(dict(row), context)
+        rows = [dict(row) for row in cursor.fetchall()]
+        for row in self._rows_by_candidate_priority(rows, candidate_index):
+            result = self._evaluate_tuple_conditions(row, context)
             if result is not None:
                 return result
 
@@ -702,14 +723,14 @@ class PermissionComputer:
         if zone_id is not None:
             cursor.execute(
                 fix(
-                    """
+                    f"""
                     SELECT tuple_id, subject_type, subject_id, subject_relation,
                            relation, object_type, object_id, conditions, expires_at
                     FROM rebac_tuples
                     WHERE subject_type = ? AND subject_id = ?
                       AND subject_relation IS NULL
                       AND relation = ?
-                      AND object_type = ? AND object_id = ?
+                      AND object_type = ? AND object_id IN ({placeholders})
                       AND (expires_at IS NULL OR expires_at >= ?)
                     """
                 ),
@@ -718,12 +739,13 @@ class PermissionComputer:
                     wildcard_entity.entity_id,
                     relation,
                     obj.entity_type,
-                    obj.entity_id,
+                    *candidates,
                     now_iso,
                 ),
             )
-            for row in cursor.fetchall():
-                result = self._evaluate_tuple_conditions(dict(row), context)
+            rows = [dict(row) for row in cursor.fetchall()]
+            for row in self._rows_by_candidate_priority(rows, candidate_index):
+                result = self._evaluate_tuple_conditions(row, context)
                 if result is None:
                     continue
                 if logger.isEnabledFor(logging.DEBUG):
@@ -748,41 +770,44 @@ class PermissionComputer:
         """Check userset-as-subject grants (e.g., group:eng#member)."""
         now_iso = datetime.now(UTC).isoformat()
         fix = self._repo.fix_sql_placeholders
+        placeholders, candidates, candidate_index = self._object_id_candidates(obj)
 
         if zone_id is None:
             cursor.execute(
                 fix(
-                    """
+                    f"""
                     SELECT tuple_id, subject_type, subject_id, subject_relation,
                            relation, object_type, object_id, conditions, expires_at
                     FROM rebac_tuples
                     WHERE zone_id IS NULL
                       AND relation = ?
-                      AND object_type = ? AND object_id = ?
+                      AND object_type = ? AND object_id IN ({placeholders})
                       AND subject_relation IS NOT NULL
                       AND (expires_at IS NULL OR expires_at >= ?)
                     """
                 ),
-                (relation, obj.entity_type, obj.entity_id, now_iso),
+                (relation, obj.entity_type, *candidates, now_iso),
             )
         else:
             cursor.execute(
                 fix(
-                    """
+                    f"""
                     SELECT tuple_id, subject_type, subject_id, subject_relation,
                            relation, object_type, object_id, conditions, expires_at
                     FROM rebac_tuples
                     WHERE zone_id = ?
                       AND relation = ?
-                      AND object_type = ? AND object_id = ?
+                      AND object_type = ? AND object_id IN ({placeholders})
                       AND subject_relation IS NOT NULL
                       AND (expires_at IS NULL OR expires_at >= ?)
                     """
                 ),
-                (zone_id, relation, obj.entity_type, obj.entity_id, now_iso),
+                (zone_id, relation, obj.entity_type, *candidates, now_iso),
             )
 
-        userset_grants = [dict(row) for row in cursor.fetchall()]
+        userset_grants = self._rows_by_candidate_priority(
+            [dict(row) for row in cursor.fetchall()], candidate_index
+        )
         for grant in userset_grants:
             set_type = grant["subject_type"]
             set_id = grant["subject_id"]

--- a/src/nexus/bricks/rebac/graph/zone_traversal.py
+++ b/src/nexus/bricks/rebac/graph/zone_traversal.py
@@ -43,6 +43,7 @@ if TYPE_CHECKING:
     from nexus.bricks.rebac.domain import NamespaceConfig
 
 logger = logging.getLogger(__name__)
+TraversalKey = tuple[str, str, str, str, str, bool]
 
 
 class ZoneAwareTraversal:
@@ -85,12 +86,13 @@ class ZoneAwareTraversal:
         permission: str,
         obj: Entity,
         zone_id: str,
-        visited: set[tuple[str, str, str, str, str]],
+        visited: set[TraversalKey],
         depth: int,
         start_time: float,
         stats: TraversalStats,
         context: dict[str, Any] | None = None,
-        memo: dict[tuple[str, str, str, str, str], bool] | None = None,
+        memo: dict[TraversalKey, bool] | None = None,
+        allow_single_level_patterns: bool = True,
     ) -> bool:
         """Compute permission with P0-5 limits enforced at each step.
 
@@ -111,6 +113,7 @@ class ZoneAwareTraversal:
             permission,
             obj.entity_type,
             obj.entity_id,
+            allow_single_level_patterns,
         )
         if memo_key in memo:
             cached_result = memo[memo_key]
@@ -162,7 +165,14 @@ class ZoneAwareTraversal:
             stats.queries += 1
             if self.enable_graph_limits and stats.queries > GraphLimits.MAX_TUPLE_QUERIES:
                 raise GraphLimitExceeded("queries", GraphLimits.MAX_TUPLE_QUERIES, stats.queries)
-            result = self.has_direct_relation(subject, permission, obj, zone_id, context)
+            result = self.has_direct_relation(
+                subject,
+                permission,
+                obj,
+                zone_id,
+                context,
+                allow_single_level_patterns=allow_single_level_patterns,
+            )
             logger.debug(f"{indent}← RESULT: {result}")
             # Direct lookups are acyclic by construction — always safe
             # to memoize.
@@ -181,7 +191,13 @@ class ZoneAwareTraversal:
         # by checking whether the recursion re-entered any key already
         # in OUR visited frame; if so, propagate cycle_observed up so
         # the parent's negative does not get memoized.
-        def _recurse(subj: Entity, perm: str, target: Entity) -> bool:
+        def _recurse(
+            subj: Entity,
+            perm: str,
+            target: Entity,
+            *,
+            allow_single_level: bool = allow_single_level_patterns,
+        ) -> bool:
             sub_visited = visited.copy()
             result = self.compute_permission(
                 subj,
@@ -194,6 +210,7 @@ class ZoneAwareTraversal:
                 stats,
                 context,
                 memo,
+                allow_single_level_patterns=allow_single_level,
             )
             if not result:
                 for key in sub_visited:
@@ -228,7 +245,14 @@ class ZoneAwareTraversal:
             stats.queries += 1
             if self.enable_graph_limits and stats.queries > GraphLimits.MAX_TUPLE_QUERIES:
                 raise GraphLimitExceeded("queries", GraphLimits.MAX_TUPLE_QUERIES, stats.queries)
-            result = self.has_direct_relation(subject, permission, obj, zone_id, context)
+            result = self.has_direct_relation(
+                subject,
+                permission,
+                obj,
+                zone_id,
+                context,
+                allow_single_level_patterns=allow_single_level_patterns,
+            )
             logger.debug(f"{indent}← RESULT: {result}")
             memo[memo_key] = result
             return result
@@ -274,7 +298,12 @@ class ZoneAwareTraversal:
                     logger.debug(
                         f"{indent}  Checking '{computed_userset}' on related object {related_obj.entity_type}:{related_obj.entity_id}"
                     )
-                    if _recurse(subject, computed_userset, related_obj):
+                    if _recurse(
+                        subject,
+                        computed_userset,
+                        related_obj,
+                        allow_single_level=False,
+                    ):
                         logger.debug(
                             f"{indent}← RESULT: True (via tupleToUserset parent pattern on {related_obj.entity_type}:{related_obj.entity_id})"
                         )
@@ -295,7 +324,13 @@ class ZoneAwareTraversal:
                         "queries", GraphLimits.MAX_TUPLE_QUERIES, stats.queries
                     )
 
-                related_subjects = self.find_subjects(obj, tupleset_relation, zone_id, context)
+                related_subjects = self.find_subjects(
+                    obj,
+                    tupleset_relation,
+                    zone_id,
+                    context,
+                    allow_single_level_patterns=allow_single_level_patterns,
+                )
                 logger.debug(
                     f"{indent}[depth={depth}]   Pattern 2 (group): Found {len(related_subjects)} subjects with '{tupleset_relation}' on obj: {[f'{s.entity_type}:{s.entity_id}' for s in related_subjects]}"
                 )
@@ -324,7 +359,14 @@ class ZoneAwareTraversal:
         stats.queries += 1
         if self.enable_graph_limits and stats.queries > GraphLimits.MAX_TUPLE_QUERIES:
             raise GraphLimitExceeded("queries", GraphLimits.MAX_TUPLE_QUERIES, stats.queries)
-        result = self.has_direct_relation(subject, permission, obj, zone_id, context)
+        result = self.has_direct_relation(
+            subject,
+            permission,
+            obj,
+            zone_id,
+            context,
+            allow_single_level_patterns=allow_single_level_patterns,
+        )
         logger.debug(f"{indent}← [EXIT depth={depth}] Direct relation result: {result}")
         memo[memo_key] = result
         return result
@@ -334,8 +376,18 @@ class ZoneAwareTraversal:
     # ------------------------------------------------------------------
 
     @staticmethod
-    def _object_id_candidates(obj: Entity) -> tuple[tuple[str, ...], dict[str, int]]:
-        candidates = tuple(path_pattern_candidates(obj.entity_type, obj.entity_id))
+    def _object_id_candidates(
+        obj: Entity,
+        *,
+        include_single_level: bool = True,
+    ) -> tuple[tuple[str, ...], dict[str, int]]:
+        candidates = tuple(
+            path_pattern_candidates(
+                obj.entity_type,
+                obj.entity_id,
+                include_single_level=include_single_level,
+            )
+        )
         candidate_index = {candidate: idx for idx, candidate in enumerate(candidates)}
         return candidates, candidate_index
 
@@ -356,6 +408,8 @@ class ZoneAwareTraversal:
         obj: Entity,
         zone_id: str,
         context: dict[str, Any] | None = None,
+        *,
+        allow_single_level_patterns: bool = True,
     ) -> bool:
         """Check if subject has direct relation to object (zone-scoped).
 
@@ -385,7 +439,10 @@ class ZoneAwareTraversal:
 
         now = datetime.now(UTC)
         expires_filter = or_(RT.expires_at.is_(None), RT.expires_at >= now)
-        candidates, candidate_index = self._object_id_candidates(obj)
+        candidates, candidate_index = self._object_id_candidates(
+            obj,
+            include_single_level=allow_single_level_patterns,
+        )
 
         with self._engine.connect() as conn:
             # Check for direct concrete subject tuple (with ABAC conditions support)
@@ -602,6 +659,8 @@ class ZoneAwareTraversal:
         relation: str,
         zone_id: str,
         context: dict[str, Any] | None = None,
+        *,
+        allow_single_level_patterns: bool = True,
     ) -> list[Entity]:
         """Find all subjects that have a relation to obj (zone-scoped).
 
@@ -618,7 +677,10 @@ class ZoneAwareTraversal:
         logger.debug(f"find_subjects: Looking for (?, '{relation}', {obj})")
 
         now = datetime.now(UTC)
-        candidates, candidate_index = self._object_id_candidates(obj)
+        candidates, candidate_index = self._object_id_candidates(
+            obj,
+            include_single_level=allow_single_level_patterns,
+        )
         stmt = select(RT.subject_type, RT.subject_id, RT.object_id, RT.conditions).where(
             RT.object_type == obj.entity_type,
             RT.object_id.in_(candidates),

--- a/src/nexus/bricks/rebac/graph/zone_traversal.py
+++ b/src/nexus/bricks/rebac/graph/zone_traversal.py
@@ -26,6 +26,7 @@ from nexus.bricks.rebac.graph._operators import (
     dispatch_relation_operators,
     parent_path_of,
 )
+from nexus.bricks.rebac.path_patterns import path_pattern_candidates
 from nexus.contracts.rebac_types import (
     GraphLimitExceeded,
     GraphLimits,
@@ -332,6 +333,22 @@ class ZoneAwareTraversal:
     # Direct relation check
     # ------------------------------------------------------------------
 
+    @staticmethod
+    def _object_id_candidates(obj: Entity) -> tuple[tuple[str, ...], dict[str, int]]:
+        candidates = tuple(path_pattern_candidates(obj.entity_type, obj.entity_id))
+        candidate_index = {candidate: idx for idx, candidate in enumerate(candidates)}
+        return candidates, candidate_index
+
+    @staticmethod
+    def _rows_by_candidate_priority(
+        rows: list[Any],
+        candidate_index: dict[str, int],
+    ) -> list[Any]:
+        return sorted(
+            rows,
+            key=lambda row: candidate_index.get(row.object_id, len(candidate_index)),
+        )
+
     def has_direct_relation(
         self,
         subject: Entity,
@@ -368,15 +385,16 @@ class ZoneAwareTraversal:
 
         now = datetime.now(UTC)
         expires_filter = or_(RT.expires_at.is_(None), RT.expires_at >= now)
+        candidates, candidate_index = self._object_id_candidates(obj)
 
         with self._engine.connect() as conn:
             # Check for direct concrete subject tuple (with ABAC conditions support)
-            stmt = select(RT.tuple_id, RT.conditions).where(
+            stmt = select(RT.tuple_id, RT.object_id, RT.conditions).where(
                 RT.subject_type == subject.entity_type,
                 RT.subject_id == subject.entity_id,
                 RT.relation == relation,
                 RT.object_type == obj.entity_type,
-                RT.object_id == obj.entity_id,
+                RT.object_id.in_(candidates),
                 RT.zone_id == zone_id,
                 RT.subject_relation.is_(None),
                 expires_filter,
@@ -392,25 +410,29 @@ class ZoneAwareTraversal:
                     zone_id,
                 )
 
-            row = conn.execute(stmt).first()
+            rows = self._rows_by_candidate_priority(list(conn.execute(stmt)), candidate_index)
             if logger.isEnabledFor(logging.DEBUG):
-                logger.debug("[DIRECT-CHECK] Query result row: %s", row)
-            if row and self._conditions_allow(row.conditions, context):
-                return True
+                logger.debug("[DIRECT-CHECK] Query result rows: %s", rows)
+            for row in rows:
+                if self._conditions_allow(row.conditions, context):
+                    return True
 
             # Cross-zone check for shared-* relations (PR #647, #648)
             if self._zone_manager.is_cross_zone_readable(relation):
-                cross_zone_stmt = select(RT.tuple_id, RT.conditions).where(
+                cross_zone_stmt = select(RT.tuple_id, RT.object_id, RT.conditions).where(
                     RT.subject_type == subject.entity_type,
                     RT.subject_id == subject.entity_id,
                     RT.relation == relation,
                     RT.object_type == obj.entity_type,
-                    RT.object_id == obj.entity_id,
+                    RT.object_id.in_(candidates),
                     RT.subject_relation.is_(None),
                     expires_filter,
                 )
                 cross_zone_allowed = False
-                for cross_zone_row in conn.execute(cross_zone_stmt):
+                cross_zone_rows = self._rows_by_candidate_priority(
+                    list(conn.execute(cross_zone_stmt)), candidate_index
+                )
+                for cross_zone_row in cross_zone_rows:
                     if self._conditions_allow(cross_zone_row.conditions, context):
                         cross_zone_allowed = True
                         break
@@ -426,17 +448,20 @@ class ZoneAwareTraversal:
 
             # Check for wildcard/public access (*:*) - Issue #1064
             if (subject.entity_type, subject.entity_id) != WILDCARD_SUBJECT:
-                wildcard_stmt = select(RT.tuple_id, RT.conditions).where(
+                wildcard_stmt = select(RT.tuple_id, RT.object_id, RT.conditions).where(
                     RT.subject_type == WILDCARD_SUBJECT[0],
                     RT.subject_id == WILDCARD_SUBJECT[1],
                     RT.relation == relation,
                     RT.object_type == obj.entity_type,
-                    RT.object_id == obj.entity_id,
+                    RT.object_id.in_(candidates),
                     RT.subject_relation.is_(None),
                     expires_filter,
                 )
                 wildcard_allowed = False
-                for wildcard_row in conn.execute(wildcard_stmt):
+                wildcard_rows = self._rows_by_candidate_priority(
+                    list(conn.execute(wildcard_stmt)), candidate_index
+                )
+                for wildcard_row in wildcard_rows:
                     if self._conditions_allow(wildcard_row.conditions, context):
                         wildcard_allowed = True
                         break
@@ -454,18 +479,22 @@ class ZoneAwareTraversal:
                 RT.subject_type,
                 RT.subject_id,
                 RT.subject_relation,
+                RT.object_id,
                 RT.conditions,
             ).where(
                 RT.relation == relation,
                 RT.object_type == obj.entity_type,
-                RT.object_id == obj.entity_id,
+                RT.object_id.in_(candidates),
                 RT.subject_relation.isnot(None),
                 RT.zone_id == zone_id,
                 expires_filter,
             )
 
             # BUGFIX (Issue #1): Use recursive ReBAC evaluation instead of direct SQL
-            for userset_row in conn.execute(userset_stmt):
+            userset_rows = self._rows_by_candidate_priority(
+                list(conn.execute(userset_stmt)), candidate_index
+            )
+            for userset_row in userset_rows:
                 if not self._conditions_allow(userset_row.conditions, context):
                     continue
 

--- a/src/nexus/bricks/rebac/graph/zone_traversal.py
+++ b/src/nexus/bricks/rebac/graph/zone_traversal.py
@@ -618,9 +618,10 @@ class ZoneAwareTraversal:
         logger.debug(f"find_subjects: Looking for (?, '{relation}', {obj})")
 
         now = datetime.now(UTC)
-        stmt = select(RT.subject_type, RT.subject_id, RT.conditions).where(
+        candidates, candidate_index = self._object_id_candidates(obj)
+        stmt = select(RT.subject_type, RT.subject_id, RT.object_id, RT.conditions).where(
             RT.object_type == obj.entity_type,
-            RT.object_id == obj.entity_id,
+            RT.object_id.in_(candidates),
             RT.relation == relation,
             RT.zone_id == zone_id,
             or_(RT.expires_at.is_(None), RT.expires_at >= now),
@@ -629,7 +630,10 @@ class ZoneAwareTraversal:
         with self._engine.connect() as conn:
             results = [
                 Entity(row.subject_type, row.subject_id)
-                for row in conn.execute(stmt)
+                for row in self._rows_by_candidate_priority(
+                    list(conn.execute(stmt)),
+                    candidate_index,
+                )
                 if self._conditions_allow(row.conditions, context)
             ]
 

--- a/src/nexus/bricks/rebac/manager.py
+++ b/src/nexus/bricks/rebac/manager.py
@@ -62,6 +62,7 @@ from nexus.bricks.rebac.graph.bulk_evaluator import (
 from nexus.bricks.rebac.graph.expand import ExpandEngine
 from nexus.bricks.rebac.graph.traversal import PermissionComputer
 from nexus.bricks.rebac.graph.zone_traversal import ZoneAwareTraversal
+from nexus.bricks.rebac.path_patterns import is_path_pattern, path_pattern_candidates
 from nexus.bricks.rebac.path_updater import PathUpdater
 from nexus.bricks.rebac.rebac_tracing import (
     record_check_result,
@@ -1310,25 +1311,34 @@ class ReBACManager:
             # Get permissions for this relation (fail-closed: unknown → [])
             permissions = RELATION_TO_PERMISSIONS.get(relation, [])
 
-            # Persist each permission grant immediately
-            for permission in permissions:
-                self.tiger_persist_grant(
-                    subject=subject_tuple,
-                    permission=permission,
-                    resource_type=object_type,
-                    resource_id=object_id,
-                    zone_id=effective_zone,
-                )
+            if is_path_pattern(object_type, object_id):
+                for permission in permissions:
+                    self.tiger_invalidate_cache(
+                        subject_tuple,
+                        permission,
+                        object_type,
+                        effective_zone,
+                    )
+            else:
+                # Persist each permission grant immediately
+                for permission in permissions:
+                    self.tiger_persist_grant(
+                        subject=subject_tuple,
+                        permission=permission,
+                        resource_type=object_type,
+                        resource_id=object_id,
+                        zone_id=effective_zone,
+                    )
 
-            # Leopard-style Directory Grant Expansion
-            # When permission is granted on a directory, expand to all descendants
-            if object_type == "file" and permissions and self._is_directory_path(object_id):
-                self._expand_directory_permission_grant(
-                    subject=subject_tuple,
-                    permissions=permissions,
-                    directory_path=object_id,
-                    zone_id=effective_zone,
-                )
+                # Leopard-style Directory Grant Expansion
+                # When permission is granted on a directory, expand to all descendants
+                if object_type == "file" and permissions and self._is_directory_path(object_id):
+                    self._expand_directory_permission_grant(
+                        subject=subject_tuple,
+                        permissions=permissions,
+                        directory_path=object_id,
+                        zone_id=effective_zone,
+                    )
 
         # Issue #922: Notify boundary cache invalidators
         self._notify_boundary_cache_invalidators(effective_zone, subject, relation, object)
@@ -1421,15 +1431,24 @@ class ReBACManager:
                     # FIX: Default to empty list for unknown relations
                     permissions = RELATION_TO_PERMISSIONS.get(relation, [])
 
-                    # Persist each permission grant immediately
-                    for permission in permissions:
-                        self.tiger_persist_grant(
-                            subject=subject_tuple,
-                            permission=permission,
-                            resource_type=object_type,
-                            resource_id=object_id,
-                            zone_id=zone_id,
-                        )
+                    if is_path_pattern(object_type, object_id):
+                        for permission in permissions:
+                            self.tiger_invalidate_cache(
+                                subject_tuple,
+                                permission,
+                                object_type,
+                                zone_id,
+                            )
+                    else:
+                        # Persist each permission grant immediately
+                        for permission in permissions:
+                            self.tiger_persist_grant(
+                                subject=subject_tuple,
+                                permission=permission,
+                                resource_type=object_type,
+                                resource_id=object_id,
+                                zone_id=zone_id,
+                            )
 
             # Issue #919: Notify directory visibility cache invalidators for all affected objects
             for t in tuples:
@@ -1702,16 +1721,26 @@ class ReBACManager:
                 if subject_type and subject_id and object_type and object_id:
                     permissions = RELATION_TO_PERMISSIONS.get(relation, [])
 
+                    effective_zone = normalize_zone_id(zone_id)
+
                     # Revoke each permission immediately
                     for permission in permissions:
                         try:
-                            self.tiger_persist_revoke(
-                                subject=(subject_type, subject_id),
-                                permission=permission,
-                                resource_type=object_type,
-                                resource_id=object_id,
-                                zone_id=normalize_zone_id(zone_id),
-                            )
+                            if is_path_pattern(object_type, object_id):
+                                self.tiger_invalidate_cache(
+                                    (subject_type, subject_id),
+                                    permission,
+                                    object_type,
+                                    effective_zone,
+                                )
+                            else:
+                                self.tiger_persist_revoke(
+                                    subject=(subject_type, subject_id),
+                                    permission=permission,
+                                    resource_type=object_type,
+                                    resource_id=object_id,
+                                    zone_id=effective_zone,
+                                )
                         except (OperationalError, ProgrammingError) as e:
                             if logger.isEnabledFor(logging.DEBUG):
                                 logger.debug(f"[TIGER] Revoke failed: {e}")
@@ -1802,6 +1831,14 @@ class ReBACManager:
         _logger: Any = None,
     ) -> None:
         """Write-through single permission result to Tiger Cache. Delegates to TupleWriter."""
+        if self._has_matching_path_pattern_tuple(object):
+            if _logger is not None and _logger.isEnabledFor(logging.DEBUG):
+                _logger.debug(
+                    "[TIGER] Skipping write-through for %s:%s; path-pattern tuples may apply",
+                    object[0],
+                    object[1],
+                )
+            return
         self._tuple_writer.tiger_write_through_single(
             subject=subject,
             permission=permission,
@@ -1809,6 +1846,46 @@ class ReBACManager:
             zone_id=zone_id,
             tiger_cache=self._tiger_cache,
         )
+
+    def _has_matching_path_pattern_tuple(self, object: tuple[str, str]) -> bool:
+        object_type, object_id = object
+        pattern_candidates = [
+            candidate
+            for candidate in path_pattern_candidates(object_type, object_id)
+            if is_path_pattern(object_type, candidate)
+        ]
+        if not pattern_candidates:
+            return False
+
+        placeholders = ", ".join("?" for _ in pattern_candidates)
+        try:
+            with self._connection(readonly=True) as conn:
+                cursor = self._create_cursor(conn)
+                cursor.execute(
+                    self._fix_sql_placeholders(
+                        f"""
+                        SELECT 1
+                        FROM rebac_tuples
+                        WHERE object_type = ? AND object_id IN ({placeholders})
+                          AND (expires_at IS NULL OR expires_at >= ?)
+                        LIMIT 1
+                        """
+                    ),
+                    (
+                        object_type,
+                        *pattern_candidates,
+                        datetime.now(UTC).isoformat(),
+                    ),
+                )
+                return cursor.fetchone() is not None
+        except Exception:
+            logger.debug(
+                "[TIGER] Could not check path-pattern tuples for %s:%s; skipping write-through",
+                object_type,
+                object_id,
+                exc_info=True,
+            )
+            return True
 
     def get_cached_permission(
         self,

--- a/src/nexus/bricks/rebac/manager.py
+++ b/src/nexus/bricks/rebac/manager.py
@@ -1533,7 +1533,13 @@ class ReBACManager:
             # Permission name maps to one or more relations — expand each
             for rel in perm_relations:
                 self._expand_permission_zone_aware(
-                    rel, object_entity, namespace, zone_id, subjects, visited=set(), depth=0
+                    rel,
+                    object_entity,
+                    namespace,
+                    zone_id,
+                    subjects,
+                    visited=set(),
+                    depth=0,
                 )
         else:
             # Already a relation name (or unknown) — expand directly
@@ -1552,6 +1558,7 @@ class ReBACManager:
         subjects: set[tuple[str, str]],
         visited: set[tuple[str, str, str]],
         depth: int,
+        allow_single_level_patterns: bool = True,
     ) -> None:
         """Recursively expand permission to find all subjects (zone-scoped)."""
         if depth > self.max_depth:
@@ -1564,7 +1571,12 @@ class ReBACManager:
 
         rel_config = namespace.get_relation_config(permission)
         if not rel_config:
-            direct_subjects = self._get_direct_subjects_zone_aware(permission, obj, zone_id)
+            direct_subjects = self._get_direct_subjects_zone_aware(
+                permission,
+                obj,
+                zone_id,
+                allow_single_level_patterns=allow_single_level_patterns,
+            )
             for subj in direct_subjects:
                 subjects.add(subj)
             return
@@ -1574,7 +1586,14 @@ class ReBACManager:
             union_relations = namespace.get_union_relations(permission)
             for rel in union_relations:
                 self._expand_permission_zone_aware(
-                    rel, obj, namespace, zone_id, subjects, visited.copy(), depth + 1
+                    rel,
+                    obj,
+                    namespace,
+                    zone_id,
+                    subjects,
+                    visited.copy(),
+                    depth + 1,
+                    allow_single_level_patterns=allow_single_level_patterns,
                 )
             return
 
@@ -1600,29 +1619,46 @@ class ReBACManager:
                             subjects,
                             visited.copy(),
                             depth + 1,
+                            allow_single_level_patterns=False,
                         )
             return
 
         # Direct relation
-        direct_subjects = self._get_direct_subjects_zone_aware(permission, obj, zone_id)
+        direct_subjects = self._get_direct_subjects_zone_aware(
+            permission,
+            obj,
+            zone_id,
+            allow_single_level_patterns=allow_single_level_patterns,
+        )
         for subj in direct_subjects:
             subjects.add(subj)
 
     def _get_direct_subjects_zone_aware(
-        self, relation: str, obj: Entity, zone_id: str
+        self,
+        relation: str,
+        obj: Entity,
+        zone_id: str,
+        *,
+        allow_single_level_patterns: bool = True,
     ) -> list[tuple[str, str]]:
         """Get all subjects with direct relation to object (zone-scoped)."""
         with self._connection(readonly=True) as conn:
             cursor = self._create_cursor(conn)
+            candidates = path_pattern_candidates(
+                obj.entity_type,
+                obj.entity_id,
+                include_single_level=allow_single_level_patterns,
+            )
+            placeholders = ", ".join("?" for _ in candidates)
 
             cursor.execute(
                 self._fix_sql_placeholders(
-                    """
-                    SELECT subject_type, subject_id
+                    f"""
+                    SELECT DISTINCT subject_type, subject_id
                     FROM rebac_tuples
                     WHERE zone_id = ?
                       AND relation = ?
-                      AND object_type = ? AND object_id = ?
+                      AND object_type = ? AND object_id IN ({placeholders})
                       AND (expires_at IS NULL OR expires_at > ?)
                     """
                 ),
@@ -1630,7 +1666,7 @@ class ReBACManager:
                     zone_id,
                     relation,
                     obj.entity_type,
-                    obj.entity_id,
+                    *candidates,
                     datetime.now(UTC).isoformat(),
                 ),
             )
@@ -2089,12 +2125,12 @@ class ReBACManager:
         permission: str,
         obj: Entity,
         zone_id: str,
-        visited: set[tuple[str, str, str, str, str]],
+        visited: set[tuple[str, str, str, str, str, bool]],
         depth: int,
         start_time: float,
         stats: TraversalStats,
         context: dict[str, Any] | None = None,
-        memo: dict[tuple[str, str, str, str, str], bool] | None = None,
+        memo: dict[tuple[str, str, str, str, str, bool], bool] | None = None,
     ) -> bool:
         """Compute permission with P0-5 limits enforced at each step.
 

--- a/src/nexus/bricks/rebac/path_patterns.py
+++ b/src/nexus/bricks/rebac/path_patterns.py
@@ -1,0 +1,112 @@
+"""Helpers for explicit ReBAC file path-pattern tuple object IDs."""
+
+from __future__ import annotations
+
+RECURSIVE_SUFFIX = "/**"
+SINGLE_LEVEL_SUFFIX = "/*"
+
+
+def _is_absolute_file_path(object_type: str, object_id: str) -> bool:
+    return object_type == "file" and object_id.startswith("/")
+
+
+def _dedupe_preserving_order(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        if value in seen:
+            continue
+        seen.add(value)
+        result.append(value)
+    return result
+
+
+def _ancestors_inclusive(path: str) -> list[str]:
+    if path == "/":
+        return ["/"]
+    parts = [part for part in path.strip("/").split("/") if part]
+    ancestors = ["/" + "/".join(parts[:idx]) for idx in range(len(parts), 0, -1)]
+    ancestors.append("/")
+    return ancestors
+
+
+def _parent(path: str) -> str | None:
+    if path == "/":
+        return None
+    parts = [part for part in path.strip("/").split("/") if part]
+    if len(parts) <= 1:
+        return "/"
+    return "/" + "/".join(parts[:-1])
+
+
+def is_path_pattern(object_type: str, object_id: str) -> bool:
+    """Return whether an object id is a supported file path pattern."""
+    if not _is_absolute_file_path(object_type, object_id):
+        return False
+    return object_id in (RECURSIVE_SUFFIX, SINGLE_LEVEL_SUFFIX) or object_id.endswith(
+        (RECURSIVE_SUFFIX, SINGLE_LEVEL_SUFFIX)
+    )
+
+
+def path_pattern_prefix(object_type: str, object_id: str) -> str | None:
+    """Return the concrete prefix for a supported path pattern."""
+    if not is_path_pattern(object_type, object_id):
+        return None
+    if object_id in (RECURSIVE_SUFFIX, SINGLE_LEVEL_SUFFIX):
+        return "/"
+    if object_id.endswith(RECURSIVE_SUFFIX):
+        return object_id[: -len(RECURSIVE_SUFFIX)] or "/"
+    return object_id[: -len(SINGLE_LEVEL_SUFFIX)] or "/"
+
+
+def path_pattern_matches(pattern_object_id: str, requested_object_id: str) -> bool:
+    """Return whether a pattern object id grants access to a requested path."""
+    if not requested_object_id.startswith("/"):
+        return pattern_object_id == requested_object_id
+    if pattern_object_id == requested_object_id:
+        return True
+    if pattern_object_id.endswith(RECURSIVE_SUFFIX):
+        prefix = (
+            "/"
+            if pattern_object_id == RECURSIVE_SUFFIX
+            else pattern_object_id[: -len(RECURSIVE_SUFFIX)]
+        )
+        return (
+            prefix == "/"
+            or requested_object_id == prefix
+            or requested_object_id.startswith(prefix + "/")
+        )
+    if pattern_object_id.endswith(SINGLE_LEVEL_SUFFIX):
+        prefix = (
+            "/"
+            if pattern_object_id == SINGLE_LEVEL_SUFFIX
+            else pattern_object_id[: -len(SINGLE_LEVEL_SUFFIX)]
+        )
+        if prefix == "/":
+            remainder = requested_object_id.strip("/")
+        elif requested_object_id.startswith(prefix + "/"):
+            remainder = requested_object_id[len(prefix) + 1 :]
+        else:
+            return False
+        return bool(remainder) and "/" not in remainder
+    return False
+
+
+def path_pattern_candidates(object_type: str, object_id: str) -> list[str]:
+    """Return exact and pattern object IDs that can match a requested object."""
+    if not _is_absolute_file_path(object_type, object_id):
+        return [object_id]
+
+    candidates = [object_id]
+    if object_id != "/":
+        candidates.append(object_id.rstrip("/") + RECURSIVE_SUFFIX)
+
+    parent = _parent(object_id)
+    if parent is not None:
+        candidates.append(SINGLE_LEVEL_SUFFIX if parent == "/" else parent + SINGLE_LEVEL_SUFFIX)
+
+    for ancestor in _ancestors_inclusive(object_id):
+        recursive = RECURSIVE_SUFFIX if ancestor == "/" else ancestor + RECURSIVE_SUFFIX
+        candidates.append(recursive)
+
+    return _dedupe_preserving_order(candidates)

--- a/src/nexus/bricks/rebac/path_patterns.py
+++ b/src/nexus/bricks/rebac/path_patterns.py
@@ -76,7 +76,12 @@ def path_pattern_matches(pattern_object_id: str, requested_object_id: str) -> bo
     return False
 
 
-def path_pattern_candidates(object_type: str, object_id: str) -> list[str]:
+def path_pattern_candidates(
+    object_type: str,
+    object_id: str,
+    *,
+    include_single_level: bool = True,
+) -> list[str]:
     """Return exact and pattern object IDs that can match a requested object."""
     if not _is_absolute_file_path(object_type, object_id):
         return [object_id]
@@ -86,7 +91,7 @@ def path_pattern_candidates(object_type: str, object_id: str) -> list[str]:
         candidates.append(object_id.rstrip("/") + RECURSIVE_SUFFIX)
 
     parent = get_parent(object_id)
-    if parent is not None:
+    if include_single_level and parent is not None:
         candidates.append(SINGLE_LEVEL_SUFFIX if parent == "/" else parent + SINGLE_LEVEL_SUFFIX)
 
     for ancestor in (*get_ancestors(object_id), "/"):

--- a/src/nexus/bricks/rebac/path_patterns.py
+++ b/src/nexus/bricks/rebac/path_patterns.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from nexus.bricks.rebac._path_utils import get_ancestors, get_parent
+
 RECURSIVE_SUFFIX = "/**"
 SINGLE_LEVEL_SUFFIX = "/*"
 
@@ -19,24 +21,6 @@ def _dedupe_preserving_order(values: list[str]) -> list[str]:
         seen.add(value)
         result.append(value)
     return result
-
-
-def _ancestors_inclusive(path: str) -> list[str]:
-    if path == "/":
-        return ["/"]
-    parts = [part for part in path.strip("/").split("/") if part]
-    ancestors = ["/" + "/".join(parts[:idx]) for idx in range(len(parts), 0, -1)]
-    ancestors.append("/")
-    return ancestors
-
-
-def _parent(path: str) -> str | None:
-    if path == "/":
-        return None
-    parts = [part for part in path.strip("/").split("/") if part]
-    if len(parts) <= 1:
-        return "/"
-    return "/" + "/".join(parts[:-1])
 
 
 def is_path_pattern(object_type: str, object_id: str) -> bool:
@@ -101,11 +85,11 @@ def path_pattern_candidates(object_type: str, object_id: str) -> list[str]:
     if object_id != "/":
         candidates.append(object_id.rstrip("/") + RECURSIVE_SUFFIX)
 
-    parent = _parent(object_id)
+    parent = get_parent(object_id)
     if parent is not None:
         candidates.append(SINGLE_LEVEL_SUFFIX if parent == "/" else parent + SINGLE_LEVEL_SUFFIX)
 
-    for ancestor in _ancestors_inclusive(object_id):
+    for ancestor in (*get_ancestors(object_id), "/"):
         recursive = RECURSIVE_SUFFIX if ancestor == "/" else ancestor + RECURSIVE_SUFFIX
         candidates.append(recursive)
 

--- a/src/nexus/bricks/rebac/rebac_service.py
+++ b/src/nexus/bricks/rebac/rebac_service.py
@@ -63,6 +63,25 @@ def _coerce_subject_tuple_optional(value: Any, name: str) -> tuple[str, str] | N
     return _coerce_subject_tuple(value, name)
 
 
+def _coerce_check_tuple(
+    value: Any,
+    index: int,
+) -> tuple[tuple[str, str], str, tuple[str, str]]:
+    if isinstance(value, list):
+        value = tuple(value)
+    if not isinstance(value, tuple) or len(value) != 3:
+        raise ValueError(f"Check {index} must be (subject, permission, object) tuple")
+
+    subject, permission, obj = value
+    if not isinstance(permission, str):
+        raise ValueError(f"Check {index}: permission must be a string, got {permission}")
+    return (
+        _coerce_subject_tuple(subject, f"Check {index}: subject"),
+        permission,
+        _coerce_object_tuple(obj, f"Check {index}: object"),
+    )
+
+
 class ReBACService(ReBACShareMixin):
     """Independent ReBAC service extracted from NexusFS.
 
@@ -666,19 +685,10 @@ class ReBACService(ReBACShareMixin):
                 (("user", "alice"), "owner", ("file", "/project")),
             ])
         """
+        normalized_checks = [_coerce_check_tuple(check, i) for i, check in enumerate(checks)]
 
         def _check_batch_sync() -> list[bool]:
             """Synchronous implementation for thread pool execution."""
-            # Validate all checks
-            for i, check in enumerate(checks):
-                if not isinstance(check, tuple) or len(check) != 3:
-                    raise ValueError(f"Check {i} must be (subject, permission, object) tuple")
-                subj, perm, obj = check
-                if not isinstance(subj, tuple) or len(subj) != 2:
-                    raise ValueError(f"Check {i}: subject must be (type, id) tuple, got {subj}")
-                if not isinstance(obj, tuple) or len(obj) != 2:
-                    raise ValueError(f"Check {i}: object must be (type, id) tuple, got {obj}")
-
             assert self._rebac_manager is not None
 
             # When zone_id is available, use individual rebac_check calls which
@@ -686,7 +696,7 @@ class ReBACService(ReBACShareMixin):
             # does not support zone_id and would query with zone_id IS NULL.
             if zone_id is not None:
                 batch_results: list[bool] = []
-                for subj, perm, obj in checks:
+                for subj, perm, obj in normalized_checks:
                     result: bool = self._rebac_manager.rebac_check(
                         subject=subj,
                         permission=perm,
@@ -697,7 +707,7 @@ class ReBACService(ReBACShareMixin):
                 return batch_results
 
             # No zone_id: use optimized batch path (Rust acceleration)
-            return self._rebac_manager.rebac_check_batch_fast(checks=checks)
+            return self._rebac_manager.rebac_check_batch_fast(checks=normalized_checks)
 
         # Issue #702: Wrap batch check in a summary span
         import time as _time
@@ -708,7 +718,7 @@ class ReBACService(ReBACShareMixin):
         )
 
         batch_start = _time.perf_counter()
-        with start_batch_check_span(batch_size=len(checks)):
+        with start_batch_check_span(batch_size=len(normalized_checks)):
             # Read operation — supports L1 cache fallback per-item (Decision 3A)
             try:
                 batch_results = await self._run_in_thread(_check_batch_sync)
@@ -2178,15 +2188,8 @@ class ReBACService(ReBACShareMixin):
     ) -> list[bool]:
         """Synchronous rebac_check_batch."""
         mgr = self._require_manager()
-        for i, check in enumerate(checks):
-            if not isinstance(check, tuple) or len(check) != 3:
-                raise ValueError(f"Check {i} must be (subject, permission, object) tuple")
-            subj, _perm, obj = check
-            if not isinstance(subj, tuple) or len(subj) != 2:
-                raise ValueError(f"Check {i}: subject must be (type, id) tuple, got {subj}")
-            if not isinstance(obj, tuple) or len(obj) != 2:
-                raise ValueError(f"Check {i}: object must be (type, id) tuple, got {obj}")
-        results: list[bool] = mgr.rebac_check_batch_fast(checks=checks)
+        normalized_checks = [_coerce_check_tuple(check, i) for i, check in enumerate(checks)]
+        results: list[bool] = mgr.rebac_check_batch_fast(checks=normalized_checks)
         return results
 
     def rebac_delete_sync(self, tuple_id: str) -> bool:

--- a/src/nexus/bricks/rebac/tuples/repository.py
+++ b/src/nexus/bricks/rebac/tuples/repository.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING, Any
 
 from nexus.bricks.rebac.consistency.metastore_version_store import MetastoreVersionStore
 from nexus.bricks.rebac.domain import WILDCARD_SUBJECT, Entity
+from nexus.bricks.rebac.path_patterns import path_pattern_candidates
 from nexus.contracts.constants import ROOT_ZONE_ID
 
 if TYPE_CHECKING:
@@ -620,18 +621,25 @@ class TupleRepository:
 
         with self.connection(readonly=True) as conn:
             cursor = self.create_cursor(conn)
+            candidates = path_pattern_candidates(obj.entity_type, obj.entity_id)
+            placeholders = ", ".join("?" for _ in candidates)
 
             cursor.execute(
                 self.fix_sql_placeholders(
-                    """
+                    f"""
                     SELECT subject_type, subject_id, conditions
                     FROM rebac_tuples
-                    WHERE object_type = ? AND object_id = ?
+                    WHERE object_type = ? AND object_id IN ({placeholders})
                       AND relation = ?
                       AND (expires_at IS NULL OR expires_at >= ?)
                     """
                 ),
-                (obj.entity_type, obj.entity_id, relation, datetime.now(UTC).isoformat()),
+                (
+                    obj.entity_type,
+                    *candidates,
+                    relation,
+                    datetime.now(UTC).isoformat(),
+                ),
             )
 
             results = []

--- a/src/nexus/bricks/rebac/tuples/repository.py
+++ b/src/nexus/bricks/rebac/tuples/repository.py
@@ -666,18 +666,25 @@ class TupleRepository:
         """
         with self.connection(readonly=True) as conn:
             cursor = self.create_cursor(conn)
+            candidates = path_pattern_candidates(obj.entity_type, obj.entity_id)
+            placeholders = ", ".join("?" for _ in candidates)
 
             cursor.execute(
                 self.fix_sql_placeholders(
-                    """
-                    SELECT subject_type, subject_id
+                    f"""
+                    SELECT DISTINCT subject_type, subject_id
                     FROM rebac_tuples
                     WHERE relation = ?
-                      AND object_type = ? AND object_id = ?
+                      AND object_type = ? AND object_id IN ({placeholders})
                       AND (expires_at IS NULL OR expires_at >= ?)
                     """
                 ),
-                (relation, obj.entity_type, obj.entity_id, datetime.now(UTC).isoformat()),
+                (
+                    relation,
+                    obj.entity_type,
+                    *candidates,
+                    datetime.now(UTC).isoformat(),
+                ),
             )
 
             return [(row["subject_type"], row["subject_id"]) for row in cursor.fetchall()]

--- a/src/nexus/bricks/rebac/utils/fast.py
+++ b/src/nexus/bricks/rebac/utils/fast.py
@@ -22,6 +22,7 @@ from nexus._rust_compat import compute_permission_single as _compute_permission_
 from nexus._rust_compat import compute_permissions_bulk as _compute_permissions_bulk
 from nexus._rust_compat import expand_subjects as _expand_subjects
 from nexus._rust_compat import list_objects_for_subject as _list_objects_for_subject
+from nexus.bricks.rebac.path_patterns import is_path_pattern
 
 if TYPE_CHECKING:
     from nexus.bricks.rebac.domain import Entity
@@ -155,6 +156,17 @@ def check_permissions_bulk_with_fallback(
         >>> results = check_permissions_bulk_with_fallback(checks, tuples, configs)
         >>> results[("user", "alice", "read", "file", "doc1")]  # True/False
     """
+    if any(
+        isinstance(t.get("object_type"), str)
+        and isinstance(t.get("object_id"), str)
+        and is_path_pattern(t["object_type"], t["object_id"])
+        for t in tuples
+    ):
+        logger.debug(
+            "Path-pattern tuples detected in bulk permission input; using Python evaluator"
+        )
+        return _check_permissions_bulk_python(checks, tuples, namespace_configs)
+
     if RUST_AVAILABLE and not force_python:
         try:
             import time

--- a/src/nexus/cli/commands/rebac.py
+++ b/src/nexus/cli/commands/rebac.py
@@ -984,7 +984,7 @@ async def _async_rebac_check_batch_cmd(
         )
         rebac_svc = nx.service("rebac")
         assert rebac_svc is not None, "ReBAC service not available"
-        results = rebac_svc.rebac_check_batch_sync(checks)
+        results = rebac_svc.rebac_check_batch_sync(checks=checks)
         nx.close()
 
         # Output results

--- a/src/nexus/server/api/v2/routers/rebac.py
+++ b/src/nexus/server/api/v2/routers/rebac.py
@@ -94,69 +94,21 @@ def _subject_tuple(body: TupleBody) -> tuple[str, str] | tuple[str, str, str]:
     return (body.subject_namespace, body.subject_id)
 
 
-class _WildcardSemanticError(ValueError):
-    """Raised when an operator supplies a wildcard shape the API can't
-    enforce semantically (e.g. shell-style ``/*`` single-level glob —
-    ReBAC has no first-level-only enforcement, so collapsing it to a
-    directory tuple would silently broaden access to all descendants).
-    """
-
-
 def _normalize_file_object_id(object_namespace: str, object_id: str) -> str:
-    """Issue #4239 (round-5 hardened): collapse RECURSIVE wildcard-style
-    ``file`` object IDs to the directory path so existing ancestor-walk /
-    directory-grant machinery grants every descendant.
+    """Normalize exact file object IDs without rewriting explicit patterns.
 
-    Accepted shapes:
-
-    - ``/workspaces/ws1/**`` → ``/workspaces/ws1``  (recursive subtree)
-    - ``/workspaces/ws1/``   → ``/workspaces/ws1``  (trailing slash)
-    - ``/**``                → ``/``                (root grant)
-
-    Rejected (round-5 review — codex HIGH):
-
-    - ``/workspaces/ws1/*``  — shell ``/*`` is one-level-only, but the
-      ReBAC enforcer inherits directory grants to ALL descendants. The
-      previous code collapsed this to the same directory tuple as
-      ``/workspaces/ws1/**``, silently broadening to the entire subtree
-      (an authorization overgrant). Reject with a clear error so the
-      operator picks ``/**`` (recursive) or lists exact paths.
-
-    Only applies to ``object_namespace == "file"``; other namespaces
-    (``approvals``, ``zone``, …) are passed through unchanged so a
-    capability id literally containing ``*`` isn't mangled.
-
-    Raises:
-        _WildcardSemanticError: when the input uses an unsupported
-        wildcard shape (currently any ``/*`` segment). Callers should
-        translate to a 400 with the error's message.
+    Issue #4239 now stores supported ``file`` path-pattern suffixes as tuple
+    object IDs. Keep ``/**`` and ``/*`` values intact so the ReBAC graph layer
+    can apply the new matcher. Non-file namespaces pass through unchanged.
     """
     if object_namespace != "file" or not object_id:
         return object_id
 
-    # Reject ``/*`` (single-level) anywhere in the path — collapsing
-    # it to a directory tuple would grant the whole subtree. Strip
-    # every ``/**`` first so we don't false-positive on the recursive
-    # form (``/**`` is fine: it IS recursive).
-    if "/*" in object_id.replace("/**", ""):
-        raise _WildcardSemanticError(
-            f"object_id contains unsupported single-level glob '/*' in {object_id!r}. "
-            "ReBAC has no first-level-only enforcement — use '/**' for a "
-            "recursive subtree grant, or list exact paths."
-        )
-
-    out = object_id
-    # Strip trailing ``/**`` suffixes (possibly repeated, e.g. ``/a/**``).
-    while out.endswith("/**"):
-        out = out[:-3]
-    # Strip a trailing slash unless we've collapsed all the way to root.
-    if len(out) > 1 and out.endswith("/"):
-        out = out.rstrip("/")
-    # An empty result means the user supplied ``/**`` at the root —
-    # collapse to the canonical root grant.
-    if not out:
-        out = "/"
-    return out
+    # Preserve pattern IDs exactly; only keep the old exact-path trailing-slash
+    # normalization for non-root values.
+    if len(object_id) > 1 and object_id.endswith("/"):
+        return object_id.rstrip("/")
+    return object_id
 
 
 # ---------------------------------------------------------------------------
@@ -182,19 +134,12 @@ async def write_tuple(
     """
     rebac_manager = _resolve_rebac_manager(request)
     subject = _subject_tuple(body)
-    # Issue #4239: normalize shell-style globs to a directory path so the
-    # tuple inherits to descendants via the existing ancestor walk.
-    # Round-5 review: ``/*`` (one-level-only) is rejected because the
-    # enforcer can't honor it — collapsing it to a directory tuple would
-    # silently broaden access to all descendants.
-    try:
-        normalized_object_id = _normalize_file_object_id(body.object_namespace, body.object_id)
-    except _WildcardSemanticError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    # Issue #4239: preserve explicit file path-pattern tuple IDs so the graph
+    # layer can distinguish recursive and single-level grants.
+    normalized_object_id = _normalize_file_object_id(body.object_namespace, body.object_id)
     if normalized_object_id != body.object_id:
         logger.info(
-            "[#4239] rebac tuple object_id normalized: %r -> %r "
-            "(wildcard glob collapsed to directory grant)",
+            "[#4239] rebac tuple object_id normalized: %r -> %r (exact path canonicalization)",
             body.object_id,
             normalized_object_id,
         )
@@ -247,16 +192,10 @@ async def list_tuples(
     """
     rebac_manager = _resolve_rebac_manager(request)
 
-    # Issue #4239: canonicalize the lookup surface so
-    # ``?object_id=/workspaces/ws1/**`` finds tuples written via any of
-    # the equivalent glob spellings. Only meaningful when an object_id
-    # was actually provided. Round-5: ``/*`` is rejected with 400
-    # (mirrors POST/DELETE).
+    # Issue #4239: keep explicit path-pattern IDs exact at the diagnostic
+    # lookup surface; only trailing slashes on exact paths are canonicalized.
     if object_id is not None and object_namespace is not None:
-        try:
-            object_id = _normalize_file_object_id(object_namespace, object_id)
-        except _WildcardSemanticError as exc:
-            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        object_id = _normalize_file_object_id(object_namespace, object_id)
 
     tuples: list[dict[str, Any]] = rebac_manager.rebac_list_tuples(
         relation=relation,
@@ -282,12 +221,9 @@ async def delete_tuple(
     the no-op case (tuple did not exist) without a separate GET.
     """
     rebac_manager = _resolve_rebac_manager(request)
-    # Issue #4239: canonicalize so DELETE matches what POST stored.
-    # Round-5: ``/*`` is rejected (mirrors POST/GET).
-    try:
-        normalized_object_id = _normalize_file_object_id(body.object_namespace, body.object_id)
-    except _WildcardSemanticError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    # Issue #4239: preserve pattern IDs so DELETE matches exactly what POST
+    # stores for recursive and single-level grants.
+    normalized_object_id = _normalize_file_object_id(body.object_namespace, body.object_id)
     obj = (body.object_namespace, normalized_object_id)
 
     # Round-10 review (codex HIGH): pass subject_relation through to

--- a/tests/e2e/self_contained/test_rebac_full_story_e2e.py
+++ b/tests/e2e/self_contained/test_rebac_full_story_e2e.py
@@ -70,6 +70,17 @@ class _ServiceBackedFilesystem:
 class _SyncRemoteReBACProxy:
     """RemoteServiceProxy-shaped service: RPC methods return sync values."""
 
+    def rebac_check_batch_sync(
+        self,
+        *,
+        checks: list[tuple[tuple[str, str], str, tuple[str, str]]],
+    ) -> list[bool]:
+        assert checks == [
+            (("agent", "alice"), "read", ("file", RESOURCE[1])),
+            (("agent", "bob"), "read", ("file", RESOURCE[1])),
+        ]
+        return [True, False]
+
     def rebac_list_objects(
         self,
         *,
@@ -282,6 +293,28 @@ async def test_rpc_dynamic_viewer_config_and_read_use_persisted_column_config(
     assert filtered == "name,email\nAda,ada@example.com\n"
 
 
+@pytest.mark.asyncio
+async def test_rebac_check_batch_accepts_rpc_list_shaped_checks(
+    rebac_service: ReBACService,
+) -> None:
+    await rebac_service.rebac_create(
+        subject=("agent", "alice"),
+        relation="direct_viewer",
+        object=RESOURCE,
+        zone_id=ZONE_ID,
+    )
+
+    results = await rebac_service.rebac_check_batch(
+        checks=[
+            [["agent", "alice"], "read", list(RESOURCE)],
+            [["agent", "bob"], "read", list(RESOURCE)],
+        ],
+        zone_id=ZONE_ID,
+    )
+
+    assert results == [True, False]
+
+
 def _json_from_output(output: str) -> Any:
     return json.loads(output)
 
@@ -395,6 +428,35 @@ def test_cli_rebac_list_objects_accepts_remote_sync_proxy(
 
     assert listed.exit_code == 0, listed.output
     assert _json_from_output(listed.output)["objects"] == [["file", RESOURCE[1]]]
+
+
+def test_cli_rebac_check_batch_accepts_remote_sync_proxy(
+    remote_cli_runner: CliRunner,
+    tmp_path,
+) -> None:
+    checks_file = tmp_path / "checks.json"
+    checks_file.write_text(
+        json.dumps(
+            [
+                {"subject": ["agent", "alice"], "permission": "read", "object": list(RESOURCE)},
+                {"subject": ["agent", "bob"], "permission": "read", "object": list(RESOURCE)},
+            ]
+        )
+    )
+
+    checked = remote_cli_runner.invoke(
+        rebac_cli.rebac,
+        [
+            "check-batch",
+            str(checks_file),
+            "--format",
+            "json",
+        ],
+    )
+
+    assert checked.exit_code == 0, checked.output
+    assert '"result": true' in checked.output
+    assert '"result": false' in checked.output
 
 
 def test_cli_dynamic_viewer_config_and_read_use_real_service(

--- a/tests/unit/bricks/rebac/test_path_pattern_permissions.py
+++ b/tests/unit/bricks/rebac/test_path_pattern_permissions.py
@@ -38,6 +38,30 @@ def rebac_manager():
         manager.close()
 
 
+@pytest.fixture
+def zone_aware_rebac_manager():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    manager = ReBACManager(
+        engine=engine,
+        cache_ttl_seconds=300,
+        max_depth=10,
+        enforce_zone_isolation=True,
+        namespace_store=MetastoreNamespaceStore(InMemoryNexusFS()),
+    )
+    manager.create_namespace(
+        NamespaceConfig(
+            namespace_id="path-pattern-permissions-file-zone-aware",
+            object_type="file",
+            config={"relations": {"read": {}}, "permissions": {}},
+        )
+    )
+    try:
+        yield manager
+    finally:
+        manager.close()
+
+
 def test_recursive_descendant_grant(rebac_manager):
     rebac_manager.rebac_write(
         subject=("agent", "alice"),
@@ -101,6 +125,75 @@ def test_single_level_child_but_not_grandchild(rebac_manager):
             zone_id="root",
         )
         is False
+    )
+
+
+def test_zone_aware_recursive_path_pattern_grants_descendant_read(
+    zone_aware_rebac_manager,
+):
+    zone_aware_rebac_manager.rebac_write(
+        subject=("agent", "alice"),
+        relation="read",
+        object=("file", "/workspaces/**"),
+        zone_id="root",
+    )
+
+    assert (
+        zone_aware_rebac_manager.rebac_check(
+            subject=("agent", "alice"),
+            permission="read",
+            object=("file", "/workspaces/ws1/a.md"),
+            zone_id="root",
+        )
+        is True
+    )
+
+
+def test_zone_aware_wildcard_path_pattern_grants_cross_zone_public_read(
+    zone_aware_rebac_manager,
+):
+    zone_aware_rebac_manager.rebac_write(
+        subject=("*", "*"),
+        relation="read",
+        object=("file", "/public/**"),
+        zone_id="shared",
+    )
+
+    assert (
+        zone_aware_rebac_manager.rebac_check(
+            subject=("agent", "visitor"),
+            permission="read",
+            object=("file", "/public/docs/readme.md"),
+            zone_id="root",
+        )
+        is True
+    )
+
+
+def test_zone_aware_userset_subject_path_pattern_grants_member_read(
+    zone_aware_rebac_manager,
+):
+    zone_aware_rebac_manager.rebac_write(
+        subject=("agent", "alice"),
+        relation="member",
+        object=("group", "eng"),
+        zone_id="root",
+    )
+    zone_aware_rebac_manager.rebac_write(
+        subject=("group", "eng", "member"),
+        relation="read",
+        object=("file", "/workspaces/**"),
+        zone_id="root",
+    )
+
+    assert (
+        zone_aware_rebac_manager.rebac_check(
+            subject=("agent", "alice"),
+            permission="read",
+            object=("file", "/workspaces/ws1/a.md"),
+            zone_id="root",
+        )
+        is True
     )
 
 

--- a/tests/unit/bricks/rebac/test_path_pattern_permissions.py
+++ b/tests/unit/bricks/rebac/test_path_pattern_permissions.py
@@ -370,6 +370,51 @@ def test_filter_list_matches_recursive_path_pattern(rebac_manager) -> None:
     ) == ["/workspaces/ws1/a.md", "/workspaces/ws2/b.md"]
 
 
+def test_zone_aware_bulk_matches_cross_zone_wildcard_path_pattern(
+    zone_aware_rebac_manager,
+) -> None:
+    zone_aware_rebac_manager.rebac_write(
+        subject=("*", "*"),
+        relation="read",
+        object=("file", "/public/**"),
+        zone_id="shared",
+    )
+
+    checks = [
+        (("user", "visitor"), "read", ("file", "/public/docs/readme.md")),
+        (("user", "visitor"), "read", ("file", "/private/readme.md")),
+    ]
+
+    assert zone_aware_rebac_manager.rebac_check_bulk(checks, zone_id="root") == {
+        checks[0]: True,
+        checks[1]: False,
+    }
+
+
+def test_zone_aware_filter_list_matches_cross_zone_wildcard_path_pattern(
+    zone_aware_rebac_manager,
+) -> None:
+    zone_aware_rebac_manager.rebac_write(
+        subject=("*", "*"),
+        relation="read",
+        object=("file", "/public/**"),
+        zone_id="shared",
+    )
+    enforcer = PermissionEnforcer(rebac_manager=zone_aware_rebac_manager)
+    context = OperationContext(
+        user_id="visitor",
+        groups=[],
+        subject_type="user",
+        subject_id="visitor",
+        zone_id="root",
+    )
+
+    assert enforcer.filter_list(
+        ["/public/docs/readme.md", "/public/guide.md", "/private/c.md"],
+        context,
+    ) == ["/public/docs/readme.md", "/public/guide.md"]
+
+
 def test_python_fast_fallback_matches_direct_path_pattern_tuple() -> None:
     from nexus.bricks.rebac.utils.fast import check_permissions_bulk_with_fallback
 
@@ -391,6 +436,38 @@ def test_python_fast_fallback_matches_direct_path_pattern_tuple() -> None:
             tuples,
             {},
             force_python=True,
+        )[("user", "admin", "read", "file", "/workspaces/a.md")]
+        is True
+    )
+
+
+def test_fast_fallback_skips_rust_when_path_pattern_tuple_present(monkeypatch) -> None:
+    from nexus.bricks.rebac.utils import fast
+
+    checks = [(("user", "admin"), "read", ("file", "/workspaces/a.md"))]
+    tuples = [
+        {
+            "subject_type": "user",
+            "subject_id": "admin",
+            "subject_relation": None,
+            "relation": "read",
+            "object_type": "file",
+            "object_id": "/workspaces/**",
+        }
+    ]
+
+    def fail_if_called(*_args, **_kwargs):
+        raise AssertionError("Rust bulk path should not run for path-pattern tuples")
+
+    monkeypatch.setattr(fast, "RUST_AVAILABLE", True)
+    monkeypatch.setattr(fast, "check_permissions_bulk_rust", fail_if_called)
+
+    assert (
+        fast.check_permissions_bulk_with_fallback(
+            checks,
+            tuples,
+            {},
+            force_python=False,
         )[("user", "admin", "read", "file", "/workspaces/a.md")]
         is True
     )

--- a/tests/unit/bricks/rebac/test_path_pattern_permissions.py
+++ b/tests/unit/bricks/rebac/test_path_pattern_permissions.py
@@ -348,6 +348,68 @@ def test_rebac_check_bulk_matches_recursive_path_pattern(rebac_manager) -> None:
     }
 
 
+def test_rebac_check_bulk_matches_userset_path_pattern(rebac_manager) -> None:
+    rebac_manager.rebac_write(
+        subject=("agent", "alice"),
+        relation="member",
+        object=("group", "eng"),
+        zone_id="root",
+    )
+    rebac_manager.rebac_write(
+        subject=("group", "eng", "member"),
+        relation="read",
+        object=("file", "/workspaces/**"),
+        zone_id="root",
+    )
+
+    checks = [
+        (("agent", "alice"), "read", ("file", "/workspaces/ws1/a.md")),
+        (("agent", "bob"), "read", ("file", "/workspaces/ws1/a.md")),
+    ]
+
+    assert rebac_manager.rebac_check_bulk(checks, zone_id="root") == {
+        checks[0]: True,
+        checks[1]: False,
+    }
+
+
+def test_rebac_check_bulk_denies_conditioned_path_pattern_without_context(
+    rebac_manager,
+) -> None:
+    rebac_manager.rebac_write(
+        subject=("agent", "alice"),
+        relation="read",
+        object=("file", "/workspaces/**"),
+        zone_id="root",
+        conditions={"department": "eng"},
+    )
+
+    check = (("agent", "alice"), "read", ("file", "/workspaces/ws1/a.md"))
+
+    assert rebac_manager.rebac_check_bulk([check], zone_id="root") == {check: False}
+
+
+def test_rebac_check_bulk_keeps_non_file_pattern_syntax_exact_only(
+    rebac_manager,
+) -> None:
+    rebac_manager.rebac_write(
+        subject=("agent", "alice"),
+        relation="member",
+        object=("group", "/teams/**"),
+        zone_id="root",
+    )
+
+    checks = [
+        (("agent", "alice"), "member", ("group", "/teams/**")),
+        (("agent", "alice"), "member", ("group", "/teams/dev")),
+    ]
+
+    assert rebac_manager.rebac_check_bulk(checks, zone_id="root") == {
+        checks[0]: True,
+        checks[1]: False,
+    }
+
+
 def test_filter_list_matches_recursive_path_pattern(rebac_manager) -> None:
     rebac_manager.rebac_write(
         subject=("user", "admin"),
@@ -368,6 +430,34 @@ def test_filter_list_matches_recursive_path_pattern(rebac_manager) -> None:
         ["/workspaces/ws1/a.md", "/workspaces/ws2/b.md", "/private/c.md"],
         context,
     ) == ["/workspaces/ws1/a.md", "/workspaces/ws2/b.md"]
+
+
+def test_filter_list_matches_userset_path_pattern(rebac_manager) -> None:
+    rebac_manager.rebac_write(
+        subject=("agent", "alice"),
+        relation="member",
+        object=("group", "eng"),
+        zone_id="root",
+    )
+    rebac_manager.rebac_write(
+        subject=("group", "eng", "member"),
+        relation="read",
+        object=("file", "/workspaces/**"),
+        zone_id="root",
+    )
+    enforcer = PermissionEnforcer(rebac_manager=rebac_manager)
+    context = OperationContext(
+        user_id="alice",
+        groups=[],
+        subject_type="agent",
+        subject_id="alice",
+        zone_id="root",
+    )
+
+    assert enforcer.filter_list(
+        ["/workspaces/ws1/a.md", "/private/c.md"],
+        context,
+    ) == ["/workspaces/ws1/a.md"]
 
 
 def test_zone_aware_bulk_matches_cross_zone_wildcard_path_pattern(

--- a/tests/unit/bricks/rebac/test_path_pattern_permissions.py
+++ b/tests/unit/bricks/rebac/test_path_pattern_permissions.py
@@ -9,6 +9,7 @@ pytest.importorskip("pyroaring")
 from sqlalchemy import create_engine
 
 from nexus.bricks.rebac.consistency.metastore_namespace_store import MetastoreNamespaceStore
+from nexus.bricks.rebac.default_namespaces import DEFAULT_FILE_NAMESPACE
 from nexus.bricks.rebac.domain import NamespaceConfig
 from nexus.bricks.rebac.enforcer import PermissionEnforcer
 from nexus.bricks.rebac.manager import ReBACManager
@@ -64,6 +65,41 @@ def zone_aware_rebac_manager():
         manager.close()
 
 
+@pytest.fixture
+def default_file_rebac_manager():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    manager = ReBACManager(
+        engine=engine,
+        cache_ttl_seconds=300,
+        max_depth=10,
+        namespace_store=MetastoreNamespaceStore(InMemoryNexusFS()),
+    )
+    manager.create_namespace(DEFAULT_FILE_NAMESPACE)
+    try:
+        yield manager
+    finally:
+        manager.close()
+
+
+@pytest.fixture
+def zone_aware_default_file_rebac_manager():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    manager = ReBACManager(
+        engine=engine,
+        cache_ttl_seconds=300,
+        max_depth=10,
+        enforce_zone_isolation=True,
+        namespace_store=MetastoreNamespaceStore(InMemoryNexusFS()),
+    )
+    manager.create_namespace(DEFAULT_FILE_NAMESPACE)
+    try:
+        yield manager
+    finally:
+        manager.close()
+
+
 def test_recursive_descendant_grant(rebac_manager):
     rebac_manager.rebac_write(
         subject=("agent", "alice"),
@@ -102,6 +138,21 @@ def test_recursive_prefix_path_grant(rebac_manager):
     )
 
 
+def test_rebac_expand_includes_recursive_path_pattern_subject(rebac_manager) -> None:
+    rebac_manager.rebac_write(
+        subject=("agent", "alice"),
+        relation="read",
+        object=("file", "/workspaces/**"),
+        zone_id="root",
+    )
+
+    assert ("agent", "alice") in rebac_manager.rebac_expand(
+        permission="read",
+        object=("file", "/workspaces/ws1/a.md"),
+        zone_id="root",
+    )
+
+
 def test_single_level_child_but_not_grandchild(rebac_manager):
     rebac_manager.rebac_write(
         subject=("agent", "alice"),
@@ -130,6 +181,41 @@ def test_single_level_child_but_not_grandchild(rebac_manager):
     )
 
 
+def test_default_file_single_level_direct_viewer_does_not_inherit_to_grandchild(
+    default_file_rebac_manager,
+) -> None:
+    default_file_rebac_manager.rebac_write(
+        subject=("agent", "alice"),
+        relation="direct_viewer",
+        object=("file", "/workspaces/*"),
+        zone_id="root",
+    )
+
+    assert (
+        default_file_rebac_manager.rebac_check(
+            subject=("agent", "alice"),
+            permission="read",
+            object=("file", "/workspaces/a.md"),
+            zone_id="root",
+        )
+        is True
+    )
+    assert (
+        default_file_rebac_manager.rebac_check(
+            subject=("agent", "alice"),
+            permission="read",
+            object=("file", "/workspaces/ws1/a.md"),
+            zone_id="root",
+        )
+        is False
+    )
+    assert ("agent", "alice") not in default_file_rebac_manager.rebac_expand(
+        permission="read",
+        object=("file", "/workspaces/ws1/a.md"),
+        zone_id="root",
+    )
+
+
 def test_zone_aware_recursive_path_pattern_grants_descendant_read(
     zone_aware_rebac_manager,
 ):
@@ -148,6 +234,58 @@ def test_zone_aware_recursive_path_pattern_grants_descendant_read(
             zone_id="root",
         )
         is True
+    )
+
+
+def test_zone_aware_rebac_expand_includes_recursive_path_pattern_subject(
+    zone_aware_rebac_manager,
+) -> None:
+    zone_aware_rebac_manager.rebac_write(
+        subject=("agent", "alice"),
+        relation="read",
+        object=("file", "/workspaces/**"),
+        zone_id="root",
+    )
+
+    assert ("agent", "alice") in zone_aware_rebac_manager.rebac_expand(
+        permission="read",
+        object=("file", "/workspaces/ws1/a.md"),
+        zone_id="root",
+    )
+
+
+def test_zone_aware_default_file_single_level_direct_viewer_does_not_inherit_to_grandchild(
+    zone_aware_default_file_rebac_manager,
+) -> None:
+    zone_aware_default_file_rebac_manager.rebac_write(
+        subject=("agent", "alice"),
+        relation="direct_viewer",
+        object=("file", "/workspaces/*"),
+        zone_id="root",
+    )
+
+    assert (
+        zone_aware_default_file_rebac_manager.rebac_check(
+            subject=("agent", "alice"),
+            permission="read",
+            object=("file", "/workspaces/a.md"),
+            zone_id="root",
+        )
+        is True
+    )
+    assert (
+        zone_aware_default_file_rebac_manager.rebac_check(
+            subject=("agent", "alice"),
+            permission="read",
+            object=("file", "/workspaces/ws1/a.md"),
+            zone_id="root",
+        )
+        is False
+    )
+    assert ("agent", "alice") not in zone_aware_default_file_rebac_manager.rebac_expand(
+        permission="read",
+        object=("file", "/workspaces/ws1/a.md"),
+        zone_id="root",
     )
 
 

--- a/tests/unit/bricks/rebac/test_path_pattern_permissions.py
+++ b/tests/unit/bricks/rebac/test_path_pattern_permissions.py
@@ -670,8 +670,107 @@ def test_path_pattern_tuple_change_invalidates_descendant_cache_entries() -> Non
         )
         is None
     )
+
+
+def test_root_path_pattern_tuple_change_invalidates_boundary_descendants() -> None:
+    from nexus.bricks.rebac.cache.boundary import PermissionBoundaryCache
+    from nexus.bricks.rebac.cache.coordinator import CacheCoordinator
+    from nexus.bricks.rebac.domain import Entity
+
+    class FakeConnection:
+        def commit(self) -> None:
+            pass
+
+    boundary_cache = PermissionBoundaryCache()
+    coordinator = CacheCoordinator(
+        boundary_cache=boundary_cache,
+        enable_async_recompute=False,
+    )
+    boundary_cache.set_boundary(
+        "root",
+        "user",
+        "admin",
+        "read",
+        "/a/b.md",
+        "/a",
+    )
+
     assert (
         boundary_cache.get_boundary(
+            "root",
+            "user",
+            "admin",
+            "read",
+            "/a/b.md",
+        )
+        == "/a"
+    )
+
+    coordinator.invalidate_for_tuple_change(
+        Entity("user", "admin"),
+        "read",
+        Entity("file", "/**"),
+        zone_id="root",
+        conn=FakeConnection(),
+    )
+
+    assert (
+        boundary_cache.get_boundary(
+            "root",
+            "user",
+            "admin",
+            "read",
+            "/a/b.md",
+        )
+        is None
+    )
+
+
+def test_path_pattern_tuple_change_invalidates_registered_boundary_cache() -> None:
+    from nexus.bricks.rebac.cache.boundary import PermissionBoundaryCache
+    from nexus.bricks.rebac.cache.coordinator import CacheCoordinator
+    from nexus.bricks.rebac.domain import Entity
+
+    class FakeConnection:
+        def commit(self) -> None:
+            pass
+
+    registered_boundary_cache = PermissionBoundaryCache()
+    coordinator = CacheCoordinator(enable_async_recompute=False)
+    coordinator.register_boundary_invalidator(
+        "registered",
+        registered_boundary_cache.invalidate_permission_change,
+    )
+    registered_boundary_cache.set_boundary(
+        "root",
+        "user",
+        "admin",
+        "read",
+        "/workspaces/ws1/a.md",
+        "/workspaces",
+    )
+
+    assert (
+        registered_boundary_cache.get_boundary(
+            "root",
+            "user",
+            "admin",
+            "read",
+            "/workspaces/ws1/a.md",
+        )
+        == "/workspaces"
+    )
+
+    coordinator.invalidate_for_tuple_change(
+        Entity("user", "admin"),
+        "read",
+        Entity("file", "/workspaces/**"),
+        zone_id="root",
+        conn=FakeConnection(),
+    )
+
+    assert (
+        registered_boundary_cache.get_boundary(
             "root",
             "user",
             "admin",

--- a/tests/unit/bricks/rebac/test_path_pattern_permissions.py
+++ b/tests/unit/bricks/rebac/test_path_pattern_permissions.py
@@ -561,3 +561,122 @@ def test_fast_fallback_skips_rust_when_path_pattern_tuple_present(monkeypatch) -
         )[("user", "admin", "read", "file", "/workspaces/a.md")]
         is True
     )
+
+
+def test_path_pattern_write_invalidates_cached_descendant_denial(rebac_manager) -> None:
+    target = ("file", "/workspaces/ws1/a.md")
+
+    assert not rebac_manager.rebac_check(
+        subject=("user", "admin"),
+        permission="read",
+        object=target,
+        zone_id="root",
+    )
+
+    rebac_manager.rebac_write(
+        subject=("user", "admin"),
+        relation="read",
+        object=("file", "/workspaces/**"),
+        zone_id="root",
+    )
+
+    assert rebac_manager.rebac_check(
+        subject=("user", "admin"),
+        permission="read",
+        object=target,
+        zone_id="root",
+    )
+
+
+def test_path_pattern_tuple_change_invalidates_descendant_cache_entries() -> None:
+    from nexus.bricks.rebac.cache.boundary import PermissionBoundaryCache
+    from nexus.bricks.rebac.cache.coordinator import CacheCoordinator
+    from nexus.bricks.rebac.cache.result_cache import ReBACPermissionCache
+    from nexus.bricks.rebac.domain import Entity
+
+    class FakeConnection:
+        def commit(self) -> None:
+            pass
+
+    l1_cache = ReBACPermissionCache(
+        max_size=100,
+        ttl_seconds=300,
+        denial_ttl_seconds=300,
+        enable_revision_quantization=False,
+    )
+    boundary_cache = PermissionBoundaryCache()
+    coordinator = CacheCoordinator(
+        l1_cache=l1_cache,
+        boundary_cache=boundary_cache,
+        enable_async_recompute=False,
+    )
+
+    l1_cache.set(
+        "user",
+        "admin",
+        "read",
+        "file",
+        "/workspaces/ws1/a.md",
+        False,
+        "root",
+    )
+    boundary_cache.set_boundary(
+        "root",
+        "user",
+        "admin",
+        "read",
+        "/workspaces/ws1/a.md",
+        "/workspaces",
+    )
+
+    assert (
+        l1_cache.get(
+            "user",
+            "admin",
+            "read",
+            "file",
+            "/workspaces/ws1/a.md",
+            "root",
+        )
+        is False
+    )
+    assert (
+        boundary_cache.get_boundary(
+            "root",
+            "user",
+            "admin",
+            "read",
+            "/workspaces/ws1/a.md",
+        )
+        == "/workspaces"
+    )
+
+    coordinator.invalidate_for_tuple_change(
+        Entity("user", "admin"),
+        "read",
+        Entity("file", "/workspaces/**"),
+        zone_id="root",
+        conn=FakeConnection(),
+    )
+
+    assert (
+        l1_cache.get(
+            "user",
+            "admin",
+            "read",
+            "file",
+            "/workspaces/ws1/a.md",
+            "root",
+        )
+        is None
+    )
+    assert (
+        boundary_cache.get_boundary(
+            "root",
+            "user",
+            "admin",
+            "read",
+            "/workspaces/ws1/a.md",
+        )
+        is None
+    )

--- a/tests/unit/bricks/rebac/test_path_pattern_permissions.py
+++ b/tests/unit/bricks/rebac/test_path_pattern_permissions.py
@@ -43,6 +43,7 @@ def test_recursive_descendant_grant(rebac_manager):
         subject=("agent", "alice"),
         relation="read",
         object=("file", "/workspaces/**"),
+        zone_id="root",
     )
 
     assert (
@@ -50,6 +51,7 @@ def test_recursive_descendant_grant(rebac_manager):
             subject=("agent", "alice"),
             permission="read",
             object=("file", "/workspaces/ws1/a.md"),
+            zone_id="root",
         )
         is True
     )
@@ -60,6 +62,7 @@ def test_recursive_prefix_path_grant(rebac_manager):
         subject=("agent", "alice"),
         relation="read",
         object=("file", "/workspaces/**"),
+        zone_id="root",
     )
 
     assert (
@@ -67,6 +70,7 @@ def test_recursive_prefix_path_grant(rebac_manager):
             subject=("agent", "alice"),
             permission="read",
             object=("file", "/workspaces"),
+            zone_id="root",
         )
         is True
     )
@@ -77,6 +81,7 @@ def test_single_level_child_but_not_grandchild(rebac_manager):
         subject=("agent", "alice"),
         relation="read",
         object=("file", "/workspaces/*"),
+        zone_id="root",
     )
 
     assert (
@@ -84,6 +89,7 @@ def test_single_level_child_but_not_grandchild(rebac_manager):
             subject=("agent", "alice"),
             permission="read",
             object=("file", "/workspaces/a.md"),
+            zone_id="root",
         )
         is True
     )
@@ -92,6 +98,7 @@ def test_single_level_child_but_not_grandchild(rebac_manager):
             subject=("agent", "alice"),
             permission="read",
             object=("file", "/workspaces/ws1/a.md"),
+            zone_id="root",
         )
         is False
     )
@@ -102,6 +109,7 @@ def test_no_partial_prefix_match(rebac_manager):
         subject=("agent", "alice"),
         relation="read",
         object=("file", "/workspaces/**"),
+        zone_id="root",
     )
 
     assert (
@@ -109,6 +117,7 @@ def test_no_partial_prefix_match(rebac_manager):
             subject=("agent", "alice"),
             permission="read",
             object=("file", "/workspaces2/a.md"),
+            zone_id="root",
         )
         is False
     )
@@ -119,21 +128,24 @@ def test_non_file_pattern_looking_object_stays_exact_only(rebac_manager):
         subject=("agent", "alice"),
         relation="member",
         object=("group", "/teams/**"),
+        zone_id="root",
     )
 
     assert (
         rebac_manager.rebac_check(
             subject=("agent", "alice"),
-            permission="read",
+            permission="member",
             object=("group", "/teams/**"),
+            zone_id="root",
         )
         is True
     )
     assert (
         rebac_manager.rebac_check(
             subject=("agent", "alice"),
-            permission="read",
+            permission="member",
             object=("group", "/teams/dev"),
+            zone_id="root",
         )
         is False
     )
@@ -144,6 +156,7 @@ def test_wildcard_subject_pattern_grants(rebac_manager):
         subject=("*", "*"),
         relation="read",
         object=("file", "/public/**"),
+        zone_id="root",
     )
 
     assert (
@@ -151,6 +164,7 @@ def test_wildcard_subject_pattern_grants(rebac_manager):
             subject=("agent", "alice"),
             permission="read",
             object=("file", "/public/docs/readme.md"),
+            zone_id="root",
         )
         is True
     )
@@ -161,11 +175,13 @@ def test_userset_as_subject_pattern_grants(rebac_manager):
         subject=("agent", "alice"),
         relation="member",
         object=("group", "eng"),
+        zone_id="root",
     )
     rebac_manager.rebac_write(
         subject=("group", "eng", "member"),
         relation="read",
         object=("file", "/workspaces/**"),
+        zone_id="root",
     )
 
     assert (
@@ -173,6 +189,7 @@ def test_userset_as_subject_pattern_grants(rebac_manager):
             subject=("agent", "alice"),
             permission="read",
             object=("file", "/workspaces/ws1/a.md"),
+            zone_id="root",
         )
         is True
     )
@@ -186,6 +203,7 @@ def test_abac_conditions_are_preserved_for_pattern_tuples(rebac_manager):
         subject=("agent", "alice"),
         relation="read",
         object=("file", "/workspaces/**"),
+        zone_id="root",
         conditions={
             "time_window": {
                 "start": datetime(2026, 1, 1, 9, tzinfo=UTC).isoformat(),
@@ -199,6 +217,7 @@ def test_abac_conditions_are_preserved_for_pattern_tuples(rebac_manager):
             subject=("agent", "alice"),
             permission="read",
             object=("file", "/workspaces/ws1/a.md"),
+            zone_id="root",
             context={"current_time": inside_window, "time": inside_window},
         )
         is True
@@ -208,6 +227,7 @@ def test_abac_conditions_are_preserved_for_pattern_tuples(rebac_manager):
             subject=("agent", "alice"),
             permission="read",
             object=("file", "/workspaces/ws1/a.md"),
+            zone_id="root",
             context={"current_time": outside_window, "time": outside_window},
         )
         is False

--- a/tests/unit/bricks/rebac/test_path_pattern_permissions.py
+++ b/tests/unit/bricks/rebac/test_path_pattern_permissions.py
@@ -1,0 +1,214 @@
+"""ReBAC path-pattern tuple behavior for issue #4239."""
+
+from datetime import UTC, datetime
+
+import pytest
+
+pytest.importorskip("pyroaring")
+
+from sqlalchemy import create_engine
+
+from nexus.bricks.rebac.consistency.metastore_namespace_store import MetastoreNamespaceStore
+from nexus.bricks.rebac.domain import NamespaceConfig
+from nexus.bricks.rebac.manager import ReBACManager
+from nexus.storage.models import Base
+from tests.testkit.metadata import InMemoryNexusFS
+
+
+@pytest.fixture
+def rebac_manager():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    manager = ReBACManager(
+        engine=engine,
+        cache_ttl_seconds=300,
+        max_depth=10,
+        namespace_store=MetastoreNamespaceStore(InMemoryNexusFS()),
+    )
+    manager.create_namespace(
+        NamespaceConfig(
+            namespace_id="path-pattern-permissions-file",
+            object_type="file",
+            config={"relations": {"read": {}}, "permissions": {}},
+        )
+    )
+    try:
+        yield manager
+    finally:
+        manager.close()
+
+
+def test_recursive_descendant_grant(rebac_manager):
+    rebac_manager.rebac_write(
+        subject=("agent", "alice"),
+        relation="read",
+        object=("file", "/workspaces/**"),
+    )
+
+    assert (
+        rebac_manager.rebac_check(
+            subject=("agent", "alice"),
+            permission="read",
+            object=("file", "/workspaces/ws1/a.md"),
+        )
+        is True
+    )
+
+
+def test_recursive_prefix_path_grant(rebac_manager):
+    rebac_manager.rebac_write(
+        subject=("agent", "alice"),
+        relation="read",
+        object=("file", "/workspaces/**"),
+    )
+
+    assert (
+        rebac_manager.rebac_check(
+            subject=("agent", "alice"),
+            permission="read",
+            object=("file", "/workspaces"),
+        )
+        is True
+    )
+
+
+def test_single_level_child_but_not_grandchild(rebac_manager):
+    rebac_manager.rebac_write(
+        subject=("agent", "alice"),
+        relation="read",
+        object=("file", "/workspaces/*"),
+    )
+
+    assert (
+        rebac_manager.rebac_check(
+            subject=("agent", "alice"),
+            permission="read",
+            object=("file", "/workspaces/a.md"),
+        )
+        is True
+    )
+    assert (
+        rebac_manager.rebac_check(
+            subject=("agent", "alice"),
+            permission="read",
+            object=("file", "/workspaces/ws1/a.md"),
+        )
+        is False
+    )
+
+
+def test_no_partial_prefix_match(rebac_manager):
+    rebac_manager.rebac_write(
+        subject=("agent", "alice"),
+        relation="read",
+        object=("file", "/workspaces/**"),
+    )
+
+    assert (
+        rebac_manager.rebac_check(
+            subject=("agent", "alice"),
+            permission="read",
+            object=("file", "/workspaces2/a.md"),
+        )
+        is False
+    )
+
+
+def test_non_file_pattern_looking_object_stays_exact_only(rebac_manager):
+    rebac_manager.rebac_write(
+        subject=("agent", "alice"),
+        relation="member",
+        object=("group", "/teams/**"),
+    )
+
+    assert (
+        rebac_manager.rebac_check(
+            subject=("agent", "alice"),
+            permission="read",
+            object=("group", "/teams/**"),
+        )
+        is True
+    )
+    assert (
+        rebac_manager.rebac_check(
+            subject=("agent", "alice"),
+            permission="read",
+            object=("group", "/teams/dev"),
+        )
+        is False
+    )
+
+
+def test_wildcard_subject_pattern_grants(rebac_manager):
+    rebac_manager.rebac_write(
+        subject=("*", "*"),
+        relation="read",
+        object=("file", "/public/**"),
+    )
+
+    assert (
+        rebac_manager.rebac_check(
+            subject=("agent", "alice"),
+            permission="read",
+            object=("file", "/public/docs/readme.md"),
+        )
+        is True
+    )
+
+
+def test_userset_as_subject_pattern_grants(rebac_manager):
+    rebac_manager.rebac_write(
+        subject=("agent", "alice"),
+        relation="member",
+        object=("group", "eng"),
+    )
+    rebac_manager.rebac_write(
+        subject=("group", "eng", "member"),
+        relation="read",
+        object=("file", "/workspaces/**"),
+    )
+
+    assert (
+        rebac_manager.rebac_check(
+            subject=("agent", "alice"),
+            permission="read",
+            object=("file", "/workspaces/ws1/a.md"),
+        )
+        is True
+    )
+
+
+def test_abac_conditions_are_preserved_for_pattern_tuples(rebac_manager):
+    inside_window = datetime(2026, 1, 1, 12, tzinfo=UTC).isoformat()
+    outside_window = datetime(2026, 1, 3, 20, tzinfo=UTC).isoformat()
+
+    rebac_manager.rebac_write(
+        subject=("agent", "alice"),
+        relation="read",
+        object=("file", "/workspaces/**"),
+        conditions={
+            "time_window": {
+                "start": datetime(2026, 1, 1, 9, tzinfo=UTC).isoformat(),
+                "end": datetime(2026, 1, 2, 17, tzinfo=UTC).isoformat(),
+            }
+        },
+    )
+
+    assert (
+        rebac_manager.rebac_check(
+            subject=("agent", "alice"),
+            permission="read",
+            object=("file", "/workspaces/ws1/a.md"),
+            context={"current_time": inside_window, "time": inside_window},
+        )
+        is True
+    )
+    assert (
+        rebac_manager.rebac_check(
+            subject=("agent", "alice"),
+            permission="read",
+            object=("file", "/workspaces/ws1/a.md"),
+            context={"current_time": outside_window, "time": outside_window},
+        )
+        is False
+    )

--- a/tests/unit/bricks/rebac/test_path_pattern_permissions.py
+++ b/tests/unit/bricks/rebac/test_path_pattern_permissions.py
@@ -199,6 +199,175 @@ def test_zone_aware_userset_subject_path_pattern_grants_member_read(
     )
 
 
+def test_group_tuple_to_userset_path_pattern_grants_member_read() -> None:
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    manager = ReBACManager(
+        engine=engine,
+        cache_ttl_seconds=300,
+        max_depth=10,
+        namespace_store=MetastoreNamespaceStore(InMemoryNexusFS()),
+    )
+    try:
+        manager.rebac_write(
+            subject=("agent", "alice"),
+            relation="member",
+            object=("group", "eng"),
+            zone_id="root",
+        )
+        manager.rebac_write(
+            subject=("group", "eng"),
+            relation="direct_viewer",
+            object=("file", "/workspaces/**"),
+            zone_id="root",
+        )
+
+        target = ("file", "/workspaces/ws1/a.md")
+        check = (("agent", "alice"), "read", target)
+
+        assert (
+            manager.rebac_check(
+                subject=("agent", "alice"),
+                permission="read",
+                object=target,
+                zone_id="root",
+            )
+            is True
+        )
+        assert manager.rebac_check_bulk([check], zone_id="root") == {check: True}
+    finally:
+        manager.close()
+
+
+def test_single_check_skips_tiger_write_through_for_path_pattern_grant(monkeypatch) -> None:
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    manager = ReBACManager(
+        engine=engine,
+        cache_ttl_seconds=300,
+        max_depth=10,
+        namespace_store=MetastoreNamespaceStore(InMemoryNexusFS()),
+    )
+    try:
+        manager.rebac_write(
+            subject=("agent", "alice"),
+            relation="direct_viewer",
+            object=("file", "/workspaces/**"),
+            zone_id="root",
+        )
+
+        tiger_writes: list[tuple[tuple[str, str], str, tuple[str, str]]] = []
+        monkeypatch.setattr(manager, "_tiger_cache", object())
+        monkeypatch.setattr(manager, "tiger_check_access", lambda **_kwargs: None)
+        monkeypatch.setattr(
+            manager._tuple_writer,
+            "tiger_write_through_single",
+            lambda *, subject, permission, object, **_kwargs: tiger_writes.append(
+                (subject, permission, object)
+            ),
+        )
+
+        assert (
+            manager.rebac_check(
+                subject=("agent", "alice"),
+                permission="read",
+                object=("file", "/workspaces/ws1/a.md"),
+                zone_id="root",
+            )
+            is True
+        )
+        assert tiger_writes == []
+    finally:
+        manager.close()
+
+
+def test_path_pattern_write_invalidates_tiger_instead_of_persisting_pattern(
+    monkeypatch,
+) -> None:
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    manager = ReBACManager(
+        engine=engine,
+        cache_ttl_seconds=300,
+        max_depth=10,
+        enable_tiger_cache=False,
+        namespace_store=MetastoreNamespaceStore(InMemoryNexusFS()),
+    )
+    try:
+        grants: list[tuple[tuple[str, str], str, str, str, str]] = []
+        invalidations: list[tuple[tuple[str, str], str, str, str]] = []
+        monkeypatch.setattr(manager, "_tiger_cache", object())
+        monkeypatch.setattr(
+            manager,
+            "tiger_persist_grant",
+            lambda *, subject, permission, resource_type, resource_id, zone_id: grants.append(
+                (subject, permission, resource_type, resource_id, zone_id)
+            ),
+        )
+        monkeypatch.setattr(
+            manager,
+            "tiger_invalidate_cache",
+            lambda subject, permission, resource_type, zone_id: invalidations.append(
+                (subject, permission, resource_type, zone_id)
+            ),
+        )
+
+        manager.rebac_write(
+            subject=("agent", "alice"),
+            relation="direct_viewer",
+            object=("file", "/workspaces/**"),
+            zone_id="root",
+        )
+
+        assert grants == []
+        assert invalidations == [(("agent", "alice"), "read", "file", "root")]
+    finally:
+        manager.close()
+
+
+def test_path_pattern_delete_invalidates_tiger_instead_of_exact_revoke(monkeypatch) -> None:
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    manager = ReBACManager(
+        engine=engine,
+        cache_ttl_seconds=300,
+        max_depth=10,
+        enable_tiger_cache=False,
+        namespace_store=MetastoreNamespaceStore(InMemoryNexusFS()),
+    )
+    try:
+        result = manager.rebac_write(
+            subject=("agent", "alice"),
+            relation="direct_viewer",
+            object=("file", "/workspaces/**"),
+            zone_id="root",
+        )
+
+        revokes: list[tuple[tuple[str, str], str, str, str, str]] = []
+        invalidations: list[tuple[tuple[str, str], str, str, str]] = []
+        monkeypatch.setattr(manager, "_tiger_cache", object())
+        monkeypatch.setattr(
+            manager,
+            "tiger_persist_revoke",
+            lambda *, subject, permission, resource_type, resource_id, zone_id: revokes.append(
+                (subject, permission, resource_type, resource_id, zone_id)
+            ),
+        )
+        monkeypatch.setattr(
+            manager,
+            "tiger_invalidate_cache",
+            lambda subject, permission, resource_type, zone_id: invalidations.append(
+                (subject, permission, resource_type, zone_id)
+            ),
+        )
+
+        assert manager.rebac_delete(result)
+        assert revokes == []
+        assert invalidations == [(("agent", "alice"), "read", "file", "root")]
+    finally:
+        manager.close()
+
+
 def test_no_partial_prefix_match(rebac_manager):
     rebac_manager.rebac_write(
         subject=("agent", "alice"),

--- a/tests/unit/bricks/rebac/test_path_pattern_permissions.py
+++ b/tests/unit/bricks/rebac/test_path_pattern_permissions.py
@@ -10,7 +10,9 @@ from sqlalchemy import create_engine
 
 from nexus.bricks.rebac.consistency.metastore_namespace_store import MetastoreNamespaceStore
 from nexus.bricks.rebac.domain import NamespaceConfig
+from nexus.bricks.rebac.enforcer import PermissionEnforcer
 from nexus.bricks.rebac.manager import ReBACManager
+from nexus.contracts.types import OperationContext
 from nexus.storage.models import Base
 from tests.testkit.metadata import InMemoryNexusFS
 
@@ -324,4 +326,71 @@ def test_abac_conditions_are_preserved_for_pattern_tuples(rebac_manager):
             context={"current_time": outside_window, "time": outside_window},
         )
         is False
+    )
+
+
+def test_rebac_check_bulk_matches_recursive_path_pattern(rebac_manager) -> None:
+    rebac_manager.rebac_write(
+        subject=("agent", "alice"),
+        relation="read",
+        object=("file", "/workspaces/**"),
+        zone_id="root",
+    )
+
+    checks = [
+        (("agent", "alice"), "read", ("file", "/workspaces/ws1/a.md")),
+        (("agent", "alice"), "read", ("file", "/private/a.md")),
+    ]
+
+    assert rebac_manager.rebac_check_bulk(checks, zone_id="root") == {
+        checks[0]: True,
+        checks[1]: False,
+    }
+
+
+def test_filter_list_matches_recursive_path_pattern(rebac_manager) -> None:
+    rebac_manager.rebac_write(
+        subject=("user", "admin"),
+        relation="read",
+        object=("file", "/workspaces/**"),
+        zone_id="root",
+    )
+    enforcer = PermissionEnforcer(rebac_manager=rebac_manager)
+    context = OperationContext(
+        user_id="admin",
+        groups=[],
+        subject_type="user",
+        subject_id="admin",
+        zone_id="root",
+    )
+
+    assert enforcer.filter_list(
+        ["/workspaces/ws1/a.md", "/workspaces/ws2/b.md", "/private/c.md"],
+        context,
+    ) == ["/workspaces/ws1/a.md", "/workspaces/ws2/b.md"]
+
+
+def test_python_fast_fallback_matches_direct_path_pattern_tuple() -> None:
+    from nexus.bricks.rebac.utils.fast import check_permissions_bulk_with_fallback
+
+    checks = [(("user", "admin"), "read", ("file", "/workspaces/a.md"))]
+    tuples = [
+        {
+            "subject_type": "user",
+            "subject_id": "admin",
+            "subject_relation": None,
+            "relation": "read",
+            "object_type": "file",
+            "object_id": "/workspaces/**",
+        }
+    ]
+
+    assert (
+        check_permissions_bulk_with_fallback(
+            checks,
+            tuples,
+            {},
+            force_python=True,
+        )[("user", "admin", "read", "file", "/workspaces/a.md")]
+        is True
     )

--- a/tests/unit/bricks/rebac/test_path_patterns.py
+++ b/tests/unit/bricks/rebac/test_path_patterns.py
@@ -1,0 +1,62 @@
+"""Path-pattern tuple helper tests for ReBAC issue #4239."""
+
+from nexus.bricks.rebac.path_patterns import (
+    is_path_pattern,
+    path_pattern_candidates,
+    path_pattern_matches,
+    path_pattern_prefix,
+)
+
+
+def test_recursive_root_pattern_matches_all_absolute_paths() -> None:
+    assert is_path_pattern("file", "/**")
+    assert path_pattern_prefix("file", "/**") == "/"
+    assert path_pattern_matches("/**", "/")
+    assert path_pattern_matches("/**", "/a")
+    assert path_pattern_matches("/**", "/a/b.txt")
+
+
+def test_recursive_prefix_matches_prefix_and_descendants_only() -> None:
+    assert is_path_pattern("file", "/workspaces/**")
+    assert path_pattern_prefix("file", "/workspaces/**") == "/workspaces"
+    assert path_pattern_matches("/workspaces/**", "/workspaces")
+    assert path_pattern_matches("/workspaces/**", "/workspaces/ws1/a.md")
+    assert not path_pattern_matches("/workspaces/**", "/workspaces2/a.md")
+
+
+def test_single_level_pattern_matches_direct_children_only() -> None:
+    assert is_path_pattern("file", "/workspaces/*")
+    assert path_pattern_prefix("file", "/workspaces/*") == "/workspaces"
+    assert path_pattern_matches("/workspaces/*", "/workspaces/a.md")
+    assert not path_pattern_matches("/workspaces/*", "/workspaces")
+    assert not path_pattern_matches("/workspaces/*", "/workspaces/a/b.md")
+    assert not path_pattern_matches("/workspaces/*", "/workspaces2/a.md")
+
+
+def test_root_single_level_pattern_matches_one_root_child() -> None:
+    assert is_path_pattern("file", "/*")
+    assert path_pattern_prefix("file", "/*") == "/"
+    assert path_pattern_matches("/*", "/a.md")
+    assert not path_pattern_matches("/*", "/")
+    assert not path_pattern_matches("/*", "/a/b.md")
+
+
+def test_non_file_and_relative_ids_are_not_patterns() -> None:
+    assert not is_path_pattern("group", "/workspaces/**")
+    assert not is_path_pattern("file", "workspaces/**")
+    assert path_pattern_prefix("group", "/workspaces/**") is None
+    assert path_pattern_candidates("group", "/workspaces/a.md") == ["/workspaces/a.md"]
+    assert path_pattern_candidates("file", "workspaces/a.md") == ["workspaces/a.md"]
+
+
+def test_candidates_are_bounded_and_ordered_from_exact_to_broad() -> None:
+    assert path_pattern_candidates("file", "/workspaces/ws1/a.md") == [
+        "/workspaces/ws1/a.md",
+        "/workspaces/ws1/a.md/**",
+        "/workspaces/ws1/*",
+        "/workspaces/ws1/**",
+        "/workspaces/**",
+        "/**",
+    ]
+    assert path_pattern_candidates("file", "/a.md") == ["/a.md", "/a.md/**", "/*", "/**"]
+    assert path_pattern_candidates("file", "/") == ["/", "/**"]

--- a/tests/unit/server/api/v2/test_rebac_router.py
+++ b/tests/unit/server/api/v2/test_rebac_router.py
@@ -230,6 +230,54 @@ def test_post_with_subject_relation_passes_3tuple(fake_rebac_manager: MagicMock)
     assert call_kwargs["subject"] == ("user", "alice", "member")
 
 
+def test_post_preserves_recursive_path_pattern_object_id(
+    fake_rebac_manager: MagicMock,
+) -> None:
+    auth = _FakeAuthProvider(admin_tokens={"admin-tok": {"is_admin": True, "subject_id": "admin"}})
+    app = _make_app(rebac_manager=fake_rebac_manager, auth_provider=auth)
+    body = {**_VALID_BODY, "object_namespace": "file", "object_id": "/workspaces/**"}
+
+    with _client(app) as client:
+        resp = client.post(
+            "/api/v2/rebac/tuples",
+            json=body,
+            headers={"Authorization": "Bearer admin-tok"},
+        )
+
+    assert resp.status_code == 201, resp.text
+    fake_rebac_manager.rebac_write.assert_called_once_with(
+        subject=("user", "alice"),
+        relation="read",
+        object=("file", "/workspaces/**"),
+        zone_id="root",
+    )
+    assert resp.json()["object_id"] == "/workspaces/**"
+
+
+def test_post_preserves_single_level_path_pattern_object_id(
+    fake_rebac_manager: MagicMock,
+) -> None:
+    auth = _FakeAuthProvider(admin_tokens={"admin-tok": {"is_admin": True, "subject_id": "admin"}})
+    app = _make_app(rebac_manager=fake_rebac_manager, auth_provider=auth)
+    body = {**_VALID_BODY, "object_namespace": "file", "object_id": "/workspaces/*"}
+
+    with _client(app) as client:
+        resp = client.post(
+            "/api/v2/rebac/tuples",
+            json=body,
+            headers={"Authorization": "Bearer admin-tok"},
+        )
+
+    assert resp.status_code == 201, resp.text
+    fake_rebac_manager.rebac_write.assert_called_once_with(
+        subject=("user", "alice"),
+        relation="read",
+        object=("file", "/workspaces/*"),
+        zone_id="root",
+    )
+    assert resp.json()["object_id"] == "/workspaces/*"
+
+
 # ---------------------------------------------------------------------------
 # GET / DELETE happy paths
 # ---------------------------------------------------------------------------
@@ -476,47 +524,28 @@ def test_delete_tuple_no_auth_returns_401(fake_rebac_manager: MagicMock) -> None
 
 
 class TestNormalizeFileObjectId:
-    """Pure helper tests — collapse shell-style globs to a directory path."""
+    """Pure helper tests for preserving explicit path-pattern tuple IDs."""
 
-    def test_double_star_collapses(self) -> None:
-        assert _normalize_file_object_id("file", "/workspaces/ws1/**") == "/workspaces/ws1"
+    def test_double_star_preserved(self) -> None:
+        assert _normalize_file_object_id("file", "/workspaces/ws1/**") == "/workspaces/ws1/**"
 
-    def test_single_star_rejected(self) -> None:
-        """Round-5 review (codex HIGH): ``/*`` previously collapsed to
-        the same directory tuple as ``/**``, silently granting the
-        entire subtree even though shell ``/*`` is one-level-only.
-        Now raises so the caller returns 400 — operator must pick
-        ``/**`` explicitly or list exact paths.
-        """
-        from nexus.server.api.v2.routers.rebac import _WildcardSemanticError
-
-        with pytest.raises(_WildcardSemanticError, match="single-level glob"):
-            _normalize_file_object_id("file", "/workspaces/ws1/*")
+    def test_single_star_preserved(self) -> None:
+        assert _normalize_file_object_id("file", "/workspaces/ws1/*") == "/workspaces/ws1/*"
 
     def test_trailing_slash_collapses(self) -> None:
         assert _normalize_file_object_id("file", "/workspaces/ws1/") == "/workspaces/ws1"
 
     def test_root_double_star(self) -> None:
-        assert _normalize_file_object_id("file", "/**") == "/"
+        assert _normalize_file_object_id("file", "/**") == "/**"
 
-    def test_root_single_star_rejected(self) -> None:
-        """Round-5 review: same as nested ``/*`` — would silently grant
-        every file in every zone."""
-        from nexus.server.api.v2.routers.rebac import _WildcardSemanticError
-
-        with pytest.raises(_WildcardSemanticError):
-            _normalize_file_object_id("file", "/*")
+    def test_root_single_star_preserved(self) -> None:
+        assert _normalize_file_object_id("file", "/*") == "/*"
 
     def test_exact_path_unchanged(self) -> None:
         assert _normalize_file_object_id("file", "/workspaces/ws1/a.md") == "/workspaces/ws1/a.md"
 
-    def test_mixed_globs_rejected(self) -> None:
-        """``/a/**/*`` mixes recursive + single-level — reject since the
-        ``/*`` semantic cannot be honored."""
-        from nexus.server.api.v2.routers.rebac import _WildcardSemanticError
-
-        with pytest.raises(_WildcardSemanticError):
-            _normalize_file_object_id("file", "/a/**/*")
+    def test_mixed_globs_preserved_as_literal_prefix_pattern(self) -> None:
+        assert _normalize_file_object_id("file", "/a/**/*") == "/a/**/*"
 
     def test_non_file_namespace_passthrough(self) -> None:
         """Capabilities like ``("approvals", "global*")`` must not be mangled."""
@@ -565,20 +594,18 @@ def _file_body(object_id: str) -> dict[str, Any]:
 @pytest.mark.parametrize(
     ("input_object_id", "expected_stored"),
     [
-        ("/workspaces/ws1/**", "/workspaces/ws1"),
+        ("/workspaces/ws1/**", "/workspaces/ws1/**"),
         ("/workspaces/ws1/", "/workspaces/ws1"),
-        ("/**", "/"),
+        ("/**", "/**"),
         ("/workspaces/ws1/a.md", "/workspaces/ws1/a.md"),
     ],
 )
-def test_post_wildcard_object_id_normalized(
+def test_post_file_object_id_normalized_without_rewriting_patterns(
     fake_rebac_manager_file: MagicMock,
     input_object_id: str,
     expected_stored: str,
 ) -> None:
-    """POST collapses RECURSIVE ``/**`` and trailing ``/`` so the existing
-    ancestor-walk machinery grants every descendant (Issue #4239).
-    Round-5: ``/*`` is rejected — see test_post_single_star_returns_400."""
+    """POST preserves explicit pattern IDs and only trims exact trailing slash."""
     auth = _FakeAuthProvider(admin_tokens={"admin-tok": {"is_admin": True, "subject_id": "admin"}})
     app = _make_app(rebac_manager=fake_rebac_manager_file, auth_provider=auth)
     with _client(app) as client:
@@ -595,12 +622,8 @@ def test_post_wildcard_object_id_normalized(
     assert body["object_id_input"] == input_object_id
 
 
-def test_post_single_star_returns_400(fake_rebac_manager_file: MagicMock) -> None:
-    """Round-5 review (codex HIGH): a ``/*`` object_id must return 400
-    rather than silently collapsing to the parent directory tuple
-    (which would grant the whole subtree). Operators should pick
-    ``/**`` for recursive or list exact paths.
-    """
+def test_post_single_star_path_pattern_is_preserved(fake_rebac_manager_file: MagicMock) -> None:
+    """Single-level path patterns are stored literally for graph matching."""
     auth = _FakeAuthProvider(admin_tokens={"admin-tok": {"is_admin": True, "subject_id": "admin"}})
     app = _make_app(rebac_manager=fake_rebac_manager_file, auth_provider=auth)
     with _client(app) as client:
@@ -609,9 +632,10 @@ def test_post_single_star_returns_400(fake_rebac_manager_file: MagicMock) -> Non
             json=_file_body("/workspaces/ws1/*"),
             headers={"Authorization": "Bearer admin-tok"},
         )
-    assert resp.status_code == 400, resp.text
-    assert "single-level glob" in resp.json()["detail"].lower()
-    fake_rebac_manager_file.rebac_write.assert_not_called()
+    assert resp.status_code == 201, resp.text
+    call_kwargs = fake_rebac_manager_file.rebac_write.call_args.kwargs
+    assert call_kwargs["object"] == ("file", "/workspaces/ws1/*")
+    assert resp.json()["object_id"] == "/workspaces/ws1/*"
 
 
 def test_post_non_file_namespace_not_normalized(fake_rebac_manager: MagicMock) -> None:
@@ -630,9 +654,8 @@ def test_post_non_file_namespace_not_normalized(fake_rebac_manager: MagicMock) -
     assert call_kwargs["object"] == ("approvals", "global*")
 
 
-def test_delete_normalizes_to_match_post(fake_rebac_manager_file: MagicMock) -> None:
-    """DELETE with ``/workspaces/ws1/**`` deletes the tuple POST wrote at
-    ``/workspaces/ws1`` — otherwise operators can't clean up by symmetry."""
+def test_delete_preserves_path_pattern_to_match_post(fake_rebac_manager_file: MagicMock) -> None:
+    """DELETE with ``/workspaces/ws1/**`` deletes the exact pattern tuple."""
     auth = _FakeAuthProvider(admin_tokens={"admin-tok": {"is_admin": True, "subject_id": "admin"}})
     app = _make_app(rebac_manager=fake_rebac_manager_file, auth_provider=auth)
     with _client(app) as client:
@@ -647,14 +670,14 @@ def test_delete_normalizes_to_match_post(fake_rebac_manager_file: MagicMock) -> 
     fake_rebac_manager_file.rebac_list_tuples.assert_called_once_with(
         subject=("user", "admin"),
         relation="read",
-        object=("file", "/workspaces/ws1"),
+        object=("file", "/workspaces/ws1/**"),
         subject_relation=None,
         zone_id="root",
     )
 
 
-def test_get_normalizes_query_object_id(fake_rebac_manager_file: MagicMock) -> None:
-    """GET ?object_id=/workspaces/ws1/** finds the tuple POST stored."""
+def test_get_preserves_query_object_id(fake_rebac_manager_file: MagicMock) -> None:
+    """GET ?object_id=/workspaces/ws1/** looks up the exact pattern tuple."""
     auth = _FakeAuthProvider(admin_tokens={"admin-tok": {"is_admin": True, "subject_id": "admin"}})
     app = _make_app(rebac_manager=fake_rebac_manager_file, auth_provider=auth)
     with _client(app) as client:
@@ -675,7 +698,7 @@ def test_get_normalizes_query_object_id(fake_rebac_manager_file: MagicMock) -> N
         subject_type="user",
         subject_id="admin",
         object_type="file",
-        object_id="/workspaces/ws1",
+        object_id="/workspaces/ws1/**",
         zone_id=None,
     )
 

--- a/tests/unit/services/permissions/test_bulk_checker_sqlite_chunking.py
+++ b/tests/unit/services/permissions/test_bulk_checker_sqlite_chunking.py
@@ -21,6 +21,43 @@ class _RecordingConnection:
         return []
 
 
+class _FakeResourceMap:
+    def __init__(self) -> None:
+        self._ids: dict[tuple[str, str], int] = {}
+
+    def get_int_ids_batch(self, resource_keys: list[tuple[str, str]]) -> dict[tuple[str, str], int]:
+        return {key: self._ids[key] for key in resource_keys if key in self._ids}
+
+    def get_or_create_int_id(self, resource_type: str, resource_id: str) -> int:
+        key = (resource_type, resource_id)
+        if key not in self._ids:
+            self._ids[key] = len(self._ids) + 1
+        return self._ids[key]
+
+
+class _FakeTigerCache:
+    def __init__(self) -> None:
+        self._resource_map = _FakeResourceMap()
+        self.bulk_adds: list[set[int]] = []
+        self.persists: list[set[int]] = []
+
+    def add_to_bitmap_bulk(
+        self,
+        *,
+        resource_int_ids: set[int],
+        **_kwargs: object,
+    ) -> None:
+        self.bulk_adds.append(set(resource_int_ids))
+
+    def persist_bitmap_bulk(
+        self,
+        *,
+        resource_int_ids: set[int],
+        **_kwargs: object,
+    ) -> None:
+        self.persists.append(set(resource_int_ids))
+
+
 def _make_checker() -> BulkPermissionChecker:
     return BulkPermissionChecker(
         engine=create_engine("sqlite:///:memory:"),
@@ -67,3 +104,40 @@ def test_sqlite_cross_zone_tuple_fetch_chunks_large_subject_lists() -> None:
     assert count == 0
     assert tuples_graph == []
     assert len(conn.param_counts) > 1
+
+
+def test_tiger_write_through_skips_results_from_path_pattern_tuples() -> None:
+    tiger_cache = _FakeTigerCache()
+    checker = BulkPermissionChecker(
+        engine=create_engine("sqlite:///:memory:"),
+        get_namespace=lambda _entity_type: None,
+        enforce_zone_isolation=False,
+        l1_cache=None,
+        tiger_cache=tiger_cache,
+        compute_bulk_helper=lambda *_args, **_kwargs: True,
+        rebac_check_single=lambda *_args, **_kwargs: False,
+        cache_result=lambda *_args, **_kwargs: None,
+        tuple_version=0,
+    )
+
+    check = (("user", "admin"), "read", ("file", "/workspaces/a.md"))
+    checker._phase_python_compute(
+        [check],
+        [
+            {
+                "subject_type": "user",
+                "subject_id": "admin",
+                "subject_relation": None,
+                "relation": "read",
+                "object_type": "file",
+                "object_id": "/workspaces/**",
+            }
+        ],
+        "root",
+        {},
+        {},
+        {"hits": 0, "misses": 0, "max_depth": 0},
+    )
+
+    assert tiger_cache.bulk_adds == []
+    assert tiger_cache.persists == []


### PR DESCRIPTION
## Summary
- Add explicit file path-pattern tuple support for ReBAC object IDs ending in `/*` or `/**`, including direct, zone-aware, and bulk permission checks.
- Update cache/Tiger behavior so path-pattern grants invalidate or avoid unsafe materialized leaf positives instead of leaving stale access after revocation.
- Fix live RPC/CLI batch-check handling discovered during `nexus up --build` validation by accepting JSON list-shaped check tuples and using keyword arguments through the remote sync proxy.

## Root Cause
ReBAC tuple object IDs were previously treated as literal values, so grants like `file:/workspaces/**` did not cover descendant files. The new bulk/live checks also exposed that RPC batch checks serialized tuple triples as lists and the CLI remote proxy call was positional, causing live `rebac check-batch` failures.

Closes #4239

## Validation
- `nexus up --build --timeout 600` on a temp demo stack from this branch.
- Live CLI/RPC scenario passed: direct recursive path-pattern grant, sibling denial, batch checks, group tupleToUserset pattern grant, group batch checks, and post-delete denial for direct and group pattern grants.
- `uv run --no-sync python -m pytest tests/e2e/self_contained/test_rebac_full_story_e2e.py -o "addopts=" -q` -> 8 passed.
- `uv run --no-sync python -m pytest tests/unit/bricks/rebac/test_path_patterns.py tests/unit/bricks/rebac/test_path_pattern_permissions.py -o "addopts=" -q` -> 35 passed.
- `uv run --no-sync python -m pytest tests/unit/bricks/rebac/test_permission_filter_chain.py tests/unit/services/permissions/test_rebac_fast_fallback.py tests/unit/services/permissions/test_bulk_checker_sqlite_chunking.py -o "addopts=" -q` -> 30 passed.
- `ruff check`, `ruff format --check`, `mypy` on touched source files, and `git diff --check` passed.
