### PR TITLE
docs(arch): update integration architecture diagram and raft taxonomy

### DIFF
--- a/docs/architecture/nexus-integration-architecture.html
+++ b/docs/architecture/nexus-integration-architecture.html
@@ -161,37 +161,52 @@ A2A messaging, audit trace, cross-instance transport.</p>
 
 <pre class="mermaid">
 graph TD
-    subgraph sw["sudowork (Electron)"]
+    subgraph sw["sudowork (Electron) — orchestrator"]
         direction LR
-        renderer["Renderer (React UI)"] <-->|IPC| mainproc["Main Process"]
+        renderer["Renderer&lpar;React UI&rpar;<br/>chat UI · audit viewer · messenger"]
+        mainproc["Main Process<br/>spawns / cancels workers<br/>copilot-worker topology"]
+        renderer <-->|"IPC bridge"| mainproc
     end
 
-    sw -->|"gRPC (VFS port)"| grpc
+    sw -->|"gRPC &lpar;VFS port&rpar;"| grpc
 
-    subgraph host["sudocode-host (one process per host)"]
-        grpc["gRPC server (VFS port)"]
+    subgraph host["sudocode-host — one process per host"]
+        grpc["gRPC server &lpar;VFS port&rpar;<br/>NexusVFSService.Call routes managed_agent<br/>+ ACP methods + sys_* for external clients"]
 
-        subgraph kernel["Embedded Rust Kernel"]
-            vfs["VFSRouter · DCache · Metastore"]
-            pipes["PipeManager · StreamManager"]
-            hooks["AuditHook · AgentRegistry"]
+        subgraph kernel["Embedded Rust Kernel &lpar;one kernel::Kernel per host&rpar;"]
+            vfs["VFSRouter · DCache · Metastore&lpar;redb&rpar; · LockManager"]
+            pipes["PipeManager&lpar;DT_PIPE&rpar; · StreamManager&lpar;DT_STREAM&rpar;"]
+            watch["FileWatchRegistry&lpar;sys_watch&rpar; · KernelDispatch&lpar;hooks&rpar;"]
+            hooks["AuditHook · AgentStatusResolver · AgentRegistry &lpar;state SSOT&rpar;"]
         end
 
         subgraph svc["Services rlib"]
-            mas["ManagedAgentService"]
-            acp["AcpService"]
-            spawn["SpawnTask‹Kernel›"]
+            mas["ManagedAgentService<br/>start_session_v1 · cancel_v1 · get_session_v1"]
+            acp["AcpService<br/>&lpar;claude / codex / scode / codebuddy / ...&rpar;"]
+            spawn["SpawnTask‹Kernel›<br/>&lpar;1 vtable dispatch per spawn&rpar;"]
         end
 
-        subgraph tasks["Agent Tasks (N tokio tasks)"]
-            agent["KernelFsBackend‹K› + ConversationRuntime<br/>cwd = /proc/{pid}/workspace"]
+        subgraph tasks["sudo-code agent tasks &lpar;N tokio tasks&rpar;"]
+            agent["KernelFsBackend‹K› + ConversationRuntime<br/>cwd = /proc/{pid}/workspace<br/>direct in-process kernel syscalls"]
         end
 
-        grpc --- kernel
-        kernel --- svc
-        kernel --- tasks
+        grpc --> kernel
+        kernel -->|"in-process Rust syscalls &lpar;KernelAbi&rpar;"| svc
+        kernel -->|"in-process Rust syscalls &lpar;KernelAbi&rpar;"| tasks
         svc -->|"spawn via DI seam"| tasks
+
+        subgraph extproc["External ACP subprocesses"]
+            ext["claude · codex · codebuddy · nanobot<br/>JSON-RPC over stdio<br/>StdioPipeBackend → /proc/{pid}/fd/{0,1,2}"]
+        end
+        acp -->|"subprocess spawn"| extproc
     end
+
+    style sw fill:#1e3a5f,stroke:#60a5fa,color:#e2e8f0
+    style host fill:#1e293b,stroke:#334155,color:#e2e8f0
+    style kernel fill:#172033,stroke:#60a5fa,color:#e2e8f0
+    style svc fill:#1a2744,stroke:#334155,color:#e2e8f0
+    style tasks fill:#1a2744,stroke:#334155,color:#e2e8f0
+    style extproc fill:#2d1f1f,stroke:#f59e0b,color:#fcd34d
 </pre>
 
 <h3>Constraints</h3>
@@ -272,18 +287,28 @@ sequenceDiagram
     Registry->>Registry: reap /proc/{pid}/
 </pre>
 
