### PR TITLE
fix(ci+scripts): handle linux-only plugins + harden master-key parse

### DIFF
--- a/.github/workflows/release-plugin-reusable.yml
+++ b/.github/workflows/release-plugin-reusable.yml
@@ -446,7 +446,18 @@ jobs:
         id: checksums
         working-directory: release-assets
         run: |
-          CHECKSUMS=$(sha256sum *.tar.gz *.zip)
+          set -euo pipefail
+          # Glob expansion would fail noisily when a plugin ships
+          # without one of the archive shapes (e.g. fuse-plugin is
+          # linux-only → no .zip). List exactly the files that exist.
+          shopt -s nullglob
+          ARCHIVES=( *.tar.gz *.zip )
+          shopt -u nullglob
+          if [ ${#ARCHIVES[@]} -eq 0 ]; then
+            echo "::error::no archives in release-assets/"
+            exit 1
+          fi
+          CHECKSUMS=$(sha256sum "${ARCHIVES[@]}")
           echo "$CHECKSUMS"
           {
             echo "checksums<<EOF"

--- a/scripts/_dogfood_vault.py
+++ b/scripts/_dogfood_vault.py
@@ -86,7 +86,12 @@ def shred_bytes(buf: bytes | bytearray) -> None:
 
 
 def read_master_key_from_env(env_var: str = "VAULT_SIGNING_MASTER_KEY") -> bytes:
-    raw = os.environ.get(env_var, "").strip()
+    # Drop ALL whitespace (not just leading/trailing) — secrets pasted
+    # through GitHub UI or shell pipelines occasionally carry embedded
+    # \r, \n, or spaces that survive a plain .strip(). `validate=True`
+    # in the next step rejects any surviving non-base64 char so a
+    # genuinely garbled value still fails loudly.
+    raw = "".join(os.environ.get(env_var, "").split())
     if not raw:
         raise SystemExit(f"{env_var} env var is required")
     try:


### PR DESCRIPTION
## Summary

Hotfixes caught by the first end-to-end exercise of the sealed-keystore
vault signing path (`fuse-v0.1.0` tag → release-plugin-reusable run).

### Bug 1 — `*.zip` glob on linux-only plugins

The `Compute SHA256 checksums` step ran `sha256sum *.tar.gz *.zip`,
which errors when no `*.zip` exists. `fuse-plugin` is Linux-only by
design (\`platforms: '[\"linux-x86_64\"]'\` in its wrapper), so the
package step has only `.tar.gz` to checksum. Switch to
\`shopt -s nullglob\` so missing archive shapes contribute nothing.

### Bug 2 — master-key parse rejects CRLF leftovers

\`read_master_key_from_env\` only \`.strip()\`s the env value, which
leaves mid-string whitespace alone but also fails to handle a
trailing \`\r\` that survived \`gh secret set --body -\` on a CRLF
file. Switch to \`\"\".join(raw.split())\` so every flavor of
whitespace is stripped before \`b64decode(validate=True)\`. The
validate step still rejects truly garbled inputs, so the
loud-failure behavior is preserved for non-base64 chars.

## Test plan

- [ ] CI green on PR
- [ ] After merge: re-trigger fuse-v0.1.0 and local-connector-v0.1.1
  release runs (gh run rerun \<id\>); both should now succeed end-to-end.