### PR TITLE
docs: telecom partnership for token distribution

### DIFF
--- a/docs/architecture/p2p-task-settlement-zh.html
+++ b/docs/architecture/p2p-task-settlement-zh.html
@@ -550,9 +550,14 @@ sequenceDiagram
   </table>
 
   <h4 style="margin-top:1rem;color:var(--purple)">Token 流通：$100 种子模型</h4>
-  <p>通过高校合作进行分发：</p>
+  <p><strong>分发渠道</strong>：</p>
+  <ul>
+    <li><strong>高校合作</strong>：通过校园活动、新生入学、就业中心直接分发。</li>
+    <li><strong>运营商合作</strong>：与通信运营商（中国移动、中国电信、中国联通）在校园办卡时联合分发。运营商批量预购 Token，随新生手机套餐附赠"AI 助手"。学生用手机号激活 sudowork（已用于注册）。<strong>先例</strong>：sudowork + 中国移动在 2025 年已试点 &mdash; 学生通过 AI 推广手机号被证明是对运营商有吸引力的获客渠道。双方边际成本接近零（运营商按批量价采购 Token，sudowork 的实际计算成本远低于面值）。</li>
+  </ul>
+  <p><strong>分发后飞轮</strong>：</p>
   <ol>
-    <li>学生注册时获得 <strong>$100 免费 Token</strong>（约 10,000 积分）</li>
+    <li>学生通过高校或运营商渠道获得 <strong>$100 免费 Token</strong>（约 10,000 积分）</li>
     <li>使用 Token 运行 sudowork 的剪辑技能 &rarr; 完成剪辑任务 &rarr; 赚取更多积分</li>
     <li>赚取的积分用于更多 AI 使用 &rarr; <strong>自循环飞轮</strong></li>
     <li>高积分学生成为<strong>微买家</strong> &mdash; 使用赚取的积分将子任务（如字幕翻译、缩略图设计）分派给其他学生</li>

--- a/docs/architecture/p2p-task-settlement.html
+++ b/docs/architecture/p2p-task-settlement.html
@@ -550,9 +550,14 @@ sequenceDiagram
   </table>
 
   <h4 style="margin-top:1rem;color:var(--purple)">Token circulation: $100 seed model</h4>
-  <p>Distribution via university partnerships:</p>
+  <p><strong>Distribution channels</strong>:</p>
+  <ul>
+    <li><strong>University partnerships</strong>: Direct distribution through campus activities, freshman orientation, career centers.</li>
+    <li><strong>Telecom partnerships</strong>: Co-distribute with mobile carriers (China Mobile, China Telecom, China Unicom) during campus SIM card enrollment. Carrier pre-purchases tokens in bulk, bundles with new student phone plans as "AI assistant included." Students activate sudowork with their phone number (already used for registration). <strong>Prior art</strong>: sudowork + China Mobile piloted this in 2025 &mdash; students promoting phone plans via AI proved an attractive acquisition channel for the carrier. Marginal cost near zero for both sides (carrier buys tokens at bulk rate, sudowork's compute cost is a fraction of face value).</li>
+  </ul>
+  <p><strong>Post-distribution flywheel</strong>:</p>
   <ol>
-    <li>Student receives <strong>$100 free tokens</strong> (&asymp; 10,000 points) upon registration</li>
+    <li>Student receives <strong>$100 free tokens</strong> (&asymp; 10,000 points) via university or telecom channel</li>
     <li>Uses tokens to run sudowork's editing skill &rarr; completes editing tasks &rarr; earns more points</li>
     <li>Earned points fund more AI usage &rarr; <strong>self-sustaining flywheel</strong></li>
     <li>High-token students become <strong>micro-buyers</strong> &mdash; dispatch sub-tasks (e.g. caption translation, thumbnail design) to other students using their earned points</li>


### PR DESCRIPTION
Add China Mobile/Telecom/Unicom as token distribution channel. 2025 pilot with China Mobile as prior art. EN + ZH.