### PR TITLE
docs: P2P task settlement v0.7 — economics cost model

### DIFF
--- a/docs/architecture/p2p-task-settlement.html
+++ b/docs/architecture/p2p-task-settlement.html
@@ -40,7 +40,7 @@
 </head>
 <body>
 
-<h1>P2P Task Settlement <span class="status status-draft">DRAFT v0.4</span></h1>
+<h1>P2P Task Settlement <span class="status status-draft">DRAFT v0.7</span></h1>
 <p class="subtitle">
   A peer-to-peer task dispatch and settlement protocol for sudowork, built on nexus-vfs primitives.<br>
   Buyer posts a task, Seller does the work, settlement in sudowork points.
@@ -57,6 +57,7 @@
     <li><a href="#s5a">5A. Reputation System</a></li>
     <li><a href="#s6">6. Delivery via VFS</a></li>
     <li><a href="#s7">7. Scenarios</a></li>
+    <li><a href="#s7a">7A. Economics: Cost Model</a></li>
     <li><a href="#s8">8. Open Questions</a></li>
   </ul>
 </div>
@@ -478,6 +479,104 @@ sequenceDiagram
 </div>
 
 <!-- ============================================================ -->
+<h2 id="s7a">7A. Economics: End-to-End Cost Model</h2>
+
+<p>Using Scenario B (Douyin engagement) as the reference micro-task. Prices in CNY.</p>
+
+<h3>Positioning: AI-Assisted Micro-Task Platform</h3>
+<div class="card">
+  <p>This is not just another crowdsourcing platform. The differentiator: <strong>every seller has an AI copilot</strong> (sudowork) that helps them understand tasks, execute efficiently, and generate delivery proofs. This lowers the skill floor &mdash; more people can do more types of work &mdash; and raises quality (AI pre-checks deliverables before submission).</p>
+  <p>The platform simultaneously serves as an <strong>adoption vehicle for AI-assisted labor</strong>: sellers who start using sudowork for micro-tasks naturally discover its value for their own work, driving organic growth.</p>
+</div>
+
+<h3>Per-Task Cost Breakdown (Scenario B: Douyin engagement)</h3>
+
+<table>
+  <tr><th>Item</th><th>Who pays</th><th>Estimate</th><th>Notes</th></tr>
+  <tr>
+    <td>Task payment (seller's labor)</td>
+    <td>Buyer</td>
+    <td>&#165;0.30 &ndash; 0.50</td>
+    <td>Market rate for social engagement micro-tasks (comparable to existing platforms)</td>
+  </tr>
+  <tr>
+    <td>Buyer's AI cost (post task + verify)</td>
+    <td>Buyer (own tokens)</td>
+    <td>&lt; &#165;0.01</td>
+    <td>~1K tokens input + ~100 output on DSV4. Negligible.</td>
+  </tr>
+  <tr>
+    <td>Seller's AI cost (understand task + generate comment + proof)</td>
+    <td>Seller (own tokens)</td>
+    <td>&lt; &#165;0.01</td>
+    <td>~500-1K tokens on DSV4. Seller's own investment.</td>
+  </tr>
+  <tr>
+    <td>Protocol overhead (signatures + VFS ops)</td>
+    <td>Both (local compute)</td>
+    <td>~0</td>
+    <td>Ed25519 sign &lt; 1ms, VFS write &lt; 5&micro;s. No network cost for P2P local ops.</td>
+  </tr>
+  <tr>
+    <td>Server transfer API (settlement)</td>
+    <td>Platform</td>
+    <td>~0</td>
+    <td>One HTTP call per contract. Platform operational cost.</td>
+  </tr>
+  <tr>
+    <td><strong>Buyer total cost</strong></td>
+    <td></td>
+    <td><strong>&#165;0.30 &ndash; 0.51</strong></td>
+    <td>Task payment + own AI. AI cost &lt; 2% of task payment.</td>
+  </tr>
+  <tr>
+    <td><strong>Seller net income</strong></td>
+    <td></td>
+    <td><strong>&#165;0.29 &ndash; 0.49</strong></td>
+    <td>Task payment minus own AI cost. AI cost &lt; 2%.</td>
+  </tr>
+</table>
+
+<div class="card">
+  <div class="card-title">Key insight: AI cost is negligible for micro-tasks</div>
+  <p>At DSV4 pricing (~$0.27/M input, ~$1.10/M output via SudoRouter), a simple task consumes &lt; 2000 tokens total &mdash; less than &#165;0.01. Against a &#165;0.30-0.50 task payment, AI overhead is <strong>&lt; 2%</strong>. The economics work.</p>
+</div>
+
+<h3>AI Assistance: Seller's Investment Decision</h3>
+<div class="card">
+  <p>The seller's AI tokens are <strong>the seller's own investment</strong>, not the platform's cost. How much AI help to use is a <strong>local optimization</strong> within the seller's L1 trust zone:</p>
+  <ul>
+    <li><strong>High-skill seller</strong>: Does most work manually, uses AI minimally (saves tokens, keeps more profit)</li>
+    <li><strong>Low-skill seller</strong>: Relies heavily on AI guidance (spends more tokens, but can complete tasks they otherwise couldn't)</li>
+    <li><strong>Model choice</strong>: Each seller picks their own model. Simple tasks &rarr; DSV4 or similar cheap model. The protocol doesn't mandate a model.</li>
+  </ul>
+  <p>This creates a <strong>natural market for AI-assisted labor</strong>: the platform makes AI assistance accessible and economically viable for micro-work, driving adoption.</p>
+</div>
+
+<h3>Market Context (China)</h3>
+<table>
+  <tr><th>Benchmark</th><th>Price</th></tr>
+  <tr><td>Ant Microwork (蚂蚁微客) simple task</td><td>&#165;0.10 &ndash; 0.50/task</td></tr>
+  <tr><td>Douyin follow (grey market)</td><td>&#165;0.05 &ndash; 0.20/follow</td></tr>
+  <tr><td>Douyin like (grey market)</td><td>&#165;0.02 &ndash; 0.10/like</td></tr>
+  <tr><td>Minimum hourly wage (varies by city)</td><td>&#165;15 &ndash; 25/hour</td></tr>
+  <tr><td>Our Scenario B (3-5 min task)</td><td>&#165;0.30 &ndash; 0.50/task &asymp; &#165;4-10/hour effective</td></tr>
+</table>
+<p>Pricing is competitive with existing micro-task platforms. The value-add is AI assistance + cryptographic settlement guarantees + no platform rake on the task payment itself.</p>
+
+<h3>Points Liquidity: Stable-Price Buyback</h3>
+<div class="card">
+  <p>Sellers earn points but need real currency. sudowork offers a <strong>stable-price buyback</strong> at 5-10% of the original charge price.</p>
+  <ul>
+    <li><strong>Framing</strong>: "refund" or "credit redemption" &mdash; not "exchange" or "withdrawal" (avoids financial instrument classification)</li>
+    <li><strong>Mechanism</strong>: Seller requests buyback &rarr; sudoprivacy credits the amount to seller's payment method at the published buyback rate</li>
+    <li><strong>Rate example</strong>: Charge rate &#165;1 = 100 points. Buyback rate: 100 points = &#165;0.05-0.10</li>
+    <li><strong>Policy risk</strong>: Needs legal review. Framing as "partial refund of unused credits" rather than "currency exchange" is safer. Many game platforms (Steam, Apple) have similar credit refund mechanisms.</li>
+  </ul>
+  <p><em>Note: Buyback rate and policy details require legal consultation before launch. Recorded here as design option.</em></p>
+</div>
+
+<!-- ============================================================ -->
 <h2 id="s8">8. Open Questions</h2>
 
 <ol>
@@ -519,6 +618,9 @@ sequenceDiagram
 
 <div class="version-info">
   <strong>Document history</strong><br>
+  v0.7 (2026-06-19) &mdash; Added §7A Economics: E2E cost model for Douyin micro-task, AI-assist micro-task platform positioning, seller AI investment rationale, China market benchmarks, points stable-price buyback mechanism.<br>
+  v0.6 (2026-06-19) &mdash; Delivery diagram with human actors + sync/async line distinction.<br>
+  v0.5 (2026-06-19) &mdash; No forced human-in-the-loop. AI-first verification, human async optional.<br>
   v0.4 (2026-06-19) &mdash; Clarified auto-execute terms come from negotiate (not server). Reputation: bilateral (buyer + seller), marketplace signal only (not settlement enforcement), agent rates on behalf of human (L1 alignment).<br>
   v0.3 (2026-06-19) &mdash; Added Buyer Pre-commitment (Option B+) to close hostage problem in low-trust markets. Added §5A Reputation System reuse from nexus (Bayesian Beta model, VFS storage).<br>
   v0.2 (2026-06-19) &mdash; Revised trust diagram (our/their perspective), real scenarios (data labeling + Douyin engagement), escrow preference (Option B), initial preferences on all open questions.<br>


### PR DESCRIPTION
## Summary

- §7A Economics: E2E cost model for Douyin micro-task (AI cost <2% of task payment)
- AI-assist micro-task platform positioning
- Seller AI cost as own investment (L1 local optimization)
- China market benchmarks
- Points stable-price buyback mechanism (5-10% refund framing)
- ShareOne: https://shareone.app/s/p2p-task-settlement

## Test plan

- [x] Docs only — no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)