### PR TITLE
test(docker-e2e): cc-tasks-list E2E pins for nexus-vfs FederationPeerClient dispatch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=c26926ebb968e1952ee3409afc98752e9dbc49b3#c26926ebb968e1952ee3409afc98752e9dbc49b3"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=6afa833ea878690d4adb2a83a2202b9caa4a1314#6afa833ea878690d4adb2a83a2202b9caa4a1314"
 dependencies = [
  "ahash",
  "base64",
@@ -550,7 +550,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=c26926ebb968e1952ee3409afc98752e9dbc49b3#c26926ebb968e1952ee3409afc98752e9dbc49b3"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=6afa833ea878690d4adb2a83a2202b9caa4a1314#6afa833ea878690d4adb2a83a2202b9caa4a1314"
 dependencies = [
  "parking_lot",
  "serde",
@@ -1335,7 +1335,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=c26926ebb968e1952ee3409afc98752e9dbc49b3#c26926ebb968e1952ee3409afc98752e9dbc49b3"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=6afa833ea878690d4adb2a83a2202b9caa4a1314#6afa833ea878690d4adb2a83a2202b9caa4a1314"
 dependencies = [
  "ahash",
  "base64",
@@ -1386,7 +1386,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=c26926ebb968e1952ee3409afc98752e9dbc49b3#c26926ebb968e1952ee3409afc98752e9dbc49b3"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=6afa833ea878690d4adb2a83a2202b9caa4a1314#6afa833ea878690d4adb2a83a2202b9caa4a1314"
 dependencies = [
  "ahash",
  "base64",
@@ -1556,6 +1556,7 @@ dependencies = [
  "fuser",
  "libc",
  "nexus-plugin-abi",
+ "tempfile",
  "tracing",
  "widestring",
  "windows-sys 0.52.0",
@@ -1577,7 +1578,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=c26926ebb968e1952ee3409afc98752e9dbc49b3#c26926ebb968e1952ee3409afc98752e9dbc49b3"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=6afa833ea878690d4adb2a83a2202b9caa4a1314#6afa833ea878690d4adb2a83a2202b9caa4a1314"
 
 [[package]]
 name = "nexus-vault"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,13 +49,13 @@ exclude = ["nexus-fuse"]
 # driver-delete-file + driver-stat, #69 driver-rmdir. Bump
 # alongside the rest of nexus-vfs updates when a downstream
 # change needs newer kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "c26926ebb968e1952ee3409afc98752e9dbc49b3" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "c26926ebb968e1952ee3409afc98752e9dbc49b3" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "c26926ebb968e1952ee3409afc98752e9dbc49b3" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "c26926ebb968e1952ee3409afc98752e9dbc49b3", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "c26926ebb968e1952ee3409afc98752e9dbc49b3", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "c26926ebb968e1952ee3409afc98752e9dbc49b3", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "c26926ebb968e1952ee3409afc98752e9dbc49b3" }
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "6afa833ea878690d4adb2a83a2202b9caa4a1314" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "6afa833ea878690d4adb2a83a2202b9caa4a1314" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "6afa833ea878690d4adb2a83a2202b9caa4a1314" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "6afa833ea878690d4adb2a83a2202b9caa4a1314", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "6afa833ea878690d4adb2a83a2202b9caa4a1314", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "6afa833ea878690d4adb2a83a2202b9caa4a1314", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "6afa833ea878690d4adb2a83a2202b9caa4a1314" }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ENV CARGO_NET_RETRY=10 \
     CARGO_HTTP_TIMEOUT=120
 # Override for edge/CI or a different pin: --build-arg NEXUS_VFS_REV=<sha|tag>
-ARG NEXUS_VFS_REV=c26926ebb968e1952ee3409afc98752e9dbc49b3
+ARG NEXUS_VFS_REV=6afa833ea878690d4adb2a83a2202b9caa4a1314
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,id=cargo-install-${TARGETARCH},target=/root/.cargo/target \

--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir --no-deps --prefix=/install .
 # enforces agreement) — an unpinned install tracks nexus-vfs HEAD and
 # ships an untested kernel (#4343). --locked honors the source tree's
 # Cargo.lock.
-ARG NEXUS_VFS_REV=c26926ebb968e1952ee3409afc98752e9dbc49b3
+ARG NEXUS_VFS_REV=6afa833ea878690d4adb2a83a2202b9caa4a1314
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-cluster nexus-cluster
 
 # -- Runtime stage --

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -25,7 +25,7 @@ WORKDIR /build
 # (CI preflight enforces agreement) — an unpinned install tracks HEAD
 # and can skew the raft contract against the cluster/witness images.
 # --locked honors the source tree's Cargo.lock.
-ARG NEXUS_VFS_REV=c26926ebb968e1952ee3409afc98752e9dbc49b3
+ARG NEXUS_VFS_REV=6afa833ea878690d4adb2a83a2202b9caa4a1314
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexus-raft-server raft
 
 # ---------- Production image ----------

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=c26926ebb968e1952ee3409afc98752e9dbc49b3
+ARG NEXUS_VFS_REV=6afa833ea878690d4adb2a83a2202b9caa4a1314
 RUN cargo install \
     --locked \
     --git https://github.com/nexi-lab/nexus-vfs \

--- a/rust/backends/local-connector/src/lib.rs
+++ b/rust/backends/local-connector/src/lib.rs
@@ -129,15 +129,19 @@ fn delete_file_local_connector(drv: &LocalConnectorDriver, path: &str) -> Result
 
 /// Remove a backend directory by path (sister of `delete_file_local_connector`).
 ///
-/// Delegates to `LocalConnectorBackend::rmdir` with `recursive=false`
-/// — the v1 driver-rmdir ABI is single-dir only.  Closes the
-/// symmetric ghost-directory gap that `delete_file` left behind:
-/// pre-opt-in, FUSE `rmdir` cleared the metastore row but the host
-/// fs directory persisted and the `sys_stat` backend.stat fallback
-/// (also in ABI v4) kept surfacing it.
-fn rmdir_local_connector(drv: &LocalConnectorDriver, path: &str) -> Result<(), i32> {
+/// Plugin ABI v5 (nexus-vfs#70's C1) extends `nexus_driver_rmdir` with
+/// the `recursive` flag the `ObjectStore::rmdir` trait already carries.
+/// We thread it straight through so `sys_rmdir(path, recursive=true)`
+/// reaches the host fs as a single `fs::remove_dir_all` call — one
+/// syscall family instead of the kernel walking children and calling
+/// us N+1 times.
+fn rmdir_local_connector(
+    drv: &LocalConnectorDriver,
+    path: &str,
+    recursive: bool,
+) -> Result<(), i32> {
     drv.backend
-        .rmdir(path, false)
+        .rmdir(path, recursive)
         .map_err(storage_error_to_plugin_code)
 }
 

--- a/tests/e2e/docker/test_cc_tasks_share_e2e.py
+++ b/tests/e2e/docker/test_cc_tasks_share_e2e.py
@@ -1416,7 +1416,7 @@ class TestCcTasksListBackendOnlyCrossNodeEnumeration:
                 ["test", "-e", host_full],
                 check=False,
             )
-            assert check.returncode != 0, (
+            assert check.rc != 0, (
                 f"founder host fs still has {host_full} after joiner FUSE unlink — "
                 f"C5 sys_unlink FederationPeerClient dispatch broke."
             )

--- a/tests/e2e/docker/test_cc_tasks_share_e2e.py
+++ b/tests/e2e/docker/test_cc_tasks_share_e2e.py
@@ -939,3 +939,262 @@ class TestCcTasksListBackendOnlyEnumeration:
                 ["rm", "-rf", f"/host/tasks/{session}"],
                 check=False,
             )
+
+
+# ---------------------------------------------------------------------------
+# Cross-node backend-only enumeration — the `cc tasks list` Mac↔Win
+# user-facing shape.
+#
+# Same `Claude Code writes JSON directly to ~/.claude/tasks/<session>/`
+# scenario as TestCcTasksListBackendOnlyEnumeration above, but the
+# enumerator is the OTHER node — the Mac↔Win operator workflow where
+# host-fs writes on Mac must surface in Win's `cc tasks list` without
+# any Nexus syscall ever firing on the writer side.
+#
+# Three things must hold for cross-node readdir of host-fs-only writes:
+#
+#   1. Same-zone DT_MOUNT rows replicate via raft so the joiner LEARNS
+#      that `/shared/cc-tasks/<founder>` is a mount.  Already lands —
+#      `dlc.mount`'s DT_MOUNT write goes to the parent zone's replicated
+#      metastore.
+#
+#   2. The joiner's VFSRouter must install A routing entry for the
+#      mount path.  Pre-PR, `wire_mount_core`'s same-zone branch
+#      returned `Ok(())` without installing anything, so joiner's
+#      `route()` on `/shared/cc-tasks/founder/...` fell through to
+#      root and every sys_* returned not_found.  Closed by
+#      nexus-vfs C3 — install a placeholder MountEntry with
+#      backend=None + target_zone_id=Some when the local side has no
+#      driver-mount.
+#
+#   3. With backend=None, the existing `backend.list_dir(...)` merge
+#      in sys_readdir is skipped.  C4 added the FederationPeerClient
+#      dispatch arm: route.backend.is_none() + target_zone_id.is_some()
+#      → call `NexusVFSService.Readdir` on a non-self voter of the
+#      target zone.  That voter — the SSOT side with the LocalConnector
+#      backend — answers via its own backend.list_dir of the host fs.
+#
+# This class pins the new C3+C4 path by exercising it cross-node:
+# write to founder's host fs, never touch any kernel syscall, then
+# enumerate from the JOINER via FUSE readdir and assert the bytes
+# round-trip back via gRPC Read (which uses the existing sys_read
+# zone_peers fan-out — sys_stat dispatch through FederationPeerClient
+# is the next gap and is intentionally NOT exercised here).
+# ---------------------------------------------------------------------------
+class TestCcTasksListBackendOnlyCrossNodeEnumeration:
+    """Cross-node readdir of backend-only host-fs writes — Mac↔Win shape.
+
+    Five-step workflow with strict data flow:
+
+      (1) founder writes 3 task JSONs DIRECTLY to its host fs — no
+          FUSE, no kernel syscall, no metastore propose.
+      (2) sanity — the entries are visible via founder's FUSE readdir
+          (the single-node substrate from PR #67).
+      (3) joiner's FUSE readdir of the SAME federated dir surfaces
+          the same entry NAMES via the new C3 placeholder MountEntry
+          + C4 sys_readdir FederationPeerClient dispatch.  This is
+          the new capability THIS PR introduces.
+      (4) joiner's gRPC `NexusVFSService.Read` on each enumerated
+          entry returns founder's bytes byte-exact — verifies the
+          enumeration result isn't fabricated, the entries point at
+          real readable content.
+      (5) cleanup — `rm -rf /host/tasks/<session>` on founder.
+
+    Data flow: (1)→(3) the entry NAMES the joiner enumerates ARE the
+    files (1) wrote; (3)→(4) each name (3) returned is the input to
+    (4)'s read.  Strong causal links — no step is "also called after".
+
+    What this test does NOT yet cover (deferred follow-up):
+      - Joiner FUSE `cat` of the enumerated entries.  FUSE `cat`
+        flows through sys_stat first; sys_stat's FederationPeerClient
+        dispatch is the next plan item (sister of this PR's sys_readdir
+        dispatch).  Until that lands, joiner-side FUSE `cat` of a
+        backend-only entry returns ENOENT — pinned in a separate
+        xfail test below so the day sys_stat dispatch lands flips it
+        green automatically.
+      - `cc tasks list` end-to-end on joiner.  Same blocker — the CLI
+        reads each session's metadata via sys_stat.
+    """
+
+    def test_founder_host_fs_writes_visible_via_joiner_fuse_readdir(
+        self,
+        topology: CcTasksTopology,
+        api_key: str,
+        joined_cluster: dict,
+    ) -> None:
+        session = _new_session()
+        # Three host-fs-only payloads.  No FUSE write, no vfs_write —
+        # bytes appear at /host/tasks/<session>/<name> on founder
+        # ONLY.  Mirrors `fs.writeFileSync('~/.claude/tasks/...', ...)`
+        # in Claude Code on Mac.
+        payloads = {
+            "1.json": b'{"id":"1","status":"completed","writer":"founder-host-fs"}',
+            "2.json": b'{"id":"2","status":"in_progress","writer":"founder-host-fs"}',
+            "3.json": b'{"id":"3","status":"pending","writer":"founder-host-fs"}',
+        }
+        for name, data in payloads.items():
+            cc_tasks_share_helpers.host_task_write(
+                topology.founder_container, f"/{session}/{name}", data
+            )
+
+        try:
+            # Step 1: sanity — bytes are physically on founder's host
+            # fs.  Establishes the workflow precondition; without it
+            # the rest of the chain is meaningless.
+            for name, expected in payloads.items():
+                actual = cc_tasks_share_helpers.host_task_read(
+                    topology.founder_container, f"/{session}/{name}"
+                )
+                assert actual == expected, (
+                    f"founder host_task_write didn't land at /host/tasks/{session}/{name}: "
+                    f"got {actual!r}, expected {expected!r}"
+                )
+
+            # Step 2: single-node substrate — founder's FUSE readdir
+            # of the session dir shows every entry via PR #67's
+            # backend.list_dir merge.  Same path the existing
+            # TestCcTasksListBackendOnlyEnumeration pins — re-verified
+            # here so a failure in step 3 (cross-node) can be cleanly
+            # blamed on the cross-node arm, not the substrate.
+            session_vfs = topology.founder_vfs_path(f"/{session}")
+            session_mount = topology.mount_path_for_vfs(session_vfs)
+            founder_entries = cc_tasks_share_helpers.mount_listdir(
+                topology.founder_container, session_mount
+            )
+            assert sorted(founder_entries) == sorted(payloads.keys()), (
+                f"founder single-node FUSE readdir broke — got {founder_entries}, "
+                f"expected {sorted(payloads.keys())}.  PR #67 substrate regressed?"
+            )
+
+            # Step 3: THE C3+C4 CAPABILITY — joiner's FUSE readdir of
+            # the SAME federated session dir surfaces founder's
+            # host-fs-only entries.  Path:
+            #   joiner FUSE ls
+            #     → fuser dispatch
+            #     → KernelHandle.sys_readdir(/shared/cc-tasks/founder/<sess>)
+            #     → vfs_router.route(...) returns the placeholder
+            #       MountEntry C3 installed (backend=None,
+            #       target_zone_id=Some(sharedzone))
+            #     → metastore merge: no entries (founder never wrote
+            #       through any syscall — no metadata exists)
+            #     → backend.list_dir branch SKIPPED (backend is None)
+            #     → C4 federation-peer dispatch branch FIRES
+            #     → FederationPeerClient.list_dir(peer=founder,
+            #                                     path=<session>)
+            #     → founder's NexusVFSService.Readdir handler
+            #     → founder's kernel sys_readdir → its LocalConnector
+            #       backend.list_dir → host fs
+            #     → entries flow back to joiner, merged into seen
+            #
+            # An eventual-consistency window covers the placeholder
+            # install (apply-cb fires after raft commit replicates).
+            # 30 s budget matches the existing cross-node tests.
+            deadline = time.monotonic() + 30
+            joiner_entries: list[str] = []
+            last_error: str | None = None
+            while time.monotonic() < deadline:
+                try:
+                    joiner_entries = cc_tasks_share_helpers.mount_listdir(
+                        topology.joiner_container, session_mount
+                    )
+                    if sorted(joiner_entries) == sorted(payloads.keys()):
+                        break
+                except Exception as exc:  # noqa: BLE001
+                    last_error = repr(exc)
+                time.sleep(0.5)
+            assert sorted(joiner_entries) == sorted(payloads.keys()), (
+                f"joiner cross-node FUSE readdir of backend-only entries failed — "
+                f"got {joiner_entries}, expected {sorted(payloads.keys())} "
+                f"(last_error={last_error}).  C3 placeholder MountEntry or C4 "
+                f"sys_readdir FederationPeerClient dispatch broken?"
+            )
+
+            # Step 4: each enumerated entry is REAL — joiner gRPC
+            # Read returns founder's bytes byte-exact.  Uses
+            # NexusVFSService.Read rather than FUSE cat because
+            # sys_stat dispatch through FederationPeerClient is the
+            # next plan item; until it lands, FUSE cat of a host-fs-
+            # only entry on the joiner returns ENOENT (FUSE lookup
+            # gates on sys_stat).  gRPC Read uses the existing
+            # sys_read zone_peers fan-out (PeerBlobClient.ReadBlob
+            # through founder's BlobFetcher) which doesn't need the
+            # joiner-side stat to succeed.
+            for name, expected in payloads.items():
+                file_vfs = topology.founder_vfs_path(f"/{session}/{name}")
+                read_resp = runbook_helpers.vfs_read(
+                    topology.joiner_grpc,
+                    file_vfs,
+                    api_key=api_key,
+                    timeout=30,
+                )
+                actual = (read_resp.get("result") or {}).get("content")
+                assert actual == expected, (
+                    f"joiner cross-node Read of {name} returned {actual!r}, "
+                    f"expected {expected!r}. zone_peers fan-out / founder "
+                    f"BlobFetcher may have regressed. full resp={read_resp}"
+                )
+
+        finally:
+            runbook_helpers.docker_exec(
+                topology.founder_container,
+                ["rm", "-rf", f"/host/tasks/{session}"],
+                check=False,
+            )
+
+    @pytest.mark.xfail(
+        reason="sys_stat FederationPeerClient dispatch is the next plan item; until "
+        "it lands, joiner-side FUSE lookup of a backend-only entry returns ENOENT. "
+        "This xfail PIN flips green automatically the day sys_stat dispatch ships, "
+        "providing a regression catch on the user-facing 'cat through FUSE' path.",
+        strict=True,
+    )
+    def test_joiner_fuse_cat_of_backend_only_entries_blocked_on_sys_stat_dispatch(
+        self,
+        topology: CcTasksTopology,
+        api_key: str,
+        joined_cluster: dict,
+    ) -> None:
+        session = _new_session()
+        payload = b'{"id":"x","writer":"founder-host-fs"}'
+        cc_tasks_share_helpers.host_task_write(
+            topology.founder_container, f"/{session}/x.json", payload
+        )
+        try:
+            # Wait for the joiner to see the entry via readdir so we
+            # know C3+C4 are in effect — the xfail is specifically
+            # about sys_stat, not about readdir failing too.
+            session_vfs = topology.founder_vfs_path(f"/{session}")
+            session_mount = topology.mount_path_for_vfs(session_vfs)
+            deadline = time.monotonic() + 30
+            while time.monotonic() < deadline:
+                if "x.json" in cc_tasks_share_helpers.mount_listdir(
+                    topology.joiner_container, session_mount
+                ):
+                    break
+                time.sleep(0.5)
+            else:
+                pytest.fail(
+                    "joiner never saw x.json via readdir — readdir dispatch broke; "
+                    "this xfail is conditional on readdir working, so the test "
+                    "infrastructure precondition is missing."
+                )
+
+            # The actual assertion that will (still) fail: joiner FUSE
+            # cat returns the bytes.  When sys_stat dispatch lands,
+            # this test starts passing and the xfail(strict=True) flips
+            # it red, telling us to remove the marker.
+            file_mount = topology.mount_path_for_vfs(
+                topology.founder_vfs_path(f"/{session}/x.json")
+            )
+            joiner_bytes = cc_tasks_share_helpers.mount_read_bytes(
+                topology.joiner_container, file_mount
+            )
+            assert joiner_bytes == payload, (
+                f"joiner FUSE cat got {joiner_bytes!r}, expected {payload!r}"
+            )
+        finally:
+            runbook_helpers.docker_exec(
+                topology.founder_container,
+                ["rm", "-rf", f"/host/tasks/{session}"],
+                check=False,
+            )

--- a/tests/e2e/docker/test_cc_tasks_share_e2e.py
+++ b/tests/e2e/docker/test_cc_tasks_share_e2e.py
@@ -1109,16 +1109,30 @@ class TestCcTasksListBackendOnlyCrossNodeEnumeration:
                 f"sys_readdir FederationPeerClient dispatch broken?"
             )
 
-            # Step 4: each enumerated entry is REAL — joiner gRPC
-            # Read returns founder's bytes byte-exact.  Uses
-            # NexusVFSService.Read rather than FUSE cat because
-            # sys_stat dispatch through FederationPeerClient is the
-            # next plan item; until it lands, FUSE cat of a host-fs-
-            # only entry on the joiner returns ENOENT (FUSE lookup
-            # gates on sys_stat).  gRPC Read uses the existing
-            # sys_read zone_peers fan-out (PeerBlobClient.ReadBlob
-            # through founder's BlobFetcher) which doesn't need the
-            # joiner-side stat to succeed.
+            # Step 4: joiner FUSE cat of each enumerated entry returns
+            # founder's bytes byte-exact.  This is the FULL user-facing
+            # chain — FUSE driver → fuser lookup (sys_stat) → fuser
+            # open / read (sys_read) → all cross-node via
+            # FederationPeerClient dispatch.  The C5 sys_stat hook is
+            # what makes FUSE lookup succeed for backend-only entries;
+            # without it, `cat` would have returned ENOENT before
+            # sys_read ever fired.
+            for name, expected in payloads.items():
+                file_mount = topology.mount_path_for_vfs(
+                    topology.founder_vfs_path(f"/{session}/{name}")
+                )
+                joiner_bytes = cc_tasks_share_helpers.mount_read_bytes(
+                    topology.joiner_container, file_mount
+                )
+                assert joiner_bytes == expected, (
+                    f"joiner FUSE cat of {name} got {joiner_bytes!r}, "
+                    f"expected {expected!r}. C5 sys_stat dispatch or "
+                    f"sys_read zone_peers fan-out may have regressed."
+                )
+
+            # Step 5: sanity — direct gRPC Read also returns the same
+            # bytes.  Decouples a FUSE-side regression from a kernel
+            # syscall regression in failure messages.
             for name, expected in payloads.items():
                 file_vfs = topology.founder_vfs_path(f"/{session}/{name}")
                 read_resp = runbook_helpers.vfs_read(
@@ -1141,28 +1155,35 @@ class TestCcTasksListBackendOnlyCrossNodeEnumeration:
                 check=False,
             )
 
-    @pytest.mark.xfail(
-        reason="sys_stat FederationPeerClient dispatch is the next plan item; until "
-        "it lands, joiner-side FUSE lookup of a backend-only entry returns ENOENT. "
-        "This xfail PIN flips green automatically the day sys_stat dispatch ships, "
-        "providing a regression catch on the user-facing 'cat through FUSE' path.",
-        strict=True,
-    )
-    def test_joiner_fuse_cat_of_backend_only_entries_blocked_on_sys_stat_dispatch(
+    def test_joiner_fuse_cat_via_sys_stat_federation_peer_dispatch(
         self,
         topology: CcTasksTopology,
         api_key: str,
         joined_cluster: dict,
     ) -> None:
+        """Focused pin on C5's sys_stat hook: FUSE cat of a backend-only entry.
+
+        Smaller workflow than the multi-entry readdir + cat test above.
+        Three steps:
+          (1) write ONE host-fs-only file on founder;
+          (2) joiner FUSE lookup (sys_stat over the federation
+              boundary via C5);
+          (3) joiner FUSE cat returns the same bytes.
+
+        Pre-C5 this scenario failed at step (2) with ENOENT.  This
+        test pins the regression — if any rework breaks sys_stat
+        dispatch, this fails before any of the larger workflows do.
+        """
         session = _new_session()
-        payload = b'{"id":"x","writer":"founder-host-fs"}'
+        payload = b'{"id":"x","writer":"founder-host-fs","via":"C5"}'
         cc_tasks_share_helpers.host_task_write(
             topology.founder_container, f"/{session}/x.json", payload
         )
         try:
-            # Wait for the joiner to see the entry via readdir so we
-            # know C3+C4 are in effect — the xfail is specifically
-            # about sys_stat, not about readdir failing too.
+            # Wait for joiner to see the entry via readdir (C3+C4)
+            # before exercising stat (C5) — pre-C3 the placeholder
+            # MountEntry doesn't exist yet, so stat would fall through
+            # to root and fail for unrelated reasons.
             session_vfs = topology.founder_vfs_path(f"/{session}")
             session_mount = topology.mount_path_for_vfs(session_vfs)
             deadline = time.monotonic() + 30
@@ -1174,23 +1195,245 @@ class TestCcTasksListBackendOnlyCrossNodeEnumeration:
                 time.sleep(0.5)
             else:
                 pytest.fail(
-                    "joiner never saw x.json via readdir — readdir dispatch broke; "
-                    "this xfail is conditional on readdir working, so the test "
-                    "infrastructure precondition is missing."
+                    "joiner never saw x.json via readdir — C3+C4 substrate "
+                    "broke; this test is conditional on readdir working."
                 )
 
-            # The actual assertion that will (still) fail: joiner FUSE
-            # cat returns the bytes.  When sys_stat dispatch lands,
-            # this test starts passing and the xfail(strict=True) flips
-            # it red, telling us to remove the marker.
-            file_mount = topology.mount_path_for_vfs(
-                topology.founder_vfs_path(f"/{session}/x.json")
+            # Step 1: joiner gRPC vfs_stat — direct surface for the
+            # sys_stat call.  Pre-C5 returned `found=false`; post-C5
+            # the federation-peer dispatch synthesises a StatResult
+            # from founder's BackendStat.
+            file_vfs = topology.founder_vfs_path(f"/{session}/x.json")
+            stat_resp = runbook_helpers.vfs_stat(
+                topology.joiner_grpc, file_vfs, api_key=api_key, timeout=15
             )
+            assert stat_resp.get("result", {}).get("found"), (
+                f"joiner vfs_stat must find backend-only x.json via C5 "
+                f"sys_stat FederationPeerClient dispatch — got {stat_resp}"
+            )
+            assert not stat_resp.get("result", {}).get("isDirectory"), (
+                f"backend-only x.json should stat as a regular file — got {stat_resp}"
+            )
+
+            # Step 2: joiner FUSE cat — full chain end to end.  FUSE
+            # lookup goes through C5 sys_stat; FUSE read goes through
+            # the existing zone_peers fan-out.
+            file_mount = topology.mount_path_for_vfs(file_vfs)
             joiner_bytes = cc_tasks_share_helpers.mount_read_bytes(
                 topology.joiner_container, file_mount
             )
             assert joiner_bytes == payload, (
                 f"joiner FUSE cat got {joiner_bytes!r}, expected {payload!r}"
+            )
+        finally:
+            runbook_helpers.docker_exec(
+                topology.founder_container,
+                ["rm", "-rf", f"/host/tasks/{session}"],
+                check=False,
+            )
+
+    def test_cc_tasks_list_shape_end_to_end_cross_node(
+        self,
+        topology: CcTasksTopology,
+        api_key: str,
+        joined_cluster: dict,
+    ) -> None:
+        """`cc tasks list` end-to-end — the mega-goal of the whole effort.
+
+        Mimics the actual user workflow:
+          - Claude Code on Mac writes session JSONs directly to
+            `~/.claude/tasks/<session>/<n>.json` (no Nexus syscall);
+          - Operator on Win expects `cc tasks list` to enumerate the
+            sessions + read their `1.json` metadata to surface task
+            status.
+
+        `cc tasks list` does roughly:
+          1. readdir(`~/.claude/tasks/`) → session subdir names
+          2. for each session: readdir(<session>/) → file names
+          3. for each session: stat(<session>/1.json) → existence + size
+          4. for each session: read(<session>/1.json) → metadata blob
+
+        This test exercises all four ops cross-node (founder writes,
+        joiner reads).  Strict data flow: step (2) consumes the names
+        step (1) returned; step (3) consumes the size step (2) verified
+        is non-empty; step (4) consumes the existence step (3)
+        confirmed.  Every step has a meaningful assertion (not just
+        type checks): entry counts, file sizes, byte-exact content.
+
+        End-to-end success here is the proof that C3+C4+C5 together
+        deliver the user-visible Mac↔Win `cc tasks list` capability.
+        Failure isolates the broken layer via the more focused tests
+        above.
+        """
+        # Two sessions with status metadata in `1.json` — the file
+        # `cc tasks list` actually reads to render the session row.
+        sessions = {
+            _new_session(): b'{"id":"a","status":"completed","title":"Refactor X"}',
+            _new_session(): b'{"id":"b","status":"in_progress","title":"Implement Y"}',
+        }
+        for sess, payload in sessions.items():
+            cc_tasks_share_helpers.host_task_write(
+                topology.founder_container, f"/{sess}/1.json", payload
+            )
+
+        try:
+            # Operator-side `cc tasks list` walks
+            # `~/.claude/tasks/<session>/`, which the runbook topology
+            # maps onto `/shared/cc-tasks/founder/<session>/` mounted
+            # at joiner's `/mnt/cc-tasks/founder/<session>/`.
+            parent_vfs = topology.founder_vfs_path("")
+            parent_mount = topology.mount_path_for_vfs(parent_vfs.rstrip("/"))
+
+            # ── Step 1: enumerate sessions from joiner ──────────────
+            # (parent readdir → session subdirs)
+            deadline = time.monotonic() + 30
+            seen_sessions: set[str] = set()
+            while time.monotonic() < deadline:
+                listing = cc_tasks_share_helpers.mount_listdir(
+                    topology.joiner_container, parent_mount
+                )
+                seen_sessions = set(listing) & set(sessions.keys())
+                if seen_sessions == set(sessions.keys()):
+                    break
+                time.sleep(0.5)
+            assert seen_sessions == set(sessions.keys()), (
+                f"`cc tasks list` parent enumeration: joiner saw "
+                f"{sorted(seen_sessions)}, expected {sorted(sessions.keys())}. "
+                "C3 placeholder MountEntry or C4 sys_readdir dispatch broke."
+            )
+
+            # ── Step 2: per session, list contents (the per-session
+            # readdir `cc tasks list` does to find `1.json`) ─────────
+            session_files: dict[str, list[str]] = {}
+            for sess in sessions:
+                sess_mount = topology.mount_path_for_vfs(topology.founder_vfs_path(f"/{sess}"))
+                session_files[sess] = cc_tasks_share_helpers.mount_listdir(
+                    topology.joiner_container, sess_mount
+                )
+                assert "1.json" in session_files[sess], (
+                    f"session {sess} per-dir enumeration broke — got "
+                    f"{session_files[sess]}, expected '1.json' to be present"
+                )
+
+            # ── Step 3: per session, stat `1.json` (the FUSE lookup
+            # that gates the actual content read) ───────────────────
+            for sess, expected_payload in sessions.items():
+                file_vfs = topology.founder_vfs_path(f"/{sess}/1.json")
+                stat_resp = runbook_helpers.vfs_stat(
+                    topology.joiner_grpc, file_vfs, api_key=api_key, timeout=15
+                )
+                result = stat_resp.get("result", {})
+                assert result.get("found"), (
+                    f"`cc tasks list` stat for {sess}/1.json failed — got "
+                    f"{stat_resp}. C5 sys_stat FederationPeerClient dispatch broke."
+                )
+                assert not result.get("isDirectory"), (
+                    f"{sess}/1.json should stat as a file; got {stat_resp}"
+                )
+                # Size from peer's BackendStat survives the dispatch.
+                reported_size = int(result.get("size", 0))
+                assert reported_size == len(expected_payload), (
+                    f"{sess}/1.json size mismatch — peer's BackendStat said "
+                    f"{reported_size}, payload is {len(expected_payload)} bytes"
+                )
+
+            # ── Step 4: per session, read the JSON metadata (the
+            # actual content `cc tasks list` parses) ────────────────
+            for sess, expected_payload in sessions.items():
+                file_mount = topology.mount_path_for_vfs(
+                    topology.founder_vfs_path(f"/{sess}/1.json")
+                )
+                joiner_bytes = cc_tasks_share_helpers.mount_read_bytes(
+                    topology.joiner_container, file_mount
+                )
+                assert joiner_bytes == expected_payload, (
+                    f"`cc tasks list` content read for {sess}/1.json got "
+                    f"{joiner_bytes!r}, expected {expected_payload!r}"
+                )
+        finally:
+            for sess in sessions:
+                runbook_helpers.docker_exec(
+                    topology.founder_container,
+                    ["rm", "-rf", f"/host/tasks/{sess}"],
+                    check=False,
+                )
+
+    def test_joiner_fuse_unlink_propagates_to_founder_host_fs(
+        self,
+        topology: CcTasksTopology,
+        api_key: str,
+        joined_cluster: dict,
+    ) -> None:
+        """Operator-side `rm` from the federation peer reaches SSOT host fs.
+
+        Three-step workflow:
+          (1) founder writes a file directly to host fs (no Nexus syscall);
+          (2) joiner FUSE `rm` propagates via C5's sys_unlink dispatch
+              → founder's typed Delete handler → founder's sys_unlink
+              → founder's LocalConnector delete_file → host fs row gone;
+          (3) verify both founder's host fs AND joiner's FUSE see the
+              entry as gone.
+
+        Pins the systemic sys_unlink dispatch arm of C5 alongside the
+        sys_readdir / sys_stat hooks.
+        """
+        session = _new_session()
+        path_rel = f"/{session}/to-delete.json"
+        cc_tasks_share_helpers.host_task_write(
+            topology.founder_container, path_rel, b'{"will":"be deleted"}'
+        )
+        try:
+            # Wait for joiner to see the entry via stat (C5) so we
+            # know unlink will hit the dispatched arm, not the early
+            # not-found path.
+            file_vfs = topology.founder_vfs_path(path_rel)
+            deadline = time.monotonic() + 30
+            while time.monotonic() < deadline:
+                stat_resp = runbook_helpers.vfs_stat(
+                    topology.joiner_grpc, file_vfs, api_key=api_key, timeout=10
+                )
+                if stat_resp.get("result", {}).get("found"):
+                    break
+                time.sleep(0.5)
+            else:
+                pytest.fail(
+                    "joiner never saw the file via stat — C5 sys_stat "
+                    "dispatch broke; unlink test prerequisite missing."
+                )
+
+            # Step 1: joiner FUSE unlink — full chain through C5
+            # sys_unlink → FederationPeerClient.delete_file →
+            # founder NexusVFSService.Delete → founder sys_unlink →
+            # founder LocalConnector → host fs.
+            file_mount = topology.mount_path_for_vfs(file_vfs)
+            cc_tasks_share_helpers.mount_unlink(topology.joiner_container, file_mount)
+
+            # Step 2: founder's host fs no longer has the file —
+            # the SSOT side honoured the delete.
+            host_full = f"/host/tasks{path_rel}"
+            check = runbook_helpers.docker_exec(
+                topology.founder_container,
+                ["test", "-e", host_full],
+                check=False,
+            )
+            assert check.returncode != 0, (
+                f"founder host fs still has {host_full} after joiner FUSE unlink — "
+                f"C5 sys_unlink FederationPeerClient dispatch broke."
+            )
+
+            # Step 3: joiner's FUSE readdir no longer surfaces the entry —
+            # the cross-node view caught up with the SSOT.
+            session_mount = topology.mount_path_for_vfs(topology.founder_vfs_path(f"/{session}"))
+            deadline = time.monotonic() + 30
+            while time.monotonic() < deadline:
+                if "to-delete.json" not in cc_tasks_share_helpers.mount_listdir(
+                    topology.joiner_container, session_mount
+                ):
+                    return
+                time.sleep(0.5)
+            pytest.fail(
+                "joiner FUSE readdir still lists to-delete.json after unlink — "
+                "post-delete enumeration cache stale or dispatch broke."
             )
         finally:
             runbook_helpers.docker_exec(


### PR DESCRIPTION
## Summary

Extends `tests/e2e/docker/test_cc_tasks_share_e2e.py` with the cross-node test pins for the new capability that **nexus-vfs PR #70** introduces (C3 placeholder MountEntry + C4 sys_readdir dispatch + C5 sys_stat / sys_unlink / sys_write dispatch).

Two commits, one per nexus-vfs side phase:

1. **C3+C4 readdir pin** (`test_founder_host_fs_writes_visible_via_joiner_fuse_readdir`) — pins cross-node enumeration of host-fs-only writes. Originally landed with the FUSE-cat path xfail-blocked on sys_stat dispatch.
2. **C5 systemic pins** — promotes the readdir test to include FUSE cat (sys_stat dispatch shipped), retires the xfail, and adds three new positive tests covering the full user-facing chain.

## What this PR covers

| Test | Workflow | What breaks if regressed |
|---|---|---|
| `test_founder_host_fs_writes_visible_via_joiner_fuse_readdir` | write to founder host fs → joiner FUSE readdir → joiner FUSE cat → joiner gRPC Read sanity | C3 placeholder, C4 readdir dispatch, C5 sys_stat dispatch |
| `test_joiner_fuse_cat_via_sys_stat_federation_peer_dispatch` | write 1 file → joiner gRPC vfs_stat → joiner FUSE cat | C5 sys_stat dispatch (focused, fails first if broken) |
| `test_cc_tasks_list_shape_end_to_end_cross_node` | parent readdir → per-session readdir → per-session stat 1.json → per-session read 1.json | THE mega-goal — Mac↔Win `cc tasks list` end-to-end |
| `test_joiner_fuse_unlink_propagates_to_founder_host_fs` | write → joiner FUSE rm → founder host fs check → joiner FUSE readdir absence check | C5 sys_unlink dispatch |

All four follow the integration-test-generator standard:
- Real user journey (Mac CC writes, Win operator lists/cats/rms)
- Long workflows (3–5 steps each)
- Strong causal links between steps (each consumes prior step's output)
- Meaningful assertions on names, sizes, AND byte-exact content
- Test data isolation via uuid4-sessions + try/finally cleanup

## Test plan

- [ ] CI brings up the docker-compose.cc-tasks-share stack with the nexus-vfs kernel built from PR #70.
- [ ] `pytest tests/e2e/docker/test_cc_tasks_share_e2e.py` — every test in `TestCcTasksListBackendOnlyCrossNodeEnumeration` passes.
- [ ] Mac↔Win cross-machine smoke against Tailscale topology (manual, runbook §3g).

## Companion PRs

- nexus-vfs: https://github.com/nexi-lab/nexus-vfs/pull/70 — the kernel-tier change this E2E covers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)