### PR TITLE
chore(deps): E2E-gate nexus-vfs PR #87 (reconstruct_global_path root-cause fix) at branch HEAD

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=fc16c58661583cbad934a7cb87716734ee951409#fc16c58661583cbad934a7cb87716734ee951409"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=b32598b1716568e0e33c7a4ad8c59661595eb323#b32598b1716568e0e33c7a4ad8c59661595eb323"
 dependencies = [
  "ahash",
  "base64",
@@ -550,7 +550,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=fc16c58661583cbad934a7cb87716734ee951409#fc16c58661583cbad934a7cb87716734ee951409"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=b32598b1716568e0e33c7a4ad8c59661595eb323#b32598b1716568e0e33c7a4ad8c59661595eb323"
 dependencies = [
  "parking_lot",
  "serde",
@@ -1333,7 +1333,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=fc16c58661583cbad934a7cb87716734ee951409#fc16c58661583cbad934a7cb87716734ee951409"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=b32598b1716568e0e33c7a4ad8c59661595eb323#b32598b1716568e0e33c7a4ad8c59661595eb323"
 dependencies = [
  "ahash",
  "base64",
@@ -1384,7 +1384,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=fc16c58661583cbad934a7cb87716734ee951409#fc16c58661583cbad934a7cb87716734ee951409"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=b32598b1716568e0e33c7a4ad8c59661595eb323#b32598b1716568e0e33c7a4ad8c59661595eb323"
 dependencies = [
  "ahash",
  "base64",
@@ -1576,7 +1576,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=fc16c58661583cbad934a7cb87716734ee951409#fc16c58661583cbad934a7cb87716734ee951409"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=b32598b1716568e0e33c7a4ad8c59661595eb323#b32598b1716568e0e33c7a4ad8c59661595eb323"
 
 [[package]]
 name = "nexus-vault"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,13 +54,13 @@ exclude = ["nexus-fuse"]
 # dispatch to kernel/federation.rs, #85 HAL extension (rename +
 # setattr).  Bump alongside the rest of nexus-vfs updates when
 # a downstream change needs newer kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "fc16c58661583cbad934a7cb87716734ee951409" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "fc16c58661583cbad934a7cb87716734ee951409" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "fc16c58661583cbad934a7cb87716734ee951409" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "fc16c58661583cbad934a7cb87716734ee951409", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "fc16c58661583cbad934a7cb87716734ee951409", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "fc16c58661583cbad934a7cb87716734ee951409", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "fc16c58661583cbad934a7cb87716734ee951409" }
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "b32598b1716568e0e33c7a4ad8c59661595eb323" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "b32598b1716568e0e33c7a4ad8c59661595eb323" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "b32598b1716568e0e33c7a4ad8c59661595eb323" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "b32598b1716568e0e33c7a4ad8c59661595eb323", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "b32598b1716568e0e33c7a4ad8c59661595eb323", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "b32598b1716568e0e33c7a4ad8c59661595eb323", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "b32598b1716568e0e33c7a4ad8c59661595eb323" }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ENV CARGO_NET_RETRY=10 \
     CARGO_HTTP_TIMEOUT=120
 # Override for edge/CI or a different pin: --build-arg NEXUS_VFS_REV=<sha|tag>
-ARG NEXUS_VFS_REV=fc16c58661583cbad934a7cb87716734ee951409
+ARG NEXUS_VFS_REV=b32598b1716568e0e33c7a4ad8c59661595eb323
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,id=cargo-install-${TARGETARCH},target=/root/.cargo/target \

--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir --no-deps --prefix=/install .
 # enforces agreement) — an unpinned install tracks nexus-vfs HEAD and
 # ships an untested kernel (#4343). --locked honors the source tree's
 # Cargo.lock.
-ARG NEXUS_VFS_REV=fc16c58661583cbad934a7cb87716734ee951409
+ARG NEXUS_VFS_REV=b32598b1716568e0e33c7a4ad8c59661595eb323
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-cluster nexus-cluster
 
 # -- Runtime stage --

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -25,7 +25,7 @@ WORKDIR /build
 # (CI preflight enforces agreement) — an unpinned install tracks HEAD
 # and can skew the raft contract against the cluster/witness images.
 # --locked honors the source tree's Cargo.lock.
-ARG NEXUS_VFS_REV=fc16c58661583cbad934a7cb87716734ee951409
+ARG NEXUS_VFS_REV=b32598b1716568e0e33c7a4ad8c59661595eb323
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexus-raft-server raft
 
 # ---------- Production image ----------

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=fc16c58661583cbad934a7cb87716734ee951409
+ARG NEXUS_VFS_REV=b32598b1716568e0e33c7a4ad8c59661595eb323
 RUN cargo install \
     --locked \
     --git https://github.com/nexi-lab/nexus-vfs \


### PR DESCRIPTION
## Summary

E2E-gating PR for **nexus-vfs PR #87** — the actual root-cause fix for the same-zone DT_MOUNT placeholder wrong-path bug that surfaced (but was misattributed) in reverted PR #82 (sys_mkdir/rename/setattr defer-to-peer) and closed Phase 3a (sys_mkdir side-effect).

Pinned at #87's BRANCH HEAD (\`b32598b17\`), NOT main yet. Same gating pattern Phases 1 & 2 used.

## What I found (via local Docker Desktop repro)

\`reconstruct_global_path\` (rust/raft/src/distributed_coordinator.rs:1837) used \`.min()\` over \`global_path\` to pick from \`cross_zone_mounts[parent_zone_id]\`. Lexicographic min is an arbitrary heuristic. It happens to work when there's exactly ONE entry (CI's typical 2-node topology with a single \`/shared → sharedzone\` gateway). When there are multiple, it picks an arbitrary one — and when that's NOT the root gateway, the same-zone placeholder gets installed at a wrong path.

Reproduced directly: joiner's wire_mount_core installs at \`/shared/cc-tasks/joiner/cc-tasks/founder\` instead of \`/shared/cc-tasks/founder\`. Joiner FUSE then sees nothing at \`/mnt/cc-tasks/founder/\`. Every \`host_task_write\`-seeded cross-node test fails.

## Why PR #82 + Phase 3a got the blame

Both PRs added kernel call sites that perturbed apply order enough to fan out \`cross_zone_mounts[sharedzone]\` to multiple entries. The bug was always there; the kernel changes just made it observable.

## Architectural self-check

- **Simple contract** — pure-function fix, no syscall/plugin/HAL ABI change.
- **No boundary leak** — fix at federation tier where the data is.
- **SSOT** — root-gateway entry IS the SSOT; was being queried via heuristic.
- **DRY** — single fix at single site.
- **Rust-first.**
- **Perf** — O(n) over tiny vec; no allocation change.
- **Raft contract** — no raft surface change; \`cross_zone_mounts\` is a node-local derived cache.
- **Systemic** — addresses gateway-selection semantics at the function that owns the contract. Future kernel-side perturbations no longer regress E2E for this reason.

## Flow

1. ✅ nexus-vfs #87 opened — kernel-tier CI in flight
2. **THIS PR** — pinned at \`b32598b17\`
3. Wait for Federation E2E + cc-tasks-share E2E
4. **If green** → admin-merge #87, re-pin THIS PR at main SHA, admin-merge this; queue Phase 3a re-attempt
5. **If red** → diagnose locally; fix in place; force-push #87; re-bump pin

## Test plan

- [ ] \`Federation E2E (Docker)\` green
- [ ] \`cc-tasks-share E2E (Docker)\` green
- [ ] All other CI gates green