### PR TITLE
docs: SM2 as default signature algorithm

### DIFF
--- a/docs/architecture/p2p-task-settlement-zh.html
+++ b/docs/architecture/p2p-task-settlement-zh.html
@@ -225,12 +225,12 @@ flowchart LR
 
   "buyer": {
     "user_id": "...",
-    "public_key": "ed25519:...",
+    "public_key": "sm2:...",
     "signature": "..."
   },
   "seller": {
     "user_id": "...",
-    "public_key": "ed25519:...",
+    "public_key": "sm2:...",
     "signature": "..."
   },
 
@@ -305,7 +305,7 @@ flowchart LR
     "to_seller": "seller_user_id",
     "condition": "delivery_submitted AND NOT rejected_within_timeout",
     "timeout_hours": 72,
-    "buyer_signature": "ed25519:..."
+    "buyer_signature": "sm2:..."
   }</pre>
   <p>此预签消息在合约创建时存储在服务器上。</p>
   <p><strong>结算路径</strong>：</p>
@@ -342,13 +342,13 @@ flowchart LR
 
 <h3>安全保障：为什么双签无需区块链也是安全的</h3>
 <div class="card">
-  <p>协议使用 <strong>Ed25519 签名 + CAS 内容寻址</strong> &mdash; 无需区块链。三层保护：</p>
+  <p>协议使用 <strong>SM2 签名（国密标准，默认）+ CAS 内容寻址</strong> &mdash; 无需区块链。国际场景可选 Ed25519。三层保护：</p>
   <table>
     <tr><th>威胁</th><th>保护</th><th>原理</th></tr>
     <tr>
       <td>一方否认签署</td>
       <td><strong>不可否认性</strong></td>
-      <td>Ed25519 签名在数学上绑定到签名者的私钥。"我没签过"可被证伪。</td>
+      <td>SM2/Ed25519 签名在数学上绑定到签名者的私钥。"我没签过"可被证伪。</td>
     </tr>
     <tr>
       <td>一方单独行动</td>
@@ -369,7 +369,7 @@ flowchart LR
   <p><strong>信任假设</strong>：服务器会诚实执行有效转账（L3 有限信任）。如果服务器拒绝处理有效的双签转账，已签署的消息可作为可审计的证据 &mdash; 与银行拒绝处理电汇的追索方式相同。</p>
 
   <div class="warn">
-    <strong>中国法律效力</strong>：我们的 Ed25519 双签满足《电子签名法》第十四条"可靠电子签名"的全部四个条件（私钥为签名人专有、签署时仅签名人控制、签名可检测篡改、内容可检测篡改）。<strong>技术上有效</strong> &mdash; 但上法庭时，举证难度高于有 CA 牌照的平台（如法大大、e签宝），后者有工信部 CA 许可证和实名认证（身份证 + 人脸识别）。我们的签名证明"这个密钥签了这条消息"，但无法直接证明"这个密钥属于张三"，需要额外举证。<strong>建议</strong>：
+    <strong>中国法律效力</strong>：我们的 SM2 双签满足《电子签名法》第十四条"可靠电子签名"的全部四个条件（私钥为签名人专有、签署时仅签名人控制、签名可检测篡改、内容可检测篡改）。使用 SM2（国密标准）而非 Ed25519，与 2025 年 CPS 监管趋势一致，在合规审查中可能获得额外加分。<strong>技术上有效</strong> &mdash; 但上法庭时，举证难度高于有 CA 牌照的平台（如法大大、e签宝），后者有工信部 CA 许可证和实名认证（身份证 + 人脸识别）。我们的签名证明"这个密钥签了这条消息"，但无法直接证明"这个密钥属于张三"，需要额外举证。<strong>建议</strong>：
     <ul style="margin-top:0.5rem">
       <li><strong>日常微任务（&#165;0.30-150）</strong>：我们的双签足够。金额小 &rarr; 诉讼概率极低。签名记录 + CAS 作为证据链已够。</li>
       <li><strong>高价值合约（&#165;1000+）</strong>：可选接入 CA 电子签名 API（法大大/e签宝 SaaS）作为"加强签约"模式。我们无需自己申请 CA 牌照 &mdash; 只需 API 集成。</li>
