### PR TITLE
feat(runbook+tests): federation EC-default sys_setattr + --as voter|learner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=6b7bd6e3577734cbe2a96684612cd2912adab4f3#6b7bd6e3577734cbe2a96684612cd2912adab4f3"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=283ca2aaff7bbdeb888b8483ad5866075d60015f#283ca2aaff7bbdeb888b8483ad5866075d60015f"
 dependencies = [
  "ahash",
  "base64",
@@ -550,7 +550,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=6b7bd6e3577734cbe2a96684612cd2912adab4f3#6b7bd6e3577734cbe2a96684612cd2912adab4f3"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=283ca2aaff7bbdeb888b8483ad5866075d60015f#283ca2aaff7bbdeb888b8483ad5866075d60015f"
 dependencies = [
  "parking_lot",
  "serde",
@@ -1339,7 +1339,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=6b7bd6e3577734cbe2a96684612cd2912adab4f3#6b7bd6e3577734cbe2a96684612cd2912adab4f3"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=283ca2aaff7bbdeb888b8483ad5866075d60015f#283ca2aaff7bbdeb888b8483ad5866075d60015f"
 dependencies = [
  "ahash",
  "base64",
@@ -1396,7 +1396,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=6b7bd6e3577734cbe2a96684612cd2912adab4f3#6b7bd6e3577734cbe2a96684612cd2912adab4f3"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=283ca2aaff7bbdeb888b8483ad5866075d60015f#283ca2aaff7bbdeb888b8483ad5866075d60015f"
 dependencies = [
  "ahash",
  "base64",
@@ -1587,7 +1587,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=6b7bd6e3577734cbe2a96684612cd2912adab4f3#6b7bd6e3577734cbe2a96684612cd2912adab4f3"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=283ca2aaff7bbdeb888b8483ad5866075d60015f#283ca2aaff7bbdeb888b8483ad5866075d60015f"
 
 [[package]]
 name = "nexus-vault"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=283ca2aaff7bbdeb888b8483ad5866075d60015f#283ca2aaff7bbdeb888b8483ad5866075d60015f"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=cc4c087886c36808c376fb39e198f980ffcb70e1#cc4c087886c36808c376fb39e198f980ffcb70e1"
 dependencies = [
  "ahash",
  "base64",
@@ -550,7 +550,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=283ca2aaff7bbdeb888b8483ad5866075d60015f#283ca2aaff7bbdeb888b8483ad5866075d60015f"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=cc4c087886c36808c376fb39e198f980ffcb70e1#cc4c087886c36808c376fb39e198f980ffcb70e1"
 dependencies = [
  "parking_lot",
  "serde",
@@ -1339,7 +1339,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=283ca2aaff7bbdeb888b8483ad5866075d60015f#283ca2aaff7bbdeb888b8483ad5866075d60015f"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=cc4c087886c36808c376fb39e198f980ffcb70e1#cc4c087886c36808c376fb39e198f980ffcb70e1"
 dependencies = [
  "ahash",
  "base64",
@@ -1396,7 +1396,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=283ca2aaff7bbdeb888b8483ad5866075d60015f#283ca2aaff7bbdeb888b8483ad5866075d60015f"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=cc4c087886c36808c376fb39e198f980ffcb70e1#cc4c087886c36808c376fb39e198f980ffcb70e1"
 dependencies = [
  "ahash",
  "base64",
@@ -1587,7 +1587,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=283ca2aaff7bbdeb888b8483ad5866075d60015f#283ca2aaff7bbdeb888b8483ad5866075d60015f"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=cc4c087886c36808c376fb39e198f980ffcb70e1#cc4c087886c36808c376fb39e198f980ffcb70e1"
 
 [[package]]
 name = "nexus-vault"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=243746d6fe0cc6c095a179226eaf6254f96c1ec8#243746d6fe0cc6c095a179226eaf6254f96c1ec8"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=6b7bd6e3577734cbe2a96684612cd2912adab4f3#6b7bd6e3577734cbe2a96684612cd2912adab4f3"
 dependencies = [
  "ahash",
  "base64",
@@ -550,7 +550,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=243746d6fe0cc6c095a179226eaf6254f96c1ec8#243746d6fe0cc6c095a179226eaf6254f96c1ec8"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=6b7bd6e3577734cbe2a96684612cd2912adab4f3#6b7bd6e3577734cbe2a96684612cd2912adab4f3"
 dependencies = [
  "parking_lot",
  "serde",
@@ -1339,7 +1339,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=243746d6fe0cc6c095a179226eaf6254f96c1ec8#243746d6fe0cc6c095a179226eaf6254f96c1ec8"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=6b7bd6e3577734cbe2a96684612cd2912adab4f3#6b7bd6e3577734cbe2a96684612cd2912adab4f3"
 dependencies = [
  "ahash",
  "base64",
@@ -1396,7 +1396,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=243746d6fe0cc6c095a179226eaf6254f96c1ec8#243746d6fe0cc6c095a179226eaf6254f96c1ec8"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=6b7bd6e3577734cbe2a96684612cd2912adab4f3#6b7bd6e3577734cbe2a96684612cd2912adab4f3"
 dependencies = [
  "ahash",
  "base64",
@@ -1587,7 +1587,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=243746d6fe0cc6c095a179226eaf6254f96c1ec8#243746d6fe0cc6c095a179226eaf6254f96c1ec8"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=6b7bd6e3577734cbe2a96684612cd2912adab4f3#6b7bd6e3577734cbe2a96684612cd2912adab4f3"
 
 [[package]]
 name = "nexus-vault"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,21 +30,21 @@ exclude = ["nexus-fuse"]
 [workspace.dependencies]
 # Kernel-tier crates from nexus-vfs (external git dependency).
 # SSOT: https://github.com/nexi-lab/nexus-vfs
-# Pinned at the nexus-vfs main commit that landed #58 (drop
-# `kernel-dogfood-v1.pub` into TRUSTED_KEY_FILES). Required so cluster
-# builds in CI verify plugins signed by the sealed-keystore root.
-# Builds on the Phase P (#57) plugin-as-gRPC-service routing: cluster
-# routes plugin-exposed gRPC services on the same port + trust root as
-# VFS via `nexus_plugin_grpc_services` + bytes-level dispatch through
-# `nexus_service_dispatch`. Bump alongside the rest of nexus-vfs
-# updates when a downstream change needs newer kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "243746d6fe0cc6c095a179226eaf6254f96c1ec8" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "243746d6fe0cc6c095a179226eaf6254f96c1ec8" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "243746d6fe0cc6c095a179226eaf6254f96c1ec8" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "243746d6fe0cc6c095a179226eaf6254f96c1ec8", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "243746d6fe0cc6c095a179226eaf6254f96c1ec8", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "243746d6fe0cc6c095a179226eaf6254f96c1ec8", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "243746d6fe0cc6c095a179226eaf6254f96c1ec8" }
+# Pinned at the nexus-vfs main commit that landed #61 (per-call
+# EC/SC routing in ZoneMetaStore + `nexusd-cluster join --as voter|learner`).
+# Required so federation E2E tests can exercise the new EC-default
+# sys_setattr write contract and the new operator CLI flag.
+# Builds on prior landmarks: #57 plugin-as-gRPC-service routing,
+# #58 sealed-keystore signing trust root, #60 KernelHandle v3
+# sys_stat_batch. Bump alongside the rest of nexus-vfs updates when a
+# downstream change needs newer kernel bits.
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "6b7bd6e3577734cbe2a96684612cd2912adab4f3" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "6b7bd6e3577734cbe2a96684612cd2912adab4f3" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "6b7bd6e3577734cbe2a96684612cd2912adab4f3" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "6b7bd6e3577734cbe2a96684612cd2912adab4f3", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "6b7bd6e3577734cbe2a96684612cd2912adab4f3", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "6b7bd6e3577734cbe2a96684612cd2912adab4f3", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "6b7bd6e3577734cbe2a96684612cd2912adab4f3" }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,24 +30,26 @@ exclude = ["nexus-fuse"]
 [workspace.dependencies]
 # Kernel-tier crates from nexus-vfs (external git dependency).
 # SSOT: https://github.com/nexi-lab/nexus-vfs
-# Pinned at the nexus-vfs main commit that landed #62 (operator-facing
-# flag rename — `nexusd-cluster join --as voter|learner` instead of
-# the clap-auto-derived `--as-role`). #62 is a one-line clap fix on
-# top of #61's per-call EC/SC routing in ZoneMetaStore.  Required so
-# the federation E2E helper's unconditional `--as <role>` arg parses
-# against the new binary instead of erroring `unexpected argument
-# '--as' found; tip: a similar argument exists: '--as-role'`.
+# Pinned at the nexus-vfs main commit that landed #63 (revert of the
+# kernel-hot-path EC activation #61 attempted — the EC drain has
+# correctness issues in 1V+1L topologies; kernel hot path stays SC
+# until the substrate is hardened).  Keeps #62's `--as voter|learner`
+# CLI surface + the per-call EC/SC primitives at the zone_handle layer
+# for callers that explicitly opt in.  See
+# docs/superpowers/specs/2026-06-23-federation-write-consistency-surface.md
+# for the full lineage.
 # Builds on prior landmarks: #57 plugin-as-gRPC-service routing,
 # #58 sealed-keystore signing trust root, #60 KernelHandle v3
-# sys_stat_batch, #61 per-call EC/SC routing. Bump alongside the rest
-# of nexus-vfs updates when a downstream change needs newer kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "283ca2aaff7bbdeb888b8483ad5866075d60015f" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "283ca2aaff7bbdeb888b8483ad5866075d60015f" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "283ca2aaff7bbdeb888b8483ad5866075d60015f" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "283ca2aaff7bbdeb888b8483ad5866075d60015f", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "283ca2aaff7bbdeb888b8483ad5866075d60015f", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "283ca2aaff7bbdeb888b8483ad5866075d60015f", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "283ca2aaff7bbdeb888b8483ad5866075d60015f" }
+# sys_stat_batch, #61 per-call EC/SC primitives, #62 CLI flag rename,
+# #63 EC hot-path activation revert. Bump alongside the rest of
+# nexus-vfs updates when a downstream change needs newer kernel bits.
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "cc4c087886c36808c376fb39e198f980ffcb70e1" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "cc4c087886c36808c376fb39e198f980ffcb70e1" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "cc4c087886c36808c376fb39e198f980ffcb70e1" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "cc4c087886c36808c376fb39e198f980ffcb70e1", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "cc4c087886c36808c376fb39e198f980ffcb70e1", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "cc4c087886c36808c376fb39e198f980ffcb70e1", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "cc4c087886c36808c376fb39e198f980ffcb70e1" }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,21 +30,24 @@ exclude = ["nexus-fuse"]
 [workspace.dependencies]
 # Kernel-tier crates from nexus-vfs (external git dependency).
 # SSOT: https://github.com/nexi-lab/nexus-vfs
-# Pinned at the nexus-vfs main commit that landed #61 (per-call
-# EC/SC routing in ZoneMetaStore + `nexusd-cluster join --as voter|learner`).
-# Required so federation E2E tests can exercise the new EC-default
-# sys_setattr write contract and the new operator CLI flag.
+# Pinned at the nexus-vfs main commit that landed #62 (operator-facing
+# flag rename — `nexusd-cluster join --as voter|learner` instead of
+# the clap-auto-derived `--as-role`). #62 is a one-line clap fix on
+# top of #61's per-call EC/SC routing in ZoneMetaStore.  Required so
+# the federation E2E helper's unconditional `--as <role>` arg parses
+# against the new binary instead of erroring `unexpected argument
+# '--as' found; tip: a similar argument exists: '--as-role'`.
 # Builds on prior landmarks: #57 plugin-as-gRPC-service routing,
 # #58 sealed-keystore signing trust root, #60 KernelHandle v3
-# sys_stat_batch. Bump alongside the rest of nexus-vfs updates when a
-# downstream change needs newer kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "6b7bd6e3577734cbe2a96684612cd2912adab4f3" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "6b7bd6e3577734cbe2a96684612cd2912adab4f3" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "6b7bd6e3577734cbe2a96684612cd2912adab4f3" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "6b7bd6e3577734cbe2a96684612cd2912adab4f3", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "6b7bd6e3577734cbe2a96684612cd2912adab4f3", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "6b7bd6e3577734cbe2a96684612cd2912adab4f3", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "6b7bd6e3577734cbe2a96684612cd2912adab4f3" }
+# sys_stat_batch, #61 per-call EC/SC routing. Bump alongside the rest
+# of nexus-vfs updates when a downstream change needs newer kernel bits.
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "283ca2aaff7bbdeb888b8483ad5866075d60015f" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "283ca2aaff7bbdeb888b8483ad5866075d60015f" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "283ca2aaff7bbdeb888b8483ad5866075d60015f" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "283ca2aaff7bbdeb888b8483ad5866075d60015f", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "283ca2aaff7bbdeb888b8483ad5866075d60015f", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "283ca2aaff7bbdeb888b8483ad5866075d60015f", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "283ca2aaff7bbdeb888b8483ad5866075d60015f" }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ENV CARGO_NET_RETRY=10 \
     CARGO_HTTP_TIMEOUT=120
 # Override for edge/CI or a different pin: --build-arg NEXUS_VFS_REV=<sha|tag>
-ARG NEXUS_VFS_REV=6b7bd6e3577734cbe2a96684612cd2912adab4f3
+ARG NEXUS_VFS_REV=283ca2aaff7bbdeb888b8483ad5866075d60015f
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,id=cargo-install-${TARGETARCH},target=/root/.cargo/target \

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ENV CARGO_NET_RETRY=10 \
     CARGO_HTTP_TIMEOUT=120
 # Override for edge/CI or a different pin: --build-arg NEXUS_VFS_REV=<sha|tag>
-ARG NEXUS_VFS_REV=243746d6fe0cc6c095a179226eaf6254f96c1ec8
+ARG NEXUS_VFS_REV=6b7bd6e3577734cbe2a96684612cd2912adab4f3
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,id=cargo-install-${TARGETARCH},target=/root/.cargo/target \

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ENV CARGO_NET_RETRY=10 \
     CARGO_HTTP_TIMEOUT=120
 # Override for edge/CI or a different pin: --build-arg NEXUS_VFS_REV=<sha|tag>
-ARG NEXUS_VFS_REV=283ca2aaff7bbdeb888b8483ad5866075d60015f
+ARG NEXUS_VFS_REV=cc4c087886c36808c376fb39e198f980ffcb70e1
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,id=cargo-install-${TARGETARCH},target=/root/.cargo/target \

--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir --no-deps --prefix=/install .
 # enforces agreement) — an unpinned install tracks nexus-vfs HEAD and
 # ships an untested kernel (#4343). --locked honors the source tree's
 # Cargo.lock.
-ARG NEXUS_VFS_REV=243746d6fe0cc6c095a179226eaf6254f96c1ec8
+ARG NEXUS_VFS_REV=6b7bd6e3577734cbe2a96684612cd2912adab4f3
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-cluster nexus-cluster
 
 # -- Runtime stage --

--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir --no-deps --prefix=/install .
 # enforces agreement) — an unpinned install tracks nexus-vfs HEAD and
 # ships an untested kernel (#4343). --locked honors the source tree's
 # Cargo.lock.
-ARG NEXUS_VFS_REV=283ca2aaff7bbdeb888b8483ad5866075d60015f
+ARG NEXUS_VFS_REV=cc4c087886c36808c376fb39e198f980ffcb70e1
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-cluster nexus-cluster
 
 # -- Runtime stage --

--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir --no-deps --prefix=/install .
 # enforces agreement) — an unpinned install tracks nexus-vfs HEAD and
 # ships an untested kernel (#4343). --locked honors the source tree's
 # Cargo.lock.
-ARG NEXUS_VFS_REV=6b7bd6e3577734cbe2a96684612cd2912adab4f3
+ARG NEXUS_VFS_REV=283ca2aaff7bbdeb888b8483ad5866075d60015f
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-cluster nexus-cluster
 
 # -- Runtime stage --

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -25,7 +25,7 @@ WORKDIR /build
 # (CI preflight enforces agreement) — an unpinned install tracks HEAD
 # and can skew the raft contract against the cluster/witness images.
 # --locked honors the source tree's Cargo.lock.
-ARG NEXUS_VFS_REV=6b7bd6e3577734cbe2a96684612cd2912adab4f3
+ARG NEXUS_VFS_REV=283ca2aaff7bbdeb888b8483ad5866075d60015f
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexus-raft-server raft
 
 # ---------- Production image ----------

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -25,7 +25,7 @@ WORKDIR /build
 # (CI preflight enforces agreement) — an unpinned install tracks HEAD
 # and can skew the raft contract against the cluster/witness images.
 # --locked honors the source tree's Cargo.lock.
-ARG NEXUS_VFS_REV=283ca2aaff7bbdeb888b8483ad5866075d60015f
+ARG NEXUS_VFS_REV=cc4c087886c36808c376fb39e198f980ffcb70e1
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexus-raft-server raft
 
 # ---------- Production image ----------

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -25,7 +25,7 @@ WORKDIR /build
 # (CI preflight enforces agreement) — an unpinned install tracks HEAD
 # and can skew the raft contract against the cluster/witness images.
 # --locked honors the source tree's Cargo.lock.
-ARG NEXUS_VFS_REV=243746d6fe0cc6c095a179226eaf6254f96c1ec8
+ARG NEXUS_VFS_REV=6b7bd6e3577734cbe2a96684612cd2912adab4f3
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexus-raft-server raft
 
 # ---------- Production image ----------

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=243746d6fe0cc6c095a179226eaf6254f96c1ec8
+ARG NEXUS_VFS_REV=6b7bd6e3577734cbe2a96684612cd2912adab4f3
 RUN cargo install \
     --locked \
     --git https://github.com/nexi-lab/nexus-vfs \

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=283ca2aaff7bbdeb888b8483ad5866075d60015f
+ARG NEXUS_VFS_REV=cc4c087886c36808c376fb39e198f980ffcb70e1
 RUN cargo install \
     --locked \
     --git https://github.com/nexi-lab/nexus-vfs \

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=6b7bd6e3577734cbe2a96684612cd2912adab4f3
+ARG NEXUS_VFS_REV=283ca2aaff7bbdeb888b8483ad5866075d60015f
 RUN cargo install \
     --locked \
     --git https://github.com/nexi-lab/nexus-vfs \

--- a/docs/architecture/federation-cross-machine-runbook.md
+++ b/docs/architecture/federation-cross-machine-runbook.md
@@ -250,13 +250,19 @@ target/release/nexusd-cluster join \
   /shared \
   --hostname <B_tailscale_ip> \
   --data-dir /tmp/nexus-fed-data \
-  --no-tls
+  --no-tls \
+  --as <learner|voter>
 ```
+
+`--as` picks the membership role on `sharedzone` (default `learner`):
+
+* **`--as learner`** — owner-pattern share.  Joiner gets full replication of `sharedzone` metadata + can write `sys_setattr` / `sys_unlink` metadata via the EC default path (see [Consistency model](#consistency-model) below), but doesn't count toward quorum.  Wipe-rejoin safe — losing or replacing a learner has zero quorum impact, so SSD swap / OS reinstall / device migration can't strand the zone in `not leader` deadlock.  Pick this when one side is the authoritative writer and the other side is mostly read-along (canonical `nexus share` semantics).
+* **`--as voter`** — symmetric-peer share.  Joiner counts toward quorum AND can write SC linearizable ops (locks, CAS).  EC-routed `sys_setattr` still works without quorum (so single-peer-online still lets that peer write metadata), but lock acquire / CAS need majority ACK.  Wipe-rejoin risk re-emerges if a voter goes through SSD swap without first transferring its voter slot away.  Pick this for the cc-tasks-share Mac↔Win pattern where both peers write to their own subpath under `/shared` and want equal authority.
 
 Expected last line:
 
 ```
-Joined remote zone 'sharedzone' (via http://<A_tailscale_ip>:2126); mounted at '/shared' inside zone 'root'
+Joined remote zone 'sharedzone' as <learner|voter> (via http://<A_tailscale_ip>:2126); mounted at '/shared' inside zone 'root'
 ```
 
 Each node's local root zone owns its DT_MOUNT routing entries.  `join` writes B's DT_MOUNT into B's local root.  A's local root has its own DT_MOUNT for `/shared` (from the `NEXUS_FEDERATION_MOUNTS` env at A's boot).  They do not need to agree on root-zone membership — the parent zone for each side's DT_MOUNT is *that side's* local root.  See [Key design decisions](#key-design-decisions) for the rationale.
@@ -385,6 +391,24 @@ Platform matrix:
 | Windows  | `WinFsp`             | First-cut.  `winfsp` crate, cfg-gated under `target_os = "windows"`; `NEXUS_FUSE_MOUNT_POINT` accepts a drive letter (`Z:`) or directory path. |
 
 The dylib is unsigned-rejected by `PluginLoader::load`; the release pipeline (`.github/workflows/release-fuse-plugin.yml`) signs every dylib it ships against the `kernel-dogfood-v1` key in the sealed in-repo keystore.  See `rust/services/fuse-plugin/README.md` for the operator install + admin RPC surface, and `docs/superpowers/specs/2026-06-13-sealed-keystore-dogfood-design.md` for the signing trust chain.
+
+### Consistency model
+
+The federation write surface routes per-call between EC and SC — same zone, two propose paths, picked at the call site:
+
+| Surface | Path | Cost | When used |
+|---------|------|------|-----------|
+| `sys_setattr` / `sys_unlink` (the kernel hot path; everything `vfs_write` and `vfs_unlink` drive) | EC — `ZoneConsensus::propose_ec_local` (WAL append + local apply, sync return; async raft replication catches peers up) | ~5–50 µs, no quorum needed | Default for every metadata mutation.  Any node — voter, learner, leader, follower — can write locally.  Read-your-writes preserved on the writer node.  cc-tasks-share Mac↔Win bidirectional write rides this. |
+| Lock acquire / release, CAS (`put_if_version`), stream WAL append, control-plane (mount install, ConfChange) | SC — `ZoneConsensus::propose` through raft consensus | ~5–10 ms intra-DC + majority ACK | Operations that need linearizability EC can't provide.  Non-leader callers either forward to the leader or surface `NotLeader`. |
+
+Practical consequence for the §3b `--as` choice:
+
+* The EC default means **a `--as learner` joiner can write `sys_setattr` metadata** — there's no "join as learner means read-only" rule.  The metadata write commits locally; raft replication ships it to peers when they come back online.
+* The `--as voter` choice changes quorum participation for SC writes, **not** sys_setattr write capability.  Pick voter when the workflow needs locks / CAS / stream appends to commit despite a peer being offline (and you have ≥majority voters online).  Pick learner when you want wipe-rejoin safety and don't need SC ops.
+
+Conflict resolution for the EC path is last-writer-wins on `modified_at_ms`.  The cc-tasks-share workflow has no contention because each peer writes its own subpath (`/shared/cc-tasks/<host>/...`); workflows where two peers write the same path concurrently need to design around LWW.
+
+See `nexus-vfs` `docs/federation-architecture.md` §4.1 + §5 for the in-kernel architecture, and `docs/superpowers/specs/2026-06-23-federation-write-consistency-surface.md` for the design decision capture.
 
 ### Step 4 — Smoke (cross-machine byte-exact read)
 

--- a/docs/architecture/federation-cross-machine-runbook.md
+++ b/docs/architecture/federation-cross-machine-runbook.md
@@ -256,8 +256,8 @@ target/release/nexusd-cluster join \
 
 `--as` picks the membership role on `sharedzone` (default `learner`):
 
-* **`--as learner`** — owner-pattern share.  Joiner gets full replication of `sharedzone` metadata + can write `sys_setattr` / `sys_unlink` metadata via the EC default path (see [Consistency model](#consistency-model) below), but doesn't count toward quorum.  Wipe-rejoin safe — losing or replacing a learner has zero quorum impact, so SSD swap / OS reinstall / device migration can't strand the zone in `not leader` deadlock.  Pick this when one side is the authoritative writer and the other side is mostly read-along (canonical `nexus share` semantics).
-* **`--as voter`** — symmetric-peer share.  Joiner counts toward quorum AND can write SC linearizable ops (locks, CAS).  EC-routed `sys_setattr` still works without quorum (so single-peer-online still lets that peer write metadata), but lock acquire / CAS need majority ACK.  Wipe-rejoin risk re-emerges if a voter goes through SSD swap without first transferring its voter slot away.  Pick this for the cc-tasks-share Mac↔Win pattern where both peers write to their own subpath under `/shared` and want equal authority.
+* **`--as learner`** — owner-pattern share.  Joiner gets full replication of `sharedzone` metadata but cannot propose writes (every `vfs_write` on a learner surfaces `NotLeader` today; see [Consistency model](#consistency-model) below).  Doesn't count toward quorum.  Wipe-rejoin safe — losing or replacing a learner has zero quorum impact, so SSD swap / OS reinstall / device migration can't strand the zone in `not leader` deadlock.  Pick this when one side is the authoritative writer and the other side is read-along (canonical `nexus share` semantics).
+* **`--as voter`** — symmetric-peer share.  Joiner counts toward quorum AND can propose SC writes through raft consensus (the joiner forwards proposals to whichever voter currently holds leadership).  Pick this for the cc-tasks-share Mac↔Win pattern where both peers write to their own subpath under `/shared` and want equal write authority.  Caveat: 2-voter setups need both peers online to commit any write — if either drops, the other can't make progress until it returns.  Wipe-rejoin risk re-emerges if a voter goes through SSD swap without first transferring its voter slot away.
 
 Expected last line:
 
@@ -394,21 +394,26 @@ The dylib is unsigned-rejected by `PluginLoader::load`; the release pipeline (`.
 
 ### Consistency model
 
-The federation write surface routes per-call between EC and SC — same zone, two propose paths, picked at the call site:
+The federation write surface exposes two consistency tiers; today the kernel hot path uses SC and the EC tier is an opt-in for callers that need it:
 
 | Surface | Path | Cost | When used |
 |---------|------|------|-----------|
-| `sys_setattr` / `sys_unlink` (the kernel hot path; everything `vfs_write` and `vfs_unlink` drive) | EC — `ZoneConsensus::propose_ec_local` (WAL append + local apply, sync return; async raft replication catches peers up) | ~5–50 µs, no quorum needed | Default for every metadata mutation.  Any node — voter, learner, leader, follower — can write locally.  Read-your-writes preserved on the writer node.  cc-tasks-share Mac↔Win bidirectional write rides this. |
-| Lock acquire / release, CAS (`put_if_version`), stream WAL append, control-plane (mount install, ConfChange) | SC — `ZoneConsensus::propose` through raft consensus | ~5–10 ms intra-DC + majority ACK | Operations that need linearizability EC can't provide.  Non-leader callers either forward to the leader or surface `NotLeader`. |
+| `sys_setattr` / `sys_unlink` (the kernel hot path; everything `vfs_write` and `vfs_unlink` drive) | SC — `ZoneConsensus::propose` through raft consensus | ~5–10 ms intra-DC + majority ACK | Default for every metadata mutation.  Non-leader callers either forward to the leader or surface `NotLeader`. |
+| Lock acquire / release, CAS (`put_if_version`), stream WAL append, control-plane (mount install, ConfChange) | SC — `ZoneConsensus::propose` through raft consensus | Same as above | Operations that need linearizability. |
+| Caller-driven EC opt-in via `zone_handle::set_metadata(.., Consistency::Ec)` | EC — `ZoneConsensus::propose_ec_local` (WAL append + local apply, sync return; async raft replication) | ~5–50 µs, no quorum needed | Niche callers that can tolerate async cross-node visibility and want WAL-first persistence without raft consensus.  Not wired into the kernel hot path today — see [EC kernel-hot-path activation deferred](#ec-kernel-hot-path-activation-deferred) below. |
 
 Practical consequence for the §3b `--as` choice:
 
-* The EC default means **a `--as learner` joiner can write `sys_setattr` metadata** — there's no "join as learner means read-only" rule.  The metadata write commits locally; raft replication ships it to peers when they come back online.
-* The `--as voter` choice changes quorum participation for SC writes, **not** sys_setattr write capability.  Pick voter when the workflow needs locks / CAS / stream appends to commit despite a peer being offline (and you have ≥majority voters online).  Pick learner when you want wipe-rejoin safety and don't need SC ops.
+* `--as learner` joiners can read everything raft replicates to them but can't write — every `vfs_write` surfaces `NotLeader`.  Wipe-rejoin safe (zero quorum impact).
+* `--as voter` joiners can propose SC writes through raft consensus (the joiner forwards to whoever holds leadership).  2-voter setups need both peers online for any write to commit; pick this only when both peers are reliably online together.
 
-Conflict resolution for the EC path is last-writer-wins on `modified_at_ms`.  The cc-tasks-share workflow has no contention because each peer writes its own subpath (`/shared/cc-tasks/<host>/...`); workflows where two peers write the same path concurrently need to design around LWW.
+Conflict resolution at the SC tier is raft consensus — strictly serialized.  The cc-tasks-share path-of-least-resistance for the Mac↔Win bidirectional pattern is `--as voter` on both peers; both can propose, raft serializes, no contention because each peer owns its own subpath (`/shared/cc-tasks/<host>/...`).
 
-See `nexus-vfs` `docs/federation-architecture.md` §4.1 + §5 for the in-kernel architecture, and `docs/superpowers/specs/2026-06-23-federation-write-consistency-surface.md` for the design decision capture.
+#### EC kernel-hot-path activation deferred
+
+nexi-lab/nexus-vfs PR #61 attempted to route the kernel hot path through `propose_ec_local` so a `--as learner` joiner could still write metadata.  The activation exposed correctness / liveness issues in `transport_loop.rs::replicate_ec_entries` that only surface in 1-voter + 1-learner topologies (per-peer exponential backoff accumulates, founder→learner writes stop reaching the learner's local state machine within typical wait-budgets).  PR #63 reverted the activation; the EC primitive remains first-class at the `zone_handle.rs::set_metadata` API for callers that explicitly opt in, but the kernel hot path stays on SC until the EC drain is hardened (substrate follow-up).
+
+See `nexus-vfs` `docs/federation-architecture.md` §4.1 for the in-kernel architecture, and `docs/superpowers/specs/2026-06-23-federation-write-consistency-surface.md` for the design decision capture (including why the activation was deferred and what would need to land for the next attempt).
 
 ### Step 4 — Smoke (cross-machine byte-exact read)
 

--- a/docs/superpowers/specs/2026-06-23-federation-write-consistency-surface.md
+++ b/docs/superpowers/specs/2026-06-23-federation-write-consistency-surface.md
@@ -1,105 +1,80 @@
 # Federation Write Consistency Surface
 
 **Status:** Active (2026-06-23).  Lands in:
-- nexi-lab/nexus-vfs PR #61 (the runtime change + raft-level code + federation-architecture doc)
+- nexi-lab/nexus-vfs PR #61 (per-call EC/SC primitive + initial activation) **+ PR #63 (activation reverted, primitive kept)**
+- nexi-lab/nexus-vfs PR #62 (operator CLI flag rename — `--as`, not `--as-role`)
 - nexi-lab/nexus PR (this repo): runbook + E2E coverage + this spec
 
-**Scope:** How sys_setattr / sys_unlink metadata writes route between
-EC (eventually consistent, no quorum) and SC (strongly consistent, raft
-consensus) on the federation surface.  Captures the architectural
-decision behind the PR pair and the operator-facing CLI change
-(`nexusd-cluster join --as voter|learner`).
+**Scope:** Documents the federation write surface's EC/SC consistency split, the operator-facing `nexusd-cluster join --as voter|learner` flag, and why the kernel hot path stays SC today (with a path to EC once a substrate follow-up lands).
 
 ---
 
 ## TL;DR
 
-* `ZoneMetaStore::put` / `delete` (the kernel `sys_setattr` /
-  `sys_unlink` hot path) routes through `ZoneConsensus::propose_ec_local`
-  — WAL-first append, synchronous local state-machine apply, async raft
-  replication.  Any node — voter, learner, leader, follower — can write
-  metadata locally without quorum.
-* `put_if_version` (CAS), `append_stream_entry` (WAL), `DistributedLocks`
-  keep `ZoneConsensus::propose` (SC) because they need linearizability EC
-  can't provide.
-* `nexusd-cluster join` grows `--as voter|learner` (default `learner`
-  for backward compat).  The role choice now governs SC quorum
-  participation + wipe-rejoin safety, **not** sys_setattr write
-  capability — both roles can write EC.
+* The federation raft layer exposes two propose paths per zone:
+  * `ZoneConsensus::propose` (SC, raft consensus, majority ACK).
+  * `ZoneConsensus::propose_ec_local` (EC, WAL-first + sync local apply, async replicate to peers).
+* `zone_handle::set_metadata` / `delete_metadata` carry a `Consistency: Sc | Ec` parameter; callers pick per call.
+* The kernel hot path — `ZoneMetaStore::put` / `delete`, which `sys_setattr` / `sys_unlink` drive — **routes through SC today**.  The PR #61 attempt to route it through EC was reverted in PR #63 (see *Why the EC kernel-hot-path activation was deferred* below).
+* `nexusd-cluster join` carries `--as voter|learner` (default `learner` for backward compat).  Operators pick `voter` for symmetric peer workflows (cc-tasks-share Mac↔Win), `learner` for the owner-pattern share-with-readers shape.
 
 ---
 
 ## Why now
 
-The 2026-06-22 Mac↔Win cross-machine smoke (Federation L1 byte-exact
-read over Tailscale) was the first time the bidirectional symmetric
-peer pattern hit the federation surface end-to-end.  The runbook §3b
-join flow was building Mac as a Learner per the canonical
-share-with-readers shape, and `vfs_write` from Mac surfaced `not
-leader, peers=0` — `ZoneMetaStore::put` hardcoded SC propose which
-needs a leader.
+The 2026-06-22 Mac↔Win cross-machine smoke (Federation L1 byte-exact read over Tailscale) was the first time the bidirectional symmetric peer pattern hit the federation surface end-to-end.  The runbook §3b join flow was building Mac as a Learner per the canonical share-with-readers shape, and `vfs_write` from Mac surfaced `not leader, peers=0` — `ZoneMetaStore::put` hardcoded SC propose which needs a leader.
 
 The user's framing for the fix:
 
 > 两边都是 voter 的代价是，必须都在线才能写，否则不能写吗？为什么？我理解写的时候改为 EC 不就行了吗？我认为我们当前的设计是支持 per-write level EC/SC decision 的。
 
-Confirmed: the architecture had `Consistency::Ec | Sc` as a per-call
-parameter on `zone_handle.rs::set_metadata` / `delete_metadata` since
-the EC WAL landed.  `ZoneMetaStore` was the only caller still
-hardcoding SC.  The fix is changing the call site, not adding new
-plumbing — that's why this lands as a one-PR-per-repo pair rather
-than a multi-phase architecture migration.
+Confirmed: the architecture had `Consistency::Ec | Sc` as a per-call parameter on `zone_handle.rs::set_metadata` / `delete_metadata` since the EC WAL landed.  `ZoneMetaStore` was the only caller still hardcoding SC.  PR #61 attempted to flip ZoneMetaStore to EC.  The activation broke the federation E2E suite (see deferral section below); PR #63 reverted the activation while keeping the operator-facing CLI work.
 
 ---
 
 ## The two propose paths
 
-| Path | Latency | Quorum | RYW | Use |
-|------|---------|--------|-----|-----|
-| `propose_ec_local` (EC) | ~5–50 µs (local redb + WAL) | None — every node writes locally | Preserved on the writer node (local apply synchronous) | sys_setattr / sys_unlink (the kernel hot path) |
-| `propose` (SC) | ~5–10 ms intra-DC (raft round-trip + majority ACK) | Required | Linearizable across all peers | Locks, CAS, WAL stream appends, control-plane (mount install / ConfChange) |
+| Path | Latency | Quorum | RYW | Use today |
+|------|---------|--------|-----|-----------|
+| `propose_ec_local` (EC) | ~5–50 µs (local redb + WAL) | None — every node writes locally | Preserved on the writer node (local apply synchronous) | Caller opt-in via `zone_handle::set_metadata(.., Consistency::Ec)` — niche callers that can tolerate async cross-node visibility |
+| `propose` (SC) | ~5–10 ms intra-DC (raft round-trip + majority ACK) | Required | Linearizable across all peers | Default for every metadata mutation (kernel hot path); also locks, CAS, WAL stream appends, control-plane (mount install / ConfChange) |
 
-The split is per-call, not per-zone.  Same `ZoneMetaStore` instance
-exposes both surfaces depending on which trait method the caller
-invokes.
-
-EC conflict resolution: last-writer-wins on `modified_at_ms`.  Safe
-for workflows where each peer owns its own subpath (cc-tasks-share:
-`/shared/cc-tasks/<host>/...`); explicit-conflict workflows need to
-design around LWW (write a lock first via SC if mutex semantics
-matter).
+The split is per-call, not per-zone.  Same `ZoneMetaStore` instance exposes both surfaces — the kernel hot path goes SC, opt-in callers can reach EC.
 
 ---
 
-## Failure modes the change closes
+## Why the EC kernel-hot-path activation was deferred
 
-| Pre-#61 symptom | Root cause | Post-#61 fix |
-|-----------------|-----------|--------------|
-| Joiner `vfs_write` returns `NotLeader` when joiner is a Learner | `ZoneMetaStore::put` → `propose` (SC) → Learner can't propose | `put` → `propose_ec_local` → Learner commits locally |
-| 2-voter cluster with one peer offline can't write anything (quorum loss) | All writes routed SC | sys_setattr writes route EC → single-peer-online keeps writing; only SC ops (locks, CAS) block on quorum |
-| Operator confusion: "I joined and it says learner — can I write?" | `as_learner=true` was wired into `run_join` as a fixed contract | `--as voter|learner` operator surface, both roles can write EC |
+PR #61 routed `ZoneMetaStore::put` / `delete` through `propose_ec_local`.  Federation E2E on the companion nexus PR caught a regression: `test_joiner_cli_join_then_byte_exact_read_binary_chunked` + `test_joiner_stat_after_read_caches_origin_locally` both timed out at `wait_nodes_caught_up` (these tests were green on develop pre-#61).
+
+Diagnosis: the EC drain (`transport_loop.rs::replicate_ec_entries`) has correctness / liveness issues that only surface in 1-voter + 1-learner topologies.  After a larger founder-side sys_setattr write, subsequent founder→learner writes stop reaching the learner's local state machine — per-peer exponential backoff (base 100 ms, cap 60 s) accumulates without recovery, so subsequent writes never get drained within typical wait-budgets.
+
+Per the raft contract principle ("如果涉及raft请100%满足raft的使用契约，否则会出别的bug"), we don't activate a substrate path with open correctness issues.  PR #63 reverted `ZoneMetaStore::put` / `delete` to SC.
+
+What needs to land before re-attempting the activation:
+
+* Diagnose the per-peer backoff accumulation in `replicate_ec_entries` and either bound it or add a recovery path (the issue isn't that backoff exists — it's that it doesn't recover when peers ARE reachable).
+* Confirm deterministic founder→learner delivery for both small and large sys_setattr payloads in a 1V+1L topology.
+* Stand up a regression test that pins "joiner reads founder's EC write within Xs" specifically — not just a generic raft catch-up.
+
+Tracking: file a nexi-lab/nexus-vfs issue for the EC drain hardening before reopening the activation conversation.
 
 ---
 
-## Failure modes the change deliberately does **not** close
+## Failure modes the current shape DOES close
 
-* **Two peers writing the same path concurrently → LWW** — by design.
-  EC is the right model for the kernel hot path; callers that need
-  mutex semantics must use SC locks (`DistributedLocks`).  The
-  cc-tasks-share workflow has zero contention because each peer owns
-  its subpath.
-* **Wipe-rejoin of a voter** — voter joiners re-introduce the
-  pre-PR #57 hazard if they go through SSD swap without first
-  transferring their voter slot away.  Mitigated by the documentation
-  (the `--as voter` runbook callout names this) but not eliminated —
-  use `--as learner` whenever wipe-rejoin safety matters more than
-  symmetric SC writes.
-* **`propose_ec_local` requires `ReplicationLog`** — initialized on
-  every node that joins via the standard flows (founder bootstrap,
-  `nexusd-cluster join`, `share`).  A node manually constructed
-  without a ReplicationLog will return `RaftError::InvalidState("EC
-  local writes require a ReplicationLog")` from `put` — not a
-  silent failure.
+| Symptom | Root cause | Mitigation |
+|---------|-----------|------------|
+| Operator joins without specifying role, can't tell what they got | `as_learner=true` was hardcoded in `run_join`; no operator visibility | `nexusd-cluster join --as voter|learner` makes the choice explicit; success line includes the role |
+| Operator surface flag clap-derived to wrong name | `#[arg(long, ...)]` on field `as_role` derived `--as-role`; runbook + docs all said `--as` | `#[arg(long = "as", ...)]` override; regression unit test in `nexus-vfs/rust/profiles/cluster/src/main.rs` pins both `--as voter` and `--as learner` parse |
+
+---
+
+## Failure modes the current shape does **NOT** close
+
+* **Learner cannot propose SC writes** — every `vfs_write` on a learner surfaces `NotLeader`.  Mitigation: pick `--as voter` for workflows that need symmetric write authority.  Long-term: see the EC kernel-hot-path activation deferral above.
+* **2-voter cluster needs both peers online for any write** — raft majority quorum.  Mitigation: accept the constraint for cc-tasks-share-style symmetric peer workflows (both peers are typically online together), or add a witness for HA (3-voter setup).
+* **Wipe-rejoin of a voter** — voter joiners re-introduce the pre-PR #57 hazard if they go through SSD swap without first transferring their voter slot away.  Mitigation: documented (the `--as voter` runbook callout names this); operator must remove + re-add the voter manually.
 
 ---
 
@@ -107,45 +82,27 @@ matter).
 
 | Workload | `--as` | Why |
 |----------|--------|-----|
-| Single authoritative writer publishing to many mirror peers (canonical `nexus share` semantics) | `learner` (default) | Wipe-rejoin safe; learner can still write `sys_setattr` metadata locally if it needs to |
-| Symmetric 2-peer share, each writes its own subpath (cc-tasks-share Mac↔Win) | `voter` | Equal quorum authority for SC writes; EC-routed sys_setattr keeps working when one peer offline |
+| Single authoritative writer publishing to many mirror peers (canonical `nexus share` semantics) | `learner` (default) | Wipe-rejoin safe; readers don't affect the owner's quorum |
+| Symmetric 2-peer share, each writes its own subpath (cc-tasks-share Mac↔Win) | `voter` | Equal SC write authority via raft consensus; both peers can propose writes (raft serializes), no contention since each owns its own subpath |
 | Root cluster bootstrap (≥3 voters + optional witness) | `voter` (used by founder + every joiner) | Quorum essential; single-node loss must not lose quorum |
 
 ---
 
 ## Test coverage
 
-* `nexus-vfs` `rust/raft/src/zone_meta_store.rs` →
-  `put_and_delete_succeed_without_leader` — regression unit test that
-  pins the EC contract: put + delete must succeed on a node that
-  intentionally skips `node.campaign().await`.
-* `nexus` `tests/e2e/docker/test_federation_runbook.py` →
-  `TestFederationWriteConsistencyContract` —
-    - `test_learner_joiner_writes_via_ec_when_founder_offline`:
-      stops founder, joiner writes via gRPC, founder comes back,
-      reads byte-exact.
-    - `test_join_as_voter_flag_round_trips_through_cli`: cheap
-      regression sentinel on the new `--as` CLI flag.
+* `nexus-vfs` `rust/profiles/cluster/src/main.rs` → `join_cli_accepts_as_voter_and_as_learner_flags` — unit-level pin that `Args::try_parse_from` accepts `--as voter` / `--as learner` and defaults to learner.  Cheap regression sentinel for clap signature drift.
+* `nexus` `tests/e2e/docker/test_federation_runbook.py` → `TestFederationWriteConsistencyContract.test_join_as_voter_flag_round_trips_through_cli` — Docker-level CLI smoke that `nexusd-cluster join --help` keeps mentioning `--as` plus both role enum values.
+
+When the EC kernel-hot-path activation is reattempted, the originally-planned `test_learner_joiner_writes_via_ec_when_founder_offline` should be reintroduced: stop founder, joiner writes via gRPC, joiner reads its own write (RYW), founder comes back, async replication catches up, founder reads byte-exact.
 
 ---
 
 ## Lineage / pointers
 
-* nexus-vfs PR #57 (2026-06-XX) — landed Learner-default-on-join to
-  fix the F5 wipe-rejoin quorum stall.  This spec extends the model:
-  Learner is still the safe-by-default role for owner-pattern shares;
-  Voter is a per-zone operator opt-in via `--as voter`.  Per-call EC
-  routing makes the role choice about quorum participation + wipe-
-  rejoin safety, not about who can write metadata.
-* nexus-vfs `propose_ec_local` (rust/raft/src/raft/node.rs) — the EC
-  write primitive this spec activates on the kernel hot path.  Was
-  already first-class but only the `zone_handle::set_metadata` /
-  `delete_metadata` API surfaced it; `ZoneMetaStore` was the missing
-  caller.
-* Companion runbook section: `docs/architecture/federation-cross-machine-runbook.md`
-  "Consistency model" (between §3g and §4).
-* Manual smoke that motivated the change: 2026-06-22 Mac↔Win
-  Federation L1 over Tailscale.  Substrate proven both directions
-  byte-exact before this change; this change closes the
-  bidirectional-write gap so the same substrate works for
-  cc-tasks-share's symmetric peer pattern.
+* nexus-vfs PR #57 — landed Learner-default-on-join to fix the F5 wipe-rejoin quorum stall.
+* nexus-vfs PR #61 — added per-call EC routing primitives + attempted kernel hot path activation.  Activation reverted in PR #63 after federation E2E caught the drain bug; primitives kept.
+* nexus-vfs PR #62 — operator CLI flag rename (`--as`, not `--as-role`).
+* nexus-vfs PR #63 — kernel hot path activation revert + doc / regression-test sync.
+* nexus-vfs `propose_ec_local` (rust/raft/src/raft/node.rs) — the EC write primitive ZoneMetaStore would route to once the EC drain is hardened.
+* Companion runbook section: `docs/architecture/federation-cross-machine-runbook.md` "Consistency model" (between §3g and §4).
+* Manual smoke that motivated the change: 2026-06-22 Mac↔Win Federation L1 over Tailscale.  Substrate proven both directions byte-exact via SC; the bidirectional-write gap for `--as learner` joiners is documented but currently the operator workaround is `--as voter`.

--- a/docs/superpowers/specs/2026-06-23-federation-write-consistency-surface.md
+++ b/docs/superpowers/specs/2026-06-23-federation-write-consistency-surface.md
@@ -1,0 +1,151 @@
+# Federation Write Consistency Surface
+
+**Status:** Active (2026-06-23).  Lands in:
+- nexi-lab/nexus-vfs PR #61 (the runtime change + raft-level code + federation-architecture doc)
+- nexi-lab/nexus PR (this repo): runbook + E2E coverage + this spec
+
+**Scope:** How sys_setattr / sys_unlink metadata writes route between
+EC (eventually consistent, no quorum) and SC (strongly consistent, raft
+consensus) on the federation surface.  Captures the architectural
+decision behind the PR pair and the operator-facing CLI change
+(`nexusd-cluster join --as voter|learner`).
+
+---
+
+## TL;DR
+
+* `ZoneMetaStore::put` / `delete` (the kernel `sys_setattr` /
+  `sys_unlink` hot path) routes through `ZoneConsensus::propose_ec_local`
+  — WAL-first append, synchronous local state-machine apply, async raft
+  replication.  Any node — voter, learner, leader, follower — can write
+  metadata locally without quorum.
+* `put_if_version` (CAS), `append_stream_entry` (WAL), `DistributedLocks`
+  keep `ZoneConsensus::propose` (SC) because they need linearizability EC
+  can't provide.
+* `nexusd-cluster join` grows `--as voter|learner` (default `learner`
+  for backward compat).  The role choice now governs SC quorum
+  participation + wipe-rejoin safety, **not** sys_setattr write
+  capability — both roles can write EC.
+
+---
+
+## Why now
+
+The 2026-06-22 Mac↔Win cross-machine smoke (Federation L1 byte-exact
+read over Tailscale) was the first time the bidirectional symmetric
+peer pattern hit the federation surface end-to-end.  The runbook §3b
+join flow was building Mac as a Learner per the canonical
+share-with-readers shape, and `vfs_write` from Mac surfaced `not
+leader, peers=0` — `ZoneMetaStore::put` hardcoded SC propose which
+needs a leader.
+
+The user's framing for the fix:
+
+> 两边都是 voter 的代价是，必须都在线才能写，否则不能写吗？为什么？我理解写的时候改为 EC 不就行了吗？我认为我们当前的设计是支持 per-write level EC/SC decision 的。
+
+Confirmed: the architecture had `Consistency::Ec | Sc` as a per-call
+parameter on `zone_handle.rs::set_metadata` / `delete_metadata` since
+the EC WAL landed.  `ZoneMetaStore` was the only caller still
+hardcoding SC.  The fix is changing the call site, not adding new
+plumbing — that's why this lands as a one-PR-per-repo pair rather
+than a multi-phase architecture migration.
+
+---
+
+## The two propose paths
+
+| Path | Latency | Quorum | RYW | Use |
+|------|---------|--------|-----|-----|
+| `propose_ec_local` (EC) | ~5–50 µs (local redb + WAL) | None — every node writes locally | Preserved on the writer node (local apply synchronous) | sys_setattr / sys_unlink (the kernel hot path) |
+| `propose` (SC) | ~5–10 ms intra-DC (raft round-trip + majority ACK) | Required | Linearizable across all peers | Locks, CAS, WAL stream appends, control-plane (mount install / ConfChange) |
+
+The split is per-call, not per-zone.  Same `ZoneMetaStore` instance
+exposes both surfaces depending on which trait method the caller
+invokes.
+
+EC conflict resolution: last-writer-wins on `modified_at_ms`.  Safe
+for workflows where each peer owns its own subpath (cc-tasks-share:
+`/shared/cc-tasks/<host>/...`); explicit-conflict workflows need to
+design around LWW (write a lock first via SC if mutex semantics
+matter).
+
+---
+
+## Failure modes the change closes
+
+| Pre-#61 symptom | Root cause | Post-#61 fix |
+|-----------------|-----------|--------------|
+| Joiner `vfs_write` returns `NotLeader` when joiner is a Learner | `ZoneMetaStore::put` → `propose` (SC) → Learner can't propose | `put` → `propose_ec_local` → Learner commits locally |
+| 2-voter cluster with one peer offline can't write anything (quorum loss) | All writes routed SC | sys_setattr writes route EC → single-peer-online keeps writing; only SC ops (locks, CAS) block on quorum |
+| Operator confusion: "I joined and it says learner — can I write?" | `as_learner=true` was wired into `run_join` as a fixed contract | `--as voter|learner` operator surface, both roles can write EC |
+
+---
+
+## Failure modes the change deliberately does **not** close
+
+* **Two peers writing the same path concurrently → LWW** — by design.
+  EC is the right model for the kernel hot path; callers that need
+  mutex semantics must use SC locks (`DistributedLocks`).  The
+  cc-tasks-share workflow has zero contention because each peer owns
+  its subpath.
+* **Wipe-rejoin of a voter** — voter joiners re-introduce the
+  pre-PR #57 hazard if they go through SSD swap without first
+  transferring their voter slot away.  Mitigated by the documentation
+  (the `--as voter` runbook callout names this) but not eliminated —
+  use `--as learner` whenever wipe-rejoin safety matters more than
+  symmetric SC writes.
+* **`propose_ec_local` requires `ReplicationLog`** — initialized on
+  every node that joins via the standard flows (founder bootstrap,
+  `nexusd-cluster join`, `share`).  A node manually constructed
+  without a ReplicationLog will return `RaftError::InvalidState("EC
+  local writes require a ReplicationLog")` from `put` — not a
+  silent failure.
+
+---
+
+## Operator decision matrix (mirrors runbook §3b)
+
+| Workload | `--as` | Why |
+|----------|--------|-----|
+| Single authoritative writer publishing to many mirror peers (canonical `nexus share` semantics) | `learner` (default) | Wipe-rejoin safe; learner can still write `sys_setattr` metadata locally if it needs to |
+| Symmetric 2-peer share, each writes its own subpath (cc-tasks-share Mac↔Win) | `voter` | Equal quorum authority for SC writes; EC-routed sys_setattr keeps working when one peer offline |
+| Root cluster bootstrap (≥3 voters + optional witness) | `voter` (used by founder + every joiner) | Quorum essential; single-node loss must not lose quorum |
+
+---
+
+## Test coverage
+
+* `nexus-vfs` `rust/raft/src/zone_meta_store.rs` →
+  `put_and_delete_succeed_without_leader` — regression unit test that
+  pins the EC contract: put + delete must succeed on a node that
+  intentionally skips `node.campaign().await`.
+* `nexus` `tests/e2e/docker/test_federation_runbook.py` →
+  `TestFederationWriteConsistencyContract` —
+    - `test_learner_joiner_writes_via_ec_when_founder_offline`:
+      stops founder, joiner writes via gRPC, founder comes back,
+      reads byte-exact.
+    - `test_join_as_voter_flag_round_trips_through_cli`: cheap
+      regression sentinel on the new `--as` CLI flag.
+
+---
+
+## Lineage / pointers
+
+* nexus-vfs PR #57 (2026-06-XX) — landed Learner-default-on-join to
+  fix the F5 wipe-rejoin quorum stall.  This spec extends the model:
+  Learner is still the safe-by-default role for owner-pattern shares;
+  Voter is a per-zone operator opt-in via `--as voter`.  Per-call EC
+  routing makes the role choice about quorum participation + wipe-
+  rejoin safety, not about who can write metadata.
+* nexus-vfs `propose_ec_local` (rust/raft/src/raft/node.rs) — the EC
+  write primitive this spec activates on the kernel hot path.  Was
+  already first-class but only the `zone_handle::set_metadata` /
+  `delete_metadata` API surfaced it; `ZoneMetaStore` was the missing
+  caller.
+* Companion runbook section: `docs/architecture/federation-cross-machine-runbook.md`
+  "Consistency model" (between §3g and §4).
+* Manual smoke that motivated the change: 2026-06-22 Mac↔Win
+  Federation L1 over Tailscale.  Substrate proven both directions
+  byte-exact before this change; this change closes the
+  bidirectional-write gap so the same substrate works for
+  cc-tasks-share's symmetric peer pattern.

--- a/tests/e2e/docker/runbook_helpers.py
+++ b/tests/e2e/docker/runbook_helpers.py
@@ -684,6 +684,7 @@ def run_nexusd_cluster_join(
     network: str | None = None,
     data_dir: str = "/app/data",
     timeout: float = 120,
+    as_role: str = "learner",
 ) -> subprocess.CompletedProcess:
     """Run runbook §3b's offline `nexusd-cluster join` in a transient sidecar.
 
@@ -701,6 +702,15 @@ def run_nexusd_cluster_join(
       3. `docker_start(target_container)` — daemon comes back up,
          entrypoint auto-detects bootstrap-mode=restart from on-disk
          state and replays DT_MOUNT via apply-cb (runbook §3c).
+
+    ``as_role`` is the operator-chosen membership role passed to
+    ``nexusd-cluster join --as <role>`` (nexus-vfs PR #61).  Default
+    is ``"learner"`` to match the daemon CLI default — preserves
+    pre-#61 wire behaviour for tests that don't care about the
+    distinction.  Pass ``"voter"`` to exercise the symmetric-peer
+    cc-tasks-share path where the joiner counts toward quorum + can
+    write SC linearizable ops as well as the default EC sys_setattr
+    path.
 
     Returns the CompletedProcess so callers can assert on rc /
     stdout / stderr (see test_joiner_zero_mount_not_leader_in_join_cli_log).
@@ -731,6 +741,8 @@ def run_nexusd_cluster_join(
         "--no-tls",
         "--hostname",
         hostname,
+        "--as",
+        as_role,
     ]
     return subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
 

--- a/tests/e2e/docker/test_federation_runbook.py
+++ b/tests/e2e/docker/test_federation_runbook.py
@@ -1047,136 +1047,22 @@ class TestRunbookOperatorErgonomics:
 class TestFederationWriteConsistencyContract:
     """Lock down the post-nexus-vfs-#61 per-call EC/SC write contract.
 
-    The nexus-vfs-#61 change set splits the federation write surface
-    into two consistency tiers, both routed at call-site granularity:
+    Today the kernel hot path (``ZoneMetaStore::put`` / ``::delete``)
+    routes through SC (raft consensus) — the EC kernel-hot-path
+    activation attempted in nexus-vfs PR #61 was reverted in PR #63
+    after the EC drain surfaced correctness issues in 1V+1L topologies.
+    Per-call EC remains available via
+    ``zone_handle::set_metadata(.., Consistency::Ec)`` for callers that
+    can tolerate async cross-node visibility, but the cc-tasks-share
+    symmetric-peer path of least resistance is now ``--as voter`` for
+    both peers so SC writes succeed as long as both stay online.
 
-      * **EC** for ``sys_setattr`` / ``sys_unlink`` metadata writes
-        (``ZoneMetaStore::put`` / ``::delete`` → ``propose_ec_local``):
-        WAL-first append + synchronous local state-machine apply +
-        async raft replication.  Any node — voter, learner, leader,
-        follower — can write metadata locally without quorum.  This
-        is the kernel hot path that ``gRPC Write`` ultimately drives.
-
-      * **SC** for locks, CAS, control-plane (kept on the existing
-        ``propose`` raft consensus path).
-
-    These tests pin the EC contract end-to-end through the gRPC
-    surface against a real two-node compose, plus a CLI-surface
-    smoke for the new ``--as voter|learner`` join flag.  Failure
-    here means the per-call routing in ``ZoneMetaStore`` got
-    silently reverted — a regression that would re-block the
-    cc-tasks-share Mac↔Win symmetric peer workflow.
+    Today this class only smokes the ``--as voter|learner`` CLI flag
+    landed in PR #62.  When the EC drain hardening lands and the
+    kernel hot path can route through EC again, the original
+    ``test_learner_joiner_writes_via_ec_when_founder_offline``
+    contract test should be reintroduced here.
     """
-
-    def test_learner_joiner_writes_via_ec_when_founder_offline(
-        self,
-        topology: RunbookTopology,
-        api_key: str,
-        joined_cluster: dict,
-    ) -> None:
-        """EC contract: learner joiner writes metadata while founder is offline.
-
-        Walks the failure shape that motivated the contract change:
-        before nexus-vfs#61, the joiner's ``vfs_write`` proposed
-        through raft SC, which surfaces ``NotLeader`` when the leader
-        (founder) is unreachable.  After #61, the same call routes
-        through ``propose_ec_local``: WAL append + local apply commit
-        synchronously, then async replicate when peers come back.
-
-        Steps:
-          1. Stop founder (release leader; sharedzone has no quorum).
-          2. Joiner ``vfs_write`` — must succeed (EC layer).
-          3. Joiner ``vfs_read`` of own write — must succeed (RYW
-             preserved on the writer node because local apply
-             happened before put returned).
-          4. Restart founder + wait for raft to catch sharedzone up.
-          5. Founder ``vfs_read`` byte-exact — proves async
-             replication shipped the EC write across the boundary.
-
-        A regression that puts ``node.propose`` back in
-        ``ZoneMetaStore`` would fail step 2 with ``NotLeader``.
-        """
-        import secrets
-
-        from tests.e2e.docker.runbook_helpers import (
-            decode_content,
-            docker_start,
-            docker_stop,
-            uid,
-            vfs_read,
-            vfs_stat,
-            vfs_write,
-            wait_healthy,
-            wait_nodes_caught_up,
-        )
-
-        suffix = uid()
-        path = f"/shared/ec-offline-{suffix}.bin"
-        payload = secrets.token_bytes(8192)
-
-        # 1. Founder offline — sharedzone loses its only voter.
-        docker_stop(topology.founder_container)
-
-        try:
-            # 2. EC write succeeds on the joiner with no leader
-            #    reachable.  Pre-#61 this returned NotLeader.
-            wr = vfs_write(
-                topology.joiner_grpc,
-                path,
-                payload,
-                api_key=api_key,
-                timeout=30,
-            )
-            assert "error" not in wr, (
-                f"EC write on joiner failed while founder offline: {wr}\n"
-                f"This is the nexus-vfs#61 contract — ZoneMetaStore::put "
-                f"must route through propose_ec_local, not propose, so "
-                f"quorum loss does not block sys_setattr.  A NotLeader "
-                f"error here means the routing regressed."
-            )
-
-            # 3. RYW on the writer node — propose_ec_local commits
-            #    local apply synchronously before returning, so the
-            #    very next stat must see the new bytes.
-            rd = vfs_read(
-                topology.joiner_grpc,
-                path,
-                api_key=api_key,
-                timeout=30,
-            )
-            assert "error" not in rd, f"joiner cannot read its own EC write: {rd}"
-            assert decode_content(rd) == payload, (
-                "joiner EC write returned different bytes on local read — "
-                "WAL-first ordering or local apply broken"
-            )
-            stat = vfs_stat(topology.joiner_grpc, path, api_key=api_key)
-            assert stat["result"]["found"], f"vfs_stat on joiner does not see the EC write: {stat}"
-        finally:
-            # 4. Bring founder back so the rest of the suite isn't poisoned.
-            docker_start(topology.founder_container)
-            wait_healthy([topology.founder_grpc], timeout=60)
-
-        # 5. Async replication catches founder up + founder reads
-        #    byte-exact.  This is the cross-machine half of the
-        #    contract — local apply is fine, but for the federation
-        #    use case the write must also reach the peer eventually.
-        wait_nodes_caught_up(
-            [topology.founder_grpc, topology.joiner_grpc],
-            "sharedzone",
-            api_key=api_key,
-            timeout=60,
-            probe_path=path,
-        )
-        rd = vfs_read(
-            topology.founder_grpc,
-            path,
-            api_key=api_key,
-            timeout=60,
-        )
-        assert "error" not in rd, f"founder cross-node EC read failed: {rd}"
-        assert decode_content(rd) == payload, (
-            "EC write replicated but bytes diverged from joiner's payload"
-        )
 
     def test_join_as_voter_flag_round_trips_through_cli(
         self,
@@ -1185,20 +1071,12 @@ class TestFederationWriteConsistencyContract:
         """CLI smoke for ``nexusd-cluster join --as voter|learner``.
 
         nexus-vfs#61 added the ``--as`` operator-facing flag (default
-        ``learner`` for backward compat).  Until this commit
-        ``run_join`` hardcoded ``as_learner: true`` in the daemon
-        binary; the flag would have surfaced as ``unrecognized
-        argument: --as`` at clap parse, so this is the cheap
-        regression sentinel that the flag still parses + the role
-        is reflected in stdout.
-
-        Doesn't actually exercise the new role through a full join
-        + raft handshake — the EC contract test above proves the
-        write-side behaviour either way (the role distinction only
-        matters for SC quorum writes which the existing
-        ``TestRunbookOperatorErgonomics`` suite covers separately).
-        Here we want a CLI-level pin so a clap signature drift fails
-        cheaply.
+        ``learner`` for backward compat); #62 fixed the clap derivation
+        so the flag is actually ``--as`` not ``--as-role``.  Pre-#62
+        the flag would surface as ``unrecognized argument: --as`` at
+        clap parse; this is the cheap regression sentinel that
+        ``nexusd-cluster join --help`` keeps mentioning ``--as`` plus
+        both role enum values.
         """
         import subprocess
 

--- a/tests/e2e/docker/test_federation_runbook.py
+++ b/tests/e2e/docker/test_federation_runbook.py
@@ -1042,3 +1042,195 @@ class TestRunbookOperatorErgonomics:
             "validator error does not mention self/peer; wrong error fired."
             f"\nstdout/stderr: {combined[-2000:]}"
         )
+
+
+class TestFederationWriteConsistencyContract:
+    """Lock down the post-nexus-vfs-#61 per-call EC/SC write contract.
+
+    The nexus-vfs-#61 change set splits the federation write surface
+    into two consistency tiers, both routed at call-site granularity:
+
+      * **EC** for ``sys_setattr`` / ``sys_unlink`` metadata writes
+        (``ZoneMetaStore::put`` / ``::delete`` → ``propose_ec_local``):
+        WAL-first append + synchronous local state-machine apply +
+        async raft replication.  Any node — voter, learner, leader,
+        follower — can write metadata locally without quorum.  This
+        is the kernel hot path that ``gRPC Write`` ultimately drives.
+
+      * **SC** for locks, CAS, control-plane (kept on the existing
+        ``propose`` raft consensus path).
+
+    These tests pin the EC contract end-to-end through the gRPC
+    surface against a real two-node compose, plus a CLI-surface
+    smoke for the new ``--as voter|learner`` join flag.  Failure
+    here means the per-call routing in ``ZoneMetaStore`` got
+    silently reverted — a regression that would re-block the
+    cc-tasks-share Mac↔Win symmetric peer workflow.
+    """
+
+    def test_learner_joiner_writes_via_ec_when_founder_offline(
+        self,
+        topology: RunbookTopology,
+        api_key: str,
+        joined_cluster: dict,
+    ) -> None:
+        """EC contract: learner joiner writes metadata while founder is offline.
+
+        Walks the failure shape that motivated the contract change:
+        before nexus-vfs#61, the joiner's ``vfs_write`` proposed
+        through raft SC, which surfaces ``NotLeader`` when the leader
+        (founder) is unreachable.  After #61, the same call routes
+        through ``propose_ec_local``: WAL append + local apply commit
+        synchronously, then async replicate when peers come back.
+
+        Steps:
+          1. Stop founder (release leader; sharedzone has no quorum).
+          2. Joiner ``vfs_write`` — must succeed (EC layer).
+          3. Joiner ``vfs_read`` of own write — must succeed (RYW
+             preserved on the writer node because local apply
+             happened before put returned).
+          4. Restart founder + wait for raft to catch sharedzone up.
+          5. Founder ``vfs_read`` byte-exact — proves async
+             replication shipped the EC write across the boundary.
+
+        A regression that puts ``node.propose`` back in
+        ``ZoneMetaStore`` would fail step 2 with ``NotLeader``.
+        """
+        import secrets
+
+        from tests.e2e.docker.runbook_helpers import (
+            decode_content,
+            docker_start,
+            docker_stop,
+            uid,
+            vfs_read,
+            vfs_stat,
+            vfs_write,
+            wait_healthy,
+            wait_nodes_caught_up,
+        )
+
+        suffix = uid()
+        path = f"/shared/ec-offline-{suffix}.bin"
+        payload = secrets.token_bytes(8192)
+
+        # 1. Founder offline — sharedzone loses its only voter.
+        docker_stop(topology.founder_container)
+
+        try:
+            # 2. EC write succeeds on the joiner with no leader
+            #    reachable.  Pre-#61 this returned NotLeader.
+            wr = vfs_write(
+                topology.joiner_grpc,
+                path,
+                payload,
+                api_key=api_key,
+                timeout=30,
+            )
+            assert "error" not in wr, (
+                f"EC write on joiner failed while founder offline: {wr}\n"
+                f"This is the nexus-vfs#61 contract — ZoneMetaStore::put "
+                f"must route through propose_ec_local, not propose, so "
+                f"quorum loss does not block sys_setattr.  A NotLeader "
+                f"error here means the routing regressed."
+            )
+
+            # 3. RYW on the writer node — propose_ec_local commits
+            #    local apply synchronously before returning, so the
+            #    very next stat must see the new bytes.
+            rd = vfs_read(
+                topology.joiner_grpc,
+                path,
+                api_key=api_key,
+                timeout=30,
+            )
+            assert "error" not in rd, f"joiner cannot read its own EC write: {rd}"
+            assert decode_content(rd) == payload, (
+                "joiner EC write returned different bytes on local read — "
+                "WAL-first ordering or local apply broken"
+            )
+            stat = vfs_stat(topology.joiner_grpc, path, api_key=api_key)
+            assert stat["result"]["found"], f"vfs_stat on joiner does not see the EC write: {stat}"
+        finally:
+            # 4. Bring founder back so the rest of the suite isn't poisoned.
+            docker_start(topology.founder_container)
+            wait_healthy([topology.founder_grpc], timeout=60)
+
+        # 5. Async replication catches founder up + founder reads
+        #    byte-exact.  This is the cross-machine half of the
+        #    contract — local apply is fine, but for the federation
+        #    use case the write must also reach the peer eventually.
+        wait_nodes_caught_up(
+            [topology.founder_grpc, topology.joiner_grpc],
+            "sharedzone",
+            api_key=api_key,
+            timeout=60,
+            probe_path=path,
+        )
+        rd = vfs_read(
+            topology.founder_grpc,
+            path,
+            api_key=api_key,
+            timeout=60,
+        )
+        assert "error" not in rd, f"founder cross-node EC read failed: {rd}"
+        assert decode_content(rd) == payload, (
+            "EC write replicated but bytes diverged from joiner's payload"
+        )
+
+    def test_join_as_voter_flag_round_trips_through_cli(
+        self,
+        topology: RunbookTopology,
+    ) -> None:
+        """CLI smoke for ``nexusd-cluster join --as voter|learner``.
+
+        nexus-vfs#61 added the ``--as`` operator-facing flag (default
+        ``learner`` for backward compat).  Until this commit
+        ``run_join`` hardcoded ``as_learner: true`` in the daemon
+        binary; the flag would have surfaced as ``unrecognized
+        argument: --as`` at clap parse, so this is the cheap
+        regression sentinel that the flag still parses + the role
+        is reflected in stdout.
+
+        Doesn't actually exercise the new role through a full join
+        + raft handshake — the EC contract test above proves the
+        write-side behaviour either way (the role distinction only
+        matters for SC quorum writes which the existing
+        ``TestRunbookOperatorErgonomics`` suite covers separately).
+        Here we want a CLI-level pin so a clap signature drift fails
+        cheaply.
+        """
+        import subprocess
+
+        cluster_image = os.environ.get("NEXUS_CLUSTER_IMAGE", "nexusd-cluster:latest")
+        result = subprocess.run(
+            [
+                "docker",
+                "run",
+                "--rm",
+                "--entrypoint",
+                "nexusd-cluster",
+                cluster_image,
+                "join",
+                "--help",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=20,
+        )
+        assert result.returncode == 0, (
+            f"`nexusd-cluster join --help` exited non-zero rc={result.returncode}"
+            f"\nstdout={result.stdout}\nstderr={result.stderr}"
+        )
+        combined = result.stdout + result.stderr
+        assert "--as" in combined, (
+            "`nexusd-cluster join --help` doesn't mention --as flag — "
+            "nexus-vfs#61 CLI surface regressed."
+            f"\nhelp text: {combined[-2000:]}"
+        )
+        for role in ("voter", "learner"):
+            assert role in combined, (
+                f"`nexusd-cluster join --help` doesn't list `{role}` as a"
+                f" valid --as value — nexus-vfs#61 ValueEnum regressed."
+                f"\nhelp text: {combined[-2000:]}"
+            )


### PR DESCRIPTION
## Summary

Companion to nexi-lab/nexus-vfs PR #61 (just merged, commit \`6b7bd6e3\`).  This PR carries the operator-facing surfaces that go with the kernel-tier change:

* **Runbook §3b** — \`nexusd-cluster join\` grows \`--as voter|learner\` (default \`learner\`), with side-by-side decision matrix.
* **New runbook "Consistency model" section** (between §3g and §4) — per-call EC/SC routing table + 2-bullet practical consequences for the \`--as\` choice.
* **New spec** \`docs/superpowers/specs/2026-06-23-federation-write-consistency-surface.md\` — architectural decision capture: TL;DR, why-now, two-propose-paths table, failure modes the change closes (and deliberately doesn't), operator decision matrix, test coverage map, lineage pointers.
* **New Docker E2E tests** under \`TestFederationWriteConsistencyContract\`:
    - \`test_learner_joiner_writes_via_ec_when_founder_offline\` — pins the EC contract end-to-end: stops founder, joiner writes via gRPC with no leader reachable, joiner reads own write (RYW), founder restarts, async replication catches up, founder reads byte-exact.
    - \`test_join_as_voter_flag_round_trips_through_cli\` — cheap CLI sentinel for the new \`--as\` flag (\`nexusd-cluster join --help\` grep).
* **\`runbook_helpers.run_nexusd_cluster_join\`** gains an \`as_role\` keyword param (default \`"learner"\`) so future tests can opt into voter joins without rebuilding the docker-run-sidecar bootstrap.
* **\`Cargo.toml\` nexus-vfs dep bump** to the #61 merge commit so CI's federation cluster image gets the new code.

## Why now

The 2026-06-22 Mac↔Win Federation L1 manual smoke proved bidirectional byte-exact replication over Tailscale.  Mac couldn't write because \`ZoneMetaStore::put\` hardcoded SC propose → \`NotLeader\` on the Learner-joined Mac peer.  User (kernel team lead) asked for the architectural fix rather than the quick "promote Mac to voter" workaround.  nexus-vfs#61 does the kernel-tier change; this PR carries everything operator-facing + the test surface.

## Test plan

- [x] Doc-only changes follow runbook + spec conventions used by sibling files.
- [x] New E2E tests reference real helper APIs that exist post the helper change in this PR.
- [ ] CI green on federation-runbook-e2e suite — proves the new tests pass on the new cluster image.
- [ ] cc-tasks-share-e2e suite stays green — no regression on the existing federation surface.