### PR TITLE
chore: gitignore redb runtime artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -269,3 +269,7 @@ privatevar/
 # never source-controlled.
 nexus-zones/
 nexus_witness_data/
+
+# redb database files (runtime artifacts from nexusd-cluster / tests)
+*.redb
+:memory:.redb


### PR DESCRIPTION
Add *.redb to .gitignore