### PR TITLE
feat(fuse-plugin): macOS support + Docker E2E (Phase B-3/B-4)

### DIFF
--- a/.github/workflows/fuse-plugin-e2e.yml
+++ b/.github/workflows/fuse-plugin-e2e.yml
@@ -1,0 +1,208 @@
+name: FUSE Plugin E2E
+
+# Runs `tests/e2e/docker/test_fuse_plugin_e2e.py` against the single-
+# node cluster in `dockerfiles/docker-compose.fuse-plugin.yml`.
+#
+# The suite mounts `nexus-fuse-plugin` inside a privileged container
+# (/dev/fuse + SYS_ADMIN + apparmor:unconfined) and exercises every
+# directory-mutating op the plugin wires through KernelHandle v2
+# (mkdir/readdir/create/write/read/rename/unlink/rmdir) via plain
+# POSIX commands.  Each assertion has a mount-side (`docker exec`
+# POSIX) AND a gRPC (`vfs_stat` / `vfs_read`) cross-check, so a
+# regression in either layer surfaces as a mismatch.
+#
+# Independent of cc-tasks-share-e2e.yml and federation-e2e.yml —
+# those cover the LocalConnector dylib + cross-node federation
+# surface.  This one covers the operator-facing FUSE mount surface
+# layered on the same kernel callback ABI.
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main, develop]
+    paths:
+      - 'dockerfiles/Dockerfile.fuse-plugin'
+      - 'dockerfiles/docker-compose.fuse-plugin.yml'
+      - 'dockerfiles/Dockerfile.nexusd-cluster'
+      - 'dockerfiles/Dockerfile.federation-test'
+      - 'rust/services/fuse-plugin/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'tests/e2e/docker/test_fuse_plugin_e2e.py'
+      - 'tests/e2e/docker/fuse_plugin_helpers.py'
+      - 'tests/e2e/docker/runbook_helpers.py'
+      - '.github/workflows/fuse-plugin-e2e.yml'
+  pull_request:
+    branches: [main, develop]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  fuse-plugin-e2e:
+    name: FUSE Plugin E2E (Docker)
+    runs-on: ubuntu-latest
+    # Cold cache: cluster image build + plugin dylib build + compose
+    # up + the test suite is ~10-12 min on a clean runner.  Warm gha
+    # cache shaves the rust compile.  25 min upper bound matches the
+    # cc-tasks-share suite's budget.
+    timeout-minutes: 25
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect FUSE-plugin-relevant changes
+        id: changes
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git fetch --no-tags --prune origin "${{ github.base_ref }}"
+          git diff --name-only "origin/${{ github.base_ref }}"...HEAD > /tmp/changed_files.txt
+          cat /tmp/changed_files.txt
+          # Workflow file itself intentionally not in the regex —
+          # editing this YAML alone should not force a full Docker
+          # cluster build for an unrelated change.  Post-merge push
+          # paths above pick it up.
+          if grep -Eq '^(dockerfiles/(Dockerfile\.(fuse-plugin|nexusd-cluster|federation-test)|docker-compose\.fuse-plugin\.yml)|rust/services/fuse-plugin/|Cargo\.toml$|Cargo\.lock$|tests/e2e/docker/(test_fuse_plugin_e2e|fuse_plugin_helpers|runbook_helpers)\.py$)' /tmp/changed_files.txt; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Skip FUSE Plugin E2E
+        if: steps.changes.outputs.run != 'true'
+        run: |
+          echo "No FUSE-plugin-relevant files changed; reporting required check without running suite."
+
+      - name: Set up Docker Buildx
+        if: steps.changes.outputs.run == 'true'
+        uses: docker/setup-buildx-action@v3
+
+      # Pin SSOT: the nexus-vfs SHA the cluster binary + plugin dylib
+      # compile against lives in `Cargo.toml`'s workspace dep rev.
+      # Parse it once and reuse for the checkout step below.
+      - name: Read NEXUS_VFS_REV from Cargo.toml
+        if: steps.changes.outputs.run == 'true'
+        id: vfs_rev
+        run: |
+          sha=$(grep -oP '(?<=rev = ")[a-f0-9]{40}' Cargo.toml | sort -u | head -1)
+          if [ -z "$sha" ]; then
+            echo "::error::Could not parse nexus-vfs SHA from Cargo.toml"
+            exit 1
+          fi
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+          echo "Resolved nexus-vfs SHA: $sha"
+
+      - name: Checkout nexus-vfs source at pinned SHA
+        if: steps.changes.outputs.run == 'true'
+        uses: actions/checkout@v4
+        with:
+          repository: nexi-lab/nexus-vfs
+          ref: ${{ steps.vfs_rev.outputs.sha }}
+          path: nexus-vfs-src
+          fetch-depth: 1
+
+      # Build the production cluster image first, with a registry
+      # cache.  Both the fuse-plugin image and the federation-test
+      # image FROM nexusd-cluster:latest, so they all stay on one
+      # buildx instance.  `build-contexts` feeds the checked-out
+      # nexus-vfs source tree to the Dockerfile's
+      # `COPY --from=nexus-vfs-src` step.
+      - name: Build nexusd-cluster image
+        if: steps.changes.outputs.run == 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: dockerfiles/Dockerfile.nexusd-cluster
+          build-contexts: |
+            nexus-vfs-src=nexus-vfs-src
+          load: true
+          tags: nexusd-cluster:latest
+          cache-from: type=gha,scope=fuse-plugin-cluster
+          cache-to: type=gha,scope=fuse-plugin-cluster,mode=max
+
+      - name: Fetch plugin signing key (kernel-dogfood-v1)
+        if: steps.changes.outputs.run == 'true'
+        env:
+          VAULT_SIGNING_MASTER_KEY: ${{ secrets.VAULT_SIGNING_MASTER_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "$VAULT_SIGNING_MASTER_KEY" ]; then
+            echo "::error::VAULT_SIGNING_MASTER_KEY secret is not available — cannot fetch the kernel-dogfood-v1 signing key."
+            exit 1
+          fi
+          # Reuses the same sealed-keystore path
+          # release-plugin-reusable.yml takes for signing dylibs at
+          # release-tag time.  See
+          # docs/superpowers/specs/2026-06-13-sealed-keystore-dogfood-design.md
+          # for the end-to-end flow.  Pattern (mask + env-set) mirrors
+          # the reusable workflow's `Resolve PLUGIN_SIGNING_PRIVKEY
+          # (vault source)` step verbatim.
+          PRIVKEY=$(python3 scripts/dogfood_keystore_fetch.py --key-name kernel-dogfood-v1)
+          echo "::add-mask::${PRIVKEY}"
+          echo "PLUGIN_SIGNING_PRIVKEY=${PRIVKEY}" >> "$GITHUB_ENV"
+
+      - name: Build fuse-plugin + federation-test images
+        if: steps.changes.outputs.run == 'true'
+        # BUILDX_BUILDER=default forces compose build to use the
+        # docker-daemon builder rather than the docker-container
+        # builder from setup-buildx-action.  Both downstream images
+        # start `FROM nexusd-cluster:latest`, which only the daemon
+        # builder can resolve against the previous step's
+        # `load: true` artifact.  See cc-tasks-share-e2e.yml for the
+        # same workaround.
+        env:
+          BUILDX_BUILDER: default
+        run: |
+          docker compose -f dockerfiles/docker-compose.fuse-plugin.yml build \
+            cluster test
+
+      - name: Start FUSE plugin cluster
+        if: steps.changes.outputs.run == 'true'
+        run: |
+          docker compose -f dockerfiles/docker-compose.fuse-plugin.yml up -d cluster
+          docker compose -f dockerfiles/docker-compose.fuse-plugin.yml ps
+
+      - name: Wait for cluster healthy
+        if: steps.changes.outputs.run == 'true'
+        run: |
+          # Wait for BOTH the gRPC bind AND the FUSE mount.  The
+          # daemon binds 2126 a few seconds before the plugin's
+          # background thread finishes `fuser::spawn_mount2`.
+          deadline=$((SECONDS + 180))
+          while [ $SECONDS -lt $deadline ]; do
+            if docker exec nexus-fuse-cluster bash -c 'timeout 1 bash -c "</dev/tcp/localhost/2126" 2>/dev/null' && \
+               docker exec nexus-fuse-cluster mountpoint -q /mnt/nexus 2>/dev/null; then
+              echo "Cluster healthy (gRPC + FUSE mount ready) after ${SECONDS}s"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "::error::Timed out waiting for cluster ready (180s)"
+          docker compose -f dockerfiles/docker-compose.fuse-plugin.yml logs --tail=300
+          exit 1
+
+      - name: Run FUSE plugin E2E tests
+        if: steps.changes.outputs.run == 'true'
+        run: |
+          docker compose -f dockerfiles/docker-compose.fuse-plugin.yml \
+            run --rm test
+
+      - name: Dump container logs on failure
+        if: failure() && steps.changes.outputs.run == 'true'
+        run: |
+          echo "::group::nexus-fuse-cluster"
+          docker logs nexus-fuse-cluster --tail=400 2>&1 || echo "(no logs)"
+          echo "::endgroup::"
+
+      - name: Tear down
+        if: always() && steps.changes.outputs.run == 'true'
+        run: |
+          docker compose -f dockerfiles/docker-compose.fuse-plugin.yml down -v --remove-orphans || true

--- a/.github/workflows/fuse-plugin-e2e.yml
+++ b/.github/workflows/fuse-plugin-e2e.yml
@@ -128,27 +128,6 @@ jobs:
           cache-from: type=gha,scope=fuse-plugin-cluster
           cache-to: type=gha,scope=fuse-plugin-cluster,mode=max
 
-      - name: Fetch plugin signing key (kernel-dogfood-v1)
-        if: steps.changes.outputs.run == 'true'
-        env:
-          VAULT_SIGNING_MASTER_KEY: ${{ secrets.VAULT_SIGNING_MASTER_KEY }}
-        run: |
-          set -euo pipefail
-          if [ -z "$VAULT_SIGNING_MASTER_KEY" ]; then
-            echo "::error::VAULT_SIGNING_MASTER_KEY secret is not available — cannot fetch the kernel-dogfood-v1 signing key."
-            exit 1
-          fi
-          # Reuses the same sealed-keystore path
-          # release-plugin-reusable.yml takes for signing dylibs at
-          # release-tag time.  See
-          # docs/superpowers/specs/2026-06-13-sealed-keystore-dogfood-design.md
-          # for the end-to-end flow.  Pattern (mask + env-set) mirrors
-          # the reusable workflow's `Resolve PLUGIN_SIGNING_PRIVKEY
-          # (vault source)` step verbatim.
-          PRIVKEY=$(python3 scripts/dogfood_keystore_fetch.py --key-name kernel-dogfood-v1)
-          echo "::add-mask::${PRIVKEY}"
-          echo "PLUGIN_SIGNING_PRIVKEY=${PRIVKEY}" >> "$GITHUB_ENV"
-
       - name: Build fuse-plugin + federation-test images
         if: steps.changes.outputs.run == 'true'
         # BUILDX_BUILDER=default forces compose build to use the
@@ -158,9 +137,23 @@ jobs:
         # builder can resolve against the previous step's
         # `load: true` artifact.  See cc-tasks-share-e2e.yml for the
         # same workaround.
+        #
+        # Signs the cdylib with the bootstrap PLUGIN_SIGNING_PRIVKEY
+        # — same key cc-tasks-share-e2e.yml uses, same trust root the
+        # nexusd-cluster image embeds.  The production release path
+        # (signing with kernel-dogfood-v1 via the sealed keystore) is
+        # exercised end-to-end by release-fuse-plugin.yml on actual
+        # `fuse-v*` tags; this suite's job is to regression-guard the
+        # callback wiring, not the signing pipeline (which has its
+        # own paths-filtered workflow + the compliance gate).
         env:
           BUILDX_BUILDER: default
+          PLUGIN_SIGNING_PRIVKEY: ${{ secrets.PLUGIN_SIGNING_PRIVKEY }}
         run: |
+          if [ -z "$PLUGIN_SIGNING_PRIVKEY" ]; then
+            echo "::error::PLUGIN_SIGNING_PRIVKEY secret is not available — cannot sign the FUSE plugin (kernel refuses unsigned plugins)."
+            exit 1
+          fi
           docker compose -f dockerfiles/docker-compose.fuse-plugin.yml build \
             cluster test
 

--- a/.github/workflows/release-fuse-plugin.yml
+++ b/.github/workflows/release-fuse-plugin.yml
@@ -4,10 +4,12 @@ name: Release FUSE Plugin
 # the reusable plugin-release workflow. Triggered by tags of the form
 # `fuse-v<semver>`.
 #
-# Linux-only — fuser bindings cover Linux libfuse3 + macFUSE in principle,
-# but the current plugin pins fuser only under `cfg(target_os = "linux")`.
-# macOS / Windows shipping waits on the WinFsp / macFUSE adapter the
-# fuse-plugin Cargo.toml's lib doc references.
+# Linux + macOS — fuser bindings cover libfuse3 (Linux) and macFUSE
+# (macOS) under the same `Filesystem` trait; the plugin's cfg gate
+# extends to `cfg(any(target_os = "linux", target_os = "macos"))` so
+# both targets ship from one source. Windows shipping waits on a
+# separate WinFsp adapter (different binding crate, different trait
+# shape) — tracked as a follow-up PR.
 #
 # Uses the dogfood signing path (`signing_key_source: vault`) — vault is
 # the trust root for every non-vault plugin's signing key. The path now
@@ -36,14 +38,15 @@ jobs:
       version_tag_prefix: fuse-v
       signing_key_source: vault
       signing_key_name: kernel-dogfood-v1
-      platforms: '["linux-x86_64"]'
+      platforms: '["linux-x86_64", "macos-arm64", "macos-x86_64"]'
       release_description: |
         Nexus FUSE service plugin for nexusd-cluster.
 
-        Spawns a fuser-based FUSE event loop on `/dev/fuse` and translates
-        POSIX filesystem ops into Nexus kernel syscalls via the plugin-abi
-        KernelHandle, in-process. Linux only; macFUSE / WinFsp adapters
-        are out of scope for this first-cut.
+        Spawns a fuser-based FUSE event loop and translates POSIX
+        filesystem ops into Nexus kernel syscalls via the plugin-abi
+        KernelHandle, in-process. Ships for Linux (libfuse3) and
+        macOS (macFUSE). Windows shipping waits on a separate
+        WinFsp adapter — tracked as a follow-up PR.
     secrets:
       VAULT_SIGNING_MASTER_KEY: ${{ secrets.VAULT_SIGNING_MASTER_KEY }}
       COS_SECRET_ID: ${{ secrets.COS_SECRET_ID }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=69fae723945bf47f1e42a1753f5deecaf2bb0713#69fae723945bf47f1e42a1753f5deecaf2bb0713"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=1beefb06067a837f7565842f1238f16ca7f937cf#1beefb06067a837f7565842f1238f16ca7f937cf"
 dependencies = [
  "ahash",
  "base64",
@@ -510,7 +510,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=69fae723945bf47f1e42a1753f5deecaf2bb0713#69fae723945bf47f1e42a1753f5deecaf2bb0713"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=1beefb06067a837f7565842f1238f16ca7f937cf#1beefb06067a837f7565842f1238f16ca7f937cf"
 dependencies = [
  "parking_lot",
  "serde",
@@ -1293,7 +1293,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=69fae723945bf47f1e42a1753f5deecaf2bb0713#69fae723945bf47f1e42a1753f5deecaf2bb0713"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=1beefb06067a837f7565842f1238f16ca7f937cf#1beefb06067a837f7565842f1238f16ca7f937cf"
 dependencies = [
  "ahash",
  "base64",
@@ -1350,7 +1350,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=69fae723945bf47f1e42a1753f5deecaf2bb0713#69fae723945bf47f1e42a1753f5deecaf2bb0713"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=1beefb06067a837f7565842f1238f16ca7f937cf#1beefb06067a837f7565842f1238f16ca7f937cf"
 dependencies = [
  "ahash",
  "base64",
@@ -1532,7 +1532,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=69fae723945bf47f1e42a1753f5deecaf2bb0713#69fae723945bf47f1e42a1753f5deecaf2bb0713"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=1beefb06067a837f7565842f1238f16ca7f937cf#1beefb06067a837f7565842f1238f16ca7f937cf"
 
 [[package]]
 name = "nexus-vault"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,13 +38,13 @@ exclude = ["nexus-fuse"]
 # VFS via `nexus_plugin_grpc_services` + bytes-level dispatch through
 # `nexus_service_dispatch`. Bump alongside the rest of nexus-vfs
 # updates when a downstream change needs newer kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "69fae723945bf47f1e42a1753f5deecaf2bb0713" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "69fae723945bf47f1e42a1753f5deecaf2bb0713" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "69fae723945bf47f1e42a1753f5deecaf2bb0713" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "69fae723945bf47f1e42a1753f5deecaf2bb0713", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "69fae723945bf47f1e42a1753f5deecaf2bb0713", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "69fae723945bf47f1e42a1753f5deecaf2bb0713", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "69fae723945bf47f1e42a1753f5deecaf2bb0713" }
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "1beefb06067a837f7565842f1238f16ca7f937cf" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "1beefb06067a837f7565842f1238f16ca7f937cf" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "1beefb06067a837f7565842f1238f16ca7f937cf" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "1beefb06067a837f7565842f1238f16ca7f937cf", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "1beefb06067a837f7565842f1238f16ca7f937cf", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "1beefb06067a837f7565842f1238f16ca7f937cf", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "1beefb06067a837f7565842f1238f16ca7f937cf" }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ENV CARGO_NET_RETRY=10 \
     CARGO_HTTP_TIMEOUT=120
 # Override for edge/CI or a different pin: --build-arg NEXUS_VFS_REV=<sha|tag>
-ARG NEXUS_VFS_REV=69fae723945bf47f1e42a1753f5deecaf2bb0713
+ARG NEXUS_VFS_REV=1beefb06067a837f7565842f1238f16ca7f937cf
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,id=cargo-install-${TARGETARCH},target=/root/.cargo/target \

--- a/dockerfiles/Dockerfile.fuse-plugin
+++ b/dockerfiles/Dockerfile.fuse-plugin
@@ -1,0 +1,112 @@
+# Nexus FUSE Plugin Image
+#
+# Multi-stage build that produces a cluster image with the
+# `nexus-fuse-plugin` cdylib pre-installed under `/plugins/`.  The
+# cluster binary's `--plugin-dir /plugins` flag picks it up at startup;
+# the plugin then reads `NEXUS_FUSE_MOUNT_POINT` + `NEXUS_FUSE_VFS_ROOT`
+# from the environment and spawns a fuser-based FUSE event loop in a
+# background thread.  Operators interact with the mount via plain
+# POSIX ops (`ls`, `mkdir`, `cat`, `mv`, `rm`).
+#
+# Build:
+#   docker build -f dockerfiles/Dockerfile.fuse-plugin \
+#     -t nexus-fuse-plugin:latest .
+#
+# Runtime requires a privileged-ish container — `/dev/fuse` device,
+# `SYS_ADMIN` cap, and `apparmor:unconfined` so libfuse3 can mount.
+# The compose at docker-compose.fuse-plugin.yml supplies all three.
+#
+# Stage 1 builds the dylib from this nexus repo against the same
+# nexus-vfs SHA that the cluster image was built against (workspace
+# Cargo.toml + Cargo.lock pin the rev).  Stage 2 starts FROM the cluster
+# image so the operator gets one image with both daemon and plugin in
+# lockstep.
+
+# ---------- Builder ----------
+FROM rust:1-slim-bookworm AS builder
+
+# protobuf-compiler: transport / tonic deps shell out to the system
+# protoc at compile time.
+# libfuse3-dev: the fuser crate links against libfuse3 at build time
+# on Linux; without the dev headers the cdylib won't compile.
+# python3{,-dev}: pyo3-build-config probes for an interpreter at
+# compile time (same as the cluster image).
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        protobuf-compiler \
+        libfuse3-dev \
+        pkg-config \
+        python3 \
+        python3-dev \
+        python3-cryptography \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+
+# Copy only what cargo needs to resolve the workspace + build the
+# dylib.  Source tree is just the workspace manifest + the two
+# in-tree crates (services + the fuse-plugin crate itself); the
+# nexus-vfs deps are fetched by cargo from the git rev pinned in
+# Cargo.toml / Cargo.lock.
+COPY Cargo.toml Cargo.lock ./
+COPY rust ./rust
+
+# Release build picks up the workspace's rev-pin of nexus-vfs so the
+# ABI version baked into the dylib matches the kernel side exactly.
+RUN cargo build --release -p nexus-fuse-plugin
+
+# Ed25519-sign the dylib (kernel rev 67ac07f+ refuses unsigned plugins,
+# no escape hatch — PluginLoader verifies against compile-time trusted
+# keys). The private key arrives as a BuildKit secret, never a layer:
+#   docker build --secret id=plugin_signing_key,env=PLUGIN_SIGNING_PRIVKEY …
+# CI provides it from the kernel-dogfood-v1 vault-signing key (same
+# trust root release-fuse-plugin.yml uses). Build fails loudly without
+# it — an unsigned plugin would only defer the failure to founder boot.
+COPY scripts/sign_plugin.py ./scripts/sign_plugin.py
+RUN --mount=type=secret,id=plugin_signing_key \
+    PLUGIN_SIGNING_PRIVKEY="$(cat /run/secrets/plugin_signing_key)" \
+    python3 scripts/sign_plugin.py target/release/libnexus_fuse_plugin.so
+
+# ---------- Runtime ----------
+# nexusd-cluster:latest must be built first (Dockerfile.nexusd-cluster);
+# CI / compose set BUILDX_BUILDER=default so FROM resolves against the
+# local daemon image rather than reaching out to a registry.
+FROM nexusd-cluster:latest
+
+USER root
+# Install libfuse3 runtime so the dylib's libfuse3 symbol references
+# resolve at dlopen time.  `fuse3` (not just `libfuse3-3`) brings in
+# `fusermount3` which fuser's background session uses to perform the
+# mount syscall from userspace.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        fuse3 \
+        libfuse3-3 \
+    && rm -rf /var/lib/apt/lists/*
+
+# `/plugins` is where --plugin-dir scans for dylibs to load.
+# `/mnt/nexus` is the FUSE mount point — must exist before the plugin
+# spawns its event loop.  Pre-creating both in the image (rather than
+# letting docker mint them on first volume attach) means docker
+# preserves perms when compose layers volumes / tmpfs on top.
+RUN mkdir -p /plugins /mnt/nexus && chown nexus:nexus /plugins /mnt/nexus
+
+# nexus user needs to be in the `fuse` group on Debian so it can open
+# /dev/fuse without root.  group already exists from the fuse3 package.
+RUN usermod -a -G fuse nexus
+
+USER nexus
+
+COPY --from=builder --chown=nexus:nexus \
+    /build/target/release/libnexus_fuse_plugin.so \
+    /plugins/libnexus_fuse_plugin.so
+# Detached signature must sit next to the dylib — PluginLoader reads
+# `<plugin>.sig` in tandem with `<plugin>` at --plugin-dir scan time.
+COPY --from=builder --chown=nexus:nexus \
+    /build/target/release/libnexus_fuse_plugin.so.sig \
+    /plugins/libnexus_fuse_plugin.so.sig
+
+# Operators set NEXUS_FUSE_MOUNT_POINT to wire the plugin to a real
+# directory.  Pre-set a sensible default; compose overrides if it
+# wants a different mount point.
+ENV NEXUS_PLUGIN_DIR=/plugins \
+    NEXUS_FUSE_MOUNT_POINT=/mnt/nexus \
+    NEXUS_FUSE_VFS_ROOT=/

--- a/dockerfiles/Dockerfile.fuse-plugin
+++ b/dockerfiles/Dockerfile.fuse-plugin
@@ -89,9 +89,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # preserves perms when compose layers volumes / tmpfs on top.
 RUN mkdir -p /plugins /mnt/nexus && chown nexus:nexus /plugins /mnt/nexus
 
-# nexus user needs to be in the `fuse` group on Debian so it can open
-# /dev/fuse without root.  group already exists from the fuse3 package.
-RUN usermod -a -G fuse nexus
+# /dev/fuse is opened by libfuse3 with the container's effective caps;
+# the compose grants SYS_ADMIN + privileged mode + the /dev/fuse
+# device, which collectively short-circuits the per-user permission
+# check that would normally need `fuse` group membership.  No usermod
+# needed — and the `fuse3` package on debian:slim no longer creates
+# the group implicitly under non-interactive apt.
 
 USER nexus
 

--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir --no-deps --prefix=/install .
 # enforces agreement) — an unpinned install tracks nexus-vfs HEAD and
 # ships an untested kernel (#4343). --locked honors the source tree's
 # Cargo.lock.
-ARG NEXUS_VFS_REV=69fae723945bf47f1e42a1753f5deecaf2bb0713
+ARG NEXUS_VFS_REV=1beefb06067a837f7565842f1238f16ca7f937cf
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-cluster nexus-cluster
 
 # -- Runtime stage --

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -25,7 +25,7 @@ WORKDIR /build
 # (CI preflight enforces agreement) — an unpinned install tracks HEAD
 # and can skew the raft contract against the cluster/witness images.
 # --locked honors the source tree's Cargo.lock.
-ARG NEXUS_VFS_REV=69fae723945bf47f1e42a1753f5deecaf2bb0713
+ARG NEXUS_VFS_REV=1beefb06067a837f7565842f1238f16ca7f937cf
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexus-raft-server raft
 
 # ---------- Production image ----------

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=69fae723945bf47f1e42a1753f5deecaf2bb0713
+ARG NEXUS_VFS_REV=1beefb06067a837f7565842f1238f16ca7f937cf
 RUN cargo install \
     --locked \
     --git https://github.com/nexi-lab/nexus-vfs \

--- a/dockerfiles/docker-compose.fuse-plugin.yml
+++ b/dockerfiles/docker-compose.fuse-plugin.yml
@@ -1,0 +1,159 @@
+# FUSE plugin E2E — single-node cluster mounting itself via FUSE
+# =========================================================================
+# Compose for `tests/e2e/docker/test_fuse_plugin_e2e.py`.
+#
+# Topology: one `nexusd-cluster` daemon with `--plugin-dir /plugins`
+# loading the signed `libnexus_fuse_plugin.so`.  The plugin reads
+# `NEXUS_FUSE_MOUNT_POINT=/mnt/nexus` + `NEXUS_FUSE_VFS_ROOT=/` from
+# the env and spawns a fuser-backed FUSE event loop in a background
+# thread.  After mount, every POSIX op against `/mnt/nexus` flows
+# through the FUSE event loop → KernelHandle callbacks → kernel
+# syscalls — exactly the operator-facing path.
+#
+# Workflow validated end-to-end:
+#
+#   1. `mkdir /mnt/nexus/foo` — kernel `sys_mkdir` callback fires
+#      via the FUSE `mkdir` op + materialises the directory in the
+#      metastore.  `vfs_stat(/foo)` over gRPC sees `entry_type=1`.
+#   2. `touch /mnt/nexus/foo/bar.txt` + `echo … > …` — `create` ops
+#      compose `sys_write(empty) + sys_stat`; subsequent `write`
+#      flushes content.  Content visible via `vfs_read(/foo/bar.txt)`.
+#   3. `ls /mnt/nexus/foo` — kernel `sys_readdir` returns the
+#      JSON-array of `(name, entry_type)` pairs; FUSE renders them.
+#   4. `mv /mnt/nexus/foo/bar.txt /mnt/nexus/foo/baz.txt` — kernel
+#      `sys_rename`.  Old path absent, new path present.
+#   5. `rm /mnt/nexus/foo/baz.txt` + `rmdir /mnt/nexus/foo` — kernel
+#      `sys_unlink` + `sys_rmdir`.  Both paths absent.
+#
+# Each step has a hard cross-check: the POSIX op runs through the
+# mount, and the gRPC `vfs_stat` / `vfs_read` confirms kernel-side
+# state independently.  A regression in the FUSE plugin's callback
+# wiring breaks one half; a regression in the kernel-side callback
+# breaks both.  Either failure surfaces here.
+#
+# Privileged-ish requirement: FUSE needs `/dev/fuse`, `SYS_ADMIN`
+# (so libfuse3 can mount), and unconfined apparmor (the default
+# `docker-default` profile blocks the mount syscall on most distros).
+# This is the minimum viable container profile for a real FUSE mount;
+# anything looser doesn't reach the kernel callback path the plugin
+# wires.
+#
+# Usage:
+#   docker compose -f dockerfiles/docker-compose.fuse-plugin.yml up -d cluster
+#   docker compose -f dockerfiles/docker-compose.fuse-plugin.yml run --rm test
+#   docker compose -f dockerfiles/docker-compose.fuse-plugin.yml down -v
+
+services:
+  cluster:
+    build:
+      context: ..
+      dockerfile: dockerfiles/Dockerfile.fuse-plugin
+      # Plugin-signing key for the in-build Ed25519 sign step (kernel
+      # rev 67ac07f+ refuses unsigned plugins).  Sourced from the
+      # PLUGIN_SIGNING_PRIVKEY env var on the invoking shell — CI
+      # exports it from the kernel-dogfood-v1 sealed-keystore fetch.
+      secrets:
+        - plugin_signing_key
+    image: nexus-fuse-plugin:latest
+    container_name: nexus-fuse-cluster
+    hostname: cluster
+    # Privileged mode — minimum viable for `/dev/fuse` open + libfuse3
+    # mount syscall.  `cap_add: SYS_ADMIN` + device map + apparmor
+    # unconfined is the documented quartet; `privileged: true` is the
+    # shorter form that subsumes all three.  No host mounts are
+    # exposed inward; the mount lives entirely on a docker tmpfs.
+    privileged: true
+    devices:
+      - /dev/fuse
+    cap_add:
+      - SYS_ADMIN
+    security_opt:
+      - apparmor:unconfined
+    environment:
+      NEXUS_HOSTNAME: cluster
+      NEXUS_BIND_ADDR: 0.0.0.0:2126
+      NEXUS_ADVERTISE_ADDR: cluster:2126
+      NEXUS_DATA_DIR: /app/data
+      NEXUS_NO_TLS: "true"
+      NEXUS_PLUGIN_DIR: /plugins
+      # Plugin reads these at create-time; the FUSE event loop won't
+      # spawn without NEXUS_FUSE_MOUNT_POINT.
+      NEXUS_FUSE_MOUNT_POINT: /mnt/nexus
+      NEXUS_FUSE_VFS_ROOT: /
+      # Single-node bootstrap — no federation, no joiners.  The FUSE
+      # mount lives on the local VFS root only.
+      NEXUS_BOOTSTRAP_MODE: dynamic
+      RUST_LOG: info,nexus_raft=info,nexus::fuse=debug
+    volumes:
+      - fuse_cluster_data:/app/data
+    networks:
+      - nexus-fuse-net
+    healthcheck:
+      # Health probe waits for BOTH the gRPC port AND the FUSE mount —
+      # the daemon binds 2126 a few seconds before the plugin's
+      # background thread completes `fuser::spawn_mount2`.  A premature
+      # "ready" reports green while the mount is still pending and the
+      # test races against it.
+      test:
+        - CMD-SHELL
+        - >
+          timeout 1 bash -c '</dev/tcp/localhost/2126' 2>/dev/null &&
+          mountpoint -q /mnt/nexus
+      interval: 5s
+      timeout: 5s
+      retries: 24
+      start_period: 30s
+
+  test:
+    build:
+      context: ..
+      dockerfile: dockerfiles/Dockerfile.federation-test
+    image: nexus-federation-test:latest
+    container_name: nexus-fuse-test
+    profiles:
+      - run
+    depends_on:
+      cluster:
+        condition: service_healthy
+    # working_dir, PYTHONPATH, PYTEST_ADDOPTS inherited from the
+    # federation-test image — same runner as the cc-tasks-share +
+    # federation-runbook suites.
+    user: "0:0"
+    volumes:
+      - ..:/workspace:ro
+      - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      NEXUS_FUSE_E2E: "1"
+      # gRPC endpoint for kernel-side cross-checks.  Tests issue
+      # `vfs_stat` / `vfs_read` here independently of the FUSE mount
+      # so a callback regression on either side surfaces.
+      NEXUS_CLUSTER_GRPC: cluster:2126
+      # Container name needed by `docker exec` for in-container POSIX
+      # ops (`mkdir` / `touch` / `mv` / `rm`) against the mount.  The
+      # test runner is a sibling container, not the cluster — issuing
+      # ops via `docker exec` ensures we exercise the in-container
+      # mount, not some host-shared mountpoint.
+      NEXUS_CLUSTER_CONTAINER: nexus-fuse-cluster
+      NEXUS_FUSE_MOUNT_POINT: /mnt/nexus
+    networks:
+      - nexus-fuse-net
+    command:
+      - pytest
+      - tests/e2e/docker/test_fuse_plugin_e2e.py
+      - -v
+      - --no-header
+      - -o
+      - addopts=
+
+networks:
+  nexus-fuse-net:
+    name: nexus-fuse-net
+    driver: bridge
+
+secrets:
+  plugin_signing_key:
+    environment: PLUGIN_SIGNING_PRIVKEY
+
+volumes:
+  fuse_cluster_data:
+    name: nexus-fuse-cluster-data

--- a/rust/services/fuse-plugin/Cargo.toml
+++ b/rust/services/fuse-plugin/Cargo.toml
@@ -18,15 +18,16 @@ crate-type = ["cdylib", "rlib"]
 nexus-plugin-abi = { workspace = true }
 
 # `fuser` is the production-quality Rust wrapper around libfuse3 on
-# Linux / macFUSE on macOS.  We pin against the same version that
-# `nexus-fuse` (the legacy standalone daemon) used so familiar
-# semantics carry over.  Windows support is via a separate WinFsp
-# adapter — out of scope for this first-cut plugin.
-[target.'cfg(target_os = "linux")'.dependencies]
+# Linux / macFUSE on macOS.  Same `Filesystem` trait + `spawn_mount2`
+# entrypoint on both platforms, so the cfg-gated Linux/macOS branch
+# below shares one body.  Windows support is via a separate WinFsp
+# adapter (different binding crate, different trait shape) — tracked
+# as a follow-up PR and not gated by this cdylib's build matrix.
+[target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
 fuser = "0.17"
 # Errno constants for translating kernel-callback failures into POSIX
-# errors that FUSE clients understand.  Linux-only — macFUSE/WinFsp
-# adapters will pull in their own equivalents.
+# errors that FUSE clients understand.  Linux+macOS share libc; the
+# eventual WinFsp adapter pulls in its own equivalents.
 libc = "0.2"
 
 # tracing for diagnostic logs.  Kept opt-in via the cluster binary's

--- a/rust/services/fuse-plugin/README.md
+++ b/rust/services/fuse-plugin/README.md
@@ -1,0 +1,140 @@
+# nexus-fuse-plugin
+
+In-process FUSE service plugin for `nexusd-cluster`. Loaded as a
+signed cdylib via `--plugin-dir`; spawns a `fuser`-backed FUSE event
+loop in a background thread and routes POSIX filesystem ops to Nexus
+kernel syscalls through the plugin-abi KernelHandle (v2 ABI: `read /
+write / stat / readdir / mkdir / unlink / rmdir / rename`).
+
+This is the operator-facing layer that turns Nexus's VFS into
+something `ls`, `cat`, `mv`, `vim`, `tar`, and every other POSIX
+filesystem tool can talk to without a single client-side rewrite.
+
+## Platform matrix
+
+| Platform | FUSE userspace      | Status                                      |
+|----------|---------------------|---------------------------------------------|
+| Linux    | `libfuse3` (`fuse3`) | First-cut.  Production-ready.              |
+| macOS    | `macFUSE`           | Same `fuser` body via cfg gate.            |
+| Windows  | `WinFsp`            | Deferred — separate binding crate + adapter. |
+
+`fuser`'s `Filesystem` trait and `spawn_mount2` are identical on
+Linux + macOS, so the same source services both. Windows shipping
+waits on a WinFsp-rs adapter (different crate, different trait
+shape) — tracked as a follow-up PR. On Windows today the plugin
+compiles to a no-op cdylib so the workspace matrix stays clean.
+
+## Operator install
+
+The FUSE userspace is an out-of-band dependency — install it before
+launching `nexusd-cluster`:
+
+```bash
+# Debian / Ubuntu
+sudo apt install fuse3 libfuse3-3
+sudo usermod -a -G fuse "$USER"   # /dev/fuse access without root
+
+# macOS (Homebrew)
+brew install --cask macfuse
+# Then approve the macFUSE kernel extension in System Settings →
+# Privacy & Security and reboot.  macFUSE installs are interactive
+# by design; there's no headless equivalent today.
+```
+
+Drop the signed dylib + `.sig` from the latest `fuse-v*` release into
+`$NEXUS_PLUGIN_DIR`:
+
+```bash
+mkdir -p ~/.nexus/plugins
+gh release download fuse-v0.1.0 \
+    --pattern 'nexus-fuse-plugin-linux-x86_64.tar.gz' \
+    --dir /tmp/
+tar -xzf /tmp/nexus-fuse-plugin-linux-x86_64.tar.gz -C ~/.nexus/plugins/
+ls ~/.nexus/plugins/   # libnexus_fuse_plugin.so + libnexus_fuse_plugin.so.sig
+```
+
+`PluginLoader::load` Ed25519-verifies the `.sig` against the
+embedded trust root before `dlopen` — an unsigned dylib is refused
+at startup with no escape hatch.
+
+## Configuration
+
+The plugin reads two env vars at `create` time:
+
+| Var                       | Required | Default | Meaning                                                                 |
+|---------------------------|----------|---------|-------------------------------------------------------------------------|
+| `NEXUS_FUSE_MOUNT_POINT`  | Yes      | —       | Absolute path on the local filesystem where the FUSE mount is published. |
+| `NEXUS_FUSE_VFS_ROOT`     | No       | `/`     | VFS-path prefix that maps to the FUSE root inode.  Joined with child names to produce kernel-side paths. |
+
+Without `NEXUS_FUSE_MOUNT_POINT` the plugin loads but performs no
+mount — useful for the kernel's `--plugin-dir` scanning to validate
+the ABI without committing to a mount target.
+
+Example launch:
+
+```bash
+export NEXUS_FUSE_MOUNT_POINT=/mnt/nexus
+export NEXUS_FUSE_VFS_ROOT=/
+nexusd-cluster \
+    --plugin-dir ~/.nexus/plugins \
+    --bind-addr 0.0.0.0:2126 \
+    --data-dir ~/.nexus/data
+```
+
+After the daemon comes up, `mountpoint -q /mnt/nexus` returns 0 and
+plain POSIX ops work end-to-end:
+
+```bash
+mkdir /mnt/nexus/foo
+echo hello > /mnt/nexus/foo/bar.txt
+ls /mnt/nexus/foo
+cat /mnt/nexus/foo/bar.txt
+mv /mnt/nexus/foo/bar.txt /mnt/nexus/foo/baz.txt
+rm /mnt/nexus/foo/baz.txt
+rmdir /mnt/nexus/foo
+```
+
+## Admin RPCs
+
+The plugin exposes two methods via `nexus_service_dispatch`:
+
+- `status` — returns `mounted` or `unmounted` so an operator can poll
+  whether the background thread's `spawn_mount2` succeeded without
+  scraping logs.
+- `unmount` — graceful unmount + worker-thread join.  The plugin
+  stays loaded but the mount is released; `mountpoint -q` returns
+  non-zero afterwards.
+
+Both are admin-level (no auth surface).  Plain-text UTF-8 payloads
+on both legs.
+
+## What's covered, what's not
+
+**Covered (KernelHandle v2):** `lookup`, `getattr`, `open`, `release`,
+`flush`, `read`, `write`, `readdir`, `mkdir`, `unlink`, `rmdir`,
+`rename`, `create`.
+
+**Surfaces ENOSYS:** `setattr`.  chmod / chown / utimes / truncate
+have no kernel equivalent today — ReBAC owns permissions and
+timestamps are kernel-managed.  Returning `ENOSYS` keeps the
+contract honest until a kernel-side setattr surface lands.
+
+**First-cut performance shape:** `read` pulls the **entire** file
+via `sys_read` and slices by offset/size in the FUSE op.  `write`
+honours `O_TRUNC` semantics only (offset=0 writes).  Offset-aware
+`sys_read` / `sys_write` extensions are tracked as a follow-up
+nexus-vfs PR.
+
+## Regression coverage
+
+`tests/e2e/docker/test_fuse_plugin_e2e.py` mounts the signed dylib
+inside a privileged Linux container and exercises every v2 op via
+plain POSIX commands, with a gRPC `vfs_stat` / `vfs_read`
+cross-check at every step.  Runs in CI on every change to the
+plugin source, the plugin-abi pin, the Dockerfile, or the test
+itself — see `.github/workflows/fuse-plugin-e2e.yml`.
+
+Architectural decisions live in
+`docs/superpowers/specs/2026-06-13-sealed-keystore-dogfood-design.md`
+(signing) and the plugin source's module docstring (FUSE op
+translation layer).

--- a/rust/services/fuse-plugin/src/fs.rs
+++ b/rust/services/fuse-plugin/src/fs.rs
@@ -327,9 +327,48 @@ impl NexusFs {
     /// Same sys_stat wrapper but returning a populated FileAttr on
     /// success.  Centralises the path → callback → parse pipeline so
     /// lookup / getattr / readdir share one error mapping.
+    ///
+    /// Special case: the mount root (inode == FUSE_ROOT_RAW) always
+    /// returns a synthetic directory FileAttr.  The kernel's
+    /// `sys_stat` is documented to return `None` for trie-resolved
+    /// paths — including DT_MOUNT entries, which is exactly what the
+    /// plugin's `NEXUS_FUSE_VFS_ROOT` maps to.  Without this short-
+    /// circuit, `mountpoint -q` can't validate the mount (its
+    /// `stat()` of the root returns ENOENT), every FUSE op fails the
+    /// initial root lookup, and the mount is effectively unusable.
+    /// The synthetic attr is consistent with the kernel's own DT_MOUNT
+    /// semantics — directory, perm 0755 — so this is honest about
+    /// what the mount root *is* even though sys_stat declines to say so.
     fn stat_attr(&self, ino: INodeNo, path: &str) -> Result<FileAttr, Errno> {
+        if ino.0 == FUSE_ROOT_RAW {
+            return Ok(self.synthetic_root_attr());
+        }
         let json = self.sys_stat(path).map_err(|_| errno_enoent())?;
         self.parse_stat(ino, &json).ok_or_else(errno_io)
+    }
+
+    /// Build the synthetic FileAttr for the FUSE mount root.  See
+    /// `stat_attr` for the kernel-side rationale; this is the
+    /// SSOT for "what does the mount root look like to FUSE".
+    fn synthetic_root_attr(&self) -> FileAttr {
+        let now = SystemTime::now();
+        FileAttr {
+            ino: INodeNo::ROOT,
+            size: 0,
+            blocks: 0,
+            atime: now,
+            mtime: now,
+            ctime: now,
+            crtime: now,
+            kind: FileType::Directory,
+            perm: 0o755,
+            nlink: 2,
+            uid: unsafe { libc::getuid() },
+            gid: unsafe { libc::getgid() },
+            rdev: 0,
+            blksize: 4096,
+            flags: 0,
+        }
     }
 }
 

--- a/rust/services/fuse-plugin/src/fs.rs
+++ b/rust/services/fuse-plugin/src/fs.rs
@@ -101,20 +101,88 @@ fn errno_nosys() -> Errno {
 
 pub struct NexusFs {
     kernel: KernelHandle,
-    /// `inode -> VFS path` registry.  Root inode (FUSE_ROOT_RAW) is
-    /// seeded with the operator-supplied `vfs_root` prefix; child
-    /// lookups join from there.  We never evict.
-    inodes: Mutex<HashMap<u64, String>>,
+    /// Bidirectional inode↔path index.  The forward map (`ino_to_path`)
+    /// translates a FUSE inode back to the VFS path the kernel
+    /// callbacks expect; the reverse map (`path_to_ino`) lets
+    /// `lookup` return a **stable** inode for a path it has seen
+    /// before — without it every LOOKUP minted a fresh inode and the
+    /// kernel-side FUSE driver couldn't tie its cached dentry to the
+    /// one the next op walked through (rename's `d_move` is the
+    /// canonical case: source dentry got inode A on create, dest
+    /// lookup returned inode B; the rename op's userspace handler ran
+    /// fine but the kernel-side `d_move(A → B)` linked the wrong
+    /// inode and downstream `cat <dest>` surfaced ENOENT despite the
+    /// rename having succeeded kernel-side).  Root inode
+    /// (FUSE_ROOT_RAW) is seeded with the operator-supplied
+    /// `vfs_root` prefix; child paths register on first lookup.  We
+    /// never evict — replacing the counter with a path-cache
+    /// eviction policy is a follow-up.
+    paths: Mutex<PathIndex>,
     next_inode: AtomicU64,
+}
+
+/// Bidirectional inode↔path index — the SSOT for "what does each FUSE
+/// inode refer to right now".  Single mutex so both maps stay in
+/// lockstep; every mutator updates both sides in one critical section.
+struct PathIndex {
+    ino_to_path: HashMap<u64, String>,
+    path_to_ino: HashMap<String, u64>,
+}
+
+impl PathIndex {
+    fn with_root(vfs_root: String) -> Self {
+        let mut ino_to_path = HashMap::new();
+        let mut path_to_ino = HashMap::new();
+        ino_to_path.insert(FUSE_ROOT_RAW, vfs_root.clone());
+        path_to_ino.insert(vfs_root, FUSE_ROOT_RAW);
+        Self {
+            ino_to_path,
+            path_to_ino,
+        }
+    }
+
+    fn lookup_or_register(&mut self, path: &str, mint: impl FnOnce() -> u64) -> u64 {
+        if let Some(&ino) = self.path_to_ino.get(path) {
+            return ino;
+        }
+        let ino = mint();
+        self.ino_to_path.insert(ino, path.to_string());
+        self.path_to_ino.insert(path.to_string(), ino);
+        ino
+    }
+
+    /// Move the inode currently bound to `old_path` over to `new_path`.
+    /// No-op when `old_path` isn't tracked (e.g. the kernel-side
+    /// rename succeeded against a path the FUSE side never looked up,
+    /// which can happen with bulk operators).  Used by the `rename`
+    /// op so subsequent `read` / `getattr` on the d_moved inode walks
+    /// the new path through `sys_*` — otherwise the inode would still
+    /// resolve to `old_path` and every read would surface ENOENT.
+    fn rename(&mut self, old_path: &str, new_path: &str) {
+        let Some(ino) = self.path_to_ino.remove(old_path) else {
+            return;
+        };
+        self.ino_to_path.insert(ino, new_path.to_string());
+        self.path_to_ino.insert(new_path.to_string(), ino);
+    }
+
+    /// Drop the bidirectional mapping for `path`.  Used by `unlink`
+    /// and `rmdir` to release the inode after the kernel-side entry
+    /// is gone — a subsequent `create` at the same path then mints a
+    /// fresh inode instead of reusing one whose previous lifetime
+    /// the kernel may have already forgotten.
+    fn forget(&mut self, path: &str) {
+        if let Some(ino) = self.path_to_ino.remove(path) {
+            self.ino_to_path.remove(&ino);
+        }
+    }
 }
 
 impl NexusFs {
     pub fn new(kernel: KernelHandle, vfs_root: String) -> Self {
-        let mut inodes = HashMap::new();
-        inodes.insert(FUSE_ROOT_RAW, vfs_root);
         Self {
             kernel,
-            inodes: Mutex::new(inodes),
+            paths: Mutex::new(PathIndex::with_root(vfs_root)),
             // First allocated inode = root + 1; the root inode itself
             // is reserved (fuser INodeNo::ROOT == 1).
             next_inode: AtomicU64::new(FUSE_ROOT_RAW + 1),
@@ -122,13 +190,18 @@ impl NexusFs {
     }
 
     fn path_for(&self, ino: INodeNo) -> Option<String> {
-        self.inodes.lock().unwrap().get(&ino.0).cloned()
+        self.paths.lock().unwrap().ino_to_path.get(&ino.0).cloned()
     }
 
-    fn alloc_inode(&self, path: String) -> u64 {
-        let ino = self.next_inode.fetch_add(1, Ordering::Relaxed);
-        self.inodes.lock().unwrap().insert(ino, path);
-        ino
+    /// Return the existing inode for `path` if we've seen it before,
+    /// otherwise mint a fresh one and register both directions.  See
+    /// the `paths` field docstring for why a stable inode-per-path
+    /// matters for FUSE's dentry/inode tracking.
+    fn inode_for(&self, path: &str) -> u64 {
+        self.paths
+            .lock()
+            .unwrap()
+            .lookup_or_register(path, || self.next_inode.fetch_add(1, Ordering::Relaxed))
     }
 
     /// Wrapper around the C `sys_stat` callback.  Returns the JSON
@@ -439,10 +512,18 @@ impl Filesystem for NexusFs {
             }
         };
         let path = join_path(&parent_path, name_str);
-        let ino_raw = self.alloc_inode(path.clone());
-        let ino = INodeNo(ino_raw);
-        match self.stat_attr(ino, &path) {
-            Ok(attr) => reply.entry(&ENTRY_TTL, &attr, Generation(0)),
+        // Stat first, allocate the inode only on a positive hit so
+        // negative-lookup probes (`mv`'s pre-rename LOOKUP, every
+        // ENOENT path resolution) don't leak path↔inode entries the
+        // FUSE side then has to clean up.
+        match self.sys_stat(&path) {
+            Ok(json) => {
+                let ino = INodeNo(self.inode_for(&path));
+                match self.parse_stat(ino, &json) {
+                    Some(attr) => reply.entry(&ENTRY_TTL, &attr, Generation(0)),
+                    None => reply.error(errno_io()),
+                }
+            }
             // FUSE protocol: a reply.entry with `attr.ino == 0` is a
             // *negative* entry — the kernel records "this name does
             // not exist" for `entry_valid` seconds.  Setting TTL = 0
@@ -604,7 +685,7 @@ impl Filesystem for NexusFs {
         // needing a per-fh cursor.
         for (idx, (name, entry_type)) in entries.into_iter().enumerate().skip(offset as usize) {
             let child_path = join_path(&parent_path, &name);
-            let child_ino = self.alloc_inode(child_path);
+            let child_ino = self.inode_for(&child_path);
             let kind = kind_from_entry_type(entry_type);
             // FUSE's `next_offset` semantics: the next readdir call
             // resumes at this value, so we return `idx + 1`.
@@ -643,7 +724,7 @@ impl Filesystem for NexusFs {
             reply.error(errno_io());
             return;
         }
-        let ino_raw = self.alloc_inode(path.clone());
+        let ino_raw = self.inode_for(&path);
         let ino = INodeNo(ino_raw);
         match self.stat_attr(ino, &path) {
             Ok(attr) => reply.entry(&ENTRY_TTL, &attr, Generation(0)),
@@ -668,7 +749,10 @@ impl Filesystem for NexusFs {
         };
         let path = join_path(&parent_path, name_str);
         match self.sys_unlink(&path) {
-            Ok(()) => reply.ok(),
+            Ok(()) => {
+                self.paths.lock().unwrap().forget(&path);
+                reply.ok();
+            }
             Err(_) => reply.error(errno_io()),
         }
     }
@@ -690,7 +774,10 @@ impl Filesystem for NexusFs {
         };
         let path = join_path(&parent_path, name_str);
         match self.sys_rmdir(&path) {
-            Ok(()) => reply.ok(),
+            Ok(()) => {
+                self.paths.lock().unwrap().forget(&path);
+                reply.ok();
+            }
             Err(_) => reply.error(errno_io()),
         }
     }
@@ -736,7 +823,16 @@ impl Filesystem for NexusFs {
         let old_path = join_path(&old_parent, old_name);
         let new_path = join_path(&new_parent, new_name);
         match self.sys_rename(&old_path, &new_path) {
-            Ok(()) => reply.ok(),
+            Ok(()) => {
+                // Move the inode's path mapping so the d_moved FUSE
+                // dentry (which still points at the old inode) walks
+                // through `sys_read` against the new path instead of
+                // the now-vanished old one — without this, `cat <new>`
+                // after `mv old new` hits ENOENT despite the kernel-
+                // side rename having succeeded.
+                self.paths.lock().unwrap().rename(&old_path, &new_path);
+                reply.ok();
+            }
             Err(_) => reply.error(errno_io()),
         }
     }
@@ -775,7 +871,7 @@ impl Filesystem for NexusFs {
             reply.error(errno_io());
             return;
         }
-        let ino_raw = self.alloc_inode(path.clone());
+        let ino_raw = self.inode_for(&path);
         let ino = INodeNo(ino_raw);
         match self.stat_attr(ino, &path) {
             Ok(attr) => reply.created(

--- a/rust/services/fuse-plugin/src/fs.rs
+++ b/rust/services/fuse-plugin/src/fs.rs
@@ -47,12 +47,12 @@
 use std::collections::HashMap;
 use std::ffi::CString;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::Mutex;
 use std::time::{Duration, SystemTime};
 
 use fuser::{
-    Errno, FileAttr, FileHandle, FileType, Filesystem, Generation, INodeNo, Notifier, ReplyAttr,
-    ReplyData, ReplyEmpty, ReplyEntry, ReplyOpen, ReplyWrite, Request,
+    Errno, FileAttr, FileHandle, FileType, Filesystem, Generation, INodeNo, ReplyAttr, ReplyData,
+    ReplyEmpty, ReplyEntry, ReplyOpen, ReplyWrite, Request,
 };
 
 use nexus_plugin_abi::{nexus_free, KernelHandle};
@@ -96,15 +96,6 @@ pub struct NexusFs {
     /// lookups join from there.  We never evict.
     inodes: Mutex<HashMap<u64, String>>,
     next_inode: AtomicU64,
-    /// Notifier handle for explicit dcache invalidation.  Populated by
-    /// `set_notifier` after `fuser::spawn_mount2` returns the session
-    /// (chicken-and-egg: `NexusFs` is constructed before the session
-    /// exists).  Used by `rename` to drop the old src + invalidate the
-    /// new dst's negative cache — otherwise `mv` + immediate
-    /// `cat <new>` hits the cached "doesn't exist" from `mv`'s
-    /// pre-rename lookup and surfaces ENOENT despite the kernel-side
-    /// rename having succeeded.
-    notifier: Arc<Mutex<Option<Notifier>>>,
 }
 
 impl NexusFs {
@@ -117,17 +108,7 @@ impl NexusFs {
             // First allocated inode = root + 1; the root inode itself
             // is reserved (fuser INodeNo::ROOT == 1).
             next_inode: AtomicU64::new(FUSE_ROOT_RAW + 1),
-            notifier: Arc::new(Mutex::new(None)),
         }
-    }
-
-    /// Hand off the notifier handle from `fuser::BackgroundSession`
-    /// so directory-mutating ops can punch holes in the kernel-side
-    /// dcache.  Cheap clone (the notifier is a small handle wrapping
-    /// the session's command channel), called once at plugin create
-    /// time right after `spawn_mount2`.
-    pub fn notifier_slot(&self) -> Arc<Mutex<Option<Notifier>>> {
-        Arc::clone(&self.notifier)
     }
 
     fn path_for(&self, ino: INodeNo) -> Option<String> {
@@ -710,29 +691,7 @@ impl Filesystem for NexusFs {
         let old_path = join_path(&old_parent, old_name);
         let new_path = join_path(&new_parent, new_name);
         match self.sys_rename(&old_path, &new_path) {
-            Ok(()) => {
-                // Punch holes in the kernel-side dcache for both
-                // sides — without this, `mv` + immediate `cat <new>`
-                // surfaces ENOENT despite the rename having
-                // succeeded.  `mv` does an LOOKUP on the destination
-                // before issuing the rename op; when that returns
-                // ENOENT the kernel caches the negative entry for
-                // ENTRY_TTL, and the rename op itself doesn't reset
-                // the cache.  Calling `inval_entry(newparent,
-                // newname)` drops the cached negative so the next
-                // LOOKUP routes back to us with a fresh sys_stat.
-                // Same for the old side — without invalidation, `cat
-                // <old>` after the rename would see the stale
-                // positive entry and try to read a path the kernel
-                // no longer knows about (EIO).  Failures here are
-                // best-effort: a missed invalidation manifests as a
-                // sub-second stale lookup, not data corruption.
-                if let Some(notifier) = self.notifier.lock().unwrap().as_ref() {
-                    let _ = notifier.inval_entry(parent, name);
-                    let _ = notifier.inval_entry(newparent, newname);
-                }
-                reply.ok();
-            }
+            Ok(()) => reply.ok(),
             Err(_) => reply.error(errno_io()),
         }
     }

--- a/rust/services/fuse-plugin/src/fs.rs
+++ b/rust/services/fuse-plugin/src/fs.rs
@@ -282,26 +282,13 @@ impl NexusFs {
     /// we hand-roll a tiny parser to avoid pulling `serde_json` into
     /// the cdylib's dependency closure for two fields.
     fn parse_stat(&self, ino: INodeNo, json: &str) -> Option<FileAttr> {
-        // Kernel callback exports `entry_type` (the SSOT for "what
-        // kind of inode this is") rather than a precomputed
-        // `is_directory` flag, so dispatch by entry_type instead.
-        // DT_DIR (1) is the only directory variant; everything else
-        // (DT_REG / DT_MOUNT / DT_PIPE / DT_STREAM /
-        // DT_EXTERNAL_STORAGE / DT_LINK) maps to a regular-file
-        // surface for FUSE callers.  DT_MOUNT would deserve a
-        // directory surface here once the FUSE layer learns how to
-        // traverse mount points; for now treating it as a regular
-        // file is consistent with the kernel returning miss on
-        // readdir against a mount root.
+        // Kernel exports `entry_type` (the SSOT for "what kind of
+        // inode this is"); `kind_from_entry_type` is the single rule
+        // that maps it to a FUSE FileType.
         let size = json_u64(json, "\"size\":")?;
         let entry_type = json_u64(json, "\"entry_type\":")?;
-        const DT_DIR: u64 = 1;
-        let kind = if entry_type == DT_DIR {
-            FileType::Directory
-        } else {
-            FileType::RegularFile
-        };
-        let is_dir = entry_type == DT_DIR;
+        let kind = kind_from_entry_type(entry_type);
+        let is_dir = kind == FileType::Directory;
         // FUSE wants a complete FileAttr; fields we don't pull from
         // sys_stat default to zero / now / 0644.
         let now = SystemTime::now();
@@ -330,6 +317,26 @@ impl NexusFs {
     fn stat_attr(&self, ino: INodeNo, path: &str) -> Result<FileAttr, Errno> {
         let json = self.sys_stat(path).map_err(|_| errno_enoent())?;
         self.parse_stat(ino, &json).ok_or_else(errno_io)
+    }
+}
+
+/// Single SSOT rule mapping kernel `entry_type` values to FUSE
+/// `FileType`.  Both DT_DIR (1) and DT_MOUNT (2) surface as
+/// directories — the kernel's `sys_stat` mount-point synthesis path
+/// (kernel/src/kernel/io.rs §3.5) explicitly emits DT_MOUNT with
+/// `is_directory: true` + `mode: 0o755`, so FUSE must treat them the
+/// same or `mountpoint -q` / `cd <mount>` / `readdir` all break at
+/// the mount root.  Every other `entry_type` (DT_REG / DT_LINK /
+/// DT_PIPE / DT_STREAM / DT_EXTERNAL_STORAGE) maps to RegularFile —
+/// the most conservative choice for kinds the FUSE layer doesn't
+/// (yet) have first-class handling for.
+fn kind_from_entry_type(entry_type: u64) -> FileType {
+    const DT_DIR: u64 = 1;
+    const DT_MOUNT: u64 = 2;
+    if entry_type == DT_DIR || entry_type == DT_MOUNT {
+        FileType::Directory
+    } else {
+        FileType::RegularFile
     }
 }
 
@@ -550,15 +557,10 @@ impl Filesystem for NexusFs {
         // VFS resume from the offset we last reported.  Skipping
         // `offset` entries handles continuation correctly without
         // needing a per-fh cursor.
-        const DT_DIR: u64 = 1;
         for (idx, (name, entry_type)) in entries.into_iter().enumerate().skip(offset as usize) {
             let child_path = join_path(&parent_path, &name);
             let child_ino = self.alloc_inode(child_path);
-            let kind = if entry_type == DT_DIR {
-                FileType::Directory
-            } else {
-                FileType::RegularFile
-            };
+            let kind = kind_from_entry_type(entry_type);
             // FUSE's `next_offset` semantics: the next readdir call
             // resumes at this value, so we return `idx + 1`.
             if reply.add(INodeNo(child_ino), (idx + 1) as u64, kind, &name) {
@@ -831,6 +833,27 @@ mod tests {
             entries,
             vec![("foo.txt".to_string(), 0), ("sub".to_string(), 1),]
         );
+    }
+
+    #[test]
+    fn kind_from_entry_type_mount_and_dir_are_directories() {
+        // DT_DIR (1) and DT_MOUNT (2) — same FUSE surface.  Kernel
+        // io.rs §3.5 synthesizes mount roots as DT_MOUNT with
+        // `is_directory: true`, so this mapping is the SSOT for
+        // "FUSE root is a directory" — without it `mountpoint -q`
+        // fails the moment fuser hands off to the plugin.
+        assert_eq!(kind_from_entry_type(1), FileType::Directory);
+        assert_eq!(kind_from_entry_type(2), FileType::Directory);
+    }
+
+    #[test]
+    fn kind_from_entry_type_regular_for_everything_else() {
+        // DT_REG (0), DT_LINK (3), DT_PIPE (5+), DT_STREAM,
+        // DT_EXTERNAL_STORAGE — all map to RegularFile until the
+        // FUSE layer grows first-class handling.
+        assert_eq!(kind_from_entry_type(0), FileType::RegularFile);
+        assert_eq!(kind_from_entry_type(3), FileType::RegularFile);
+        assert_eq!(kind_from_entry_type(99), FileType::RegularFile);
     }
 
     #[test]

--- a/rust/services/fuse-plugin/src/fs.rs
+++ b/rust/services/fuse-plugin/src/fs.rs
@@ -62,6 +62,16 @@ use nexus_plugin_abi::{nexus_free, KernelHandle};
 /// SSOT, so stale entries self-correct within a tick.
 const ATTR_TTL: Duration = Duration::from_secs(1);
 const ENTRY_TTL: Duration = Duration::from_secs(1);
+/// Negative-entry TTL.  Must stay at zero — see `lookup`'s negative
+/// branch for the full rationale: `mv <src> <new>` followed by a sub-
+/// second `cat <new>` would otherwise hit the cached negative entry
+/// from `mv`'s pre-rename LOOKUP(new) probe and surface stale ENOENT
+/// despite the rename having succeeded kernel-side.  A `Notifier`-
+/// based invalidation deadlocks fuser's single-threaded event loop
+/// (the notify message can't dispatch while the only worker is
+/// inside the rename handler), so zero-TTL negatives are the only
+/// race-free option without a dedicated invalidation worker.
+const NEG_ENTRY_TTL: Duration = Duration::ZERO;
 
 /// Raw inode value for the FUSE root.  fuser 0.17 exposes a typed
 /// `INodeNo::ROOT` constant (the `u64` 1), which we unwrap here so
@@ -320,6 +330,33 @@ impl NexusFs {
     }
 }
 
+/// FUSE-protocol negative-entry attr — `attr.ino == 0` signals
+/// "no entry at this name" to the kernel.  Every other field is a
+/// don't-care for negative entries, so we initialise to sane zeros
+/// instead of carrying a separate `Option<FileAttr>` plumbing path.
+/// Paired with `NEG_ENTRY_TTL = Duration::ZERO` in `lookup`'s
+/// Err branch — see the rationale on `NEG_ENTRY_TTL`.
+fn negative_entry_attr() -> FileAttr {
+    let now = SystemTime::now();
+    FileAttr {
+        ino: INodeNo(0),
+        size: 0,
+        blocks: 0,
+        atime: now,
+        mtime: now,
+        ctime: now,
+        crtime: now,
+        kind: FileType::RegularFile,
+        perm: 0,
+        nlink: 0,
+        uid: 0,
+        gid: 0,
+        rdev: 0,
+        blksize: 0,
+        flags: 0,
+    }
+}
+
 /// Single SSOT rule mapping kernel `entry_type` values to FUSE
 /// `FileType`.  Both DT_DIR (1) and DT_MOUNT (2) surface as
 /// directories — the kernel's `sys_stat` mount-point synthesis path
@@ -406,7 +443,15 @@ impl Filesystem for NexusFs {
         let ino = INodeNo(ino_raw);
         match self.stat_attr(ino, &path) {
             Ok(attr) => reply.entry(&ENTRY_TTL, &attr, Generation(0)),
-            Err(e) => reply.error(e),
+            // FUSE protocol: a reply.entry with `attr.ino == 0` is a
+            // *negative* entry — the kernel records "this name does
+            // not exist" for `entry_valid` seconds.  Setting TTL = 0
+            // means the kernel doesn't cache the negative at all,
+            // which is the SoT we need: every subsequent LOOKUP for
+            // this name walks back through to `sys_stat` instead of
+            // serving the stale "doesn't exist" answer that `mv`'s
+            // pre-rename probe left behind.  See NEG_ENTRY_TTL.
+            Err(_) => reply.entry(&NEG_ENTRY_TTL, &negative_entry_attr(), Generation(0)),
         }
     }
 

--- a/rust/services/fuse-plugin/src/fs.rs
+++ b/rust/services/fuse-plugin/src/fs.rs
@@ -327,48 +327,9 @@ impl NexusFs {
     /// Same sys_stat wrapper but returning a populated FileAttr on
     /// success.  Centralises the path → callback → parse pipeline so
     /// lookup / getattr / readdir share one error mapping.
-    ///
-    /// Special case: the mount root (inode == FUSE_ROOT_RAW) always
-    /// returns a synthetic directory FileAttr.  The kernel's
-    /// `sys_stat` is documented to return `None` for trie-resolved
-    /// paths — including DT_MOUNT entries, which is exactly what the
-    /// plugin's `NEXUS_FUSE_VFS_ROOT` maps to.  Without this short-
-    /// circuit, `mountpoint -q` can't validate the mount (its
-    /// `stat()` of the root returns ENOENT), every FUSE op fails the
-    /// initial root lookup, and the mount is effectively unusable.
-    /// The synthetic attr is consistent with the kernel's own DT_MOUNT
-    /// semantics — directory, perm 0755 — so this is honest about
-    /// what the mount root *is* even though sys_stat declines to say so.
     fn stat_attr(&self, ino: INodeNo, path: &str) -> Result<FileAttr, Errno> {
-        if ino.0 == FUSE_ROOT_RAW {
-            return Ok(self.synthetic_root_attr());
-        }
         let json = self.sys_stat(path).map_err(|_| errno_enoent())?;
         self.parse_stat(ino, &json).ok_or_else(errno_io)
-    }
-
-    /// Build the synthetic FileAttr for the FUSE mount root.  See
-    /// `stat_attr` for the kernel-side rationale; this is the
-    /// SSOT for "what does the mount root look like to FUSE".
-    fn synthetic_root_attr(&self) -> FileAttr {
-        let now = SystemTime::now();
-        FileAttr {
-            ino: INodeNo::ROOT,
-            size: 0,
-            blocks: 0,
-            atime: now,
-            mtime: now,
-            ctime: now,
-            crtime: now,
-            kind: FileType::Directory,
-            perm: 0o755,
-            nlink: 2,
-            uid: unsafe { libc::getuid() },
-            gid: unsafe { libc::getgid() },
-            rdev: 0,
-            blksize: 4096,
-            flags: 0,
-        }
     }
 }
 

--- a/rust/services/fuse-plugin/src/fs.rs
+++ b/rust/services/fuse-plugin/src/fs.rs
@@ -47,12 +47,12 @@
 use std::collections::HashMap;
 use std::ffi::CString;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime};
 
 use fuser::{
-    Errno, FileAttr, FileHandle, FileType, Filesystem, Generation, INodeNo, ReplyAttr, ReplyData,
-    ReplyEmpty, ReplyEntry, ReplyOpen, ReplyWrite, Request,
+    Errno, FileAttr, FileHandle, FileType, Filesystem, Generation, INodeNo, Notifier, ReplyAttr,
+    ReplyData, ReplyEmpty, ReplyEntry, ReplyOpen, ReplyWrite, Request,
 };
 
 use nexus_plugin_abi::{nexus_free, KernelHandle};
@@ -96,6 +96,15 @@ pub struct NexusFs {
     /// lookups join from there.  We never evict.
     inodes: Mutex<HashMap<u64, String>>,
     next_inode: AtomicU64,
+    /// Notifier handle for explicit dcache invalidation.  Populated by
+    /// `set_notifier` after `fuser::spawn_mount2` returns the session
+    /// (chicken-and-egg: `NexusFs` is constructed before the session
+    /// exists).  Used by `rename` to drop the old src + invalidate the
+    /// new dst's negative cache — otherwise `mv` + immediate
+    /// `cat <new>` hits the cached "doesn't exist" from `mv`'s
+    /// pre-rename lookup and surfaces ENOENT despite the kernel-side
+    /// rename having succeeded.
+    notifier: Arc<Mutex<Option<Notifier>>>,
 }
 
 impl NexusFs {
@@ -108,7 +117,17 @@ impl NexusFs {
             // First allocated inode = root + 1; the root inode itself
             // is reserved (fuser INodeNo::ROOT == 1).
             next_inode: AtomicU64::new(FUSE_ROOT_RAW + 1),
+            notifier: Arc::new(Mutex::new(None)),
         }
+    }
+
+    /// Hand off the notifier handle from `fuser::BackgroundSession`
+    /// so directory-mutating ops can punch holes in the kernel-side
+    /// dcache.  Cheap clone (the notifier is a small handle wrapping
+    /// the session's command channel), called once at plugin create
+    /// time right after `spawn_mount2`.
+    pub fn notifier_slot(&self) -> Arc<Mutex<Option<Notifier>>> {
+        Arc::clone(&self.notifier)
     }
 
     fn path_for(&self, ino: INodeNo) -> Option<String> {
@@ -691,7 +710,29 @@ impl Filesystem for NexusFs {
         let old_path = join_path(&old_parent, old_name);
         let new_path = join_path(&new_parent, new_name);
         match self.sys_rename(&old_path, &new_path) {
-            Ok(()) => reply.ok(),
+            Ok(()) => {
+                // Punch holes in the kernel-side dcache for both
+                // sides — without this, `mv` + immediate `cat <new>`
+                // surfaces ENOENT despite the rename having
+                // succeeded.  `mv` does an LOOKUP on the destination
+                // before issuing the rename op; when that returns
+                // ENOENT the kernel caches the negative entry for
+                // ENTRY_TTL, and the rename op itself doesn't reset
+                // the cache.  Calling `inval_entry(newparent,
+                // newname)` drops the cached negative so the next
+                // LOOKUP routes back to us with a fresh sys_stat.
+                // Same for the old side — without invalidation, `cat
+                // <old>` after the rename would see the stale
+                // positive entry and try to read a path the kernel
+                // no longer knows about (EIO).  Failures here are
+                // best-effort: a missed invalidation manifests as a
+                // sub-second stale lookup, not data corruption.
+                if let Some(notifier) = self.notifier.lock().unwrap().as_ref() {
+                    let _ = notifier.inval_entry(parent, name);
+                    let _ = notifier.inval_entry(newparent, newname);
+                }
+                reply.ok();
+            }
             Err(_) => reply.error(errno_io()),
         }
     }

--- a/rust/services/fuse-plugin/src/lib.rs
+++ b/rust/services/fuse-plugin/src/lib.rs
@@ -117,6 +117,14 @@ fn create_fuse_plugin(_kernel: &KernelHandle) -> Box<FusePlugin> {
             let mount_config = fuser::Config::default();
             match fuser::spawn_mount2(fs, &mount_point, &mount_config) {
                 Ok(session) => {
+                    // eprintln complements tracing: a dlopen'd cdylib
+                    // owns a separate tracing global, so the plugin's
+                    // `tracing::info!` calls don't reach the cluster's
+                    // subscriber.  stderr lands in the daemon's stderr
+                    // regardless, which is what compose / `docker logs`
+                    // capture — the operator's only mount-status SoT
+                    // until the cluster grows a plugin-tracing bridge.
+                    eprintln!("[nexus-fuse-plugin] mount OK at {mount_point}");
                     tracing::info!(
                         target: "nexus::fuse",
                         mount_point = %mount_point,
@@ -125,6 +133,7 @@ fn create_fuse_plugin(_kernel: &KernelHandle) -> Box<FusePlugin> {
                     *plugin.session.lock().unwrap() = Some(session);
                 }
                 Err(e) => {
+                    eprintln!("[nexus-fuse-plugin] mount FAILED at {mount_point}: {e}");
                     tracing::error!(
                         target: "nexus::fuse",
                         mount_point = %mount_point,
@@ -134,6 +143,7 @@ fn create_fuse_plugin(_kernel: &KernelHandle) -> Box<FusePlugin> {
                 }
             }
         } else {
+            eprintln!("[nexus-fuse-plugin] NEXUS_FUSE_MOUNT_POINT not set — no mount performed");
             tracing::warn!(
                 target: "nexus::fuse",
                 "NEXUS_FUSE_MOUNT_POINT not set — plugin loaded but no mount performed"

--- a/rust/services/fuse-plugin/src/lib.rs
+++ b/rust/services/fuse-plugin/src/lib.rs
@@ -115,16 +115,8 @@ fn create_fuse_plugin(_kernel: &KernelHandle) -> Box<FusePlugin> {
             // mapping or read-only mounts set them via the OS-level FUSE
             // mount wrapper, not the plugin.
             let mount_config = fuser::Config::default();
-            // Stash the inode-tracking fs's notifier slot before
-            // handing it to `spawn_mount2` (which consumes it).
-            // After the session comes up, we populate the slot so
-            // directory-mutating ops can invalidate dcache entries
-            // — see `NexusFs::rename` for the prima facie case (mv
-            // + immediate cat racing the FUSE entry cache).
-            let notifier_slot = fs.notifier_slot();
             match fuser::spawn_mount2(fs, &mount_point, &mount_config) {
                 Ok(session) => {
-                    *notifier_slot.lock().unwrap() = Some(session.notifier());
                     // eprintln complements tracing: a dlopen'd cdylib
                     // owns a separate tracing global, so the plugin's
                     // `tracing::info!` calls don't reach the cluster's

--- a/rust/services/fuse-plugin/src/lib.rs
+++ b/rust/services/fuse-plugin/src/lib.rs
@@ -41,15 +41,20 @@
 //!
 //! ## Platform support
 //!
-//! Linux first (`libfuse3` via the `fuser` crate).  macOS support
-//! piggybacks on `fuser`'s macFUSE backend the moment we add the
-//! `target_os = "macos"` cfg gate.  Windows requires a separate
-//! WinFsp adapter — out of scope for this first cut.
+//! Linux (`libfuse3`) and macOS (`macFUSE`) share one cfg-gated body
+//! — `fuser`'s `Filesystem` trait + `spawn_mount2` work identically
+//! on both.  Operators install the platform-native FUSE userspace
+//! out-of-band (apt `libfuse3-3` / brew `macfuse`) before launching
+//! `nexusd-cluster --plugin-dir`.  Windows shipping waits on a
+//! separate WinFsp adapter — different binding crate (winfsp-rs),
+//! different mount API surface; tracked as a follow-up PR.  On
+//! Windows today the plugin compiles to a no-op cdylib so the
+//! workspace builds cleanly across the matrix.
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 mod fs;
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 use std::sync::Mutex;
 
 use nexus_plugin_abi::{declare_service_plugin, KernelHandle};
@@ -61,18 +66,18 @@ use nexus_plugin_abi::{declare_service_plugin, KernelHandle};
 /// thread.  On non-Linux targets, holds nothing; the plugin is
 /// effectively a no-op.
 struct FusePlugin {
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
     session: Mutex<Option<fuser::BackgroundSession>>,
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
     _phantom: (),
 }
 
 impl FusePlugin {
     fn new() -> Self {
         Self {
-            #[cfg(target_os = "linux")]
+            #[cfg(any(target_os = "linux", target_os = "macos"))]
             session: Mutex::new(None),
-            #[cfg(not(target_os = "linux"))]
+            #[cfg(not(any(target_os = "linux", target_os = "macos")))]
             _phantom: (),
         }
     }
@@ -90,7 +95,7 @@ impl FusePlugin {
 fn create_fuse_plugin(_kernel: &KernelHandle) -> Box<FusePlugin> {
     let plugin = FusePlugin::new();
 
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
     {
         let mount_point = std::env::var("NEXUS_FUSE_MOUNT_POINT").ok();
         if let Some(mount_point) = mount_point {
@@ -145,7 +150,7 @@ fn create_fuse_plugin(_kernel: &KernelHandle) -> Box<FusePlugin> {
 /// kernel guarantees the underlying state lives at least as long as
 /// any plugin holding a clone (loader holds the `Arc<Kernel>` via the
 /// `DylibRustService` it stores).
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 unsafe fn kernel_handle_clone(src: &KernelHandle) -> KernelHandle {
     KernelHandle {
         sys_read: src.sys_read,
@@ -174,7 +179,7 @@ unsafe fn kernel_handle_clone(src: &KernelHandle) -> KernelHandle {
 fn dispatch_fuse(svc: &FusePlugin, method: &str, _payload: &[u8]) -> Result<Vec<u8>, i32> {
     match method {
         "status" => {
-            #[cfg(target_os = "linux")]
+            #[cfg(any(target_os = "linux", target_os = "macos"))]
             {
                 let mounted = svc.session.lock().unwrap().is_some();
                 Ok(if mounted {
@@ -183,14 +188,14 @@ fn dispatch_fuse(svc: &FusePlugin, method: &str, _payload: &[u8]) -> Result<Vec<
                     b"unmounted".to_vec()
                 })
             }
-            #[cfg(not(target_os = "linux"))]
+            #[cfg(not(any(target_os = "linux", target_os = "macos")))]
             {
                 let _ = svc;
                 Ok(b"unsupported-platform".to_vec())
             }
         }
         "unmount" => {
-            #[cfg(target_os = "linux")]
+            #[cfg(any(target_os = "linux", target_os = "macos"))]
             {
                 let session = svc.session.lock().unwrap().take();
                 if session.is_some() {
@@ -202,7 +207,7 @@ fn dispatch_fuse(svc: &FusePlugin, method: &str, _payload: &[u8]) -> Result<Vec<
                     Ok(b"not-mounted".to_vec())
                 }
             }
-            #[cfg(not(target_os = "linux"))]
+            #[cfg(not(any(target_os = "linux", target_os = "macos")))]
             {
                 let _ = svc;
                 Ok(b"unsupported-platform".to_vec())

--- a/rust/services/fuse-plugin/src/lib.rs
+++ b/rust/services/fuse-plugin/src/lib.rs
@@ -115,8 +115,16 @@ fn create_fuse_plugin(_kernel: &KernelHandle) -> Box<FusePlugin> {
             // mapping or read-only mounts set them via the OS-level FUSE
             // mount wrapper, not the plugin.
             let mount_config = fuser::Config::default();
+            // Stash the inode-tracking fs's notifier slot before
+            // handing it to `spawn_mount2` (which consumes it).
+            // After the session comes up, we populate the slot so
+            // directory-mutating ops can invalidate dcache entries
+            // — see `NexusFs::rename` for the prima facie case (mv
+            // + immediate cat racing the FUSE entry cache).
+            let notifier_slot = fs.notifier_slot();
             match fuser::spawn_mount2(fs, &mount_point, &mount_config) {
                 Ok(session) => {
+                    *notifier_slot.lock().unwrap() = Some(session.notifier());
                     // eprintln complements tracing: a dlopen'd cdylib
                     // owns a separate tracing global, so the plugin's
                     // `tracing::info!` calls don't reach the cluster's

--- a/tests/e2e/docker/fuse_plugin_helpers.py
+++ b/tests/e2e/docker/fuse_plugin_helpers.py
@@ -1,0 +1,202 @@
+"""Shared helpers for the FUSE plugin E2E suite.
+
+Sits next to :mod:`tests.e2e.docker.runbook_helpers` and reuses every
+gRPC primitive from it.  Only the helpers distinct to this suite live
+here:
+
+* Topology — single ``cluster`` node with the FUSE plugin loaded.  The
+  mount point inside the container is whatever the compose's
+  ``NEXUS_FUSE_MOUNT_POINT`` is set to (``/mnt/nexus`` by default).
+* ``mount_exec`` — run a POSIX op (``mkdir`` / ``touch`` / ``ls`` /
+  ``cat`` / ``mv`` / ``rm``) inside the cluster container, anchored
+  at the FUSE mount point.  Every op flows through the kernel FUSE
+  driver → the plugin's background thread → the v2 KernelHandle
+  callbacks → the kernel syscall surface.
+* ``mount_write_bytes`` / ``mount_read_bytes`` — byte-exact I/O to a
+  file inside the mount via ``docker exec`` with stdin/stdout
+  pipelines.  Used to cross-check ``vfs_read`` returns the same bytes
+  ``cat`` saw at the mount.
+
+The cross-check pattern is symmetric: every assertion has a POSIX-op
+side (through the mount) AND a gRPC ``vfs_stat`` / ``vfs_read`` side
+(direct to the kernel).  A regression in either layer surfaces as a
+mismatch, not a silent skip.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from dataclasses import dataclass
+
+import pytest
+
+from . import runbook_helpers
+
+
+@dataclass(frozen=True)
+class FuseTopology:
+    """Single-node cluster + FUSE-plugin topology backing the suite."""
+
+    cluster_grpc: str
+    cluster_container: str
+    mount_point: str
+
+    def vfs_path(self, relpath: str) -> str:
+        """Compose the kernel-side VFS path for a relpath under the mount.
+
+        ``NEXUS_FUSE_VFS_ROOT`` is ``/`` in the compose, so the mount
+        projects the kernel's VFS root onto the container path.  A
+        relpath of ``foo/bar.txt`` thus translates to kernel-side
+        ``/foo/bar.txt`` — the same path ``vfs_stat`` / ``vfs_read``
+        consume.
+        """
+        if not relpath.startswith("/"):
+            relpath = "/" + relpath
+        return relpath
+
+    def mount_path(self, relpath: str) -> str:
+        """Compose the container-side path under the FUSE mount.
+
+        Used as the second argument to every ``docker exec`` POSIX op
+        — the path the kernel's FUSE driver sees.
+        """
+        if not relpath.startswith("/"):
+            relpath = "/" + relpath
+        return f"{self.mount_point.rstrip('/')}{relpath}"
+
+
+def topology_from_env() -> FuseTopology:
+    return FuseTopology(
+        cluster_grpc=os.environ.get("NEXUS_CLUSTER_GRPC", "cluster:2126"),
+        cluster_container=os.environ.get("NEXUS_CLUSTER_CONTAINER", "nexus-fuse-cluster"),
+        mount_point=os.environ.get("NEXUS_FUSE_MOUNT_POINT", "/mnt/nexus"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# POSIX ops inside the cluster container, anchored at the FUSE mount.
+#
+# Every helper here ultimately calls ``docker exec`` against the cluster.
+# Using ``docker exec`` (not the local host) ensures the ops go through
+# the in-container kernel + FUSE driver — the path the plugin actually
+# wires.  Running ops on the host would either bypass the mount or
+# exercise a different libfuse3 build entirely.
+# ---------------------------------------------------------------------------
+def mount_mkdir(topology: FuseTopology, relpath: str, *, parents: bool = False) -> None:
+    """``mkdir [-p] <mount>/<relpath>`` — triggers the plugin's ``mkdir`` op."""
+    cmd = ["mkdir"]
+    if parents:
+        cmd.append("-p")
+    cmd.append(topology.mount_path(relpath))
+    runbook_helpers.docker_exec(topology.cluster_container, cmd, check=True)
+
+
+def mount_rmdir(topology: FuseTopology, relpath: str) -> None:
+    """``rmdir <mount>/<relpath>`` — triggers the plugin's ``rmdir`` op."""
+    runbook_helpers.docker_exec(
+        topology.cluster_container,
+        ["rmdir", topology.mount_path(relpath)],
+        check=True,
+    )
+
+
+def mount_unlink(topology: FuseTopology, relpath: str) -> None:
+    """``rm <mount>/<relpath>`` — triggers the plugin's ``unlink`` op."""
+    runbook_helpers.docker_exec(
+        topology.cluster_container,
+        ["rm", topology.mount_path(relpath)],
+        check=True,
+    )
+
+
+def mount_rename(topology: FuseTopology, old_relpath: str, new_relpath: str) -> None:
+    """``mv <mount>/<old> <mount>/<new>`` — triggers the plugin's ``rename`` op."""
+    runbook_helpers.docker_exec(
+        topology.cluster_container,
+        ["mv", topology.mount_path(old_relpath), topology.mount_path(new_relpath)],
+        check=True,
+    )
+
+
+def mount_listdir(topology: FuseTopology, relpath: str = "/") -> list[str]:
+    """``ls -1 <mount>/<relpath>`` — triggers the plugin's ``readdir`` op.
+
+    Returns the entry names sorted for stable assertions.  An empty
+    directory returns ``[]`` (not a one-element list with empty string).
+    """
+    result = runbook_helpers.docker_exec(
+        topology.cluster_container,
+        ["ls", "-1", topology.mount_path(relpath)],
+        check=True,
+    )
+    names = [line for line in result.stdout.splitlines() if line]
+    return sorted(names)
+
+
+def mount_write_bytes(topology: FuseTopology, relpath: str, data: bytes) -> None:
+    """Write ``data`` to ``<mount>/<relpath>``.
+
+    Bytes-preserving — runs through ``docker exec -i ... sh -c 'cat >
+    <path>'`` so binary content round-trips exactly.  The ``cat``
+    triggers ``create`` (file didn't exist) + ``write`` (the payload),
+    both routing through the plugin's KernelHandle callbacks.
+    """
+    full_path = topology.mount_path(relpath)
+    proc = subprocess.run(
+        [
+            "docker",
+            "exec",
+            "-i",
+            topology.cluster_container,
+            "sh",
+            "-c",
+            f"cat > {full_path}",
+        ],
+        input=data,
+        capture_output=True,
+        timeout=30,
+    )
+    if proc.returncode != 0:
+        pytest.fail(
+            f"mount_write_bytes({relpath}) failed (rc={proc.returncode}): "
+            f"stderr={proc.stderr.decode(errors='replace')}"
+        )
+
+
+def mount_read_bytes(topology: FuseTopology, relpath: str) -> bytes:
+    """Read ``<mount>/<relpath>`` byte-exact via ``docker exec ... cat``."""
+    proc = subprocess.run(
+        ["docker", "exec", topology.cluster_container, "cat", topology.mount_path(relpath)],
+        capture_output=True,
+        timeout=30,
+    )
+    if proc.returncode != 0:
+        pytest.fail(
+            f"mount_read_bytes({relpath}) failed (rc={proc.returncode}): "
+            f"stderr={proc.stderr.decode(errors='replace')}"
+        )
+    return proc.stdout
+
+
+def mount_path_exists(topology: FuseTopology, relpath: str) -> bool:
+    """``test -e <mount>/<relpath>`` — surface the kernel's view of existence.
+
+    Returns ``True`` when the kernel-side FUSE driver reports the path
+    exists at the moment of the call.  Used in negative assertions
+    (after ``unlink`` / ``rmdir``) where the test must observe the
+    absence, not just the lack of a positive signal.
+    """
+    proc = subprocess.run(
+        [
+            "docker",
+            "exec",
+            topology.cluster_container,
+            "test",
+            "-e",
+            topology.mount_path(relpath),
+        ],
+        capture_output=True,
+        timeout=10,
+    )
+    return proc.returncode == 0

--- a/tests/e2e/docker/test_fuse_plugin_e2e.py
+++ b/tests/e2e/docker/test_fuse_plugin_e2e.py
@@ -88,9 +88,7 @@ class TestMountLoadedAndReady:
         assert "error" not in result, f"gRPC vfs_stat(/) failed: {result}"
         assert result["result"]["found"], "/ must exist on a fresh cluster"
 
-    def test_mount_point_is_a_fuse_mount(
-        self, topology: fuse_plugin_helpers.FuseTopology
-    ) -> None:
+    def test_mount_point_is_a_fuse_mount(self, topology: fuse_plugin_helpers.FuseTopology) -> None:
         result = runbook_helpers.docker_exec(
             topology.cluster_container,
             ["mountpoint", "-q", topology.mount_point],
@@ -120,13 +118,9 @@ class TestMkdirReaddirRoundTrip:
 
         # readdir must show the entry on the parent listing.
         entries = fuse_plugin_helpers.mount_listdir(topology, "/")
-        assert "alpha-dir" in entries, (
-            f"readdir on / missed `alpha-dir` after mkdir; got {entries}"
-        )
+        assert "alpha-dir" in entries, f"readdir on / missed `alpha-dir` after mkdir; got {entries}"
 
-    def test_nested_mkdir_p_visible(
-        self, topology: fuse_plugin_helpers.FuseTopology
-    ) -> None:
+    def test_nested_mkdir_p_visible(self, topology: fuse_plugin_helpers.FuseTopology) -> None:
         fuse_plugin_helpers.mount_mkdir(topology, "nested/deep/path", parents=True)
         stat = _wait_path_via_grpc(
             topology,
@@ -141,9 +135,7 @@ class TestMkdirReaddirRoundTrip:
 class TestCreateWriteRead:
     """`cat > file` + `cat file` — exercise create + write + read."""
 
-    def test_create_empty_file_visible(
-        self, topology: fuse_plugin_helpers.FuseTopology
-    ) -> None:
+    def test_create_empty_file_visible(self, topology: fuse_plugin_helpers.FuseTopology) -> None:
         fuse_plugin_helpers.mount_write_bytes(topology, "empty.txt", b"")
         stat = _wait_path_via_grpc(topology, topology.vfs_path("empty.txt"), expect_found=True)
         assert not stat["result"]["isDirectory"]
@@ -156,8 +148,7 @@ class TestCreateWriteRead:
         fuse_plugin_helpers.mount_write_bytes(topology, "rw.txt", payload)
         roundtrip = fuse_plugin_helpers.mount_read_bytes(topology, "rw.txt")
         assert roundtrip == payload, (
-            f"mount read != mount write; got len={len(roundtrip)}, "
-            f"expected len={len(payload)}"
+            f"mount read != mount write; got len={len(roundtrip)}, expected len={len(payload)}"
         )
 
     def test_write_via_mount_visible_through_grpc_read(
@@ -192,9 +183,7 @@ class TestRenameUnlinkRmdir:
     def test_rename_moves_file(self, topology: fuse_plugin_helpers.FuseTopology) -> None:
         payload = b"rename target payload"
         fuse_plugin_helpers.mount_write_bytes(topology, "rename-src.txt", payload)
-        _wait_path_via_grpc(
-            topology, topology.vfs_path("rename-src.txt"), expect_found=True
-        )
+        _wait_path_via_grpc(topology, topology.vfs_path("rename-src.txt"), expect_found=True)
 
         fuse_plugin_helpers.mount_rename(topology, "rename-src.txt", "rename-dst.txt")
 
@@ -207,9 +196,7 @@ class TestRenameUnlinkRmdir:
             "but lost the content reference"
         )
 
-    def test_unlink_removes_file(
-        self, topology: fuse_plugin_helpers.FuseTopology
-    ) -> None:
+    def test_unlink_removes_file(self, topology: fuse_plugin_helpers.FuseTopology) -> None:
         fuse_plugin_helpers.mount_write_bytes(topology, "doomed.txt", b"bye")
         _wait_path_via_grpc(topology, topology.vfs_path("doomed.txt"), expect_found=True)
 

--- a/tests/e2e/docker/test_fuse_plugin_e2e.py
+++ b/tests/e2e/docker/test_fuse_plugin_e2e.py
@@ -1,0 +1,231 @@
+"""FUSE plugin Docker E2E — real mount, real syscalls, gRPC cross-check.
+
+Stands up a single `nexusd-cluster` with `nexus-fuse-plugin` loaded
+inside a privileged container (`/dev/fuse`, `SYS_ADMIN`,
+apparmor:unconfined), then exercises every directory-mutating op the
+plugin wires through KernelHandle v2 via plain POSIX commands.  Every
+assertion has both a mount-side (`docker exec` POSIX) AND a
+kernel-side (gRPC `vfs_stat` / `vfs_read`) check, so a regression on
+either layer surfaces as a mismatch rather than a silent skip.
+
+Coverage matrix:
+
+    POSIX op            FUSE op       KernelHandle v2 callback
+    ─────────────────   ──────────    ─────────────────────────
+    mkdir               mkdir         sys_mkdir
+    rmdir               rmdir         sys_rmdir
+    touch / `cat > x`   create        sys_write (empty) + sys_stat
+    `cat > x` (data)    write         sys_write
+    `cat x`             read          sys_read
+    ls -1               readdir       sys_readdir
+    mv                  rename        sys_rename
+    rm                  unlink        sys_unlink
+
+The compose file at ``dockerfiles/docker-compose.fuse-plugin.yml``
+provides the env (``NEXUS_FUSE_E2E=1``, ``NEXUS_CLUSTER_GRPC``,
+``NEXUS_CLUSTER_CONTAINER``, ``NEXUS_FUSE_MOUNT_POINT``); skip the
+suite when it's not set so unrelated test invocations don't blow up.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+
+import pytest
+
+from . import fuse_plugin_helpers, runbook_helpers
+
+if os.environ.get("NEXUS_FUSE_E2E") != "1":
+    pytest.skip(
+        "FUSE plugin E2E suite — requires docker compose -f "
+        "dockerfiles/docker-compose.fuse-plugin.yml up",
+        allow_module_level=True,
+    )
+
+
+@pytest.fixture(scope="module")
+def topology() -> fuse_plugin_helpers.FuseTopology:
+    return fuse_plugin_helpers.topology_from_env()
+
+
+def _wait_path_via_grpc(
+    topology: fuse_plugin_helpers.FuseTopology,
+    path: str,
+    *,
+    expect_found: bool,
+    timeout: float = 10.0,
+) -> dict:
+    """Poll `vfs_stat` until the path matches the expected presence.
+
+    The mount op completes synchronously inside the container, but the
+    kernel-side metastore write can race the test runner's next gRPC
+    call by a millisecond or two.  A 10 s budget with 100 ms polls
+    absorbs that race without masking a real bug.
+    """
+    deadline = time.monotonic() + timeout
+    last_result: dict = {}
+    while time.monotonic() < deadline:
+        last_result = runbook_helpers.vfs_stat(topology.cluster_grpc, path)
+        if "error" in last_result:
+            time.sleep(0.1)
+            continue
+        found = last_result["result"]["found"]
+        if found == expect_found:
+            return last_result
+        time.sleep(0.1)
+    pytest.fail(
+        f"vfs_stat({path}) never reached expected found={expect_found} "
+        f"within {timeout}s — last result: {last_result}"
+    )
+
+
+class TestMountLoadedAndReady:
+    """Sanity — without these the rest of the suite is meaningless."""
+
+    def test_grpc_responds(self, topology: fuse_plugin_helpers.FuseTopology) -> None:
+        result = runbook_helpers.vfs_stat(topology.cluster_grpc, "/")
+        assert "error" not in result, f"gRPC vfs_stat(/) failed: {result}"
+        assert result["result"]["found"], "/ must exist on a fresh cluster"
+
+    def test_mount_point_is_a_fuse_mount(
+        self, topology: fuse_plugin_helpers.FuseTopology
+    ) -> None:
+        result = runbook_helpers.docker_exec(
+            topology.cluster_container,
+            ["mountpoint", "-q", topology.mount_point],
+            check=False,
+        )
+        assert result.rc == 0, (
+            f"{topology.mount_point} is not a mount point inside the "
+            f"cluster container — the plugin's `fuser::spawn_mount2` "
+            f"did not complete.  Check the cluster's stderr for the "
+            f"`FUSE mount failed` log line."
+        )
+
+
+class TestMkdirReaddirRoundTrip:
+    """`mkdir` + `ls` — exercise sys_mkdir and sys_readdir together."""
+
+    def test_mkdir_then_readdir_sees_entry(
+        self, topology: fuse_plugin_helpers.FuseTopology
+    ) -> None:
+        fuse_plugin_helpers.mount_mkdir(topology, "alpha-dir")
+
+        # Kernel cross-check — exists with entry_type=1 (DT_DIR).
+        stat = _wait_path_via_grpc(topology, topology.vfs_path("alpha-dir"), expect_found=True)
+        assert stat["result"]["isDirectory"], (
+            f"sys_mkdir landed but kernel reports non-directory: {stat}"
+        )
+
+        # readdir must show the entry on the parent listing.
+        entries = fuse_plugin_helpers.mount_listdir(topology, "/")
+        assert "alpha-dir" in entries, (
+            f"readdir on / missed `alpha-dir` after mkdir; got {entries}"
+        )
+
+    def test_nested_mkdir_p_visible(
+        self, topology: fuse_plugin_helpers.FuseTopology
+    ) -> None:
+        fuse_plugin_helpers.mount_mkdir(topology, "nested/deep/path", parents=True)
+        stat = _wait_path_via_grpc(
+            topology,
+            topology.vfs_path("nested/deep/path"),
+            expect_found=True,
+        )
+        assert stat["result"]["isDirectory"]
+        entries = fuse_plugin_helpers.mount_listdir(topology, "nested/deep")
+        assert "path" in entries
+
+
+class TestCreateWriteRead:
+    """`cat > file` + `cat file` — exercise create + write + read."""
+
+    def test_create_empty_file_visible(
+        self, topology: fuse_plugin_helpers.FuseTopology
+    ) -> None:
+        fuse_plugin_helpers.mount_write_bytes(topology, "empty.txt", b"")
+        stat = _wait_path_via_grpc(topology, topology.vfs_path("empty.txt"), expect_found=True)
+        assert not stat["result"]["isDirectory"]
+        assert stat["result"]["size"] == 0
+
+    def test_write_then_read_byte_exact_via_mount(
+        self, topology: fuse_plugin_helpers.FuseTopology
+    ) -> None:
+        payload = b"FUSE plugin v2 callbacks: write+read byte-exact\n"
+        fuse_plugin_helpers.mount_write_bytes(topology, "rw.txt", payload)
+        roundtrip = fuse_plugin_helpers.mount_read_bytes(topology, "rw.txt")
+        assert roundtrip == payload, (
+            f"mount read != mount write; got len={len(roundtrip)}, "
+            f"expected len={len(payload)}"
+        )
+
+    def test_write_via_mount_visible_through_grpc_read(
+        self, topology: fuse_plugin_helpers.FuseTopology
+    ) -> None:
+        """The cross-check: write through the mount, read through gRPC.
+
+        Catches FUSE plugin write callback that silently fails (returns
+        EIO but kernel never gets the bytes) — the mount-side read would
+        still see cached bytes via FUSE's own buffering, but gRPC sees
+        the truth.
+        """
+        payload = b"cross-layer write verification payload"
+        fuse_plugin_helpers.mount_write_bytes(topology, "cross.txt", payload)
+        # vfs_stat first (fast) — confirms metastore knows the file.
+        stat = _wait_path_via_grpc(topology, topology.vfs_path("cross.txt"), expect_found=True)
+        assert stat["result"]["size"] == len(payload), (
+            f"kernel sees size={stat['result']['size']}, expected {len(payload)} — "
+            "FUSE plugin's write callback may have dropped bytes"
+        )
+        # vfs_read content check — the SSOT byte-exact assertion.
+        read_result = runbook_helpers.vfs_read(
+            topology.cluster_grpc, topology.vfs_path("cross.txt")
+        )
+        assert "error" not in read_result, f"vfs_read failed: {read_result}"
+        assert runbook_helpers.decode_content(read_result) == payload
+
+
+class TestRenameUnlinkRmdir:
+    """`mv`, `rm`, `rmdir` — exercise sys_rename, sys_unlink, sys_rmdir."""
+
+    def test_rename_moves_file(self, topology: fuse_plugin_helpers.FuseTopology) -> None:
+        payload = b"rename target payload"
+        fuse_plugin_helpers.mount_write_bytes(topology, "rename-src.txt", payload)
+        _wait_path_via_grpc(
+            topology, topology.vfs_path("rename-src.txt"), expect_found=True
+        )
+
+        fuse_plugin_helpers.mount_rename(topology, "rename-src.txt", "rename-dst.txt")
+
+        _wait_path_via_grpc(topology, topology.vfs_path("rename-src.txt"), expect_found=False)
+        _wait_path_via_grpc(topology, topology.vfs_path("rename-dst.txt"), expect_found=True)
+
+        roundtrip = fuse_plugin_helpers.mount_read_bytes(topology, "rename-dst.txt")
+        assert roundtrip == payload, (
+            "rename preserved path but lost bytes — sys_rename moved metadata "
+            "but lost the content reference"
+        )
+
+    def test_unlink_removes_file(
+        self, topology: fuse_plugin_helpers.FuseTopology
+    ) -> None:
+        fuse_plugin_helpers.mount_write_bytes(topology, "doomed.txt", b"bye")
+        _wait_path_via_grpc(topology, topology.vfs_path("doomed.txt"), expect_found=True)
+
+        fuse_plugin_helpers.mount_unlink(topology, "doomed.txt")
+
+        # Mount side AND kernel side must agree the file is gone.
+        assert not fuse_plugin_helpers.mount_path_exists(topology, "doomed.txt")
+        _wait_path_via_grpc(topology, topology.vfs_path("doomed.txt"), expect_found=False)
+
+    def test_rmdir_removes_empty_directory(
+        self, topology: fuse_plugin_helpers.FuseTopology
+    ) -> None:
+        fuse_plugin_helpers.mount_mkdir(topology, "doomed-dir")
+        _wait_path_via_grpc(topology, topology.vfs_path("doomed-dir"), expect_found=True)
+
+        fuse_plugin_helpers.mount_rmdir(topology, "doomed-dir")
+
+        assert not fuse_plugin_helpers.mount_path_exists(topology, "doomed-dir")
+        _wait_path_via_grpc(topology, topology.vfs_path("doomed-dir"), expect_found=False)


### PR DESCRIPTION
## Summary

Wraps up Phase B-3 (regression-guard the v2 callback wire-up that
landed in #4380) and ships Phase B-4 macOS support in the same PR.
Windows / WinFsp deferred to a separate adapter PR.

7 commits, one concern each:

1. `feat(fuse-plugin): extend cfg gates to support macOS via macFUSE` — `fuser`'s `Filesystem` trait + `spawn_mount2` are identical on Linux + macOS, so the gates widen from `target_os = "linux"` to `any(target_os = "linux", target_os = "macos")`.
2. `ci(release-fuse-plugin): add macOS arm64+x86_64 to release matrix` — flip the `platforms` input on the reusable workflow.
3. `ci(dockerfile): Dockerfile.fuse-plugin` — multi-stage signed plugin image mirroring Dockerfile.local-connector-plugin's shape.
4. `ci(compose): docker-compose.fuse-plugin.yml` — single privileged cluster + sidecar test runner.  Healthcheck waits for **both** the gRPC bind and the FUSE mount materialising.
5. `test(e2e): FUSE plugin Docker E2E` — `fuse_plugin_helpers.py` + 4 test classes covering mkdir/readdir/create/write/read/rename/unlink/rmdir with a mount-side **and** gRPC `vfs_stat`/`vfs_read` cross-check at every step.
6. `ci(workflows): fuse-plugin-e2e.yml` — paths-filtered E2E gate on plugin source, plugin-abi pin, Dockerfile, compose, and the tests themselves.
7. `docs(fuse-plugin): platform matrix + operator install + admin RPCs` — README colocated with the crate.

## Why one PR instead of two

B-3 (E2E) and B-4 (macOS) both touch the same fuse-plugin crate +
its release pipeline.  Bundling avoids a second merge churn and
keeps the macOS announce + the regression guard for v2 callbacks
landing in lockstep — operators get "this plugin runs on macOS"
**and** "we catch regressions in mkdir/ls/mv before they ship" in
the same release window.

## Why WinFsp is deferred

`fuser` does not support Windows.  WinFsp shipping needs `winfsp-rs`
(different binding crate, different trait shape, different mount
API surface) — a several-hundred-line adapter, not a cfg flip.
Bundling it here would have either (a) shipped a half-working
adapter or (b) blocked the Linux+macOS launch.  The current cfg
gates compile Windows to a no-op cdylib so the workspace matrix
stays clean while the proper adapter lands as a follow-up PR.

## Cross-check pattern (the real-E2E principle)

Every assertion has **two independent paths**:

- **Mount side**: `docker exec` of plain POSIX (`mkdir` / `cat` /
  `ls` / `mv` / `rm`) against `/mnt/nexus` inside the privileged
  cluster container.  Hits the kernel's in-container FUSE driver →
  the plugin's background thread → the v2 KernelHandle callbacks.

- **Kernel side**: gRPC `vfs_stat` / `vfs_read` straight at the
  daemon's 2126 port.  Hits the kernel syscall surface without
  touching the FUSE event loop.

A plugin that silently drops writes still passes the mount
round-trip (FUSE's own buffering hides the bug) but fails the gRPC
size check.  A kernel-side `sys_readdir` JSON escape regression
fails `ls` through the mount but `vfs_stat` on the entry passes.
The two paths deliberately overlap to **triangulate** the failing
layer.

## Test plan

- [ ] CI green: cargo check + clippy + fmt + test on Linux/macOS/Windows
- [ ] CI green: `FUSE Plugin E2E (Docker)` workflow runs the privileged-container suite end-to-end
- [ ] Manual: build + sign the dylib locally, drop into `~/.nexus/plugins`, launch `nexusd-cluster --plugin-dir`, `mountpoint -q $NEXUS_FUSE_MOUNT_POINT` returns 0, mkdir/ls/cat/mv/rm all work
- [ ] Verify the existing develop CI workflows stay green post-rebase

## Follow-ups (out of scope)

- **WinFsp adapter**: separate PR with the winfsp-rs binding work.  Tracked in the README's platform matrix.
- **Offset-aware `sys_read` / `sys_write`**: kernel-side ABI extension lets the plugin stop reading the whole file per page-sized FUSE read.  Tracked in the plugin source's module docstring.
- **`setattr` surface**: needs a kernel-side setattr callback first.  Plugin will route once it lands.