### PR TITLE
feat(vault-signing): provision kernel-dogfood-v1 + cluster-flag fixes

### DIFF
--- a/data/vault-signing/keys.json
+++ b/data/vault-signing/keys.json
@@ -1,1 +1,8 @@
-{}
+{
+  "kernel-dogfood-v1": {
+    "ciphertext": "MstEIrXkO/PGCOmTr9M9yeHZOB/ZA1MZploDlMrWEyWAuB8WTh6wtWa0SHOjqpALN1R/iR4+wBT4tIgy",
+    "description": "kernel team dogfood signing root v1",
+    "namespace": "signing-keys",
+    "nonce": "+9Ouo7AxPCkcI4XJ"
+  }
+}

--- a/data/vault-signing/pubkeys/kernel-dogfood-v1.pub
+++ b/data/vault-signing/pubkeys/kernel-dogfood-v1.pub
@@ -1,0 +1,1 @@
+G9SouryyJSBYRzH/EfPnoU2eLGH6RbQ56rxHS/tJkkU=

--- a/scripts/_dogfood_vault.py
+++ b/scripts/_dogfood_vault.py
@@ -174,20 +174,37 @@ def boot_cluster(
     plugin_dir = data_dir / "plugins"
     plugin_dir.mkdir(parents=True, exist_ok=True)
     (plugin_dir / vault_dylib.name).write_bytes(vault_dylib.read_bytes())
+    # The cluster's plugin loader requires `<plugin>.sig` next to the
+    # binary and Ed25519-verifies the dylib bytes against the embedded
+    # `trusted_keys/*.pub`. Carry the sig that ships in the release
+    # archive — the dylib without it is rejected at boot.
+    sig_src = vault_dylib.with_name(vault_dylib.name + ".sig")
+    if sig_src.is_file():
+        (plugin_dir / sig_src.name).write_bytes(sig_src.read_bytes())
 
     port = free_port()
     env = os.environ.copy()
     env["NEXUS_DATA_DIR"] = str(data_dir)
     env["RUST_LOG"] = env.get("RUST_LOG", "warn")
 
+    # `--bind-addr` (not `--bind`) and an explicit `--bootstrap-mode`
+    # are both required for daemon mode; without them the cluster either
+    # rejects the CLI or silently picks a non-ephemeral path. `static`
+    # = single-node, no federation — the right shape for a tempdir-only
+    # ephemeral vault. `--data-dir` keeps every redb file inside the
+    # tempdir so the cluster has no path to anything persistent.
     proc = subprocess.Popen(
         [
             str(nexusd_cluster),
             "--plugin-dir",
             str(plugin_dir),
+            "--data-dir",
+            str(data_dir),
             "--no-tls",
-            "--bind",
+            "--bind-addr",
             f"127.0.0.1:{port}",
+            "--bootstrap-mode",
+            "static",
         ],
         env=env,
         stdout=subprocess.PIPE,


### PR DESCRIPTION
## Summary

Phase B2a' — first signing entry in the sealed-keystore plugin
signing chain. Bundles two concerns:

  1. **Bug fix in `_dogfood_vault.boot_cluster`** — three real
     nexusd-cluster CLI bugs surfaced when running provision for the
     first time against an actual binary:
     - `--bind` → `--bind-addr`
     - `--bootstrap-mode static` is required for daemon mode
     - `--data-dir` was missing so cluster wrote redb into the
       operator's CWD
     Also: copy the `<plugin>.sig` sibling alongside the dylib so
     the kernel's plugin loader doesn't silently skip vault with a
     "missing signature" warning (which then makes the downstream
     `PutSecret` look like a Phase P routing regression).

  2. **`data/vault-signing/{keys.json, pubkeys/kernel-dogfood-v1.pub}`**
     — provisioned locally 2026-06-13 against the
     `VAULT_SIGNING_MASTER_KEY` repo secret.

The matching pubkey lands in nexus-vfs's `TRUSTED_KEY_FILES` via
[`nexi-lab/nexus-vfs#58`](https://github.com/nexi-lab/nexus-vfs/pull/58)
— **merge that first** so any cluster build picking up a
`kernel-dogfood-v1`-signed plugin already trusts the root.

## Round-trip verification

Done on the para-pc Windows box with the rebuilt nexusd-cluster at
`5ac7d15c3` (workspace pin) + `vault-v0.1.3` Windows release dylib:

1. `provision_dogfood_key.py` → wrote keys.json + pubkey + ran the
   sign-verify self-test against the in-memory keypair.
2. `dogfood_keystore_fetch.py` (separate fresh ephemeral cluster,
   same master key) → returned the plaintext privkey.
3. Signed a sample blob with the fetched privkey; the committed
   pubkey verified the signature.

## Sequencing

| Order | Action |
|---|---|
| 1 | nexus-vfs#58 merges → trust root has `kernel-dogfood-v1.pub` |
| 2 | This PR merges → nexus source tree has the sealed keystore entry |
| 3 | nexus workspace pin bump to nexus-vfs HEAD (separate small PR) |
| 4 | C2a' — tag `local-connector-v0.1.1`; CI exercises sealed-keystore path |
| 5 | C2b' — tag `fuse-plugin-v0.1.0`; same path |

## Test plan

- [x] Round-trip locally (provision → fetch → sign → verify)
- [x] `cargo check -p kernel` on nexus-vfs side
- [ ] CI green on this PR
- [ ] CI green on nexus-vfs#58
- [ ] After both merge: pin bump PR, then C2a'/C2b'