### PR TITLE
feat(search): read-side macro-chunk (neighbor-context) expansion (#4398)

### DIFF
--- a/alembic/versions/add_chunk_heading_prefix.py
+++ b/alembic/versions/add_chunk_heading_prefix.py
@@ -1,0 +1,36 @@
+"""add_chunk_heading_prefix
+
+Add heading_prefix column to document_chunks table.
+Stores the nearest ancestor heading text for each chunk,
+enabling heading-aware macro-chunk expansion in search results.
+
+Revision ID: add_chunk_heading_prefix
+Revises: merge_us_pay_amounts
+Create Date: 2026-06-17
+
+"""
+
+from collections.abc import Sequence
+from typing import Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "add_chunk_heading_prefix"
+down_revision: Union[str, Sequence[str], None] = "merge_us_pay_amounts"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add heading_prefix column to document_chunks."""
+    with op.batch_alter_table("document_chunks", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("heading_prefix", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    """Remove heading_prefix column from document_chunks."""
+    with op.batch_alter_table("document_chunks", schema=None) as batch_op:
+        batch_op.drop_column("heading_prefix")

--- a/docs/superpowers/plans/2026-06-17-macro-chunk-expansion.md
+++ b/docs/superpowers/plans/2026-06-17-macro-chunk-expansion.md
@@ -1,0 +1,1023 @@
+# Macro-chunk Expansion Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an opt-in, read-side macro-chunk expansion stage to hybrid search that stitches each search hit into its surrounding section and returns it in additive `macro_text` fields.
+
+**Architecture:** A pure, backend-agnostic module (`macro_chunk.py`) implements the expansion algorithm over a `NeighborFetcher` protocol. Each storage backend (`PgVectorBackend`, `SqliteVecBackend`) implements `fetch_ranges`. The daemon invokes expansion after assembling the final result list, gated on a new `expand=macro` request param.
+
+**Tech Stack:** Python 3.x, SQLAlchemy async (`text()` bound params), Alembic migrations, sqlite-vec (SANDBOX), pgvector (FULL), pytest + `pytest.mark.asyncio`.
+
+## Global Constraints
+
+- Default response (no `expand` param) MUST be byte-identical to today. Expansion is opt-in.
+- Server emits **snake_case** fields (`macro_text`, `macro_line_start`, `macro_line_end`) — there is no camelCase serializer server-side. The TS `nexus-client` SDK surfaces camelCase to Koodle (out of scope here).
+- Do NOT name external reference repos in code/comments.
+- Expansion is **best-effort**: any failure leaves the hit's `chunk_text` untouched and never errors the search.
+- Both profiles must work: FULL (pgvector / `document_chunks`) and SANDBOX (sqlite-vec / `nexus_vec`).
+- Env knobs follow `config.py` pattern via `get_env_int` / `get_env_bool`.
+- SQL uses `:named` bound params (Postgres async engine) / sqlite3 via `asyncio.to_thread`.
+- Tests: `pytest.mark.asyncio` for async; `AsyncMock` session fixtures for unit; real DB fixtures for integration.
+
+---
+
+### Task 1: Pure expansion core — types, span-merge, section bounds, window selection, stitch
+
+**Files:**
+- Create: `src/nexus/bricks/search/macro_chunk.py`
+- Test: `tests/unit/bricks/search/test_macro_chunk_core.py`
+
+**Interfaces:**
+- Produces:
+  - `ChunkRow(path: str, chunk_index: int, text: str, tokens: int, line_start: int|None, line_end: int|None, heading_prefix: str|None)` (frozen dataclass)
+  - `ExpansionConfig(token_budget: int = 1024, window: int = 8, code_forward_bias: bool = True)` (frozen dataclass)
+  - `NeighborFetcher` Protocol: `async def fetch_ranges(self, spans: Sequence[tuple[str,int,int]], zone_id: str|None) -> list[ChunkRow]`
+  - `merge_spans(spans: list[tuple[str,int,int]]) -> list[tuple[str,int,int]]`
+  - `_is_code_path(path: str) -> bool`
+  - `_section_bounds(by_index: dict[int,ChunkRow], anchor_idx: int) -> tuple[int,int]`
+  - `_window_for_anchor(by_index: dict[int,ChunkRow], anchor_idx: int, cfg: ExpansionConfig, is_code: bool) -> tuple[int,int]`
+  - `_stitch(by_index: dict[int,ChunkRow], lo: int, hi: int) -> tuple[str, int|None, int|None]`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/unit/bricks/search/test_macro_chunk_core.py
+from nexus.bricks.search.macro_chunk import (
+    ChunkRow, ExpansionConfig, merge_spans, _is_code_path,
+    _section_bounds, _window_for_anchor, _stitch,
+)
+
+
+def _row(idx, tokens=10, heading="H1", text=None, ls=None, le=None, path="/a.md"):
+    return ChunkRow(
+        path=path, chunk_index=idx, text=text or f"c{idx}", tokens=tokens,
+        line_start=ls, line_end=le, heading_prefix=heading,
+    )
+
+
+def _map(rows):
+    return {r.chunk_index: r for r in rows}
+
+
+def test_merge_spans_collapses_overlapping_and_adjacent():
+    spans = [("/a", 0, 5), ("/a", 6, 9), ("/a", 20, 22), ("/b", 0, 3)]
+    out = sorted(merge_spans(spans))
+    assert out == [("/a", 0, 9), ("/a", 20, 22), ("/b", 0, 3)]
+
+
+def test_is_code_path():
+    assert _is_code_path("/x/foo.py") is True
+    assert _is_code_path("/x/foo.md") is False
+
+
+def test_section_bounds_stops_at_heading_change():
+    rows = [_row(0, heading="A"), _row(1, heading="A"),
+            _row(2, heading="B"), _row(3, heading="B")]
+    assert _section_bounds(_map(rows), 1) == (0, 1)
+    assert _section_bounds(_map(rows), 2) == (2, 3)
+
+
+def test_window_whole_section_when_under_budget():
+    rows = [_row(i, tokens=10, heading="A") for i in range(4)]
+    # section tokens = 40 <= budget 1024 -> whole section
+    lo, hi = _window_for_anchor(_map(rows), 2, ExpansionConfig(token_budget=1024), False)
+    assert (lo, hi) == (0, 3)
+
+
+def test_window_prose_centered_when_over_budget():
+    rows = [_row(i, tokens=100, heading="A") for i in range(7)]
+    # budget 250 -> anchor(3)=100, then centered: 2,4 -> 300>250 stop at 250
+    lo, hi = _window_for_anchor(_map(rows), 3, ExpansionConfig(token_budget=250), False)
+    assert lo <= 3 <= hi
+    assert sum(rows[i].tokens for i in range(lo, hi + 1)) <= 250
+    assert (hi - lo) >= 1  # expanded beyond the single anchor
+
+
+def test_window_code_forward_bias():
+    rows = [_row(i, tokens=100, heading="A", path="/f.py") for i in range(7)]
+    lo, hi = _window_for_anchor(_map(rows), 3, ExpansionConfig(token_budget=250), True)
+    # forward-first: should include 4 before 2
+    assert hi >= 4
+    assert sum(rows[i].tokens for i in range(lo, hi + 1)) <= 250
+
+
+def test_stitch_concats_and_spans_lines():
+    rows = [_row(0, text="alpha", ls=1, le=2), _row(1, text="beta", ls=3, le=5)]
+    text, ls, le = _stitch(_map(rows), 0, 1)
+    assert text == "alpha\nbeta"
+    assert (ls, le) == (1, 5)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `PYTHONPATH=$PWD/src python -m pytest tests/unit/bricks/search/test_macro_chunk_core.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'nexus.bricks.search.macro_chunk'`
+
+- [ ] **Step 3: Write the module**
+
+```python
+# src/nexus/bricks/search/macro_chunk.py
+"""Read-side macro-chunk (neighbor-context) expansion for hybrid search (Issue #4398).
+
+Pure and backend-agnostic. Given ranked results and a NeighborFetcher that returns
+chunk rows for (path, chunk_index range) spans, expand each hit into its surrounding
+section (bounded by heading_prefix, file edge, and a token budget) and attach the
+stitched text as ``macro_text``.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol, Sequence
+
+_CODE_EXTENSIONS = (
+    ".c", ".cc", ".cpp", ".h", ".hpp", ".py", ".rs", ".go", ".java",
+    ".ts", ".tsx", ".js", ".jsx", ".v", ".vh", ".sv", ".svh",
+    ".scala", ".rb", ".swift", ".kt",
+)
+
+
+@dataclass(frozen=True)
+class ChunkRow:
+    path: str
+    chunk_index: int
+    text: str
+    tokens: int
+    line_start: int | None = None
+    line_end: int | None = None
+    heading_prefix: str | None = None
+
+
+@dataclass(frozen=True)
+class ExpansionConfig:
+    token_budget: int = 1024
+    window: int = 8
+    code_forward_bias: bool = True
+
+
+class NeighborFetcher(Protocol):
+    async def fetch_ranges(
+        self, spans: Sequence[tuple[str, int, int]], zone_id: str | None
+    ) -> list["ChunkRow"]: ...
+
+
+def _is_code_path(path: str) -> bool:
+    lower = path.lower()
+    return any(lower.endswith(ext) for ext in _CODE_EXTENSIONS)
+
+
+def merge_spans(spans: list[tuple[str, int, int]]) -> list[tuple[str, int, int]]:
+    """Merge overlapping/adjacent (path, lo, hi) spans into a minimal set."""
+    by_path: dict[str, list[tuple[int, int]]] = {}
+    for path, lo, hi in spans:
+        by_path.setdefault(path, []).append((lo, hi))
+    out: list[tuple[str, int, int]] = []
+    for path, ranges in by_path.items():
+        ranges.sort()
+        clo, chi = ranges[0]
+        for lo, hi in ranges[1:]:
+            if lo <= chi + 1:
+                chi = max(chi, hi)
+            else:
+                out.append((path, clo, chi))
+                clo, chi = lo, hi
+        out.append((path, clo, chi))
+    return out
+
+
+def _section_bounds(by_index: dict[int, ChunkRow], anchor_idx: int) -> tuple[int, int]:
+    """Maximal contiguous run around anchor sharing its heading_prefix."""
+    target = by_index[anchor_idx].heading_prefix
+    lo = anchor_idx
+    while (lo - 1) in by_index and by_index[lo - 1].heading_prefix == target:
+        lo -= 1
+    hi = anchor_idx
+    while (hi + 1) in by_index and by_index[hi + 1].heading_prefix == target:
+        hi += 1
+    return lo, hi
+
+
+def _window_for_anchor(
+    by_index: dict[int, ChunkRow], anchor_idx: int, cfg: ExpansionConfig, is_code: bool
+) -> tuple[int, int]:
+    s_lo, s_hi = _section_bounds(by_index, anchor_idx)
+    section_tokens = sum(
+        by_index[i].tokens for i in range(s_lo, s_hi + 1) if i in by_index
+    )
+    if section_tokens <= cfg.token_budget:
+        return s_lo, s_hi
+
+    used = by_index[anchor_idx].tokens
+    lo = hi = anchor_idx
+
+    def _can(i: int) -> bool:
+        return i in by_index and used + by_index[i].tokens <= cfg.token_budget
+
+    if is_code and cfg.code_forward_bias:
+        while hi + 1 <= s_hi and _can(hi + 1):
+            hi += 1
+            used += by_index[hi].tokens
+        while lo - 1 >= s_lo and _can(lo - 1):
+            lo -= 1
+            used += by_index[lo].tokens
+        return lo, hi
+
+    back = True
+    while True:
+        moved = False
+        if back and lo - 1 >= s_lo and _can(lo - 1):
+            lo -= 1
+            used += by_index[lo].tokens
+            moved = True
+        elif (not back) and hi + 1 <= s_hi and _can(hi + 1):
+            hi += 1
+            used += by_index[hi].tokens
+            moved = True
+        else:
+            if back and hi + 1 <= s_hi and _can(hi + 1):
+                hi += 1
+                used += by_index[hi].tokens
+                moved = True
+            elif (not back) and lo - 1 >= s_lo and _can(lo - 1):
+                lo -= 1
+                used += by_index[lo].tokens
+                moved = True
+        if not moved:
+            break
+        back = not back
+    return lo, hi
+
+
+def _stitch(
+    by_index: dict[int, ChunkRow], lo: int, hi: int
+) -> tuple[str, int | None, int | None]:
+    rows = [by_index[i] for i in range(lo, hi + 1) if i in by_index]
+    text = "\n".join(r.text for r in rows)
+    starts = [r.line_start for r in rows if r.line_start is not None]
+    ends = [r.line_end for r in rows if r.line_end is not None]
+    return text, (min(starts) if starts else None), (max(ends) if ends else None)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `PYTHONPATH=$PWD/src python -m pytest tests/unit/bricks/search/test_macro_chunk_core.py -v`
+Expected: PASS (7 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/nexus/bricks/search/macro_chunk.py tests/unit/bricks/search/test_macro_chunk_core.py
+git commit -m "feat(search): macro-chunk pure core — span-merge, section bounds, window selection (#4398)"
+```
+
+---
+
+### Task 2: `expand_results` orchestrator (range-merge → fetch → section-dedup → attach)
+
+**Files:**
+- Modify: `src/nexus/bricks/search/macro_chunk.py`
+- Test: `tests/unit/bricks/search/test_macro_chunk_expand.py`
+
+**Interfaces:**
+- Consumes: `ChunkRow`, `ExpansionConfig`, `NeighborFetcher`, `merge_spans`, `_section_bounds`, `_window_for_anchor`, `_stitch`, `_is_code_path` (Task 1).
+- Produces: `async def expand_results(results: list, fetcher: NeighborFetcher, cfg: ExpansionConfig, zone_id: str|None = None) -> list` — mutates each result, setting `result.macro_text`, `result.macro_line_start`, `result.macro_line_end`. Results must expose `.path` and `.chunk_index`; settable attrs `macro_text`/`macro_line_start`/`macro_line_end`. Returns the same list. Never raises on a single-result failure.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/unit/bricks/search/test_macro_chunk_expand.py
+import pytest
+
+from nexus.bricks.search.macro_chunk import ChunkRow, ExpansionConfig, expand_results
+
+
+class _Result:
+    def __init__(self, path, chunk_index):
+        self.path = path
+        self.chunk_index = chunk_index
+        self.macro_text = None
+        self.macro_line_start = None
+        self.macro_line_end = None
+
+
+class _FakeFetcher:
+    def __init__(self, rows):
+        self._rows = rows
+        self.calls = []
+
+    async def fetch_ranges(self, spans, zone_id):
+        self.calls.append(list(spans))
+        wanted = list(spans)
+        out = []
+        for r in self._rows:
+            for path, lo, hi in wanted:
+                if r.path == path and lo <= r.chunk_index <= hi:
+                    out.append(r)
+                    break
+        return out
+
+
+def _row(idx, path="/a.md", heading="A", tokens=10, text=None, ls=None, le=None):
+    return ChunkRow(path=path, chunk_index=idx, text=text or f"c{idx}",
+                    tokens=tokens, line_start=ls, line_end=le, heading_prefix=heading)
+
+
+@pytest.mark.asyncio
+async def test_expand_attaches_macro_text_for_section():
+    rows = [_row(i, heading="A", ls=i + 1, le=i + 1) for i in range(3)]
+    fetcher = _FakeFetcher(rows)
+    res = [_Result("/a.md", 1)]
+    out = await expand_results(res, fetcher, ExpansionConfig(token_budget=1024, window=8))
+    assert out[0].macro_text == "c0\nc1\nc2"
+    assert (out[0].macro_line_start, out[0].macro_line_end) == (1, 3)
+
+
+@pytest.mark.asyncio
+async def test_expand_single_batched_fetch_and_section_dedup():
+    rows = [_row(i, heading="A") for i in range(4)]
+    fetcher = _FakeFetcher(rows)
+    # two hits in the SAME section
+    res = [_Result("/a.md", 1), _Result("/a.md", 2)]
+    out = await expand_results(res, fetcher, ExpansionConfig(token_budget=1024, window=8))
+    assert len(fetcher.calls) == 1                 # one batched fetch
+    assert out[0].macro_text == out[1].macro_text  # section computed once, shared
+
+
+@pytest.mark.asyncio
+async def test_expand_missing_anchor_leaves_result_untouched():
+    fetcher = _FakeFetcher([])  # eventual-consistency gap: nothing returned
+    res = [_Result("/a.md", 5)]
+    out = await expand_results(res, fetcher, ExpansionConfig())
+    assert out[0].macro_text is None  # never errors, no expansion
+
+
+@pytest.mark.asyncio
+async def test_expand_empty_results_noop():
+    fetcher = _FakeFetcher([])
+    assert await expand_results([], fetcher, ExpansionConfig()) == []
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `PYTHONPATH=$PWD/src python -m pytest tests/unit/bricks/search/test_macro_chunk_expand.py -v`
+Expected: FAIL — `ImportError: cannot import name 'expand_results'`
+
+- [ ] **Step 3: Append `expand_results` to `macro_chunk.py`**
+
+```python
+# append to src/nexus/bricks/search/macro_chunk.py
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+async def expand_results(
+    results: list,
+    fetcher: NeighborFetcher,
+    cfg: ExpansionConfig,
+    zone_id: str | None = None,
+) -> list:
+    """Attach macro_text/macro_line_start/macro_line_end to each result. Best-effort."""
+    if not results:
+        return results
+
+    spans = [
+        (r.path, max(0, r.chunk_index - cfg.window), r.chunk_index + cfg.window)
+        for r in results
+    ]
+    try:
+        rows = await fetcher.fetch_ranges(merge_spans(spans), zone_id)
+    except Exception:
+        logger.warning("macro-chunk fetch failed; returning unexpanded", exc_info=True)
+        return results
+
+    by_path: dict[str, dict[int, ChunkRow]] = {}
+    for row in rows:
+        by_path.setdefault(row.path, {})[row.chunk_index] = row
+
+    section_cache: dict[tuple[str, int, int], tuple[str, int | None, int | None]] = {}
+    for r in results:
+        by_index = by_path.get(r.path)
+        if not by_index or r.chunk_index not in by_index:
+            continue  # gap — leave chunk_text as-is
+        try:
+            s_lo, s_hi = _section_bounds(by_index, r.chunk_index)
+            key = (r.path, s_lo, s_hi)
+            if key not in section_cache:
+                w_lo, w_hi = _window_for_anchor(
+                    by_index, r.chunk_index, cfg, _is_code_path(r.path)
+                )
+                section_cache[key] = _stitch(by_index, w_lo, w_hi)
+            text, ls, le = section_cache[key]
+            r.macro_text = text
+            r.macro_line_start = ls
+            r.macro_line_end = le
+        except Exception:
+            logger.warning("macro-chunk expansion failed for %s", r.path, exc_info=True)
+            continue
+    return results
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `PYTHONPATH=$PWD/src python -m pytest tests/unit/bricks/search/test_macro_chunk_expand.py -v`
+Expected: PASS (4 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/nexus/bricks/search/macro_chunk.py tests/unit/bricks/search/test_macro_chunk_expand.py
+git commit -m "feat(search): macro-chunk expand_results orchestrator with section dedup (#4398)"
+```
+
+---
+
+### Task 3: Migration — persist `heading_prefix` on `document_chunks`
+
+**Files:**
+- Create: `alembic/versions/add_chunk_heading_prefix.py`
+- Test: `tests/integration/bricks/search/test_migration_heading_prefix.py`
+
+**Interfaces:**
+- Produces: a nullable `heading_prefix TEXT` column on `document_chunks` (Postgres + SQLite via batch_alter_table).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/integration/bricks/search/test_migration_heading_prefix.py
+import sqlalchemy as sa
+from sqlalchemy import create_engine
+
+
+def test_document_chunks_has_heading_prefix_column(tmp_path):
+    # The migration suite is applied by the shared test DB fixture; here we assert
+    # the column exists on a freshly migrated sqlite DB.
+    from nexus.bricks.search.testing import build_migrated_sqlite_url  # helper (Task 3 step 3)
+
+    url = build_migrated_sqlite_url(tmp_path / "m.db")
+    engine = create_engine(url)
+    insp = sa.inspect(engine)
+    cols = {c["name"] for c in insp.get_columns("document_chunks")}
+    assert "heading_prefix" in cols
+```
+
+> Note: if the repo already has a migrated-DB fixture (check `tests/integration/bricks/search/conftest.py` for an existing `migrated_engine`/`db_url` fixture), use that fixture instead of a new `build_migrated_sqlite_url` helper and assert the column on it. Prefer the existing fixture; only add the helper if none exists.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `PYTHONPATH=$PWD/src python -m pytest tests/integration/bricks/search/test_migration_heading_prefix.py -v`
+Expected: FAIL — column `heading_prefix` not present.
+
+- [ ] **Step 3: Write the migration**
+
+Find the current head revision: `PYTHONPATH=$PWD/src alembic heads` (note the revision id; set `down_revision` to it).
+
+```python
+# alembic/versions/add_chunk_heading_prefix.py
+"""add heading_prefix to document_chunks
+
+Revision ID: add_chunk_heading_prefix
+Revises: <CURRENT_HEAD>
+Create Date: 2026-06-17
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "add_chunk_heading_prefix"
+down_revision = "<CURRENT_HEAD>"  # replace with `alembic heads` output
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("document_chunks", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("heading_prefix", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("document_chunks", schema=None) as batch_op:
+        batch_op.drop_column("heading_prefix")
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `PYTHONPATH=$PWD/src python -m pytest tests/integration/bricks/search/test_migration_heading_prefix.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add alembic/versions/add_chunk_heading_prefix.py tests/integration/bricks/search/test_migration_heading_prefix.py
+git commit -m "feat(search): migration — persist heading_prefix on document_chunks (#4398)"
+```
+
+---
+
+### Task 4: Persist `heading_prefix` through `ChunkStore` + indexing
+
+**Files:**
+- Modify: `src/nexus/bricks/search/chunk_store.py` (ChunkRecord + both INSERT column lists + params)
+- Modify: the indexing path that builds `ChunkRecord` from `DocumentChunk` (grep `ChunkRecord(` under `src/nexus/bricks/search/` — likely `pipeline_indexer.py` / `indexing.py`)
+- Test: `tests/integration/bricks/search/test_chunk_store.py` (extend existing)
+
+**Interfaces:**
+- Consumes: migration from Task 3.
+- Produces: `ChunkRecord.heading_prefix: str | None = None`; written to `document_chunks.heading_prefix`.
+
+- [ ] **Step 1: Write the failing test** (extend existing `test_chunk_store.py`)
+
+```python
+# add to tests/integration/bricks/search/test_chunk_store.py
+@pytest.mark.asyncio
+async def test_chunk_store_writes_heading_prefix():
+    from unittest.mock import AsyncMock, MagicMock
+    from nexus.bricks.search.chunk_store import ChunkStore, ChunkRecord
+
+    session = AsyncMock()
+    ctx = AsyncMock()
+    ctx.__aenter__.return_value = session
+    ctx.__aexit__.return_value = False
+    store = ChunkStore(async_session_factory=MagicMock(return_value=ctx), db_type="sqlite")
+
+    await store.replace_document_chunks(
+        "pid-1",
+        [ChunkRecord(chunk_text="hi", chunk_tokens=1, heading_prefix="## H")],
+    )
+    # the INSERT params for the last execute include heading_prefix
+    insert_call = session.execute.await_args_list[-1]
+    params = insert_call.args[1]
+    rows = params if isinstance(params, list) else [params]
+    assert any(p.get("heading_prefix") == "## H" for p in rows)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `PYTHONPATH=$PWD/src python -m pytest tests/integration/bricks/search/test_chunk_store.py::test_chunk_store_writes_heading_prefix -v`
+Expected: FAIL — `heading_prefix` not in params (or `ChunkRecord` has no such field).
+
+- [ ] **Step 3: Implement**
+
+In `chunk_store.py`:
+1. Add to `ChunkRecord` (after `line_end`): `heading_prefix: str | None = None`
+2. In BOTH INSERT statements (with-embedding lines ~140-144 and without-embedding lines ~156-161), add `heading_prefix` to the column list and `:heading_prefix` to the VALUES list.
+3. In the params dict built per chunk (near line 118-123), add `"heading_prefix": chunk.heading_prefix`.
+
+In the indexing path (where `ChunkRecord(...)` is constructed from a `DocumentChunk`): add `heading_prefix=doc_chunk.heading_prefix` to the constructor call.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `PYTHONPATH=$PWD/src python -m pytest tests/integration/bricks/search/test_chunk_store.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/nexus/bricks/search/chunk_store.py src/nexus/bricks/search/*indexer*.py src/nexus/bricks/search/indexing.py tests/integration/bricks/search/test_chunk_store.py
+git commit -m "feat(search): persist heading_prefix through ChunkStore and indexing (#4398)"
+```
+
+---
+
+### Task 5: Result fields + serializer (`macro_text`, `macro_line_start`, `macro_line_end`)
+
+**Files:**
+- Modify: `src/nexus/bricks/search/results.py` (`BaseSearchResult`)
+- Modify: `src/nexus/server/api/v2/routers/search.py` (`_serialize_search_result`, ~lines 156-183)
+- Test: `tests/integration/bricks/search/test_results.py` (extend) + `tests/unit/bricks/search/test_search_result_serialize.py`
+
+**Interfaces:**
+- Produces: `BaseSearchResult.macro_text: str|None`, `.macro_line_start: int|None`, `.macro_line_end: int|None` (defaults None). `_serialize_search_result` emits these keys ONLY when `macro_text is not None` (keeps default response byte-identical).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/unit/bricks/search/test_search_result_serialize.py
+from nexus.server.api.v2.routers.search import _serialize_search_result
+from nexus.bricks.search.results import BaseSearchResult
+
+
+def test_serialize_omits_macro_when_absent():
+    r = BaseSearchResult(path="/a", chunk_text="x", score=1.0, chunk_index=0)
+    out = _serialize_search_result(r)
+    assert "macro_text" not in out  # default response unchanged
+
+
+def test_serialize_includes_macro_when_present():
+    r = BaseSearchResult(path="/a", chunk_text="x", score=1.0, chunk_index=0)
+    r.macro_text = "x\ny"
+    r.macro_line_start = 1
+    r.macro_line_end = 4
+    out = _serialize_search_result(r)
+    assert out["macro_text"] == "x\ny"
+    assert out["macro_line_start"] == 1
+    assert out["macro_line_end"] == 4
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `PYTHONPATH=$PWD/src python -m pytest tests/unit/bricks/search/test_search_result_serialize.py -v`
+Expected: FAIL — `AttributeError: 'BaseSearchResult' object has no attribute 'macro_text'`
+
+- [ ] **Step 3: Implement**
+
+In `results.py` `BaseSearchResult` (after `context`): add
+```python
+    macro_text: str | None = None
+    macro_line_start: int | None = None
+    macro_line_end: int | None = None
+```
+
+In `search.py` `_serialize_search_result`, before `return out`:
+```python
+    macro_text = getattr(result, "macro_text", None)
+    if macro_text is not None:
+        out["macro_text"] = macro_text
+        out["macro_line_start"] = getattr(result, "macro_line_start", None)
+        out["macro_line_end"] = getattr(result, "macro_line_end", None)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `PYTHONPATH=$PWD/src python -m pytest tests/unit/bricks/search/test_search_result_serialize.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/nexus/bricks/search/results.py src/nexus/server/api/v2/routers/search.py tests/unit/bricks/search/test_search_result_serialize.py
+git commit -m "feat(search): additive macro_text result fields + serializer (#4398)"
+```
+
+---
+
+### Task 6: `PgVectorBackend.fetch_ranges`
+
+**Files:**
+- Modify: `src/nexus/bricks/search/pg_vector_backend.py`
+- Test: `tests/integration/bricks/search/test_pg_macro_fetch.py`
+
+**Interfaces:**
+- Consumes: `ChunkRow` (Task 1).
+- Produces: `async def fetch_ranges(self, spans: Sequence[tuple[str,int,int]], zone_id: str|None) -> list[ChunkRow]` on `PgVectorBackend` — satisfies `NeighborFetcher`.
+
+- [ ] **Step 1: Write the failing test** (requires the pg integration fixture used by `test_daemon_search_pg.py`)
+
+```python
+# tests/integration/bricks/search/test_pg_macro_fetch.py
+import pytest
+# reuse the same pg backend fixture pattern as test_pg_vector_backend.py / test_daemon_search_pg.py
+
+
+@pytest.mark.asyncio
+async def test_pg_fetch_ranges_returns_contiguous_rows(pg_vector_backend, seeded_doc):
+    # seeded_doc indexes a doc at path "/ws/doc.md" with >=3 chunks in zone "z1"
+    rows = await pg_vector_backend.fetch_ranges([("/ws/doc.md", 0, 2)], zone_id="z1")
+    idxs = sorted(r.chunk_index for r in rows)
+    assert idxs == [0, 1, 2]
+    assert all(r.path == "/ws/doc.md" for r in rows)
+    assert rows[0].tokens >= 0  # chunk_tokens populated
+```
+
+> Use the existing pg fixtures from `tests/integration/bricks/search/conftest.py`. If `seeded_doc`/`pg_vector_backend` fixtures don't exist, mirror the setup in `test_daemon_search_pg.py` (index a small doc, then call the backend).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `PYTHONPATH=$PWD/src python -m pytest tests/integration/bricks/search/test_pg_macro_fetch.py -v`
+Expected: FAIL — `AttributeError: 'PgVectorBackend' object has no attribute 'fetch_ranges'`
+
+- [ ] **Step 3: Implement** — add to `PgVectorBackend`:
+
+```python
+from typing import Sequence
+from nexus.bricks.search.macro_chunk import ChunkRow
+
+async def fetch_ranges(
+    self, spans: Sequence[tuple[str, int, int]], zone_id: str | None
+) -> list[ChunkRow]:
+    if not spans:
+        return []
+    clauses = []
+    params: dict = {"zone_id": zone_id}
+    for i, (path, lo, hi) in enumerate(spans):
+        clauses.append(
+            f"(fp.virtual_path = :p{i} AND c.chunk_index BETWEEN :lo{i} AND :hi{i})"
+        )
+        params[f"p{i}"] = path
+        params[f"lo{i}"] = lo
+        params[f"hi{i}"] = hi
+    sql = text(
+        "SELECT fp.virtual_path AS path, c.chunk_index, c.chunk_text, "
+        "       c.chunk_tokens, c.line_start, c.line_end, c.heading_prefix "
+        "FROM document_chunks c "
+        "JOIN file_paths fp ON c.path_id = fp.path_id "
+        "WHERE fp.zone_id = :zone_id AND fp.deleted_at IS NULL "
+        "  AND (" + " OR ".join(clauses) + ") "
+        "ORDER BY fp.virtual_path, c.chunk_index"
+    )
+    async with self._engine.connect() as conn:
+        rows = (await conn.execute(sql, params)).mappings().all()
+    return [
+        ChunkRow(
+            path=r["path"], chunk_index=int(r["chunk_index"]), text=r["chunk_text"],
+            tokens=int(r["chunk_tokens"] or 0), line_start=r["line_start"],
+            line_end=r["line_end"], heading_prefix=r["heading_prefix"],
+        )
+        for r in rows
+    ]
+```
+
+(Ensure `from sqlalchemy import text` is imported — it is already used by the module.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `PYTHONPATH=$PWD/src python -m pytest tests/integration/bricks/search/test_pg_macro_fetch.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/nexus/bricks/search/pg_vector_backend.py tests/integration/bricks/search/test_pg_macro_fetch.py
+git commit -m "feat(search): PgVectorBackend.fetch_ranges neighbor primitive (#4398)"
+```
+
+---
+
+### Task 7: `SqliteVecBackend.fetch_ranges` + `nexus_vec` aux columns + schema bump
+
+**Files:**
+- Modify: `src/nexus/bricks/search/sqlite_vec_backend.py` (table DDL: add `chunk_tokens`, `line_start`, `line_end`, `heading_prefix` aux columns; bump the stored schema version so the existing rebuild path recreates the table; the side-write that inserts rows; new `fetch_ranges`)
+- Modify: the SANDBOX side-write caller if it passes explicit columns (grep `nexus_vec` inserts)
+- Test: `tests/unit/bricks/search/test_sqlite_vec_backend.py` (extend) + `tests/integration/bricks/search/test_sqlite_macro_fetch.py`
+
+**Interfaces:**
+- Consumes: `ChunkRow` (Task 1).
+- Produces: `async def fetch_ranges(self, spans, zone_id) -> list[ChunkRow]` on `SqliteVecBackend`; `nexus_vec` now stores `chunk_tokens`/`line_start`/`line_end`/`heading_prefix`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/integration/bricks/search/test_sqlite_macro_fetch.py
+import pytest
+# reuse sqlite_vec fixtures from test_sqlite_vec_backend.py / test_daemon_search_sqlite.py
+
+
+@pytest.mark.asyncio
+async def test_sqlite_fetch_ranges_returns_rows_with_metadata(sqlite_vec_backend, seeded_doc_sqlite):
+    rows = await sqlite_vec_backend.fetch_ranges([("/ws/doc.md", 0, 2)], zone_id="z1")
+    idxs = sorted(r.chunk_index for r in rows)
+    assert idxs == [0, 1, 2]
+    assert rows[0].heading_prefix is not None or rows[0].heading_prefix is None  # column present
+    assert rows[0].tokens >= 0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `PYTHONPATH=$PWD/src python -m pytest tests/integration/bricks/search/test_sqlite_macro_fetch.py -v`
+Expected: FAIL — no `fetch_ranges` / missing columns.
+
+- [ ] **Step 3: Implement**
+1. In the `nexus_vec` CREATE (vec0) DDL, add auxiliary columns `+chunk_tokens INTEGER, +line_start INTEGER, +line_end INTEGER, +heading_prefix TEXT` (sqlite-vec aux columns use the `+col` syntax).
+2. Bump the schema-version value stored in `nexus_vec_meta` so the existing mismatch→rebuild path drops and recreates the table.
+3. In the row INSERT side-write, pass the four new values (from the `ChunkRecord`/`DocumentChunk`).
+4. Add `fetch_ranges` (runs sync sqlite under `asyncio.to_thread`, mirroring `semantic_search`):
+
+```python
+async def fetch_ranges(self, spans, zone_id):
+    if not spans:
+        return []
+    return await asyncio.to_thread(self._fetch_ranges_sync, list(spans), zone_id)
+
+def _fetch_ranges_sync(self, spans, zone_id):
+    from nexus.bricks.search.macro_chunk import ChunkRow
+    out = []
+    with self._lock:  # mirror existing connection-guard pattern in this module
+        cur = self._conn.cursor()
+        for path, lo, hi in spans:
+            cur.execute(
+                "SELECT path, chunk_index, chunk_text, chunk_tokens, "
+                "       line_start, line_end, heading_prefix "
+                "FROM nexus_vec "
+                "WHERE zone_id = ? AND path = ? AND chunk_index BETWEEN ? AND ? "
+                "ORDER BY chunk_index",
+                (zone_id, path, lo, hi),
+            )
+            for row in cur.fetchall():
+                out.append(ChunkRow(
+                    path=row[0], chunk_index=int(row[1]), text=row[2],
+                    tokens=int(row[3] or 0), line_start=row[4],
+                    line_end=row[5], heading_prefix=row[6],
+                ))
+    return out
+```
+
+> Match this module's actual connection/lock attribute names (grep for `self._conn`/`self._lock`/`asyncio.to_thread` in `sqlite_vec_backend.py`) — adjust the guard to the existing pattern.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `PYTHONPATH=$PWD/src python -m pytest tests/integration/bricks/search/test_sqlite_macro_fetch.py tests/unit/bricks/search/test_sqlite_vec_backend.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/nexus/bricks/search/sqlite_vec_backend.py tests/integration/bricks/search/test_sqlite_macro_fetch.py tests/unit/bricks/search/test_sqlite_vec_backend.py
+git commit -m "feat(search): SqliteVecBackend.fetch_ranges + nexus_vec metadata columns (#4398)"
+```
+
+---
+
+### Task 8: Daemon wiring + config knobs
+
+**Files:**
+- Modify: `src/nexus/bricks/search/config.py` (add `macro_chunk_tokens`, `macro_chunk_window`, `macro_chunk_code_forward_bias`)
+- Modify: `src/nexus/bricks/search/daemon.py` (`search` signature + post-assembly expansion call)
+- Test: `tests/unit/bricks/search/test_search_config.py` (extend) + `tests/integration/bricks/search/test_daemon_macro_expansion.py`
+
+**Interfaces:**
+- Consumes: `expand_results` (Task 2), backend `fetch_ranges` (Tasks 6/7), `BaseSearchResult.macro_text` (Task 5), `SearchConfig` knobs.
+- Produces: `daemon.search(..., expand: str = "none")`. When `expand == "macro"`, after the final result list is assembled, call `expand_results(results, <active vector backend>, ExpansionConfig(...from config...), zone_id=zone_id)`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/integration/bricks/search/test_daemon_macro_expansion.py
+import pytest
+# reuse the sqlite daemon fixture from test_daemon_search_sqlite.py
+
+
+@pytest.mark.asyncio
+async def test_daemon_default_response_has_no_macro_text(sqlite_daemon, seeded):
+    results = await sqlite_daemon.search("vector search", search_type="hybrid", limit=5)
+    assert all(getattr(r, "macro_text", None) is None for r in results)
+
+
+@pytest.mark.asyncio
+async def test_daemon_expand_macro_attaches_macro_text(sqlite_daemon, seeded):
+    results = await sqlite_daemon.search(
+        "vector search", search_type="hybrid", limit=5, expand="macro"
+    )
+    assert any(getattr(r, "macro_text", None) for r in results)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `PYTHONPATH=$PWD/src python -m pytest tests/integration/bricks/search/test_daemon_macro_expansion.py -v`
+Expected: FAIL — `search()` has no `expand` kwarg.
+
+- [ ] **Step 3: Implement**
+
+In `config.py` `SearchConfig` + `search_config_from_env()`:
+```python
+    macro_chunk_tokens: int = 1024
+    macro_chunk_window: int = 8
+    macro_chunk_code_forward_bias: bool = True
+```
+```python
+    macro_chunk_tokens=get_env_int("NEXUS_SEARCH_MACRO_CHUNK_TOKENS", 1024),
+    macro_chunk_window=get_env_int("NEXUS_SEARCH_MACRO_CHUNK_WINDOW", 8),
+    macro_chunk_code_forward_bias=get_env_bool("NEXUS_SEARCH_MACRO_CHUNK_FORWARD_BIAS", True),
+```
+
+In `daemon.py` `search`: add `expand: str = "none"` (last param). After the final `results` list is built and before returning:
+```python
+    if expand == "macro" and results:
+        from nexus.bricks.search.macro_chunk import expand_results, ExpansionConfig
+        fetcher = self._vector_backend_for(zone_id)  # the active PgVectorBackend/SqliteVecBackend
+        cfg = ExpansionConfig(
+            token_budget=self._config.macro_chunk_tokens,
+            window=self._config.macro_chunk_window,
+            code_forward_bias=self._config.macro_chunk_code_forward_bias,
+        )
+        await expand_results(results, fetcher, cfg, zone_id=zone_id)
+```
+
+> `_vector_backend_for` / the backend handle: use whatever attribute the daemon already holds for the active vector backend (grep `PgVectorBackend(`/`SqliteVecBackend(` in `daemon.py` to find the stored attribute, e.g. `self._vec_backend`). If the daemon stores the backend per-zone, fetch that; otherwise use the single stored backend. Do NOT add new construction — reuse the existing backend instance.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `PYTHONPATH=$PWD/src python -m pytest tests/integration/bricks/search/test_daemon_macro_expansion.py tests/unit/bricks/search/test_search_config.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/nexus/bricks/search/config.py src/nexus/bricks/search/daemon.py tests/integration/bricks/search/test_daemon_macro_expansion.py tests/unit/bricks/search/test_search_config.py
+git commit -m "feat(search): daemon expand=macro wiring + config knobs (#4398)"
+```
+
+---
+
+### Task 9: API router `expand` param
+
+**Files:**
+- Modify: `src/nexus/server/api/v2/routers/search.py` (`search_query`, ~line 291)
+- Test: `tests/integration/bricks/search/test_search_query_expand.py` (or the existing API/router test module — grep for tests hitting `search_query`)
+
+**Interfaces:**
+- Consumes: `daemon.search(..., expand=...)` (Task 8), serializer (Task 5).
+- Produces: `expand: str = "none"` query param on `POST /api/v2/search/query`, threaded into the search call.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/integration/bricks/search/test_search_query_expand.py
+import pytest
+# use the existing API test client/fixture used elsewhere for /api/v2/search/query
+
+
+@pytest.mark.asyncio
+async def test_search_query_default_no_macro(api_client, seeded):
+    resp = await api_client.post("/api/v2/search/query", params={"q": "vector search"})
+    body = resp.json()
+    assert all("macro_text" not in hit for hit in body["results"])
+
+
+@pytest.mark.asyncio
+async def test_search_query_expand_macro(api_client, seeded):
+    resp = await api_client.post(
+        "/api/v2/search/query", params={"q": "vector search", "expand": "macro"}
+    )
+    body = resp.json()
+    assert any(hit.get("macro_text") for hit in body["results"])
+```
+
+> Use whichever client fixture the existing router tests use (grep `search/query` in tests). If routers are tested via FastAPI `TestClient`/`httpx.AsyncClient`, mirror that.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `PYTHONPATH=$PWD/src python -m pytest tests/integration/bricks/search/test_search_query_expand.py -v`
+Expected: FAIL — `expand` not accepted / `macro_text` absent.
+
+- [ ] **Step 3: Implement**
+
+In `search_query()` add the query param (next to `fusion`):
+```python
+    expand: str = "none",
+```
+Thread it into the daemon/search-service call that produces `results`:
+```python
+    ... search(..., expand=expand)
+```
+(Match the exact call site that invokes `daemon.search` / the search service; pass `expand=expand`.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `PYTHONPATH=$PWD/src python -m pytest tests/integration/bricks/search/test_search_query_expand.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/nexus/server/api/v2/routers/search.py tests/integration/bricks/search/test_search_query_expand.py
+git commit -m "feat(search): expand=macro request param on /api/v2/search/query (#4398)"
+```
+
+---
+
+### Task 10: Benchmark guard + full suite
+
+**Files:**
+- Modify: `tests/benchmarks/gbrain_eval.py` only if a flag is needed to run with `expand=macro` (otherwise none)
+- Test: run existing `gbrain_eval` + the new search tests
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces: evidence that ranking is unchanged and expansion works end-to-end.
+
+- [ ] **Step 1: Run the full search test suite**
+
+Run: `PYTHONPATH=$PWD/src python -m pytest tests/unit/bricks/search tests/integration/bricks/search -v`
+Expected: PASS (all, including new tests)
+
+- [ ] **Step 2: Confirm default-response invariance on the benchmark**
+
+Run: `just bench-search` (requires `GBRAIN_EVALS_DIR` + `NEXUS_DATABASE_URL`)
+Expected: `recall@5` / `NDCG@5` within the existing 1pp slack of baseline (0.9489 / 0.9028) — expansion is off by default, so numbers must not move.
+
+- [ ] **Step 3: Smoke the expansion path on the tiny fixture first**
+
+Run a 10-item check before the full corpus (per the validate-small-first rule): index `tests/benchmarks/_tiny_fixture/`, issue a query with `expand=macro`, confirm `macro_text` is populated and contains neighbor content beyond the single chunk. Document the observed context-quality delta.
+
+- [ ] **Step 4: Commit any benchmark-harness changes**
+
+```bash
+git add tests/benchmarks/
+git commit -m "test(search): macro-chunk benchmark guard + tiny-fixture smoke (#4398)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Output contract (opt-in `expand`, additive snake_case fields) → Tasks 5, 8, 9. ✓
+- Architecture (pure module + protocol + backend fetch_ranges + daemon wiring) → Tasks 1, 2, 6, 7, 8. ✓
+- Expansion algorithm (section, heading clip, token budget, forward-bias, adaptive, dedup) → Tasks 1, 2. ✓
+- Fetch primitive (both profiles) → Tasks 6, 7. ✓
+- Migration (heading_prefix) + SANDBOX columns → Tasks 3, 4, 7. ✓
+- Error handling (best-effort) → Task 2 (`expand_results` try/except). ✓
+- Test plan + benchmark guard + both profiles → Tasks 1-2 (unit), 6-9 (integration), 10 (bench). ✓
+- Config knobs → Task 8. ✓
+
+**Type consistency:** `ChunkRow` / `ExpansionConfig` / `NeighborFetcher.fetch_ranges(spans, zone_id)` / `expand_results(results, fetcher, cfg, zone_id)` are used identically across Tasks 1, 2, 6, 7, 8. `macro_text`/`macro_line_start`/`macro_line_end` consistent across Tasks 2, 5, 8, 9.
+
+**Known fixture-dependent steps** (flagged inline, resolve against existing fixtures during execution): migrated-DB fixture name (Task 3), pg/sqlite seed fixtures (Tasks 6-9), daemon backend attribute name (Task 8), indexing `ChunkRecord(` construction site (Task 4), `nexus_vec` connection/lock attr names (Task 7).

--- a/docs/superpowers/plans/2026-06-17-macro-chunk-expansion.md
+++ b/docs/superpowers/plans/2026-06-17-macro-chunk-expansion.md
@@ -765,7 +765,7 @@ async def test_sqlite_fetch_ranges_returns_rows_with_metadata(sqlite_vec_backend
     rows = await sqlite_vec_backend.fetch_ranges([("/ws/doc.md", 0, 2)], zone_id="z1")
     idxs = sorted(r.chunk_index for r in rows)
     assert idxs == [0, 1, 2]
-    assert rows[0].heading_prefix is not None or rows[0].heading_prefix is None  # column present
+    assert rows[0].heading_prefix is None or isinstance(rows[0].heading_prefix, str)  # metadata column present + typed
     assert rows[0].tokens >= 0
 ```
 

--- a/docs/superpowers/specs/2026-06-17-macro-chunk-expansion-design.md
+++ b/docs/superpowers/specs/2026-06-17-macro-chunk-expansion-design.md
@@ -1,0 +1,233 @@
+# Macro-chunk (neighbor-context) expansion for hybrid search
+
+- **Issue:** #4398
+- **Status:** Design approved — pending implementation plan
+- **Date:** 2026-06-17
+
+## Summary
+
+Add an opt-in, read-side **macro-chunk expansion** stage to hybrid search. We keep
+indexing and ranking small chunks (good recall/precision), but when a caller sets
+`expand=macro`, each returned hit is expanded into its surrounding **section** —
+adjacent chunks by `chunk_index`, bounded by section headings, the file boundary,
+and a token budget — and the stitched text is returned in an additive `macroText`
+field next to the original `chunkText`.
+
+Model-free, no new infrastructure.
+
+## Motivation
+
+Hybrid search ranking is at bench ceiling (`tests/benchmarks/gbrain_eval.py`:
+recall@5 ≈ 0.9489 / NDCG@5 ≈ 0.9028 with RRF + top-rank bonus), so further *ranking*
+work is low ROI. The remaining headroom is **answer-context quality**, which
+recall@5 / NDCG@5 do not measure: we return ~500–1000 byte chunks, not the section
+a consumer needs to answer.
+
+The technique is to **decouple retrieval granularity from context granularity**:
+index small chunks for precise matching, then at read time stitch each hit into its
+surrounding section under a token budget, with a forward-biased variant for code so a
+signature hit also pulls in the function body that follows.
+
+`result_builders.py` already max-pools chunk *scores* to page granularity
+(`_aggregate_chunks_to_pages`) but never stitches *content*. This adds the content
+stitching.
+
+## Goals / Non-goals
+
+**Goals**
+- Richer answer context for RAG consumers, opt-in, with no change to default behavior
+  or ranking metrics.
+- One shared, backend-agnostic, unit-testable expansion implementation across both
+  FULL (pgvector) and SANDBOX (sqlite-vec) profiles.
+
+**Non-goals (explicitly parked)**
+- Cross-encoder / hosted reranker (hosting + latency cost; ~no lift at current ceiling).
+- Multi-step / agentic retrieval.
+- Knowledge-graph retrieval layer.
+
+## Output contract
+
+- New request param `expand` on `POST /api/v2/search/query`: enum `none` (default) |
+  `macro`. Default → response byte-identical to today.
+- When `expand=macro`, each hit gains an additive `macroText` field
+  (`macro_text` internally → `macroText` over the API), plus `macroLineStart` /
+  `macroLineEnd` for the covered line span. The short `chunkText` stays as the matched
+  snippet / citation anchor.
+- Additive field in the shared `nexus-client` `SearchHit` schema. Ranking,
+  `gbrain_eval`, and existing callers are unaffected.
+
+## Consumer context
+
+The primary consumer is the external Koodle app. It calls
+`services.nexusClient.search.query()` → `POST /api/v2/search/query` with
+`{ q, type:"hybrid", limit (over-fetched ×5, cap 80), path:/workspaces/{id}/ }`, reads
+`path, chunkText, score, chunkIndex, lineStart, lineEnd`, and feeds `chunkText`
+straight into an LLM (a deepagents tool result). It **never re-fetches source or widens
+context itself**, so server-side expansion is the only path to richer context for it.
+
+Because that consumer is external and over-fetches heavily, expansion is **opt-in** —
+to avoid token blow-up and to avoid doing neighbor-fetch work for callers that don't use
+it. Koodle opts in by sending `expand=macro`, reading `macroText ?? chunkText`, and
+lowering its over-fetch multiplier in the same change.
+
+## Architecture (shared module + thin fetch primitive)
+
+Pipeline in the daemon query path, only when `expand=macro`:
+
+```
+hybrid retrieve + RRF fuse                 (existing)
+        ↓ ranked results [{path, chunk_index, chunk_text, score, ...}]
+_aggregate_chunks_to_pages                 (existing, unchanged)
+        ↓ final ordered chunk rows
+macro_chunk.expand_results(rows, fetcher, cfg)   ← NEW, gated on expand=macro
+        ↓ each row gains macro_text + line span
+serialize → API: macro_text → macroText
+```
+
+Components:
+
+1. **`macro_chunk.py`** (new, pure Python, zero DB knowledge):
+   - `ExpansionConfig` — token budget `T`, window radius `W`, code forward-bias flag.
+   - `NeighborFetcher` (Protocol) — `fetch_ranges(spans: list[(path, lo, hi)]) -> list[ChunkRow]`.
+   - `ChunkRow` (dataclass) — `path, chunk_index, text, tokens, line_start, line_end, heading_prefix`.
+   - `expand_results(rows, fetcher, cfg)` — derive anchors → merge overlapping
+     `(path, index-range)` spans → one batched fetch → build per-path `index→row` map →
+     run the expansion algorithm per anchor → attach `macro_text` + line span. All
+     sub-steps are pure functions.
+
+2. **Backend fetchers** (thin, one per profile): `PgNeighborFetcher`,
+   `SqliteNeighborFetcher` implement `fetch_ranges` as a single batched SQL. They resolve
+   `path → path_id` internally; the algorithm never sees storage identity.
+
+3. **Daemon wiring** — one call site after page aggregation, behind the `expand` flag.
+   No algorithm logic in `daemon.py`.
+
+Data-flow decisions:
+- Anchor identity = the result's existing `path` + `chunk_index` (no new identity threading).
+- **One batched, range-merged fetch per query** — two hits in the same section share a span.
+- Page aggregation runs **before** expansion, so we only expand chunks that survive to
+  the final list (bounded work).
+- `macro_text` is attached additively; `chunk_text` / `score` / ordering untouched.
+
+## Expansion algorithm
+
+**The "section" unifies heading-clipping and adaptive sizing.** A *section* is the
+maximal contiguous run of chunks (same `path`) sharing the anchor's `heading_prefix`.
+That one concept is both the clip boundary and the adaptive target.
+
+Per anchor:
+
+```
+section = contiguous neighbors of anchor with heading_prefix == anchor.heading_prefix
+          (bounded by file edge and the fetch radius W)
+
+if section_tokens <= T:
+    window = whole section                      # adaptive: size to the real section
+else:
+    window = budgeted sub-window within section, anchored on the hit:
+        - prose: grow outward centered (backward/forward balanced) until T
+        - code (path has a code extension): forward-bias — grow forward first
+          (capture the body after the signature), then backward with leftover T
+
+macro_text = concat(window chunks, ascending chunk_index, "\n"-joined)
+line span  = (min line_start, max line_end) over the window
+```
+
+Caps (whichever binds first):
+- `T` = `NEXUS_SEARCH_MACRO_CHUNK_TOKENS` — token budget, using stored `chunk_tokens`.
+- `W` = `NEXUS_SEARCH_MACRO_CHUNK_WINDOW` — index radius (also the fetch radius); hard
+  cap for pathological sections. Token budget normally binds first; `W` truncation is a
+  safety rail and is logged (no silent cap).
+
+**Small-section dedup:** group final anchors by `(path, section-span)`. For each group,
+compute `macro_text` once from the top-ranked anchor and attach it to every member. No
+N near-duplicate windows, no recompute; the consumer's existing `path+chunkIndex` dedup
+collapses the rest if it wants.
+
+Edge cases:
+- `heading_prefix is None` (code without headings, plain text, non-markdown): no heading
+  boundary → section bounded only by file edge + `T`/`W`. Code still forward-biases;
+  prose centers.
+- 1-chunk section → `macro_text == chunk_text` (no-op, still emitted for shape consistency).
+- Section extends past fetch radius `W` → truncate at `W`, log it.
+- Anchor chunk missing from the fetch (eventual-consistency gap) → skip expansion, leave
+  `chunk_text` as-is; never error the search.
+
+## Fetch primitive
+
+`fetch_ranges(spans: list[(path, lo, hi)]) -> list[ChunkRow]` — **one batched query per
+search**:
+- Postgres: single SQL, `(path_id, chunk_index)` spans OR'd (or a VALUES join),
+  `file_paths` join to resolve `path → path_id`; selects
+  `chunk_index, chunk_text, chunk_tokens, line_start, line_end, heading_prefix`, ordered
+  by `chunk_index`.
+- SQLite (SANDBOX): same shape, SQLite dialect.
+
+Open implementation detail to verify during planning: confirm the SANDBOX chunk store
+persists `chunk_tokens` / `line_start` / `heading_prefix` (the Postgres `document_chunks`
+writer in `chunk_store.py` does). If its table is leaner, the migration adds those columns
+there too.
+
+## Migration (persist `heading_prefix`)
+
+Add `heading_prefix TEXT NULL` to the chunk table(s). The chunker already computes it
+(`chunking.py`, #3719); the writer just stores it now.
+
+**No blocking backfill:** existing rows have `NULL` `heading_prefix` → expansion treats
+NULL as "no heading boundary" (degrades to a token/file-bounded window — still correct,
+just less section-precise) until natural reindex. An optional reindex restores full
+section precision.
+
+## Config / defaults
+
+- `expand` request param: `none` (default) | `macro`.
+- `NEXUS_SEARCH_MACRO_CHUNK_TOKENS` (default 1024) — per-result token budget.
+- `NEXUS_SEARCH_MACRO_CHUNK_WINDOW` (default 8) — index radius / fetch radius.
+- Code forward-bias: on by default.
+
+All server-side knobs are tunable against the benchmark.
+
+## Error handling / observability
+
+Expansion is **best-effort and never fails search**: any fetch error, missing chunk, or
+edge condition → return the hit with `chunk_text` only. `expand_results` is wrapped in a
+guard; degradation is logged and counted. Add `macro_expand_ms` timing plus a
+truncation/fallback counter, consistent with existing daemon instrumentation.
+
+## Test plan (TDD, failing-first)
+
+- **Unit** (pure module, in-memory fake `NeighborFetcher`, no DB): whole-section-fits;
+  section > budget centered (prose) vs forward-biased (code); heading boundary stops;
+  `heading_prefix=None` path; 1-chunk no-op; section > `W` truncate + log; small-section
+  dedup shares one window; range-merge collapses overlapping spans.
+- **Integration** (both profiles): seed docs → `expand=macro` returns stitched
+  `macroText`; default (no `expand`) response byte-identical to today.
+- **Benchmark guard:** `gbrain_eval.py` recall@5 / NDCG@5 unchanged with expansion off
+  *and* on (text-only addition); add a context-quality run on
+  `benchmarks/longmemeval/run_retrieval.py`.
+- Validate on a 10-item fixture first, then the full corpus.
+
+## Rollout / coordination
+
+1. Server: migration + fetcher + `macro_chunk.py` + daemon wiring + `expand` param +
+   `macroText` response field. Default off → safe to ship independently.
+2. Shared `nexus-client` `SearchHit` schema: add optional `macroText` /
+   `macroLineStart` / `macroLineEnd`.
+3. Koodle: send `expand=macro`, read `macroText ?? chunkText`, lower its over-fetch
+   multiplier.
+
+## Acceptance criteria
+
+- [ ] Opt-in `expand=macro`; default response byte-identical to today.
+- [ ] Neighbor stitch clips at `heading_prefix` change, file boundary, and token budget.
+- [ ] `heading_prefix` persisted (migration); both profiles; graceful NULL degradation.
+- [ ] Code forward-bias path.
+- [ ] Adaptive section sizing + small-section dedup.
+- [ ] `macroText` (+ line span) returned additively; `chunkText` unchanged.
+- [ ] No `recall@5` / `NDCG@5` change on `gbrain_eval.py`.
+- [ ] Context-quality delta measured on `gbrain_eval.py` + `longmemeval`.
+- [ ] Works in FULL (pgvector) and SANDBOX (sqlite-vec).
+
+## Related
+
+#3773 / #3797 (RRF top-rank bonus), #3699 (search backend rework).

--- a/docs/superpowers/specs/2026-06-17-macro-chunk-expansion-design.md
+++ b/docs/superpowers/specs/2026-06-17-macro-chunk-expansion-design.md
@@ -49,12 +49,14 @@ stitching.
 
 - New request param `expand` on `POST /api/v2/search/query`: enum `none` (default) |
   `macro`. Default → response byte-identical to today.
-- When `expand=macro`, each hit gains an additive `macroText` field
-  (`macro_text` internally → `macroText` over the API), plus `macroLineStart` /
-  `macroLineEnd` for the covered line span. The short `chunkText` stays as the matched
-  snippet / citation anchor.
-- Additive field in the shared `nexus-client` `SearchHit` schema. Ranking,
-  `gbrain_eval`, and existing callers are unaffected.
+- When `expand=macro`, each hit gains additive `macro_text` plus `macro_line_start` /
+  `macro_line_end` fields. These are emitted **snake_case** by the server, consistent
+  with the existing `/api/v2/search/query` response (which is snake_case throughout —
+  there is no camelCase serializer server-side). The TypeScript `nexus-client` SDK is
+  what surfaces them to Koodle as `macroText` / `macroLineStart` / `macroLineEnd`. The
+  short `chunk_text` stays as the matched snippet / citation anchor.
+- Additive field in `_serialize_search_result` and the shared `nexus-client` schema.
+  Ranking, `gbrain_eval`, and existing callers are unaffected.
 
 ## Consumer context
 
@@ -95,9 +97,11 @@ Components:
      run the expansion algorithm per anchor → attach `macro_text` + line span. All
      sub-steps are pure functions.
 
-2. **Backend fetchers** (thin, one per profile): `PgNeighborFetcher`,
-   `SqliteNeighborFetcher` implement `fetch_ranges` as a single batched SQL. They resolve
-   `path → path_id` internally; the algorithm never sees storage identity.
+2. **Backend `fetch_ranges`** (thin, one per profile): `PgVectorBackend` and
+   `SqliteVecBackend` each implement the `NeighborFetcher` protocol via a `fetch_ranges`
+   method — a single batched SQL. They resolve `path → path_id` (Postgres) / scope by
+   `path` (SQLite) internally; the algorithm never sees storage identity. The daemon
+   passes whichever backend matches the active profile as the fetcher.
 
 3. **Daemon wiring** — one call site after page aggregation, behind the `expand` flag.
    No algorithm logic in `daemon.py`.
@@ -163,10 +167,11 @@ search**:
   by `chunk_index`.
 - SQLite (SANDBOX): same shape, SQLite dialect.
 
-Open implementation detail to verify during planning: confirm the SANDBOX chunk store
-persists `chunk_tokens` / `line_start` / `heading_prefix` (the Postgres `document_chunks`
-writer in `chunk_store.py` does). If its table is leaner, the migration adds those columns
-there too.
+Resolved during planning: the SANDBOX store is the sqlite-vec `nexus_vec` table, which
+persists only `path`, `chunk_index`, `chunk_text` (not `chunk_tokens` / `line_start` /
+`line_end` / `heading_prefix`). The plan therefore adds those as auxiliary columns to the
+`nexus_vec` side-write and bumps the store schema version (triggering a SANDBOX rebuild
+via the existing dim/embedder-mismatch rebuild path), for full fidelity in both profiles.
 
 ## Migration (persist `heading_prefix`)
 
@@ -223,7 +228,8 @@ truncation/fallback counter, consistent with existing daemon instrumentation.
 - [ ] `heading_prefix` persisted (migration); both profiles; graceful NULL degradation.
 - [ ] Code forward-bias path.
 - [ ] Adaptive section sizing + small-section dedup.
-- [ ] `macroText` (+ line span) returned additively; `chunkText` unchanged.
+- [ ] `macro_text` (+ `macro_line_start`/`macro_line_end`) returned additively;
+  `chunk_text` unchanged.
 - [ ] No `recall@5` / `NDCG@5` change on `gbrain_eval.py`.
 - [ ] Context-quality delta measured on `gbrain_eval.py` + `longmemeval`.
 - [ ] Works in FULL (pgvector) and SANDBOX (sqlite-vec).

--- a/docs/surface-coverage/api-rpc-surface-coverage.yaml
+++ b/docs/surface-coverage/api-rpc-surface-coverage.yaml
@@ -7625,7 +7625,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/consumers/{consumer_name}/skip-to
-      source: src/nexus/server/api/v2/routers/search.py:272
+      source: src/nexus/server/api/v2/routers/search.py:277
   profiles:
     lite: supported
     sandbox: supported
@@ -7642,7 +7642,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/expand
-      source: src/nexus/server/api/v2/routers/search.py:1534
+      source: src/nexus/server/api/v2/routers/search.py:1550
   profiles:
     lite: supported
     sandbox: supported
@@ -7666,7 +7666,7 @@ operations:
       source: src/nexus/bricks/search/search_service.py:1791
     http:
       name: POST /api/v2/search/glob
-      source: src/nexus/server/api/v2/routers/search.py:1415
+      source: src/nexus/server/api/v2/routers/search.py:1431
     mcp:
       name: nexus_glob
       source: src/nexus/config/tool_profiles.yaml:1
@@ -7693,7 +7693,7 @@ operations:
       source: src/nexus/bricks/search/search_service.py:2101
     http:
       name: POST /api/v2/search/grep
-      source: src/nexus/server/api/v2/routers/search.py:1292
+      source: src/nexus/server/api/v2/routers/search.py:1308
     mcp:
       name: nexus_grep
       source: src/nexus/config/tool_profiles.yaml:1
@@ -7729,7 +7729,7 @@ operations:
   transports:
     http:
       name: GET /api/v2/search/health
-      source: src/nexus/server/api/v2/routers/search.py:191
+      source: src/nexus/server/api/v2/routers/search.py:196
   profiles:
     lite: supported
     sandbox: supported
@@ -7746,7 +7746,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/index
-      source: src/nexus/server/api/v2/routers/search.py:1477
+      source: src/nexus/server/api/v2/routers/search.py:1493
   profiles:
     lite: supported
     sandbox: supported
@@ -7764,7 +7764,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/index-directory
-      source: src/nexus/server/api/v2/routers/search.py:1676
+      source: src/nexus/server/api/v2/routers/search.py:1692
   profiles:
     lite: supported
     sandbox: supported
@@ -7781,7 +7781,7 @@ operations:
   transports:
     http:
       name: GET /api/v2/search/indexed-dirs
-      source: src/nexus/server/api/v2/routers/search.py:1894
+      source: src/nexus/server/api/v2/routers/search.py:1910
   profiles:
     lite: supported
     sandbox: supported
@@ -7798,7 +7798,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/indexing-mode
-      source: src/nexus/server/api/v2/routers/search.py:1931
+      source: src/nexus/server/api/v2/routers/search.py:1947
   profiles:
     lite: supported
     sandbox: supported
@@ -7815,7 +7815,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/locate
-      source: src/nexus/server/api/v2/routers/search.py:2112
+      source: src/nexus/server/api/v2/routers/search.py:2128
   profiles:
     lite: supported
     sandbox: supported
@@ -7832,7 +7832,7 @@ operations:
   transports:
     http:
       name: GET /api/v2/search/parked
-      source: src/nexus/server/api/v2/routers/search.py:229
+      source: src/nexus/server/api/v2/routers/search.py:234
   profiles:
     lite: supported
     sandbox: supported
@@ -7849,7 +7849,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/parked/discard
-      source: src/nexus/server/api/v2/routers/search.py:255
+      source: src/nexus/server/api/v2/routers/search.py:260
   profiles:
     lite: supported
     sandbox: supported
@@ -7867,7 +7867,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/parked/retry
-      source: src/nexus/server/api/v2/routers/search.py:238
+      source: src/nexus/server/api/v2/routers/search.py:243
   profiles:
     lite: supported
     sandbox: supported
@@ -7884,7 +7884,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/purge-unscoped
-      source: src/nexus/server/api/v2/routers/search.py:2058
+      source: src/nexus/server/api/v2/routers/search.py:2074
   profiles:
     lite: supported
     sandbox: supported
@@ -7902,7 +7902,7 @@ operations:
   transports:
     http:
       name: GET /api/v2/search/query
-      source: src/nexus/server/api/v2/routers/search.py:290
+      source: src/nexus/server/api/v2/routers/search.py:295
   profiles:
     lite: supported
     sandbox: supported
@@ -7920,7 +7920,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/query/batch
-      source: src/nexus/server/api/v2/routers/search.py:722
+      source: src/nexus/server/api/v2/routers/search.py:738
   profiles:
     lite: supported
     sandbox: supported
@@ -7937,7 +7937,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/refresh
-      source: src/nexus/server/api/v2/routers/search.py:1513
+      source: src/nexus/server/api/v2/routers/search.py:1529
   profiles:
     lite: supported
     sandbox: supported
@@ -7972,7 +7972,7 @@ operations:
   transports:
     http:
       name: GET /api/v2/search/stats
-      source: src/nexus/server/api/v2/routers/search.py:206
+      source: src/nexus/server/api/v2/routers/search.py:211
   profiles:
     lite: supported
     sandbox: supported

--- a/src/nexus/bricks/search/chunk_store.py
+++ b/src/nexus/bricks/search/chunk_store.py
@@ -34,6 +34,7 @@ class ChunkRecord:
     end_offset: int | None = None
     line_start: int | None = None
     line_end: int | None = None
+    heading_prefix: str | None = None
     embedding: list[float] | None = None
     embedding_model: str | None = None
     chunk_context: str | None = None
@@ -122,6 +123,7 @@ class ChunkStore:
             "end_offset": chunk.end_offset,
             "line_start": chunk.line_start,
             "line_end": chunk.line_end,
+            "heading_prefix": chunk.heading_prefix,
             "embedding_model": chunk.embedding_model,
             "chunk_context": _strip_null_bytes(chunk.chunk_context),
             "chunk_position": chunk.chunk_position,
@@ -138,13 +140,13 @@ class ChunkStore:
                 """
                 INSERT INTO document_chunks
                 (chunk_id, path_id, chunk_index, chunk_text, chunk_tokens,
-                 start_offset, end_offset, line_start, line_end,
+                 start_offset, end_offset, line_start, line_end, heading_prefix,
                  embedding_model, embedding,
                  chunk_context, chunk_position, source_document_id,
                  created_at)
                 VALUES
                 (:chunk_id, :path_id, :chunk_index, :chunk_text, :chunk_tokens,
-                 :start_offset, :end_offset, :line_start, :line_end,
+                 :start_offset, :end_offset, :line_start, :line_end, :heading_prefix,
                  :embedding_model, CAST(:embedding AS halfvec),
                  :chunk_context, :chunk_position, :source_document_id,
                  :created_at)
@@ -154,13 +156,13 @@ class ChunkStore:
             """
             INSERT INTO document_chunks
             (chunk_id, path_id, chunk_index, chunk_text, chunk_tokens,
-             start_offset, end_offset, line_start, line_end,
+             start_offset, end_offset, line_start, line_end, heading_prefix,
              embedding_model,
              chunk_context, chunk_position, source_document_id,
              created_at)
             VALUES
             (:chunk_id, :path_id, :chunk_index, :chunk_text, :chunk_tokens,
-             :start_offset, :end_offset, :line_start, :line_end,
+             :start_offset, :end_offset, :line_start, :line_end, :heading_prefix,
              :embedding_model,
              :chunk_context, :chunk_position, :source_document_id,
              :created_at)

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -1772,7 +1772,14 @@ class SearchDaemon:
             window=self.config.macro_chunk_window,
             code_forward_bias=self.config.macro_chunk_code_forward_bias,
         )
+        _t0 = time.perf_counter()
         await expand_results(results, self._vector_backend, cfg, zone_id=zone_id)
+        timing = self.last_search_timing
+        timing["macro_expand_ms"] = (time.perf_counter() - _t0) * 1000.0
+        timing["macro_expanded_count"] = sum(
+            1 for r in results if getattr(r, "macro_text", None) is not None
+        )
+        self.last_search_timing = timing
 
     async def search(
         self,

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -47,6 +47,8 @@ from sqlalchemy import text as sa_text
 
 from nexus.bricks.search import consumer_metrics
 from nexus.bricks.search.chunk_store import ChunkRecord, ChunkStore
+from nexus.bricks.search.config import get_env_bool as _get_env_bool
+from nexus.bricks.search.config import get_env_int as _get_env_int
 from nexus.bricks.search.mutation_events import (
     SearchMutationEvent,
     SearchMutationOp,
@@ -286,6 +288,21 @@ class DaemonConfig:
     mutation_unresolved_permanent_attempts: int = 3
     mutation_unresolved_transient_attempts: int = 30
     mutation_parked_max_entries: int = 200
+
+    # Macro-chunk (neighbor-context) expansion knobs (Issue #4398).
+    # When search() is called with expand="macro", each result is expanded
+    # into its surrounding section bounded by a token budget and a window of
+    # neighbor chunks. Configured via environment variables so operators can
+    # tune without a code change.
+    macro_chunk_tokens: int = field(
+        default_factory=lambda: _get_env_int("NEXUS_SEARCH_MACRO_CHUNK_TOKENS", 1024)
+    )
+    macro_chunk_window: int = field(
+        default_factory=lambda: _get_env_int("NEXUS_SEARCH_MACRO_CHUNK_WINDOW", 8)
+    )
+    macro_chunk_code_forward_bias: bool = field(
+        default_factory=lambda: _get_env_bool("NEXUS_SEARCH_MACRO_CHUNK_FORWARD_BIAS", True)
+    )
 
 
 class SearchDaemon:
@@ -1736,6 +1753,27 @@ class SearchDaemon:
                     exc,
                 )
 
+    async def _apply_macro_expansion(
+        self,
+        results: Any,
+        *,
+        expand: str,
+        zone_id: str,
+    ) -> None:
+        """Best-effort: when expand=='macro', attach macro_text to each result by
+        stitching neighbor chunks via the active vector backend. No-op when
+        disabled, no results, or no vector backend (Issue #4398)."""
+        if expand != "macro" or not results or self._vector_backend is None:
+            return
+        from nexus.bricks.search.macro_chunk import ExpansionConfig, expand_results
+
+        cfg = ExpansionConfig(
+            token_budget=self.config.macro_chunk_tokens,
+            window=self.config.macro_chunk_window,
+            code_forward_bias=self.config.macro_chunk_code_forward_bias,
+        )
+        await expand_results(results, self._vector_backend, cfg, zone_id=zone_id)
+
     async def search(
         self,
         query: str,
@@ -1745,9 +1783,10 @@ class SearchDaemon:
         alpha: float = 0.5,
         fusion_method: str = "rrf",
         zone_id: str | None = None,
+        expand: str = "none",
     ) -> list[SearchResult]:
         if zone_id is None:
-            return await self._search_on_current_loop(
+            results = await self._search_on_current_loop(
                 query,
                 search_type=search_type,
                 limit=limit,
@@ -1756,19 +1795,23 @@ class SearchDaemon:
                 fusion_method=fusion_method,
                 zone_id=zone_id,
             )
+        else:
 
-        async def _work() -> list[SearchResult]:
-            return await self._search_on_current_loop(
-                query,
-                search_type=search_type,
-                limit=limit,
-                path_filter=path_filter,
-                alpha=alpha,
-                fusion_method=fusion_method,
-                zone_id=zone_id,
-            )
+            async def _work() -> list[SearchResult]:
+                return await self._search_on_current_loop(
+                    query,
+                    search_type=search_type,
+                    limit=limit,
+                    path_filter=path_filter,
+                    alpha=alpha,
+                    fusion_method=fusion_method,
+                    zone_id=zone_id,
+                )
 
-        return await self._run_on_owner_loop(_work)
+            results = await self._run_on_owner_loop(_work)
+
+        await self._apply_macro_expansion(results, expand=expand, zone_id=zone_id or ROOT_ZONE_ID)
+        return results
 
     async def _search_on_current_loop(
         self,

--- a/src/nexus/bricks/search/indexing.py
+++ b/src/nexus/bricks/search/indexing.py
@@ -536,6 +536,7 @@ class IndexingPipeline:
                 end_offset=chunk.end_offset,
                 line_start=chunk.line_start,
                 line_end=chunk.line_end,
+                heading_prefix=chunk.heading_prefix,
                 embedding=embeddings[i] if embeddings else None,
                 embedding_model=embedding_model,
                 chunk_context=doc.context_jsons[i] if doc.context_jsons else None,

--- a/src/nexus/bricks/search/indexing.py
+++ b/src/nexus/bricks/search/indexing.py
@@ -583,6 +583,10 @@ class IndexingPipeline:
                         "path": canonical_path,
                         "text": chunk.text,
                         "chunk_index": i,
+                        "chunk_tokens": chunk.tokens,
+                        "line_start": chunk.line_start,
+                        "line_end": chunk.line_end,
+                        "heading_prefix": chunk.heading_prefix,
                     }
                     for i, chunk in enumerate(doc.chunks)
                 ]

--- a/src/nexus/bricks/search/macro_chunk.py
+++ b/src/nexus/bricks/search/macro_chunk.py
@@ -1,0 +1,154 @@
+"""Read-side macro-chunk (neighbor-context) expansion for hybrid search (Issue #4398).
+
+Pure and backend-agnostic. Given ranked results and a NeighborFetcher that returns
+chunk rows for (path, chunk_index range) spans, expand each hit into its surrounding
+section (bounded by heading_prefix, file edge, and a token budget) and attach the
+stitched text as ``macro_text``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Protocol
+
+_CODE_EXTENSIONS = (
+    ".c",
+    ".cc",
+    ".cpp",
+    ".h",
+    ".hpp",
+    ".py",
+    ".rs",
+    ".go",
+    ".java",
+    ".ts",
+    ".tsx",
+    ".js",
+    ".jsx",
+    ".v",
+    ".vh",
+    ".sv",
+    ".svh",
+    ".scala",
+    ".rb",
+    ".swift",
+    ".kt",
+)
+
+
+@dataclass(frozen=True)
+class ChunkRow:
+    path: str
+    chunk_index: int
+    text: str
+    tokens: int
+    line_start: int | None = None
+    line_end: int | None = None
+    heading_prefix: str | None = None
+
+
+@dataclass(frozen=True)
+class ExpansionConfig:
+    token_budget: int = 1024
+    window: int = 8
+    code_forward_bias: bool = True
+
+
+class NeighborFetcher(Protocol):
+    async def fetch_ranges(
+        self, spans: Sequence[tuple[str, int, int]], zone_id: str | None
+    ) -> list["ChunkRow"]: ...
+
+
+def _is_code_path(path: str) -> bool:
+    lower = path.lower()
+    return any(lower.endswith(ext) for ext in _CODE_EXTENSIONS)
+
+
+def merge_spans(spans: list[tuple[str, int, int]]) -> list[tuple[str, int, int]]:
+    """Merge overlapping/adjacent (path, lo, hi) spans into a minimal set."""
+    by_path: dict[str, list[tuple[int, int]]] = {}
+    for path, lo, hi in spans:
+        by_path.setdefault(path, []).append((lo, hi))
+    out: list[tuple[str, int, int]] = []
+    for path, ranges in by_path.items():
+        ranges.sort()
+        clo, chi = ranges[0]
+        for lo, hi in ranges[1:]:
+            if lo <= chi + 1:
+                chi = max(chi, hi)
+            else:
+                out.append((path, clo, chi))
+                clo, chi = lo, hi
+        out.append((path, clo, chi))
+    return out
+
+
+def _section_bounds(by_index: dict[int, ChunkRow], anchor_idx: int) -> tuple[int, int]:
+    """Maximal contiguous run around anchor sharing its heading_prefix."""
+    target = by_index[anchor_idx].heading_prefix
+    lo = anchor_idx
+    while (lo - 1) in by_index and by_index[lo - 1].heading_prefix == target:
+        lo -= 1
+    hi = anchor_idx
+    while (hi + 1) in by_index and by_index[hi + 1].heading_prefix == target:
+        hi += 1
+    return lo, hi
+
+
+def _window_for_anchor(
+    by_index: dict[int, ChunkRow], anchor_idx: int, cfg: ExpansionConfig, is_code: bool
+) -> tuple[int, int]:
+    s_lo, s_hi = _section_bounds(by_index, anchor_idx)
+    section_tokens = sum(by_index[i].tokens for i in range(s_lo, s_hi + 1) if i in by_index)
+    if section_tokens <= cfg.token_budget:
+        return s_lo, s_hi
+
+    used = by_index[anchor_idx].tokens
+    lo = hi = anchor_idx
+
+    def _can(i: int) -> bool:
+        return i in by_index and used + by_index[i].tokens <= cfg.token_budget
+
+    if is_code and cfg.code_forward_bias:
+        while hi + 1 <= s_hi and _can(hi + 1):
+            hi += 1
+            used += by_index[hi].tokens
+        while lo - 1 >= s_lo and _can(lo - 1):
+            lo -= 1
+            used += by_index[lo].tokens
+        return lo, hi
+
+    back = True
+    while True:
+        moved = False
+        if back and lo - 1 >= s_lo and _can(lo - 1):
+            lo -= 1
+            used += by_index[lo].tokens
+            moved = True
+        elif (not back) and hi + 1 <= s_hi and _can(hi + 1):
+            hi += 1
+            used += by_index[hi].tokens
+            moved = True
+        else:
+            if back and hi + 1 <= s_hi and _can(hi + 1):
+                hi += 1
+                used += by_index[hi].tokens
+                moved = True
+            elif (not back) and lo - 1 >= s_lo and _can(lo - 1):
+                lo -= 1
+                used += by_index[lo].tokens
+                moved = True
+        if not moved:
+            break
+        back = not back
+    return lo, hi
+
+
+def _stitch(by_index: dict[int, ChunkRow], lo: int, hi: int) -> tuple[str, int | None, int | None]:
+    rows = [by_index[i] for i in range(lo, hi + 1) if i in by_index]
+    text = "\n".join(r.text for r in rows)
+    starts = [r.line_start for r in rows if r.line_start is not None]
+    ends = [r.line_end for r in rows if r.line_end is not None]
+    return text, (min(starts) if starts else None), (max(ends) if ends else None)

--- a/src/nexus/bricks/search/macro_chunk.py
+++ b/src/nexus/bricks/search/macro_chunk.py
@@ -8,9 +8,12 @@ stitched text as ``macro_text``.
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Protocol
+
+logger = logging.getLogger(__name__)
 
 _CODE_EXTENSIONS = (
     ".c",
@@ -152,3 +155,47 @@ def _stitch(by_index: dict[int, ChunkRow], lo: int, hi: int) -> tuple[str, int |
     starts = [r.line_start for r in rows if r.line_start is not None]
     ends = [r.line_end for r in rows if r.line_end is not None]
     return text, (min(starts) if starts else None), (max(ends) if ends else None)
+
+
+async def expand_results(
+    results: list,
+    fetcher: NeighborFetcher,
+    cfg: ExpansionConfig,
+    zone_id: str | None = None,
+) -> list:
+    """Attach macro_text/macro_line_start/macro_line_end to each result. Best-effort."""
+    if not results:
+        return results
+
+    spans = [
+        (r.path, max(0, r.chunk_index - cfg.window), r.chunk_index + cfg.window) for r in results
+    ]
+    try:
+        rows = await fetcher.fetch_ranges(merge_spans(spans), zone_id)
+    except Exception:
+        logger.warning("macro-chunk fetch failed; returning unexpanded", exc_info=True)
+        return results
+
+    by_path: dict[str, dict[int, ChunkRow]] = {}
+    for row in rows:
+        by_path.setdefault(row.path, {})[row.chunk_index] = row
+
+    section_cache: dict[tuple[str, int, int], tuple[str, int | None, int | None]] = {}
+    for r in results:
+        by_index = by_path.get(r.path)
+        if not by_index or r.chunk_index not in by_index:
+            continue  # gap — leave chunk_text as-is
+        try:
+            s_lo, s_hi = _section_bounds(by_index, r.chunk_index)
+            key = (r.path, s_lo, s_hi)
+            if key not in section_cache:
+                w_lo, w_hi = _window_for_anchor(by_index, r.chunk_index, cfg, _is_code_path(r.path))
+                section_cache[key] = _stitch(by_index, w_lo, w_hi)
+            text, ls, le = section_cache[key]
+            r.macro_text = text
+            r.macro_line_start = ls
+            r.macro_line_end = le
+        except Exception:
+            logger.warning("macro-chunk expansion failed for %s", r.path, exc_info=True)
+            continue
+    return results

--- a/src/nexus/bricks/search/pg_vector_backend.py
+++ b/src/nexus/bricks/search/pg_vector_backend.py
@@ -23,6 +23,7 @@ from typing import Any
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncEngine
 
+from nexus.bricks.search.macro_chunk import ChunkRow
 from nexus.bricks.search.results import BaseSearchResult
 
 # ---------------------------------------------------------------------------
@@ -196,6 +197,68 @@ class PgVectorBackend:
                 chunk_index=int(r["chunk_index"]),
                 vector_score=float(r["score"]),
                 zone_id=zone_id,
+            )
+            for r in rows
+        ]
+
+    # -------------------------------------------------------------------------
+    # Neighbor fetch — NeighborFetcher protocol (macro-chunk expansion, T6)
+    # -------------------------------------------------------------------------
+
+    async def fetch_ranges(
+        self, spans: Sequence[tuple[str, int, int]], zone_id: str | None
+    ) -> list[ChunkRow]:
+        """Fetch contiguous chunk ranges from Postgres for macro-chunk expansion.
+
+        Satisfies the ``NeighborFetcher`` protocol defined in
+        ``nexus.bricks.search.macro_chunk``. Called by ``expand_results`` with a
+        merged, de-overlapped list of (path, lo, hi) spans and returns all
+        matching rows ordered by path then chunk_index.
+
+        Args:
+            spans: Sequence of ``(virtual_path, lo_index, hi_index)`` tuples
+                specifying which chunks to fetch (inclusive on both ends).
+            zone_id: Zone filter — only chunks belonging to this zone are
+                returned. Pass ``None`` to skip zone filtering (not recommended
+                in production; useful for testing).
+
+        Returns:
+            List of ``ChunkRow`` ordered by ``virtual_path``, ``chunk_index``.
+            Rows with NULL ``chunk_tokens`` are returned with ``tokens=0``.
+        """
+        if not spans:
+            return []
+
+        clauses: list[str] = []
+        params: dict = {"zone_id": zone_id}
+        for i, (path, lo, hi) in enumerate(spans):
+            clauses.append(f"(fp.virtual_path = :p{i} AND c.chunk_index BETWEEN :lo{i} AND :hi{i})")
+            params[f"p{i}"] = path
+            params[f"lo{i}"] = lo
+            params[f"hi{i}"] = hi
+
+        sql = text(
+            "SELECT fp.virtual_path AS path, c.chunk_index, c.chunk_text, "
+            "       c.chunk_tokens, c.line_start, c.line_end, c.heading_prefix "
+            "FROM document_chunks c "
+            "JOIN file_paths fp ON c.path_id = fp.path_id "
+            "WHERE fp.zone_id = :zone_id AND fp.deleted_at IS NULL "
+            "  AND (" + " OR ".join(clauses) + ") "
+            "ORDER BY fp.virtual_path, c.chunk_index"
+        )
+
+        async with self._engine.connect() as conn:
+            rows = (await conn.execute(sql, params)).mappings().all()
+
+        return [
+            ChunkRow(
+                path=r["path"],
+                chunk_index=int(r["chunk_index"]),
+                text=r["chunk_text"],
+                tokens=int(r["chunk_tokens"] or 0),
+                line_start=r["line_start"],
+                line_end=r["line_end"],
+                heading_prefix=r["heading_prefix"],
             )
             for r in rows
         ]

--- a/src/nexus/bricks/search/pg_vector_backend.py
+++ b/src/nexus/bricks/search/pg_vector_backend.py
@@ -230,19 +230,25 @@ class PgVectorBackend:
             return []
 
         clauses: list[str] = []
-        params: dict = {"zone_id": zone_id}
+        params: dict[str, Any] = {}
         for i, (path, lo, hi) in enumerate(spans):
             clauses.append(f"(fp.virtual_path = :p{i} AND c.chunk_index BETWEEN :lo{i} AND :hi{i})")
             params[f"p{i}"] = path
             params[f"lo{i}"] = lo
             params[f"hi{i}"] = hi
 
+        if zone_id is not None:
+            zone_predicate = "fp.zone_id = :zone_id AND "
+            params["zone_id"] = zone_id
+        else:
+            zone_predicate = ""
+
         sql = text(
             "SELECT fp.virtual_path AS path, c.chunk_index, c.chunk_text, "
             "       c.chunk_tokens, c.line_start, c.line_end, c.heading_prefix "
             "FROM document_chunks c "
             "JOIN file_paths fp ON c.path_id = fp.path_id "
-            "WHERE fp.zone_id = :zone_id AND fp.deleted_at IS NULL "
+            "WHERE " + zone_predicate + "fp.deleted_at IS NULL "
             "  AND (" + " OR ".join(clauses) + ") "
             "ORDER BY fp.virtual_path, c.chunk_index"
         )

--- a/src/nexus/bricks/search/results.py
+++ b/src/nexus/bricks/search/results.py
@@ -41,6 +41,10 @@ class BaseSearchResult:
     # Issue #3773: admin-configured path description for LLM consumers
     context: str | None = None
     semantic_degraded: bool | None = None  # Issue #3778: federation fell back to BM25S
+    # Issue #4398: macro-chunk expansion fields for hybrid search context
+    macro_text: str | None = None
+    macro_line_start: int | None = None
+    macro_line_end: int | None = None
 
     @property
     def zone_qualified_path(self) -> str | None:

--- a/src/nexus/bricks/search/sqlite_vec_backend.py
+++ b/src/nexus/bricks/search/sqlite_vec_backend.py
@@ -418,10 +418,10 @@ class SqliteVecBackend:
                     f"path text, "
                     f"chunk_text text, "
                     f"chunk_index integer, "
-                    f"chunk_tokens integer, "
-                    f"line_start integer, "
-                    f"line_end integer, "
-                    f"heading_prefix text"
+                    f"+chunk_tokens integer, "
+                    f"+line_start integer, "
+                    f"+line_end integer, "
+                    f"+heading_prefix text"
                     f");"
                 )
                 conn.commit()

--- a/src/nexus/bricks/search/sqlite_vec_backend.py
+++ b/src/nexus/bricks/search/sqlite_vec_backend.py
@@ -47,6 +47,7 @@ import weakref
 from collections.abc import Sequence
 from typing import Any
 
+from nexus.bricks.search.macro_chunk import ChunkRow
 from nexus.bricks.search.results import BaseSearchResult
 
 logger = logging.getLogger(__name__)
@@ -383,47 +384,33 @@ class SqliteVecBackend:
                 existing = _read_existing_dim(conn)
                 if existing is not None and existing != self._embedding_dim:
                     raise _dim_mismatch(existing, race=False)
-                # Rebuild trigger (Issue #4398): if the table exists but
-                # predates the macro-chunk aux columns, drop it so the
-                # CREATE below recreates it with the new schema. The vec
-                # table rows will repopulate on reindex; the meta table
-                # (nexus_vec_meta) is preserved so embedder-identity
-                # validation still works correctly after the rebuild.
-                existing_sql_row = conn.execute(
-                    "SELECT sql FROM sqlite_master WHERE type='table' AND name=?",
-                    (_VEC_TABLE,),
-                ).fetchone()
-                if (
-                    existing_sql_row
-                    and existing_sql_row[0]
-                    and "heading_prefix" not in existing_sql_row[0]
-                ):
-                    logger.warning(
-                        "Rebuilding '%s': existing table predates macro-chunk metadata "
-                        "columns; dropping and recreating (index will repopulate on reindex).",
-                        _VEC_TABLE,
-                    )
-                    conn.execute(f"DROP TABLE {_VEC_TABLE}")
-                    conn.commit()
+
                 # Create vec0 virtual table; embedding dim is fixed at
                 # init time (sqlite-vec requirement). Auxiliary columns
                 # carry zone isolation + result rendering data. The four
                 # macro-chunk columns (chunk_tokens, line_start, line_end,
                 # heading_prefix) support fetch_ranges neighbor expansion
                 # (Issue #4398 T7).
-                conn.execute(
-                    f"CREATE VIRTUAL TABLE IF NOT EXISTS {_VEC_TABLE} USING vec0("
-                    f"embedding float[{self._embedding_dim}], "
-                    f"zone_id text, "
-                    f"path text, "
-                    f"chunk_text text, "
-                    f"chunk_index integer, "
-                    f"+chunk_tokens integer, "
-                    f"+line_start integer, "
-                    f"+line_end integer, "
-                    f"+heading_prefix text"
-                    f");"
-                )
+                # NOTE: on a legacy old-schema DB (no heading_prefix), this
+                # CREATE IF NOT EXISTS is a no-op — the old table survives
+                # intact until embedder identity is validated (Fix 1: we
+                # only DROP after confirming identity matches).
+                def _create_vec_table() -> None:
+                    conn.execute(
+                        f"CREATE VIRTUAL TABLE IF NOT EXISTS {_VEC_TABLE} USING vec0("
+                        f"embedding float[{self._embedding_dim}], "
+                        f"zone_id text, "
+                        f"path text, "
+                        f"chunk_text text, "
+                        f"chunk_index integer, "
+                        f"+chunk_tokens integer, "
+                        f"+line_start integer, "
+                        f"+line_end integer, "
+                        f"+heading_prefix text"
+                        f");"
+                    )
+
+                _create_vec_table()
                 conn.commit()
                 # Codex review R2 (high): post-check — re-read the
                 # schema after CREATE to catch the race where a
@@ -508,6 +495,30 @@ class SqliteVecBackend:
                             or stored_model == self._embedding_model
                         )
                         raise _embedder_mismatch(stored_kind, stored_model, race=race_now)
+                # Fix 1 (Issue #4398): Rebuild old-schema table AFTER identity is
+                # confirmed-ours. For a legacy DB with the same dim but missing
+                # heading_prefix, the CREATE IF NOT EXISTS above was a no-op (old
+                # schema survived). Now that identity is validated, it is safe to
+                # DROP and recreate with the new schema. Rows repopulate on reindex.
+                rebuild_sql_row = conn.execute(
+                    "SELECT sql FROM sqlite_master WHERE type='table' AND name=?",
+                    (_VEC_TABLE,),
+                ).fetchone()
+                if (
+                    rebuild_sql_row
+                    and rebuild_sql_row[0]
+                    and "heading_prefix" not in rebuild_sql_row[0]
+                ):
+                    logger.warning(
+                        "Rebuilding '%s': existing table predates macro-chunk metadata "
+                        "columns; dropping and recreating (index will repopulate on reindex). "
+                        "Embedder identity confirmed — data destruction is safe.",
+                        _VEC_TABLE,
+                    )
+                    conn.execute(f"DROP TABLE {_VEC_TABLE}")
+                    conn.commit()
+                    _create_vec_table()
+                    conn.commit()
                 return conn
 
             self._conn = await self._run_native(_open)
@@ -1015,8 +1026,8 @@ class SqliteVecBackend:
     async def fetch_ranges(
         self,
         spans: list[tuple[str, int, int]],
-        zone_id: str,
-    ) -> list[Any]:
+        zone_id: str | None,
+    ) -> list[ChunkRow]:
         """Return ChunkRow objects for all chunks in the given (path, lo, hi) spans.
 
         Implements the NeighborFetcher protocol consumed by the macro-chunk
@@ -1031,8 +1042,6 @@ class SqliteVecBackend:
             return []
         await self.startup()
         conn = self._require_conn()
-
-        from nexus.bricks.search.macro_chunk import ChunkRow
 
         def _fetch() -> list[ChunkRow]:
             out: list[ChunkRow] = []

--- a/src/nexus/bricks/search/sqlite_vec_backend.py
+++ b/src/nexus/bricks/search/sqlite_vec_backend.py
@@ -383,16 +383,45 @@ class SqliteVecBackend:
                 existing = _read_existing_dim(conn)
                 if existing is not None and existing != self._embedding_dim:
                     raise _dim_mismatch(existing, race=False)
+                # Rebuild trigger (Issue #4398): if the table exists but
+                # predates the macro-chunk aux columns, drop it so the
+                # CREATE below recreates it with the new schema. The vec
+                # table rows will repopulate on reindex; the meta table
+                # (nexus_vec_meta) is preserved so embedder-identity
+                # validation still works correctly after the rebuild.
+                existing_sql_row = conn.execute(
+                    "SELECT sql FROM sqlite_master WHERE type='table' AND name=?",
+                    (_VEC_TABLE,),
+                ).fetchone()
+                if (
+                    existing_sql_row
+                    and existing_sql_row[0]
+                    and "heading_prefix" not in existing_sql_row[0]
+                ):
+                    logger.warning(
+                        "Rebuilding '%s': existing table predates macro-chunk metadata "
+                        "columns; dropping and recreating (index will repopulate on reindex).",
+                        _VEC_TABLE,
+                    )
+                    conn.execute(f"DROP TABLE {_VEC_TABLE}")
+                    conn.commit()
                 # Create vec0 virtual table; embedding dim is fixed at
                 # init time (sqlite-vec requirement). Auxiliary columns
-                # carry zone isolation + result rendering data.
+                # carry zone isolation + result rendering data. The four
+                # macro-chunk columns (chunk_tokens, line_start, line_end,
+                # heading_prefix) support fetch_ranges neighbor expansion
+                # (Issue #4398 T7).
                 conn.execute(
                     f"CREATE VIRTUAL TABLE IF NOT EXISTS {_VEC_TABLE} USING vec0("
                     f"embedding float[{self._embedding_dim}], "
                     f"zone_id text, "
                     f"path text, "
                     f"chunk_text text, "
-                    f"chunk_index integer"
+                    f"chunk_index integer, "
+                    f"chunk_tokens integer, "
+                    f"line_start integer, "
+                    f"line_end integer, "
+                    f"heading_prefix text"
                     f");"
                 )
                 conn.commit()
@@ -636,18 +665,37 @@ class SqliteVecBackend:
                 f"{len(documents)} documents (model={self._embedding_model})"
             )
 
-        rows: list[tuple[int, bytes, str, str, str, int]] = []
+        rows: list[
+            tuple[int, bytes, str, str, str, int, int, int | None, int | None, str | None]
+        ] = []
         for doc, vec in zip(documents, vectors, strict=True):
             path = str(doc.get("path", ""))
             chunk_index = int(doc.get("chunk_index", 0) or 0)
             chunk_text = str(doc.get("text") or doc.get("chunk_text") or "")
+            chunk_tokens = int(doc.get("chunk_tokens", 0) or 0)
+            line_start = doc.get("line_start")
+            line_end = doc.get("line_end")
+            heading_prefix = doc.get("heading_prefix")
             if len(vec) != self._embedding_dim:
                 raise RuntimeError(
                     f"Embedding dim mismatch: got {len(vec)} expected "
                     f"{self._embedding_dim} (model={self._embedding_model}, path={path})"
                 )
             rowid = self._stable_rowid(zone_id, path, chunk_index)
-            rows.append((rowid, self._pack_vector(vec), zone_id, path, chunk_text, chunk_index))
+            rows.append(
+                (
+                    rowid,
+                    self._pack_vector(vec),
+                    zone_id,
+                    path,
+                    chunk_text,
+                    chunk_index,
+                    chunk_tokens,
+                    line_start,
+                    line_end,
+                    heading_prefix,
+                )
+            )
 
         def _write() -> int:
             # vec0 doesn't support UPSERT; emulate by deleting any row with
@@ -661,8 +709,9 @@ class SqliteVecBackend:
                 )
                 conn.executemany(
                     f"INSERT INTO {_VEC_TABLE}"
-                    f"(rowid, embedding, zone_id, path, chunk_text, chunk_index) "
-                    f"VALUES (?, ?, ?, ?, ?, ?)",
+                    f"(rowid, embedding, zone_id, path, chunk_text, chunk_index, "
+                    f"chunk_tokens, line_start, line_end, heading_prefix) "
+                    f"VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                     rows,
                 )
             return len(rows)
@@ -694,18 +743,37 @@ class SqliteVecBackend:
                 f"{len(documents)} documents (model={self._embedding_model})"
             )
 
-        rows: list[tuple[int, bytes, str, str, str, int]] = []
+        rows: list[
+            tuple[int, bytes, str, str, str, int, int, int | None, int | None, str | None]
+        ] = []
         for doc, vec in zip(documents, vectors, strict=True):
             path = str(doc.get("path", ""))
             chunk_index = int(doc.get("chunk_index", 0) or 0)
             chunk_text = str(doc.get("text") or doc.get("chunk_text") or "")
+            chunk_tokens = int(doc.get("chunk_tokens", 0) or 0)
+            line_start = doc.get("line_start")
+            line_end = doc.get("line_end")
+            heading_prefix = doc.get("heading_prefix")
             if len(vec) != self._embedding_dim:
                 raise RuntimeError(
                     f"Embedding dim mismatch: got {len(vec)} expected "
                     f"{self._embedding_dim} (model={self._embedding_model}, path={path})"
                 )
             rowid = self._stable_rowid(zone_id, path, chunk_index)
-            rows.append((rowid, self._pack_vector(vec), zone_id, path, chunk_text, chunk_index))
+            rows.append(
+                (
+                    rowid,
+                    self._pack_vector(vec),
+                    zone_id,
+                    path,
+                    chunk_text,
+                    chunk_index,
+                    chunk_tokens,
+                    line_start,
+                    line_end,
+                    heading_prefix,
+                )
+            )
 
         # Phase 2: atomic delete+insert in a single transaction. sqlite3's
         # `with conn:` uses BEGIN/COMMIT/ROLLBACK, so if executemany fails
@@ -718,8 +786,9 @@ class SqliteVecBackend:
                 )
                 conn.executemany(
                     f"INSERT INTO {_VEC_TABLE}"
-                    f"(rowid, embedding, zone_id, path, chunk_text, chunk_index) "
-                    f"VALUES (?, ?, ?, ?, ?, ?)",
+                    f"(rowid, embedding, zone_id, path, chunk_text, chunk_index, "
+                    f"chunk_tokens, line_start, line_end, heading_prefix) "
+                    f"VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                     rows,
                 )
             return len(rows)
@@ -938,3 +1007,57 @@ class SqliteVecBackend:
                 )
             )
         return results
+
+    # ------------------------------------------------------------------
+    # NeighborFetcher protocol: fetch_ranges (Issue #4398 T7)
+    # ------------------------------------------------------------------
+
+    async def fetch_ranges(
+        self,
+        spans: list[tuple[str, int, int]],
+        zone_id: str,
+    ) -> list[Any]:
+        """Return ChunkRow objects for all chunks in the given (path, lo, hi) spans.
+
+        Implements the NeighborFetcher protocol consumed by the macro-chunk
+        expander (``nexus.bricks.search.macro_chunk``). Each element of
+        ``spans`` is ``(path, chunk_index_lo, chunk_index_hi)``; the range
+        is inclusive on both ends.
+
+        Runs the synchronous SQLite query in a worker thread via
+        ``_run_native`` so the event loop stays responsive.
+        """
+        if not spans:
+            return []
+        await self.startup()
+        conn = self._require_conn()
+
+        from nexus.bricks.search.macro_chunk import ChunkRow
+
+        def _fetch() -> list[ChunkRow]:
+            out: list[ChunkRow] = []
+            for path, lo, hi in spans:
+                cur = conn.execute(
+                    f"SELECT path, chunk_index, chunk_text, chunk_tokens, "
+                    f"line_start, line_end, heading_prefix "
+                    f"FROM {_VEC_TABLE} "
+                    f"WHERE zone_id = ? AND path = ? AND chunk_index BETWEEN ? AND ? "
+                    f"ORDER BY chunk_index",
+                    (zone_id, path, lo, hi),
+                )
+                for row in cur.fetchall():
+                    out.append(
+                        ChunkRow(
+                            path=row[0],
+                            chunk_index=int(row[1]),
+                            text=row[2],
+                            tokens=int(row[3] or 0),
+                            line_start=row[4],
+                            line_end=row[5],
+                            heading_prefix=row[6],
+                        )
+                    )
+            return out
+
+        async with self._get_loop_lock(self._op_locks):
+            return await self._run_native(_fetch)

--- a/src/nexus/bricks/search/sqlite_vec_backend.py
+++ b/src/nexus/bricks/search/sqlite_vec_backend.py
@@ -1069,4 +1069,5 @@ class SqliteVecBackend:
             return out
 
         async with self._get_loop_lock(self._op_locks):
-            return await self._run_native(_fetch)
+            rows: list[ChunkRow] = await self._run_native(_fetch)
+            return rows

--- a/src/nexus/server/api/v2/routers/search.py
+++ b/src/nexus/server/api/v2/routers/search.py
@@ -180,6 +180,11 @@ def _serialize_search_result(result: Any) -> dict[str, Any]:
     context = getattr(result, "context", None)
     if context is not None:
         out["context"] = context
+    macro_text = getattr(result, "macro_text", None)
+    if macro_text is not None:
+        out["macro_text"] = macro_text
+        out["macro_line_start"] = getattr(result, "macro_line_start", None)
+        out["macro_line_end"] = getattr(result, "macro_line_end", None)
     return out
 
 

--- a/src/nexus/server/api/v2/routers/search.py
+++ b/src/nexus/server/api/v2/routers/search.py
@@ -301,6 +301,7 @@ async def search_query(
     path: str | None = Query(None, description="Optional path prefix filter"),
     alpha: float = Query(0.5, description="Semantic vs keyword weight (0.0-1.0)", ge=0.0, le=1.0),
     fusion: str = Query("rrf", description="Fusion method: rrf, weighted, or rrf_weighted"),
+    expand: str = Query("none", description="Context expansion: none or macro"),
     rerank: bool | None = Query(  # noqa: ARG001
         None, description="Override reranker (true/false, default: use config)"
     ),
@@ -342,6 +343,12 @@ async def search_query(
             detail=f"Invalid fusion method: {fusion}. Must be 'rrf', 'weighted', or 'rrf_weighted'",
         )
 
+    if expand not in ("none", "macro"):
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid expand: {expand}. Must be 'none' or 'macro'",
+        )
+
     if graph_mode not in ("none", "low", "high", "dual", "auto"):
         raise HTTPException(
             status_code=400,
@@ -352,6 +359,7 @@ async def search_query(
 
     async def _work() -> dict[str, Any]:
         # --- Federated search path (Issue #3147) ---
+        # NOTE: expand= is single-zone only; federated path does not support it.
         if federated:
             return await _handle_federated_search(
                 q=q,
@@ -375,6 +383,7 @@ async def search_query(
             alpha=alpha,
             fusion_method=fusion,
             graph_mode=graph_mode,
+            expand=expand,
             auth_result=auth_result,
             search_daemon=search_daemon,
             async_session_factory=async_session_factory,
@@ -396,6 +405,7 @@ async def _handle_single_zone_search(
     alpha: float,
     fusion_method: str,
     graph_mode: str,
+    expand: str,
     auth_result: dict[str, Any],
     search_daemon: Any,
     async_session_factory: Any,
@@ -515,6 +525,7 @@ async def _handle_single_zone_search(
             alpha=alpha,
             fusion_method=fusion_method,
             zone_id=zone_id,
+            expand=expand,
         )
 
         # Prefer the request-local snapshot carried by SearchDaemon results.

--- a/src/nexus/storage/models/filesystem.py
+++ b/src/nexus/storage/models/filesystem.py
@@ -147,6 +147,7 @@ class DocumentChunkModel(Base):
 
     line_start: Mapped[int | None] = mapped_column(Integer, nullable=True)
     line_end: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    heading_prefix: Mapped[str | None] = mapped_column(Text, nullable=True)
 
     embedding_model: Mapped[str | None] = mapped_column(String(100), nullable=True)
 

--- a/tests/integration/bricks/search/test_chunk_store.py
+++ b/tests/integration/bricks/search/test_chunk_store.py
@@ -93,3 +93,22 @@ async def test_chunk_store_strips_null_bytes_before_insert() -> None:
     assert rows[0]["chunk_text"] == "alphabetagamma"
     assert "\x00" not in rows[0]["chunk_context"]
     assert rows[0]["chunk_context"] == "ctxwithnuls"
+
+
+@pytest.mark.asyncio
+async def test_chunk_store_writes_heading_prefix() -> None:
+    session = AsyncMock()
+    ctx = AsyncMock()
+    ctx.__aenter__.return_value = session
+    ctx.__aexit__.return_value = False
+    store = ChunkStore(async_session_factory=MagicMock(return_value=ctx), db_type="sqlite")
+
+    await store.replace_document_chunks(
+        "pid-1",
+        [ChunkRecord(chunk_text="hi", chunk_tokens=1, heading_prefix="## H")],
+    )
+    # the INSERT params for the last execute include heading_prefix
+    insert_call = session.execute.await_args_list[-1]
+    params = insert_call.args[1]
+    rows = params if isinstance(params, list) else [params]
+    assert any(p.get("heading_prefix") == "## H" for p in rows)

--- a/tests/integration/bricks/search/test_migration_heading_prefix.py
+++ b/tests/integration/bricks/search/test_migration_heading_prefix.py
@@ -1,0 +1,7 @@
+import sqlalchemy as sa
+
+
+def test_document_chunks_has_heading_prefix_column(sqlite_engine_after_upgrade):
+    insp = sa.inspect(sqlite_engine_after_upgrade)
+    cols = {c["name"] for c in insp.get_columns("document_chunks")}
+    assert "heading_prefix" in cols

--- a/tests/integration/bricks/search/test_pg_macro_fetch.py
+++ b/tests/integration/bricks/search/test_pg_macro_fetch.py
@@ -63,9 +63,10 @@ async def pg_engine_macro() -> AsyncIterator[AsyncEngine]:
                 )
                 """)
             )
+            await conn.execute(text("DROP TABLE IF EXISTS document_chunks CASCADE"))
             await conn.execute(
                 text("""
-                CREATE TABLE IF NOT EXISTS document_chunks (
+                CREATE TABLE document_chunks (
                     chunk_id       TEXT PRIMARY KEY,
                     path_id        TEXT NOT NULL REFERENCES file_paths(path_id) ON DELETE CASCADE,
                     chunk_index    INTEGER NOT NULL,

--- a/tests/integration/bricks/search/test_pg_macro_fetch.py
+++ b/tests/integration/bricks/search/test_pg_macro_fetch.py
@@ -1,0 +1,163 @@
+"""Integration test for PgVectorBackend.fetch_ranges (Issue #4398 T6).
+
+Verifies that fetch_ranges correctly pulls contiguous chunks from Postgres and
+returns them as ChunkRow objects conforming to the NeighborFetcher protocol.
+
+Skips cleanly when NEXUS_TEST_DATABASE_URL / POSTGRES_URL is unset — matches
+the established pattern across the search integration suite. CI runs this
+against a real Postgres instance.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import AsyncIterator
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
+
+from nexus.bricks.search.pg_vector_backend import PgVectorBackend
+
+
+def _get_pg_url() -> str | None:
+    """Return an asyncpg-dialect Postgres URL from the environment, or None."""
+    url = os.environ.get("NEXUS_TEST_DATABASE_URL") or os.environ.get("POSTGRES_URL")
+    if not url:
+        return None
+    if url.startswith("postgresql://"):
+        url = "postgresql+asyncpg://" + url[len("postgresql://") :]
+    elif url.startswith("postgres://"):
+        url = "postgresql+asyncpg://" + url[len("postgres://") :]
+    return url
+
+
+@pytest_asyncio.fixture
+async def pg_engine_macro() -> AsyncIterator[AsyncEngine]:
+    """Async engine with file_paths + document_chunks tables seeded for fetch_ranges tests.
+
+    Creates the extended document_chunks schema that includes line_start,
+    line_end, and heading_prefix — columns required by fetch_ranges but absent
+    from the minimal DDL used in the daemon-search fixture.
+
+    Yields the engine then truncates and disposes on teardown.
+    """
+    url = _get_pg_url()
+    if not url:
+        pytest.skip(
+            "No Postgres URL configured. Set NEXUS_TEST_DATABASE_URL to run macro-fetch PG tests."
+        )
+
+    engine = create_async_engine(url, echo=False)
+    try:
+        async with engine.begin() as conn:
+            await conn.execute(
+                text("""
+                CREATE TABLE IF NOT EXISTS file_paths (
+                    path_id      TEXT PRIMARY KEY,
+                    zone_id      TEXT NOT NULL,
+                    virtual_path TEXT NOT NULL,
+                    deleted_at   TIMESTAMPTZ,
+                    created_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+                )
+                """)
+            )
+            await conn.execute(
+                text("""
+                CREATE TABLE IF NOT EXISTS document_chunks (
+                    chunk_id       TEXT PRIMARY KEY,
+                    path_id        TEXT NOT NULL REFERENCES file_paths(path_id) ON DELETE CASCADE,
+                    chunk_index    INTEGER NOT NULL,
+                    chunk_text     TEXT NOT NULL,
+                    chunk_tokens   INTEGER,
+                    line_start     INTEGER,
+                    line_end       INTEGER,
+                    heading_prefix TEXT,
+                    created_at     TIMESTAMPTZ NOT NULL DEFAULT now()
+                )
+                """)
+            )
+
+        # Seed one path with three chunks (indices 0, 1, 2).
+        async with engine.begin() as conn:
+            await conn.execute(
+                text("TRUNCATE document_chunks, file_paths RESTART IDENTITY CASCADE")
+            )
+            await conn.execute(
+                text(
+                    "INSERT INTO file_paths (path_id, zone_id, virtual_path, deleted_at) "
+                    "VALUES ('macro-p1', 'z1', '/ws/doc.md', NULL)"
+                )
+            )
+            await conn.execute(
+                text(
+                    "INSERT INTO document_chunks "
+                    "(chunk_id, path_id, chunk_index, chunk_text, chunk_tokens, "
+                    " line_start, line_end, heading_prefix) VALUES "
+                    "('macro-c0', 'macro-p1', 0, 'intro text', 10, 1, 5, '## Intro'), "
+                    "('macro-c1', 'macro-p1', 1, 'body text',  20, 6, 12, '## Intro'), "
+                    "('macro-c2', 'macro-p1', 2, 'outro text', 15, 13, 18, '## Outro')"
+                )
+            )
+
+        yield engine
+
+        async with engine.begin() as conn:
+            await conn.execute(
+                text("TRUNCATE document_chunks, file_paths RESTART IDENTITY CASCADE")
+            )
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_fetch_ranges_returns_all_chunks_in_span(pg_engine_macro: AsyncEngine) -> None:
+    """fetch_ranges([('/ws/doc.md', 0, 2)], 'z1') returns all three seeded chunks."""
+    backend = PgVectorBackend(pg_engine_macro)
+    rows = await backend.fetch_ranges([("/ws/doc.md", 0, 2)], zone_id="z1")
+
+    idxs = sorted(r.chunk_index for r in rows)
+    assert idxs == [0, 1, 2]
+    assert all(r.path == "/ws/doc.md" for r in rows)
+    assert all(r.tokens >= 0 for r in rows)
+
+
+@pytest.mark.asyncio
+async def test_fetch_ranges_respects_zone_isolation(pg_engine_macro: AsyncEngine) -> None:
+    """fetch_ranges with a different zone_id returns no rows."""
+    backend = PgVectorBackend(pg_engine_macro)
+    rows = await backend.fetch_ranges([("/ws/doc.md", 0, 2)], zone_id="other-zone")
+    assert rows == []
+
+
+@pytest.mark.asyncio
+async def test_fetch_ranges_empty_spans(pg_engine_macro: AsyncEngine) -> None:
+    """fetch_ranges with an empty spans list short-circuits and returns []."""
+    backend = PgVectorBackend(pg_engine_macro)
+    rows = await backend.fetch_ranges([], zone_id="z1")
+    assert rows == []
+
+
+@pytest.mark.asyncio
+async def test_fetch_ranges_partial_span(pg_engine_macro: AsyncEngine) -> None:
+    """fetch_ranges honours inclusive lo/hi bounds — (0, 1) excludes chunk 2."""
+    backend = PgVectorBackend(pg_engine_macro)
+    rows = await backend.fetch_ranges([("/ws/doc.md", 0, 1)], zone_id="z1")
+    idxs = sorted(r.chunk_index for r in rows)
+    assert idxs == [0, 1]
+
+
+@pytest.mark.asyncio
+async def test_fetch_ranges_chunk_row_fields(pg_engine_macro: AsyncEngine) -> None:
+    """ChunkRow fields (line_start, line_end, heading_prefix) are populated."""
+    backend = PgVectorBackend(pg_engine_macro)
+    rows = await backend.fetch_ranges([("/ws/doc.md", 0, 0)], zone_id="z1")
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.chunk_index == 0
+    assert row.line_start == 1
+    assert row.line_end == 5
+    assert row.heading_prefix == "## Intro"
+    assert row.text == "intro text"
+    assert row.tokens == 10

--- a/tests/integration/bricks/search/test_sqlite_macro_fetch.py
+++ b/tests/integration/bricks/search/test_sqlite_macro_fetch.py
@@ -1,0 +1,187 @@
+"""Integration tests for SqliteVecBackend.fetch_ranges (Issue #4398 T7).
+
+Verifies that:
+- nexus_vec stores chunk_tokens, line_start, line_end, heading_prefix
+- fetch_ranges returns ChunkRow objects with correct metadata
+- Zone isolation is enforced
+- Empty spans return empty list
+
+Uses an in-memory SQLite DB with a mocked litellm embedder (same pattern
+as test_sqlite_vec_backend.py) — no network required.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+# Skip cleanly when the optional sqlite-vec / litellm deps aren't installed.
+sqlite_vec = pytest.importorskip("sqlite_vec")
+pytest.importorskip("litellm")
+
+from nexus.bricks.search.sqlite_vec_backend import SqliteVecBackend  # noqa: E402
+
+TEST_DIM = 4
+
+
+def _det_vec(seed: float) -> list[float]:
+    return [seed, seed + 0.1, seed + 0.2, seed + 0.3]
+
+
+class _FakeEmbedItem(dict):
+    pass
+
+
+def _fake_response(vectors: list[list[float]]) -> Any:
+    class _Resp:
+        def __init__(self, vecs: list[list[float]]) -> None:
+            self.data = [_FakeEmbedItem(embedding=v, index=i) for i, v in enumerate(vecs)]
+
+    return _Resp(vectors)
+
+
+@pytest.fixture
+def mock_embed():
+    """Patch litellm.aembedding to return deterministic vectors."""
+
+    async def _aembedding(*, model: str, input: list[str], **_kwargs: Any) -> Any:
+        return _fake_response([_det_vec(float(i + 1)) for i, _ in enumerate(input)])
+
+    with patch("litellm.aembedding", side_effect=_aembedding):
+        yield
+
+
+@pytest.fixture
+async def backend(mock_embed):
+    """In-memory SqliteVecBackend started with a 4-d embedding column."""
+    b = SqliteVecBackend(
+        db_path=":memory:",
+        embedding_model="fake-model",
+        embedding_dim=TEST_DIM,
+        embedder="litellm",
+    )
+    await b.startup()
+    yield b
+    await b.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# Test 1: metadata round-trip
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fetch_ranges_returns_metadata(backend: SqliteVecBackend) -> None:
+    """fetch_ranges returns ChunkRow objects with all metadata columns."""
+    docs = [
+        {
+            "path": "/ws/doc.md",
+            "text": f"chunk {i}",
+            "chunk_index": i,
+            "chunk_tokens": 10 + i,
+            "line_start": i * 5,
+            "line_end": i * 5 + 4,
+            "heading_prefix": f"## Section {i}" if i > 0 else None,
+        }
+        for i in range(3)
+    ]
+    n = await backend.upsert(docs, zone_id="z1")
+    assert n == 3
+
+    rows = await backend.fetch_ranges([("/ws/doc.md", 0, 2)], zone_id="z1")
+    assert len(rows) == 3
+
+    idxs = sorted(r.chunk_index for r in rows)
+    assert idxs == [0, 1, 2]
+
+    # Sort by chunk_index for deterministic assertions
+    rows_sorted = sorted(rows, key=lambda r: r.chunk_index)
+
+    # Chunk 0
+    r0 = rows_sorted[0]
+    assert r0.path == "/ws/doc.md"
+    assert r0.chunk_index == 0
+    assert r0.tokens == 10
+    assert r0.line_start == 0
+    assert r0.line_end == 4
+    assert r0.heading_prefix is None
+
+    # Chunk 1
+    r1 = rows_sorted[1]
+    assert r1.tokens == 11
+    assert r1.line_start == 5
+    assert r1.line_end == 9
+    assert r1.heading_prefix == "## Section 1"
+
+    # Chunk 2
+    r2 = rows_sorted[2]
+    assert r2.tokens == 12
+    assert r2.line_start == 10
+    assert r2.line_end == 14
+    assert r2.heading_prefix == "## Section 2"
+
+
+# ---------------------------------------------------------------------------
+# Test 2: empty spans
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fetch_ranges_empty_spans(backend: SqliteVecBackend) -> None:
+    """fetch_ranges([]) returns an empty list without errors."""
+    result = await backend.fetch_ranges([], zone_id="z1")
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# Test 3: zone isolation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fetch_ranges_zone_isolation(backend: SqliteVecBackend) -> None:
+    """Chunks stored in zone z2 are NOT returned when querying zone z1."""
+    # Write a chunk in z2
+    await backend.upsert(
+        [
+            {
+                "path": "/ws/doc.md",
+                "text": "z2 chunk",
+                "chunk_index": 0,
+                "chunk_tokens": 5,
+                "line_start": 0,
+                "line_end": 2,
+                "heading_prefix": None,
+            }
+        ],
+        zone_id="z2",
+    )
+    # Write a chunk in z1
+    await backend.upsert(
+        [
+            {
+                "path": "/ws/doc.md",
+                "text": "z1 chunk",
+                "chunk_index": 0,
+                "chunk_tokens": 7,
+                "line_start": 10,
+                "line_end": 12,
+                "heading_prefix": "# Z1",
+            }
+        ],
+        zone_id="z1",
+    )
+
+    # Query z1 — should only return the z1 chunk
+    rows = await backend.fetch_ranges([("/ws/doc.md", 0, 0)], zone_id="z1")
+    assert len(rows) == 1
+    assert rows[0].tokens == 7
+    assert rows[0].heading_prefix == "# Z1"
+
+    # Query z2 — should only return the z2 chunk
+    rows_z2 = await backend.fetch_ranges([("/ws/doc.md", 0, 0)], zone_id="z2")
+    assert len(rows_z2) == 1
+    assert rows_z2[0].tokens == 5
+    assert rows_z2[0].heading_prefix is None

--- a/tests/integration/bricks/search/test_sqlite_macro_fetch.py
+++ b/tests/integration/bricks/search/test_sqlite_macro_fetch.py
@@ -12,6 +12,9 @@ as test_sqlite_vec_backend.py) — no network required.
 
 from __future__ import annotations
 
+import os
+import sqlite3
+import tempfile
 from typing import Any
 from unittest.mock import patch
 
@@ -185,3 +188,165 @@ async def test_fetch_ranges_zone_isolation(backend: SqliteVecBackend) -> None:
     assert len(rows_z2) == 1
     assert rows_z2[0].tokens == 5
     assert rows_z2[0].heading_prefix is None
+
+
+# ---------------------------------------------------------------------------
+# Test 4: rebuild path — old-schema DB with matching identity (Fix 1)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rebuild_old_schema_matching_identity(mock_embed) -> None:
+    """Opening a file-backed DB with old schema (no heading_prefix) but
+    matching embedder identity should DROP+recreate, return usable new-schema
+    table with all metadata columns readable after a subsequent upsert.
+    """
+    import sqlite_vec
+
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as tf:
+        db_path = tf.name
+
+    try:
+        # --- Phase 1: manually create an OLD-schema nexus_vec + matching meta ---
+        conn = sqlite3.connect(db_path)
+        conn.enable_load_extension(True)
+        sqlite_vec.load(conn)
+        conn.enable_load_extension(False)
+
+        # Old schema: no macro-chunk columns
+        conn.execute(
+            "CREATE VIRTUAL TABLE nexus_vec USING vec0("
+            "embedding float[4], "
+            "zone_id text, "
+            "path text, "
+            "chunk_text text, "
+            "chunk_index integer"
+            ");"
+        )
+        conn.execute("CREATE TABLE nexus_vec_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL)")
+        # Insert identity matching THIS backend (litellm / fake-model)
+        conn.executemany(
+            "INSERT INTO nexus_vec_meta(key, value) VALUES (?, ?)",
+            [("embedder_kind", "litellm"), ("embedding_model", "fake-model")],
+        )
+        conn.commit()
+        conn.close()
+
+        # --- Phase 2: open a backend on the same DB ---
+        b = SqliteVecBackend(
+            db_path=db_path,
+            embedding_model="fake-model",
+            embedding_dim=TEST_DIM,
+            embedder="litellm",
+        )
+        await b.startup()  # should NOT raise; old-schema rebuild runs here
+
+        # Upsert a doc with macro-chunk metadata
+        docs = [
+            {
+                "path": "/doc.md",
+                "text": "hello",
+                "chunk_index": 0,
+                "chunk_tokens": 42,
+                "line_start": 1,
+                "line_end": 5,
+                "heading_prefix": "## Intro",
+            }
+        ]
+        n = await b.upsert(docs, zone_id="z1")
+        assert n == 1
+
+        # fetch_ranges should return ChunkRow with heading_prefix populated
+        rows = await b.fetch_ranges([("/doc.md", 0, 0)], zone_id="z1")
+        assert len(rows) == 1
+        assert rows[0].heading_prefix == "## Intro"
+        assert rows[0].tokens == 42
+        assert rows[0].line_start == 1
+        assert rows[0].line_end == 5
+
+        await b.shutdown()
+    finally:
+        os.unlink(db_path)
+
+
+# ---------------------------------------------------------------------------
+# Test 5: data-preservation on identity mismatch (Fix 1)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_data_destruction_on_identity_mismatch(mock_embed) -> None:
+    """When embedder identity does NOT match the stored meta, startup() must
+    raise SqliteVecEmbedderMismatchError WITHOUT destroying any existing rows.
+
+    This locks in Fix 1: the old DROP ran before identity validation, so a
+    same-dim-but-different-model backend would silently erase the index then
+    refuse. After the fix, the rows must still be present after the error.
+    """
+    import sqlite_vec
+
+    from nexus.bricks.search.sqlite_vec_backend import SqliteVecEmbedderMismatchError
+
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as tf:
+        db_path = tf.name
+
+    try:
+        # --- Phase 1: create old-schema table with identity "original-model" ---
+        conn = sqlite3.connect(db_path)
+        conn.enable_load_extension(True)
+        sqlite_vec.load(conn)
+        conn.enable_load_extension(False)
+
+        # Old schema without heading_prefix so the rebuild trigger would fire
+        conn.execute(
+            "CREATE VIRTUAL TABLE nexus_vec USING vec0("
+            "embedding float[4], "
+            "zone_id text, "
+            "path text, "
+            "chunk_text text, "
+            "chunk_index integer"
+            ");"
+        )
+        # Insert a sentinel row (rowid=1)
+        import struct
+
+        sentinel_vec = struct.pack("4f", 0.1, 0.2, 0.3, 0.4)
+        conn.execute(
+            "INSERT INTO nexus_vec(rowid, embedding, zone_id, path, chunk_text, chunk_index) "
+            "VALUES (1, ?, 'z1', '/sentinel.md', 'sentinel data', 0)",
+            (sentinel_vec,),
+        )
+        conn.execute("CREATE TABLE nexus_vec_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL)")
+        # Store a DIFFERENT model identity (same dim=4, different model name)
+        conn.executemany(
+            "INSERT INTO nexus_vec_meta(key, value) VALUES (?, ?)",
+            [("embedder_kind", "litellm"), ("embedding_model", "original-model")],
+        )
+        conn.commit()
+        conn.close()
+
+        # --- Phase 2: open with a DIFFERENT model (same dim=4, different name) ---
+        b = SqliteVecBackend(
+            db_path=db_path,
+            embedding_model="fake-model",  # <-- mismatch
+            embedding_dim=TEST_DIM,
+            embedder="litellm",
+        )
+        with pytest.raises(SqliteVecEmbedderMismatchError):
+            await b.startup()
+
+        # --- Phase 3: verify the old rows are STILL PRESENT (not destroyed) ---
+        conn2 = sqlite3.connect(db_path)
+        conn2.enable_load_extension(True)
+        sqlite_vec.load(conn2)
+        conn2.enable_load_extension(False)
+        row = conn2.execute("SELECT chunk_text FROM nexus_vec WHERE rowid = 1").fetchone()
+        conn2.close()
+
+        assert row is not None, (
+            "REGRESSION (Fix 1): identity mismatch destroyed existing row before raising! "
+            "The DROP must only run AFTER identity is confirmed-ours."
+        )
+        assert row[0] == "sentinel data", f"Expected 'sentinel data', got {row[0]!r}"
+    finally:
+        os.unlink(db_path)

--- a/tests/unit/bricks/search/test_daemon_macro_wiring.py
+++ b/tests/unit/bricks/search/test_daemon_macro_wiring.py
@@ -1,0 +1,125 @@
+"""Unit tests for daemon expand=macro wiring and DaemonConfig knobs (Issue #4398).
+
+These tests run without a DB, embedder, or startup() call by injecting a fake
+fetcher directly onto _vector_backend.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from nexus.bricks.search.macro_chunk import ChunkRow
+
+
+class _FakeFetcher:
+    def __init__(self, rows: list[ChunkRow]) -> None:
+        self._rows = rows
+
+    async def fetch_ranges(
+        self, spans: list[tuple[str, int, int]], zone_id: str | None
+    ) -> list[ChunkRow]:
+        out: list[ChunkRow] = []
+        for path, lo, hi in spans:
+            out += [r for r in self._rows if r.path == path and lo <= r.chunk_index <= hi]
+        return out
+
+
+def _rows() -> list[ChunkRow]:
+    return [
+        ChunkRow(
+            path="/a.md",
+            chunk_index=i,
+            text=f"c{i}",
+            tokens=10,
+            line_start=i + 1,
+            line_end=i + 1,
+            heading_prefix="H",
+        )
+        for i in range(3)
+    ]
+
+
+def _make_daemon() -> Any:
+    """Construct a SearchDaemon without startup() using __new__ + minimal attrs."""
+    from nexus.bricks.search.daemon import DaemonConfig, SearchDaemon
+
+    d: Any = SearchDaemon.__new__(SearchDaemon)
+    d.config = DaemonConfig()
+    d._vector_backend = None
+    return d
+
+
+@pytest.mark.asyncio
+async def test_apply_macro_expansion_attaches() -> None:
+    """expand='macro' with a live backend attaches macro_text to results."""
+    from nexus.bricks.search.results import BaseSearchResult
+
+    d = _make_daemon()
+    d._vector_backend = _FakeFetcher(_rows())
+    r = BaseSearchResult(path="/a.md", chunk_text="c1", score=1.0, chunk_index=1)
+    await d._apply_macro_expansion([r], expand="macro", zone_id="z1")
+    assert r.macro_text == "c0\nc1\nc2"
+
+
+@pytest.mark.asyncio
+async def test_apply_macro_expansion_noop_when_disabled() -> None:
+    """expand='none' must not modify results even with a live backend."""
+    from nexus.bricks.search.results import BaseSearchResult
+
+    d = _make_daemon()
+    d._vector_backend = _FakeFetcher(_rows())
+    r = BaseSearchResult(path="/a.md", chunk_text="c1", score=1.0, chunk_index=1)
+    await d._apply_macro_expansion([r], expand="none", zone_id="z1")
+    assert r.macro_text is None
+
+
+@pytest.mark.asyncio
+async def test_apply_macro_expansion_noop_without_backend() -> None:
+    """expand='macro' with no vector backend must be a silent no-op."""
+    from nexus.bricks.search.results import BaseSearchResult
+
+    d = _make_daemon()
+    d._vector_backend = None
+    r = BaseSearchResult(path="/a.md", chunk_text="c1", score=1.0, chunk_index=1)
+    await d._apply_macro_expansion([r], expand="macro", zone_id="z1")
+    assert r.macro_text is None
+
+
+@pytest.mark.asyncio
+async def test_apply_macro_expansion_noop_empty_results() -> None:
+    """expand='macro' with an empty result list must not call the backend."""
+    d = _make_daemon()
+    d._vector_backend = _FakeFetcher(_rows())
+    # Should complete without error and not raise
+    await d._apply_macro_expansion([], expand="macro", zone_id="z1")
+
+
+# ---------------------------------------------------------------------------
+# DaemonConfig knob tests
+# ---------------------------------------------------------------------------
+
+
+def test_daemon_config_macro_chunk_defaults() -> None:
+    """DaemonConfig default macro-chunk knobs match documented defaults."""
+    from nexus.bricks.search.daemon import DaemonConfig
+
+    cfg = DaemonConfig()
+    assert cfg.macro_chunk_tokens == 1024
+    assert cfg.macro_chunk_window == 8
+    assert cfg.macro_chunk_code_forward_bias is True
+
+
+def test_daemon_config_macro_chunk_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """DaemonConfig macro-chunk knobs respect environment variables."""
+    from nexus.bricks.search.daemon import DaemonConfig
+
+    monkeypatch.setenv("NEXUS_SEARCH_MACRO_CHUNK_TOKENS", "256")
+    monkeypatch.setenv("NEXUS_SEARCH_MACRO_CHUNK_WINDOW", "4")
+    monkeypatch.setenv("NEXUS_SEARCH_MACRO_CHUNK_FORWARD_BIAS", "false")
+
+    cfg = DaemonConfig()
+    assert cfg.macro_chunk_tokens == 256
+    assert cfg.macro_chunk_window == 4
+    assert cfg.macro_chunk_code_forward_bias is False

--- a/tests/unit/bricks/search/test_macro_chunk_core.py
+++ b/tests/unit/bricks/search/test_macro_chunk_core.py
@@ -1,0 +1,73 @@
+from nexus.bricks.search.macro_chunk import (
+    ChunkRow,
+    ExpansionConfig,
+    _is_code_path,
+    _section_bounds,
+    _stitch,
+    _window_for_anchor,
+    merge_spans,
+)
+
+
+def _row(idx, tokens=10, heading="H1", text=None, ls=None, le=None, path="/a.md"):
+    return ChunkRow(
+        path=path,
+        chunk_index=idx,
+        text=text or f"c{idx}",
+        tokens=tokens,
+        line_start=ls,
+        line_end=le,
+        heading_prefix=heading,
+    )
+
+
+def _map(rows):
+    return {r.chunk_index: r for r in rows}
+
+
+def test_merge_spans_collapses_overlapping_and_adjacent():
+    spans = [("/a", 0, 5), ("/a", 6, 9), ("/a", 20, 22), ("/b", 0, 3)]
+    out = sorted(merge_spans(spans))
+    assert out == [("/a", 0, 9), ("/a", 20, 22), ("/b", 0, 3)]
+
+
+def test_is_code_path():
+    assert _is_code_path("/x/foo.py") is True
+    assert _is_code_path("/x/foo.md") is False
+
+
+def test_section_bounds_stops_at_heading_change():
+    rows = [_row(0, heading="A"), _row(1, heading="A"), _row(2, heading="B"), _row(3, heading="B")]
+    assert _section_bounds(_map(rows), 1) == (0, 1)
+    assert _section_bounds(_map(rows), 2) == (2, 3)
+
+
+def test_window_whole_section_when_under_budget():
+    rows = [_row(i, tokens=10, heading="A") for i in range(4)]
+    # section tokens = 40 <= budget 1024 -> whole section
+    lo, hi = _window_for_anchor(_map(rows), 2, ExpansionConfig(token_budget=1024), False)
+    assert (lo, hi) == (0, 3)
+
+
+def test_window_prose_centered_when_over_budget():
+    rows = [_row(i, tokens=100, heading="A") for i in range(7)]
+    # budget 250 -> anchor(3)=100, then centered: 2,4 -> 300>250 stop at 250
+    lo, hi = _window_for_anchor(_map(rows), 3, ExpansionConfig(token_budget=250), False)
+    assert lo <= 3 <= hi
+    assert sum(rows[i].tokens for i in range(lo, hi + 1)) <= 250
+    assert (hi - lo) >= 1  # expanded beyond the single anchor
+
+
+def test_window_code_forward_bias():
+    rows = [_row(i, tokens=100, heading="A", path="/f.py") for i in range(7)]
+    lo, hi = _window_for_anchor(_map(rows), 3, ExpansionConfig(token_budget=250), True)
+    # forward-first: should include 4 before 2
+    assert hi >= 4
+    assert sum(rows[i].tokens for i in range(lo, hi + 1)) <= 250
+
+
+def test_stitch_concats_and_spans_lines():
+    rows = [_row(0, text="alpha", ls=1, le=2), _row(1, text="beta", ls=3, le=5)]
+    text, ls, le = _stitch(_map(rows), 0, 1)
+    assert text == "alpha\nbeta"
+    assert (ls, le) == (1, 5)

--- a/tests/unit/bricks/search/test_macro_chunk_expand.py
+++ b/tests/unit/bricks/search/test_macro_chunk_expand.py
@@ -1,0 +1,76 @@
+import pytest
+
+from nexus.bricks.search.macro_chunk import ChunkRow, ExpansionConfig, expand_results
+
+
+class _Result:
+    def __init__(self, path, chunk_index):
+        self.path = path
+        self.chunk_index = chunk_index
+        self.macro_text = None
+        self.macro_line_start = None
+        self.macro_line_end = None
+
+
+class _FakeFetcher:
+    def __init__(self, rows):
+        self._rows = rows
+        self.calls = []
+
+    async def fetch_ranges(self, spans, zone_id):
+        self.calls.append(list(spans))
+        wanted = list(spans)
+        out = []
+        for r in self._rows:
+            for path, lo, hi in wanted:
+                if r.path == path and lo <= r.chunk_index <= hi:
+                    out.append(r)
+                    break
+        return out
+
+
+def _row(idx, path="/a.md", heading="A", tokens=10, text=None, ls=None, le=None):
+    return ChunkRow(
+        path=path,
+        chunk_index=idx,
+        text=text or f"c{idx}",
+        tokens=tokens,
+        line_start=ls,
+        line_end=le,
+        heading_prefix=heading,
+    )
+
+
+@pytest.mark.asyncio
+async def test_expand_attaches_macro_text_for_section():
+    rows = [_row(i, heading="A", ls=i + 1, le=i + 1) for i in range(3)]
+    fetcher = _FakeFetcher(rows)
+    res = [_Result("/a.md", 1)]
+    out = await expand_results(res, fetcher, ExpansionConfig(token_budget=1024, window=8))
+    assert out[0].macro_text == "c0\nc1\nc2"
+    assert (out[0].macro_line_start, out[0].macro_line_end) == (1, 3)
+
+
+@pytest.mark.asyncio
+async def test_expand_single_batched_fetch_and_section_dedup():
+    rows = [_row(i, heading="A") for i in range(4)]
+    fetcher = _FakeFetcher(rows)
+    # two hits in the SAME section
+    res = [_Result("/a.md", 1), _Result("/a.md", 2)]
+    out = await expand_results(res, fetcher, ExpansionConfig(token_budget=1024, window=8))
+    assert len(fetcher.calls) == 1  # one batched fetch
+    assert out[0].macro_text == out[1].macro_text  # section computed once, shared
+
+
+@pytest.mark.asyncio
+async def test_expand_missing_anchor_leaves_result_untouched():
+    fetcher = _FakeFetcher([])  # eventual-consistency gap: nothing returned
+    res = [_Result("/a.md", 5)]
+    out = await expand_results(res, fetcher, ExpansionConfig())
+    assert out[0].macro_text is None  # never errors, no expansion
+
+
+@pytest.mark.asyncio
+async def test_expand_empty_results_noop():
+    fetcher = _FakeFetcher([])
+    assert await expand_results([], fetcher, ExpansionConfig()) == []

--- a/tests/unit/bricks/search/test_macro_chunk_expand.py
+++ b/tests/unit/bricks/search/test_macro_chunk_expand.py
@@ -74,3 +74,61 @@ async def test_expand_missing_anchor_leaves_result_untouched():
 async def test_expand_empty_results_noop():
     fetcher = _FakeFetcher([])
     assert await expand_results([], fetcher, ExpansionConfig()) == []
+
+
+class _RaisingFetcher:
+    async def fetch_ranges(self, spans, zone_id):
+        raise RuntimeError("fetch failed")
+
+
+@pytest.mark.asyncio
+async def test_expand_fetch_failure_returns_results_unexpanded():
+    """Fetch-level error: expand_results catches and returns results unexpanded."""
+    fetcher = _RaisingFetcher()
+    res = [_Result("/a.md", 1), _Result("/b.md", 2)]
+    out = await expand_results(res, fetcher, ExpansionConfig())
+    assert len(out) == 2
+    assert out[0].macro_text is None
+    assert out[1].macro_text is None
+
+
+class _PartialRaisingFetcher:
+    """Returns good rows for one path, malformed rows (text=None) for another."""
+
+    def __init__(self, good_path, bad_path):
+        self.good_path = good_path
+        self.bad_path = bad_path
+
+    async def fetch_ranges(self, spans, zone_id):
+        rows = []
+        for path, lo, hi in spans:
+            if path == self.good_path:
+                rows.extend(
+                    [_row(i, path=path, heading="A", ls=i + 1, le=i + 1) for i in range(lo, hi + 1)]
+                )
+            elif path == self.bad_path:
+                rows.extend(
+                    [
+                        ChunkRow(
+                            path=path,
+                            chunk_index=i,
+                            text=None,  # malformed: will fail on "\n".join()
+                            tokens=10,
+                            line_start=None,
+                            line_end=None,
+                            heading_prefix="A",
+                        )
+                        for i in range(lo, hi + 1)
+                    ]
+                )
+        return rows
+
+
+@pytest.mark.asyncio
+async def test_expand_per_result_error_is_isolated():
+    """Per-result error: good result still expands; bad result left untouched."""
+    fetcher = _PartialRaisingFetcher(good_path="/good.md", bad_path="/bad.md")
+    res = [_Result("/good.md", 1), _Result("/bad.md", 1)]
+    out = await expand_results(res, fetcher, ExpansionConfig(token_budget=1024, window=8))
+    assert out[0].macro_text is not None  # good result expanded
+    assert out[1].macro_text is None  # bad result untouched

--- a/tests/unit/bricks/search/test_search_result_serialize.py
+++ b/tests/unit/bricks/search/test_search_result_serialize.py
@@ -1,0 +1,23 @@
+"""Tests for BaseSearchResult serialization (#4398)."""
+
+from nexus.bricks.search.results import BaseSearchResult
+from nexus.server.api.v2.routers.search import _serialize_search_result
+
+
+def test_serialize_omits_macro_when_absent():
+    """Default response unchanged when macro_text is absent."""
+    r = BaseSearchResult(path="/a", chunk_text="x", score=1.0, chunk_index=0)
+    out = _serialize_search_result(r)
+    assert "macro_text" not in out
+
+
+def test_serialize_includes_macro_when_present():
+    """Macro fields included in response when macro_text is set."""
+    r = BaseSearchResult(path="/a", chunk_text="x", score=1.0, chunk_index=0)
+    r.macro_text = "x\ny"
+    r.macro_line_start = 1
+    r.macro_line_end = 4
+    out = _serialize_search_result(r)
+    assert out["macro_text"] == "x\ny"
+    assert out["macro_line_start"] == 1
+    assert out["macro_line_end"] == 4

--- a/tests/unit/server/api/v2/test_search_expand_param.py
+++ b/tests/unit/server/api/v2/test_search_expand_param.py
@@ -1,0 +1,151 @@
+"""Unit tests for the expand= request param on GET /api/v2/search/query (#4398 Task 9).
+
+Covers:
+(a) expand=macro is accepted (not a 400) and daemon.search is called with expand="macro"
+(b) expand=bogus returns 400 with the validation detail message
+(c) default (expand omitted) passes expand="none" to daemon.search
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+try:
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    _HAS_FASTAPI = True
+except ImportError:
+    _HAS_FASTAPI = False
+
+pytestmark = pytest.mark.skipif(not _HAS_FASTAPI, reason="fastapi test client unavailable")
+
+
+# ---------------------------------------------------------------------------
+# Shared harness
+# ---------------------------------------------------------------------------
+
+_AUTH = {
+    "authenticated": True,
+    "subject_type": "user",
+    "subject_id": "alice",
+    "zone_id": "eng",
+    "zone_perms": [["eng", "r"]],
+    "is_admin": False,
+}
+
+
+class _RecordingRunner:
+    async def call(self, work: Any) -> Any:
+        return await work()
+
+
+class _RecordingRegistry:
+    def __init__(self) -> None:
+        self.zones: list[str] = []
+
+    def runner_for(self, zone_id: str) -> _RecordingRunner:
+        self.zones.append(zone_id)
+        return _RecordingRunner()
+
+
+def _build_app(daemon: Any) -> "FastAPI":
+    """Minimal FastAPI app with search router and a controllable daemon."""
+    from nexus.server.api.v2.routers.search import router
+    from nexus.server.dependencies import require_auth
+
+    app = FastAPI()
+    app.state.search_daemon = daemon
+    app.state.record_store = object()
+    app.state.async_read_session_factory = object()
+    app.state.permission_enforcer = None
+    app.state.zone_registry = _RecordingRegistry()
+    app.dependency_overrides[require_auth] = lambda: _AUTH
+    app.include_router(router)
+    return app
+
+
+def _make_daemon() -> MagicMock:
+    """Return a daemon mock that records .search() calls."""
+    daemon = MagicMock()
+    daemon.is_initialized = True
+    daemon.config = MagicMock()
+    daemon.config.txtai_graph = False
+
+    async def fake_search(**kwargs: Any) -> list[Any]:
+        return []
+
+    daemon.search = AsyncMock(side_effect=fake_search)
+    return daemon
+
+
+# ---------------------------------------------------------------------------
+# (b) expand=bogus -> 400
+# ---------------------------------------------------------------------------
+
+
+def test_expand_bogus_returns_400() -> None:
+    """expand=bogus must be rejected with HTTP 400 before touching the daemon."""
+    daemon = _make_daemon()
+    app = _build_app(daemon)
+
+    with TestClient(app) as client:
+        response = client.get("/api/v2/search/query", params={"q": "hello", "expand": "bogus"})
+
+    assert response.status_code == 400, response.text
+    body = response.json()
+    detail = body.get("detail", "")
+    assert "expand" in detail.lower(), f"Expected 'expand' in detail, got: {detail!r}"
+    # daemon.search must NOT have been called
+    daemon.search.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# (a) expand=macro is accepted; daemon receives expand="macro"
+# ---------------------------------------------------------------------------
+
+
+def test_expand_macro_accepted_and_threaded() -> None:
+    """expand=macro must reach daemon.search as expand='macro'."""
+    daemon = _make_daemon()
+    app = _build_app(daemon)
+
+    with TestClient(app) as client:
+        response = client.get("/api/v2/search/query", params={"q": "hello", "expand": "macro"})
+
+    # Must NOT be a 400/422
+    assert response.status_code != 400, response.text
+    assert response.status_code != 422, response.text
+
+    # daemon.search must have been called with expand="macro"
+    daemon.search.assert_called_once()
+    call_kwargs = daemon.search.call_args.kwargs
+    assert call_kwargs.get("expand") == "macro", (
+        f"Expected expand='macro' in daemon.search kwargs, got: {call_kwargs!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# (c) expand omitted -> daemon receives expand="none"
+# ---------------------------------------------------------------------------
+
+
+def test_expand_default_none_threaded() -> None:
+    """When expand is omitted, daemon.search must be called with expand='none'."""
+    daemon = _make_daemon()
+    app = _build_app(daemon)
+
+    with TestClient(app) as client:
+        response = client.get("/api/v2/search/query", params={"q": "hello"})
+
+    # Response must not be a validation error
+    assert response.status_code not in (400, 422), response.text
+
+    daemon.search.assert_called_once()
+    call_kwargs = daemon.search.call_args.kwargs
+    assert call_kwargs.get("expand") == "none", (
+        f"Expected expand='none' in daemon.search kwargs, got: {call_kwargs!r}"
+    )


### PR DESCRIPTION
## Summary

Adds opt-in **read-side macro-chunk (neighbor-context) expansion** to hybrid search (closes #4398). Search keeps indexing and ranking small chunks (good recall/precision), but when a caller sets `expand=macro`, each hit is stitched into its surrounding **section** — adjacent chunks by `chunk_index`, bounded by `heading_prefix`, the file edge, and a token budget — returned in additive `macro_text` / `macro_line_start` / `macro_line_end` fields. The short `chunk_text` stays as the matched snippet/citation anchor.

Model-free, no new services. **Default (`expand` omitted → `none`) is byte-identical to today** — ranking, the gbrain benchmark, and all existing callers are unaffected.

Why this and not a reranker: hybrid ranking is already at bench ceiling (recall@5 ≈ 0.9489 / NDCG@5 ≈ 0.9028), so the remaining headroom is **answer-context quality**, which recall@5/NDCG@5 don't measure. A cross-encoder reranker was evaluated and deliberately left out (hosting + latency cost; ~no lift at the current ceiling).

Design spec: `docs/superpowers/specs/2026-06-17-macro-chunk-expansion-design.md`.

## Architecture

- **`macro_chunk.py`** — pure, backend-agnostic algorithm: section bounds (heading-aware), token-budgeted window selection (prose grows centered; code grows forward-first to capture a function body after a signature hit), adaptive sizing, small-section dedup, and `expand_results` orchestration (one batched fetch, best-effort — never breaks a search).
- **`NeighborFetcher` protocol** — implemented by `PgVectorBackend.fetch_ranges` (FULL) and `SqliteVecBackend.fetch_ranges` (SANDBOX) as a single batched range query. The daemon passes the active vector backend as the fetcher.
- **Daemon** wires `expand=macro` after result assembly (`_apply_macro_expansion`), with `NEXUS_SEARCH_MACRO_CHUNK_*` config knobs; records `macro_expand_ms` + `macro_expanded_count`.
- **HTTP** `GET /api/v2/search/query` gains a validated `expand` param (single-zone path; federated is a documented v1 scope cut).

## Persistence

`heading_prefix` is now persisted per chunk: ORM model + Alembic migration (single clean head) for Postgres; `create_all` for SQLite; threaded through `ChunkStore` INSERTs and the indexing side-write. SANDBOX `nexus_vec` gains `+chunk_tokens/+line_start/+line_end/+heading_prefix` **auxiliary** columns (the `+` allows NULL — required for the degradation case), with a self-healing rebuild trigger for pre-existing tables. NULL `heading_prefix` degrades gracefully to a token/file-bounded window.

## Testing

- Pure algorithm + orchestration, serializer, daemon wiring, API param/validation, SANDBOX `fetch_ranges` (real sqlite-vec, incl. NULL round-trip), chunk-store, migration — all green locally.
- Full search-brick suite: **625 passed**, 17 skipped (Postgres/fastembed env-gated), 1 deselected (pre-existing).
- **Real end-to-end smoke** (fastembed-backed live daemon): hit on a middle chunk → `macro_text` stitched all 3 neighbors with correct line span; `expand=none` → no-op.
- Reorder of the SANDBOX rebuild trigger is locked in by a data-preservation test (rows survive on embedder-identity mismatch).
- **CI-validated (not run locally — no Postgres):** `PgVectorBackend.fetch_ranges` + `test_pg_macro_fetch.py`, the migration `upgrade()`, and the gbrain recall@5/NDCG@5 guard. These need `NEXUS_TEST_DATABASE_URL` / `GBRAIN_EVALS_DIR`.

## Rollout / follow-ups (not in this PR)

1. Shared `nexus-client` `SearchHit` schema: surface `macroText` / `macroLineStart` / `macroLineEnd` (camelCase) to the TS SDK.
2. Koodle: send `expand=macro`, read `macroText ?? chunkText`, and lower its over-fetch multiplier in the same change (avoids token blow-up).
3. Federated (cross-zone) `expand` wiring — deferred; currently a documented single-zone-only no-op.

Closes #4398.
