### PR TITLE
feat: cc-tasks-list backend-only enumeration via FUSE (depends on nexus-vfs#67)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=f72020717f79d920f4429aec8aa6368dd676adde#f72020717f79d920f4429aec8aa6368dd676adde"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5849444330563cc414be577efa1d9e71e4546338#5849444330563cc414be577efa1d9e71e4546338"
 dependencies = [
  "ahash",
  "base64",
@@ -550,7 +550,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=f72020717f79d920f4429aec8aa6368dd676adde#f72020717f79d920f4429aec8aa6368dd676adde"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5849444330563cc414be577efa1d9e71e4546338#5849444330563cc414be577efa1d9e71e4546338"
 dependencies = [
  "parking_lot",
  "serde",
@@ -1335,7 +1335,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=f72020717f79d920f4429aec8aa6368dd676adde#f72020717f79d920f4429aec8aa6368dd676adde"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5849444330563cc414be577efa1d9e71e4546338#5849444330563cc414be577efa1d9e71e4546338"
 dependencies = [
  "ahash",
  "base64",
@@ -1386,7 +1386,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=f72020717f79d920f4429aec8aa6368dd676adde#f72020717f79d920f4429aec8aa6368dd676adde"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5849444330563cc414be577efa1d9e71e4546338#5849444330563cc414be577efa1d9e71e4546338"
 dependencies = [
  "ahash",
  "base64",
@@ -1556,7 +1556,6 @@ dependencies = [
  "fuser",
  "libc",
  "nexus-plugin-abi",
- "tempfile",
  "tracing",
  "widestring",
  "windows-sys 0.52.0",
@@ -1578,7 +1577,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=f72020717f79d920f4429aec8aa6368dd676adde#f72020717f79d920f4429aec8aa6368dd676adde"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5849444330563cc414be577efa1d9e71e4546338#5849444330563cc414be577efa1d9e71e4546338"
 
 [[package]]
 name = "nexus-vault"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5849444330563cc414be577efa1d9e71e4546338#5849444330563cc414be577efa1d9e71e4546338"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=09b7bd869657d2b56c18dd1d924bbfac742aced0#09b7bd869657d2b56c18dd1d924bbfac742aced0"
 dependencies = [
  "ahash",
  "base64",
@@ -550,7 +550,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5849444330563cc414be577efa1d9e71e4546338#5849444330563cc414be577efa1d9e71e4546338"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=09b7bd869657d2b56c18dd1d924bbfac742aced0#09b7bd869657d2b56c18dd1d924bbfac742aced0"
 dependencies = [
  "parking_lot",
  "serde",
@@ -1335,7 +1335,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5849444330563cc414be577efa1d9e71e4546338#5849444330563cc414be577efa1d9e71e4546338"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=09b7bd869657d2b56c18dd1d924bbfac742aced0#09b7bd869657d2b56c18dd1d924bbfac742aced0"
 dependencies = [
  "ahash",
  "base64",
@@ -1386,7 +1386,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5849444330563cc414be577efa1d9e71e4546338#5849444330563cc414be577efa1d9e71e4546338"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=09b7bd869657d2b56c18dd1d924bbfac742aced0#09b7bd869657d2b56c18dd1d924bbfac742aced0"
 dependencies = [
  "ahash",
  "base64",
@@ -1577,7 +1577,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5849444330563cc414be577efa1d9e71e4546338#5849444330563cc414be577efa1d9e71e4546338"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=09b7bd869657d2b56c18dd1d924bbfac742aced0#09b7bd869657d2b56c18dd1d924bbfac742aced0"
 
 [[package]]
 name = "nexus-vault"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=09b7bd869657d2b56c18dd1d924bbfac742aced0#09b7bd869657d2b56c18dd1d924bbfac742aced0"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=c26926ebb968e1952ee3409afc98752e9dbc49b3#c26926ebb968e1952ee3409afc98752e9dbc49b3"
 dependencies = [
  "ahash",
  "base64",
@@ -550,7 +550,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=09b7bd869657d2b56c18dd1d924bbfac742aced0#09b7bd869657d2b56c18dd1d924bbfac742aced0"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=c26926ebb968e1952ee3409afc98752e9dbc49b3#c26926ebb968e1952ee3409afc98752e9dbc49b3"
 dependencies = [
  "parking_lot",
  "serde",
@@ -1335,7 +1335,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=09b7bd869657d2b56c18dd1d924bbfac742aced0#09b7bd869657d2b56c18dd1d924bbfac742aced0"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=c26926ebb968e1952ee3409afc98752e9dbc49b3#c26926ebb968e1952ee3409afc98752e9dbc49b3"
 dependencies = [
  "ahash",
  "base64",
@@ -1386,7 +1386,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=09b7bd869657d2b56c18dd1d924bbfac742aced0#09b7bd869657d2b56c18dd1d924bbfac742aced0"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=c26926ebb968e1952ee3409afc98752e9dbc49b3#c26926ebb968e1952ee3409afc98752e9dbc49b3"
 dependencies = [
  "ahash",
  "base64",
@@ -1577,7 +1577,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=09b7bd869657d2b56c18dd1d924bbfac742aced0#09b7bd869657d2b56c18dd1d924bbfac742aced0"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=c26926ebb968e1952ee3409afc98752e9dbc49b3#c26926ebb968e1952ee3409afc98752e9dbc49b3"
 
 [[package]]
 name = "nexus-vault"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,28 +30,33 @@ exclude = ["nexus-fuse"]
 [workspace.dependencies]
 # Kernel-tier crates from nexus-vfs (external git dependency).
 # SSOT: https://github.com/nexi-lab/nexus-vfs
-# Pinned at the nexus-vfs main commit that landed #67 (driver-plugin
-# ABI v4 — `nexus_driver_readdir` required symbol so dylib-backed
-# mounts surface their directory listings through `sys_readdir`, plus
-# the symmetric `sys_stat` backend.list_dir fallback so per-file
-# stat works for backend-only entries).  Unblocks the cc-tasks-list
-# mega-goal: `cc tasks list` on Mac / Win can enumerate the peer's
-# `~/.claude/tasks/<session>/...` through the FUSE mount even though
-# the JSON files are written by plain OS I/O outside Nexus.
+# Pinned at the nexus-vfs main commit that landed #68 (additive
+# optional driver ABI: `nexus_driver_delete_file` so FUSE `rm`
+# reaches the backend file and `nexus_driver_stat` so backend-only
+# entries get correct sizes for FUSE reads — Linux fuser clamps
+# reads to stat.size, so a synthesised stat.size=0 broke `cat` on
+# host-fs-only files).  Builds on #67's required
+# `nexus_driver_readdir`, together unblocking the cc-tasks-list
+# mega-goal end-to-end: `cc tasks list` on Mac / Win can enumerate
+# the peer's `~/.claude/tasks/<session>/...` through the FUSE
+# mount, stat each entry, read its bytes, and clean up via FUSE
+# `rm` so the host fs file is removed in lockstep with its
+# metastore entry.
 # Builds on prior landmarks: #57 plugin-as-gRPC-service routing,
 # #58 sealed-keystore signing trust root, #60 KernelHandle v3
 # sys_stat_batch, #61 per-call EC/SC primitives, #62 CLI flag rename,
 # #63 EC hot-path activation revert, #65 EC drain hardening, #66
-# voter-default flip, #67 driver-readdir ABI v4. Bump alongside the
-# rest of nexus-vfs updates when a downstream change needs newer
-# kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5849444330563cc414be577efa1d9e71e4546338" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5849444330563cc414be577efa1d9e71e4546338" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5849444330563cc414be577efa1d9e71e4546338" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5849444330563cc414be577efa1d9e71e4546338", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5849444330563cc414be577efa1d9e71e4546338", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5849444330563cc414be577efa1d9e71e4546338", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5849444330563cc414be577efa1d9e71e4546338" }
+# voter-default flip, #67 driver-readdir ABI v4, #68
+# driver-delete-file + driver-stat optional symbols. Bump alongside
+# the rest of nexus-vfs updates when a downstream change needs
+# newer kernel bits.
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "09b7bd869657d2b56c18dd1d924bbfac742aced0" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "09b7bd869657d2b56c18dd1d924bbfac742aced0" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "09b7bd869657d2b56c18dd1d924bbfac742aced0" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "09b7bd869657d2b56c18dd1d924bbfac742aced0", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "09b7bd869657d2b56c18dd1d924bbfac742aced0", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "09b7bd869657d2b56c18dd1d924bbfac742aced0", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "09b7bd869657d2b56c18dd1d924bbfac742aced0" }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,33 +30,32 @@ exclude = ["nexus-fuse"]
 [workspace.dependencies]
 # Kernel-tier crates from nexus-vfs (external git dependency).
 # SSOT: https://github.com/nexi-lab/nexus-vfs
-# Pinned at the nexus-vfs main commit that landed #68 (additive
-# optional driver ABI: `nexus_driver_delete_file` so FUSE `rm`
-# reaches the backend file and `nexus_driver_stat` so backend-only
-# entries get correct sizes for FUSE reads — Linux fuser clamps
-# reads to stat.size, so a synthesised stat.size=0 broke `cat` on
-# host-fs-only files).  Builds on #67's required
-# `nexus_driver_readdir`, together unblocking the cc-tasks-list
-# mega-goal end-to-end: `cc tasks list` on Mac / Win can enumerate
-# the peer's `~/.claude/tasks/<session>/...` through the FUSE
-# mount, stat each entry, read its bytes, and clean up via FUSE
-# `rm` so the host fs file is removed in lockstep with its
-# metastore entry.
+# Pinned at the nexus-vfs main commit that landed #69 (additive
+# optional `nexus_driver_rmdir` — sister of #68's
+# `nexus_driver_delete_file` for directories).  Closes the last
+# cc-tasks-share docker E2E gap: FUSE `rmdir` now reaches
+# `backend.rmdir` so the host fs directory is removed in lockstep
+# with the metastore row.  Builds on #67's required
+# `nexus_driver_readdir` and #68's `nexus_driver_delete_file` +
+# `nexus_driver_stat`, together unblocking the cc-tasks-list
+# mega-goal end-to-end: `cc tasks list` enumerates → stats →
+# reads → cleans up, all with the host fs as the SSOT and the
+# kernel metastore in lockstep.
 # Builds on prior landmarks: #57 plugin-as-gRPC-service routing,
 # #58 sealed-keystore signing trust root, #60 KernelHandle v3
 # sys_stat_batch, #61 per-call EC/SC primitives, #62 CLI flag rename,
 # #63 EC hot-path activation revert, #65 EC drain hardening, #66
 # voter-default flip, #67 driver-readdir ABI v4, #68
-# driver-delete-file + driver-stat optional symbols. Bump alongside
-# the rest of nexus-vfs updates when a downstream change needs
-# newer kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "09b7bd869657d2b56c18dd1d924bbfac742aced0" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "09b7bd869657d2b56c18dd1d924bbfac742aced0" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "09b7bd869657d2b56c18dd1d924bbfac742aced0" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "09b7bd869657d2b56c18dd1d924bbfac742aced0", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "09b7bd869657d2b56c18dd1d924bbfac742aced0", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "09b7bd869657d2b56c18dd1d924bbfac742aced0", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "09b7bd869657d2b56c18dd1d924bbfac742aced0" }
+# driver-delete-file + driver-stat, #69 driver-rmdir. Bump
+# alongside the rest of nexus-vfs updates when a downstream
+# change needs newer kernel bits.
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "c26926ebb968e1952ee3409afc98752e9dbc49b3" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "c26926ebb968e1952ee3409afc98752e9dbc49b3" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "c26926ebb968e1952ee3409afc98752e9dbc49b3" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "c26926ebb968e1952ee3409afc98752e9dbc49b3", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "c26926ebb968e1952ee3409afc98752e9dbc49b3", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "c26926ebb968e1952ee3409afc98752e9dbc49b3", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "c26926ebb968e1952ee3409afc98752e9dbc49b3" }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,32 +30,28 @@ exclude = ["nexus-fuse"]
 [workspace.dependencies]
 # Kernel-tier crates from nexus-vfs (external git dependency).
 # SSOT: https://github.com/nexi-lab/nexus-vfs
-# Pinned at the nexus-vfs main commit that landed #65 (EC drain
-# hardening — voter-only watermark, fire-and-forget replicate,
-# drain_unreplicated walks the WAL boundary, server returns failure
-# on deserialize error, integration-tested in 1V+1L) and #66 (CLI
-# `--as` default flipped from learner → voter so the operator-facing
-# default matches the wire-level `JoinZoneRequest.as_learner=false`
-# default).  Substrate is now ready for a separate kernel-hot-path
-# EC reactivation PR (the #61 attempt that #63 reverted).  Keeps
-# #62's `--as voter|learner` CLI surface + the per-call EC/SC
-# primitives at the zone_handle layer for callers that explicitly
-# opt in.  See
-# docs/superpowers/specs/2026-06-23-federation-write-consistency-surface.md
-# for the full lineage.
+# Pinned at the nexus-vfs main commit that landed #67 (driver-plugin
+# ABI v4 — `nexus_driver_readdir` required symbol so dylib-backed
+# mounts surface their directory listings through `sys_readdir`, plus
+# the symmetric `sys_stat` backend.list_dir fallback so per-file
+# stat works for backend-only entries).  Unblocks the cc-tasks-list
+# mega-goal: `cc tasks list` on Mac / Win can enumerate the peer's
+# `~/.claude/tasks/<session>/...` through the FUSE mount even though
+# the JSON files are written by plain OS I/O outside Nexus.
 # Builds on prior landmarks: #57 plugin-as-gRPC-service routing,
 # #58 sealed-keystore signing trust root, #60 KernelHandle v3
 # sys_stat_batch, #61 per-call EC/SC primitives, #62 CLI flag rename,
 # #63 EC hot-path activation revert, #65 EC drain hardening, #66
-# voter-default flip. Bump alongside the rest of nexus-vfs updates
-# when a downstream change needs newer kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "f72020717f79d920f4429aec8aa6368dd676adde" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "f72020717f79d920f4429aec8aa6368dd676adde" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "f72020717f79d920f4429aec8aa6368dd676adde" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "f72020717f79d920f4429aec8aa6368dd676adde", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "f72020717f79d920f4429aec8aa6368dd676adde", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "f72020717f79d920f4429aec8aa6368dd676adde", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "f72020717f79d920f4429aec8aa6368dd676adde" }
+# voter-default flip, #67 driver-readdir ABI v4. Bump alongside the
+# rest of nexus-vfs updates when a downstream change needs newer
+# kernel bits.
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5849444330563cc414be577efa1d9e71e4546338" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5849444330563cc414be577efa1d9e71e4546338" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5849444330563cc414be577efa1d9e71e4546338" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5849444330563cc414be577efa1d9e71e4546338", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5849444330563cc414be577efa1d9e71e4546338", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5849444330563cc414be577efa1d9e71e4546338", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5849444330563cc414be577efa1d9e71e4546338" }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ENV CARGO_NET_RETRY=10 \
     CARGO_HTTP_TIMEOUT=120
 # Override for edge/CI or a different pin: --build-arg NEXUS_VFS_REV=<sha|tag>
-ARG NEXUS_VFS_REV=5849444330563cc414be577efa1d9e71e4546338
+ARG NEXUS_VFS_REV=09b7bd869657d2b56c18dd1d924bbfac742aced0
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,id=cargo-install-${TARGETARCH},target=/root/.cargo/target \

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ENV CARGO_NET_RETRY=10 \
     CARGO_HTTP_TIMEOUT=120
 # Override for edge/CI or a different pin: --build-arg NEXUS_VFS_REV=<sha|tag>
-ARG NEXUS_VFS_REV=f72020717f79d920f4429aec8aa6368dd676adde
+ARG NEXUS_VFS_REV=5849444330563cc414be577efa1d9e71e4546338
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,id=cargo-install-${TARGETARCH},target=/root/.cargo/target \

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ENV CARGO_NET_RETRY=10 \
     CARGO_HTTP_TIMEOUT=120
 # Override for edge/CI or a different pin: --build-arg NEXUS_VFS_REV=<sha|tag>
-ARG NEXUS_VFS_REV=09b7bd869657d2b56c18dd1d924bbfac742aced0
+ARG NEXUS_VFS_REV=c26926ebb968e1952ee3409afc98752e9dbc49b3
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,id=cargo-install-${TARGETARCH},target=/root/.cargo/target \

--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir --no-deps --prefix=/install .
 # enforces agreement) — an unpinned install tracks nexus-vfs HEAD and
 # ships an untested kernel (#4343). --locked honors the source tree's
 # Cargo.lock.
-ARG NEXUS_VFS_REV=f72020717f79d920f4429aec8aa6368dd676adde
+ARG NEXUS_VFS_REV=5849444330563cc414be577efa1d9e71e4546338
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-cluster nexus-cluster
 
 # -- Runtime stage --

--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir --no-deps --prefix=/install .
 # enforces agreement) — an unpinned install tracks nexus-vfs HEAD and
 # ships an untested kernel (#4343). --locked honors the source tree's
 # Cargo.lock.
-ARG NEXUS_VFS_REV=09b7bd869657d2b56c18dd1d924bbfac742aced0
+ARG NEXUS_VFS_REV=c26926ebb968e1952ee3409afc98752e9dbc49b3
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-cluster nexus-cluster
 
 # -- Runtime stage --

--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir --no-deps --prefix=/install .
 # enforces agreement) — an unpinned install tracks nexus-vfs HEAD and
 # ships an untested kernel (#4343). --locked honors the source tree's
 # Cargo.lock.
-ARG NEXUS_VFS_REV=5849444330563cc414be577efa1d9e71e4546338
+ARG NEXUS_VFS_REV=09b7bd869657d2b56c18dd1d924bbfac742aced0
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-cluster nexus-cluster
 
 # -- Runtime stage --

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -25,7 +25,7 @@ WORKDIR /build
 # (CI preflight enforces agreement) — an unpinned install tracks HEAD
 # and can skew the raft contract against the cluster/witness images.
 # --locked honors the source tree's Cargo.lock.
-ARG NEXUS_VFS_REV=09b7bd869657d2b56c18dd1d924bbfac742aced0
+ARG NEXUS_VFS_REV=c26926ebb968e1952ee3409afc98752e9dbc49b3
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexus-raft-server raft
 
 # ---------- Production image ----------

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -25,7 +25,7 @@ WORKDIR /build
 # (CI preflight enforces agreement) — an unpinned install tracks HEAD
 # and can skew the raft contract against the cluster/witness images.
 # --locked honors the source tree's Cargo.lock.
-ARG NEXUS_VFS_REV=f72020717f79d920f4429aec8aa6368dd676adde
+ARG NEXUS_VFS_REV=5849444330563cc414be577efa1d9e71e4546338
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexus-raft-server raft
 
 # ---------- Production image ----------

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -25,7 +25,7 @@ WORKDIR /build
 # (CI preflight enforces agreement) — an unpinned install tracks HEAD
 # and can skew the raft contract against the cluster/witness images.
 # --locked honors the source tree's Cargo.lock.
-ARG NEXUS_VFS_REV=5849444330563cc414be577efa1d9e71e4546338
+ARG NEXUS_VFS_REV=09b7bd869657d2b56c18dd1d924bbfac742aced0
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexus-raft-server raft
 
 # ---------- Production image ----------

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=09b7bd869657d2b56c18dd1d924bbfac742aced0
+ARG NEXUS_VFS_REV=c26926ebb968e1952ee3409afc98752e9dbc49b3
 RUN cargo install \
     --locked \
     --git https://github.com/nexi-lab/nexus-vfs \

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=f72020717f79d920f4429aec8aa6368dd676adde
+ARG NEXUS_VFS_REV=5849444330563cc414be577efa1d9e71e4546338
 RUN cargo install \
     --locked \
     --git https://github.com/nexi-lab/nexus-vfs \

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=5849444330563cc414be577efa1d9e71e4546338
+ARG NEXUS_VFS_REV=09b7bd869657d2b56c18dd1d924bbfac742aced0
 RUN cargo install \
     --locked \
     --git https://github.com/nexi-lab/nexus-vfs \

--- a/rust/backends/local-connector/src/lib.rs
+++ b/rust/backends/local-connector/src/lib.rs
@@ -116,6 +116,36 @@ fn readdir_local_connector(
         .map_err(storage_error_to_plugin_code)
 }
 
+/// Remove a backend file by path (sister of `write_local_connector`).
+///
+/// Delegates to `LocalConnectorBackend::delete_file`, which after
+/// the standard path-escape check calls `fs::remove_file`.  Opting
+/// into the `delete_file:` arm of `declare_driver_plugin!` closes
+/// the FUSE-`rm`-leaves-ghost-file gap: pre-opt-in, `sys_unlink`
+/// removed the metastore entry but the host fs file persisted, and
+/// the now-working `list_dir` re-surfaced it on the next ls.
+fn delete_file_local_connector(drv: &LocalConnectorDriver, path: &str) -> Result<(), i32> {
+    drv.backend
+        .delete_file(path)
+        .map_err(storage_error_to_plugin_code)
+}
+
+/// Point-lookup metadata for `path` — returns `(size, is_dir)`.
+///
+/// Delegates to `LocalConnectorBackend::stat`, which uses
+/// `fs::metadata` — O(1).  Opting into the `stat:` arm of
+/// `declare_driver_plugin!` lets the kernel's `sys_stat` backend
+/// fallback give callers the real size for backend-only files
+/// (host fs entries Claude Code wrote directly), instead of the
+/// trait-default `NotSupported` that would surface as ENOENT
+/// against the FUSE layer.
+fn stat_local_connector(drv: &LocalConnectorDriver, path: &str) -> Result<(u64, bool), i32> {
+    drv.backend
+        .stat(path)
+        .map(|s| (s.size, s.is_dir))
+        .map_err(storage_error_to_plugin_code)
+}
+
 fn system_ctx() -> OperationContext {
     // Driver runs inside the kernel's trust boundary; the syscall's
     // OperationContext already authorized the request upstream.  We
@@ -139,6 +169,8 @@ declare_driver_plugin!("local-connector", LocalConnectorDriver, {
     read: read_local_connector,
     write: write_local_connector,
     readdir: readdir_local_connector,
+    delete_file: delete_file_local_connector,
+    stat: stat_local_connector,
 });
 
 #[cfg(test)]

--- a/rust/backends/local-connector/src/lib.rs
+++ b/rust/backends/local-connector/src/lib.rs
@@ -107,10 +107,7 @@ fn write_local_connector(drv: &LocalConnectorDriver, path: &str, data: &[u8]) ->
 /// `local_root` contents under the mount path — what the
 /// cc-tasks-share Mac↔Win flow needs to find Claude Code session
 /// directories.
-fn readdir_local_connector(
-    drv: &LocalConnectorDriver,
-    path: &str,
-) -> Result<Vec<String>, i32> {
+fn readdir_local_connector(drv: &LocalConnectorDriver, path: &str) -> Result<Vec<String>, i32> {
     drv.backend
         .list_dir(path)
         .map_err(storage_error_to_plugin_code)

--- a/rust/backends/local-connector/src/lib.rs
+++ b/rust/backends/local-connector/src/lib.rs
@@ -127,6 +127,20 @@ fn delete_file_local_connector(drv: &LocalConnectorDriver, path: &str) -> Result
         .map_err(storage_error_to_plugin_code)
 }
 
+/// Remove a backend directory by path (sister of `delete_file_local_connector`).
+///
+/// Delegates to `LocalConnectorBackend::rmdir` with `recursive=false`
+/// — the v1 driver-rmdir ABI is single-dir only.  Closes the
+/// symmetric ghost-directory gap that `delete_file` left behind:
+/// pre-opt-in, FUSE `rmdir` cleared the metastore row but the host
+/// fs directory persisted and the `sys_stat` backend.stat fallback
+/// (also in ABI v4) kept surfacing it.
+fn rmdir_local_connector(drv: &LocalConnectorDriver, path: &str) -> Result<(), i32> {
+    drv.backend
+        .rmdir(path, false)
+        .map_err(storage_error_to_plugin_code)
+}
+
 /// Point-lookup metadata for `path` — returns `(size, is_dir)`.
 ///
 /// Delegates to `LocalConnectorBackend::stat`, which uses
@@ -167,6 +181,7 @@ declare_driver_plugin!("local-connector", LocalConnectorDriver, {
     write: write_local_connector,
     readdir: readdir_local_connector,
     delete_file: delete_file_local_connector,
+    rmdir: rmdir_local_connector,
     stat: stat_local_connector,
 });
 

--- a/rust/backends/local-connector/src/lib.rs
+++ b/rust/backends/local-connector/src/lib.rs
@@ -97,6 +97,25 @@ fn write_local_connector(drv: &LocalConnectorDriver, path: &str, data: &[u8]) ->
         .map_err(storage_error_to_plugin_code)
 }
 
+/// Enumerate immediate children at `path` (relative to `local_root`).
+///
+/// Wraps the existing `LocalConnectorBackend::list_dir` — the
+/// `ObjectStore` impl already produced the right wire shape
+/// (`Vec<String>` with trailing `/` for directories), so the bridge
+/// is one function call.  Opting in via the `declare_driver_plugin!`
+/// `readdir:` arm makes the kernel's `sys_readdir` surface
+/// `local_root` contents under the mount path — what the
+/// cc-tasks-share Mac↔Win flow needs to find Claude Code session
+/// directories.
+fn readdir_local_connector(
+    drv: &LocalConnectorDriver,
+    path: &str,
+) -> Result<Vec<String>, i32> {
+    drv.backend
+        .list_dir(path)
+        .map_err(storage_error_to_plugin_code)
+}
+
 fn system_ctx() -> OperationContext {
     // Driver runs inside the kernel's trust boundary; the syscall's
     // OperationContext already authorized the request upstream.  We
@@ -119,6 +138,7 @@ declare_driver_plugin!("local-connector", LocalConnectorDriver, {
     create: create_local_connector,
     read: read_local_connector,
     write: write_local_connector,
+    readdir: readdir_local_connector,
 });
 
 #[cfg(test)]

--- a/rust/services/fuse-plugin/src/fs_winfsp.rs
+++ b/rust/services/fuse-plugin/src/fs_winfsp.rs
@@ -793,16 +793,16 @@ mod tests {
         // contents (raft/, sm, ...) instead of the configured
         // subtree.
         let root = "/shared/cc-tasks";
-        assert_eq!(kernel_path_for(root, w("\\").as_ucstr()), "/shared/cc-tasks");
+        assert_eq!(
+            kernel_path_for(root, w("\\").as_ucstr()),
+            "/shared/cc-tasks"
+        );
         assert_eq!(
             kernel_path_for(root, w("\\songym-win").as_ucstr()),
             "/shared/cc-tasks/songym-win"
         );
         assert_eq!(
-            kernel_path_for(
-                root,
-                w("\\songym-win\\session-1\\1.json").as_ucstr()
-            ),
+            kernel_path_for(root, w("\\songym-win\\session-1\\1.json").as_ucstr()),
             "/shared/cc-tasks/songym-win/session-1/1.json"
         );
     }

--- a/rust/services/fuse-plugin/src/fs_winfsp.rs
+++ b/rust/services/fuse-plugin/src/fs_winfsp.rs
@@ -174,6 +174,12 @@ pub struct NexusWinFsp {
     kernel: KernelHandle,
     paths: Mutex<PathIndex>,
     next_inode: AtomicU64,
+    /// Kernel-side VFS prefix this mount is rooted at — every WinFsp
+    /// callback prepends this to the relative path WinFsp hands us.
+    /// Stored without a trailing slash (and as `""` when the
+    /// configured root is `"/"`) so the concat is a single
+    /// `format!("{vfs_root}{rel}")` with no double-slash hazard.
+    vfs_root: String,
 }
 
 // SAFETY: see struct doc — every field is `Send + Sync` either by
@@ -186,25 +192,41 @@ unsafe impl Sync for NexusWinFsp {}
 
 impl NexusWinFsp {
     pub fn new(kernel: KernelHandle, vfs_root: String) -> Self {
+        // Normalise `vfs_root` so `to_kernel_path` can rely on a
+        // single concat shape: `"" + "/foo"` (root case) vs
+        // `"/shared/cc-tasks" + "/foo"` (nested case).  Treat
+        // `"/"` and `""` as the same root-case sentinel because
+        // `NEXUS_FUSE_VFS_ROOT="/"` is the documented default and
+        // we don't want to leak `"//foo"` to the kernel.
+        let normalised = match vfs_root.trim_end_matches('/') {
+            "" => String::new(),
+            trimmed => trimmed.to_string(),
+        };
+        // PathIndex still wants the canonical root path so reverse
+        // lookups (`path_for(root_ino)`) return what the kernel
+        // would call this mount's root — `"/"` for the default,
+        // `"/shared/cc-tasks"` for the cc-tasks-share case.
+        let pi_root = if normalised.is_empty() {
+            "/".to_string()
+        } else {
+            normalised.clone()
+        };
         Self {
             kernel,
-            paths: Mutex::new(PathIndex::with_root(WINFSP_ROOT_INODE, vfs_root)),
+            paths: Mutex::new(PathIndex::with_root(WINFSP_ROOT_INODE, pi_root)),
             next_inode: AtomicU64::new(WINFSP_ROOT_INODE + 1),
+            vfs_root: normalised,
         }
     }
 
     /// Convert a WinFsp wide path (UTF-16, backslash separators) into
-    /// the kernel-side path (UTF-8, forward-slash separators).
-    /// `\` → `/` is the only transformation; WinFsp already strips
-    /// the drive letter / mount point prefix before handing the path
-    /// to the filesystem.
-    fn to_kernel_path(win_path: &U16CStr) -> String {
-        let s = win_path.to_string_lossy();
-        if s == "\\" {
-            "/".to_string()
-        } else {
-            s.replace('\\', "/")
-        }
+    /// the kernel-side path (UTF-8, forward-slash separators), with
+    /// the configured `vfs_root` prefix applied.  Thin wrapper over
+    /// [`kernel_path_for`] — keeping the translation logic in a
+    /// free function lets the unit tests pin the contract without
+    /// having to fabricate a `KernelHandle`.
+    fn to_kernel_path(&self, win_path: &U16CStr) -> String {
+        kernel_path_for(&self.vfs_root, win_path)
     }
 
     // ── Helpers ─────────────────────────────────────────────────────
@@ -274,7 +296,7 @@ impl FileSystemContext for NexusWinFsp {
         _security_descriptor: Option<&mut [std::os::raw::c_void]>,
         _reparse_point_resolver: impl FnOnce(&U16CStr) -> Option<FileSecurity>,
     ) -> Result<FileSecurity, FspError> {
-        let path = Self::to_kernel_path(file_name);
+        let path = self.to_kernel_path(file_name);
         winfsp_diag!("get_security_by_name path={:?}", path);
         let json = kernel_callbacks::sys_stat(&self.kernel, &path)
             .map_err(|e| FspError::NTSTATUS(errno_to_status(e)))?;
@@ -300,7 +322,7 @@ impl FileSystemContext for NexusWinFsp {
         granted_access: u32,
         file_info: &mut OpenFileInfo,
     ) -> Result<Self::FileContext, FspError> {
-        let path = Self::to_kernel_path(file_name);
+        let path = self.to_kernel_path(file_name);
         winfsp_diag!(
             "open path={:?} create_opts=0x{:x} granted=0x{:x} raw_widebytes={}",
             path,
@@ -340,7 +362,7 @@ impl FileSystemContext for NexusWinFsp {
         _extra_buffer_is_reparse_point: bool,
         file_info: &mut OpenFileInfo,
     ) -> Result<Self::FileContext, FspError> {
-        let path = Self::to_kernel_path(file_name);
+        let path = self.to_kernel_path(file_name);
         winfsp_diag!("create path={:?} create_opts=0x{:x}", path, create_options);
         let is_dir = (create_options & FILE_DIRECTORY_FILE) != 0;
         if is_dir {
@@ -553,8 +575,8 @@ impl FileSystemContext for NexusWinFsp {
         new_file_name: &U16CStr,
         _replace_if_exists: bool,
     ) -> Result<(), FspError> {
-        let old_path = Self::to_kernel_path(file_name);
-        let new_path = Self::to_kernel_path(new_file_name);
+        let old_path = self.to_kernel_path(file_name);
+        let new_path = self.to_kernel_path(new_file_name);
         let res = kernel_callbacks::sys_rename(&self.kernel, &old_path, &new_path);
         // Trace kept while the rename callsite is still being
         // debugged on CI — diagnostic on CI run 27515796611 showed
@@ -710,5 +732,87 @@ impl FileSystemContext for NexusWinFsp {
         out.free_size = 1 << 39;
         let _ = out.set_volume_label("NexusVFS");
         Ok(())
+    }
+}
+
+/// Pure-function path translator extracted from
+/// [`NexusWinFsp::to_kernel_path`] so unit tests can pin the
+/// contract without fabricating a `KernelHandle`.
+///
+/// Translates a WinFsp wide path (UTF-16, backslash separators,
+/// always rooted at `\`) into a kernel-side absolute VFS path
+/// (UTF-8, forward slashes) by prepending the mount's `vfs_root`.
+/// `vfs_root` is expected pre-normalised: no trailing slash, empty
+/// string sentinel for the `"/"` default case.
+fn kernel_path_for(vfs_root: &str, win_path: &U16CStr) -> String {
+    let s = win_path.to_string_lossy();
+    let relative = if s == "\\" {
+        String::new()
+    } else {
+        s.replace('\\', "/")
+    };
+    if vfs_root.is_empty() {
+        if relative.is_empty() {
+            "/".to_string()
+        } else {
+            relative
+        }
+    } else if relative.is_empty() {
+        vfs_root.to_string()
+    } else {
+        format!("{}{}", vfs_root, relative)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use widestring::U16CString;
+
+    fn w(s: &str) -> U16CString {
+        U16CString::from_str(s).expect("utf-16 conversion")
+    }
+
+    #[test]
+    fn kernel_path_for_root_default() {
+        // Default mount (`NEXUS_FUSE_VFS_ROOT="/"` → normalised to "")
+        // surfaces the global VFS root on `M:\`.
+        assert_eq!(kernel_path_for("", w("\\").as_ucstr()), "/");
+        assert_eq!(kernel_path_for("", w("\\foo").as_ucstr()), "/foo");
+        assert_eq!(
+            kernel_path_for("", w("\\dir\\file.txt").as_ucstr()),
+            "/dir/file.txt"
+        );
+    }
+
+    #[test]
+    fn kernel_path_for_subtree_mount() {
+        // cc-tasks-share scope: M:\ surfaces /shared/cc-tasks,
+        // M:\songym-win surfaces /shared/cc-tasks/songym-win, etc.
+        // Regression pin for the bug where `ls M:\` showed `/`s
+        // contents (raft/, sm, ...) instead of the configured
+        // subtree.
+        let root = "/shared/cc-tasks";
+        assert_eq!(kernel_path_for(root, w("\\").as_ucstr()), "/shared/cc-tasks");
+        assert_eq!(
+            kernel_path_for(root, w("\\songym-win").as_ucstr()),
+            "/shared/cc-tasks/songym-win"
+        );
+        assert_eq!(
+            kernel_path_for(
+                root,
+                w("\\songym-win\\session-1\\1.json").as_ucstr()
+            ),
+            "/shared/cc-tasks/songym-win/session-1/1.json"
+        );
+    }
+
+    #[test]
+    fn kernel_path_for_normalised_vfs_root_no_double_slash() {
+        // Even if the caller forgets to normalise, the constructor
+        // does — verify the post-normalisation contract: `vfs_root`
+        // never carries a trailing slash, so the concat is a single
+        // `{root}{relative}` with no `"//"` hazard.
+        assert!(!kernel_path_for("/shared/cc-tasks", w("\\foo").as_ucstr()).contains("//"));
     }
 }

--- a/tests/e2e/docker/test_cc_tasks_share_e2e.py
+++ b/tests/e2e/docker/test_cc_tasks_share_e2e.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 
 import concurrent.futures
 import os
+import subprocess
 import time
 import uuid
 
@@ -789,6 +790,149 @@ class TestCrossNodeConcurrentBurst:
             assert sorted(joiner_entries) == sorted(payloads.keys()), (
                 f"joiner FUSE readdir returned {joiner_entries}, expected {sorted(payloads.keys())}"
             )
+        finally:
+            runbook_helpers.docker_exec(
+                topology.founder_container,
+                ["rm", "-rf", f"/host/tasks/{session}"],
+                check=False,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Backend-only enumeration — the cc-tasks-list mega-goal shape.
+#
+# Claude Code writes task JSON via plain OS file operations
+# (`fs.writeFileSync("~/.claude/tasks/<session>/<n>.json", ...)`) —
+# nothing in Nexus's syscall surface ever runs.  No `vfs_write`, no
+# metadata propose, no metastore entry.  The bytes live on the host
+# fs the LocalConnector points at.
+#
+# For `cc tasks list` to enumerate those tasks through the FUSE mount,
+# two pieces have to hold:
+#   1. `sys_readdir` must merge the LocalConnector backend's
+#      `list_dir(...)` output into its result set — this was already
+#      in kernel/io.rs:3102-3118, but the DylibObjectStore wrapper
+#      around dylib drivers returned `NotSupported` until
+#      nexus-vfs#67 added the `nexus_driver_readdir` ABI symbol +
+#      the LocalConnector implementation.
+#   2. `sys_stat` must be symmetric — without a metastore entry it
+#      historically returned `None` for backend-owned paths, so every
+#      WinFsp `get_security_by_name` / FUSE `lookup` against the
+#      enumerated entries failed with ENOENT.  nexus-vfs#67's
+#      `sys_stat` backend.list_dir fallback closes that gap.
+#
+# This class pins both pieces by exercising the no-kernel-write path:
+# write directly to `/host/tasks/<session>/<n>.json`, then enumerate +
+# read via the FUSE mount.  A regression in either piece surfaces here.
+# ---------------------------------------------------------------------------
+class TestCcTasksListBackendOnlyEnumeration:
+    """`cc tasks list` mega-goal pin — backend-only host-fs writes are
+    discoverable + readable through the FUSE mount surface without any
+    intervening kernel syscall write.
+
+    Single-node first (the substrate); cross-node enumeration of
+    backend-only entries is plan-deferred to a follow-up that lazily
+    propagates listings across federation.
+    """
+
+    def test_host_fs_only_writes_enumerate_and_read_via_fuse(
+        self,
+        topology: CcTasksTopology,
+        api_key: str,
+        joined_cluster: dict,
+    ) -> None:
+        session = _new_session()
+        # Drop three task JSONs straight onto founder's host fs — no
+        # vfs_write, no metastore, no propose.  Mirrors what Claude
+        # Code does at the OS layer outside Nexus.
+        payloads = {
+            "1.json": b'{"id":"1","status":"completed","backend_only":true}',
+            "2.json": b'{"id":"2","status":"in_progress","backend_only":true}',
+            "3.json": b'{"id":"3","status":"pending","backend_only":true}',
+        }
+        for name, data in payloads.items():
+            cc_tasks_share_helpers.host_task_write(
+                topology.founder_container, f"/{session}/{name}", data
+            )
+
+        try:
+            # Step 1: backend-only writes do NOT create metastore
+            # entries — the kernel-side surface knows nothing about
+            # them until enumeration walks the backend.  Pin the
+            # precondition so a future kernel change that quietly
+            # starts propagating these wouldn't silently turn this
+            # test into a different scenario.
+            session_vfs = topology.founder_vfs_path(f"/{session}")
+            pre_stat = runbook_helpers.vfs_stat(topology.founder_grpc, session_vfs, api_key=api_key)
+            # `found` reflects the SSOT view: with PR #67 the kernel's
+            # sys_stat backend-fallback DOES synthesise a DT_DIR
+            # result for this path because the backend list_dir
+            # returns the session dir among the mount's children.
+            # That's exactly the contract this PR ships — the stat
+            # surface is now symmetric with readdir over driver-owned
+            # entries.  Keep the assertion narrow: we need `found`,
+            # `is_directory`, AND `entry_type == 2 (DT_DIR)`.
+            assert pre_stat["result"]["found"], (
+                f"sys_stat must surface the backend-only session dir "
+                f"after PR #67's fallback — got {pre_stat}"
+            )
+            assert pre_stat["result"]["isDirectory"], (
+                f"backend-only session dir should stat as a directory — got {pre_stat}"
+            )
+
+            # Step 2: FUSE-level readdir of the session dir surfaces
+            # every host-fs file we wrote.  This is the path
+            # `cc tasks list` actually walks — the kernel readdir
+            # delegates to the LocalConnector dylib's
+            # nexus_driver_readdir symbol added in PR #67.
+            session_mount = topology.mount_path_for_vfs(session_vfs)
+            entries = cc_tasks_share_helpers.mount_listdir(
+                topology.founder_container, session_mount
+            )
+            assert sorted(entries) == sorted(payloads.keys()), (
+                f"FUSE readdir of backend-only session dir got {entries}, "
+                f"expected {sorted(payloads.keys())} — driver_readdir wiring may be broken"
+            )
+
+            # Step 3: lookup each individual file via FUSE — exercises
+            # the sys_stat backend-fallback path on a per-file basis,
+            # the codepath that was returning ENOENT pre-PR.  Without
+            # it, `cat M:\songym-win\<session>\1.json` failed because
+            # WinFsp's get_security_by_name → sys_stat returned None.
+            for name in payloads:
+                file_vfs = topology.founder_vfs_path(f"/{session}/{name}")
+                file_stat = runbook_helpers.vfs_stat(
+                    topology.founder_grpc, file_vfs, api_key=api_key
+                )
+                assert file_stat["result"]["found"], (
+                    f"sys_stat must find backend-only file {name} via "
+                    f"backend.list_dir(parent) fallback — got {file_stat}"
+                )
+                assert not file_stat["result"]["isDirectory"], (
+                    f"backend-only file {name} should stat as a regular file"
+                )
+
+            # Step 4: read the bytes back through the FUSE mount —
+            # full chain `cat /mnt/.../<session>/<n>.json` → FUSE
+            # lookup → sys_stat (backend fallback) → sys_open →
+            # sys_read → LocalConnector backend → host fs.  Confirms
+            # the enumeration entries map back to readable content.
+            for name, expected in payloads.items():
+                file_mount = topology.mount_path_for_vfs(
+                    topology.founder_vfs_path(f"/{session}/{name}")
+                )
+                proc = subprocess.run(
+                    ["docker", "exec", topology.founder_container, "cat", file_mount],
+                    capture_output=True,
+                    timeout=30,
+                )
+                assert proc.returncode == 0, (
+                    f"FUSE read of {name} failed (rc={proc.returncode}): "
+                    f"stderr={proc.stderr.decode(errors='replace')}"
+                )
+                assert proc.stdout == expected, (
+                    f"FUSE read of {name} got {proc.stdout!r}, expected {expected!r}"
+                )
         finally:
             runbook_helpers.docker_exec(
                 topology.founder_container,


### PR DESCRIPTION
Unblocks the cc-tasks-list mega-goal: \`cc tasks list\` on Mac sees Win's tasks dir and vice versa through the FUSE mount, with task JSON files written directly to host fs by Claude Code (no intervening Nexus syscall write).

Three coordinated pieces. **Depends on [nexi-lab/nexus-vfs#67](https://github.com/nexi-lab/nexus-vfs/pull/67)** (driver ABI v4: \`nexus_driver_readdir\` + \`sys_stat\` backend.list_dir fallback).

## What changes

### 1. \`local-connector\`: wire \`nexus_driver_readdir\` (~20 LOC)
\`LocalConnectorBackend::list_dir\` already returned the right wire shape (\`Vec<String>\` with trailing \`/\` for directories) for in-process backends. Bridging it through the new driver-plugin ABI symbol is a one-function delegate: \`readdir_local_connector(drv, path)\` → \`drv.backend.list_dir(path)\`, errors mapped via the existing \`storage_error_to_plugin_code\` helper.

### 2. \`fuse-plugin/winfsp\`: \`to_kernel_path\` prepends configured \`vfs_root\` (~120 LOC + tests)
\`fs_winfsp.rs::to_kernel_path\` was converting \`\foo\` → \`/foo\` but NEVER prepending the configured \`NEXUS_FUSE_VFS_ROOT\` prefix. \`ls M:\\` asked the kernel about \`/\` (global VFS root, surfacing \`raft/\` and \`sm\` from the cluster's internal layout) instead of the operator's scoped \`/shared/cc-tasks\` subtree. Fix: store \`vfs_root\` (normalised — no trailing slash, empty sentinel for the \`\"/\"\` default) on \`NexusWinFsp\` and prepend on every translation. SSOT in one place. Pinned by three new \`kernel_path_for_*\` unit tests.

### 3. \`TestCcTasksListBackendOnlyEnumeration\` (~140 LOC, docker E2E pin)
New test class in \`tests/e2e/docker/test_cc_tasks_share_e2e.py\`. Writes three task JSONs DIRECTLY to founder's \`/host/tasks/<session>/...\` via \`docker exec\` — bypassing every Nexus syscall, mirroring exactly what Claude Code does outside Nexus. Then asserts the full chain works without any kernel-side write:

1. \`sys_stat\` on the backend-only session dir returns \`found=true, isDirectory=true\` (PR #67's backend fallback).
2. FUSE \`mount_listdir\` of the session dir surfaces all three \`.json\` entries (PR #67 \`nexus_driver_readdir\` + LocalConnector wiring above).
3. Per-file \`sys_stat\` finds each entry as DT_REG (same fallback path, individual-file granularity).
4. FUSE \`cat /mnt/.../<session>/<n>.json\` returns byte-identical content.

\`.github/workflows/cc-tasks-share-e2e.yml\` already drives the docker compose + pytest invocation. New class is auto-picked-up by the existing suite on every PR touching the cc-tasks-share files — **CI protection of the milestone in place once this merges**.

## Local end-to-end verification on Win (with #67 + this PR's code applied locally)

- \`ls M:\songym-win\\` → 33 session UUID directories from \`~/.claude/tasks/\` ✓
- \`ls M:\songym-win\<session>\\` → real \`1.json\` \`2.json\` ... files ✓
- \`cat M:\songym-win\<session>\1.json\` → byte-identical to local fs read ✓

## Dep bump — separate follow-up commit

This PR DOES NOT yet bump \`Cargo.toml\` / \`Cargo.lock\` / Dockerfile \`NEXUS_VFS_REV\`. CI will fail at \`cargo check\` against the still-v3 ABI until those move. A follow-up commit on this branch (or an amend before merge) bumps the rev once #67 merges to nexus-vfs main.

## Memory references

- \`reference_local_plugin_signing_dev_root\` — songym Windows dev key (workaround for broken release pipeline)
- \`feedback_kernel_tier_in_nexus_vfs\` — kernel-tier crates moved 2026-06-03