@@ -670,7 +670,7 @@ sequenceDiagram
     <td>协议开销（签名 + VFS 操作）</td>
     <td>双方（本地计算）</td>
     <td>~0</td>
-    <td>Ed25519 签名 &lt; 1ms，VFS 写入 &lt; 5&micro;s</td>
+    <td>SM2 签名 &lt; 1ms，VFS 写入 &lt; 5&micro;s</td>
   </tr>
   <tr>
     <td>服务器转账 API（结算）</td>
@@ -876,7 +876,7 @@ sequenceDiagram
   </li>
   <li>
     <strong>积分转账 API</strong>：sudoprivacy 是否已支持用户间转账？
-    <div class="pref">已确认：无转账 API。当前系统仅支持充值（向 sudoprivacy 付款）和消费（使用 LLM）。需要新端点：<code>POST /api/v1/transfer</code>，带双重签名验证。转账接口必须接受 <code>(release_msg + buyer_sig + seller_sig)</code>，验证双方 Ed25519 签名是否匹配合约条款，并原子性地在账户间移动积分。最小接口 &mdash; 一个新端点，无托管状态。</div>
+    <div class="pref">已确认：无转账 API。当前系统仅支持充值（向 sudoprivacy 付款）和消费（使用 LLM）。需要新端点：<code>POST /api/v1/transfer</code>，带双重签名验证。转账接口必须接受 <code>(release_msg + buyer_sig + seller_sig)</code>，验证双方 SM2 签名是否匹配合约条款，并原子性地在账户间移动积分。最小接口 &mdash; 一个新端点，无托管状态。</div>
   </li>
   <li>
     <strong>发现/市场</strong>：买家如何找到卖家？

--- a/docs/architecture/p2p-task-settlement.html
+++ b/docs/architecture/p2p-task-settlement.html
@@ -225,12 +225,12 @@ flowchart LR
 
   "buyer": {
     "user_id": "...",
-    "public_key": "ed25519:...",
+    "public_key": "sm2:...",
     "signature": "..."
   },
   "seller": {
     "user_id": "...",
-    "public_key": "ed25519:...",
+    "public_key": "sm2:...",
     "signature": "..."
   },
 
@@ -305,7 +305,7 @@ flowchart LR
     "to_seller": "seller_user_id",
     "condition": "delivery_submitted AND NOT rejected_within_timeout",
     "timeout_hours": 72,
-    "buyer_signature": "ed25519:..."
+    "buyer_signature": "sm2:..."
   }</pre>
   <p>This pre-signed message is stored on the server at contract creation time.</p>
   <p><strong>Settlement paths</strong>:</p>
@@ -342,13 +342,13 @@ flowchart LR
 
 <h3>Security Guarantees: why dual-sig is safe without blockchain</h3>
 <div class="card">
-  <p>The protocol uses <strong>Ed25519 signatures + CAS content-addressing</strong> &mdash; no blockchain needed. Three layers of protection:</p>
+  <p>The protocol uses <strong>SM2 signatures (China national standard, default) + CAS content-addressing</strong> &mdash; no blockchain needed. Ed25519 available as alternative for international scenarios. Three layers of protection:</p>
   <table>
     <tr><th>Threat</th><th>Protection</th><th>How</th></tr>
     <tr>
       <td>Party denies signing</td>
       <td><strong>Non-repudiation</strong></td>
-      <td>Ed25519 signature is mathematically bound to the signer's private key. "I didn't sign" is provably false.</td>
+      <td>SM2/Ed25519 signature is mathematically bound to the signer's private key. "I didn't sign" is provably false.</td>
     </tr>
     <tr>
       <td>One party acts alone</td>
