### PR TITLE
chore(deps): E2E-gate nexus-vfs PR #88 (Phase 3 cross-node mkdir/rename/setattr bundle)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=20d54ebe7920d82e0057759d61fefe6748076079#20d54ebe7920d82e0057759d61fefe6748076079"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=286c3e93a9c5cbd20c585b2c71873133a107c245#286c3e93a9c5cbd20c585b2c71873133a107c245"
 dependencies = [
  "ahash",
  "base64",
@@ -550,7 +550,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=20d54ebe7920d82e0057759d61fefe6748076079#20d54ebe7920d82e0057759d61fefe6748076079"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=286c3e93a9c5cbd20c585b2c71873133a107c245#286c3e93a9c5cbd20c585b2c71873133a107c245"
 dependencies = [
  "parking_lot",
  "serde",
@@ -1333,7 +1333,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=20d54ebe7920d82e0057759d61fefe6748076079#20d54ebe7920d82e0057759d61fefe6748076079"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=286c3e93a9c5cbd20c585b2c71873133a107c245#286c3e93a9c5cbd20c585b2c71873133a107c245"
 dependencies = [
  "ahash",
  "base64",
@@ -1384,7 +1384,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=20d54ebe7920d82e0057759d61fefe6748076079#20d54ebe7920d82e0057759d61fefe6748076079"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=286c3e93a9c5cbd20c585b2c71873133a107c245#286c3e93a9c5cbd20c585b2c71873133a107c245"
 dependencies = [
  "ahash",
  "base64",
@@ -1576,7 +1576,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=20d54ebe7920d82e0057759d61fefe6748076079#20d54ebe7920d82e0057759d61fefe6748076079"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=286c3e93a9c5cbd20c585b2c71873133a107c245#286c3e93a9c5cbd20c585b2c71873133a107c245"
 
 [[package]]
 name = "nexus-vault"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=b98324a7d#b98324a7d339468d5ad1e4a7d45083c398c9e350"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=e0c419c405a7d8f7d7493143fe94435f906f7dfd#e0c419c405a7d8f7d7493143fe94435f906f7dfd"
 dependencies = [
  "ahash",
  "base64",
@@ -550,7 +550,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=b98324a7d#b98324a7d339468d5ad1e4a7d45083c398c9e350"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=e0c419c405a7d8f7d7493143fe94435f906f7dfd#e0c419c405a7d8f7d7493143fe94435f906f7dfd"
 dependencies = [
  "parking_lot",
  "serde",
@@ -1175,9 +1175,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
 dependencies = [
  "typenum",
 ]
@@ -1333,7 +1333,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=b98324a7d#b98324a7d339468d5ad1e4a7d45083c398c9e350"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=e0c419c405a7d8f7d7493143fe94435f906f7dfd#e0c419c405a7d8f7d7493143fe94435f906f7dfd"
 dependencies = [
  "ahash",
  "base64",
@@ -1384,7 +1384,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=b98324a7d#b98324a7d339468d5ad1e4a7d45083c398c9e350"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=e0c419c405a7d8f7d7493143fe94435f906f7dfd#e0c419c405a7d8f7d7493143fe94435f906f7dfd"
 dependencies = [
  "ahash",
  "base64",
@@ -1576,7 +1576,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=b98324a7d#b98324a7d339468d5ad1e4a7d45083c398c9e350"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=e0c419c405a7d8f7d7493143fe94435f906f7dfd#e0c419c405a7d8f7d7493143fe94435f906f7dfd"
 
 [[package]]
 name = "nexus-vault"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=ec02b1a8f7935041733e1e5e657c4c7f793e05d3#ec02b1a8f7935041733e1e5e657c4c7f793e05d3"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=b98324a7d#b98324a7d339468d5ad1e4a7d45083c398c9e350"
 dependencies = [
  "ahash",
  "base64",
@@ -550,7 +550,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=ec02b1a8f7935041733e1e5e657c4c7f793e05d3#ec02b1a8f7935041733e1e5e657c4c7f793e05d3"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=b98324a7d#b98324a7d339468d5ad1e4a7d45083c398c9e350"
 dependencies = [
  "parking_lot",
  "serde",
@@ -1333,7 +1333,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=ec02b1a8f7935041733e1e5e657c4c7f793e05d3#ec02b1a8f7935041733e1e5e657c4c7f793e05d3"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=b98324a7d#b98324a7d339468d5ad1e4a7d45083c398c9e350"
 dependencies = [
  "ahash",
  "base64",
@@ -1384,7 +1384,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=ec02b1a8f7935041733e1e5e657c4c7f793e05d3#ec02b1a8f7935041733e1e5e657c4c7f793e05d3"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=b98324a7d#b98324a7d339468d5ad1e4a7d45083c398c9e350"
 dependencies = [
  "ahash",
  "base64",
@@ -1576,7 +1576,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=ec02b1a8f7935041733e1e5e657c4c7f793e05d3#ec02b1a8f7935041733e1e5e657c4c7f793e05d3"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=b98324a7d#b98324a7d339468d5ad1e4a7d45083c398c9e350"
 
 [[package]]
 name = "nexus-vault"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=52d749e5fe3bd6e45d1fa727491fe1d06de3db30#52d749e5fe3bd6e45d1fa727491fe1d06de3db30"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=18a661228120ccbfaf8a6710788ce9cfe69bc6ed#18a661228120ccbfaf8a6710788ce9cfe69bc6ed"
 dependencies = [
  "ahash",
  "base64",
@@ -550,7 +550,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=52d749e5fe3bd6e45d1fa727491fe1d06de3db30#52d749e5fe3bd6e45d1fa727491fe1d06de3db30"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=18a661228120ccbfaf8a6710788ce9cfe69bc6ed#18a661228120ccbfaf8a6710788ce9cfe69bc6ed"
 dependencies = [
  "parking_lot",
  "serde",
@@ -1333,7 +1333,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=52d749e5fe3bd6e45d1fa727491fe1d06de3db30#52d749e5fe3bd6e45d1fa727491fe1d06de3db30"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=18a661228120ccbfaf8a6710788ce9cfe69bc6ed#18a661228120ccbfaf8a6710788ce9cfe69bc6ed"
 dependencies = [
  "ahash",
  "base64",
@@ -1384,7 +1384,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=52d749e5fe3bd6e45d1fa727491fe1d06de3db30#52d749e5fe3bd6e45d1fa727491fe1d06de3db30"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=18a661228120ccbfaf8a6710788ce9cfe69bc6ed#18a661228120ccbfaf8a6710788ce9cfe69bc6ed"
 dependencies = [
  "ahash",
  "base64",
@@ -1576,7 +1576,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=52d749e5fe3bd6e45d1fa727491fe1d06de3db30#52d749e5fe3bd6e45d1fa727491fe1d06de3db30"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=18a661228120ccbfaf8a6710788ce9cfe69bc6ed#18a661228120ccbfaf8a6710788ce9cfe69bc6ed"
 
 [[package]]
 name = "nexus-vault"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=18a661228120ccbfaf8a6710788ce9cfe69bc6ed#18a661228120ccbfaf8a6710788ce9cfe69bc6ed"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=20d54ebe7920d82e0057759d61fefe6748076079#20d54ebe7920d82e0057759d61fefe6748076079"
 dependencies = [
  "ahash",
  "base64",
@@ -550,7 +550,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=18a661228120ccbfaf8a6710788ce9cfe69bc6ed#18a661228120ccbfaf8a6710788ce9cfe69bc6ed"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=20d54ebe7920d82e0057759d61fefe6748076079#20d54ebe7920d82e0057759d61fefe6748076079"
 dependencies = [
  "parking_lot",
  "serde",
@@ -1333,7 +1333,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=18a661228120ccbfaf8a6710788ce9cfe69bc6ed#18a661228120ccbfaf8a6710788ce9cfe69bc6ed"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=20d54ebe7920d82e0057759d61fefe6748076079#20d54ebe7920d82e0057759d61fefe6748076079"
 dependencies = [
  "ahash",
  "base64",
@@ -1384,7 +1384,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=18a661228120ccbfaf8a6710788ce9cfe69bc6ed#18a661228120ccbfaf8a6710788ce9cfe69bc6ed"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=20d54ebe7920d82e0057759d61fefe6748076079#20d54ebe7920d82e0057759d61fefe6748076079"
 dependencies = [
  "ahash",
  "base64",
@@ -1576,7 +1576,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=18a661228120ccbfaf8a6710788ce9cfe69bc6ed#18a661228120ccbfaf8a6710788ce9cfe69bc6ed"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=20d54ebe7920d82e0057759d61fefe6748076079#20d54ebe7920d82e0057759d61fefe6748076079"
 
 [[package]]
 name = "nexus-vault"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=e0c419c405a7d8f7d7493143fe94435f906f7dfd#e0c419c405a7d8f7d7493143fe94435f906f7dfd"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=52d749e5fe3bd6e45d1fa727491fe1d06de3db30#52d749e5fe3bd6e45d1fa727491fe1d06de3db30"
 dependencies = [
  "ahash",
  "base64",
@@ -550,7 +550,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=e0c419c405a7d8f7d7493143fe94435f906f7dfd#e0c419c405a7d8f7d7493143fe94435f906f7dfd"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=52d749e5fe3bd6e45d1fa727491fe1d06de3db30#52d749e5fe3bd6e45d1fa727491fe1d06de3db30"
 dependencies = [
  "parking_lot",
  "serde",
@@ -1333,7 +1333,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=e0c419c405a7d8f7d7493143fe94435f906f7dfd#e0c419c405a7d8f7d7493143fe94435f906f7dfd"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=52d749e5fe3bd6e45d1fa727491fe1d06de3db30#52d749e5fe3bd6e45d1fa727491fe1d06de3db30"
 dependencies = [
  "ahash",
  "base64",
@@ -1384,7 +1384,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=e0c419c405a7d8f7d7493143fe94435f906f7dfd#e0c419c405a7d8f7d7493143fe94435f906f7dfd"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=52d749e5fe3bd6e45d1fa727491fe1d06de3db30#52d749e5fe3bd6e45d1fa727491fe1d06de3db30"
 dependencies = [
  "ahash",
  "base64",
@@ -1576,7 +1576,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=e0c419c405a7d8f7d7493143fe94435f906f7dfd#e0c419c405a7d8f7d7493143fe94435f906f7dfd"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=52d749e5fe3bd6e45d1fa727491fe1d06de3db30#52d749e5fe3bd6e45d1fa727491fe1d06de3db30"
 
 [[package]]
 name = "nexus-vault"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,9 +126,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arrayref"
@@ -218,7 +218,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=fc16c58661583cbad934a7cb87716734ee951409#fc16c58661583cbad934a7cb87716734ee951409"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=ec02b1a8f7935041733e1e5e657c4c7f793e05d3#ec02b1a8f7935041733e1e5e657c4c7f793e05d3"
 dependencies = [
  "ahash",
  "base64",
@@ -350,12 +350,12 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.12.1"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+checksum = "5cee35f73844aa3014bb606320a6c1f010249dbdf43342fe54b5a4f6a8ed4b79"
 dependencies = [
  "memchr",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -550,7 +550,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=fc16c58661583cbad934a7cb87716734ee951409#fc16c58661583cbad934a7cb87716734ee951409"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=ec02b1a8f7935041733e1e5e657c4c7f793e05d3#ec02b1a8f7935041733e1e5e657c4c7f793e05d3"
 dependencies = [
  "parking_lot",
  "serde",
@@ -1321,9 +1321,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.102"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1333,7 +1333,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=fc16c58661583cbad934a7cb87716734ee951409#fc16c58661583cbad934a7cb87716734ee951409"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=ec02b1a8f7935041733e1e5e657c4c7f793e05d3#ec02b1a8f7935041733e1e5e657c4c7f793e05d3"
 dependencies = [
  "ahash",
  "base64",
@@ -1384,7 +1384,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=fc16c58661583cbad934a7cb87716734ee951409#fc16c58661583cbad934a7cb87716734ee951409"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=ec02b1a8f7935041733e1e5e657c4c7f793e05d3#ec02b1a8f7935041733e1e5e657c4c7f793e05d3"
 dependencies = [
  "ahash",
  "base64",
@@ -1576,7 +1576,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=fc16c58661583cbad934a7cb87716734ee951409#fc16c58661583cbad934a7cb87716734ee951409"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=ec02b1a8f7935041733e1e5e657c4c7f793e05d3#ec02b1a8f7935041733e1e5e657c4c7f793e05d3"
 
 [[package]]
 name = "nexus-vault"
@@ -1978,9 +1978,9 @@ dependencies = [
 
 [[package]]
 name = "quick_cache"
-version = "0.6.23"
+version = "0.6.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a3db184a8b66cfe87f0263a1de147a6b554c864d1767c6f7fa4eb0e5497b565"
+checksum = "b9c6658afe513a3b484e3abfdaa0d03ef3c0bbf017542c178dd55f94eb3051f9"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
@@ -2880,9 +2880,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.3"
+version = "1.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
+checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -2924,9 +2924,9 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2937,9 +2937,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2947,9 +2947,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2960,9 +2960,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,13 +54,13 @@ exclude = ["nexus-fuse"]
 # dispatch to kernel/federation.rs, #85 HAL extension (rename +
 # setattr).  Bump alongside the rest of nexus-vfs updates when
 # a downstream change needs newer kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "18a661228120ccbfaf8a6710788ce9cfe69bc6ed" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "18a661228120ccbfaf8a6710788ce9cfe69bc6ed" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "18a661228120ccbfaf8a6710788ce9cfe69bc6ed" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "18a661228120ccbfaf8a6710788ce9cfe69bc6ed", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "18a661228120ccbfaf8a6710788ce9cfe69bc6ed", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "18a661228120ccbfaf8a6710788ce9cfe69bc6ed", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "18a661228120ccbfaf8a6710788ce9cfe69bc6ed" }
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "20d54ebe7920d82e0057759d61fefe6748076079" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "20d54ebe7920d82e0057759d61fefe6748076079" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "20d54ebe7920d82e0057759d61fefe6748076079" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "20d54ebe7920d82e0057759d61fefe6748076079", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "20d54ebe7920d82e0057759d61fefe6748076079", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "20d54ebe7920d82e0057759d61fefe6748076079", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "20d54ebe7920d82e0057759d61fefe6748076079" }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,13 +54,13 @@ exclude = ["nexus-fuse"]
 # dispatch to kernel/federation.rs, #85 HAL extension (rename +
 # setattr).  Bump alongside the rest of nexus-vfs updates when
 # a downstream change needs newer kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "b98324a7d339468d5ad1e4a7d45083c398c9e350" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "b98324a7d339468d5ad1e4a7d45083c398c9e350" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "b98324a7d339468d5ad1e4a7d45083c398c9e350" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "b98324a7d339468d5ad1e4a7d45083c398c9e350", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "b98324a7d339468d5ad1e4a7d45083c398c9e350", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "b98324a7d339468d5ad1e4a7d45083c398c9e350", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "b98324a7d339468d5ad1e4a7d45083c398c9e350" }
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "e0c419c405a7d8f7d7493143fe94435f906f7dfd" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "e0c419c405a7d8f7d7493143fe94435f906f7dfd" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "e0c419c405a7d8f7d7493143fe94435f906f7dfd" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "e0c419c405a7d8f7d7493143fe94435f906f7dfd", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "e0c419c405a7d8f7d7493143fe94435f906f7dfd", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "e0c419c405a7d8f7d7493143fe94435f906f7dfd", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "e0c419c405a7d8f7d7493143fe94435f906f7dfd" }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,13 +54,13 @@ exclude = ["nexus-fuse"]
 # dispatch to kernel/federation.rs, #85 HAL extension (rename +
 # setattr).  Bump alongside the rest of nexus-vfs updates when
 # a downstream change needs newer kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "52d749e5fe3bd6e45d1fa727491fe1d06de3db30" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "52d749e5fe3bd6e45d1fa727491fe1d06de3db30" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "52d749e5fe3bd6e45d1fa727491fe1d06de3db30" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "52d749e5fe3bd6e45d1fa727491fe1d06de3db30", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "52d749e5fe3bd6e45d1fa727491fe1d06de3db30", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "52d749e5fe3bd6e45d1fa727491fe1d06de3db30", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "52d749e5fe3bd6e45d1fa727491fe1d06de3db30" }
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "18a661228120ccbfaf8a6710788ce9cfe69bc6ed" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "18a661228120ccbfaf8a6710788ce9cfe69bc6ed" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "18a661228120ccbfaf8a6710788ce9cfe69bc6ed" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "18a661228120ccbfaf8a6710788ce9cfe69bc6ed", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "18a661228120ccbfaf8a6710788ce9cfe69bc6ed", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "18a661228120ccbfaf8a6710788ce9cfe69bc6ed", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "18a661228120ccbfaf8a6710788ce9cfe69bc6ed" }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,13 +54,13 @@ exclude = ["nexus-fuse"]
 # dispatch to kernel/federation.rs, #85 HAL extension (rename +
 # setattr).  Bump alongside the rest of nexus-vfs updates when
 # a downstream change needs newer kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "fc16c58661583cbad934a7cb87716734ee951409" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "fc16c58661583cbad934a7cb87716734ee951409" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "fc16c58661583cbad934a7cb87716734ee951409" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "fc16c58661583cbad934a7cb87716734ee951409", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "fc16c58661583cbad934a7cb87716734ee951409", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "fc16c58661583cbad934a7cb87716734ee951409", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "fc16c58661583cbad934a7cb87716734ee951409" }
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ec02b1a8f7935041733e1e5e657c4c7f793e05d3" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ec02b1a8f7935041733e1e5e657c4c7f793e05d3" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ec02b1a8f7935041733e1e5e657c4c7f793e05d3" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ec02b1a8f7935041733e1e5e657c4c7f793e05d3", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ec02b1a8f7935041733e1e5e657c4c7f793e05d3", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ec02b1a8f7935041733e1e5e657c4c7f793e05d3", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ec02b1a8f7935041733e1e5e657c4c7f793e05d3" }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,13 +54,13 @@ exclude = ["nexus-fuse"]
 # dispatch to kernel/federation.rs, #85 HAL extension (rename +
 # setattr).  Bump alongside the rest of nexus-vfs updates when
 # a downstream change needs newer kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "20d54ebe7920d82e0057759d61fefe6748076079" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "20d54ebe7920d82e0057759d61fefe6748076079" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "20d54ebe7920d82e0057759d61fefe6748076079" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "20d54ebe7920d82e0057759d61fefe6748076079", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "20d54ebe7920d82e0057759d61fefe6748076079", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "20d54ebe7920d82e0057759d61fefe6748076079", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "20d54ebe7920d82e0057759d61fefe6748076079" }
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "286c3e93a9c5cbd20c585b2c71873133a107c245" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "286c3e93a9c5cbd20c585b2c71873133a107c245" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "286c3e93a9c5cbd20c585b2c71873133a107c245" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "286c3e93a9c5cbd20c585b2c71873133a107c245", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "286c3e93a9c5cbd20c585b2c71873133a107c245", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "286c3e93a9c5cbd20c585b2c71873133a107c245", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "286c3e93a9c5cbd20c585b2c71873133a107c245" }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,13 +54,13 @@ exclude = ["nexus-fuse"]
 # dispatch to kernel/federation.rs, #85 HAL extension (rename +
 # setattr).  Bump alongside the rest of nexus-vfs updates when
 # a downstream change needs newer kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "e0c419c405a7d8f7d7493143fe94435f906f7dfd" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "e0c419c405a7d8f7d7493143fe94435f906f7dfd" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "e0c419c405a7d8f7d7493143fe94435f906f7dfd" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "e0c419c405a7d8f7d7493143fe94435f906f7dfd", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "e0c419c405a7d8f7d7493143fe94435f906f7dfd", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "e0c419c405a7d8f7d7493143fe94435f906f7dfd", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "e0c419c405a7d8f7d7493143fe94435f906f7dfd" }
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "52d749e5fe3bd6e45d1fa727491fe1d06de3db30" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "52d749e5fe3bd6e45d1fa727491fe1d06de3db30" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "52d749e5fe3bd6e45d1fa727491fe1d06de3db30" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "52d749e5fe3bd6e45d1fa727491fe1d06de3db30", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "52d749e5fe3bd6e45d1fa727491fe1d06de3db30", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "52d749e5fe3bd6e45d1fa727491fe1d06de3db30", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "52d749e5fe3bd6e45d1fa727491fe1d06de3db30" }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,13 +54,13 @@ exclude = ["nexus-fuse"]
 # dispatch to kernel/federation.rs, #85 HAL extension (rename +
 # setattr).  Bump alongside the rest of nexus-vfs updates when
 # a downstream change needs newer kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ec02b1a8f7935041733e1e5e657c4c7f793e05d3" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ec02b1a8f7935041733e1e5e657c4c7f793e05d3" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ec02b1a8f7935041733e1e5e657c4c7f793e05d3" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ec02b1a8f7935041733e1e5e657c4c7f793e05d3", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ec02b1a8f7935041733e1e5e657c4c7f793e05d3", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ec02b1a8f7935041733e1e5e657c4c7f793e05d3", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ec02b1a8f7935041733e1e5e657c4c7f793e05d3" }
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "b98324a7d339468d5ad1e4a7d45083c398c9e350" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "b98324a7d339468d5ad1e4a7d45083c398c9e350" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "b98324a7d339468d5ad1e4a7d45083c398c9e350" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "b98324a7d339468d5ad1e4a7d45083c398c9e350", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "b98324a7d339468d5ad1e4a7d45083c398c9e350", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "b98324a7d339468d5ad1e4a7d45083c398c9e350", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "b98324a7d339468d5ad1e4a7d45083c398c9e350" }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ENV CARGO_NET_RETRY=10 \
     CARGO_HTTP_TIMEOUT=120
 # Override for edge/CI or a different pin: --build-arg NEXUS_VFS_REV=<sha|tag>
-ARG NEXUS_VFS_REV=20d54ebe7920d82e0057759d61fefe6748076079
+ARG NEXUS_VFS_REV=286c3e93a9c5cbd20c585b2c71873133a107c245
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,id=cargo-install-${TARGETARCH},target=/root/.cargo/target \

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ENV CARGO_NET_RETRY=10 \
     CARGO_HTTP_TIMEOUT=120
 # Override for edge/CI or a different pin: --build-arg NEXUS_VFS_REV=<sha|tag>
-ARG NEXUS_VFS_REV=e0c419c405a7d8f7d7493143fe94435f906f7dfd
+ARG NEXUS_VFS_REV=52d749e5fe3bd6e45d1fa727491fe1d06de3db30
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,id=cargo-install-${TARGETARCH},target=/root/.cargo/target \

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ENV CARGO_NET_RETRY=10 \
     CARGO_HTTP_TIMEOUT=120
 # Override for edge/CI or a different pin: --build-arg NEXUS_VFS_REV=<sha|tag>
-ARG NEXUS_VFS_REV=52d749e5fe3bd6e45d1fa727491fe1d06de3db30
+ARG NEXUS_VFS_REV=18a661228120ccbfaf8a6710788ce9cfe69bc6ed
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,id=cargo-install-${TARGETARCH},target=/root/.cargo/target \

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ENV CARGO_NET_RETRY=10 \
     CARGO_HTTP_TIMEOUT=120
 # Override for edge/CI or a different pin: --build-arg NEXUS_VFS_REV=<sha|tag>
-ARG NEXUS_VFS_REV=b98324a7d339468d5ad1e4a7d45083c398c9e350
+ARG NEXUS_VFS_REV=e0c419c405a7d8f7d7493143fe94435f906f7dfd
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,id=cargo-install-${TARGETARCH},target=/root/.cargo/target \

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ENV CARGO_NET_RETRY=10 \
     CARGO_HTTP_TIMEOUT=120
 # Override for edge/CI or a different pin: --build-arg NEXUS_VFS_REV=<sha|tag>
-ARG NEXUS_VFS_REV=18a661228120ccbfaf8a6710788ce9cfe69bc6ed
+ARG NEXUS_VFS_REV=20d54ebe7920d82e0057759d61fefe6748076079
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,id=cargo-install-${TARGETARCH},target=/root/.cargo/target \

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ENV CARGO_NET_RETRY=10 \
     CARGO_HTTP_TIMEOUT=120
 # Override for edge/CI or a different pin: --build-arg NEXUS_VFS_REV=<sha|tag>
-ARG NEXUS_VFS_REV=fc16c58661583cbad934a7cb87716734ee951409
+ARG NEXUS_VFS_REV=b98324a7d339468d5ad1e4a7d45083c398c9e350
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,id=cargo-install-${TARGETARCH},target=/root/.cargo/target \

--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir --no-deps --prefix=/install .
 # enforces agreement) — an unpinned install tracks nexus-vfs HEAD and
 # ships an untested kernel (#4343). --locked honors the source tree's
 # Cargo.lock.
-ARG NEXUS_VFS_REV=e0c419c405a7d8f7d7493143fe94435f906f7dfd
+ARG NEXUS_VFS_REV=52d749e5fe3bd6e45d1fa727491fe1d06de3db30
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-cluster nexus-cluster
 
 # -- Runtime stage --

--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir --no-deps --prefix=/install .
 # enforces agreement) — an unpinned install tracks nexus-vfs HEAD and
 # ships an untested kernel (#4343). --locked honors the source tree's
 # Cargo.lock.
-ARG NEXUS_VFS_REV=b98324a7d339468d5ad1e4a7d45083c398c9e350
+ARG NEXUS_VFS_REV=e0c419c405a7d8f7d7493143fe94435f906f7dfd
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-cluster nexus-cluster
 
 # -- Runtime stage --

--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir --no-deps --prefix=/install .
 # enforces agreement) — an unpinned install tracks nexus-vfs HEAD and
 # ships an untested kernel (#4343). --locked honors the source tree's
 # Cargo.lock.
-ARG NEXUS_VFS_REV=fc16c58661583cbad934a7cb87716734ee951409
+ARG NEXUS_VFS_REV=b98324a7d339468d5ad1e4a7d45083c398c9e350
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-cluster nexus-cluster
 
 # -- Runtime stage --

--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir --no-deps --prefix=/install .
 # enforces agreement) — an unpinned install tracks nexus-vfs HEAD and
 # ships an untested kernel (#4343). --locked honors the source tree's
 # Cargo.lock.
-ARG NEXUS_VFS_REV=20d54ebe7920d82e0057759d61fefe6748076079
+ARG NEXUS_VFS_REV=286c3e93a9c5cbd20c585b2c71873133a107c245
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-cluster nexus-cluster
 
 # -- Runtime stage --

--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir --no-deps --prefix=/install .
 # enforces agreement) — an unpinned install tracks nexus-vfs HEAD and
 # ships an untested kernel (#4343). --locked honors the source tree's
 # Cargo.lock.
-ARG NEXUS_VFS_REV=18a661228120ccbfaf8a6710788ce9cfe69bc6ed
+ARG NEXUS_VFS_REV=20d54ebe7920d82e0057759d61fefe6748076079
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-cluster nexus-cluster
 
 # -- Runtime stage --

--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir --no-deps --prefix=/install .
 # enforces agreement) — an unpinned install tracks nexus-vfs HEAD and
 # ships an untested kernel (#4343). --locked honors the source tree's
 # Cargo.lock.
-ARG NEXUS_VFS_REV=52d749e5fe3bd6e45d1fa727491fe1d06de3db30
+ARG NEXUS_VFS_REV=18a661228120ccbfaf8a6710788ce9cfe69bc6ed
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-cluster nexus-cluster
 
 # -- Runtime stage --

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -25,7 +25,7 @@ WORKDIR /build
 # (CI preflight enforces agreement) — an unpinned install tracks HEAD
 # and can skew the raft contract against the cluster/witness images.
 # --locked honors the source tree's Cargo.lock.
-ARG NEXUS_VFS_REV=20d54ebe7920d82e0057759d61fefe6748076079
+ARG NEXUS_VFS_REV=286c3e93a9c5cbd20c585b2c71873133a107c245
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexus-raft-server raft
 
 # ---------- Production image ----------

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -25,7 +25,7 @@ WORKDIR /build
 # (CI preflight enforces agreement) — an unpinned install tracks HEAD
 # and can skew the raft contract against the cluster/witness images.
 # --locked honors the source tree's Cargo.lock.
-ARG NEXUS_VFS_REV=e0c419c405a7d8f7d7493143fe94435f906f7dfd
+ARG NEXUS_VFS_REV=52d749e5fe3bd6e45d1fa727491fe1d06de3db30
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexus-raft-server raft
 
 # ---------- Production image ----------

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -25,7 +25,7 @@ WORKDIR /build
 # (CI preflight enforces agreement) — an unpinned install tracks HEAD
 # and can skew the raft contract against the cluster/witness images.
 # --locked honors the source tree's Cargo.lock.
-ARG NEXUS_VFS_REV=fc16c58661583cbad934a7cb87716734ee951409
+ARG NEXUS_VFS_REV=b98324a7d339468d5ad1e4a7d45083c398c9e350
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexus-raft-server raft
 
 # ---------- Production image ----------

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -25,7 +25,7 @@ WORKDIR /build
 # (CI preflight enforces agreement) — an unpinned install tracks HEAD
 # and can skew the raft contract against the cluster/witness images.
 # --locked honors the source tree's Cargo.lock.
-ARG NEXUS_VFS_REV=b98324a7d339468d5ad1e4a7d45083c398c9e350
+ARG NEXUS_VFS_REV=e0c419c405a7d8f7d7493143fe94435f906f7dfd
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexus-raft-server raft
 
 # ---------- Production image ----------

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -25,7 +25,7 @@ WORKDIR /build
 # (CI preflight enforces agreement) — an unpinned install tracks HEAD
 # and can skew the raft contract against the cluster/witness images.
 # --locked honors the source tree's Cargo.lock.
-ARG NEXUS_VFS_REV=18a661228120ccbfaf8a6710788ce9cfe69bc6ed
+ARG NEXUS_VFS_REV=20d54ebe7920d82e0057759d61fefe6748076079
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexus-raft-server raft
 
 # ---------- Production image ----------

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -25,7 +25,7 @@ WORKDIR /build
 # (CI preflight enforces agreement) — an unpinned install tracks HEAD
 # and can skew the raft contract against the cluster/witness images.
 # --locked honors the source tree's Cargo.lock.
-ARG NEXUS_VFS_REV=52d749e5fe3bd6e45d1fa727491fe1d06de3db30
+ARG NEXUS_VFS_REV=18a661228120ccbfaf8a6710788ce9cfe69bc6ed
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexus-raft-server raft
 
 # ---------- Production image ----------

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=e0c419c405a7d8f7d7493143fe94435f906f7dfd
+ARG NEXUS_VFS_REV=52d749e5fe3bd6e45d1fa727491fe1d06de3db30
 RUN cargo install \
     --locked \
     --git https://github.com/nexi-lab/nexus-vfs \

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=52d749e5fe3bd6e45d1fa727491fe1d06de3db30
+ARG NEXUS_VFS_REV=18a661228120ccbfaf8a6710788ce9cfe69bc6ed
 RUN cargo install \
     --locked \
     --git https://github.com/nexi-lab/nexus-vfs \

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=fc16c58661583cbad934a7cb87716734ee951409
+ARG NEXUS_VFS_REV=b98324a7d339468d5ad1e4a7d45083c398c9e350
 RUN cargo install \
     --locked \
     --git https://github.com/nexi-lab/nexus-vfs \

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=20d54ebe7920d82e0057759d61fefe6748076079
+ARG NEXUS_VFS_REV=286c3e93a9c5cbd20c585b2c71873133a107c245
 RUN cargo install \
     --locked \
     --git https://github.com/nexi-lab/nexus-vfs \

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=18a661228120ccbfaf8a6710788ce9cfe69bc6ed
+ARG NEXUS_VFS_REV=20d54ebe7920d82e0057759d61fefe6748076079
 RUN cargo install \
     --locked \
     --git https://github.com/nexi-lab/nexus-vfs \

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=b98324a7d339468d5ad1e4a7d45083c398c9e350
+ARG NEXUS_VFS_REV=e0c419c405a7d8f7d7493143fe94435f906f7dfd
 RUN cargo install \
     --locked \
     --git https://github.com/nexi-lab/nexus-vfs \


### PR DESCRIPTION
## Summary

E2E-gating PR for [nexus-vfs PR #88](https://github.com/nexi-lab/nexus-vfs/pull/88) — Phase 3 cross-node `sys_mkdir` / `sys_rename` / `sys_setattr` SSOT-peer supplement dispatch bundle + kernel-side federation/ refactor.

Same gating pattern Phases 1 & 2 used.

Pinned at PR #88's branch HEAD (`ec02b1a8f7935041733e1e5e657c4c7f793e05d3`), NOT main yet.

## What's bundled

| Phase | nexus-vfs commit | Syscall | New helper |
|---|---|---|---|
| 3a | `52d749e5f` | `sys_mkdir` §2.7 | `federation_peer_mkdir` |
| 3b | `18a661228` | `sys_rename` §2.7 | `federation_peer_rename` |
| 3c | `e0c419c40` | `sys_setattr` UPDATE §X.7 | `federation_peer_setattr` |
| refactor | `ec02b1a8f` | — | `kernel/src/kernel/federation.rs` → `kernel/src/federation/{mod,coordinator_wiring,peer_dispatch,blob_fetcher_slot}.rs` |

All three syscall phases share the *exact same shape*: supplement (not replace) — peer RPC fires as a SIDE EFFECT, legacy local-side flow STILL runs so the joiner's VFSRouter / dcache observes routing/metadata immediately.  Raft LWW dedupes the two metastore mutations on `modified_at_ms`.

## Why bundled (vs three separate gating PRs)

`feedback_single_pr_many_commits`: big multi-phase efforts go on ONE PR with many granular commits.  The three phases are mechanically identical — reviewing them together makes the pattern legibility immediate.

## Flow

1. ✅ nexus-vfs #88 opened — kernel-tier CI gates clean check / clippy / fmt / test on lib + kernel + raft (all-features) + profiles/cluster (expected — verified `cargo check` clean locally).
2. **THIS PR** — pinned at #88's branch HEAD `ec02b1a8f`.
3. Wait for Federation E2E + cc-tasks-share E2E.
4. **If green** → admin-merge nexus-vfs #88; re-pin THIS PR at the resulting main SHA; admin-merge.
5. **If red** → local Docker reproduce + diagnose (already green 12/12 + 16/16 locally on Windows Docker Desktop; CI red would suggest infra flake, not Phase 3 correctness issue).

## Local verification (Windows Docker Desktop, fresh rebuild)

| Suite | Phase 2 baseline (fc16c5866) | Phase 3 bundle (this PR) |
|---|---|---|
| cc-tasks-share E2E (12 tests) | 12/12 ✓ | 12/12 ✓ |
| Federation E2E (16 tests) | 15/16 (timing flake) | 16/16 ✓ |

The 1/16 baseline failure (`test_founder_static_topology_converges_under_two_seconds`) is a pre-existing 2-second cold-boot timing flake on Windows Docker Desktop, NOT Phase 3-caused.  Same test passed on Phase 3 run.

## Test plan

- [ ] `Federation E2E (Docker)` green
- [ ] `cc-tasks-share E2E (Docker)` green
- [ ] All other CI gates green