-<p>A managed agent runs as one in-process tokio task inside <code>sudocode-host</code>, reaching the kernel through direct Rust syscalls. External ACP agents (claude / codex) run as subprocesses over stdio JSON-RPC; that path lives in <code>AcpService</code>.</p>
+<p>A managed agent runs as one in-process tokio task inside <code>sudocode-host</code>, reaching the kernel through direct Rust syscalls (<code>kernel.sys_read</code>, <code>sys_write</code>, <code>sys_watch</code>) and the dispatch hooks through the same in-process channel every kernel observer uses. External ACP agents (claude / codex / codebuddy / nanobot) run as subprocesses over stdio, because JSON-RPC over stdio is the only protocol those binaries speak; that path lives in <code>AcpService</code> (&sect;1).</p>
 
-<p>The session identifier IS the AgentRegistry pid. <code>ManagedAgentService</code> plants the per-pid <code>AgentDescriptor</code> and returns <code>{session_id=pid, workspace_path}</code> to the caller.</p>
+<p>The session identifier IS the AgentRegistry pid. <code>ManagedAgentService</code> plants the per-pid <code>AgentDescriptor</code> &mdash; the spawn-time SSOT (<code>agent_id</code> &rarr; <code>desc.name</code>, <code>model</code> &rarr; <code>desc.labels["model"]</code>, workspace list &rarr; <code>desc.repos</code>) &mdash; stamps the <code>/proc/{pid}/</code> entries (&sect;2.2), and returns <code>{session_id=pid, workspace_path}</code> to the caller.</p>
+
+<p><code>ManagedAgentService</code> hands off to the runtime through the <code>SpawnTask&lt;K: KernelAbi&gt;</code> DI seam &mdash; one indirect call per session start. The binary edge, <code>sudocode-host</code> in the sudocode repo, constructs a concrete <code>SpawnTask&lt;Kernel&gt;</code> adapter wrapping <code>sudocode_runtime::spawn_task</code> and registers it via <code>install_managed_agent_with_spawn(kernel, adapter)</code>. <code>start_session</code> calls <code>provider.spawn(kernel, desc, observer)</code> through <code>Arc&lt;dyn SpawnTask&lt;K&gt;&gt;</code>: exactly one vtable dispatch per session, and the returned <code>Box&lt;dyn SpawnHandle&gt;</code> lands in the service's <code>spawn_handles</code> sidecar. Inside the spawn body the surface is plain monomorphic Rust: <code>spawn_task::&lt;Kernel&gt;</code> and its inner <code>run_loop</code> are generic over <code>K: KernelAbi</code>, specialised against the concrete <code>Kernel</code> at the binary edge, so every <code>sys_read</code> / <code>sys_write</code> / <code>sys_watch</code> in the mailbox loop is an inline direct call. The services rlib depends on the <code>SpawnTask</code> trait only; pure-Rust slim builds call <code>install_managed_agent</code> (no spawn provider, no per-pid task).</p>
+
+<p><code>sudocode-host</code> is the single binary-edge where the nexus and sudocode source trees link: it consumes <code>sudocode_runtime</code> as a library and the nexus <code>kernel</code> / <code>services</code> crates as git deps pinned to one nexus rev (so <code>SpawnTask&lt;Kernel&gt;</code> monomorphises), and the dependency edge stays <code>sudocode &rarr; nexus</code> (&sect;8).</p>
+
+<p>A worker boots by reading its profile + <code>--session-id</code> transcript from <code>/agents/{name}/</code> (&sect;2.1), works (appending to the session jsonl and the mailbox), and exits; the <code>/proc/{pid}/</code> subtree is reaped. Resuming re-reads the same session-id &mdash; persistent state lives in <code>/agents/{name}/</code>, not in a long-running process. Out-of-band termination (SIGTERM / SIGKILL / orphan reap) flows through <code>AgentRegistry::on_terminate</code>, which reaps <code>/proc/{pid}/</code> and aborts the worker via its <code>SpawnHandle</code>; <code>cancel(session)</code> calls <code>AgentRegistry::kill(pid, 0)</code> for the same outcome.</p>
+
+<p>After spawn, prompts and responses flow over the chat-with-me VFS surface &mdash; the same A2A primitive every agent uses (&sect;3). sudowork writes prompts to <code>/proc/{pid}/chat-with-me</code>; the worker <code>sys_watch</code>es it and writes responses to <code>/agents/{user}/chat-with-me</code>, which sudowork's UI watches in turn.</p>
 
 <p><strong>ManagedAgentService surface</strong> (over <code>NexusVFSService.Call</code>):</p>
 <ul>
