### PR TITLE
chore(docker): libfuse3-4 fallback for local-connector-plugin runtime

### DIFF
--- a/dockerfiles/Dockerfile.local-connector-plugin
+++ b/dockerfiles/Dockerfile.local-connector-plugin
@@ -95,7 +95,8 @@ USER root
 # daemon to be root.
 RUN apt-get update && apt-get install -y --no-install-recommends \
         fuse3 \
-        libfuse3-3 \
+        && (apt-get install -y --no-install-recommends libfuse3-4 \
+            || apt-get install -y --no-install-recommends libfuse3-3) \
     && rm -rf /var/lib/apt/lists/*
 
 # `/plugins`     — --plugin-dir scan target.


### PR DESCRIPTION
## Summary

- Add libfuse3-4 install attempt before falling back to libfuse3-3 in the local-connector-plugin runtime stage
- Debian trixie ships `fuse3` depending on `libfuse3-4`, so the pinned `libfuse3-3` install fails when the cluster base image rolls to trixie
- No kernel touch, no ABI change, no behavioural change for bookworm-based runtimes (libfuse3-4 install fails fast, then libfuse3-3 installs as before)

## Test plan

- [ ] CI image build green on bookworm-pinned cluster base (current state)
- [ ] cc-tasks-share E2E (`tests/e2e/docker/test_cc_tasks_share_e2e.py`) green — exercises the image at runtime, confirms FUSE plugin still loads libfuse3 OK