### PR TITLE
fix: release.yml tag filter — exclude plugin tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,10 @@ name: Release
 on:
   push:
     tags:
-      - "v*"
+      # Only match bare version tags (v1.2.3), not plugin tags
+      # (fuse-v0.4.2, vault-v0.3.0, local-connector-v0.2.0).
+      # Plugin releases have their own workflows with prefixed patterns.
+      - "v[0-9]*"
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
- `release.yml` triggered on `v*` which matched plugin tags (`fuse-v0.4.2`, `vault-v0.3.0`), causing spurious "Verify version matches tag" failures
- Changed to `v[0-9]*` — only matches bare version tags (`v1.2.3`)
- Plugin releases have their own workflows with prefixed patterns

## Root cause
Every `fuse-v*`, `vault-v*`, `local-connector-v*` tag push also triggered the main `release.yml` whose `Verify version matches tag` step compares pyproject.toml/Cargo.toml versions against the tag — obviously mismatches since `fuse-v0.4.2` != pyproject version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)