### PR TITLE
chore(deps): E2E-gate nexus-vfs PR #84 (Phase 1 refactor) at branch HEAD before merge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=775a1a16a5bcd71aa649699faa31b97eac2d684e#775a1a16a5bcd71aa649699faa31b97eac2d684e"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=de3bdef3f0dc38a6c11dccda51ec3a9c339ffd43#de3bdef3f0dc38a6c11dccda51ec3a9c339ffd43"
 dependencies = [
  "ahash",
  "base64",
@@ -550,7 +550,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=775a1a16a5bcd71aa649699faa31b97eac2d684e#775a1a16a5bcd71aa649699faa31b97eac2d684e"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=de3bdef3f0dc38a6c11dccda51ec3a9c339ffd43#de3bdef3f0dc38a6c11dccda51ec3a9c339ffd43"
 dependencies = [
  "parking_lot",
  "serde",
@@ -1333,7 +1333,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=775a1a16a5bcd71aa649699faa31b97eac2d684e#775a1a16a5bcd71aa649699faa31b97eac2d684e"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=de3bdef3f0dc38a6c11dccda51ec3a9c339ffd43#de3bdef3f0dc38a6c11dccda51ec3a9c339ffd43"
 dependencies = [
  "ahash",
  "base64",
@@ -1384,7 +1384,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=775a1a16a5bcd71aa649699faa31b97eac2d684e#775a1a16a5bcd71aa649699faa31b97eac2d684e"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=de3bdef3f0dc38a6c11dccda51ec3a9c339ffd43#de3bdef3f0dc38a6c11dccda51ec3a9c339ffd43"
 dependencies = [
  "ahash",
  "base64",
@@ -1576,7 +1576,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=775a1a16a5bcd71aa649699faa31b97eac2d684e#775a1a16a5bcd71aa649699faa31b97eac2d684e"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=de3bdef3f0dc38a6c11dccda51ec3a9c339ffd43#de3bdef3f0dc38a6c11dccda51ec3a9c339ffd43"
 
 [[package]]
 name = "nexus-vault"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=de3bdef3f0dc38a6c11dccda51ec3a9c339ffd43#de3bdef3f0dc38a6c11dccda51ec3a9c339ffd43"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=3bae5089409c8b5e1a6c30dd9eef4d9cbf543385#3bae5089409c8b5e1a6c30dd9eef4d9cbf543385"
 dependencies = [
  "ahash",
  "base64",
@@ -550,7 +550,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=de3bdef3f0dc38a6c11dccda51ec3a9c339ffd43#de3bdef3f0dc38a6c11dccda51ec3a9c339ffd43"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=3bae5089409c8b5e1a6c30dd9eef4d9cbf543385#3bae5089409c8b5e1a6c30dd9eef4d9cbf543385"
 dependencies = [
  "parking_lot",
  "serde",
@@ -1333,7 +1333,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=de3bdef3f0dc38a6c11dccda51ec3a9c339ffd43#de3bdef3f0dc38a6c11dccda51ec3a9c339ffd43"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=3bae5089409c8b5e1a6c30dd9eef4d9cbf543385#3bae5089409c8b5e1a6c30dd9eef4d9cbf543385"
 dependencies = [
  "ahash",
  "base64",
@@ -1384,7 +1384,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=de3bdef3f0dc38a6c11dccda51ec3a9c339ffd43#de3bdef3f0dc38a6c11dccda51ec3a9c339ffd43"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=3bae5089409c8b5e1a6c30dd9eef4d9cbf543385#3bae5089409c8b5e1a6c30dd9eef4d9cbf543385"
 dependencies = [
  "ahash",
  "base64",
@@ -1576,7 +1576,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=de3bdef3f0dc38a6c11dccda51ec3a9c339ffd43#de3bdef3f0dc38a6c11dccda51ec3a9c339ffd43"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=3bae5089409c8b5e1a6c30dd9eef4d9cbf543385#3bae5089409c8b5e1a6c30dd9eef4d9cbf543385"
 
 [[package]]
 name = "nexus-vault"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,16 +30,23 @@ exclude = ["nexus-fuse"]
 [workspace.dependencies]
 # Kernel-tier crates from nexus-vfs (external git dependency).
 # SSOT: https://github.com/nexi-lab/nexus-vfs
-# Pinned at the nexus-vfs main commit that landed #80 (sys_write
-# defers fully to federation peer for backend-less placeholder
-# mounts).  Closes the joiner-readback gap PR #4433's docker E2E
-# exposed: founder host fs received bytes byte-exact after a
-# joiner FUSE write, but joiner's OWN subsequent FUSE lookup
-# missed for >30s because the old shape had joiner ALSO propose
-# its own metastore.put (double-propose racing founder's
-# replicated apply through raft).  #80 makes founder the single
-# proposer for placeholder-mount writes — mirror of #77's
-# sys_unlink short-circuit.
+# E2E-GATING PIN at nexus-vfs PR #84's BRANCH HEAD (not main yet):
+# this nexus PR exists solely to run Federation E2E + cc-tasks-share
+# E2E against the unmerged Phase 1 refactor.  Per the lesson from
+# the reverted PR #82, merging kernel work BEFORE the full E2E
+# suite validates it leaves regressions in develop until the next
+# companion PR catches them.  Once #84's CI on this nexus PR shows
+# Federation E2E + cc-tasks-share E2E green, nexus-vfs #84 admin-
+# merges to main, and this PR's pin re-bumps to the resulting main
+# merge commit.  If E2E catches a regression, nexus-vfs #84 gets
+# fixed BEFORE merging.
+#
+# nexus-vfs #84 is a pure file-organization refactor (zero
+# behavioural delta): relocates `dispatch_federation_peer` + 5
+# `federation_peer_X` helpers + 2 slot accessors from io.rs / mod.rs
+# to kernel/federation.rs (their architecturally correct home per
+# docs/KERNEL-ARCHITECTURE.md §3).  No syscall ABI / plugin ABI /
+# trait change.
 # Builds on prior landmarks: #57 plugin-as-gRPC-service routing,
 # #58 sealed-keystore signing trust root, #60 KernelHandle v3
 # sys_stat_batch, #61 per-call EC/SC primitives, #62 CLI flag rename,
@@ -52,13 +59,13 @@ exclude = ["nexus-fuse"]
 # reentrancy, #80 sys_write defer-to-peer.  Bump alongside the
 # rest of nexus-vfs updates when a downstream change needs newer
 # kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "775a1a16a5bcd71aa649699faa31b97eac2d684e" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "775a1a16a5bcd71aa649699faa31b97eac2d684e" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "775a1a16a5bcd71aa649699faa31b97eac2d684e" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "775a1a16a5bcd71aa649699faa31b97eac2d684e", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "775a1a16a5bcd71aa649699faa31b97eac2d684e", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "775a1a16a5bcd71aa649699faa31b97eac2d684e", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "775a1a16a5bcd71aa649699faa31b97eac2d684e" }
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "de3bdef3f0dc38a6c11dccda51ec3a9c339ffd43" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "de3bdef3f0dc38a6c11dccda51ec3a9c339ffd43" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "de3bdef3f0dc38a6c11dccda51ec3a9c339ffd43" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "de3bdef3f0dc38a6c11dccda51ec3a9c339ffd43", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "de3bdef3f0dc38a6c11dccda51ec3a9c339ffd43", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "de3bdef3f0dc38a6c11dccda51ec3a9c339ffd43", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "de3bdef3f0dc38a6c11dccda51ec3a9c339ffd43" }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,23 +30,14 @@ exclude = ["nexus-fuse"]
 [workspace.dependencies]
 # Kernel-tier crates from nexus-vfs (external git dependency).
 # SSOT: https://github.com/nexi-lab/nexus-vfs
-# E2E-GATING PIN at nexus-vfs PR #84's BRANCH HEAD (not main yet):
-# this nexus PR exists solely to run Federation E2E + cc-tasks-share
-# E2E against the unmerged Phase 1 refactor.  Per the lesson from
-# the reverted PR #82, merging kernel work BEFORE the full E2E
-# suite validates it leaves regressions in develop until the next
-# companion PR catches them.  Once #84's CI on this nexus PR shows
-# Federation E2E + cc-tasks-share E2E green, nexus-vfs #84 admin-
-# merges to main, and this PR's pin re-bumps to the resulting main
-# merge commit.  If E2E catches a regression, nexus-vfs #84 gets
-# fixed BEFORE merging.
-#
-# nexus-vfs #84 is a pure file-organization refactor (zero
-# behavioural delta): relocates `dispatch_federation_peer` + 5
-# `federation_peer_X` helpers + 2 slot accessors from io.rs / mod.rs
-# to kernel/federation.rs (their architecturally correct home per
-# docs/KERNEL-ARCHITECTURE.md §3).  No syscall ABI / plugin ABI /
-# trait change.
+# Pinned at the nexus-vfs main commit that landed #84 (Phase 1 of
+# the bottom-up re-attempt of reverted PR #82): pure file-
+# organization refactor relocating `dispatch_federation_peer` + 5
+# `federation_peer_X` helpers + 2 slot accessors from io.rs /
+# mod.rs to kernel/federation.rs — their architecturally correct
+# home per docs/KERNEL-ARCHITECTURE.md §3.  Zero behavioural
+# delta; E2E-validated against Federation E2E + cc-tasks-share
+# E2E suites before merge.
 # Builds on prior landmarks: #57 plugin-as-gRPC-service routing,
 # #58 sealed-keystore signing trust root, #60 KernelHandle v3
 # sys_stat_batch, #61 per-call EC/SC primitives, #62 CLI flag rename,
@@ -56,16 +47,18 @@ exclude = ["nexus-fuse"]
 # FederationPeerClient + DRIVER_RMDIR ABI v5, #75 placeholder
 # inherits parent metastore, #76–#78 sys_unlink dispatch chain,
 # #79 DRY federation-peer-mount predicate + PeerBlobClient
-# reentrancy, #80 sys_write defer-to-peer.  Bump alongside the
-# rest of nexus-vfs updates when a downstream change needs newer
-# kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "de3bdef3f0dc38a6c11dccda51ec3a9c339ffd43" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "de3bdef3f0dc38a6c11dccda51ec3a9c339ffd43" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "de3bdef3f0dc38a6c11dccda51ec3a9c339ffd43" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "de3bdef3f0dc38a6c11dccda51ec3a9c339ffd43", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "de3bdef3f0dc38a6c11dccda51ec3a9c339ffd43", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "de3bdef3f0dc38a6c11dccda51ec3a9c339ffd43", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "de3bdef3f0dc38a6c11dccda51ec3a9c339ffd43" }
+# reentrancy, #80 sys_write defer-to-peer, #81 preserve miss-on-
+# dispatch-failure semantics, #84 relocate federation-peer
+# dispatch to kernel/federation.rs.  Bump alongside the rest of
+# nexus-vfs updates when a downstream change needs newer kernel
+# bits.
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "3bae5089409c8b5e1a6c30dd9eef4d9cbf543385" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "3bae5089409c8b5e1a6c30dd9eef4d9cbf543385" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "3bae5089409c8b5e1a6c30dd9eef4d9cbf543385" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "3bae5089409c8b5e1a6c30dd9eef4d9cbf543385", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "3bae5089409c8b5e1a6c30dd9eef4d9cbf543385", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "3bae5089409c8b5e1a6c30dd9eef4d9cbf543385", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "3bae5089409c8b5e1a6c30dd9eef4d9cbf543385" }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ENV CARGO_NET_RETRY=10 \
     CARGO_HTTP_TIMEOUT=120
 # Override for edge/CI or a different pin: --build-arg NEXUS_VFS_REV=<sha|tag>
-ARG NEXUS_VFS_REV=775a1a16a5bcd71aa649699faa31b97eac2d684e
+ARG NEXUS_VFS_REV=de3bdef3f0dc38a6c11dccda51ec3a9c339ffd43
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,id=cargo-install-${TARGETARCH},target=/root/.cargo/target \

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ENV CARGO_NET_RETRY=10 \
     CARGO_HTTP_TIMEOUT=120
 # Override for edge/CI or a different pin: --build-arg NEXUS_VFS_REV=<sha|tag>
-ARG NEXUS_VFS_REV=de3bdef3f0dc38a6c11dccda51ec3a9c339ffd43
+ARG NEXUS_VFS_REV=3bae5089409c8b5e1a6c30dd9eef4d9cbf543385
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,id=cargo-install-${TARGETARCH},target=/root/.cargo/target \

--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir --no-deps --prefix=/install .
 # enforces agreement) — an unpinned install tracks nexus-vfs HEAD and
 # ships an untested kernel (#4343). --locked honors the source tree's
 # Cargo.lock.
-ARG NEXUS_VFS_REV=de3bdef3f0dc38a6c11dccda51ec3a9c339ffd43
+ARG NEXUS_VFS_REV=3bae5089409c8b5e1a6c30dd9eef4d9cbf543385
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-cluster nexus-cluster
 
 # -- Runtime stage --

--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir --no-deps --prefix=/install .
 # enforces agreement) — an unpinned install tracks nexus-vfs HEAD and
 # ships an untested kernel (#4343). --locked honors the source tree's
 # Cargo.lock.
-ARG NEXUS_VFS_REV=775a1a16a5bcd71aa649699faa31b97eac2d684e
+ARG NEXUS_VFS_REV=de3bdef3f0dc38a6c11dccda51ec3a9c339ffd43
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-cluster nexus-cluster
 
 # -- Runtime stage --

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -25,7 +25,7 @@ WORKDIR /build
 # (CI preflight enforces agreement) — an unpinned install tracks HEAD
 # and can skew the raft contract against the cluster/witness images.
 # --locked honors the source tree's Cargo.lock.
-ARG NEXUS_VFS_REV=775a1a16a5bcd71aa649699faa31b97eac2d684e
+ARG NEXUS_VFS_REV=de3bdef3f0dc38a6c11dccda51ec3a9c339ffd43
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexus-raft-server raft
 
 # ---------- Production image ----------

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -25,7 +25,7 @@ WORKDIR /build
 # (CI preflight enforces agreement) — an unpinned install tracks HEAD
 # and can skew the raft contract against the cluster/witness images.
 # --locked honors the source tree's Cargo.lock.
-ARG NEXUS_VFS_REV=de3bdef3f0dc38a6c11dccda51ec3a9c339ffd43
+ARG NEXUS_VFS_REV=3bae5089409c8b5e1a6c30dd9eef4d9cbf543385
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexus-raft-server raft
 
 # ---------- Production image ----------

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=775a1a16a5bcd71aa649699faa31b97eac2d684e
+ARG NEXUS_VFS_REV=de3bdef3f0dc38a6c11dccda51ec3a9c339ffd43
 RUN cargo install \
     --locked \
     --git https://github.com/nexi-lab/nexus-vfs \

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=de3bdef3f0dc38a6c11dccda51ec3a9c339ffd43
+ARG NEXUS_VFS_REV=3bae5089409c8b5e1a6c30dd9eef4d9cbf543385
 RUN cargo install \
     --locked \
     --git https://github.com/nexi-lab/nexus-vfs \


### PR DESCRIPTION
## Summary

E2E-gating PR for **nexus-vfs PR #84** (Phase 1 of the bottom-up re-attempt of reverted PR #82). Pinned at #84's BRANCH HEAD (\`de3bdef3f\`), NOT main yet — this PR runs nexus's docker E2E suites against the unmerged refactor.

## Why this gating step exists

The reverted PR #82 taught us: kernel-tier CI (\`cargo check / clippy / fmt / test / binary builds\`) doesn't catch the regressions that \`Federation E2E (Docker)\` + \`cc-tasks-share E2E (Docker)\` catch. Merging nexus-vfs kernel work to main first, then finding breakage on the companion nexus rev-bump PR, leaves develop dirty. Pinning the unmerged nexus-vfs branch SHA in nexus's deps lets nexus's CI run the full E2E suite against the actual code that will land on main.

## Flow

1. ✅ nexus-vfs #84 opened — all kernel-tier CI green (4 binary builds + cargo check/clippy/fmt/test)
2. **THIS PR** — pinned at #84's branch HEAD \`de3bdef3f\`
3. Wait for Federation E2E + cc-tasks-share E2E on THIS PR
4. **If green** → admin-merge nexus-vfs #84; re-pin THIS PR at the resulting main merge commit; admin-merge THIS PR
5. **If red** → fix nexus-vfs #84 in place; force-push branch; re-bump THIS PR's pin to new SHA; loop step 3

## nexus-vfs #84 scope

**Pure file-organization refactor — zero behavioral delta.** Relocates:
- \`dispatch_federation_peer\` (generic core)
- 5 per-syscall thin wrappers (\`federation_peer_readdir\` / \`_stat\` / \`_write\` / \`_delete_file\`)
- 2 slot accessors (\`set_federation_peer_client\` / \`federation_peer_client_arc\`)

From \`kernel/src/kernel/io.rs\` + \`kernel/src/kernel/mod.rs\` → \`kernel/src/kernel/federation.rs\` (their architecturally correct home per \`docs/KERNEL-ARCHITECTURE.md\` §3). No syscall ABI / plugin ABI / trait change.

## Architectural self-check

- **Simple contract** — no API surface change.
- **No boundary leak** — helpers properly homed in the federation submodule.
- **SSOT** — kernel/federation.rs becomes the sole home for kernel-side federation-domain code.
- **DRY** — opposite refactor (de-sprawl io.rs).
- **Rust-first.**
- **Perf** — zero delta, \`#[inline]\` preserved.
- **Raft contract** — no raft surface change.
- **Systemic** — fixes PR #4427's mis-placement at its root, and validates the file relocation alone against E2E suites.

## Test plan

- [ ] \`Federation E2E (Docker)\` green on this PR
- [ ] \`cc-tasks-share E2E (Docker)\` green on this PR
- [ ] All other CI gates green
- [ ] Confirm Cargo.lock pinning works cross-PR (cargo pulls de3bdef3f, not main)