### PR TITLE
feat(release-vault-plugin): publish standalone nexusd-vault binary

### DIFF
--- a/.github/workflows/release-plugin-reusable.yml
+++ b/.github/workflows/release-plugin-reusable.yml
@@ -55,6 +55,16 @@ on:
         required: false
         type: number
         default: 8388608   # 8 MiB
+      binary_basename:
+        description: 'Optional standalone binary name (e.g. `nexusd-vault`). When set, the build job also picks `target/release/<binary_basename>[.exe]` and the package job ships it as a separate signed archive (`<binary_basename>-<platform>.tar.gz` / `.zip`) alongside the cdylib. Leave empty for plugins that have no [[bin]] target.'
+        required: false
+        type: string
+        default: ""
+      binary_max_size_bytes:
+        description: Per-platform max binary size in bytes. Only consulted when `binary_basename` is set. Same regression-budget motivation as `max_size_bytes`.
+        required: false
+        type: number
+        default: 8388608   # 8 MiB
       platforms:
         description: 'JSON array of platform suffixes to build. Plugins that don''t support all 4 platforms (e.g. nexus-fuse-plugin is Linux-only) shrink the matrix here. Valid entries: linux-x86_64, macos-arm64, macos-x86_64, windows-x86_64.'
         required: false
@@ -273,6 +283,60 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
+      # ── Optional standalone binary (gated on `binary_basename` input) ────
+      # `cargo build --release -p <plugin_name>` above also compiles the
+      # package's `[[bin]]` target if it has one, so we just pick the
+      # resulting executable from target/release/. Shipped as a separate
+      # signed archive so consumers who only want the cdylib don't have to
+      # download the binary.
+      - name: Compute binary filename
+        if: contains(fromJSON(inputs.platforms), matrix.artifact_name_suffix) && inputs.binary_basename != ''
+        id: binary
+        shell: bash
+        env:
+          BASENAME: ${{ inputs.binary_basename }}
+        run: |
+          set -euo pipefail
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            name="${BASENAME}.exe"
+          else
+            name="${BASENAME}"
+          fi
+          echo "name=${name}" >> "$GITHUB_OUTPUT"
+          if [ -n "${{ matrix.target }}" ]; then
+            echo "path=target/${{ matrix.target }}/release/${name}" >> "$GITHUB_OUTPUT"
+          else
+            echo "path=target/release/${name}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check binary size
+        if: contains(fromJSON(inputs.platforms), matrix.artifact_name_suffix) && inputs.binary_basename != ''
+        shell: bash
+        env:
+          MAX_SIZE_BYTES: ${{ inputs.binary_max_size_bytes }}
+          BIN_PATH: ${{ steps.binary.outputs.path }}
+        run: |
+          set -euo pipefail
+          if [ "$RUNNER_OS" = "macOS" ]; then
+            actual=$(stat -f '%z' "$BIN_PATH")
+          else
+            actual=$(stat -c '%s' "$BIN_PATH")
+          fi
+          echo "Binary size: $actual bytes (max: $MAX_SIZE_BYTES)"
+          if [ "$actual" -gt "$MAX_SIZE_BYTES" ]; then
+            echo "::error::${{ inputs.binary_basename }} ${{ matrix.artifact_name_suffix }} exceeds size budget ($actual > $MAX_SIZE_BYTES bytes)"
+            exit 1
+          fi
+
+      - name: Upload binary artifact
+        if: contains(fromJSON(inputs.platforms), matrix.artifact_name_suffix) && inputs.binary_basename != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.binary_basename }}-${{ matrix.artifact_name_suffix }}
+          path: ${{ steps.binary.outputs.path }}
+          if-no-files-found: error
+          retention-days: 1
+
   # ── Package, sign, upload ──────────────────────────────────────────────────
   # Downloads all 4 dylibs, signs each (privkey source per `signing_key_source`),
   # packages into tar.gz / zip, uploads to COS at <cos_subdir>/v<version>/.
@@ -302,6 +366,13 @@ jobs:
         with:
           path: artifacts
           pattern: ${{ inputs.archive_prefix }}-*
+
+      - name: Download binary build artifacts
+        if: inputs.binary_basename != ''
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          pattern: ${{ inputs.binary_basename }}-*
 
       - name: Set up Python for signing
         uses: actions/setup-python@v5
@@ -416,6 +487,7 @@ jobs:
         env:
           PREFIX: ${{ inputs.archive_prefix }}
           BASENAME: ${{ inputs.dylib_basename }}
