### PR TITLE
chore(deps): E2E-gate nexus-vfs PR #86 (Phase 3a sys_mkdir supplement design) at branch HEAD

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=fc16c58661583cbad934a7cb87716734ee951409#fc16c58661583cbad934a7cb87716734ee951409"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=3517e9348fff95707a0e856b3c6c0a72b7378448#3517e9348fff95707a0e856b3c6c0a72b7378448"
 dependencies = [
  "ahash",
  "base64",
@@ -550,7 +550,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=fc16c58661583cbad934a7cb87716734ee951409#fc16c58661583cbad934a7cb87716734ee951409"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=3517e9348fff95707a0e856b3c6c0a72b7378448#3517e9348fff95707a0e856b3c6c0a72b7378448"
 dependencies = [
  "parking_lot",
  "serde",
@@ -1333,7 +1333,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=fc16c58661583cbad934a7cb87716734ee951409#fc16c58661583cbad934a7cb87716734ee951409"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=3517e9348fff95707a0e856b3c6c0a72b7378448#3517e9348fff95707a0e856b3c6c0a72b7378448"
 dependencies = [
  "ahash",
  "base64",
@@ -1384,7 +1384,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=fc16c58661583cbad934a7cb87716734ee951409#fc16c58661583cbad934a7cb87716734ee951409"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=3517e9348fff95707a0e856b3c6c0a72b7378448#3517e9348fff95707a0e856b3c6c0a72b7378448"
 dependencies = [
  "ahash",
  "base64",
@@ -1576,7 +1576,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=fc16c58661583cbad934a7cb87716734ee951409#fc16c58661583cbad934a7cb87716734ee951409"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=3517e9348fff95707a0e856b3c6c0a72b7378448#3517e9348fff95707a0e856b3c6c0a72b7378448"
 
 [[package]]
 name = "nexus-vault"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,16 +30,25 @@ exclude = ["nexus-fuse"]
 [workspace.dependencies]
 # Kernel-tier crates from nexus-vfs (external git dependency).
 # SSOT: https://github.com/nexi-lab/nexus-vfs
-# Pinned at the nexus-vfs main commit that landed #85 (Phase 2 of
-# the bottom-up re-attempt of reverted PR #82): HAL surface
-# extension — adds rename + setattr methods to the
-# FederationPeerClient trait + matching Noop + FederationClient
-# async + sync bridges + backends StubClient impls.  No kernel
-# call site uses the new methods yet (Phase 3a / 3b / 3c will
-# add per-syscall short-circuits one at a time, each with its
-# own E2E gate, using the corrected design from
-# `feedback_defer_to_peer_only_for_byte_ops`).  E2E-validated
-# against Federation E2E + cc-tasks-share E2E suites before merge.
+# E2E-GATING PIN at nexus-vfs PR #86's BRANCH HEAD (not main yet)
+# — same pattern Phases 1 & 2 used and validated end-to-end.
+#
+# nexus-vfs #86 is Phase 3a of the bottom-up re-attempt of
+# reverted PR #82: sys_mkdir's federation-peer SIDE EFFECT for
+# placeholder mounts.  First kernel-side BEHAVIOUR change in the
+# rebuilt stack (Phase 1 was a pure refactor; Phase 2 was HAL
+# surface only).  CORRECTED design vs reverted PR #82:
+# supplement-not-replace.  New §2.7 short-circuit in mkdir()
+# fires `federation_peer_mkdir` as a SIDE EFFECT (no early
+# return), then the LEGACY local-side flow (existence check +
+# metastore.put + ensure_parent_directories + OBSERVE) STILL
+# runs.  Result: SSOT-side host fs gets the directory created
+# (fixes the Win-operator-creates-CC-session → Mac-CC-walks-
+# host-fs gap), AND joiner's local routing remains immediate
+# (the regression PR #82 introduced).  Raft LWW dedupes the
+# double DT_DIR put — correct raft usage for routing-state ops.
+# See `feedback_defer_to_peer_only_for_byte_ops` memory for full
+# rationale.
 # Builds on prior landmarks: #57 plugin-as-gRPC-service routing,
 # #58 sealed-keystore signing trust root, #60 KernelHandle v3
 # sys_stat_batch, #61 per-call EC/SC primitives, #62 CLI flag rename,
@@ -54,13 +63,13 @@ exclude = ["nexus-fuse"]
 # dispatch to kernel/federation.rs, #85 HAL extension (rename +
 # setattr).  Bump alongside the rest of nexus-vfs updates when
 # a downstream change needs newer kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "fc16c58661583cbad934a7cb87716734ee951409" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "fc16c58661583cbad934a7cb87716734ee951409" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "fc16c58661583cbad934a7cb87716734ee951409" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "fc16c58661583cbad934a7cb87716734ee951409", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "fc16c58661583cbad934a7cb87716734ee951409", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "fc16c58661583cbad934a7cb87716734ee951409", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "fc16c58661583cbad934a7cb87716734ee951409" }
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "3517e9348fff95707a0e856b3c6c0a72b7378448" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "3517e9348fff95707a0e856b3c6c0a72b7378448" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "3517e9348fff95707a0e856b3c6c0a72b7378448" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "3517e9348fff95707a0e856b3c6c0a72b7378448", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "3517e9348fff95707a0e856b3c6c0a72b7378448", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "3517e9348fff95707a0e856b3c6c0a72b7378448", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "3517e9348fff95707a0e856b3c6c0a72b7378448" }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ENV CARGO_NET_RETRY=10 \
     CARGO_HTTP_TIMEOUT=120
 # Override for edge/CI or a different pin: --build-arg NEXUS_VFS_REV=<sha|tag>
-ARG NEXUS_VFS_REV=fc16c58661583cbad934a7cb87716734ee951409
+ARG NEXUS_VFS_REV=3517e9348fff95707a0e856b3c6c0a72b7378448
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,id=cargo-install-${TARGETARCH},target=/root/.cargo/target \

--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir --no-deps --prefix=/install .
 # enforces agreement) — an unpinned install tracks nexus-vfs HEAD and
 # ships an untested kernel (#4343). --locked honors the source tree's
 # Cargo.lock.
-ARG NEXUS_VFS_REV=fc16c58661583cbad934a7cb87716734ee951409
+ARG NEXUS_VFS_REV=3517e9348fff95707a0e856b3c6c0a72b7378448
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-cluster nexus-cluster
 
 # -- Runtime stage --

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -25,7 +25,7 @@ WORKDIR /build
 # (CI preflight enforces agreement) — an unpinned install tracks HEAD
 # and can skew the raft contract against the cluster/witness images.
 # --locked honors the source tree's Cargo.lock.
-ARG NEXUS_VFS_REV=fc16c58661583cbad934a7cb87716734ee951409
+ARG NEXUS_VFS_REV=3517e9348fff95707a0e856b3c6c0a72b7378448
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexus-raft-server raft
 
 # ---------- Production image ----------

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=fc16c58661583cbad934a7cb87716734ee951409
+ARG NEXUS_VFS_REV=3517e9348fff95707a0e856b3c6c0a72b7378448
 RUN cargo install \
     --locked \
     --git https://github.com/nexi-lab/nexus-vfs \


### PR DESCRIPTION
## Summary

E2E-gating PR for **nexus-vfs PR #86** (Phase 3a: \`sys_mkdir\` fires SSOT-peer side effect with the corrected supplement-not-replace design). Pinned at #86's BRANCH HEAD (\`3517e9348\`), NOT main yet.

Same gating pattern Phases 1 & 2 used.

## Why this PR matters more than Phases 1 & 2

Phases 1 & 2 were behaviorally zero-delta — refactor + HAL surface. This is the **first behavior change** in the rebuilt stack, and the first E2E test of the [\`feedback_defer_to_peer_only_for_byte_ops\`](../memory/feedback_defer_to_peer_only_for_byte_ops.md) design hypothesis.

If Federation E2E + cc-tasks-share E2E stay green here → the supplement-design hypothesis is validated. Phase 3b (sys_rename) and Phase 3c (sys_setattr) can use the same pattern with confidence.

If they go red → diagnose locally with Docker Desktop per the user's suggestion (\`docker compose -f dockerfiles/docker-compose.cc-tasks-share.yml up -d founder joiner\` + \`pytest tests/e2e/docker/test_cc_tasks_share_e2e.py -v\`) BEFORE pushing fixes — faster iteration than CI round-trips.

## What's in nexus-vfs #86

- new \`federation_peer_mkdir\` helper in \`kernel/src/kernel/federation.rs\` (next to the existing 4 \`federation_peer_X\` helpers, same shape)
- new §2.7 in \`mkdir()\` at \`kernel/src/kernel/io.rs\` fires the helper as a SIDE EFFECT — no early return
- legacy local-side flow (existence check + metastore.put + ensure_parent_directories + OBSERVE) STILL runs
- silent miss-on-dispatch-failure per PR #81 lesson

## Flow

1. ✅ nexus-vfs #86 opened — all kernel-tier CI green (4 binary builds + cargo check/clippy/fmt/test)
2. **THIS PR** — pinned at #86's branch HEAD \`3517e9348\`
3. Wait for Federation E2E + cc-tasks-share E2E
4. **If green** → admin-merge nexus-vfs #86; re-pin THIS PR at main SHA; admin-merge; queue Phase 3b
5. **If red** → local Docker reproduce + diagnose; fix nexus-vfs #86; force-push; re-bump pin; loop

## Test plan

- [ ] \`Federation E2E (Docker)\` green
- [ ] \`cc-tasks-share E2E (Docker)\` green
- [ ] All other CI gates green