### PR TITLE
fix: plugin release workflow_dispatch retry support

### DIFF
--- a/.github/workflows/release-fuse-plugin.yml
+++ b/.github/workflows/release-fuse-plugin.yml
@@ -23,6 +23,12 @@ on:
   push:
     tags:
       - "fuse-v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to release (e.g. fuse-v0.5.0). Used for retry without delete+repush."
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -39,6 +45,7 @@ jobs:
       signing_key_source: vault
       signing_key_name: kernel-dogfood-v1
       platforms: '["linux-x86_64", "macos-arm64", "macos-x86_64"]'
+      override_ref: ${{ inputs.tag && format('refs/tags/{0}', inputs.tag) || '' }}
       release_description: |
         Nexus FUSE service plugin for nexusd-cluster.
 

--- a/.github/workflows/release-local-connector-plugin.yml
+++ b/.github/workflows/release-local-connector-plugin.yml
@@ -16,6 +16,12 @@ on:
   push:
     tags:
       - "local-connector-v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to release (e.g. local-connector-v0.3.0). Used for retry without delete+repush."
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -31,6 +37,7 @@ jobs:
       version_tag_prefix: local-connector-v
       signing_key_source: vault
       signing_key_name: kernel-dogfood-v1
+      override_ref: ${{ inputs.tag && format('refs/tags/{0}', inputs.tag) || '' }}
       release_description: |
         Nexus local-connector driver plugin for nexusd-cluster.
 

--- a/.github/workflows/release-plugin-reusable.yml
+++ b/.github/workflows/release-plugin-reusable.yml
@@ -75,6 +75,15 @@ on:
         required: false
         type: string
         default: ""
+      override_ref:
+        description: |
+          Override GITHUB_REF for workflow_dispatch retries. Pass the
+          full tag ref (e.g. `refs/tags/fuse-v0.4.2`). When empty, falls
+          back to GITHUB_REF (normal tag-push path). This unblocks
+          dispatch-based release retries without delete+repush tag.
+        required: false
+        type: string
+        default: ""
 
     secrets:
       PLUGIN_SIGNING_PRIVKEY:
@@ -353,10 +362,13 @@ jobs:
         id: version
         env:
           PREFIX: refs/tags/${{ inputs.version_tag_prefix }}
+          OVERRIDE_REF: ${{ inputs.override_ref }}
         run: |
-          VERSION="${GITHUB_REF#${PREFIX}}"
-          if [ "$VERSION" = "$GITHUB_REF" ]; then
-            echo "::error::tag $GITHUB_REF does not start with prefix ${{ inputs.version_tag_prefix }}"
+          # Use override_ref when set (workflow_dispatch retry), else GITHUB_REF (tag push).
+          EFFECTIVE_REF="${OVERRIDE_REF:-$GITHUB_REF}"
+          VERSION="${EFFECTIVE_REF#${PREFIX}}"
+          if [ "$VERSION" = "$EFFECTIVE_REF" ]; then
+            echo "::error::ref $EFFECTIVE_REF does not start with prefix ${{ inputs.version_tag_prefix }}"
             exit 1
           fi
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release-vault-plugin.yml
+++ b/.github/workflows/release-vault-plugin.yml
@@ -37,6 +37,7 @@ jobs:
       cos_subdir: nexus-vault/release
       version_tag_prefix: vault-v
       signing_key_source: github-secret
+      override_ref: ${{ inputs.tag && format('refs/tags/{0}', inputs.tag) || '' }}
       # 7.5 MiB — matches the loosest pre-reusable platform budget (macOS).
       # Stricter than the reusable's 8 MiB default; tightens regression
       # detection for the only plugin where we've measured a stable size.


### PR DESCRIPTION
## Summary
- All 3 plugin release workflows now support `workflow_dispatch` with a `tag` input
- Reusable workflow accepts `override_ref` that overrides `GITHUB_REF` for version extraction
- Release retries no longer require delete+repush tag

## Root cause
`workflow_dispatch` sets `GITHUB_REF=refs/heads/develop`, but the reusable workflow's "Extract version from tag" step strips the tag prefix from `GITHUB_REF` — fails because `refs/heads/develop` doesn't start with `refs/tags/fuse-v`.

## Fix
- `override_ref` input on reusable: `EFFECTIVE_REF="${OVERRIDE_REF:-$GITHUB_REF}"`
- Wrapper workflows pass `override_ref: ${{ inputs.tag && format('refs/tags/{0}', inputs.tag) || '' }}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)