### PR TITLE
test(docker-e2e) + deps: cross-node mkdir/rename/setattr pins; bump nexus-vfs to #82

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=775a1a16a5bcd71aa649699faa31b97eac2d684e#775a1a16a5bcd71aa649699faa31b97eac2d684e"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=aa86f93cd7067e8406b264d204d0c49e191105b7#aa86f93cd7067e8406b264d204d0c49e191105b7"
 dependencies = [
  "ahash",
  "base64",
@@ -550,7 +550,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=775a1a16a5bcd71aa649699faa31b97eac2d684e#775a1a16a5bcd71aa649699faa31b97eac2d684e"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=aa86f93cd7067e8406b264d204d0c49e191105b7#aa86f93cd7067e8406b264d204d0c49e191105b7"
 dependencies = [
  "parking_lot",
  "serde",
@@ -1333,7 +1333,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=775a1a16a5bcd71aa649699faa31b97eac2d684e#775a1a16a5bcd71aa649699faa31b97eac2d684e"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=aa86f93cd7067e8406b264d204d0c49e191105b7#aa86f93cd7067e8406b264d204d0c49e191105b7"
 dependencies = [
  "ahash",
  "base64",
@@ -1384,7 +1384,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=775a1a16a5bcd71aa649699faa31b97eac2d684e#775a1a16a5bcd71aa649699faa31b97eac2d684e"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=aa86f93cd7067e8406b264d204d0c49e191105b7#aa86f93cd7067e8406b264d204d0c49e191105b7"
 dependencies = [
  "ahash",
  "base64",
@@ -1576,7 +1576,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=775a1a16a5bcd71aa649699faa31b97eac2d684e#775a1a16a5bcd71aa649699faa31b97eac2d684e"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=aa86f93cd7067e8406b264d204d0c49e191105b7#aa86f93cd7067e8406b264d204d0c49e191105b7"
 
 [[package]]
 name = "nexus-vault"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,16 +30,16 @@ exclude = ["nexus-fuse"]
 [workspace.dependencies]
 # Kernel-tier crates from nexus-vfs (external git dependency).
 # SSOT: https://github.com/nexi-lab/nexus-vfs
-# Pinned at the nexus-vfs main commit that landed #80 (sys_write
-# defers fully to federation peer for backend-less placeholder
-# mounts).  Closes the joiner-readback gap PR #4433's docker E2E
-# exposed: founder host fs received bytes byte-exact after a
-# joiner FUSE write, but joiner's OWN subsequent FUSE lookup
-# missed for >30s because the old shape had joiner ALSO propose
-# its own metastore.put (double-propose racing founder's
-# replicated apply through raft).  #80 makes founder the single
-# proposer for placeholder-mount writes — mirror of #77's
-# sys_unlink short-circuit.
+# Pinned at the nexus-vfs main commit that landed #82 (closes the
+# FULL cross-node mutation matrix: sys_mkdir + sys_rename +
+# sys_setattr DT_REG all defer fully to the SSOT peer, mirroring
+# PR #77 sys_unlink + PR #80 sys_write).  Single-proposer raft
+# semantics across the entire mutation surface.  Also relocates
+# the federation-peer dispatch convention from kernel/io.rs to
+# kernel/federation.rs — its architecturally correct home per
+# docs/KERNEL-ARCHITECTURE.md §3 (file-organization fix; zero
+# behavioural delta).  Closes the kernel side of the Mac↔Win
+# cc-tasks-share workflow.
 # Builds on prior landmarks: #57 plugin-as-gRPC-service routing,
 # #58 sealed-keystore signing trust root, #60 KernelHandle v3
 # sys_stat_batch, #61 per-call EC/SC primitives, #62 CLI flag rename,
@@ -49,16 +49,18 @@ exclude = ["nexus-fuse"]
 # FederationPeerClient + DRIVER_RMDIR ABI v5, #75 placeholder
 # inherits parent metastore, #76–#78 sys_unlink dispatch chain,
 # #79 DRY federation-peer-mount predicate + PeerBlobClient
-# reentrancy, #80 sys_write defer-to-peer.  Bump alongside the
-# rest of nexus-vfs updates when a downstream change needs newer
-# kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "775a1a16a5bcd71aa649699faa31b97eac2d684e" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "775a1a16a5bcd71aa649699faa31b97eac2d684e" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "775a1a16a5bcd71aa649699faa31b97eac2d684e" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "775a1a16a5bcd71aa649699faa31b97eac2d684e", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "775a1a16a5bcd71aa649699faa31b97eac2d684e", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "775a1a16a5bcd71aa649699faa31b97eac2d684e", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "775a1a16a5bcd71aa649699faa31b97eac2d684e" }
+# reentrancy, #80 sys_write defer-to-peer, #81 preserve miss-on-
+# dispatch-failure semantics, #82 sys_mkdir/rename/setattr
+# defer-to-peer + kernel/federation.rs architecture fix.
+# Bump alongside the rest of nexus-vfs updates when a downstream
+# change needs newer kernel bits.
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "aa86f93cd7067e8406b264d204d0c49e191105b7" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "aa86f93cd7067e8406b264d204d0c49e191105b7" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "aa86f93cd7067e8406b264d204d0c49e191105b7" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "aa86f93cd7067e8406b264d204d0c49e191105b7", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "aa86f93cd7067e8406b264d204d0c49e191105b7", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "aa86f93cd7067e8406b264d204d0c49e191105b7", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "aa86f93cd7067e8406b264d204d0c49e191105b7" }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ENV CARGO_NET_RETRY=10 \
     CARGO_HTTP_TIMEOUT=120
 # Override for edge/CI or a different pin: --build-arg NEXUS_VFS_REV=<sha|tag>
-ARG NEXUS_VFS_REV=775a1a16a5bcd71aa649699faa31b97eac2d684e
+ARG NEXUS_VFS_REV=aa86f93cd7067e8406b264d204d0c49e191105b7
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,id=cargo-install-${TARGETARCH},target=/root/.cargo/target \

--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir --no-deps --prefix=/install .
 # enforces agreement) — an unpinned install tracks nexus-vfs HEAD and
 # ships an untested kernel (#4343). --locked honors the source tree's
 # Cargo.lock.
-ARG NEXUS_VFS_REV=775a1a16a5bcd71aa649699faa31b97eac2d684e
+ARG NEXUS_VFS_REV=aa86f93cd7067e8406b264d204d0c49e191105b7
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-cluster nexus-cluster
 
 # -- Runtime stage --

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -25,7 +25,7 @@ WORKDIR /build
 # (CI preflight enforces agreement) — an unpinned install tracks HEAD
 # and can skew the raft contract against the cluster/witness images.
 # --locked honors the source tree's Cargo.lock.
-ARG NEXUS_VFS_REV=775a1a16a5bcd71aa649699faa31b97eac2d684e
+ARG NEXUS_VFS_REV=aa86f93cd7067e8406b264d204d0c49e191105b7
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexus-raft-server raft
 
 # ---------- Production image ----------

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=775a1a16a5bcd71aa649699faa31b97eac2d684e
+ARG NEXUS_VFS_REV=aa86f93cd7067e8406b264d204d0c49e191105b7
 RUN cargo install \
     --locked \
     --git https://github.com/nexi-lab/nexus-vfs \

--- a/tests/e2e/docker/test_cc_tasks_share_e2e.py
+++ b/tests/e2e/docker/test_cc_tasks_share_e2e.py
@@ -1587,3 +1587,358 @@ class TestCcTasksListBackendOnlyCrossNodeEnumeration:
                 ["rm", "-rf", f"/host/tasks/{session}"],
                 check=False,
             )
+
+    def test_joiner_fuse_mkdir_propagates_to_founder_host_fs(
+        self,
+        topology: CcTasksTopology,
+        api_key: str,
+        joined_cluster: dict,
+    ) -> None:
+        """Operator-side `mkdir` from the federation peer reaches SSOT host fs.
+
+        Closes the cross-node mkdir half of the cc-tasks-share loop
+        (sister of sys_unlink / sys_write / sys_rename / sys_setattr).
+        This is the FIRST step of the Mac↔Win cc-tasks-share workflow:
+        Win operator creates a brand-new CC session dir via FUSE; Mac
+        CC then walks ~/.claude/tasks/ directly via host fs (NOT via
+        Nexus) and must find that session dir there.
+
+        Four-step workflow (data flows step → step):
+          (1) joiner FUSE `mkdir /mnt/cc-tasks/founder/<session>` runs
+              through the plugin's KernelHandle.mkdir → kernel
+              sys_mkdir → with placeholder MountEntry shape (backend=
+              None + target_zone_id=Some) the kernel routes the mkdir
+              to the peer via the FederationPeerClient.mkdir dispatch
+              added in nexus-vfs#82;
+          (2) founder's typed NexusVFSService.Mkdir handler reaches
+              its own sys_mkdir → LocalConnector.backend.mkdir → host
+              fs has the directory;
+          (3) verify founder host fs has the directory (the SSOT side
+              honoured the create through its own LocalConnector);
+          (4) joiner FUSE writes a JSON inside the new dir (the
+              realistic continuation — operator creates session, then
+              CC writes session state).  Bytes land on founder host
+              fs byte-exact, proving the dir created in step 1 is the
+              one step 4's write lands into.
+
+        Pins the systemic sys_mkdir dispatch arm of the
+        FederationPeerClient family.  Pre-nexus-vfs#82 shape registered
+        DT_DIR metadata in raft but neither node ran backend.mkdir —
+        SSOT-side host fs got no directory and every subsequent
+        host-fs-level read from the SSOT side missed.
+        """
+        session = _new_session()
+        sess_path_rel = f"/{session}"
+        file_path_rel = f"/{session}/1.json"
+        payload = b'{"id":"session-init","status":"created","title":"First session metadata"}'
+        try:
+            # Step 1: joiner FUSE mkdir for the new session dir.
+            session_vfs = topology.founder_vfs_path(sess_path_rel)
+            session_mount = topology.mount_path_for_vfs(session_vfs)
+            cc_tasks_share_helpers.mount_mkdir(topology.joiner_container, session_mount)
+
+            # Step 2: founder host fs has the directory.  Bounded wait
+            # tolerates the founder-side apply window — sys_mkdir
+            # defer-to-peer fires the RPC synchronously so this is
+            # usually immediate, but a transient peer-discovery blip
+            # would otherwise surface as a hang.
+            host_session_dir = f"/host/tasks{sess_path_rel}"
+            deadline = time.monotonic() + 30
+            saw_dir = False
+            while time.monotonic() < deadline:
+                check = runbook_helpers.docker_exec(
+                    topology.founder_container,
+                    ["test", "-d", host_session_dir],
+                    check=False,
+                )
+                if check.rc == 0:
+                    saw_dir = True
+                    break
+                time.sleep(0.5)
+            assert saw_dir, (
+                f"founder host fs at {host_session_dir} did not receive "
+                "joiner's FUSE mkdir — sys_mkdir FederationPeerClient "
+                "dispatch arm (nexus-vfs#82) broke."
+            )
+
+            # Step 3: joiner FUSE write inside the just-created dir.
+            # Data flow: the dir created in step 1 is the parent of
+            # the file step 3 writes; without step 1's success step 3
+            # would error "Directory nonexistent" (proven by PR #4433's
+            # earlier seed-dir fix).
+            file_vfs = topology.founder_vfs_path(file_path_rel)
+            file_mount = topology.mount_path_for_vfs(file_vfs)
+            cc_tasks_share_helpers.mount_write_bytes(topology.joiner_container, file_mount, payload)
+
+            # Step 4: founder host fs has the bytes byte-exact.
+            host_file = f"/host/tasks{file_path_rel}"
+            deadline = time.monotonic() + 30
+            host_bytes: bytes | None = None
+            while time.monotonic() < deadline:
+                check = runbook_helpers.docker_exec(
+                    topology.founder_container,
+                    ["test", "-e", host_file],
+                    check=False,
+                )
+                if check.rc == 0:
+                    host_bytes = cc_tasks_share_helpers.host_task_read(
+                        topology.founder_container, file_path_rel
+                    )
+                    if host_bytes == payload:
+                        break
+                time.sleep(0.5)
+            assert host_bytes == payload, (
+                f"founder host fs at {host_file} did not receive bytes "
+                f"after joiner mkdir-then-write — got {host_bytes!r}, "
+                f"expected {payload!r}.  Either the mkdir didn't actually "
+                "materialise the parent dir (step 1+2 false positive) "
+                "or the subsequent sys_write regressed."
+            )
+        finally:
+            runbook_helpers.docker_exec(
+                topology.founder_container,
+                ["rm", "-rf", f"/host/tasks/{session}"],
+                check=False,
+            )
+
+    def test_joiner_fuse_rename_propagates_to_founder_host_fs(
+        self,
+        topology: CcTasksTopology,
+        api_key: str,
+        joined_cluster: dict,
+    ) -> None:
+        """Operator-side `mv` from the federation peer reaches SSOT host fs.
+
+        Closes the cross-node rename half of the cc-tasks-share loop.
+        Real user pattern: CC's atomic-write convention (write to
+        `.tmp`, rename to final).  Without sys_rename defer-to-peer,
+        joiner's metastore moved the row but neither node ran
+        backend.rename — SSOT-side host fs still had the `.tmp`
+        residue with NOTHING at the intended final name.
+
+        Four-step workflow:
+          (1) seed file on founder host fs at `<session>/draft.tmp`
+              with payload bytes (the realistic precondition: an
+              earlier write put the .tmp there);
+          (2) wait for joiner readdir to enumerate `<session>/`
+              (data flow guard: the next step depends on the joiner
+              having the rename's source path materialised in route);
+          (3) joiner FUSE `mv draft.tmp final.json` runs through the
+              plugin's KernelHandle.rename → kernel sys_rename →
+              FederationPeerClient.rename dispatch (nexus-vfs#82) →
+              founder NexusVFSService.Rename → founder sys_rename →
+              LocalConnector.backend.rename → host fs has final.json
+              with the same bytes, draft.tmp gone;
+          (4) verify founder host fs: final.json exists with payload
+              byte-exact AND draft.tmp is gone (both halves of the
+              rename atomicity contract).
+
+        Pins the systemic sys_rename dispatch arm of the
+        FederationPeerClient family.
+        """
+        session = _new_session()
+        old_path_rel = f"/{session}/draft.tmp"
+        new_path_rel = f"/{session}/final.json"
+        payload = b'{"id":"d","status":"draft-promoted-to-final","title":"Atomic rename"}'
+        try:
+            # Step 1: seed the .tmp file on founder host fs (the
+            # realistic predecessor of the rename).
+            cc_tasks_share_helpers.host_task_write(
+                topology.founder_container, old_path_rel, payload
+            )
+
+            # Step 2: wait for joiner to see the session via readdir.
+            # Data flow: the rename in step 3 needs the source path
+            # routed via the placeholder mount, which depends on the
+            # parent dir + DT_REG row replicating to joiner via raft.
+            parent_vfs = topology.founder_vfs_path("")
+            parent_mount = topology.mount_path_for_vfs(parent_vfs.rstrip("/"))
+            deadline = time.monotonic() + 30
+            while time.monotonic() < deadline:
+                if session in cc_tasks_share_helpers.mount_listdir(
+                    topology.joiner_container, parent_mount
+                ):
+                    break
+                time.sleep(0.5)
+            else:
+                pytest.fail(
+                    f"joiner never saw seeded session dir {session} via readdir "
+                    "— sys_readdir federation peer dispatch broke or raft "
+                    "drain hung; sys_rename test prerequisite missing."
+                )
+
+            # Step 3: joiner FUSE rename — full chain through
+            # kernel sys_rename → FederationPeerClient.rename →
+            # founder NexusVFSService.Rename → founder sys_rename →
+            # founder LocalConnector → host fs.
+            old_mount = topology.mount_path_for_vfs(topology.founder_vfs_path(old_path_rel))
+            new_mount = topology.mount_path_for_vfs(topology.founder_vfs_path(new_path_rel))
+            cc_tasks_share_helpers.mount_rename(topology.joiner_container, old_mount, new_mount)
+
+            # Step 4a: founder host fs has the NEW name with byte-
+            # exact payload.
+            new_host = f"/host/tasks{new_path_rel}"
+            deadline = time.monotonic() + 30
+            host_new_bytes: bytes | None = None
+            while time.monotonic() < deadline:
+                check = runbook_helpers.docker_exec(
+                    topology.founder_container,
+                    ["test", "-e", new_host],
+                    check=False,
+                )
+                if check.rc == 0:
+                    host_new_bytes = cc_tasks_share_helpers.host_task_read(
+                        topology.founder_container, new_path_rel
+                    )
+                    if host_new_bytes == payload:
+                        break
+                time.sleep(0.5)
+            assert host_new_bytes == payload, (
+                f"founder host fs at {new_host} did not receive the renamed "
+                f"file — got {host_new_bytes!r}, expected {payload!r}.  "
+                "sys_rename FederationPeerClient dispatch arm (nexus-vfs#82) broke."
+            )
+
+            # Step 4b: founder host fs no longer has the OLD name.
+            # Two-halves-of-atomicity check: a rename that creates the
+            # new path but leaves the old behind would silently corrupt
+            # CC's atomic-write contract.
+            old_host = f"/host/tasks{old_path_rel}"
+            deadline = time.monotonic() + 30
+            old_gone = False
+            while time.monotonic() < deadline:
+                check = runbook_helpers.docker_exec(
+                    topology.founder_container,
+                    ["test", "-e", old_host],
+                    check=False,
+                )
+                if check.rc != 0:
+                    old_gone = True
+                    break
+                time.sleep(0.5)
+            assert old_gone, (
+                f"founder host fs still has the OLD name {old_host} after "
+                "joiner FUSE rename — backend.rename didn't fire on the "
+                "SSOT side, atomicity contract broken."
+            )
+        finally:
+            runbook_helpers.docker_exec(
+                topology.founder_container,
+                ["rm", "-rf", f"/host/tasks/{session}"],
+                check=False,
+            )
+
+    def test_joiner_fuse_touch_propagates_modified_at_to_founder_metastore(
+        self,
+        topology: CcTasksTopology,
+        api_key: str,
+        joined_cluster: dict,
+    ) -> None:
+        """Operator-side `touch -m` from the federation peer updates SSOT metastore.
+
+        Closes the cross-node setattr half of the cc-tasks-share loop
+        (DT_REG metadata-update path).  CC and standard tooling fire
+        FUSE setattr via `utimensat()` (touch, build-system stat
+        cache invalidations, file-watcher resync).  Without sys_setattr
+        DT_REG defer-to-peer (nexus-vfs#82), joiner's local
+        metastore.put for the new modified_at_ms raft-replicated to the
+        SSOT side, but the SSOT-side backend (LocalConnector) never
+        saw the call — divergence between metastore-of-record and
+        host-fs-truth on the SSOT side.
+
+        Four-step workflow:
+          (1) seed file on founder host fs (a typical CC session
+              JSON's predecessor state);
+          (2) wait for joiner gRPC stat to see the file AND capture
+              the initial modified_at_ms (the BASELINE the assertion
+              compares against);
+          (3) joiner FUSE `touch -m <file>` runs through the plugin's
+              KernelHandle.setattr → kernel sys_setattr DT_REG with
+              modified_at_ms = now → FederationPeerClient.setattr
+              dispatch (nexus-vfs#82) → founder NexusVFSService.Setattr
+              → founder sys_setattr → founder's metastore.put with new
+              modified_at_ms (and raft replicates back to joiner);
+          (4) verify both nodes' gRPC stat report modified_at_ms
+              strictly GREATER than the baseline from step 2 — i.e.
+              the setattr propagated AND the metastore-of-record on
+              the founder side reflects the joiner-triggered touch.
+
+        Pins the systemic sys_setattr (DT_REG) dispatch arm of the
+        FederationPeerClient family.
+        """
+        session = _new_session()
+        path_rel = f"/{session}/state.json"
+        payload = b'{"id":"touch-target","status":"initial","title":"For touch-modify test"}'
+        try:
+            # Step 1: seed file on founder host fs.
+            cc_tasks_share_helpers.host_task_write(topology.founder_container, path_rel, payload)
+
+            # Step 2: joiner gRPC stat sees the file + capture baseline
+            # modified_at_ms.  Data flow: step 3's touch must produce a
+            # strictly-greater modified_at_ms than this baseline,
+            # otherwise the assertion in step 4 can't distinguish the
+            # post-touch state from the pre-touch state.
+            file_vfs = topology.founder_vfs_path(path_rel)
+            deadline = time.monotonic() + 30
+            baseline_modified_at_ms: int | None = None
+            while time.monotonic() < deadline:
+                stat_resp = runbook_helpers.vfs_stat(
+                    topology.joiner_grpc, file_vfs, api_key=api_key, timeout=10
+                )
+                result = stat_resp.get("result", {})
+                if result.get("found"):
+                    baseline_modified_at_ms = int(result.get("modifiedAtMs", 0))
+                    if baseline_modified_at_ms > 0:
+                        break
+                time.sleep(0.5)
+            assert baseline_modified_at_ms and baseline_modified_at_ms > 0, (
+                "joiner never saw seeded file via gRPC stat with a non-zero "
+                "modified_at_ms baseline — sys_setattr test prerequisite missing."
+            )
+
+            # Step 3: joiner FUSE touch.  `touch <file>` without
+            # explicit time updates BOTH atime and mtime to "now",
+            # exercising FUSE setattr with modified_at_ms = now.
+            # We give it a small sleep before to guarantee the kernel
+            # clock has ticked past the baseline (millisecond
+            # granularity — 1.5s buffer is generous).
+            time.sleep(1.5)
+            file_mount = topology.mount_path_for_vfs(file_vfs)
+            runbook_helpers.docker_exec(
+                topology.joiner_container,
+                ["touch", file_mount],
+                check=True,
+            )
+
+            # Step 4: founder gRPC stat reports modified_at_ms STRICTLY
+            # GREATER than baseline.  Strict-greater (not just non-
+            # zero) catches a defer-to-peer regression that propagated
+            # the put back as the OLD modified_at_ms (would happen if
+            # the short-circuit dispatched but the peer used a stale
+            # timestamp from its own metastore).
+            deadline = time.monotonic() + 30
+            new_modified_at_ms: int | None = None
+            while time.monotonic() < deadline:
+                stat_resp = runbook_helpers.vfs_stat(
+                    topology.founder_grpc, file_vfs, api_key=api_key, timeout=10
+                )
+                result = stat_resp.get("result", {})
+                if result.get("found"):
+                    candidate = int(result.get("modifiedAtMs", 0))
+                    if candidate > baseline_modified_at_ms:
+                        new_modified_at_ms = candidate
+                        break
+                time.sleep(0.5)
+            assert new_modified_at_ms and new_modified_at_ms > baseline_modified_at_ms, (
+                f"founder gRPC stat modified_at_ms did not advance past "
+                f"baseline {baseline_modified_at_ms} after joiner touch — "
+                f"got {new_modified_at_ms} (or None).  sys_setattr DT_REG "
+                "FederationPeerClient dispatch arm (nexus-vfs#82) broke OR "
+                "raft replication of the SSOT-side metastore.put hung."
+            )
+        finally:
+            runbook_helpers.docker_exec(
+                topology.founder_container,
+                ["rm", "-rf", f"/host/tasks/{session}"],
+                check=False,
+            )


### PR DESCRIPTION
## Summary

Companion to **nexus-vfs#82** (closes the FULL cross-node mutation matrix via sys_mkdir / sys_rename / sys_setattr defer-to-peer + relocates federation-peer dispatch to its architecturally correct home).

Two coupled changes shipped together:

1. **Three new E2E tests** in \`TestCcTasksListBackendOnlyCrossNodeEnumeration\` (\`tests/e2e/docker/test_cc_tasks_share_e2e.py\`) — each follows the integration-test-generator skill conventions (3+ step workflows with strict data flow, byte-exact assertions, finally-cleanup, meaningful failure messages pointing at the specific kernel arm).

2. **Rev-bump nexus-vfs** (\`775a1a16a\` → \`aa86f93cd\`) across \`Cargo.toml\` / \`Cargo.lock\` / 4 Dockerfiles. Header comment rewritten to capture #82's landmark.

## Test plan

### test_joiner_fuse_mkdir_propagates_to_founder_host_fs
- (1) joiner FUSE \`mkdir /mnt/cc-tasks/founder/<session>\`
- (2) verify founder host fs has the directory (the SSOT-side LocalConnector.backend.mkdir must have fired via the federation dispatch)
- (3) joiner FUSE writes a JSON into the dir (data flow: depends on step 1's dir existing — without it the FUSE create-write fails ENOENT)
- (4) byte-exact host-fs check for the written file

Pins the FIRST step of the Mac↔Win cc-tasks-share workflow: Win operator creates a brand-new CC session dir via FUSE → Mac CC's direct host-fs walk finds it.

### test_joiner_fuse_rename_propagates_to_founder_host_fs
- (1) seed \`.tmp\` on founder host fs
- (2) wait for joiner readdir to enumerate (data-flow guard)
- (3) joiner FUSE \`mv .tmp -> final\`
- (4) verify founder host fs has new name with byte-exact payload AND old name is gone (atomicity contract)

Pins CC's atomic-write pattern (\`write tmp; rename tmp -> final\`) cross-node.

### test_joiner_fuse_touch_propagates_modified_at_to_founder_metastore
- (1) seed file
- (2) joiner gRPC stat captures baseline \`modified_at_ms\`
- (3) 1.5s wait + joiner FUSE \`touch\` (which fires \`utimensat\` → FUSE setattr → kernel sys_setattr DT_REG with new modified_at_ms)
- (4) founder gRPC stat reports \`modified_at_ms\` STRICTLY GREATER than baseline

Strict-greater (not just non-zero) catches a regression where the short-circuit dispatches but the peer used a stale timestamp.

## Why coupled

Test commit alone would fail on the old kernel (no defer-to-peer arm for mkdir/rename/setattr → SSOT-side host fs gets nothing → host-fs assertions miss). Rev-bump alone leaves the kernel's new arms unverified. Pairing the test + bump in one PR is the explicit dependency unit (same pattern as PR #4433+#4435).

## Architectural posture preserved

- Follows integration-test-generator skill standards: long-workflow (4 steps each), real user problem (Mac↔Win cc-tasks-share lifecycle), strong data-flow links between steps, byte-exact / strict-greater assertions, test data isolation (\`_new_session()\` per test), finally-cleanup.
- Each test's failure message names the specific kernel arm under test, so a regression bisect points at the right commit immediately.