### PR TITLE
chore(deps): bump nexus-vfs to #65 #66 + flip runbook fixture default to voter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,9 +138,9 @@ checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
 
 [[package]]
 name = "async-trait"
@@ -218,7 +218,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=cc4c087886c36808c376fb39e198f980ffcb70e1#cc4c087886c36808c376fb39e198f980ffcb70e1"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=f72020717f79d920f4429aec8aa6368dd676adde#f72020717f79d920f4429aec8aa6368dd676adde"
 dependencies = [
  "ahash",
  "base64",
@@ -289,7 +289,7 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "itertools",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -384,9 +384,9 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "byteview"
@@ -396,9 +396,9 @@ checksum = "1c53ba0f290bfc610084c05582d9c5d421662128fc69f4bf236707af6fd321b9"
 
 [[package]]
 name = "cc"
-version = "1.2.63"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
  "shlex 2.0.1",
@@ -550,7 +550,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=cc4c087886c36808c376fb39e198f980ffcb70e1#cc4c087886c36808c376fb39e198f980ffcb70e1"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=f72020717f79d920f4429aec8aa6368dd676adde#f72020717f79d920f4429aec8aa6368dd676adde"
 dependencies = [
  "parking_lot",
  "serde",
@@ -715,9 +715,6 @@ name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
-dependencies = [
- "powerfmt",
-]
 
 [[package]]
 name = "digest"
@@ -1024,16 +1021,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
  "r-efi",
- "wasip2",
- "wasip3",
  "wasm-bindgen",
 ]
 
@@ -1068,9 +1063,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1256,7 +1251,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -1269,12 +1264,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1282,8 +1271,6 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
- "serde",
- "serde_core",
 ]
 
 [[package]]
@@ -1320,6 +1307,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1327,9 +1323,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.100"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2025f20d7a4fa7785846e7b63d10a76d3f1cee98ee5cb79ea59703f95e42162"
+checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1339,7 +1335,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=cc4c087886c36808c376fb39e198f980ffcb70e1#cc4c087886c36808c376fb39e198f980ffcb70e1"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=f72020717f79d920f4429aec8aa6368dd676adde#f72020717f79d920f4429aec8aa6368dd676adde"
 dependencies = [
  "ahash",
  "base64",
@@ -1388,15 +1384,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=cc4c087886c36808c376fb39e198f980ffcb70e1#cc4c087886c36808c376fb39e198f980ffcb70e1"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=f72020717f79d920f4429aec8aa6368dd676adde#f72020717f79d920f4429aec8aa6368dd676adde"
 dependencies = [
  "ahash",
  "base64",
@@ -1404,7 +1394,7 @@ dependencies = [
  "contracts",
  "crc32fast",
  "dashmap",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "globset",
  "memchr",
  "parking_lot",
@@ -1456,9 +1446,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.32"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru"
@@ -1514,9 +1504,9 @@ checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]
@@ -1587,7 +1577,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=cc4c087886c36808c376fb39e198f980ffcb70e1#cc4c087886c36808c376fb39e198f980ffcb70e1"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=f72020717f79d920f4429aec8aa6368dd676adde#f72020717f79d920f4429aec8aa6368dd676adde"
 
 [[package]]
 name = "nexus-vault"
@@ -1867,7 +1857,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph",
@@ -1888,7 +1878,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -1999,9 +1989,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -2162,9 +2152,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.40"
+version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
  "log",
  "once_cell",
@@ -2493,9 +2483,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2515,7 +2505,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -2552,12 +2542,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "85c17d80feb7334b40c484e45ed1a5273dfd8bfda537c3be2e74a06a6686f327"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -2567,15 +2556,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "dcef1a61bdb119096e153208ec5cbec23944ce8bca13be5c7f60c634f7403935"
 dependencies = [
  "num-conv",
  "time-core",
@@ -2869,12 +2858,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
 name = "universal-hash"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2902,7 +2885,7 @@ version = "1.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
 dependencies = [
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -2941,28 +2924,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
-name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
-dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
-]
-
-[[package]]
 name = "wasm-bindgen"
-version = "0.2.123"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a254a4b10c19a76f09a27640e7ffbf9bc30bf67e16a3bf28aaefa4920fe81563"
+checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2973,9 +2938,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.123"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a40fc75b0ec6f3746ceb10d36f53a93dcd68a93b11b6445983945d79eba0dc"
+checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2983,9 +2948,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.123"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "908f34bd9b9ce3d4caf07b72dfab63d61504d156856c6bd3cd87fa350cf3985b"
+checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2996,45 +2961,11 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.123"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7acbf7616c27b194bbb550bf77ed0c2c3e5b7fd1260a93082b95fb7f47959b92"
+checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
 ]
 
 [[package]]
@@ -3072,7 +3003,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
  "windows-collections",
- "windows-core",
+ "windows-core 0.61.2",
  "windows-future",
  "windows-link 0.1.3",
  "windows-numerics",
@@ -3084,7 +3015,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
- "windows-core",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -3096,8 +3027,21 @@ dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-link 0.1.3",
- "windows-result",
- "windows-strings",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]
@@ -3106,7 +3050,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
- "windows-core",
+ "windows-core 0.61.2",
  "windows-link 0.1.3",
  "windows-threading",
 ]
