### PR TITLE
chore(deps): E2E-gate nexus-vfs PR #85 (Phase 2 HAL extension) at branch HEAD before merge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=3bae5089409c8b5e1a6c30dd9eef4d9cbf543385#3bae5089409c8b5e1a6c30dd9eef4d9cbf543385"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=61340ca697529cf486a7a593032ea8c6a096afe1#61340ca697529cf486a7a593032ea8c6a096afe1"
 dependencies = [
  "ahash",
  "base64",
@@ -550,7 +550,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=3bae5089409c8b5e1a6c30dd9eef4d9cbf543385#3bae5089409c8b5e1a6c30dd9eef4d9cbf543385"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=61340ca697529cf486a7a593032ea8c6a096afe1#61340ca697529cf486a7a593032ea8c6a096afe1"
 dependencies = [
  "parking_lot",
  "serde",
@@ -1333,7 +1333,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=3bae5089409c8b5e1a6c30dd9eef4d9cbf543385#3bae5089409c8b5e1a6c30dd9eef4d9cbf543385"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=61340ca697529cf486a7a593032ea8c6a096afe1#61340ca697529cf486a7a593032ea8c6a096afe1"
 dependencies = [
  "ahash",
  "base64",
@@ -1384,7 +1384,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=3bae5089409c8b5e1a6c30dd9eef4d9cbf543385#3bae5089409c8b5e1a6c30dd9eef4d9cbf543385"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=61340ca697529cf486a7a593032ea8c6a096afe1#61340ca697529cf486a7a593032ea8c6a096afe1"
 dependencies = [
  "ahash",
  "base64",
@@ -1576,7 +1576,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=3bae5089409c8b5e1a6c30dd9eef4d9cbf543385#3bae5089409c8b5e1a6c30dd9eef4d9cbf543385"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=61340ca697529cf486a7a593032ea8c6a096afe1#61340ca697529cf486a7a593032ea8c6a096afe1"
 
 [[package]]
 name = "nexus-vault"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=61340ca697529cf486a7a593032ea8c6a096afe1#61340ca697529cf486a7a593032ea8c6a096afe1"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=fc16c58661583cbad934a7cb87716734ee951409#fc16c58661583cbad934a7cb87716734ee951409"
 dependencies = [
  "ahash",
  "base64",
@@ -550,7 +550,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=61340ca697529cf486a7a593032ea8c6a096afe1#61340ca697529cf486a7a593032ea8c6a096afe1"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=fc16c58661583cbad934a7cb87716734ee951409#fc16c58661583cbad934a7cb87716734ee951409"
 dependencies = [
  "parking_lot",
  "serde",
@@ -1333,7 +1333,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=61340ca697529cf486a7a593032ea8c6a096afe1#61340ca697529cf486a7a593032ea8c6a096afe1"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=fc16c58661583cbad934a7cb87716734ee951409#fc16c58661583cbad934a7cb87716734ee951409"
 dependencies = [
  "ahash",
  "base64",
@@ -1384,7 +1384,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=61340ca697529cf486a7a593032ea8c6a096afe1#61340ca697529cf486a7a593032ea8c6a096afe1"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=fc16c58661583cbad934a7cb87716734ee951409#fc16c58661583cbad934a7cb87716734ee951409"
 dependencies = [
  "ahash",
  "base64",
@@ -1576,7 +1576,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=61340ca697529cf486a7a593032ea8c6a096afe1#61340ca697529cf486a7a593032ea8c6a096afe1"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=fc16c58661583cbad934a7cb87716734ee951409#fc16c58661583cbad934a7cb87716734ee951409"
 
 [[package]]
 name = "nexus-vault"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,14 +30,24 @@ exclude = ["nexus-fuse"]
 [workspace.dependencies]
 # Kernel-tier crates from nexus-vfs (external git dependency).
 # SSOT: https://github.com/nexi-lab/nexus-vfs
-# Pinned at the nexus-vfs main commit that landed #84 (Phase 1 of
-# the bottom-up re-attempt of reverted PR #82): pure file-
-# organization refactor relocating `dispatch_federation_peer` + 5
-# `federation_peer_X` helpers + 2 slot accessors from io.rs /
-# mod.rs to kernel/federation.rs — their architecturally correct
-# home per docs/KERNEL-ARCHITECTURE.md §3.  Zero behavioural
-# delta; E2E-validated against Federation E2E + cc-tasks-share
-# E2E suites before merge.
+# E2E-GATING PIN at nexus-vfs PR #85's BRANCH HEAD (not main yet) —
+# same pattern Phase 1 used: cargo pins to the unmerged nexus-vfs
+# branch SHA so nexus's docker E2E suites run against the actual
+# code that will land on main, BEFORE it lands.  Once Federation
+# E2E + cc-tasks-share E2E are green on this PR's CI, nexus-vfs
+# #85 admin-merges and this PR re-pins to the resulting main
+# merge commit.
+#
+# nexus-vfs #85 is Phase 2 of the bottom-up re-attempt of reverted
+# PR #82: HAL surface extension only — adds rename + setattr
+# methods to the FederationPeerClient trait + matching Noop +
+# FederationClient async + sync bridges + backends StubClient
+# impls.  NO kernel call site uses the new methods yet (Phase 3a
+# / 3b / 3c will add per-syscall short-circuits one at a time,
+# each with its own E2E gate, using the corrected design from
+# `feedback_defer_to_peer_only_for_byte_ops`).  Expected E2E
+# outcome on this PR: 100% green (no consumer of the new HAL
+# methods).
 # Builds on prior landmarks: #57 plugin-as-gRPC-service routing,
 # #58 sealed-keystore signing trust root, #60 KernelHandle v3
 # sys_stat_batch, #61 per-call EC/SC primitives, #62 CLI flag rename,
@@ -52,13 +62,13 @@ exclude = ["nexus-fuse"]
 # dispatch to kernel/federation.rs.  Bump alongside the rest of
 # nexus-vfs updates when a downstream change needs newer kernel
 # bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "3bae5089409c8b5e1a6c30dd9eef4d9cbf543385" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "3bae5089409c8b5e1a6c30dd9eef4d9cbf543385" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "3bae5089409c8b5e1a6c30dd9eef4d9cbf543385" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "3bae5089409c8b5e1a6c30dd9eef4d9cbf543385", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "3bae5089409c8b5e1a6c30dd9eef4d9cbf543385", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "3bae5089409c8b5e1a6c30dd9eef4d9cbf543385", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "3bae5089409c8b5e1a6c30dd9eef4d9cbf543385" }
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "61340ca697529cf486a7a593032ea8c6a096afe1" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "61340ca697529cf486a7a593032ea8c6a096afe1" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "61340ca697529cf486a7a593032ea8c6a096afe1" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "61340ca697529cf486a7a593032ea8c6a096afe1", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "61340ca697529cf486a7a593032ea8c6a096afe1", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "61340ca697529cf486a7a593032ea8c6a096afe1", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "61340ca697529cf486a7a593032ea8c6a096afe1" }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,24 +30,16 @@ exclude = ["nexus-fuse"]
 [workspace.dependencies]
 # Kernel-tier crates from nexus-vfs (external git dependency).
 # SSOT: https://github.com/nexi-lab/nexus-vfs
-# E2E-GATING PIN at nexus-vfs PR #85's BRANCH HEAD (not main yet) —
-# same pattern Phase 1 used: cargo pins to the unmerged nexus-vfs
-# branch SHA so nexus's docker E2E suites run against the actual
-# code that will land on main, BEFORE it lands.  Once Federation
-# E2E + cc-tasks-share E2E are green on this PR's CI, nexus-vfs
-# #85 admin-merges and this PR re-pins to the resulting main
-# merge commit.
-#
-# nexus-vfs #85 is Phase 2 of the bottom-up re-attempt of reverted
-# PR #82: HAL surface extension only — adds rename + setattr
-# methods to the FederationPeerClient trait + matching Noop +
-# FederationClient async + sync bridges + backends StubClient
-# impls.  NO kernel call site uses the new methods yet (Phase 3a
-# / 3b / 3c will add per-syscall short-circuits one at a time,
-# each with its own E2E gate, using the corrected design from
-# `feedback_defer_to_peer_only_for_byte_ops`).  Expected E2E
-# outcome on this PR: 100% green (no consumer of the new HAL
-# methods).
+# Pinned at the nexus-vfs main commit that landed #85 (Phase 2 of
+# the bottom-up re-attempt of reverted PR #82): HAL surface
+# extension — adds rename + setattr methods to the
+# FederationPeerClient trait + matching Noop + FederationClient
+# async + sync bridges + backends StubClient impls.  No kernel
+# call site uses the new methods yet (Phase 3a / 3b / 3c will
+# add per-syscall short-circuits one at a time, each with its
+# own E2E gate, using the corrected design from
+# `feedback_defer_to_peer_only_for_byte_ops`).  E2E-validated
+# against Federation E2E + cc-tasks-share E2E suites before merge.
 # Builds on prior landmarks: #57 plugin-as-gRPC-service routing,
 # #58 sealed-keystore signing trust root, #60 KernelHandle v3
 # sys_stat_batch, #61 per-call EC/SC primitives, #62 CLI flag rename,
@@ -59,16 +51,16 @@ exclude = ["nexus-fuse"]
 # #79 DRY federation-peer-mount predicate + PeerBlobClient
 # reentrancy, #80 sys_write defer-to-peer, #81 preserve miss-on-
 # dispatch-failure semantics, #84 relocate federation-peer
-# dispatch to kernel/federation.rs.  Bump alongside the rest of
-# nexus-vfs updates when a downstream change needs newer kernel
-# bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "61340ca697529cf486a7a593032ea8c6a096afe1" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "61340ca697529cf486a7a593032ea8c6a096afe1" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "61340ca697529cf486a7a593032ea8c6a096afe1" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "61340ca697529cf486a7a593032ea8c6a096afe1", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "61340ca697529cf486a7a593032ea8c6a096afe1", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "61340ca697529cf486a7a593032ea8c6a096afe1", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "61340ca697529cf486a7a593032ea8c6a096afe1" }
+# dispatch to kernel/federation.rs, #85 HAL extension (rename +
+# setattr).  Bump alongside the rest of nexus-vfs updates when
+# a downstream change needs newer kernel bits.
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "fc16c58661583cbad934a7cb87716734ee951409" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "fc16c58661583cbad934a7cb87716734ee951409" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "fc16c58661583cbad934a7cb87716734ee951409" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "fc16c58661583cbad934a7cb87716734ee951409", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "fc16c58661583cbad934a7cb87716734ee951409", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "fc16c58661583cbad934a7cb87716734ee951409", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "fc16c58661583cbad934a7cb87716734ee951409" }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ENV CARGO_NET_RETRY=10 \
     CARGO_HTTP_TIMEOUT=120
 # Override for edge/CI or a different pin: --build-arg NEXUS_VFS_REV=<sha|tag>
-ARG NEXUS_VFS_REV=3bae5089409c8b5e1a6c30dd9eef4d9cbf543385
+ARG NEXUS_VFS_REV=61340ca697529cf486a7a593032ea8c6a096afe1
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,id=cargo-install-${TARGETARCH},target=/root/.cargo/target \

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ENV CARGO_NET_RETRY=10 \
     CARGO_HTTP_TIMEOUT=120
 # Override for edge/CI or a different pin: --build-arg NEXUS_VFS_REV=<sha|tag>
-ARG NEXUS_VFS_REV=61340ca697529cf486a7a593032ea8c6a096afe1
+ARG NEXUS_VFS_REV=fc16c58661583cbad934a7cb87716734ee951409
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,id=cargo-install-${TARGETARCH},target=/root/.cargo/target \

--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir --no-deps --prefix=/install .
 # enforces agreement) — an unpinned install tracks nexus-vfs HEAD and
 # ships an untested kernel (#4343). --locked honors the source tree's
 # Cargo.lock.
-ARG NEXUS_VFS_REV=3bae5089409c8b5e1a6c30dd9eef4d9cbf543385
+ARG NEXUS_VFS_REV=61340ca697529cf486a7a593032ea8c6a096afe1
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-cluster nexus-cluster
 
 # -- Runtime stage --

--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir --no-deps --prefix=/install .
 # enforces agreement) — an unpinned install tracks nexus-vfs HEAD and
 # ships an untested kernel (#4343). --locked honors the source tree's
 # Cargo.lock.
-ARG NEXUS_VFS_REV=61340ca697529cf486a7a593032ea8c6a096afe1
+ARG NEXUS_VFS_REV=fc16c58661583cbad934a7cb87716734ee951409
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-cluster nexus-cluster
 
 # -- Runtime stage --

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -25,7 +25,7 @@ WORKDIR /build
 # (CI preflight enforces agreement) — an unpinned install tracks HEAD
 # and can skew the raft contract against the cluster/witness images.
 # --locked honors the source tree's Cargo.lock.
-ARG NEXUS_VFS_REV=61340ca697529cf486a7a593032ea8c6a096afe1
+ARG NEXUS_VFS_REV=fc16c58661583cbad934a7cb87716734ee951409
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexus-raft-server raft
 
 # ---------- Production image ----------

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -25,7 +25,7 @@ WORKDIR /build
 # (CI preflight enforces agreement) — an unpinned install tracks HEAD
 # and can skew the raft contract against the cluster/witness images.
 # --locked honors the source tree's Cargo.lock.
-ARG NEXUS_VFS_REV=3bae5089409c8b5e1a6c30dd9eef4d9cbf543385
+ARG NEXUS_VFS_REV=61340ca697529cf486a7a593032ea8c6a096afe1
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexus-raft-server raft
 
 # ---------- Production image ----------

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=3bae5089409c8b5e1a6c30dd9eef4d9cbf543385
+ARG NEXUS_VFS_REV=61340ca697529cf486a7a593032ea8c6a096afe1
 RUN cargo install \
     --locked \
     --git https://github.com/nexi-lab/nexus-vfs \

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=61340ca697529cf486a7a593032ea8c6a096afe1
+ARG NEXUS_VFS_REV=fc16c58661583cbad934a7cb87716734ee951409
 RUN cargo install \
     --locked \
     --git https://github.com/nexi-lab/nexus-vfs \


### PR DESCRIPTION
## Summary

E2E-gating PR for **nexus-vfs PR #85** (Phase 2: HAL surface extension — \`rename\` + \`setattr\` on \`FederationPeerClient\`). Pinned at #85's BRANCH HEAD (\`61340ca69\`), NOT main yet.

Same gating pattern Phase 1 (nexus PR #4438) used and validated end-to-end.

## Why this PR exists

Phase 2 adds HAL trait surface only — no kernel call site uses the new methods. Behaviorally an E2E no-op. **Expected:** Federation E2E + cc-tasks-share E2E stay 100% green. If they don't, the HAL surface itself has a subtle issue (proto field omission, signature mismatch with server handler, etc.) — worth catching BEFORE Phase 3 ships a consumer.

## What landed in nexus-vfs #85

- 2 new trait methods on \`FederationPeerClient\` (\`rename\`, \`setattr\` for DT_REG)
- 2 new Noop impls on \`NoopFederationPeerClient\`
- 2 new async \`vfs_X\` wrappers + 2 new sync trait bridges via \`block_on_safely\` on \`FederationClient\`
- 2 new test stub impls on \`StubClient\`
- macos-arm64 binary size budget bumped 12.5 → 13.0 MiB to absorb the genuine code growth

## Flow

1. ✅ nexus-vfs #85 opened — all kernel-tier CI green
2. **THIS PR** — pinned at #85's branch HEAD \`61340ca69\`
3. Wait for Federation E2E + cc-tasks-share E2E
4. **If green** → admin-merge nexus-vfs #85; re-pin THIS PR at the resulting main merge commit; admin-merge THIS PR
5. **If red** → fix nexus-vfs #85 in place; force-push; re-bump pin; loop step 3

## Test plan

- [ ] \`Federation E2E (Docker)\` green
- [ ] \`cc-tasks-share E2E (Docker)\` green
- [ ] All other CI gates green
- [ ] Confirm cargo pulls 61340ca69 (not main)