### PR TITLE
fix(ci): drop deprecated brew --no-quarantine flag for macFUSE install

### DIFF
--- a/.github/workflows/release-plugin-reusable.yml
+++ b/.github/workflows/release-plugin-reusable.yml
@@ -171,15 +171,16 @@ jobs:
 
       # The `fuser` crate's build.rs requires pkg-config to find
       # libfuse3 (Linux — the cluster image installs `libfuse3-dev`
-      # already) or macFUSE (macOS — runners don't have it).  macFUSE
-      # ships as a Cask; `--no-quarantine` skips Gatekeeper's GUI
-      # prompt so CI can install non-interactively.  The kernel
-      # extension load still needs sudo at runtime on the operator's
-      # machine — that's fine, build-time only needs the framework
-      # headers + pkg-config file, which the cask drops at
-      # /Library/Frameworks/macfuse.framework + /usr/local/lib/
-      # pkgconfig/fuse.pc.  Gated on the plugin name so vault /
-      # local-connector releases don't pay the install cost.
+      # already) or macFUSE (macOS — runners don't have it).  The
+      # cask install drops the framework headers + the `fuse.pc`
+      # pkg-config file at /Library/Frameworks/macfuse.framework +
+      # /usr/local/lib/pkgconfig.  The kernel extension load still
+      # needs sudo at runtime on the operator's machine — that's
+      # fine, this is build-time only.  Gated on the plugin name so
+      # vault / local-connector releases don't pay the install cost.
+      # `--no-quarantine` was removed from Homebrew in late 2025;
+      # headless runners don't see Gatekeeper prompts anyway, so
+      # the plain `--cask` install is all we need.
       - name: Install macFUSE (nexus-fuse-plugin only)
         if: |
           contains(fromJSON(inputs.platforms), matrix.artifact_name_suffix)
@@ -187,7 +188,7 @@ jobs:
             && inputs.plugin_name == 'nexus-fuse-plugin'
         run: |
           set -euo pipefail
-          brew install --no-quarantine --cask macfuse
+          brew install --cask macfuse
           # Verify the framework + pkg-config file are where fuser's
           # build.rs expects to find them.
           ls -d /Library/Frameworks/macfuse.framework


### PR DESCRIPTION
## Summary

Homebrew removed the `--[no-]quarantine` switch in late 2025; my `release-plugin-reusable.yml` step from #4388 still passes it, so the `fuse-v0.2.0` release pipeline fails immediately on macOS:

```
Calling the `--[no-]quarantine` switch is disabled! There is no replacement.
```

Headless runners don't see Gatekeeper prompts anyway, so the plain `brew install --cask macfuse` is all we need.

## Test plan

- [ ] CI green
- [ ] Re-tag `fuse-v0.2.0` after merge; verify the macOS arm64 + x86_64 build steps complete and the release pipeline ships all 3 dylibs + .sig.