@@ -3151,7 +3095,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
- "windows-core",
+ "windows-core 0.61.2",
  "windows-link 0.1.3",
 ]
 
@@ -3165,12 +3109,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "windows-strings"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -3299,100 +3261,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.57.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
-
-[[package]]
 name = "xxhash-rust"
 version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3420,9 +3288,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,26 +30,32 @@ exclude = ["nexus-fuse"]
 [workspace.dependencies]
 # Kernel-tier crates from nexus-vfs (external git dependency).
 # SSOT: https://github.com/nexi-lab/nexus-vfs
-# Pinned at the nexus-vfs main commit that landed #63 (revert of the
-# kernel-hot-path EC activation #61 attempted — the EC drain has
-# correctness issues in 1V+1L topologies; kernel hot path stays SC
-# until the substrate is hardened).  Keeps #62's `--as voter|learner`
-# CLI surface + the per-call EC/SC primitives at the zone_handle layer
-# for callers that explicitly opt in.  See
+# Pinned at the nexus-vfs main commit that landed #65 (EC drain
+# hardening — voter-only watermark, fire-and-forget replicate,
+# drain_unreplicated walks the WAL boundary, server returns failure
+# on deserialize error, integration-tested in 1V+1L) and #66 (CLI
+# `--as` default flipped from learner → voter so the operator-facing
+# default matches the wire-level `JoinZoneRequest.as_learner=false`
+# default).  Substrate is now ready for a separate kernel-hot-path
+# EC reactivation PR (the #61 attempt that #63 reverted).  Keeps
+# #62's `--as voter|learner` CLI surface + the per-call EC/SC
+# primitives at the zone_handle layer for callers that explicitly
+# opt in.  See
 # docs/superpowers/specs/2026-06-23-federation-write-consistency-surface.md
 # for the full lineage.
 # Builds on prior landmarks: #57 plugin-as-gRPC-service routing,
 # #58 sealed-keystore signing trust root, #60 KernelHandle v3
 # sys_stat_batch, #61 per-call EC/SC primitives, #62 CLI flag rename,
-# #63 EC hot-path activation revert. Bump alongside the rest of
-# nexus-vfs updates when a downstream change needs newer kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "cc4c087886c36808c376fb39e198f980ffcb70e1" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "cc4c087886c36808c376fb39e198f980ffcb70e1" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "cc4c087886c36808c376fb39e198f980ffcb70e1" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "cc4c087886c36808c376fb39e198f980ffcb70e1", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "cc4c087886c36808c376fb39e198f980ffcb70e1", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "cc4c087886c36808c376fb39e198f980ffcb70e1", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "cc4c087886c36808c376fb39e198f980ffcb70e1" }
+# #63 EC hot-path activation revert, #65 EC drain hardening, #66
+# voter-default flip. Bump alongside the rest of nexus-vfs updates
+# when a downstream change needs newer kernel bits.
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "f72020717f79d920f4429aec8aa6368dd676adde" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "f72020717f79d920f4429aec8aa6368dd676adde" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "f72020717f79d920f4429aec8aa6368dd676adde" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "f72020717f79d920f4429aec8aa6368dd676adde", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "f72020717f79d920f4429aec8aa6368dd676adde", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "f72020717f79d920f4429aec8aa6368dd676adde", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "f72020717f79d920f4429aec8aa6368dd676adde" }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ENV CARGO_NET_RETRY=10 \
     CARGO_HTTP_TIMEOUT=120
 # Override for edge/CI or a different pin: --build-arg NEXUS_VFS_REV=<sha|tag>
