### PR TITLE
chore: bump nexus-vfs pin to 69fae7239 (trust root) + local-connector 0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5ac7d15c3e25e9bfb2d9d64fecb3c2daeae48d9c#5ac7d15c3e25e9bfb2d9d64fecb3c2daeae48d9c"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=69fae723945bf47f1e42a1753f5deecaf2bb0713#69fae723945bf47f1e42a1753f5deecaf2bb0713"
 dependencies = [
  "ahash",
  "base64",
@@ -510,7 +510,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5ac7d15c3e25e9bfb2d9d64fecb3c2daeae48d9c#5ac7d15c3e25e9bfb2d9d64fecb3c2daeae48d9c"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=69fae723945bf47f1e42a1753f5deecaf2bb0713#69fae723945bf47f1e42a1753f5deecaf2bb0713"
 dependencies = [
  "parking_lot",
  "serde",
@@ -1293,7 +1293,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5ac7d15c3e25e9bfb2d9d64fecb3c2daeae48d9c#5ac7d15c3e25e9bfb2d9d64fecb3c2daeae48d9c"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=69fae723945bf47f1e42a1753f5deecaf2bb0713#69fae723945bf47f1e42a1753f5deecaf2bb0713"
 dependencies = [
  "ahash",
  "base64",
@@ -1350,7 +1350,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5ac7d15c3e25e9bfb2d9d64fecb3c2daeae48d9c#5ac7d15c3e25e9bfb2d9d64fecb3c2daeae48d9c"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=69fae723945bf47f1e42a1753f5deecaf2bb0713#69fae723945bf47f1e42a1753f5deecaf2bb0713"
 dependencies = [
  "ahash",
  "base64",
@@ -1519,7 +1519,7 @@ dependencies = [
 
 [[package]]
 name = "nexus-local-connector"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "backends",
  "kernel",
@@ -1532,7 +1532,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5ac7d15c3e25e9bfb2d9d64fecb3c2daeae48d9c#5ac7d15c3e25e9bfb2d9d64fecb3c2daeae48d9c"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=69fae723945bf47f1e42a1753f5deecaf2bb0713#69fae723945bf47f1e42a1753f5deecaf2bb0713"
 
 [[package]]
 name = "nexus-vault"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,20 +30,21 @@ exclude = ["nexus-fuse"]
 [workspace.dependencies]
 # Kernel-tier crates from nexus-vfs (external git dependency).
 # SSOT: https://github.com/nexi-lab/nexus-vfs
-# Pinned at the nexus-vfs main commit that landed #57 (Phase P —
-# plugin-as-gRPC-service routing). Cluster now routes plugin-exposed
-# gRPC services on the same port + trust root as VFS, via the optional
-# `nexus_plugin_grpc_services` symbol + bytes-level dispatch through
-# the existing `nexus_service_dispatch`. Required for vault.dylib to
-# serve external PutSecret/GetSecret calls. Bump alongside the rest of
-# nexus-vfs updates when a downstream change needs newer kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5ac7d15c3e25e9bfb2d9d64fecb3c2daeae48d9c" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5ac7d15c3e25e9bfb2d9d64fecb3c2daeae48d9c" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5ac7d15c3e25e9bfb2d9d64fecb3c2daeae48d9c" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5ac7d15c3e25e9bfb2d9d64fecb3c2daeae48d9c", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5ac7d15c3e25e9bfb2d9d64fecb3c2daeae48d9c", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5ac7d15c3e25e9bfb2d9d64fecb3c2daeae48d9c", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5ac7d15c3e25e9bfb2d9d64fecb3c2daeae48d9c" }
+# Pinned at the nexus-vfs main commit that landed #58 (drop
+# `kernel-dogfood-v1.pub` into TRUSTED_KEY_FILES). Required so cluster
+# builds in CI verify plugins signed by the sealed-keystore root.
+# Builds on the Phase P (#57) plugin-as-gRPC-service routing: cluster
+# routes plugin-exposed gRPC services on the same port + trust root as
+# VFS via `nexus_plugin_grpc_services` + bytes-level dispatch through
+# `nexus_service_dispatch`. Bump alongside the rest of nexus-vfs
+# updates when a downstream change needs newer kernel bits.
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "69fae723945bf47f1e42a1753f5deecaf2bb0713" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "69fae723945bf47f1e42a1753f5deecaf2bb0713" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "69fae723945bf47f1e42a1753f5deecaf2bb0713" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "69fae723945bf47f1e42a1753f5deecaf2bb0713", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "69fae723945bf47f1e42a1753f5deecaf2bb0713", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "69fae723945bf47f1e42a1753f5deecaf2bb0713", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "69fae723945bf47f1e42a1753f5deecaf2bb0713" }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ENV CARGO_NET_RETRY=10 \
     CARGO_HTTP_TIMEOUT=120
 # Override for edge/CI or a different pin: --build-arg NEXUS_VFS_REV=<sha|tag>
-ARG NEXUS_VFS_REV=5ac7d15c3e25e9bfb2d9d64fecb3c2daeae48d9c
+ARG NEXUS_VFS_REV=69fae723945bf47f1e42a1753f5deecaf2bb0713
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,id=cargo-install-${TARGETARCH},target=/root/.cargo/target \

--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir --no-deps --prefix=/install .
 # enforces agreement) — an unpinned install tracks nexus-vfs HEAD and
 # ships an untested kernel (#4343). --locked honors the source tree's
 # Cargo.lock.
-ARG NEXUS_VFS_REV=5ac7d15c3e25e9bfb2d9d64fecb3c2daeae48d9c
+ARG NEXUS_VFS_REV=69fae723945bf47f1e42a1753f5deecaf2bb0713
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-cluster nexus-cluster
 
 # -- Runtime stage --

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -25,7 +25,7 @@ WORKDIR /build
 # (CI preflight enforces agreement) — an unpinned install tracks HEAD
 # and can skew the raft contract against the cluster/witness images.
 # --locked honors the source tree's Cargo.lock.
-ARG NEXUS_VFS_REV=5ac7d15c3e25e9bfb2d9d64fecb3c2daeae48d9c
+ARG NEXUS_VFS_REV=69fae723945bf47f1e42a1753f5deecaf2bb0713
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexus-raft-server raft
 
 # ---------- Production image ----------

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=5ac7d15c3e25e9bfb2d9d64fecb3c2daeae48d9c
+ARG NEXUS_VFS_REV=69fae723945bf47f1e42a1753f5deecaf2bb0713
 RUN cargo install \
     --locked \
     --git https://github.com/nexi-lab/nexus-vfs \

--- a/rust/backends/local-connector/Cargo.toml
+++ b/rust/backends/local-connector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nexus-local-connector"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "Nexus local-connector plugin — cdylib loaded by `nexusd-cluster` via `--plugin-dir`. Wraps `backends::storage::local_connector::LocalConnectorBackend` as a driver dylib so operators can mount a host filesystem path through the kernel's normal VFS surface (and, by extension, through federation)."
 authors = ["Nexus Team"]


### PR DESCRIPTION
## Summary

Pin bump + local-connector version bump in preparation for C2a' /
C2b' tags.

nexus-vfs#58 merged at `69fae7239` — drops `kernel-dogfood-v1.pub`
into `TRUSTED_KEY_FILES`. Cluster builds picking up plugins signed by
the sealed-keystore root now verify against the right trust chain.

## Files

| File | Change |
|---|---|
| `Cargo.toml` (workspace) | rev → `69fae7239...` |
| `Cargo.lock` | propagate the new git hash |
| `Dockerfile`, `dockerfiles/Dockerfile.{minimal,raft-server,raft-witness}` | `ARG NEXUS_VFS_REV` → same rev (smoke-test enforces alignment) |
| `rust/backends/local-connector/Cargo.toml` | 0.1.0 → 0.1.1 (C2a tag target) |

`rust/services/fuse-plugin/Cargo.toml` stays at 0.1.0 — C2b cuts the
first tag at that version.

## Test plan

- [x] `cargo update -p contracts -p lib -p backends -p kernel -p nexus-plugin-abi` clean
- [ ] CI green on PR (nexusd-cluster smoke-test enforces the four pins agree)
- [ ] After merge: tag `local-connector-v0.1.1` → release-plugin-reusable runs the sealed-keystore vault path for the first time
- [ ] After merge: tag `fuse-plugin-v0.1.0` → same path, Linux-only matrix