### PR TITLE
chore(deps): E2E-gate nexus-vfs PR #91 (sys_readdir basename SSOT fix)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=87e52733cc1a053d136416403262b4a732831c0d#87e52733cc1a053d136416403262b4a732831c0d"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=69e45e6fd11ab2ba19e9b299a5ff269eac1c4e8a#69e45e6fd11ab2ba19e9b299a5ff269eac1c4e8a"
 dependencies = [
  "ahash",
  "base64",
@@ -550,7 +550,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=87e52733cc1a053d136416403262b4a732831c0d#87e52733cc1a053d136416403262b4a732831c0d"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=69e45e6fd11ab2ba19e9b299a5ff269eac1c4e8a#69e45e6fd11ab2ba19e9b299a5ff269eac1c4e8a"
 dependencies = [
  "parking_lot",
  "serde",
@@ -1333,7 +1333,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=87e52733cc1a053d136416403262b4a732831c0d#87e52733cc1a053d136416403262b4a732831c0d"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=69e45e6fd11ab2ba19e9b299a5ff269eac1c4e8a#69e45e6fd11ab2ba19e9b299a5ff269eac1c4e8a"
 dependencies = [
  "ahash",
  "base64",
@@ -1384,7 +1384,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=87e52733cc1a053d136416403262b4a732831c0d#87e52733cc1a053d136416403262b4a732831c0d"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=69e45e6fd11ab2ba19e9b299a5ff269eac1c4e8a#69e45e6fd11ab2ba19e9b299a5ff269eac1c4e8a"
 dependencies = [
  "ahash",
  "base64",
@@ -1576,7 +1576,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=87e52733cc1a053d136416403262b4a732831c0d#87e52733cc1a053d136416403262b4a732831c0d"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=69e45e6fd11ab2ba19e9b299a5ff269eac1c4e8a#69e45e6fd11ab2ba19e9b299a5ff269eac1c4e8a"
 
 [[package]]
 name = "nexus-vault"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,13 +54,13 @@ exclude = ["nexus-fuse"]
 # dispatch to kernel/federation.rs, #85 HAL extension (rename +
 # setattr).  Bump alongside the rest of nexus-vfs updates when
 # a downstream change needs newer kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "87e52733cc1a053d136416403262b4a732831c0d" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "87e52733cc1a053d136416403262b4a732831c0d" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "87e52733cc1a053d136416403262b4a732831c0d" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "87e52733cc1a053d136416403262b4a732831c0d", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "87e52733cc1a053d136416403262b4a732831c0d", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "87e52733cc1a053d136416403262b4a732831c0d", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "87e52733cc1a053d136416403262b4a732831c0d" }
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "69e45e6fd11ab2ba19e9b299a5ff269eac1c4e8a" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "69e45e6fd11ab2ba19e9b299a5ff269eac1c4e8a" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "69e45e6fd11ab2ba19e9b299a5ff269eac1c4e8a" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "69e45e6fd11ab2ba19e9b299a5ff269eac1c4e8a", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "69e45e6fd11ab2ba19e9b299a5ff269eac1c4e8a", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "69e45e6fd11ab2ba19e9b299a5ff269eac1c4e8a", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "69e45e6fd11ab2ba19e9b299a5ff269eac1c4e8a" }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ENV CARGO_NET_RETRY=10 \
     CARGO_HTTP_TIMEOUT=120
 # Override for edge/CI or a different pin: --build-arg NEXUS_VFS_REV=<sha|tag>
-ARG NEXUS_VFS_REV=87e52733cc1a053d136416403262b4a732831c0d
+ARG NEXUS_VFS_REV=69e45e6fd11ab2ba19e9b299a5ff269eac1c4e8a
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,id=cargo-install-${TARGETARCH},target=/root/.cargo/target \

--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir --no-deps --prefix=/install .
 # enforces agreement) — an unpinned install tracks nexus-vfs HEAD and
 # ships an untested kernel (#4343). --locked honors the source tree's
 # Cargo.lock.
-ARG NEXUS_VFS_REV=87e52733cc1a053d136416403262b4a732831c0d
+ARG NEXUS_VFS_REV=69e45e6fd11ab2ba19e9b299a5ff269eac1c4e8a
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-cluster nexus-cluster
 
 # -- Runtime stage --

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -25,7 +25,7 @@ WORKDIR /build
 # (CI preflight enforces agreement) — an unpinned install tracks HEAD
 # and can skew the raft contract against the cluster/witness images.
 # --locked honors the source tree's Cargo.lock.
-ARG NEXUS_VFS_REV=87e52733cc1a053d136416403262b4a732831c0d
+ARG NEXUS_VFS_REV=69e45e6fd11ab2ba19e9b299a5ff269eac1c4e8a
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexus-raft-server raft
 
 # ---------- Production image ----------

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=87e52733cc1a053d136416403262b4a732831c0d
+ARG NEXUS_VFS_REV=69e45e6fd11ab2ba19e9b299a5ff269eac1c4e8a
 RUN cargo install \
     --locked \
     --git https://github.com/nexi-lab/nexus-vfs \


### PR DESCRIPTION
## Summary

E2E gate for [nexus-vfs PR #91](https://github.com/nexi-lab/nexus-vfs/pull/91) — moves the basename strip from the FFI plugin bridge INTO `Kernel::sys_readdir` itself, so both transports (FFI + gRPC) return the same shape.

Pinned at #91 branch HEAD (`69e45e6fd11ab2ba19e9b299a5ff269eac1c4e8a`), NOT main yet.

## Why this PR exists

Mac↔Win cc-tasks-share Direction A smoke (Win-host-fs-seed → Mac-FUSE-read) surfaced FUSE-T silently dropping name-with-`/` entries while WinFsp auto-extracted basenames. Two transport boundaries (FFI vs gRPC) returning different shapes was SSOT violation; PR #91 fixes by aligning to POSIX basename semantics in `Kernel::sys_readdir`.

## Backward compatibility

FUSE plugin saw basenames BEFORE (FFI bridge stripped) and continues to see basenames AFTER (kernel strips). Federation E2E + cc-tasks-share E2E (FFI-path Docker E2E suites) must stay green.

## Test plan

- [ ] Federation E2E green
- [ ] cc-tasks-share E2E green
- [ ] nexusd-cluster Smoke Test green
- [ ] All other CI gates green