### PR TITLE
test(docker-e2e) + deps: bump nexus-vfs to #80; re-enable joiner-readback in sys_write cross-node pin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=6afa833ea878690d4adb2a83a2202b9caa4a1314#6afa833ea878690d4adb2a83a2202b9caa4a1314"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=29e1079ae7cc7c557e07801d5dd2c2b45dead15c#29e1079ae7cc7c557e07801d5dd2c2b45dead15c"
 dependencies = [
  "ahash",
  "base64",
@@ -550,7 +550,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=6afa833ea878690d4adb2a83a2202b9caa4a1314#6afa833ea878690d4adb2a83a2202b9caa4a1314"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=29e1079ae7cc7c557e07801d5dd2c2b45dead15c#29e1079ae7cc7c557e07801d5dd2c2b45dead15c"
 dependencies = [
  "parking_lot",
  "serde",
@@ -1333,7 +1333,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=6afa833ea878690d4adb2a83a2202b9caa4a1314#6afa833ea878690d4adb2a83a2202b9caa4a1314"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=29e1079ae7cc7c557e07801d5dd2c2b45dead15c#29e1079ae7cc7c557e07801d5dd2c2b45dead15c"
 dependencies = [
  "ahash",
  "base64",
@@ -1384,7 +1384,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=6afa833ea878690d4adb2a83a2202b9caa4a1314#6afa833ea878690d4adb2a83a2202b9caa4a1314"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=29e1079ae7cc7c557e07801d5dd2c2b45dead15c#29e1079ae7cc7c557e07801d5dd2c2b45dead15c"
 dependencies = [
  "ahash",
  "base64",
@@ -1576,7 +1576,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=6afa833ea878690d4adb2a83a2202b9caa4a1314#6afa833ea878690d4adb2a83a2202b9caa4a1314"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=29e1079ae7cc7c557e07801d5dd2c2b45dead15c#29e1079ae7cc7c557e07801d5dd2c2b45dead15c"
 
 [[package]]
 name = "nexus-vault"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=29e1079ae7cc7c557e07801d5dd2c2b45dead15c#29e1079ae7cc7c557e07801d5dd2c2b45dead15c"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=775a1a16a5bcd71aa649699faa31b97eac2d684e#775a1a16a5bcd71aa649699faa31b97eac2d684e"
 dependencies = [
  "ahash",
  "base64",
@@ -550,7 +550,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=29e1079ae7cc7c557e07801d5dd2c2b45dead15c#29e1079ae7cc7c557e07801d5dd2c2b45dead15c"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=775a1a16a5bcd71aa649699faa31b97eac2d684e#775a1a16a5bcd71aa649699faa31b97eac2d684e"
 dependencies = [
  "parking_lot",
  "serde",
@@ -1333,7 +1333,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=29e1079ae7cc7c557e07801d5dd2c2b45dead15c#29e1079ae7cc7c557e07801d5dd2c2b45dead15c"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=775a1a16a5bcd71aa649699faa31b97eac2d684e#775a1a16a5bcd71aa649699faa31b97eac2d684e"
 dependencies = [
  "ahash",
  "base64",
@@ -1384,7 +1384,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=29e1079ae7cc7c557e07801d5dd2c2b45dead15c#29e1079ae7cc7c557e07801d5dd2c2b45dead15c"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=775a1a16a5bcd71aa649699faa31b97eac2d684e#775a1a16a5bcd71aa649699faa31b97eac2d684e"
 dependencies = [
  "ahash",
  "base64",
@@ -1576,7 +1576,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=29e1079ae7cc7c557e07801d5dd2c2b45dead15c#29e1079ae7cc7c557e07801d5dd2c2b45dead15c"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=775a1a16a5bcd71aa649699faa31b97eac2d684e#775a1a16a5bcd71aa649699faa31b97eac2d684e"
 
 [[package]]
 name = "nexus-vault"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,13 +52,13 @@ exclude = ["nexus-fuse"]
 # reentrancy, #80 sys_write defer-to-peer.  Bump alongside the
 # rest of nexus-vfs updates when a downstream change needs newer
 # kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "29e1079ae7cc7c557e07801d5dd2c2b45dead15c" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "29e1079ae7cc7c557e07801d5dd2c2b45dead15c" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "29e1079ae7cc7c557e07801d5dd2c2b45dead15c" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "29e1079ae7cc7c557e07801d5dd2c2b45dead15c", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "29e1079ae7cc7c557e07801d5dd2c2b45dead15c", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "29e1079ae7cc7c557e07801d5dd2c2b45dead15c", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "29e1079ae7cc7c557e07801d5dd2c2b45dead15c" }
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "775a1a16a5bcd71aa649699faa31b97eac2d684e" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "775a1a16a5bcd71aa649699faa31b97eac2d684e" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "775a1a16a5bcd71aa649699faa31b97eac2d684e" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "775a1a16a5bcd71aa649699faa31b97eac2d684e", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "775a1a16a5bcd71aa649699faa31b97eac2d684e", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "775a1a16a5bcd71aa649699faa31b97eac2d684e", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "775a1a16a5bcd71aa649699faa31b97eac2d684e" }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,32 +30,35 @@ exclude = ["nexus-fuse"]
 [workspace.dependencies]
 # Kernel-tier crates from nexus-vfs (external git dependency).
 # SSOT: https://github.com/nexi-lab/nexus-vfs
-# Pinned at the nexus-vfs main commit that landed #69 (additive
-# optional `nexus_driver_rmdir` — sister of #68's
-# `nexus_driver_delete_file` for directories).  Closes the last
-# cc-tasks-share docker E2E gap: FUSE `rmdir` now reaches
-# `backend.rmdir` so the host fs directory is removed in lockstep
-# with the metastore row.  Builds on #67's required
-# `nexus_driver_readdir` and #68's `nexus_driver_delete_file` +
-# `nexus_driver_stat`, together unblocking the cc-tasks-list
-# mega-goal end-to-end: `cc tasks list` enumerates → stats →
-# reads → cleans up, all with the host fs as the SSOT and the
-# kernel metastore in lockstep.
+# Pinned at the nexus-vfs main commit that landed #80 (sys_write
+# defers fully to federation peer for backend-less placeholder
+# mounts).  Closes the joiner-readback gap PR #4433's docker E2E
+# exposed: founder host fs received bytes byte-exact after a
+# joiner FUSE write, but joiner's OWN subsequent FUSE lookup
+# missed for >30s because the old shape had joiner ALSO propose
+# its own metastore.put (double-propose racing founder's
+# replicated apply through raft).  #80 makes founder the single
+# proposer for placeholder-mount writes — mirror of #77's
+# sys_unlink short-circuit.
 # Builds on prior landmarks: #57 plugin-as-gRPC-service routing,
 # #58 sealed-keystore signing trust root, #60 KernelHandle v3
 # sys_stat_batch, #61 per-call EC/SC primitives, #62 CLI flag rename,
 # #63 EC hot-path activation revert, #65 EC drain hardening, #66
 # voter-default flip, #67 driver-readdir ABI v4, #68
-# driver-delete-file + driver-stat, #69 driver-rmdir. Bump
-# alongside the rest of nexus-vfs updates when a downstream
-# change needs newer kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "6afa833ea878690d4adb2a83a2202b9caa4a1314" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "6afa833ea878690d4adb2a83a2202b9caa4a1314" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "6afa833ea878690d4adb2a83a2202b9caa4a1314" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "6afa833ea878690d4adb2a83a2202b9caa4a1314", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "6afa833ea878690d4adb2a83a2202b9caa4a1314", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "6afa833ea878690d4adb2a83a2202b9caa4a1314", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "6afa833ea878690d4adb2a83a2202b9caa4a1314" }
+# driver-delete-file + driver-stat, #69 driver-rmdir, #70
+# FederationPeerClient + DRIVER_RMDIR ABI v5, #75 placeholder
+# inherits parent metastore, #76–#78 sys_unlink dispatch chain,
+# #79 DRY federation-peer-mount predicate + PeerBlobClient
+# reentrancy, #80 sys_write defer-to-peer.  Bump alongside the
+# rest of nexus-vfs updates when a downstream change needs newer
+# kernel bits.
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "29e1079ae7cc7c557e07801d5dd2c2b45dead15c" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "29e1079ae7cc7c557e07801d5dd2c2b45dead15c" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "29e1079ae7cc7c557e07801d5dd2c2b45dead15c" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "29e1079ae7cc7c557e07801d5dd2c2b45dead15c", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "29e1079ae7cc7c557e07801d5dd2c2b45dead15c", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "29e1079ae7cc7c557e07801d5dd2c2b45dead15c", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "29e1079ae7cc7c557e07801d5dd2c2b45dead15c" }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ENV CARGO_NET_RETRY=10 \
     CARGO_HTTP_TIMEOUT=120
 # Override for edge/CI or a different pin: --build-arg NEXUS_VFS_REV=<sha|tag>
-ARG NEXUS_VFS_REV=6afa833ea878690d4adb2a83a2202b9caa4a1314
+ARG NEXUS_VFS_REV=29e1079ae7cc7c557e07801d5dd2c2b45dead15c
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,id=cargo-install-${TARGETARCH},target=/root/.cargo/target \

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ENV CARGO_NET_RETRY=10 \
     CARGO_HTTP_TIMEOUT=120
 # Override for edge/CI or a different pin: --build-arg NEXUS_VFS_REV=<sha|tag>
-ARG NEXUS_VFS_REV=29e1079ae7cc7c557e07801d5dd2c2b45dead15c
+ARG NEXUS_VFS_REV=775a1a16a5bcd71aa649699faa31b97eac2d684e
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,id=cargo-install-${TARGETARCH},target=/root/.cargo/target \

--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir --no-deps --prefix=/install .
 # enforces agreement) — an unpinned install tracks nexus-vfs HEAD and
 # ships an untested kernel (#4343). --locked honors the source tree's
 # Cargo.lock.
-ARG NEXUS_VFS_REV=29e1079ae7cc7c557e07801d5dd2c2b45dead15c
+ARG NEXUS_VFS_REV=775a1a16a5bcd71aa649699faa31b97eac2d684e
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-cluster nexus-cluster
 
 # -- Runtime stage --

--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir --no-deps --prefix=/install .
 # enforces agreement) — an unpinned install tracks nexus-vfs HEAD and
 # ships an untested kernel (#4343). --locked honors the source tree's
 # Cargo.lock.
-ARG NEXUS_VFS_REV=6afa833ea878690d4adb2a83a2202b9caa4a1314
+ARG NEXUS_VFS_REV=29e1079ae7cc7c557e07801d5dd2c2b45dead15c
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-cluster nexus-cluster
 
 # -- Runtime stage --

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -25,7 +25,7 @@ WORKDIR /build
 # (CI preflight enforces agreement) — an unpinned install tracks HEAD
 # and can skew the raft contract against the cluster/witness images.
 # --locked honors the source tree's Cargo.lock.
-ARG NEXUS_VFS_REV=29e1079ae7cc7c557e07801d5dd2c2b45dead15c
+ARG NEXUS_VFS_REV=775a1a16a5bcd71aa649699faa31b97eac2d684e
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexus-raft-server raft
 
 # ---------- Production image ----------

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -25,7 +25,7 @@ WORKDIR /build
 # (CI preflight enforces agreement) — an unpinned install tracks HEAD
 # and can skew the raft contract against the cluster/witness images.
 # --locked honors the source tree's Cargo.lock.
-ARG NEXUS_VFS_REV=6afa833ea878690d4adb2a83a2202b9caa4a1314
+ARG NEXUS_VFS_REV=29e1079ae7cc7c557e07801d5dd2c2b45dead15c
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexus-raft-server raft
 
 # ---------- Production image ----------

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=29e1079ae7cc7c557e07801d5dd2c2b45dead15c
+ARG NEXUS_VFS_REV=775a1a16a5bcd71aa649699faa31b97eac2d684e
 RUN cargo install \
     --locked \
     --git https://github.com/nexi-lab/nexus-vfs \

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=6afa833ea878690d4adb2a83a2202b9caa4a1314
+ARG NEXUS_VFS_REV=29e1079ae7cc7c557e07801d5dd2c2b45dead15c
 RUN cargo install \
     --locked \
     --git https://github.com/nexi-lab/nexus-vfs \

--- a/tests/e2e/docker/test_cc_tasks_share_e2e.py
+++ b/tests/e2e/docker/test_cc_tasks_share_e2e.py
@@ -1455,7 +1455,7 @@ class TestCcTasksListBackendOnlyCrossNodeEnumeration:
         sys_unlink (PR #4427) lets the joiner REMOVE them, this pin
         covers the joiner CREATING/UPDATING them.
 
-        Two-step workflow:
+        Three-step workflow:
           (1) joiner FUSE `cat > <mount-path>` runs through the
               plugin's KernelHandle.write → kernel sys_write → with
               placeholder MountEntry shape (backend=None +
@@ -1464,21 +1464,17 @@ class TestCcTasksListBackendOnlyCrossNodeEnumeration:
               added alongside sys_readdir/sys_stat/sys_unlink;
           (2) founder's typed NexusVFSService.Write handler reaches
               its own sys_write → LocalConnector.write_content →
-              bytes land on founder host fs, byte-exact.
+              bytes land on founder host fs, byte-exact;
+          (3) joiner FUSE reads its own just-written file back
+              byte-exact — closes the cross-node write round-trip.
 
         Pins the systemic sys_write dispatch arm of the
-        FederationPeerClient family so a future refactor that
-        breaks the placeholder-mount write path lights up the
-        cc-tasks-share E2E suite instead of waiting for an
-        operator on a real Mac↔Win pair to notice.
-
-        Out of scope: a "step 3 round-trip" read from the joiner FUSE
-        side after the write would exercise a SEPARATE kernel path
-        (joiner-side metastore population after a cross-node write),
-        currently broken end-to-end — the founder receives the bytes
-        but the joiner's own FUSE lookup misses for >30s.  Tracked
-        as a follow-up; not in this PR's scope, which is the write-
-        dispatch arm only.
+        FederationPeerClient family + the symmetric joiner-side
+        readback (single-proposer raft semantics post nexus-vfs#80:
+        founder is the sole metastore.put proposer for placeholder
+        mount writes; joiner sees the row via raft apply or via
+        sys_stat's federation_peer_stat fallback during the apply
+        window).
         """
         session = _new_session()
         path_rel = f"/{session}/new.json"
@@ -1546,19 +1542,45 @@ class TestCcTasksListBackendOnlyCrossNodeEnumeration:
                 "sys_write FederationPeerClient dispatch arm broke."
             )
 
-            # NB: a "step 3 round-trip" — joiner FUSE reads the file
-            # back — would exercise an ORTHOGONAL kernel path
-            # (joiner-side metastore population after a cross-node
-            # write).  We empirically know that path is currently
-            # broken end-to-end: the founder receives the bytes (the
-            # step-2 assertion above is the hard proof) but the
-            # joiner's own FUSE lookup for the just-written path
-            # misses for >30s.  Tracked separately; this test
-            # intentionally stops here so it pins only the SYS_WRITE
-            # FEDERATION-PEER DISPATCH arm — which is exactly the
-            # arm this PR is responsible for.  See follow-up plan
-            # entry "joiner-side metastore population after
-            # cross-node write" for the orthogonal gap.
+            # Step 3: joiner FUSE round-trip read.  After nexus-vfs#80
+            # made sys_write single-proposer (founder is the sole
+            # metastore.put proposer; joiner sees the row via raft
+            # apply, no double-propose race), this read should
+            # succeed promptly.  Bounded wait at 30s tolerates the
+            # raft apply window — joiner's sys_stat falls back to
+            # federation_peer_stat against founder during that
+            # window, so cat should never actually need the full 30s
+            # in practice.
+            #
+            # Drive `docker exec ... cat` directly, NOT via
+            # `mount_read_bytes`: that helper raises `pytest.fail`
+            # on rc!=0, which raises `BaseException`, which
+            # `except Exception` would miss in a retry loop.
+            deadline = time.monotonic() + 30
+            joiner_bytes = b""
+            last_stderr = ""
+            while time.monotonic() < deadline:
+                proc = subprocess.run(
+                    ["docker", "exec", topology.joiner_container, "cat", file_mount],
+                    capture_output=True,
+                    timeout=30,
+                )
+                if proc.returncode == 0:
+                    joiner_bytes = proc.stdout
+                    if joiner_bytes == payload:
+                        break
+                else:
+                    last_stderr = proc.stderr.decode(errors="replace").strip()
+                time.sleep(0.5)
+            assert joiner_bytes == payload, (
+                f"joiner FUSE read got {joiner_bytes!r} for the file it "
+                f"just wrote, expected {payload!r} "
+                f"(last_cat_stderr={last_stderr!r}). "
+                "sys_write defer-to-peer (nexus-vfs#80) didn't converge "
+                "joiner's local view within 30s — likely a regression in "
+                "raft apply replication of the placeholder mount's "
+                "metastore.put OR in sys_stat federation_peer_stat fallback."
+            )
         finally:
             runbook_helpers.docker_exec(
                 topology.founder_container,


### PR DESCRIPTION
## Summary

Companion to **nexus-vfs#80** (sys_write defers fully to federation peer for placeholder mounts). Two coupled changes that have to ship together:

1. **Rev-bump nexus-vfs** (\`6afa833ea\` → \`29e1079ae\`) across \`Cargo.toml\` + the three downstream Dockerfiles (\`Dockerfile.minimal\`, \`Dockerfile.raft-server\`, \`Dockerfile.raft-witness\`). Cargo.toml header rewritten to capture the new landmark + condense the post-#69 history.

2. **Re-enable step 3** of \`test_joiner_fuse_write_propagates_to_founder_host_fs\`: joiner FUSE round-trip read after the write. Bounded 30s wait tolerates the raft apply window; sys_stat's federation_peer_stat fallback covers it during the apply window so cat should never need the full 30s in practice.

## Why coupled

The rev-bump alone would fail CI on the now-step-3-failing pin against the old kernel; the test change alone would also fail (kernel doesn't have #80 yet). Pairing them in one commit makes the dependency explicit and the rollback unit clean.

## Background — the joiner-readback gap, root-caused

PR #4433's docker E2E (this same test, before scope-narrowing) revealed that founder host fs received bytes byte-exact after a joiner FUSE write — but joiner's OWN subsequent FUSE lookup missed for >30s. Root cause: \`commit_write_through\` did a DOUBLE PROPOSE for placeholder federation mounts (joiner dispatched the write to founder, then ALSO proposed its own metastore.put for the same (zone, path) key — racing through raft).

nexus-vfs#80 mirrors PR #77's sys_unlink short-circuit shape for sys_write: defer the ENTIRE write to the peer, drop joiner's redundant metastore.put. Single-proposer semantics. The joiner sees the row via raft apply or via sys_stat's federation_peer_stat fallback during the apply window — same SSOT contract sys_unlink already enforces.

## Test plan

- [ ] cc-tasks-share Docker E2E suite passes the now-three-step test
- [ ] Existing tests in TestCcTasksListBackendOnlyCrossNodeEnumeration remain green (no regression on host-fs-seeded paths)