### PR TITLE
fix(ci): PKG_CONFIG_ALLOW_CROSS=1 for macos-x86_64 fuser build

### DIFF
--- a/.github/workflows/release-plugin-reusable.yml
+++ b/.github/workflows/release-plugin-reusable.yml
@@ -232,6 +232,16 @@ jobs:
 
       - name: Build release cdylib
         if: contains(fromJSON(inputs.platforms), matrix.artifact_name_suffix)
+        # PKG_CONFIG_ALLOW_CROSS=1: macos-x86_64 is a cross-compile
+        # from the macos-14 (arm64) runner.  fuser's build.rs calls
+        # pkg-config, which refuses cross-compile probes unless this
+        # is set — the macFUSE `fuse.pc` lives at the same
+        # /usr/local/lib/pkgconfig path on both architectures, so
+        # the cross-compile probe finds a valid pc file once the
+        # cross-flag is granted.  Linux + macOS-arm64 + Windows are
+        # native builds where the flag is a no-op.
+        env:
+          PKG_CONFIG_ALLOW_CROSS: "1"
         run: |
           cargo build --release -p ${{ inputs.plugin_name }} ${{ matrix.target && format('--target {0}', matrix.target) || '' }}
 


### PR DESCRIPTION
## Summary

`fuse-v0.2.0` release pipeline run #27483582683 results:

| target | status |
|---|---|
| linux-x86_64 | ✅ |
| macos-arm64 | ✅ |
| macos-x86_64 | ❌ — pkg-config cross-compile guard |
| windows-x86_64 | ✅ (no-op cdylib) |

macFUSE installed cleanly on both macOS runners, arm64 (native) built fine.  macos-x86_64 cross-compiles from the macos-14 (arm64) runner — fuser's build.rs calls pkg-config, which panics on a cross-compile probe unless `PKG_CONFIG_ALLOW_CROSS=1` is set.  The macFUSE `fuse.pc` lives at the same `/usr/local/lib/pkgconfig` path on both architectures (fat framework), so the cross-flag is genuinely all that's needed.

## Test plan

- [ ] CI green
- [ ] Re-tag `fuse-v0.2.0`; verify all 4 build matrix entries complete and the release pipeline ships the linux + macos-arm64 + macos-x86_64 dylibs + .sig (windows step is a no-op compile of the cfg-gated stub).