### PR TITLE
chore(deps): E2E-gate nexus-vfs PR #92 (gRPC readdir basename symmetry)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=87e52733cc1a053d136416403262b4a732831c0d#87e52733cc1a053d136416403262b4a732831c0d"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=a7411f47f9e2417a150a3db74959758250f8d58f#a7411f47f9e2417a150a3db74959758250f8d58f"
 dependencies = [
  "ahash",
  "base64",
@@ -550,7 +550,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=87e52733cc1a053d136416403262b4a732831c0d#87e52733cc1a053d136416403262b4a732831c0d"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=a7411f47f9e2417a150a3db74959758250f8d58f#a7411f47f9e2417a150a3db74959758250f8d58f"
 dependencies = [
  "parking_lot",
  "serde",
@@ -1333,7 +1333,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=87e52733cc1a053d136416403262b4a732831c0d#87e52733cc1a053d136416403262b4a732831c0d"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=a7411f47f9e2417a150a3db74959758250f8d58f#a7411f47f9e2417a150a3db74959758250f8d58f"
 dependencies = [
  "ahash",
  "base64",
@@ -1384,7 +1384,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=87e52733cc1a053d136416403262b4a732831c0d#87e52733cc1a053d136416403262b4a732831c0d"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=a7411f47f9e2417a150a3db74959758250f8d58f#a7411f47f9e2417a150a3db74959758250f8d58f"
 dependencies = [
  "ahash",
  "base64",
@@ -1576,7 +1576,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=87e52733cc1a053d136416403262b4a732831c0d#87e52733cc1a053d136416403262b4a732831c0d"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=a7411f47f9e2417a150a3db74959758250f8d58f#a7411f47f9e2417a150a3db74959758250f8d58f"
 
 [[package]]
 name = "nexus-vault"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=a7411f47f9e2417a150a3db74959758250f8d58f#a7411f47f9e2417a150a3db74959758250f8d58f"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=fb996caa5cd1c38cad8a78da33e2c56e8a865222#fb996caa5cd1c38cad8a78da33e2c56e8a865222"
 dependencies = [
  "ahash",
  "base64",
@@ -550,7 +550,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=a7411f47f9e2417a150a3db74959758250f8d58f#a7411f47f9e2417a150a3db74959758250f8d58f"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=fb996caa5cd1c38cad8a78da33e2c56e8a865222#fb996caa5cd1c38cad8a78da33e2c56e8a865222"
 dependencies = [
  "parking_lot",
  "serde",
@@ -1333,7 +1333,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=a7411f47f9e2417a150a3db74959758250f8d58f#a7411f47f9e2417a150a3db74959758250f8d58f"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=fb996caa5cd1c38cad8a78da33e2c56e8a865222#fb996caa5cd1c38cad8a78da33e2c56e8a865222"
 dependencies = [
  "ahash",
  "base64",
@@ -1384,7 +1384,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=a7411f47f9e2417a150a3db74959758250f8d58f#a7411f47f9e2417a150a3db74959758250f8d58f"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=fb996caa5cd1c38cad8a78da33e2c56e8a865222#fb996caa5cd1c38cad8a78da33e2c56e8a865222"
 dependencies = [
  "ahash",
  "base64",
@@ -1576,7 +1576,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=a7411f47f9e2417a150a3db74959758250f8d58f#a7411f47f9e2417a150a3db74959758250f8d58f"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=fb996caa5cd1c38cad8a78da33e2c56e8a865222#fb996caa5cd1c38cad8a78da33e2c56e8a865222"
 
 [[package]]
 name = "nexus-vault"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,37 +30,27 @@ exclude = ["nexus-fuse"]
 [workspace.dependencies]
 # Kernel-tier crates from nexus-vfs (external git dependency).
 # SSOT: https://github.com/nexi-lab/nexus-vfs
-# Pinned at the nexus-vfs main commit that landed #85 (Phase 2 of
-# the bottom-up re-attempt of reverted PR #82): HAL surface
-# extension — adds rename + setattr methods to the
-# FederationPeerClient trait + matching Noop + FederationClient
-# async + sync bridges + backends StubClient impls.  No kernel
-# call site uses the new methods yet (Phase 3a / 3b / 3c will
-# add per-syscall short-circuits one at a time, each with its
-# own E2E gate, using the corrected design from
-# `feedback_defer_to_peer_only_for_byte_ops`).  E2E-validated
-# against Federation E2E + cc-tasks-share E2E suites before merge.
-# Builds on prior landmarks: #57 plugin-as-gRPC-service routing,
-# #58 sealed-keystore signing trust root, #60 KernelHandle v3
-# sys_stat_batch, #61 per-call EC/SC primitives, #62 CLI flag rename,
-# #63 EC hot-path activation revert, #65 EC drain hardening, #66
-# voter-default flip, #67 driver-readdir ABI v4, #68
-# driver-delete-file + driver-stat, #69 driver-rmdir, #70
-# FederationPeerClient + DRIVER_RMDIR ABI v5, #75 placeholder
-# inherits parent metastore, #76–#78 sys_unlink dispatch chain,
-# #79 DRY federation-peer-mount predicate + PeerBlobClient
-# reentrancy, #80 sys_write defer-to-peer, #81 preserve miss-on-
-# dispatch-failure semantics, #84 relocate federation-peer
-# dispatch to kernel/federation.rs, #85 HAL extension (rename +
-# setattr).  Bump alongside the rest of nexus-vfs updates when
-# a downstream change needs newer kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "87e52733cc1a053d136416403262b4a732831c0d" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "87e52733cc1a053d136416403262b4a732831c0d" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "87e52733cc1a053d136416403262b4a732831c0d" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "87e52733cc1a053d136416403262b4a732831c0d", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "87e52733cc1a053d136416403262b4a732831c0d", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "87e52733cc1a053d136416403262b4a732831c0d", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "87e52733cc1a053d136416403262b4a732831c0d" }
+# Pinned at the nexus-vfs `fix/grpc-readdir-basename-symmetry`
+# branch tip (PR #92): gRPC `readdir` handler strips full-path
+# entries down to POSIX basenames at the transport boundary,
+# symmetric with the FFI bridge that already strips.  This fixes
+# the Mac↔Win `cc tasks list` Direction-A smoke wedge, where
+# macOS FUSE-T silently dropped `reply.add(name)` entries whose
+# names contained `/` (Windows WinFsp auto-extracted the trailing
+# segment and masked the bug for months).  No kernel ABI change —
+# `Kernel::sys_readdir` (Tier 1) still returns full VFS paths for
+# its 18+ Tier 2 callers (vault storage, password_vault, ACP) that
+# benefit from full-path-return for compose convenience.
+# Builds on the prior pin (87e52733c — root-SOLO contract).
+# Bump alongside the rest of nexus-vfs updates when a downstream
+# change needs newer kernel bits.
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "a7411f47f9e2417a150a3db74959758250f8d58f" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "a7411f47f9e2417a150a3db74959758250f8d58f" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "a7411f47f9e2417a150a3db74959758250f8d58f" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "a7411f47f9e2417a150a3db74959758250f8d58f", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "a7411f47f9e2417a150a3db74959758250f8d58f", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "a7411f47f9e2417a150a3db74959758250f8d58f", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "a7411f47f9e2417a150a3db74959758250f8d58f" }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,8 +30,8 @@ exclude = ["nexus-fuse"]
 [workspace.dependencies]
 # Kernel-tier crates from nexus-vfs (external git dependency).
 # SSOT: https://github.com/nexi-lab/nexus-vfs
-# Pinned at the nexus-vfs `fix/grpc-readdir-basename-symmetry`
-# branch tip (PR #92): gRPC `readdir` handler strips full-path
+# Pinned at the nexus-vfs main commit that landed PR #92
+# (fb996caa5, merged 2026-06-28): gRPC `readdir` handler strips full-path
 # entries down to POSIX basenames at the transport boundary,
 # symmetric with the FFI bridge that already strips.  This fixes
 # the Mac↔Win `cc tasks list` Direction-A smoke wedge, where
@@ -44,13 +44,13 @@ exclude = ["nexus-fuse"]
 # Builds on the prior pin (87e52733c — root-SOLO contract).
 # Bump alongside the rest of nexus-vfs updates when a downstream
 # change needs newer kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "a7411f47f9e2417a150a3db74959758250f8d58f" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "a7411f47f9e2417a150a3db74959758250f8d58f" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "a7411f47f9e2417a150a3db74959758250f8d58f" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "a7411f47f9e2417a150a3db74959758250f8d58f", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "a7411f47f9e2417a150a3db74959758250f8d58f", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "a7411f47f9e2417a150a3db74959758250f8d58f", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "a7411f47f9e2417a150a3db74959758250f8d58f" }
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "fb996caa5cd1c38cad8a78da33e2c56e8a865222" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "fb996caa5cd1c38cad8a78da33e2c56e8a865222" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "fb996caa5cd1c38cad8a78da33e2c56e8a865222" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "fb996caa5cd1c38cad8a78da33e2c56e8a865222", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "fb996caa5cd1c38cad8a78da33e2c56e8a865222", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "fb996caa5cd1c38cad8a78da33e2c56e8a865222", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "fb996caa5cd1c38cad8a78da33e2c56e8a865222" }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ENV CARGO_NET_RETRY=10 \
     CARGO_HTTP_TIMEOUT=120
 # Override for edge/CI or a different pin: --build-arg NEXUS_VFS_REV=<sha|tag>
-ARG NEXUS_VFS_REV=87e52733cc1a053d136416403262b4a732831c0d
+ARG NEXUS_VFS_REV=a7411f47f9e2417a150a3db74959758250f8d58f
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,id=cargo-install-${TARGETARCH},target=/root/.cargo/target \

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ENV CARGO_NET_RETRY=10 \
     CARGO_HTTP_TIMEOUT=120
 # Override for edge/CI or a different pin: --build-arg NEXUS_VFS_REV=<sha|tag>
-ARG NEXUS_VFS_REV=a7411f47f9e2417a150a3db74959758250f8d58f
+ARG NEXUS_VFS_REV=fb996caa5cd1c38cad8a78da33e2c56e8a865222
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,id=cargo-install-${TARGETARCH},target=/root/.cargo/target \

--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir --no-deps --prefix=/install .
 # enforces agreement) — an unpinned install tracks nexus-vfs HEAD and
 # ships an untested kernel (#4343). --locked honors the source tree's
 # Cargo.lock.
-ARG NEXUS_VFS_REV=87e52733cc1a053d136416403262b4a732831c0d
+ARG NEXUS_VFS_REV=a7411f47f9e2417a150a3db74959758250f8d58f
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-cluster nexus-cluster
 
 # -- Runtime stage --

--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir --no-deps --prefix=/install .
 # enforces agreement) — an unpinned install tracks nexus-vfs HEAD and
 # ships an untested kernel (#4343). --locked honors the source tree's
 # Cargo.lock.
-ARG NEXUS_VFS_REV=a7411f47f9e2417a150a3db74959758250f8d58f
+ARG NEXUS_VFS_REV=fb996caa5cd1c38cad8a78da33e2c56e8a865222
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-cluster nexus-cluster
 
 # -- Runtime stage --

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -25,7 +25,7 @@ WORKDIR /build
 # (CI preflight enforces agreement) — an unpinned install tracks HEAD
 # and can skew the raft contract against the cluster/witness images.
 # --locked honors the source tree's Cargo.lock.
-ARG NEXUS_VFS_REV=a7411f47f9e2417a150a3db74959758250f8d58f
+ARG NEXUS_VFS_REV=fb996caa5cd1c38cad8a78da33e2c56e8a865222
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexus-raft-server raft
 
 # ---------- Production image ----------

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -25,7 +25,7 @@ WORKDIR /build
 # (CI preflight enforces agreement) — an unpinned install tracks HEAD
 # and can skew the raft contract against the cluster/witness images.
 # --locked honors the source tree's Cargo.lock.
-ARG NEXUS_VFS_REV=87e52733cc1a053d136416403262b4a732831c0d
+ARG NEXUS_VFS_REV=a7411f47f9e2417a150a3db74959758250f8d58f
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexus-raft-server raft
 
 # ---------- Production image ----------

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=a7411f47f9e2417a150a3db74959758250f8d58f
+ARG NEXUS_VFS_REV=fb996caa5cd1c38cad8a78da33e2c56e8a865222
 RUN cargo install \
     --locked \
     --git https://github.com/nexi-lab/nexus-vfs \

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=87e52733cc1a053d136416403262b4a732831c0d
+ARG NEXUS_VFS_REV=a7411f47f9e2417a150a3db74959758250f8d58f
 RUN cargo install \
     --locked \
     --git https://github.com/nexi-lab/nexus-vfs \


### PR DESCRIPTION
## Summary

E2E gate for [nexus-vfs PR #92](https://github.com/nexi-lab/nexus-vfs/pull/92) — bumps the nexus-vfs pin from `87e52733c` (root-SOLO contract) to `a7411f47f` (`fix/grpc-readdir-basename-symmetry`).

The nexus-vfs PR fixes the Mac↔Win `cc tasks list` Direction-A smoke wedge at the transport boundary:

- `Kernel::sys_readdir` (Tier 1) returns full VFS paths for compose convenience to its 18+ Tier 2 callers (vault storage, `password_vault`, ACP). That contract stays.
- The **gRPC `readdir` handler** at `rust/transport/src/grpc.rs` now strips those full paths down to POSIX basenames at the transport boundary, **symmetric with the FFI bridge** at `kernel/src/kernel/plugins/mod.rs` that already strips via `rsplit_once('/')`.
- macOS FUSE-T silently dropped `reply.add(_, _, _, "/shared/cc-tasks/macos")` entries (POSIX `dirent` names cannot contain `/`); Windows WinFsp auto-extracted the trailing segment and masked the bug for months.

## What this PR runs

- Federation E2E (`test_federation_runbook.py`)
- cc-tasks-share E2E (`test_cc_tasks_share_e2e.py`, including `TestCcTasksListBackendOnlyCrossNodeEnumeration`)
- Standard nexus checks (clippy / fmt / unit tests on services + plugins)

## Merge plan

1. nexus-vfs PR #92 admin-merges first once its kernel-tier CI is green.
2. Repoint this PR's pin from `a7411f47f` (branch tip) to the post-merge `main` SHA.
3. Re-run CI here.
4. Admin-merge this PR once both green.

## Closed dead-ends in this thread

- nexus PR #4451 — companion to closed nexus-vfs PR #91 (`Kernel::sys_readdir` returns basenames). Wrong tier; would have broken 18+ Tier 2 callers. Replaced by this PR + nexus-vfs PR #92's transport-boundary fix.