### PR TITLE
fix(#4425): suppress vendored fuser lint for release -D warnings

### DIFF
--- a/rust/vendor/fuser-0.17.0-fuset/src/lib.rs
+++ b/rust/vendor/fuser-0.17.0-fuset/src/lib.rs
@@ -1,5 +1,5 @@
 // Vendored upstream code — suppress warnings from unmodified sources.
-#![allow(dead_code, unused_imports)]
+#![allow(dead_code, unused_imports, unfulfilled_lint_expectations)]
 
 //! FUSE userspace library implementation
 //!


### PR DESCRIPTION
## Summary
- Add `unfulfilled_lint_expectations` to vendored fuser's `#![allow(...)]` list
- Release workflow uses `-D warnings` which promotes the unfulfilled lint expectation to an error
- Follow-up to #4430 (already merged)

## Test plan
- [ ] Release workflow macOS builds pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)