-ARG NEXUS_VFS_REV=cc4c087886c36808c376fb39e198f980ffcb70e1
+ARG NEXUS_VFS_REV=f72020717f79d920f4429aec8aa6368dd676adde
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,id=cargo-install-${TARGETARCH},target=/root/.cargo/target \

--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir --no-deps --prefix=/install .
 # enforces agreement) — an unpinned install tracks nexus-vfs HEAD and
 # ships an untested kernel (#4343). --locked honors the source tree's
 # Cargo.lock.
-ARG NEXUS_VFS_REV=cc4c087886c36808c376fb39e198f980ffcb70e1
+ARG NEXUS_VFS_REV=f72020717f79d920f4429aec8aa6368dd676adde
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-cluster nexus-cluster
 
 # -- Runtime stage --

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -25,7 +25,7 @@ WORKDIR /build
 # (CI preflight enforces agreement) — an unpinned install tracks HEAD
 # and can skew the raft contract against the cluster/witness images.
 # --locked honors the source tree's Cargo.lock.
-ARG NEXUS_VFS_REV=cc4c087886c36808c376fb39e198f980ffcb70e1
+ARG NEXUS_VFS_REV=f72020717f79d920f4429aec8aa6368dd676adde
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexus-raft-server raft
 
 # ---------- Production image ----------

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=cc4c087886c36808c376fb39e198f980ffcb70e1
+ARG NEXUS_VFS_REV=f72020717f79d920f4429aec8aa6368dd676adde
 RUN cargo install \
     --locked \
     --git https://github.com/nexi-lab/nexus-vfs \

