### PR TITLE
chore(deps): E2E-gate nexus-vfs PR #94 (federation dispatch observability)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=87e52733cc1a053d136416403262b4a732831c0d#87e52733cc1a053d136416403262b4a732831c0d"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=051bc598439d2cb801e2dc0c282407a4dbd158a0#051bc598439d2cb801e2dc0c282407a4dbd158a0"
 dependencies = [
  "ahash",
  "base64",
@@ -550,7 +550,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=87e52733cc1a053d136416403262b4a732831c0d#87e52733cc1a053d136416403262b4a732831c0d"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=051bc598439d2cb801e2dc0c282407a4dbd158a0#051bc598439d2cb801e2dc0c282407a4dbd158a0"
 dependencies = [
  "parking_lot",
  "serde",
@@ -1333,7 +1333,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=87e52733cc1a053d136416403262b4a732831c0d#87e52733cc1a053d136416403262b4a732831c0d"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=051bc598439d2cb801e2dc0c282407a4dbd158a0#051bc598439d2cb801e2dc0c282407a4dbd158a0"
 dependencies = [
  "ahash",
  "base64",
@@ -1384,7 +1384,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=87e52733cc1a053d136416403262b4a732831c0d#87e52733cc1a053d136416403262b4a732831c0d"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=051bc598439d2cb801e2dc0c282407a4dbd158a0#051bc598439d2cb801e2dc0c282407a4dbd158a0"
 dependencies = [
  "ahash",
  "base64",
@@ -1576,7 +1576,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=87e52733cc1a053d136416403262b4a732831c0d#87e52733cc1a053d136416403262b4a732831c0d"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=051bc598439d2cb801e2dc0c282407a4dbd158a0#051bc598439d2cb801e2dc0c282407a4dbd158a0"
 
 [[package]]
 name = "nexus-vault"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,37 +30,22 @@ exclude = ["nexus-fuse"]
 [workspace.dependencies]
 # Kernel-tier crates from nexus-vfs (external git dependency).
 # SSOT: https://github.com/nexi-lab/nexus-vfs
-# Pinned at the nexus-vfs main commit that landed #85 (Phase 2 of
-# the bottom-up re-attempt of reverted PR #82): HAL surface
-# extension — adds rename + setattr methods to the
-# FederationPeerClient trait + matching Noop + FederationClient
-# async + sync bridges + backends StubClient impls.  No kernel
-# call site uses the new methods yet (Phase 3a / 3b / 3c will
-# add per-syscall short-circuits one at a time, each with its
-# own E2E gate, using the corrected design from
-# `feedback_defer_to_peer_only_for_byte_ops`).  E2E-validated
-# against Federation E2E + cc-tasks-share E2E suites before merge.
-# Builds on prior landmarks: #57 plugin-as-gRPC-service routing,
-# #58 sealed-keystore signing trust root, #60 KernelHandle v3
-# sys_stat_batch, #61 per-call EC/SC primitives, #62 CLI flag rename,
-# #63 EC hot-path activation revert, #65 EC drain hardening, #66
-# voter-default flip, #67 driver-readdir ABI v4, #68
-# driver-delete-file + driver-stat, #69 driver-rmdir, #70
-# FederationPeerClient + DRIVER_RMDIR ABI v5, #75 placeholder
-# inherits parent metastore, #76–#78 sys_unlink dispatch chain,
-# #79 DRY federation-peer-mount predicate + PeerBlobClient
-# reentrancy, #80 sys_write defer-to-peer, #81 preserve miss-on-
-# dispatch-failure semantics, #84 relocate federation-peer
-# dispatch to kernel/federation.rs, #85 HAL extension (rename +
-# setattr).  Bump alongside the rest of nexus-vfs updates when
-# a downstream change needs newer kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "87e52733cc1a053d136416403262b4a732831c0d" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "87e52733cc1a053d136416403262b4a732831c0d" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "87e52733cc1a053d136416403262b4a732831c0d" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "87e52733cc1a053d136416403262b4a732831c0d", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "87e52733cc1a053d136416403262b4a732831c0d", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "87e52733cc1a053d136416403262b4a732831c0d", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "87e52733cc1a053d136416403262b4a732831c0d" }
+# Pinned at the nexus-vfs main commit that landed PR #94
+# (051bc598, merged 2026-06-29): warn-loud diagnostics on the
+# three silent-failure paths of `dispatch_federation_peer`
+# (target_zone_id=None / zone_peers empty / all peers RPC failed).
+# Pure observability — no contract change.  Drives the Federation
+# E2E + cc-tasks-share E2E suites against the new logs so the
+# Mac↔Win Direction-A re-investigation has ground-truth signals.
+# Bump alongside the rest of nexus-vfs updates when a downstream
+# change needs newer kernel bits.
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "051bc598439d2cb801e2dc0c282407a4dbd158a0" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "051bc598439d2cb801e2dc0c282407a4dbd158a0" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "051bc598439d2cb801e2dc0c282407a4dbd158a0" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "051bc598439d2cb801e2dc0c282407a4dbd158a0", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "051bc598439d2cb801e2dc0c282407a4dbd158a0", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "051bc598439d2cb801e2dc0c282407a4dbd158a0", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "051bc598439d2cb801e2dc0c282407a4dbd158a0" }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ENV CARGO_NET_RETRY=10 \
     CARGO_HTTP_TIMEOUT=120
 # Override for edge/CI or a different pin: --build-arg NEXUS_VFS_REV=<sha|tag>
-ARG NEXUS_VFS_REV=87e52733cc1a053d136416403262b4a732831c0d
+ARG NEXUS_VFS_REV=051bc598439d2cb801e2dc0c282407a4dbd158a0
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,id=cargo-install-${TARGETARCH},target=/root/.cargo/target \

--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir --no-deps --prefix=/install .
 # enforces agreement) — an unpinned install tracks nexus-vfs HEAD and
 # ships an untested kernel (#4343). --locked honors the source tree's
 # Cargo.lock.
-ARG NEXUS_VFS_REV=87e52733cc1a053d136416403262b4a732831c0d
+ARG NEXUS_VFS_REV=051bc598439d2cb801e2dc0c282407a4dbd158a0
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-cluster nexus-cluster
 
 # -- Runtime stage --

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -25,7 +25,7 @@ WORKDIR /build
 # (CI preflight enforces agreement) — an unpinned install tracks HEAD
 # and can skew the raft contract against the cluster/witness images.
 # --locked honors the source tree's Cargo.lock.
-ARG NEXUS_VFS_REV=87e52733cc1a053d136416403262b4a732831c0d
+ARG NEXUS_VFS_REV=051bc598439d2cb801e2dc0c282407a4dbd158a0
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexus-raft-server raft
 
 # ---------- Production image ----------

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=87e52733cc1a053d136416403262b4a732831c0d
+ARG NEXUS_VFS_REV=051bc598439d2cb801e2dc0c282407a4dbd158a0
 RUN cargo install \
     --locked \
     --git https://github.com/nexi-lab/nexus-vfs \


### PR DESCRIPTION
## Summary

E2E gate for [nexus-vfs PR #94](https://github.com/nexi-lab/nexus-vfs/pull/94) — bumps the nexus-vfs pin from \`87e52733c\` to the post-merge \`051bc598\` so the Federation E2E + cc-tasks-share E2E suites validate the new warn-level dispatch diagnostics.

PR #94 makes \`dispatch_federation_peer\` (the SSOT for every federation-peer RPC: readdir / stat / write / unlink / mkdir / rename / setattr) **warn-loud** on three silent-failure paths that all previously presented to the caller as \"directory is empty\":
- \`route.target_zone_id == None\` despite caller checking \`is_federation_peer_mount()\` → routing-table SSOT regression
- \`zone_peers()\` returned empty → joiner not joined / stale conf / 0-voter zone
- Every non-self voter's RPC errored → only debug-level pre-#94, easy to miss

Pure observability — no contract change, no syscall ABI change, every caller still receives \`Option<T>\` with the same semantics. Mac↔Win Direction-A wedge presents exactly as the silent-empty pattern; the next diagnostic round will have ground-truth signals via the new warn lines.

## What this PR runs

- Federation E2E (\`test_federation_runbook.py\`)
- cc-tasks-share E2E (\`test_cc_tasks_share_e2e.py\`, full suite)
- Self-contained E2E (\`tests/e2e/self_contained/\`) — the suite that caught the PR #92 regression
- Standard nexus checks (clippy / fmt / unit tests on services + plugins)

## Merge plan

Once all CI green, admin-merge per \`feedback_admin_merge_self_approve\` (we are elfenlieds7).