### PR TITLE
chore(deps): E2E-gate nexus-vfs PR #89 (root-SOLO contract fix)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5804dae6ed5720d158b3c63c711899c4416bc011#5804dae6ed5720d158b3c63c711899c4416bc011"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=87e52733cc1a053d136416403262b4a732831c0d#87e52733cc1a053d136416403262b4a732831c0d"
 dependencies = [
  "ahash",
  "base64",
@@ -550,7 +550,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5804dae6ed5720d158b3c63c711899c4416bc011#5804dae6ed5720d158b3c63c711899c4416bc011"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=87e52733cc1a053d136416403262b4a732831c0d#87e52733cc1a053d136416403262b4a732831c0d"
 dependencies = [
  "parking_lot",
  "serde",
@@ -1333,7 +1333,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5804dae6ed5720d158b3c63c711899c4416bc011#5804dae6ed5720d158b3c63c711899c4416bc011"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=87e52733cc1a053d136416403262b4a732831c0d#87e52733cc1a053d136416403262b4a732831c0d"
 dependencies = [
  "ahash",
  "base64",
@@ -1384,7 +1384,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5804dae6ed5720d158b3c63c711899c4416bc011#5804dae6ed5720d158b3c63c711899c4416bc011"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=87e52733cc1a053d136416403262b4a732831c0d#87e52733cc1a053d136416403262b4a732831c0d"
 dependencies = [
  "ahash",
  "base64",
@@ -1576,7 +1576,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5804dae6ed5720d158b3c63c711899c4416bc011#5804dae6ed5720d158b3c63c711899c4416bc011"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=87e52733cc1a053d136416403262b4a732831c0d#87e52733cc1a053d136416403262b4a732831c0d"
 
 [[package]]
 name = "nexus-vault"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=286c3e93a9c5cbd20c585b2c71873133a107c245#286c3e93a9c5cbd20c585b2c71873133a107c245"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5804dae6ed5720d158b3c63c711899c4416bc011#5804dae6ed5720d158b3c63c711899c4416bc011"
 dependencies = [
  "ahash",
  "base64",
@@ -550,7 +550,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=286c3e93a9c5cbd20c585b2c71873133a107c245#286c3e93a9c5cbd20c585b2c71873133a107c245"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5804dae6ed5720d158b3c63c711899c4416bc011#5804dae6ed5720d158b3c63c711899c4416bc011"
 dependencies = [
  "parking_lot",
  "serde",
@@ -1333,7 +1333,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=286c3e93a9c5cbd20c585b2c71873133a107c245#286c3e93a9c5cbd20c585b2c71873133a107c245"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5804dae6ed5720d158b3c63c711899c4416bc011#5804dae6ed5720d158b3c63c711899c4416bc011"
 dependencies = [
  "ahash",
  "base64",
@@ -1384,7 +1384,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=286c3e93a9c5cbd20c585b2c71873133a107c245#286c3e93a9c5cbd20c585b2c71873133a107c245"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5804dae6ed5720d158b3c63c711899c4416bc011#5804dae6ed5720d158b3c63c711899c4416bc011"
 dependencies = [
  "ahash",
  "base64",
@@ -1576,7 +1576,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=286c3e93a9c5cbd20c585b2c71873133a107c245#286c3e93a9c5cbd20c585b2c71873133a107c245"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5804dae6ed5720d158b3c63c711899c4416bc011#5804dae6ed5720d158b3c63c711899c4416bc011"
 
 [[package]]
 name = "nexus-vault"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,13 +54,13 @@ exclude = ["nexus-fuse"]
 # dispatch to kernel/federation.rs, #85 HAL extension (rename +
 # setattr).  Bump alongside the rest of nexus-vfs updates when
 # a downstream change needs newer kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "286c3e93a9c5cbd20c585b2c71873133a107c245" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "286c3e93a9c5cbd20c585b2c71873133a107c245" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "286c3e93a9c5cbd20c585b2c71873133a107c245" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "286c3e93a9c5cbd20c585b2c71873133a107c245", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "286c3e93a9c5cbd20c585b2c71873133a107c245", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "286c3e93a9c5cbd20c585b2c71873133a107c245", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "286c3e93a9c5cbd20c585b2c71873133a107c245" }
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5804dae6ed5720d158b3c63c711899c4416bc011" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5804dae6ed5720d158b3c63c711899c4416bc011" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5804dae6ed5720d158b3c63c711899c4416bc011" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5804dae6ed5720d158b3c63c711899c4416bc011", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5804dae6ed5720d158b3c63c711899c4416bc011", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5804dae6ed5720d158b3c63c711899c4416bc011", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5804dae6ed5720d158b3c63c711899c4416bc011" }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,13 +54,13 @@ exclude = ["nexus-fuse"]
 # dispatch to kernel/federation.rs, #85 HAL extension (rename +
 # setattr).  Bump alongside the rest of nexus-vfs updates when
 # a downstream change needs newer kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5804dae6ed5720d158b3c63c711899c4416bc011" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5804dae6ed5720d158b3c63c711899c4416bc011" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5804dae6ed5720d158b3c63c711899c4416bc011" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5804dae6ed5720d158b3c63c711899c4416bc011", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5804dae6ed5720d158b3c63c711899c4416bc011", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5804dae6ed5720d158b3c63c711899c4416bc011", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5804dae6ed5720d158b3c63c711899c4416bc011" }
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "87e52733cc1a053d136416403262b4a732831c0d" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "87e52733cc1a053d136416403262b4a732831c0d" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "87e52733cc1a053d136416403262b4a732831c0d" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "87e52733cc1a053d136416403262b4a732831c0d", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "87e52733cc1a053d136416403262b4a732831c0d", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "87e52733cc1a053d136416403262b4a732831c0d", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "87e52733cc1a053d136416403262b4a732831c0d" }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ENV CARGO_NET_RETRY=10 \
     CARGO_HTTP_TIMEOUT=120
 # Override for edge/CI or a different pin: --build-arg NEXUS_VFS_REV=<sha|tag>
-ARG NEXUS_VFS_REV=5804dae6ed5720d158b3c63c711899c4416bc011
+ARG NEXUS_VFS_REV=87e52733cc1a053d136416403262b4a732831c0d
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,id=cargo-install-${TARGETARCH},target=/root/.cargo/target \

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ENV CARGO_NET_RETRY=10 \
     CARGO_HTTP_TIMEOUT=120
 # Override for edge/CI or a different pin: --build-arg NEXUS_VFS_REV=<sha|tag>
-ARG NEXUS_VFS_REV=286c3e93a9c5cbd20c585b2c71873133a107c245
+ARG NEXUS_VFS_REV=5804dae6ed5720d158b3c63c711899c4416bc011
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,id=cargo-install-${TARGETARCH},target=/root/.cargo/target \

--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir --no-deps --prefix=/install .
 # enforces agreement) — an unpinned install tracks nexus-vfs HEAD and
 # ships an untested kernel (#4343). --locked honors the source tree's
 # Cargo.lock.
-ARG NEXUS_VFS_REV=5804dae6ed5720d158b3c63c711899c4416bc011
+ARG NEXUS_VFS_REV=87e52733cc1a053d136416403262b4a732831c0d
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-cluster nexus-cluster
 
 # -- Runtime stage --

--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir --no-deps --prefix=/install .
 # enforces agreement) — an unpinned install tracks nexus-vfs HEAD and
 # ships an untested kernel (#4343). --locked honors the source tree's
 # Cargo.lock.
-ARG NEXUS_VFS_REV=286c3e93a9c5cbd20c585b2c71873133a107c245
+ARG NEXUS_VFS_REV=5804dae6ed5720d158b3c63c711899c4416bc011
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-cluster nexus-cluster
 
 # -- Runtime stage --

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -25,7 +25,7 @@ WORKDIR /build
 # (CI preflight enforces agreement) — an unpinned install tracks HEAD
 # and can skew the raft contract against the cluster/witness images.
 # --locked honors the source tree's Cargo.lock.
-ARG NEXUS_VFS_REV=286c3e93a9c5cbd20c585b2c71873133a107c245
+ARG NEXUS_VFS_REV=5804dae6ed5720d158b3c63c711899c4416bc011
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexus-raft-server raft
 
 # ---------- Production image ----------

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -25,7 +25,7 @@ WORKDIR /build
 # (CI preflight enforces agreement) — an unpinned install tracks HEAD
 # and can skew the raft contract against the cluster/witness images.
 # --locked honors the source tree's Cargo.lock.
-ARG NEXUS_VFS_REV=5804dae6ed5720d158b3c63c711899c4416bc011
+ARG NEXUS_VFS_REV=87e52733cc1a053d136416403262b4a732831c0d
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexus-raft-server raft
 
 # ---------- Production image ----------

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=286c3e93a9c5cbd20c585b2c71873133a107c245
+ARG NEXUS_VFS_REV=5804dae6ed5720d158b3c63c711899c4416bc011
 RUN cargo install \
     --locked \
     --git https://github.com/nexi-lab/nexus-vfs \

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=5804dae6ed5720d158b3c63c711899c4416bc011
+ARG NEXUS_VFS_REV=87e52733cc1a053d136416403262b4a732831c0d
 RUN cargo install \
     --locked \
     --git https://github.com/nexi-lab/nexus-vfs \


### PR DESCRIPTION
## Summary

E2E gate for [nexus-vfs PR #89](https://github.com/nexi-lab/nexus-vfs/pull/89) — codifies the **root zone is per-node SOLO by design** invariant at the kernel-internal entry point, so the operator misconfig `NEXUS_PEERS=<peer> for federation` surfaces at boot with a clear error instead of cascading through ConfChange / heartbeat / cross-federation pollution.

Pinned at #89's branch HEAD (`5804dae6ed5720d158b3c63c711899c4416bc011`), NOT main yet.

## Why this PR exists

Pre-existing contract bug surfaced during Mac↔Win cross-machine federation smoke (the cc-tasks-list Mac↔Win shape that drove Phase 1/2/3 of nexus-vfs).  See nexus-vfs #89 body for full root cause + 8-principle verification.

## Backward compatibility

Pure contract narrowing.  Every existing deployment (Federation E2E, cc-tasks-share E2E, every integration test) uses per-node 1-voter root + named-zone federation — the SOLO gate never fires for them.  These suites must stay green; that's exactly what this E2E gate validates.

## Test plan

- [ ] Federation E2E (Docker) green
- [ ] cc-tasks-share E2E (Docker) green
- [ ] nexusd-cluster Smoke Test green (pin alignment across Cargo.toml / Cargo.lock / 4 Dockerfiles)
- [ ] All other CI gates green