-  <li><code>start_session_v1</code> &mdash; <code>{agent_id, repos, model, owner_id, zone_id}</code> &rarr; <code>{session_id, workspace_path}</code></li>
-  <li><code>cancel_v1</code> &mdash; <code>{session_id, mode}</code> &rarr; <code>{cancelled}</code>; <code>mode &isin; {turn, session}</code></li>
-  <li><code>get_session_v1</code> &mdash; <code>{session_id}</code> &rarr; <code>{session_id, agent_id, workspace_path, model, state}</code></li>
+  <li><code>start_session_v1</code> &mdash; <code>{agent_id, repos, model, owner_id, zone_id}</code> &rarr; <code>{session_id, workspace_path}</code>. <code>agent_id</code> names the profile (<code>/agents/{agent_id}/</code>); <code>session_id</code> is the runtime pid.</li>
+  <li><code>cancel_v1</code> &mdash; <code>{session_id, mode}</code> &rarr; <code>{cancelled}</code>; <code>mode &isin; {turn, session}</code> (turn aborts the current generation, session reaps the pid).</li>
+  <li><code>get_session_v1</code> &mdash; <code>{session_id}</code> &rarr; <code>{session_id, agent_id, workspace_path, model, state}</code>.</li>
 </ul>
 
-<p><code>AgentState</code> FSM: <code>REGISTERED &rarr; WARMING_UP &rarr; READY &harr; BUSY &rarr; SUSPENDED &rarr; TERMINATED</code>.</p>
+<p>Prompt / event flow reuses <code>sys_write</code> / <code>sys_watch</code> / <code>sys_read</code> over the chat-with-me paths; the A2A surface carries it without a bespoke SendPrompt or SubscribeEvents gRPC.</p>
+
+<p><code>AgentState</code> FSM: <code>REGISTERED &rarr; WARMING_UP &rarr; READY &harr; BUSY &rarr; SUSPENDED &rarr; TERMINATED</code>. <code>AgentRegistry</code> is the SSOT: <code>update_state(&amp;pid, new_state)</code> (<code>kernel/src/core/agents/registry.rs</code>) is the only runtime-path writer &mdash; it enforces the FSM via <code>can_transition_to</code>, updates <code>updated_at_ms</code>, and fires <code>on_terminate</code> on TERMINATED. The writer is a state-observer closure that <code>ManagedAgentService::start_session</code> constructs (capturing <code>Arc&lt;AgentRegistry&gt;</code> + pid, mapping the runtime's <code>AgentLoopState</code> onto <code>AgentState</code>) and passes through the <code>SpawnTask::spawn</code> seam; the adapter forwards it to the runtime's <code>state_callback</code> and never touches <code>AgentRegistry</code>. <code>kernel.agent_wait(pid, target_state, timeout_ms)</code> parks on the per-pid condvar for event-driven waits.</p>
 
 <h3>2.4 sudo-code state placement</h3>
 
@@ -299,6 +324,8 @@ sequenceDiagram
 </table>
 
 <p>Inside <code>sudocode-host</code> the agent task runs on <code>KernelFsBackend&lt;Kernel&gt;</code>, so <code>SessionStore</code>, <code>ConfigLoader</code>, and the workspace-bounded <code>file_ops</code> helpers all issue kernel syscalls against nexus VFS paths:</p>
+
+<p><code>workspace_hash</code> is sudo-code's FNV-1a 64-bit fingerprint (16-char hex) of the canonical workspace path, so one profile talking to multiple repos partitions sessions per-repo. Static prompt sections embed as <code>&amp;'static str</code> and need no IO.</p>
 
 <table>
   <thead><tr><th>sudo-code surface</th><th>nexus VFS path</th></tr></thead>
@@ -348,9 +375,18 @@ sequenceDiagram
     Kernel->>Stream: append (stamped envelope)
 </pre>
 
+<p>The rewrite is implemented as a registered <code>NativeInterceptHook</code> (<code>MailboxStampingHook</code>) that delegates the actual envelope policy to <code>mailbox_stamping_policy::maybe_stamp_chat_envelope</code>. Both live under <code>rust/services/src/managed_agent/</code> &mdash; owned by <code>ManagedAgentService</code> (the chat-with-me mailbox is a managed-agent concern, not a generic agent-table concern). The hook struct owns "how to be a hook" (dispatch wiring + content-clone bypass); the policy module owns "what to rewrite" (envelope schema, identity guarantee). The hook trait was widened to support content rewriting &mdash; <code>on_pre</code> returns <code>Result&lt;HookOutcome, String&gt;</code> where <code>HookOutcome::Replace(bytes)</code> is the new variant that substitutes write content. Accept/reject hooks (audit, permission, workspace boundary) all return <code>HookOutcome::Pass</code>.</p>
+
+<p>To keep the hot path allocation-free for the writes that don't need rewriting, hooks declare a <code>mutating_path_suffix</code> and the dispatcher uses it as a double bypass:</p>
+
+<ul>
+  <li><strong>Layer 1 (no mutating hooks registered):</strong> empty-Vec check, dispatcher goes straight to <code>WriteHookCtx::content = vec![]</code> &mdash; identical to the pre-widening cost.</li>
+  <li><strong>Layer 2 (mutating hook registered, write path doesn't match):</strong> suffix scan returns false, dispatcher still passes <code>vec![]</code>. Only writes whose path ends in a registered suffix (<code>*/chat-with-me</code>) pay the content clone.</li>
+</ul>
+
 <h3>3.4 Boundary teaching UX</h3>
 
-<p><code>WorkspaceBoundaryHook</code> is registered as an <code>INTERCEPT pre-write</code> hook. On mismatch the hook returns <code>Err(EPERM)</code> with a structured payload:</p>
+<p><code>WorkspaceBoundaryHook</code> is registered as an <code>INTERCEPT pre-write</code> hook scoped to <code>/proc/{pid}/workspace/{...}</code>. It compares the caller's <code>agent_id</code> to the workspace owner derived from the path (<code>pid &rarr; AgentRegistry.lookup(pid).name</code>). On mismatch the hook returns <code>Err(EPERM)</code> with a structured payload:</p>
 
 <pre><code>EPERM at /proc/p_scode/workspace/projects/nexus/src/main.rs:
   This workspace is owned by agent 'scode-standard' (pid p_scode).
@@ -587,13 +623,22 @@ graph TB
 
 <p>All commands in a zone's Raft cluster share a single <code>Command</code> enum (<code>state_machine.rs</code>):</p>
 
-<pre><code>Command::SetMetadata           &mdash; VFS file/dir metadata (path, size, etag, ...)
-Command::DeleteMetadata        &mdash; VFS delete
-Command::AcquireLock           &mdash; distributed lock
-Command::ReleaseLock           &mdash; lock release
-Command::AppendStreamEntry{..} &mdash; WalStreamBackend stream data (chat, audit)
-Command::DeleteStreamEntry     &mdash; stream cleanup
-... (others)</code></pre>
+<table>
+  <thead><tr><th>Command</th><th>Purpose</th></tr></thead>
+  <tbody>
+    <tr><td><code>SetMetadata { key, value }</code></td><td>VFS file/dir metadata (path, size, etag, &hellip;)</td></tr>
+    <tr><td><code>DeleteMetadata { key }</code></td><td>VFS delete</td></tr>
+    <tr><td><code>CasSetMetadata { key, value, expected_version }</code></td><td>Compare-and-swap metadata update</td></tr>
+    <tr><td><code>AdjustCounter { key, delta }</code></td><td>Read-modify-write atomic counter</td></tr>
+    <tr><td><code>AcquireLock { path, lock_id, max_holders, ttl_secs, &hellip; }</code></td><td>Distributed mutex or semaphore</td></tr>
+    <tr><td><code>ReleaseLock { path, lock_id }</code></td><td>Release lock by ID</td></tr>
+    <tr><td><code>ExtendLock { path, lock_id, new_ttl_secs, now_secs }</code></td><td>Extend lock TTL</td></tr>
+    <tr><td><code>ForceReleaseLock { path }</code></td><td>Admin override &mdash; force-release a stuck lock</td></tr>
+    <tr><td><code>AppendStreamEntry { key, data }</code></td><td>WalStreamBackend stream data (chat, audit)</td></tr>
+    <tr><td><code>DeleteStreamEntry { key }</code></td><td>Stream cleanup</td></tr>
+    <tr><td><code>Noop</code></td><td>Leader election confirmation</td></tr>
+  </tbody>
+</table>
 
 <footer>
   <p>Nexus Integration Architecture &mdash; joint-owned by the nexus and sudocode teams. Apache-2.0.</p>


### PR DESCRIPTION
## Summary

- Expand §1 System Overview Mermaid diagram to match the original MD spec detail level — all kernel sub-components, gRPC routing description, KernelAbi connection labels, ManagedAgentService methods, AcpService backend list, external ACP subprocess box
- Expand Appendix B Raft Command Taxonomy from 6 items to complete 11-command table matching `state_machine.rs` (add CasSetMetadata, AdjustCounter, ExtendLock, ForceReleaseLock, Noop)

## Test plan

- [x] ShareOne preview verified via ai-dev-browser — diagram renders correctly
- [x] All 10 sections intact, no content loss