+          BINARY_BASENAME: ${{ inputs.binary_basename }}
         run: |
           set -euo pipefail
           win_dll="${BASENAME#lib}.dll"
@@ -430,6 +502,19 @@ jobs:
               *) echo "::error::unknown platform suffix '$suffix' under $art_dir" ; exit 1 ;;
             esac
           done
+          # Binaries (gated on binary_basename input). Same Ed25519
+          # contract as the cdylib — sign_plugin.py is file-agnostic.
+          if [ -n "${BINARY_BASENAME}" ]; then
+            for art_dir in artifacts/${BINARY_BASENAME}-*/; do
+              [ -d "$art_dir" ] || continue
+              suffix=$(basename "$art_dir" | sed "s/^${BINARY_BASENAME}-//")
+              case "$suffix" in
+                linux-*|macos-*) files+=("${art_dir}${BINARY_BASENAME}") ;;
+                windows-*)       files+=("${art_dir}${BINARY_BASENAME}.exe") ;;
+                *) echo "::error::unknown platform suffix '$suffix' under $art_dir" ; exit 1 ;;
+              esac
+            done
+          fi
           if [ "${#files[@]}" -eq 0 ]; then
             echo "::error::no plugin artifacts found under artifacts/${PREFIX}-*"
             exit 1
@@ -444,6 +529,7 @@ jobs:
         env:
           PREFIX: ${{ inputs.archive_prefix }}
           BASENAME: ${{ inputs.dylib_basename }}
+          BINARY_BASENAME: ${{ inputs.binary_basename }}
         run: |
           set -euo pipefail
           mkdir -p release-assets
@@ -473,6 +559,31 @@ jobs:
               *) echo "::error::unknown platform suffix '$suffix' under $art_dir" ; exit 1 ;;
             esac
           done
+
+          # Binaries (gated on binary_basename input). Separate per-platform
+          # archive so cdylib-only consumers don't have to download the binary.
+          # Same sig-bundled-with-payload shape as dylib archives.
+          if [ -n "${BINARY_BASENAME}" ]; then
+            for art_dir in artifacts/${BINARY_BASENAME}-*/; do
+              [ -d "$art_dir" ] || continue
+              suffix=$(basename "$art_dir" | sed "s/^${BINARY_BASENAME}-//")
+              case "$suffix" in
+                linux-*|macos-*)
+                  cp "${art_dir}${BINARY_BASENAME}" "${BINARY_BASENAME}"
+                  cp "${art_dir}${BINARY_BASENAME}.sig" "${BINARY_BASENAME}.sig"
+                  tar -czf "release-assets/${BINARY_BASENAME}-${suffix}.tar.gz" "${BINARY_BASENAME}" "${BINARY_BASENAME}.sig"
+                  rm "${BINARY_BASENAME}" "${BINARY_BASENAME}.sig"
+                  ;;
+                windows-*)
+                  cp "${art_dir}${BINARY_BASENAME}.exe" "${BINARY_BASENAME}.exe"
+                  cp "${art_dir}${BINARY_BASENAME}.exe.sig" "${BINARY_BASENAME}.exe.sig"
+                  zip "release-assets/${BINARY_BASENAME}-${suffix}.zip" "${BINARY_BASENAME}.exe" "${BINARY_BASENAME}.exe.sig"
+                  rm "${BINARY_BASENAME}.exe" "${BINARY_BASENAME}.exe.sig"
+                  ;;
+                *) echo "::error::unknown platform suffix '$suffix' under $art_dir" ; exit 1 ;;
+              esac
+            done
+          fi
 
           echo "=== release-assets ==="
           ls -lh release-assets/

--- a/.github/workflows/release-vault-plugin.yml
+++ b/.github/workflows/release-vault-plugin.yml
@@ -41,12 +41,23 @@ jobs:
       # Stricter than the reusable's 8 MiB default; tightens regression
       # detection for the only plugin where we've measured a stable size.
       max_size_bytes: 7864320
+      # Also ship the standalone `nexusd-vault` binary. It hosts the same
+      # services as the cdylib over loopback gRPC and is used by clients
+      # (e.g. password-agent) that spawn vault on-demand outside a cluster.
+      binary_basename: nexusd-vault
+      # 8 MiB — release binary observed at ~5 MB; budget gives ~60% headroom.
+      binary_max_size_bytes: 8388608
       release_description: |
