### PR TITLE
feat(fuse-plugin): macOS preflight — detect FUSE-T + report fuse-t-missing via status dispatch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1566,6 +1566,7 @@ dependencies = [
  "fuser",
  "libc",
  "nexus-plugin-abi",
+ "tempfile",
  "tracing",
  "widestring",
  "windows-sys 0.52.0",

--- a/rust/services/fuse-plugin/Cargo.toml
+++ b/rust/services/fuse-plugin/Cargo.toml
@@ -46,6 +46,12 @@ libc = "0.2"
 # winfsp-rs ships with a bundled import library so no WinFsp SDK is
 # needed at build time; the runtime DLL must be installed on the
 # operator's machine before launching nexusd-cluster.
+[target.'cfg(target_os = "macos")'.dev-dependencies]
+# fuse_t_detect tests stage candidate paths in a tempdir to avoid
+# touching /Library/Filesystems on the developer's host. macOS-only
+# because that's the only target where `fuse_t_detect` compiles.
+tempfile = "3"
+
 [target.'cfg(target_os = "windows")'.dependencies]
 winfsp = "0.13"
 # `widestring` for U16CStr ↔ String path conversion at the FFI

--- a/rust/services/fuse-plugin/src/fuse_t_detect.rs
+++ b/rust/services/fuse-plugin/src/fuse_t_detect.rs
@@ -1,0 +1,222 @@
+//! Detect whether macOS' FUSE-T userspace driver is provisioned on this
+//! host. Called from `create_fuse_plugin` on macOS before any
+//! `fuser::spawn_mount2` attempt — if the driver isn't there, the mount
+//! will fail with a confusing low-level error (`fuse: device not found`
+//! or similar), so we surface a clean `MountOutcome::FuseTMissing`
+//! instead and let the supervisor (sudowork on the desktop) handle the
+//! one-shot install via `osascript`.
+//!
+//! Split into three layers, probed in order:
+//!
+//!   1. FSKit framework at `/Library/Frameworks/fuse_t.framework`
+//!      — FUSE-T 1.2+ canonical location (Apple's kext-free FSKit
+//!      replacement).
+//!   2. Legacy filesystem bundle at `/Library/Filesystems/fuse-t.fs`
+//!      — FUSE-T 1.0 / 1.1 layout, still present on dev machines that
+//!      haven't upgraded.
+//!   3. `pkgutil --pkgs --regexp '^org\.fuse-t\.'` — fallback for a
+//!      future layout shift. Slow (subprocess), only runs when the disk
+//!      probes miss.
+//!
+//! The three-tier shape mirrors the sudowork TS detector
+//! (`src/process/services/fuset/FuseTInstallService.ts`) so the two
+//! sides agree on what counts as "installed". The Rust copy is the
+//! source of truth for in-cluster decisions; sudowork's copy is for
+//! pre-install UI state only.
+
+#![cfg(target_os = "macos")]
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Conventional install locations, probed in order. First match wins.
+pub(crate) const FUSE_T_BUNDLE_CANDIDATES: &[&str] = &[
+    "/Library/Frameworks/fuse_t.framework", // FUSE-T 1.2+ (FSKit)
+    "/Library/Filesystems/fuse-t.fs",       // FUSE-T 1.0 / 1.1 (legacy bundle)
+];
+
+/// `pkgutil --pkgs` regex matching any version-suffixed FUSE-T package id
+/// (`org.fuse-t.fskit.1.2.7`, `org.fuse-t.core.1.2.7`, future
+/// `org.fuse-t.<whatever>`).
+pub(crate) const FUSE_T_PKGUTIL_REGEX: &str = r"^org\.fuse-t\.";
+
+/// Which layer confirmed the install — useful for logs / telemetry, and
+/// caught in tests so a regression in the disk-path-vs-pkgutil ordering
+/// doesn't silently make every detection fall through to the slow path.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum DetectionHit {
+    /// One of `FUSE_T_BUNDLE_CANDIDATES` exists on disk.
+    DiskPath(PathBuf),
+    /// pkgutil registry has at least one matching package receipt.
+    PkgutilRegistry,
+}
+
+/// Result of a single detection pass.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum DetectionResult {
+    Found(DetectionHit),
+    NotFound,
+}
+
+/// Production probe — uses the real `FUSE_T_BUNDLE_CANDIDATES` and
+/// shells out to `pkgutil`. Cheap on the happy path: two `Path::exists`
+/// calls, short-circuits on the first hit. The subprocess only fires
+/// when both disk paths miss.
+pub(crate) fn is_fuse_t_installed() -> DetectionResult {
+    detect(FUSE_T_BUNDLE_CANDIDATES.iter().map(Path::new), || {
+        run_pkgutil_probe(FUSE_T_PKGUTIL_REGEX)
+    })
+}
+
+/// Pure detection core — paths to probe + a function that runs the
+/// pkgutil query. Lifted out of `is_fuse_t_installed` for tests; the
+/// production caller passes the real constants, tests pass tempdir
+/// paths + a closure that returns canned stdout.
+pub(crate) fn detect<'a, I, F>(candidates: I, pkgutil: F) -> DetectionResult
+where
+    I: IntoIterator<Item = &'a Path>,
+    F: FnOnce() -> bool,
+{
+    for candidate in candidates {
+        if path_exists(candidate) {
+            return DetectionResult::Found(DetectionHit::DiskPath(candidate.to_path_buf()));
+        }
+    }
+    if pkgutil() {
+        return DetectionResult::Found(DetectionHit::PkgutilRegistry);
+    }
+    DetectionResult::NotFound
+}
+
+/// Existence probe that treats every error (permission denied, broken
+/// symlink, ...) as "not found" rather than propagating it. The
+/// supervisor only needs a boolean here — diagnostic detail belongs in
+/// tracing, not the return value. Matches the sudowork TS `fileExists`
+/// helper's swallow-and-log shape.
+fn path_exists(p: &Path) -> bool {
+    match p.try_exists() {
+        Ok(exists) => exists,
+        Err(err) => {
+            tracing::warn!(
+                target: "nexus::fuse",
+                path = %p.display(),
+                error = %err,
+                "fuse_t_detect: path probe errored; treating as not-found"
+            );
+            false
+        }
+    }
+}
+
+/// Shell out to `pkgutil --pkgs --regexp <pattern>`. Returns true iff
+/// the command exits 0 with non-empty stdout. Any other outcome
+/// (non-zero exit, missing pkgutil binary, IO error) is "not found".
+fn run_pkgutil_probe(regex: &str) -> bool {
+    match Command::new("pkgutil")
+        .args(["--pkgs", "--regexp", regex])
+        .output()
+    {
+        Ok(out) if out.status.success() => !out.stdout.iter().all(u8::is_ascii_whitespace),
+        Ok(out) => {
+            tracing::debug!(
+                target: "nexus::fuse",
+                exit_code = ?out.status.code(),
+                stderr = %String::from_utf8_lossy(&out.stderr),
+                "pkgutil probe returned non-success"
+            );
+            false
+        }
+        Err(err) => {
+            tracing::warn!(
+                target: "nexus::fuse",
+                error = %err,
+                "pkgutil probe failed to spawn — treating as not-found"
+            );
+            false
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    /// Helper: build a tempdir with a single "framework directory"
+    /// inside so the detector treats it as present.
+    fn touch_dir(dir: &Path, name: &str) -> PathBuf {
+        let p = dir.join(name);
+        fs::create_dir_all(&p).expect("create dir candidate");
+        p
+    }
+
+    #[test]
+    fn detect_returns_first_disk_hit_when_framework_present() {
+        let tmp = TempDir::new().unwrap();
+        let framework = touch_dir(tmp.path(), "fuse_t.framework");
+        let legacy = tmp.path().join("fuse-t.fs"); // not created
+        let candidates = [framework.as_path(), legacy.as_path()];
+        let result = detect(candidates.iter().copied(), || {
+            panic!("pkgutil must not run when a disk candidate hits");
+        });
+        assert_eq!(
+            result,
+            DetectionResult::Found(DetectionHit::DiskPath(framework))
+        );
+    }
+
+    #[test]
+    fn detect_falls_through_to_legacy_when_framework_absent() {
+        let tmp = TempDir::new().unwrap();
+        let framework = tmp.path().join("fuse_t.framework"); // not created
+        let legacy = touch_dir(tmp.path(), "fuse-t.fs");
+        let candidates = [framework.as_path(), legacy.as_path()];
+        let result = detect(candidates.iter().copied(), || {
+            panic!("pkgutil must not run when a disk candidate hits");
+        });
+        assert_eq!(
+            result,
+            DetectionResult::Found(DetectionHit::DiskPath(legacy))
+        );
+    }
+
+    #[test]
+    fn detect_falls_through_to_pkgutil_when_both_disk_candidates_miss() {
+        let tmp = TempDir::new().unwrap();
+        let framework = tmp.path().join("fuse_t.framework");
+        let legacy = tmp.path().join("fuse-t.fs");
+        let candidates = [framework.as_path(), legacy.as_path()];
+        let result = detect(candidates.iter().copied(), || true);
+        assert_eq!(
+            result,
+            DetectionResult::Found(DetectionHit::PkgutilRegistry)
+        );
+    }
+
+    #[test]
+    fn detect_returns_not_found_when_every_layer_misses() {
+        let tmp = TempDir::new().unwrap();
+        let framework = tmp.path().join("fuse_t.framework");
+        let legacy = tmp.path().join("fuse-t.fs");
+        let candidates = [framework.as_path(), legacy.as_path()];
+        let result = detect(candidates.iter().copied(), || false);
+        assert_eq!(result, DetectionResult::NotFound);
+    }
+
+    #[test]
+    fn pkgutil_probe_only_runs_on_disk_miss() {
+        // Sanity: the iterator-based core MUST short-circuit. If it
+        // doesn't, the production caller will run pkgutil on every
+        // single mount even when the framework path is present —
+        // perf gate.
+        let tmp = TempDir::new().unwrap();
+        let present = touch_dir(tmp.path(), "fuse_t.framework");
+        let mut ran = false;
+        let _ = detect([present.as_path()].iter().copied(), || {
+            ran = true;
+            true
+        });
+        assert!(!ran, "pkgutil ran despite a disk hit");
+    }
+}

--- a/rust/services/fuse-plugin/src/lib.rs
+++ b/rust/services/fuse-plugin/src/lib.rs
@@ -60,6 +60,9 @@ mod path_index;
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 mod fs;
 
+#[cfg(target_os = "macos")]
+mod fuse_t_detect;
+
 #[cfg(target_os = "windows")]
 mod fs_winfsp;
 
@@ -78,6 +81,17 @@ use nexus_plugin_abi::{declare_service_plugin, KernelHandle};
 struct FusePlugin {
     #[cfg(any(target_os = "linux", target_os = "macos"))]
     session: Mutex<Option<fuser::BackgroundSession>>,
+    /// Names a host-side prerequisite the platform-native FUSE userspace
+    /// driver needs that we couldn't satisfy at plugin-create time. Only
+    /// populated on macOS today, where FUSE-T is a user-installed `.pkg`
+    /// the supervisor (sudowork on the desktop) provisions via
+    /// `osascript` after this plugin reports the gap. `Some("fuse-t")`
+    /// means "the FUSE event loop was skipped because FUSE-T isn't
+    /// installed" — surfaced over `dispatch("status")` as
+    /// `"fuse-t-missing"` so the supervisor can match without parsing
+    /// a free-form message.
+    #[cfg(target_os = "macos")]
+    prereq_missing: Mutex<Option<&'static str>>,
     #[cfg(target_os = "windows")]
     host: Mutex<
         Option<winfsp::host::FileSystemHost<fs_winfsp::NexusWinFsp, winfsp::host::CoarseGuard>>,
@@ -89,6 +103,8 @@ impl FusePlugin {
         Self {
             #[cfg(any(target_os = "linux", target_os = "macos"))]
             session: Mutex::new(None),
+            #[cfg(target_os = "macos")]
+            prereq_missing: Mutex::new(None),
             #[cfg(target_os = "windows")]
             host: Mutex::new(None),
         }
@@ -111,6 +127,33 @@ fn create_fuse_plugin(_kernel: &KernelHandle) -> Box<FusePlugin> {
     {
         let mount_point = std::env::var("NEXUS_FUSE_MOUNT_POINT").ok();
         if let Some(mount_point) = mount_point {
+            // macOS-only preflight: FUSE-T is a user-installed `.pkg`
+            // shipping the kernel-side FUSE userspace driver. Without
+            // it `fuser::spawn_mount2` fails with a low-level
+            // "device not found" that's confusing to surface up. Probe
+            // for it first, and if missing, register a clean
+            // `prereq_missing = Some("fuse-t")` state the supervisor
+            // (sudowork on the desktop) can poll via
+            // `dispatch("status")`. The supervisor installs FUSE-T via
+            // `osascript` and re-creates this plugin to retry the mount.
+            // No supervisor-visible spawn failure, no half-mounted state.
+            #[cfg(target_os = "macos")]
+            {
+                use fuse_t_detect::{is_fuse_t_installed, DetectionResult};
+                if matches!(is_fuse_t_installed(), DetectionResult::NotFound) {
+                    eprintln!(
+                        "[nexus-fuse-plugin] FUSE-T not installed; mount at {mount_point} skipped (status=fuse-t-missing)"
+                    );
+                    tracing::warn!(
+                        target: "nexus::fuse",
+                        mount_point = %mount_point,
+                        "FUSE-T not installed; supervisor must install before mount can succeed"
+                    );
+                    *plugin.prereq_missing.lock().unwrap() = Some("fuse-t");
+                    return Box::new(plugin);
+                }
+            }
+
             let vfs_root = std::env::var("NEXUS_FUSE_VFS_ROOT").unwrap_or_else(|_| "/".to_string());
 
             // SAFETY: KernelHandle's function pointers and `kernel_ptr`
@@ -308,6 +351,20 @@ unsafe fn kernel_handle_clone(src: &KernelHandle) -> KernelHandle {
 fn dispatch_fuse(svc: &FusePlugin, method: &str, _payload: &[u8]) -> Result<Vec<u8>, i32> {
     match method {
         "status" => {
+            #[cfg(target_os = "macos")]
+            {
+                // FUSE-T (or whatever future macOS preflight names
+                // itself) takes precedence over the session check —
+                // the session can't possibly be `Some(_)` when the
+                // preflight bailed, but `<prereq>-missing` is the
+                // signal the supervisor needs to know which action
+                // to take. The format `"<prereq>-missing"` is the
+                // contract sudowork's nexusd-cluster supervisor matches
+                // on; adding a new prereq is a single-line change here.
+                if let Some(prereq) = *svc.prereq_missing.lock().unwrap() {
+                    return Ok(format!("{prereq}-missing").into_bytes());
+                }
+            }
             #[cfg(any(target_os = "linux", target_os = "macos"))]
             {
                 let mounted = svc.session.lock().unwrap().is_some();


### PR DESCRIPTION
## Summary

Pair with sudowork [#916](https://github.com/sudoprivacy/sudowork/pull/916). That PR landed a lazy FUSE-T installer in sudowork (`fuseTInstallService.ensureInstalled()`) but **nothing in the codebase calls it** — the IPC surface is wired but no trigger fires it. We discussed four placement options in sudowork chat; this PR is the Rust half of the "D" path (trigger lives where the dependency is actually needed, in the plugin) so the install becomes truly lazy without bolting a UI toggle on top.

### Rationale (option D vs A / B / C)

- **A** — sudowork eagerly ensures FUSE-T before `nexusd-cluster` spawn. Breaks the lazy contract — every Mac user gets prompted on cold start even if they never mount.
- **B** — sudowork settings toggle. Patch over patch; the UI surface becomes a no-op as soon as detection lives in the plugin.
- **C** — sudocode → sudowork IPC for arbitrary runtime requests. Cross-repo protocol surface that grows with every new runtime.
- **D** — plugin reports `"<prereq>-missing"` over its existing `dispatch("status")` surface, sudowork supervisor matches the string and runs `ensureInstalled`, then re-creates the plugin. Detection lives once (Rust, this PR), install lives once (sudowork TS, already merged). No new cross-repo protocol.

### Changes

- New `fuse_t_detect` module (macOS-only, `cfg`-gated). Three-tier probe, identical shape to sudowork's TS detector:
  1. `/Library/Frameworks/fuse_t.framework` (FUSE-T 1.2+ FSKit canonical path).
  2. `/Library/Filesystems/fuse-t.fs` (1.0 / 1.1 legacy filesystem bundle).
  3. `pkgutil --pkgs --regexp '^org\.fuse-t\.'` (future-layout fallback).
- Pure detection core `detect(candidates, pkgutil)` takes an iterator + closure so tests stage tempdir paths + a canned closure instead of touching the host's `/Library/Frameworks`.
- `FusePlugin::prereq_missing: Mutex<Option<&'static str>>` records `Some("fuse-t")` when the probe misses. `create_fuse_plugin` returns early — no `fuser::spawn_mount2` against a host that can't satisfy it.
- `dispatch_fuse("status")` checks `prereq_missing` first, returns `"<prereq>-missing"` (today only `"fuse-t-missing"`; the format generalises to a future Linux `"libfuse3-missing"` or Windows `"winfsp-missing"` without a wire-format change). Existing `"mounted"` / `"unmounted"` paths unchanged.

### Why a string contract for `status` (and not a structured error code)

The `dispatch` surface is plain UTF-8 bytes today (see existing `"mounted"` / `"unmounted"` returns and the doc on `dispatch_fuse`). Promoting to a typed error here would mean churning the plugin ABI for one new state — exactly the "don't easily modify infra ABI" pushback. A `<prereq>-missing` literal extends the existing string shape without changing the contract.

### Out of scope

- **Sudowork supervisor side** — separate PR. Will poll cluster `dispatch("status")` on the fuse plugin, match `"fuse-t-missing"`, invoke `ipcBridge.fuseT.ensureInstalled.invoke()`, then dispatch `"unmount"` + re-create. Cross-repo timing: this PR merges first so sudowork has a stable status string to depend on.
- **Linux `libfuse3` preflight** + **Windows WinFsp preflight** — symmetric pattern available (probe → set `prereq_missing` → status string), not done here because no sudowork-side caller has asked for it yet.
- **Auto-retry inside the plugin** — supervisor decides re-creation timing; this PR just exposes the gap.

### Test plan

- [x] Unit: `detect_returns_first_disk_hit_when_framework_present` — tempdir framework + missing legacy + closure that panics if invoked. Locks the "happy path doesn't shell out" invariant.
- [x] Unit: `detect_falls_through_to_legacy_when_framework_absent` — only legacy created, framework missing. Confirms ordered fallback.
- [x] Unit: `detect_falls_through_to_pkgutil_when_both_disk_candidates_miss` — closure returns true, no disk candidate exists.
- [x] Unit: `detect_returns_not_found_when_every_layer_misses` — all probes miss.
- [x] Unit: `pkgutil_probe_only_runs_on_disk_miss` — explicit perf gate (disk hit short-circuits the subprocess).
- [ ] CI: macOS Build Test must compile the new module; Linux + Windows must stay green since the module is `cfg(target_os = "macos")` and the `lib.rs` insertions are cfg-gated.
- [ ] Real-host smoke (post-merge): sudowork pulls the new release into `runtime-versions.json`, supervisor polls `dispatch("status")` against a Mac without FUSE-T installed, confirms it sees `"fuse-t-missing"`.