--- a/docs/architecture/federation-cross-machine-runbook.md
+++ b/docs/architecture/federation-cross-machine-runbook.md
@@ -254,10 +254,10 @@ target/release/nexusd-cluster join \
   --as <learner|voter>
 ```
 
-`--as` picks the membership role on `sharedzone` (default `learner`):
+`--as` picks the membership role on `sharedzone` (default `voter`):
 
-* **`--as learner`** — owner-pattern share.  Joiner gets full replication of `sharedzone` metadata but cannot propose writes (every `vfs_write` on a learner surfaces `NotLeader` today; see [Consistency model](#consistency-model) below).  Doesn't count toward quorum.  Wipe-rejoin safe — losing or replacing a learner has zero quorum impact, so SSD swap / OS reinstall / device migration can't strand the zone in `not leader` deadlock.  Pick this when one side is the authoritative writer and the other side is read-along (canonical `nexus share` semantics).
-* **`--as voter`** — symmetric-peer share.  Joiner counts toward quorum AND can propose SC writes through raft consensus (the joiner forwards proposals to whichever voter currently holds leadership).  Pick this for the cc-tasks-share Mac↔Win pattern where both peers write to their own subpath under `/shared` and want equal write authority.  Caveat: 2-voter setups need both peers online to commit any write — if either drops, the other can't make progress until it returns.  Wipe-rejoin risk re-emerges if a voter goes through SSD swap without first transferring its voter slot away.
+* **`--as voter`** *(default)* — symmetric-peer share.  Joiner counts toward quorum AND can propose SC writes through raft consensus (the joiner forwards proposals to whichever voter currently holds leadership).  This is the path-of-least-resistance for the cc-tasks-share Mac↔Win pattern where both peers write to their own subpath under `/shared` and want equal write authority.  The flag-level default matches the wire-level default (`JoinZoneRequest.as_learner` defaults to `false` under proto3, i.e. voter).  Caveat: 2-voter setups need both peers online to commit any write — if either drops, the other can't make progress until it returns.  Wipe-rejoin risk re-emerges if a voter goes through SSD swap without first transferring its voter slot away.
+* **`--as learner`** — owner-pattern share.  Joiner gets full replication of `sharedzone` metadata but cannot propose writes (every `vfs_write` on a learner surfaces `NotLeader` today; see [Consistency model](#consistency-model) below).  Doesn't count toward quorum.  Wipe-rejoin safe — losing or replacing a learner has zero quorum impact, so SSD swap / OS reinstall / device migration can't strand the zone in `not leader` deadlock.  Pick this opt-in when one side is the authoritative writer and the other side is read-along (canonical `nexus share` semantics).
 
 Expected last line:
 
@@ -335,6 +335,8 @@ nexusd-cluster --bootstrap-mode static \
   ...
 
 # 2. Offline join (daemon stopped) — seeds sharedzone's ConfState + log into B's data dir.
+#    Bare `join` defaults to `--as voter` (symmetric peer); pass `--as learner` for
+#    owner-pattern wipe-rejoin safety instead.
 nexusd-cluster join <A_node_id>@<A_addr> sharedzone /shared --data-dir ./data --hostname B
 
 # 3. Restart — entrypoint auto-detects restart mode; sharedzone replays from disk and

--- a/tests/e2e/docker/runbook_helpers.py
+++ b/tests/e2e/docker/runbook_helpers.py
@@ -684,7 +684,7 @@ def run_nexusd_cluster_join(
     network: str | None = None,
     data_dir: str = "/app/data",
     timeout: float = 120,
-    as_role: str = "learner",
+    as_role: str = "voter",
 ) -> subprocess.CompletedProcess:
     """Run runbook §3b's offline `nexusd-cluster join` in a transient sidecar.
 
@@ -704,13 +704,14 @@ def run_nexusd_cluster_join(
          state and replays DT_MOUNT via apply-cb (runbook §3c).
 
     ``as_role`` is the operator-chosen membership role passed to
-    ``nexusd-cluster join --as <role>`` (nexus-vfs PR #61).  Default
-    is ``"learner"`` to match the daemon CLI default — preserves
-    pre-#61 wire behaviour for tests that don't care about the
-    distinction.  Pass ``"voter"`` to exercise the symmetric-peer
-    cc-tasks-share path where the joiner counts toward quorum + can
-    write SC linearizable ops as well as the default EC sys_setattr
-    path.
+    ``nexusd-cluster join --as <role>``.  Default is ``"voter"`` to
+    match the daemon CLI default (nexus-vfs PR #66 flipped the CLI
+    default from ``learner`` to ``voter`` so the operator-facing
+    default aligns with the wire-level protocol default — proto3
+    ``JoinZoneRequest.as_learner`` defaults to ``false`` = voter).
+    Pass ``"learner"`` to exercise the owner-pattern share where the
+    joiner gets full replication but doesn't count toward quorum
+    (wipe-rejoin safe).
 
     Returns the CompletedProcess so callers can assert on rc /
     stdout / stderr (see test_joiner_zero_mount_not_leader_in_join_cli_log).


### PR DESCRIPTION
Companion to the two nexus-vfs PRs merged today:

- **nexi-lab/nexus-vfs#65** — EC drain hardening (nexi-lab/nexus-vfs#64).  Voter-only watermark, fire-and-forget per-peer replicate, `drain_unreplicated` decoupled from the quorum watermark, hard failure on EC deserialize error, integration-tested in a 1V+1L topology.
- **nexi-lab/nexus-vfs#66** — `nexusd-cluster join --as <role>` default flipped from `learner` to `voter` (aligns the operator-facing default with proto3's wire-level `JoinZoneRequest.as_learner=false` default).

## Scope

1. **Bump the nexus-vfs pin** in `Cargo.toml`, `Cargo.lock`, and the four Dockerfiles that hard-code it (`Dockerfile`, `dockerfiles/Dockerfile.{minimal,raft-server,raft-witness}`) from `cc4c08788` → `f72020717` (nexus-vfs main after both PRs).
2. **Flip the Python test-helper default** to match: `tests/e2e/docker/runbook_helpers.py::run_nexusd_cluster_join` parameter `as_role` defaults to `\"voter\"` so it tracks the daemon CLI default.  Callers that want learner pass `as_role=\"learner\"`.
3. **Update the runbook prose** in `docs/architecture/federation-cross-machine-runbook.md` §3b: voter is now the first bullet + default, learner is the opt-in.  Add a one-line note on the minimal join example (§3c) noting bare `join` picks voter by default.

## Verification

- `cargo check --workspace` clean against the new nexus-vfs rev.
- Smoke verified manually on the cross-machine §3g path: Win founder + Mac joiner over Tailscale, both as voters, bidirectional `vfs_write` + `vfs_read` byte-exact through the federation tunnel.  Will run the docker federation E2E in CI.

## Follow-up (not in this PR)

- Kernel-hot-path EC reactivation (the nexus-vfs#61 attempt that #63 reverted).  Substrate is ready; will land as a small follow-up nexus-vfs PR + reinstating `test_learner_joiner_writes_via_ec_when_founder_offline` here.