-        Vault dylib plugin for nexusd-cluster.
+        Vault dylib plugin for nexusd-cluster, plus the `nexusd-vault`
+        standalone binary for out-of-cluster deployments.
 
         ### Included services
         - **GenericSecretsService** — namespace:key encrypted KV with versioning, soft-delete, and batch operations
         - **PasswordVaultService** — password manager with TOTP, search, and bulk migration
+
+        ### Artifacts
+        - `nexus-vault-<platform>.tar.gz` / `.zip` — cdylib plugin loaded by `nexusd-cluster --plugin-dir`
+        - `nexusd-vault-<platform>.tar.gz` / `.zip` — standalone gRPC daemon; loopback-only, optional `--idle-shutdown-seconds` flag for cloud-sync hosts
     secrets:
       PLUGIN_SIGNING_PRIVKEY: ${{ secrets.PLUGIN_SIGNING_PRIVKEY }}
       COS_SECRET_ID: ${{ secrets.COS_SECRET_ID }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1536,7 +1536,7 @@ source = "git+https://github.com/nexi-lab/nexus-vfs?rev=1beefb06067a837f7565842f
 
 [[package]]
 name = "nexus-vault"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "backends",
  "clap",

--- a/rust/services/vault/Cargo.toml
+++ b/rust/services/vault/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nexus-vault"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 description = "Nexus vault plugin — cdylib loaded by `nexusd-cluster` via `--plugin-dir`. Hosts PasswordVaultService as a dylib plugin with C ABI dispatch."
 authors = ["Nexus Team"]


### PR DESCRIPTION
## Summary

Extends the release pipeline to also publish the `nexusd-vault` standalone binary alongside the cdylib. Same Ed25519 signing, same COS path, same GitHub Release.

After this merges + we push a `vault-v<X>` tag, consumers (e.g. password-agent) can `curl` the wrapper binary directly from COS instead of needing the nexus source tree + cargo + protoc + vcvars to build it themselves.

## What changes

**Commit 1 — reusable workflow** (generic infra, benefits any plugin with a `[[bin]]` target):

Two new optional inputs:
- `binary_basename` (default `""` = skip — current behavior preserved)
- `binary_max_size_bytes` (default 8 MiB)

When `binary_basename` is set, the build job picks `target/release/<binary_basename>[.exe]` after the existing `cargo build --release -p <plugin_name>` step (which already builds `[[bin]]` targets in the same package — no extra compile cost). The package job downloads, Ed25519-signs (same `sign_plugin.py` — file-agnostic), and packages into separate per-platform archives. COS upload and GitHub Release loops already process `release-assets/*`, no change needed there.

**Commit 2 — vault wrapper** (opts in):

```yaml
binary_basename: nexusd-vault
binary_max_size_bytes: 8388608   # 8 MiB
```

## After this PR + a `vault-v<X>` tag

```
COS  nexus-vault/release/v<X>/
  nexus-vault-{linux,macos-arm64,macos-x86_64,windows}-x86_64.tar.gz / .zip   (cdylib + .sig — already shipped)
  nexusd-vault-{linux,macos-arm64,macos-x86_64,windows}-x86_64.tar.gz / .zip  (NEW — standalone binary + .sig)
GitHub Release: both sets, with checksums
```

## Architecture audit

| Concern | Result |
|---|---|
| Kernel / syscall / proto / ABI | Zero touched — workflow YAML only |
| Default behavior | Identical (`binary_basename` empty → existing callers unaffected) |
| SSOT | Binary built once, signed once, uploaded once |
| DRY | Reuses sign script (file-agnostic), COS upload loop, GH Release file glob |
| Compile cost | Zero new — `[[bin]]` target was already built in the same cargo invocation |
| Genericity | Any future plugin with a `[[bin]]` target gets it free |
| Size budget enforcement | Same per-platform regression-budget pattern as cdylib |

## Test plan

- [ ] Workflow YAML parses on both files (verified locally with `yaml.safe_load`)
- [ ] CI on the PR (no real tag — workflow is `workflow_call` reusable so it only fires under a real release; the PR itself only validates YAML)
- [ ] After merge: push `vault-v0.1.4` tag → release-vault-plugin.yml fires → both cdylib AND nexusd-vault archives land in COS + GH Release
- [ ] Verify `nexusd-vault-linux-x86_64.tar.gz` extracts to a runnable `nexusd-vault` + `nexusd-vault.sig`
- [ ] Verify size budget (8 MiB) is enough; bump if release binary turns out bigger than expected