### PR TITLE
feat(vault): v0.1.3 — gRPC service routing + sealed Get/Put for dogfood signing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1536,7 +1536,7 @@ source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5ac7d15c3e25e9bfb2d9d64f
 
 [[package]]
 name = "nexus-vault"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "backends",
  "clap",
@@ -1547,7 +1547,9 @@ dependencies = [
  "services",
  "tempfile",
  "tokio",
+ "tokio-stream",
  "tonic",
+ "tonic-prost",
  "tracing",
  "tracing-subscriber",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=e68353c4b1556e20321efbfd52e4ed1a045f66a5#e68353c4b1556e20321efbfd52e4ed1a045f66a5"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5ac7d15c3e25e9bfb2d9d64fecb3c2daeae48d9c#5ac7d15c3e25e9bfb2d9d64fecb3c2daeae48d9c"
 dependencies = [
  "ahash",
  "base64",
@@ -264,6 +264,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bincode"
@@ -465,6 +471,12 @@ checksum = "ea0095f6103c2a8b44acd6fd15960c801dafebf02e21940360833e0673f48ba7"
 
 [[package]]
 name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
@@ -498,7 +510,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=e68353c4b1556e20321efbfd52e4ed1a045f66a5#e68353c4b1556e20321efbfd52e4ed1a045f66a5"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5ac7d15c3e25e9bfb2d9d64fecb3c2daeae48d9c#5ac7d15c3e25e9bfb2d9d64fecb3c2daeae48d9c"
 dependencies = [
  "parking_lot",
  "serde",
@@ -608,6 +620,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "digest 0.10.7",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "dashmap"
 version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -619,6 +658,16 @@ dependencies = [
  "lock_api",
  "once_cell",
  "parking_lot_core",
+]
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid 0.9.6",
+ "zeroize",
 ]
 
 [[package]]
@@ -648,8 +697,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.1",
- "const-oid",
+ "const-oid 0.10.2",
  "crypto-common 0.2.2",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "serde",
+ "sha2 0.10.9",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -706,6 +779,12 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "find-msvc-tools"
@@ -1214,7 +1293,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=e68353c4b1556e20321efbfd52e4ed1a045f66a5#e68353c4b1556e20321efbfd52e4ed1a045f66a5"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5ac7d15c3e25e9bfb2d9d64fecb3c2daeae48d9c#5ac7d15c3e25e9bfb2d9d64fecb3c2daeae48d9c"
 dependencies = [
  "ahash",
  "base64",
@@ -1225,6 +1304,7 @@ dependencies = [
  "contracts",
  "crc32fast",
  "dashmap",
+ "ed25519-dalek",
  "fastcdc",
  "futures",
  "globset",
@@ -1270,7 +1350,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=e68353c4b1556e20321efbfd52e4ed1a045f66a5#e68353c4b1556e20321efbfd52e4ed1a045f66a5"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5ac7d15c3e25e9bfb2d9d64fecb3c2daeae48d9c#5ac7d15c3e25e9bfb2d9d64fecb3c2daeae48d9c"
 dependencies = [
  "ahash",
  "base64",
@@ -1288,7 +1368,7 @@ dependencies = [
  "roaring",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "string-interner",
  "thiserror",
  "time",
@@ -1452,7 +1532,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=e68353c4b1556e20321efbfd52e4ed1a045f66a5#e68353c4b1556e20321efbfd52e4ed1a045f66a5"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5ac7d15c3e25e9bfb2d9d64fecb3c2daeae48d9c#5ac7d15c3e25e9bfb2d9d64fecb3c2daeae48d9c"
 
 [[package]]
 name = "nexus-vault"
@@ -1634,6 +1714,16 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
 
 [[package]]
 name = "pkg-config"
@@ -1976,6 +2066,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2178,6 +2277,17 @@ dependencies = [
 
 [[package]]
 name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
@@ -2210,6 +2320,15 @@ checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
  "errno",
  "libc",
+]
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "rand_core",
 ]
 
 [[package]]
@@ -2253,6 +2372,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,20 +30,20 @@ exclude = ["nexus-fuse"]
 [workspace.dependencies]
 # Kernel-tier crates from nexus-vfs (external git dependency).
 # SSOT: https://github.com/nexi-lab/nexus-vfs
-# Pinned at the nexus-vfs main commit that landed #41 (closes the
-# latent replay_existing_mounts iter_dt_mount_entries try_read race
-# that #40's timing change exposed reliably — the boot DT_MOUNT scan
-# now waits for `applied_index >= commit_index` before reading, so a
-# restart's cross-zone routes are always re-wired).  Bump alongside
-# the rest of nexus-vfs updates when a downstream change needs newer
-# kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "e68353c4b1556e20321efbfd52e4ed1a045f66a5" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "e68353c4b1556e20321efbfd52e4ed1a045f66a5" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "e68353c4b1556e20321efbfd52e4ed1a045f66a5" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "e68353c4b1556e20321efbfd52e4ed1a045f66a5", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "e68353c4b1556e20321efbfd52e4ed1a045f66a5", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "e68353c4b1556e20321efbfd52e4ed1a045f66a5", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "e68353c4b1556e20321efbfd52e4ed1a045f66a5" }
+# Pinned at the nexus-vfs main commit that landed #57 (Phase P —
+# plugin-as-gRPC-service routing). Cluster now routes plugin-exposed
+# gRPC services on the same port + trust root as VFS, via the optional
+# `nexus_plugin_grpc_services` symbol + bytes-level dispatch through
+# the existing `nexus_service_dispatch`. Required for vault.dylib to
+# serve external PutSecret/GetSecret calls. Bump alongside the rest of
+# nexus-vfs updates when a downstream change needs newer kernel bits.
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5ac7d15c3e25e9bfb2d9d64fecb3c2daeae48d9c" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5ac7d15c3e25e9bfb2d9d64fecb3c2daeae48d9c" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5ac7d15c3e25e9bfb2d9d64fecb3c2daeae48d9c" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5ac7d15c3e25e9bfb2d9d64fecb3c2daeae48d9c", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5ac7d15c3e25e9bfb2d9d64fecb3c2daeae48d9c", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5ac7d15c3e25e9bfb2d9d64fecb3c2daeae48d9c", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5ac7d15c3e25e9bfb2d9d64fecb3c2daeae48d9c" }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ENV CARGO_NET_RETRY=10 \
     CARGO_HTTP_TIMEOUT=120
 # Override for edge/CI or a different pin: --build-arg NEXUS_VFS_REV=<sha|tag>
-ARG NEXUS_VFS_REV=e68353c4b1556e20321efbfd52e4ed1a045f66a5
+ARG NEXUS_VFS_REV=5ac7d15c3e25e9bfb2d9d64fecb3c2daeae48d9c
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,id=cargo-install-${TARGETARCH},target=/root/.cargo/target \

--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir --no-deps --prefix=/install .
 # enforces agreement) — an unpinned install tracks nexus-vfs HEAD and
 # ships an untested kernel (#4343). --locked honors the source tree's
 # Cargo.lock.
-ARG NEXUS_VFS_REV=e68353c4b1556e20321efbfd52e4ed1a045f66a5
+ARG NEXUS_VFS_REV=5ac7d15c3e25e9bfb2d9d64fecb3c2daeae48d9c
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-cluster nexus-cluster
 
 # -- Runtime stage --

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -25,7 +25,7 @@ WORKDIR /build
 # (CI preflight enforces agreement) — an unpinned install tracks HEAD
 # and can skew the raft contract against the cluster/witness images.
 # --locked honors the source tree's Cargo.lock.
-ARG NEXUS_VFS_REV=e68353c4b1556e20321efbfd52e4ed1a045f66a5
+ARG NEXUS_VFS_REV=5ac7d15c3e25e9bfb2d9d64fecb3c2daeae48d9c
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexus-raft-server raft
 
 # ---------- Production image ----------

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=e68353c4b1556e20321efbfd52e4ed1a045f66a5
+ARG NEXUS_VFS_REV=5ac7d15c3e25e9bfb2d9d64fecb3c2daeae48d9c
 RUN cargo install \
     --locked \
     --git https://github.com/nexi-lab/nexus-vfs \

--- a/rust/backends/local-connector/src/lib.rs
+++ b/rust/backends/local-connector/src/lib.rs
@@ -163,11 +163,37 @@ mod tests {
         -3
     }
 
+    unsafe extern "C" fn stub_sys_readdir(
+        _: *const c_void,
+        _: *const std::ffi::c_char,
+        _: *mut *mut u8,
+        _: *mut usize,
+    ) -> i32 {
+        -3
+    }
+
+    unsafe extern "C" fn stub_sys_path(_: *const c_void, _: *const std::ffi::c_char) -> i32 {
+        -3
+    }
+
+    unsafe extern "C" fn stub_sys_rename(
+        _: *const c_void,
+        _: *const std::ffi::c_char,
+        _: *const std::ffi::c_char,
+    ) -> i32 {
+        -3
+    }
+
     fn stub_handle() -> KernelHandle {
         KernelHandle {
             sys_read: stub_sys_read,
             sys_write: stub_sys_write,
             sys_stat: stub_sys_stat,
+            sys_readdir: stub_sys_readdir,
+            sys_unlink: stub_sys_path,
+            sys_mkdir: stub_sys_path,
+            sys_rmdir: stub_sys_path,
+            sys_rename: stub_sys_rename,
             kernel_ptr: std::ptr::null(),
         }
     }

--- a/rust/services/build.rs
+++ b/rust/services/build.rs
@@ -26,7 +26,11 @@ fn compile_password_vault_proto() -> Result<(), Box<dyn std::error::Error>> {
 
     tonic_prost_build::configure()
         .build_server(true)
-        .build_client(false) // server-only; clients live in password-agent (Python) and sudowork (TS)
+        // Rust clients are required by `vault`'s gRPC E2E test
+        // (`rust/services/vault/tests/grpc_e2e.rs`). Production
+        // callers remain TS / Python in sudowork + password-agent;
+        // the Rust client stubs are dead code in any normal build.
+        .build_client(true)
         .compile_protos(&[proto], &["proto"])?;
 
     Ok(())
@@ -43,7 +47,7 @@ fn compile_secrets_proto() -> Result<(), Box<dyn std::error::Error>> {
 
     tonic_prost_build::configure()
         .build_server(true)
-        .build_client(false)
+        .build_client(true)
         .compile_protos(&[proto], &["proto"])?;
 
     Ok(())

--- a/rust/services/fuse-plugin/src/lib.rs
+++ b/rust/services/fuse-plugin/src/lib.rs
@@ -151,6 +151,11 @@ unsafe fn kernel_handle_clone(src: &KernelHandle) -> KernelHandle {
         sys_read: src.sys_read,
         sys_write: src.sys_write,
         sys_stat: src.sys_stat,
+        sys_readdir: src.sys_readdir,
+        sys_unlink: src.sys_unlink,
+        sys_mkdir: src.sys_mkdir,
+        sys_rmdir: src.sys_rmdir,
+        sys_rename: src.sys_rename,
         kernel_ptr: src.kernel_ptr,
     }
 }

--- a/rust/services/proto/nexus/secrets/v1/secrets.proto
+++ b/rust/services/proto/nexus/secrets/v1/secrets.proto
@@ -58,6 +58,20 @@ service GenericSecretsService {
   // Update description metadata without creating a new version.
   // Metadata-only operation — does not touch encrypted version files.
   rpc UpdateSecretDescription(UpdateSecretDescriptionRequest) returns (UpdateSecretDescriptionResponse);
+
+  // Sealed (raw-bytes) variants of Get/Put. The caller supplies or
+  // receives the AES-256-GCM (nonce, ciphertext+tag) pair without
+  // vault performing the seal/open step. Used by the encrypted-in-git
+  // dogfood signing-key keystore: CI hands vault opaque sealed bytes
+  // committed in `data/vault-signing/keys.json`, vault rehydrates
+  // them with `PutSecretSealed`, then the standard `GetSecret`
+  // (which DOES decrypt with the master key) returns plaintext.
+  //
+  // Localhost-only: handlers reject non-loopback peer addresses with
+  // PERMISSION_DENIED. Bypassing the master-key seal is not a safe
+  // operation to expose remotely.
+  rpc GetSecretSealed(GetSecretRequest) returns (GetSecretSealedResponse);
+  rpc PutSecretSealed(PutSecretSealedRequest) returns (PutSecretResponse);
 }
 
 // SecretMetadata — returned by list/put operations. Values are never
@@ -214,4 +228,32 @@ message UpdateSecretDescriptionResponse {
   string namespace = 1;
   string key = 2;
   string description = 3;
+}
+
+// --- Sealed Get / Put (raw AEAD bytes) ---
+//
+// Sealed variants expose vault's internal (nonce, ciphertext) pair
+// without performing the AES-256-GCM seal/open. The master key never
+// leaves vault — `nonce` and `ciphertext` are opaque from the caller's
+// perspective; only a vault instance holding the same master key can
+// decrypt them via standard `GetSecret`.
+
+message GetSecretSealedResponse {
+  string namespace = 1;
+  string key = 2;
+  // 12 raw bytes — the GCM nonce used at seal time.
+  bytes nonce = 3;
+  // GCM ciphertext (contains the 16-byte authentication tag at end).
+  bytes ciphertext = 4;
+  int32 version = 5;
+}
+
+message PutSecretSealedRequest {
+  string namespace = 1;
+  string key = 2;
+  // 12 raw bytes — the GCM nonce produced by a prior seal call.
+  bytes nonce = 3;
+  // GCM ciphertext (contains the 16-byte authentication tag at end).
+  bytes ciphertext = 4;
+  optional string description = 5;
 }

--- a/rust/services/src/generic_secrets/mod.rs
+++ b/rust/services/src/generic_secrets/mod.rs
@@ -37,6 +37,27 @@ fn unix_ms_to_proto_ts(ms: u64) -> prost_types::Timestamp {
     }
 }
 
+/// Reject non-loopback callers on sealed Get/Put.
+///
+/// The sealed variants expose vault's internal AEAD bytes — they
+/// bypass the master-key seal/open and so they must not leak outside
+/// the host. Loopback peers (`127.0.0.1` / `::1`) are trusted; absence
+/// of peer info — in-process tonic calls and FFI dispatches forwarded
+/// by `nexus-vfs` `PluginProxyService` — is also accepted because the
+/// caller's environment is responsible for binding the outer gRPC
+/// listener to loopback when sealed traffic is allowed at all. Any
+/// other peer is rejected with `PERMISSION_DENIED`.
+fn require_localhost_caller<T>(req: &Request<T>) -> Result<(), Status> {
+    if let Some(addr) = req.remote_addr() {
+        if !addr.ip().is_loopback() {
+            return Err(Status::permission_denied(
+                "sealed Get/Put are restricted to loopback callers",
+            ));
+        }
+    }
+    Ok(())
+}
+
 fn index_to_metadata(ns: &str, key: &str, idx: &SecretIndex) -> SecretMetadata {
     SecretMetadata {
         namespace: ns.to_string(),
@@ -239,6 +260,115 @@ impl GenericSecretsServiceImpl {
             .ok_or_else(|| PasswordVaultError::NotFound(format!("{namespace}/{key}")))?;
         let stored = self.inner.storage.list_versions(namespace, key)?;
         Ok((stored, idx))
+    }
+
+    /// Internal sealed-put — store an already-sealed `(nonce, ciphertext)`
+    /// pair as a new version, skipping the AES-GCM seal step. The caller
+    /// is responsible for producing bytes that the configured master key
+    /// can later decrypt via the standard `do_get` path.
+    ///
+    /// Used by the encrypted-in-git dogfood keystore: CI rehydrates
+    /// committed sealed blobs into vault state so the master-key-driven
+    /// `GetSecret` then returns plaintext to the signing pipeline.
+    pub(crate) fn do_put_sealed(
+        &self,
+        namespace: &str,
+        key: &str,
+        nonce: &[u8],
+        ciphertext: &[u8],
+        description: Option<&str>,
+    ) -> Result<SecretMetadata, Status> {
+        if namespace.is_empty() {
+            return Err(Status::invalid_argument("namespace is required"));
+        }
+        if key.is_empty() {
+            return Err(Status::invalid_argument("key is required"));
+        }
+        if nonce.len() != 12 {
+            return Err(Status::invalid_argument("nonce must be exactly 12 bytes"));
+        }
+        if ciphertext.is_empty() {
+            return Err(Status::invalid_argument("ciphertext is required"));
+        }
+
+        let mut nonce_arr = [0u8; 12];
+        nonce_arr.copy_from_slice(nonce);
+
+        let current = self.inner.storage.get_index(namespace, key)?;
+        let now = now_unix_ms();
+        let next_version = current.as_ref().map_or(1, |idx| idx.current_version + 1);
+
+        let stored = StoredEntry {
+            version: next_version,
+            created_at_ms: now,
+            nonce: nonce_arr,
+            ciphertext: ciphertext.to_vec(),
+        };
+        self.inner
+            .storage
+            .put_version(namespace, key, next_version, &stored)?;
+
+        let idx = SecretIndex {
+            current_version: next_version,
+            deleted_at_ms: None,
+            description: description
+                .map(|d| d.to_string())
+                .or_else(|| current.as_ref().map(|c| c.description.clone()))
+                .unwrap_or_default(),
+            created_at_ms: current.as_ref().map_or(now, |c| c.created_at_ms),
+            updated_at_ms: now,
+        };
+        self.inner.storage.set_index(namespace, key, &idx)?;
+
+        Ok(index_to_metadata(namespace, key, &idx))
+    }
+
+    /// Internal sealed-get — return the raw `(nonce, ciphertext, version)`
+    /// for a stored version, skipping the AES-GCM open step.
+    ///
+    /// The returned bytes are opaque to the caller; only a vault instance
+    /// holding the same master key can decrypt them through `do_get`.
+    pub(crate) fn do_get_sealed(
+        &self,
+        namespace: &str,
+        key: &str,
+        version: Option<i32>,
+    ) -> Result<([u8; 12], Vec<u8>, i32), Status> {
+        if namespace.is_empty() {
+            return Err(Status::invalid_argument("namespace is required"));
+        }
+        if key.is_empty() {
+            return Err(Status::invalid_argument("key is required"));
+        }
+
+        let idx = self
+            .inner
+            .storage
+            .get_index(namespace, key)?
+            .ok_or_else(|| PasswordVaultError::NotFound(format!("{namespace}/{key}")))?;
+
+        let version_to_read = match version {
+            None => {
+                if idx.deleted_at_ms.is_some() {
+                    return Err(PasswordVaultError::NotFound(format!("{namespace}/{key}")).into());
+                }
+                idx.current_version
+            }
+            Some(v) if v < 0 => {
+                return Err(Status::invalid_argument("version must be >= 0"));
+            }
+            Some(v) => v as u32,
+        };
+
+        let stored = self
+            .inner
+            .storage
+            .get_version(namespace, key, version_to_read)?
+            .ok_or_else(|| {
+                PasswordVaultError::NotFound(format!("{namespace}/{key}/v{version_to_read}"))
+            })?;
+
+        Ok((stored.nonce, stored.ciphertext, stored.version as i32))
     }
 
     /// Internal list metadata — returns `(namespace, key, SecretIndex)` triples.
@@ -450,6 +580,41 @@ impl GenericSecretsService for GenericSecretsServiceImpl {
             key: req.key,
             version: req.version,
             deleted: true,
+        }))
+    }
+
+    async fn get_secret_sealed(
+        &self,
+        req: Request<GetSecretRequest>,
+    ) -> Result<Response<GetSecretSealedResponse>, Status> {
+        require_localhost_caller(&req)?;
+        let req = req.into_inner();
+        let (nonce, ciphertext, version) =
+            self.do_get_sealed(&req.namespace, &req.key, req.version)?;
+        Ok(Response::new(GetSecretSealedResponse {
+            namespace: req.namespace,
+            key: req.key,
+            nonce: nonce.to_vec(),
+            ciphertext,
+            version,
+        }))
+    }
+
+    async fn put_secret_sealed(
+        &self,
+        req: Request<PutSecretSealedRequest>,
+    ) -> Result<Response<PutSecretResponse>, Status> {
+        require_localhost_caller(&req)?;
+        let req = req.into_inner();
+        let metadata = self.do_put_sealed(
+            &req.namespace,
+            &req.key,
+            &req.nonce,
+            &req.ciphertext,
+            req.description.as_deref(),
+        )?;
+        Ok(Response::new(PutSecretResponse {
+            metadata: Some(metadata),
         }))
     }
 
@@ -1131,5 +1296,177 @@ mod tests {
             secrets.secrets[0].description.as_deref(),
             Some("updated desc")
         );
+    }
+
+    // ── Sealed Get/Put tests ──────────────────────────────────────────
+
+    /// Put plaintext, fetch the sealed `(nonce, ciphertext)`, then write
+    /// it back under a fresh `(namespace, key)` via PutSecretSealed.
+    /// Standard GetSecret on the new key must return the original
+    /// plaintext — proves the master key still owns the seal contract.
+    #[tokio::test]
+    async fn sealed_round_trip_via_put_sealed_then_get() {
+        let svc = fresh_service();
+
+        svc.put_secret(Request::new(PutSecretRequest {
+            namespace: "signing-keys".into(),
+            key: "kernel-dogfood-v1".into(),
+            value: "ed25519-privkey-bytes".into(),
+            description: Some("dogfood signing".into()),
+        }))
+        .await
+        .unwrap();
+
+        let sealed = svc
+            .get_secret_sealed(Request::new(GetSecretRequest {
+                namespace: "signing-keys".into(),
+                key: "kernel-dogfood-v1".into(),
+                version: None,
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(sealed.nonce.len(), 12);
+        assert!(!sealed.ciphertext.is_empty());
+        assert_eq!(sealed.version, 1);
+
+        svc.put_secret_sealed(Request::new(PutSecretSealedRequest {
+            namespace: "signing-keys".into(),
+            key: "kernel-dogfood-v1-restored".into(),
+            nonce: sealed.nonce,
+            ciphertext: sealed.ciphertext,
+            description: Some("rehydrated".into()),
+        }))
+        .await
+        .unwrap();
+
+        let got = svc
+            .get_secret(Request::new(GetSecretRequest {
+                namespace: "signing-keys".into(),
+                key: "kernel-dogfood-v1-restored".into(),
+                version: None,
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(got.value, "ed25519-privkey-bytes");
+    }
+
+    /// Sealed bytes from `GetSecretSealed` must NOT equal plaintext
+    /// (basic sanity that the data is actually encrypted under the
+    /// master key).
+    #[tokio::test]
+    async fn sealed_get_returns_opaque_bytes() {
+        let svc = fresh_service();
+        svc.put_secret(Request::new(PutSecretRequest {
+            namespace: "ns".into(),
+            key: "k".into(),
+            value: "plaintext-marker-abc123".into(),
+            description: None,
+        }))
+        .await
+        .unwrap();
+
+        let sealed = svc
+            .get_secret_sealed(Request::new(GetSecretRequest {
+                namespace: "ns".into(),
+                key: "k".into(),
+                version: None,
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+        assert!(!sealed
+            .ciphertext
+            .windows("plaintext-marker-abc123".len())
+            .any(|w| w == b"plaintext-marker-abc123"));
+    }
+
+    #[tokio::test]
+    async fn sealed_put_rejects_short_nonce() {
+        let svc = fresh_service();
+        let err = svc
+            .put_secret_sealed(Request::new(PutSecretSealedRequest {
+                namespace: "ns".into(),
+                key: "k".into(),
+                nonce: vec![0u8; 8],
+                ciphertext: vec![1u8; 32],
+                description: None,
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+    }
+
+    /// A non-loopback peer must be rejected before the sealed handler
+    /// touches storage — covers the dogfood threat model where vault's
+    /// outer gRPC bind is loopback-only but a misconfiguration would
+    /// otherwise expose the master-key bypass.
+    #[tokio::test]
+    async fn sealed_handlers_reject_non_loopback_peer() {
+        use tonic::transport::server::TcpConnectInfo;
+
+        let svc = fresh_service();
+        svc.put_secret(Request::new(PutSecretRequest {
+            namespace: "ns".into(),
+            key: "k".into(),
+            value: "v".into(),
+            description: None,
+        }))
+        .await
+        .unwrap();
+
+        let mut get_req = Request::new(GetSecretRequest {
+            namespace: "ns".into(),
+            key: "k".into(),
+            version: None,
+        });
+        get_req.extensions_mut().insert(TcpConnectInfo {
+            local_addr: Some("0.0.0.0:8080".parse().unwrap()),
+            remote_addr: Some("203.0.113.7:51000".parse().unwrap()),
+        });
+        let err = svc.get_secret_sealed(get_req).await.unwrap_err();
+        assert_eq!(err.code(), tonic::Code::PermissionDenied);
+
+        let mut put_req = Request::new(PutSecretSealedRequest {
+            namespace: "ns".into(),
+            key: "k".into(),
+            nonce: vec![0u8; 12],
+            ciphertext: vec![1u8; 32],
+            description: None,
+        });
+        put_req.extensions_mut().insert(TcpConnectInfo {
+            local_addr: Some("0.0.0.0:8080".parse().unwrap()),
+            remote_addr: Some("203.0.113.7:51000".parse().unwrap()),
+        });
+        let err = svc.put_secret_sealed(put_req).await.unwrap_err();
+        assert_eq!(err.code(), tonic::Code::PermissionDenied);
+    }
+
+    #[tokio::test]
+    async fn sealed_handlers_allow_loopback_peer() {
+        use tonic::transport::server::TcpConnectInfo;
+
+        let svc = fresh_service();
+        svc.put_secret(Request::new(PutSecretRequest {
+            namespace: "ns".into(),
+            key: "k".into(),
+            value: "v".into(),
+            description: None,
+        }))
+        .await
+        .unwrap();
+
+        let mut get_req = Request::new(GetSecretRequest {
+            namespace: "ns".into(),
+            key: "k".into(),
+            version: None,
+        });
+        get_req.extensions_mut().insert(TcpConnectInfo {
+            local_addr: Some("127.0.0.1:8080".parse().unwrap()),
+            remote_addr: Some("127.0.0.1:51000".parse().unwrap()),
+        });
+        let resp = svc.get_secret_sealed(get_req).await.unwrap().into_inner();
+        assert_eq!(resp.nonce.len(), 12);
     }
 }

--- a/rust/services/vault/Cargo.toml
+++ b/rust/services/vault/Cargo.toml
@@ -48,3 +48,8 @@ tempfile = "3"
 # Linux/macOS/Windows plugin-load regression gap surfaced by SEV
 # nexus-vfs#45.
 libloading = "0.8"
+# Real tonic server + client end-to-end in tests/grpc_e2e.rs — locks
+# in Discovery (2) (vault data layout) + the sealed Get/Put contract
+# under actual network transport.
+tokio-stream = { version = "0.1", features = ["net"] }
+tonic-prost = "0.14"

--- a/rust/services/vault/Cargo.toml
+++ b/rust/services/vault/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nexus-vault"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 description = "Nexus vault plugin — cdylib loaded by `nexusd-cluster` via `--plugin-dir`. Hosts PasswordVaultService as a dylib plugin with C ABI dispatch."
 authors = ["Nexus Team"]

--- a/rust/services/vault/src/lib.rs
+++ b/rust/services/vault/src/lib.rs
@@ -369,7 +369,9 @@ fn dispatch_grpc(plugin: &VaultPlugin, full_path: &str, payload: &[u8]) -> Resul
         ("nexus.secrets.v1.GenericSecretsService", "ListSecretVersions") => "secret_list_versions",
         ("nexus.secrets.v1.GenericSecretsService", "BatchPutSecrets") => "secret_batch_put",
         ("nexus.secrets.v1.GenericSecretsService", "BatchGetSecrets") => "secret_batch_get",
-        ("nexus.secrets.v1.GenericSecretsService", "DeleteSecretVersion") => "secret_delete_version",
+        ("nexus.secrets.v1.GenericSecretsService", "DeleteSecretVersion") => {
+            "secret_delete_version"
+        }
         ("nexus.secrets.v1.GenericSecretsService", "UpdateSecretDescription") => {
             "secret_update_description"
         }
@@ -410,6 +412,11 @@ declare_service_plugin!("password-vault", VaultPlugin, {
 // happens via the existing v2 symbol — no API version bump needed.
 //
 // Storage is `'static` so the kernel never frees the pointer.
+
+/// # Safety
+///
+/// Pure data lookup — returns a pointer to a `'static` null-terminated
+/// JSON byte slice. No invariants required from the caller.
 #[no_mangle]
 pub unsafe extern "C" fn nexus_plugin_grpc_services() -> *const c_char {
     const SERVICES_JSON: &[u8] = b"[\
@@ -524,11 +531,7 @@ mod dylib_e2e {
     unsafe extern "C" fn noop_rmdir(_: *const c_void, _: *const c_char) -> i32 {
         -1
     }
-    unsafe extern "C" fn noop_rename(
-        _: *const c_void,
-        _: *const c_char,
-        _: *const c_char,
-    ) -> i32 {
+    unsafe extern "C" fn noop_rename(_: *const c_void, _: *const c_char, _: *const c_char) -> i32 {
         -1
     }
 

--- a/rust/services/vault/src/lib.rs
+++ b/rust/services/vault/src/lib.rs
@@ -345,8 +345,10 @@ declare_service_plugin!("password-vault", VaultPlugin, {
 // Storage is `'static` so the kernel never frees the pointer.
 #[no_mangle]
 pub unsafe extern "C" fn nexus_plugin_grpc_services() -> *const c_char {
-    const SERVICES_JSON: &[u8] =
-        b"[\"nexus.secrets.v1.GenericSecretsService\",\"nexus.secrets.v1.PasswordVaultService\"]\0";
+    const SERVICES_JSON: &[u8] = b"[\
+        \"nexus.secrets.v1.GenericSecretsService\",\
+        \"nexus.password_vault.v1.PasswordVaultService\"\
+    ]\0";
     SERVICES_JSON.as_ptr() as *const c_char
 }
 
@@ -609,7 +611,7 @@ mod dylib_e2e {
             assert_eq!(
                 json,
                 "[\"nexus.secrets.v1.GenericSecretsService\",\
-                 \"nexus.secrets.v1.PasswordVaultService\"]"
+                 \"nexus.password_vault.v1.PasswordVaultService\"]"
             );
         }
     }

--- a/rust/services/vault/src/lib.rs
+++ b/rust/services/vault/src/lib.rs
@@ -16,6 +16,7 @@
 //!   /vault/versions/passwords/{title}/{v:010}   → StoredEntry
 //!   /vault/versions/{namespace}/{key}/{v:010}   → StoredEntry
 
+use std::ffi::c_char;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -333,6 +334,22 @@ declare_service_plugin!("password-vault", VaultPlugin, {
     dispatch: dispatch_vault,
 });
 
+// ── Optional Phase P symbol: opt this plugin into cluster gRPC routing ──
+//
+// Exposes the two gRPC service full names hosted by this plugin so
+// `nexusd-cluster` can route external tonic traffic at `/<service>/<method>`
+// into our `nexus_service_dispatch`. See `nexus-plugin-abi`'s
+// `symbols::SERVICE_GRPC_SERVICES` for the contract. Bytes-level dispatch
+// happens via the existing v2 symbol — no API version bump needed.
+//
+// Storage is `'static` so the kernel never frees the pointer.
+#[no_mangle]
+pub unsafe extern "C" fn nexus_plugin_grpc_services() -> *const c_char {
+    const SERVICES_JSON: &[u8] =
+        b"[\"nexus.secrets.v1.GenericSecretsService\",\"nexus.secrets.v1.PasswordVaultService\"]\0";
+    SERVICES_JSON.as_ptr() as *const c_char
+}
+
 // ── Dylib E2E tests — load the compiled cdylib via dlopen ─────────
 //
 // These tests verify the real C ABI boundary: dlopen → symbol lookup →
@@ -421,12 +438,41 @@ mod dylib_e2e {
     ) -> i32 {
         -1
     }
+    unsafe extern "C" fn noop_readdir(
+        _: *const c_void,
+        _: *const c_char,
+        _: *mut *mut u8,
+        _: *mut usize,
+    ) -> i32 {
+        -1
+    }
+    unsafe extern "C" fn noop_unlink(_: *const c_void, _: *const c_char) -> i32 {
+        -1
+    }
+    unsafe extern "C" fn noop_mkdir(_: *const c_void, _: *const c_char) -> i32 {
+        -1
+    }
+    unsafe extern "C" fn noop_rmdir(_: *const c_void, _: *const c_char) -> i32 {
+        -1
+    }
+    unsafe extern "C" fn noop_rename(
+        _: *const c_void,
+        _: *const c_char,
+        _: *const c_char,
+    ) -> i32 {
+        -1
+    }
 
     fn dummy_kernel_handle() -> nexus_plugin_abi::KernelHandle {
         nexus_plugin_abi::KernelHandle {
             sys_read: noop_read,
             sys_write: noop_write,
             sys_stat: noop_stat,
+            sys_readdir: noop_readdir,
+            sys_unlink: noop_unlink,
+            sys_mkdir: noop_mkdir,
+            sys_rmdir: noop_rmdir,
+            sys_rename: noop_rename,
             kernel_ptr: std::ptr::null(),
         }
     }
@@ -552,6 +598,18 @@ mod dylib_e2e {
             assert_eq!(
                 CStr::from_ptr(name_fn()).to_str().unwrap(),
                 "password-vault"
+            );
+
+            // ── Phase P opt-in: cluster reads this to route /<svc>/<method>
+            //     gRPC traffic into our nexus_service_dispatch. ──
+            let grpc_fn: libloading::Symbol<nexus_plugin_abi::PluginGrpcServicesFn> = lib
+                .get(nexus_plugin_abi::symbols::SERVICE_GRPC_SERVICES.as_bytes())
+                .expect("plugin_grpc_services");
+            let json = CStr::from_ptr(grpc_fn()).to_str().unwrap();
+            assert_eq!(
+                json,
+                "[\"nexus.secrets.v1.GenericSecretsService\",\
+                 \"nexus.secrets.v1.PasswordVaultService\"]"
             );
         }
     }

--- a/rust/services/vault/src/lib.rs
+++ b/rust/services/vault/src/lib.rs
@@ -123,6 +123,13 @@ fn create_vault(_kernel_handle: &KernelHandle) -> Box<VaultPlugin> {
 }
 
 fn dispatch_vault(plugin: &VaultPlugin, method: &str, payload: &[u8]) -> Result<Vec<u8>, i32> {
+    // Phase P bytes-level gRPC routing. Methods starting with '/' are
+    // full gRPC paths forwarded by `nexus-vfs` `PluginProxyService` —
+    // translate to the legacy short-name arms below so there is exactly
+    // one match table per concern.
+    if method.starts_with('/') {
+        return dispatch_grpc(plugin, method, payload);
+    }
     match method {
         "put_entry" => {
             let req = PutEntryRequest::decode(payload).map_err(|_| -2)?;
@@ -317,8 +324,68 @@ fn dispatch_vault(plugin: &VaultPlugin, method: &str, payload: &[u8]) -> Result<
             resp.encode(&mut buf).map_err(|_| -3)?;
             Ok(buf)
         }
+        "secret_get_sealed" => {
+            let req = secrets_proto::GetSecretRequest::decode(payload).map_err(|_| -2)?;
+            let resp = plugin
+                .rt
+                .block_on(plugin.secrets_svc.get_secret_sealed(Request::new(req)))
+                .map_err(status_to_plugin_error)?
+                .into_inner();
+            let mut buf = Vec::new();
+            resp.encode(&mut buf).map_err(|_| -3)?;
+            Ok(buf)
+        }
+        "secret_put_sealed" => {
+            let req = secrets_proto::PutSecretSealedRequest::decode(payload).map_err(|_| -2)?;
+            let resp = plugin
+                .rt
+                .block_on(plugin.secrets_svc.put_secret_sealed(Request::new(req)))
+                .map_err(status_to_plugin_error)?
+                .into_inner();
+            let mut buf = Vec::new();
+            resp.encode(&mut buf).map_err(|_| -3)?;
+            Ok(buf)
+        }
         _ => Err(-1), // PluginResult::NotFound
     }
+}
+
+/// Translate a Phase P bytes-level gRPC path into a `dispatch_vault`
+/// legacy method name, then re-enter. Keeping a single match table
+/// per concern avoids duplicating prost-decode + tonic-call boilerplate.
+///
+/// `full_path` is the gRPC `:path` header verbatim, including the
+/// leading `/` (e.g. `/nexus.secrets.v1.GenericSecretsService/PutSecret`).
+fn dispatch_grpc(plugin: &VaultPlugin, full_path: &str, payload: &[u8]) -> Result<Vec<u8>, i32> {
+    let path = full_path.trim_start_matches('/');
+    let (service, method) = path.split_once('/').ok_or(-2)?;
+    let legacy = match (service, method) {
+        // GenericSecretsService
+        ("nexus.secrets.v1.GenericSecretsService", "PutSecret") => "secret_put",
+        ("nexus.secrets.v1.GenericSecretsService", "GetSecret") => "secret_get",
+        ("nexus.secrets.v1.GenericSecretsService", "DeleteSecret") => "secret_delete",
+        ("nexus.secrets.v1.GenericSecretsService", "RestoreSecret") => "secret_restore",
+        ("nexus.secrets.v1.GenericSecretsService", "ListSecrets") => "secret_list",
+        ("nexus.secrets.v1.GenericSecretsService", "ListSecretVersions") => "secret_list_versions",
+        ("nexus.secrets.v1.GenericSecretsService", "BatchPutSecrets") => "secret_batch_put",
+        ("nexus.secrets.v1.GenericSecretsService", "BatchGetSecrets") => "secret_batch_get",
+        ("nexus.secrets.v1.GenericSecretsService", "DeleteSecretVersion") => "secret_delete_version",
+        ("nexus.secrets.v1.GenericSecretsService", "UpdateSecretDescription") => {
+            "secret_update_description"
+        }
+        ("nexus.secrets.v1.GenericSecretsService", "GetSecretSealed") => "secret_get_sealed",
+        ("nexus.secrets.v1.GenericSecretsService", "PutSecretSealed") => "secret_put_sealed",
+        // PasswordVaultService
+        ("nexus.password_vault.v1.PasswordVaultService", "PutEntry") => "put_entry",
+        ("nexus.password_vault.v1.PasswordVaultService", "GetEntry") => "get_entry",
+        ("nexus.password_vault.v1.PasswordVaultService", "ListEntries") => "list_entries",
+        ("nexus.password_vault.v1.PasswordVaultService", "DeleteEntry") => "delete_entry",
+        ("nexus.password_vault.v1.PasswordVaultService", "RestoreEntry") => "restore_entry",
+        ("nexus.password_vault.v1.PasswordVaultService", "ListVersions") => "list_versions",
+        ("nexus.password_vault.v1.PasswordVaultService", "GenerateTotp") => "generate_totp",
+        _ => return Err(-1), // PluginResult::NotFound
+    };
+    dispatch_vault(plugin, legacy, payload)
 }
 
 fn status_to_plugin_error(status: tonic::Status) -> i32 {
@@ -2125,5 +2192,133 @@ mod dispatch_e2e {
         );
 
         println!("\n=== Migration verification PASSED ===");
+    }
+
+    // ── Phase P bytes-level gRPC dispatch ─────────────────────────────
+
+    #[test]
+    fn grpc_path_routes_generic_secrets_put_get() {
+        let (_dir, plugin) = fresh_plugin();
+
+        let put = encode(&secrets_proto::PutSecretRequest {
+            namespace: "provider:openai".into(),
+            key: "api_key".into(),
+            value: "sk-grpc-routed".into(),
+            description: None,
+        });
+        let resp = dispatch_vault(
+            &plugin,
+            "/nexus.secrets.v1.GenericSecretsService/PutSecret",
+            &put,
+        )
+        .unwrap();
+        let put_resp = secrets_proto::PutSecretResponse::decode(resp.as_slice()).unwrap();
+        assert_eq!(put_resp.metadata.as_ref().unwrap().current_version, 1);
+
+        let get = encode(&secrets_proto::GetSecretRequest {
+            namespace: "provider:openai".into(),
+            key: "api_key".into(),
+            version: None,
+        });
+        let resp = dispatch_vault(
+            &plugin,
+            "/nexus.secrets.v1.GenericSecretsService/GetSecret",
+            &get,
+        )
+        .unwrap();
+        let got = secrets_proto::GetSecretResponse::decode(resp.as_slice()).unwrap();
+        assert_eq!(got.value, "sk-grpc-routed");
+    }
+
+    #[test]
+    fn grpc_path_routes_password_vault_put_entry() {
+        let (_dir, plugin) = fresh_plugin();
+        let payload = encode(&PutEntryRequest {
+            entry: Some(entry("grpc-routed", "pw", None)),
+            audit: None,
+        });
+        let resp = dispatch_vault(
+            &plugin,
+            "/nexus.password_vault.v1.PasswordVaultService/PutEntry",
+            &payload,
+        )
+        .unwrap();
+        let put_resp = PutEntryResponse::decode(resp.as_slice()).unwrap();
+        assert_eq!(put_resp.title, "grpc-routed");
+    }
+
+    #[test]
+    fn grpc_path_routes_sealed_round_trip() {
+        let (_dir, plugin) = fresh_plugin();
+
+        let put = encode(&secrets_proto::PutSecretRequest {
+            namespace: "signing-keys".into(),
+            key: "dogfood".into(),
+            value: "ed25519-bytes".into(),
+            description: None,
+        });
+        dispatch_vault(
+            &plugin,
+            "/nexus.secrets.v1.GenericSecretsService/PutSecret",
+            &put,
+        )
+        .unwrap();
+
+        let get_sealed = encode(&secrets_proto::GetSecretRequest {
+            namespace: "signing-keys".into(),
+            key: "dogfood".into(),
+            version: None,
+        });
+        let resp = dispatch_vault(
+            &plugin,
+            "/nexus.secrets.v1.GenericSecretsService/GetSecretSealed",
+            &get_sealed,
+        )
+        .unwrap();
+        let sealed = secrets_proto::GetSecretSealedResponse::decode(resp.as_slice()).unwrap();
+        assert_eq!(sealed.nonce.len(), 12);
+        assert!(!sealed.ciphertext.is_empty());
+
+        let put_sealed = encode(&secrets_proto::PutSecretSealedRequest {
+            namespace: "signing-keys".into(),
+            key: "dogfood-restored".into(),
+            nonce: sealed.nonce,
+            ciphertext: sealed.ciphertext,
+            description: None,
+        });
+        dispatch_vault(
+            &plugin,
+            "/nexus.secrets.v1.GenericSecretsService/PutSecretSealed",
+            &put_sealed,
+        )
+        .unwrap();
+
+        let get = encode(&secrets_proto::GetSecretRequest {
+            namespace: "signing-keys".into(),
+            key: "dogfood-restored".into(),
+            version: None,
+        });
+        let resp = dispatch_vault(
+            &plugin,
+            "/nexus.secrets.v1.GenericSecretsService/GetSecret",
+            &get,
+        )
+        .unwrap();
+        let got = secrets_proto::GetSecretResponse::decode(resp.as_slice()).unwrap();
+        assert_eq!(got.value, "ed25519-bytes");
+    }
+
+    #[test]
+    fn grpc_path_unknown_service_returns_not_found() {
+        let (_dir, plugin) = fresh_plugin();
+        let err = dispatch_vault(&plugin, "/some.unknown.Svc/Foo", &[]).unwrap_err();
+        assert_eq!(err, -1);
+    }
+
+    #[test]
+    fn grpc_path_missing_method_returns_invalid_argument() {
+        let (_dir, plugin) = fresh_plugin();
+        let err = dispatch_vault(&plugin, "/no-method-separator-here", &[]).unwrap_err();
+        assert_eq!(err, -2);
     }
 }

--- a/rust/services/vault/tests/grpc_e2e.rs
+++ b/rust/services/vault/tests/grpc_e2e.rs
@@ -1,0 +1,214 @@
+//! gRPC end-to-end integration test for the dogfood signing path.
+//!
+//! Locks in the empirical findings of the 2026-06-13 verification:
+//!
+//!   Discovery (1) — pre-Phase-P, external `PutSecret` returned
+//!                   `UNIMPLEMENTED` because cluster routes never
+//!                   wired the plugin service. Phase P fixes this at
+//!                   the cluster layer; here we keep a regression
+//!                   test of vault's tonic-server contract so any
+//!                   future tonic-trait drift on vault's side fails
+//!                   at PR time rather than dogfood-runtime.
+//!
+//!   Discovery (2) — vault's data layout (`NEXUS_DATA_DIR/vault/`
+//!                   with `master.key` + `vault-meta.redb` + `content/`)
+//!                   is created by `create_vault` and must round-trip
+//!                   plaintext through real network transport.
+//!
+//! The test stands up `GenericSecretsServiceImpl` against a fresh
+//! kernel + path-local backend in a temp dir, hosts it under a real
+//! `tonic::transport::Server` bound to `127.0.0.1:0`, and exercises:
+//!
+//!   1. `PutSecret` → `GetSecret` round-trip                  (plaintext path)
+//!   2. `GetSecretSealed` → `PutSecretSealed` (fresh key)
+//!      → `GetSecret`                                          (sealed path)
+//!
+//! Non-localhost peer rejection is covered by the unit tests in
+//! `services::generic_secrets::tests::sealed_handlers_reject_non_loopback_peer`
+//! — the integration test can only observe real TCP peers and so
+//! always sees loopback by construction.
+
+use std::sync::Arc;
+
+use kernel::abc::object_store::ObjectStore;
+use services::generic_secrets::proto::generic_secrets_service_client::GenericSecretsServiceClient;
+use services::generic_secrets::proto::generic_secrets_service_server::GenericSecretsServiceServer;
+use services::generic_secrets::proto::*;
+use services::generic_secrets::GenericSecretsServiceImpl;
+use services::password_vault::crypto;
+use tempfile::TempDir;
+use tokio::net::TcpListener;
+use tokio_stream::wrappers::TcpListenerStream;
+
+struct Harness {
+    _dir: TempDir,
+    addr: std::net::SocketAddr,
+    shutdown: tokio::sync::oneshot::Sender<()>,
+    server: tokio::task::JoinHandle<()>,
+}
+
+impl Harness {
+    async fn start() -> Self {
+        let dir = TempDir::new().unwrap();
+        let vault_dir = dir.path().join("vault");
+        std::fs::create_dir_all(&vault_dir).unwrap();
+
+        let kernel = Arc::new(kernel::kernel::Kernel::new());
+        let meta_path = vault_dir.join("vault-meta.redb");
+        kernel
+            .set_metastore_path(meta_path.to_str().unwrap())
+            .unwrap();
+
+        let content_dir = vault_dir.join("content");
+        let backend: Arc<dyn ObjectStore> = Arc::new(
+            backends::storage::path_local::PathLocalBackend::new(&content_dir, true).unwrap(),
+        );
+        let backend_name = backend.name().to_string();
+
+        kernel
+            .sys_setattr(
+                "/vault",
+                /* DT_MOUNT */ 2,
+                &backend_name,
+                Some(backend),
+                None,
+                None,
+                "memory",
+                "root",
+                false,
+                0,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+            .unwrap();
+
+        let master_key_path = vault_dir.join("master.key");
+        let master_key = crypto::load_or_create_master_key(&master_key_path).unwrap();
+
+        let svc =
+            GenericSecretsServiceImpl::new_on_existing_mount(kernel, "/vault", master_key).unwrap();
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+        let server = tokio::spawn(async move {
+            tonic::transport::Server::builder()
+                .add_service(GenericSecretsServiceServer::new(svc))
+                .serve_with_incoming_shutdown(TcpListenerStream::new(listener), async move {
+                    let _ = shutdown_rx.await;
+                })
+                .await
+                .expect("tonic server");
+        });
+
+        Self {
+            _dir: dir,
+            addr,
+            shutdown: shutdown_tx,
+            server,
+        }
+    }
+
+    fn url(&self) -> String {
+        format!("http://{}", self.addr)
+    }
+
+    async fn shutdown(self) {
+        let _ = self.shutdown.send(());
+        let _ = self.server.await;
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn put_get_round_trip_through_real_grpc_transport() {
+    let h = Harness::start().await;
+    let mut client = GenericSecretsServiceClient::connect(h.url()).await.unwrap();
+
+    let put = client
+        .put_secret(PutSecretRequest {
+            namespace: "provider:openai".into(),
+            key: "api_key".into(),
+            value: "sk-grpc-e2e".into(),
+            description: Some("E2E".into()),
+        })
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(put.metadata.as_ref().unwrap().current_version, 1);
+
+    let got = client
+        .get_secret(GetSecretRequest {
+            namespace: "provider:openai".into(),
+            key: "api_key".into(),
+            version: None,
+        })
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(got.value, "sk-grpc-e2e");
+    assert_eq!(got.version, 1);
+
+    h.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn sealed_round_trip_through_real_grpc_transport() {
+    let h = Harness::start().await;
+    let mut client = GenericSecretsServiceClient::connect(h.url()).await.unwrap();
+
+    client
+        .put_secret(PutSecretRequest {
+            namespace: "signing-keys".into(),
+            key: "kernel-dogfood-v1".into(),
+            value: "ed25519-grpc-e2e-bytes".into(),
+            description: None,
+        })
+        .await
+        .unwrap();
+
+    let sealed = client
+        .get_secret_sealed(GetSecretRequest {
+            namespace: "signing-keys".into(),
+            key: "kernel-dogfood-v1".into(),
+            version: None,
+        })
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(sealed.nonce.len(), 12);
+    assert!(!sealed.ciphertext.is_empty());
+
+    client
+        .put_secret_sealed(PutSecretSealedRequest {
+            namespace: "signing-keys".into(),
+            key: "kernel-dogfood-v1-restored".into(),
+            nonce: sealed.nonce,
+            ciphertext: sealed.ciphertext,
+            description: Some("rehydrated by E2E".into()),
+        })
+        .await
+        .unwrap();
+
+    let restored = client
+        .get_secret(GetSecretRequest {
+            namespace: "signing-keys".into(),
+            key: "kernel-dogfood-v1-restored".into(),
+            version: None,
+        })
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(restored.value, "ed25519-grpc-e2e-bytes");
+
+    h.shutdown().await;
+}


### PR DESCRIPTION
## Summary

Phase E' of the plugin-signing dogfood plan — readies `vault.dylib` for
release `vault-v0.1.3`:

1. **Opt vault into Phase P's plugin-as-gRPC-service routing**
   (nexus-vfs#57 `5ac7d15c3`). `nexusd-cluster` now serves vault's
   `GenericSecretsService` + `PasswordVaultService` on its main gRPC
   port; vault exports the new optional `nexus_plugin_grpc_services`
   symbol and dispatches `/<service>/<method>` traffic through the
   existing bytes-level `nexus_service_dispatch`. No plugin-ABI version
   bump (the new symbol is additive).

2. **Sealed `Get`/`Put` RPCs** on `GenericSecretsService` for the
   encrypted-in-git signing-key keystore. Callers exchange the raw
   AES-256-GCM `(nonce, ciphertext)` pair without touching the master
   key. Localhost-only via peer-address gate (non-loopback callers get
   `PERMISSION_DENIED`).

3. **Discovery (1) + (2) regression locks** via a real-tonic end-to-end
   test that boots vault against a fresh `NEXUS_DATA_DIR` and round-
   trips both plaintext + sealed paths through loopback gRPC.

Closes the architectural follow-up to PR #4376; unblocks Phase D'
(sealed-keystore CI + `dogfood_keystore_fetch.py`) and Phase B2'
(`kernel-dogfood-v1` provisioning).

## Why sealed Get/Put over alternatives

Empirical 2026-06-13 verification proved `vault-meta.redb` is dirtied
on mere open+close, so the original "commit vault's internal files to
git" approach is unbuildable. Sealed Get/Put commits only opaque
ciphertext + a JSON-friendly keystore, while vault stays the SSOT for
the master-key contract.

## Commits (granular per concern, no squash)

1. `feat(workspace)`: bump nexus-vfs pin to 5ac7d15c3 (Phase P)
2. `feat(vault/proto)`: sealed Get/Put RPCs in secrets.proto
3. `feat(vault/secrets)`: sealed Get/Put impls + localhost auth + unit tests
4. `feat(vault)`: export nexus_plugin_grpc_services for cluster routing
5. `fix(vault)`: correct PasswordVaultService package in grpc_services JSON
6. `feat(vault)`: full-path gRPC dispatch in nexus_service_dispatch
7. `test(vault)`: grpc_e2e covers Discovery (1)+(2) regressions
8. `feat(vault)`: bump version to 0.1.3
9. `feat(plugin-callers)`: propagate KernelHandle Phase P fields
10. `style(vault)`: cargo fmt + clippy::missing_safety_doc

## Test plan

- [x] `cargo test -p services --features service-generic-secrets,service-password-vault generic_secrets::tests::sealed` — 5 new tests pass
- [x] `cargo test -p nexus-vault --lib` — 30 tests pass (5 new `grpc_path_*` covering bytes-level dispatch)
- [x] `cargo test -p nexus-vault --test grpc_e2e` — 2 new tests pass (real-tonic plaintext + sealed round-trips)
- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [ ] CI green on PR
- [ ] After merge: tag `vault-v0.1.3` to fire `release-vault-plugin.yml`

## Follow-ups (not in this PR)

- Phase D': sealed-keystore CI + `dogfood_keystore_fetch.py` (fresh PR cut from develop)
- Phase B2': provision `kernel-dogfood-v1` (depends on D' + nexus-vfs trust-root PR)
- Phase C': dogfood-sign `local-connector` + `fuse-plugin` releases