@@ -369,7 +369,7 @@ flowchart LR
   <p><strong>Trust assumption</strong>: Server will honestly execute valid transfers (L3 limited trust). If server refuses to process a valid dual-signed transfer, the signed messages serve as auditable evidence &mdash; same recourse as a bank failing to process a wire transfer.</p>
 
   <div class="warn">
-    <strong>Legal standing in China</strong>: Our Ed25519 dual-sig meets all four conditions of a "reliable electronic signature" under Article 14 of the <em>Electronic Signature Law</em> (private key is user-exclusive, user-controlled at signing, signature tamper-detectable, content tamper-detectable). <strong>Technically valid</strong> &mdash; but in court, burden of proof is harder than CA-backed platforms (e.g. 法大大, e签宝) which have Ministry of Industry CA licenses and identity verification (ID + face recognition). Our signatures prove "this key signed this message" but not "this key belongs to Zhang San" without extra evidence. <strong>Recommendation</strong>:
+    <strong>Legal standing in China</strong>: Our SM2 dual-sig meets all four conditions of a "reliable electronic signature" under Article 14 of the <em>Electronic Signature Law</em> (private key is user-exclusive, user-controlled at signing, signature tamper-detectable, content tamper-detectable). Using SM2 (national cryptographic standard) rather than Ed25519 aligns with the 2025 CPS regulatory trend and may carry additional weight in compliance review. <strong>Technically valid</strong> &mdash; but in court, burden of proof is harder than CA-backed platforms (e.g. 法大大, e签宝) which have Ministry of Industry CA licenses and identity verification (ID + face recognition). Our signatures prove "this key signed this message" but not "this key belongs to Zhang San" without extra evidence. <strong>Recommendation</strong>:
     <ul style="margin-top:0.5rem">
       <li><strong>Daily micro-tasks (&#165;0.30-150)</strong>: Our dual-sig is sufficient. Low value &rarr; litigation probability near zero. Signed records + CAS serve as evidence chain.</li>
       <li><strong>High-value contracts (&#165;1000+)</strong>: Optionally integrate a CA-backed e-signature API (法大大/e签宝 SaaS) as an "enhanced signing" mode. We don't need a CA license ourselves &mdash; just API integration.</li>
@@ -670,7 +670,7 @@ sequenceDiagram
     <td>Protocol overhead (signatures + VFS ops)</td>
     <td>Both (local compute)</td>
     <td>~0</td>
-    <td>Ed25519 sign &lt; 1ms, VFS write &lt; 5&micro;s</td>
+    <td>SM2 sign &lt; 1ms, VFS write &lt; 5&micro;s</td>
   </tr>
   <tr>
     <td>Server transfer API (settlement)</td>
@@ -876,7 +876,7 @@ sequenceDiagram
   </li>
   <li>
     <strong>Points transfer API</strong>: Does sudoprivacy already support user-to-user transfers?
-    <div class="pref">Confirmed: no transfer API exists. Current system is charge (pay sudoprivacy) and consume (use LLM) only. Need new endpoint: <code>POST /api/v1/transfer</code> with dual-signature verification. The transfer must accept <code>(release_msg + buyer_sig + seller_sig)</code>, verify both Ed25519 signatures against the contract terms, and atomically move points between accounts. Minimal surface &mdash; one new endpoint, no escrow state.</div>
+    <div class="pref">Confirmed: no transfer API exists. Current system is charge (pay sudoprivacy) and consume (use LLM) only. Need new endpoint: <code>POST /api/v1/transfer</code> with dual-signature verification. The transfer must accept <code>(release_msg + buyer_sig + seller_sig)</code>, verify both SM2 signatures against the contract terms, and atomically move points between accounts. Minimal surface &mdash; one new endpoint, no escrow state.</div>
   </li>
   <li>
     <strong>Discovery / Marketplace</strong>: How do buyers find sellers?


### PR DESCRIPTION
Switch from Ed25519 to SM2 (national cryptographic standard) as default. Ed25519 available for international scenarios. EN + ZH.