### PR TITLE
[codex] Close Koodle edge qualification gaps

### DIFF
--- a/alembic/versions/align_graph_zone_columns.py
+++ b/alembic/versions/align_graph_zone_columns.py
@@ -1,0 +1,696 @@
+"""Align graph storage tenant columns with the zone-scoped ORM models.
+
+Revision ID: align_graph_zone_columns
+Revises: add_chunk_heading_prefix
+Create Date: 2026-06-28
+"""
+
+import re
+from collections.abc import Mapping, Sequence
+from typing import Any, Literal, Union
+
+import sqlalchemy as sa
+from sqlalchemy.engine.interfaces import ReflectedIndex, ReflectedUniqueConstraint
+
+from alembic import op
+
+revision: str = "align_graph_zone_columns"
+down_revision: Union[str, Sequence[str], None] = "add_chunk_heading_prefix"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_GRAPH_TABLES = ("entities", "relationships")
+_INDEX_RENAMES = (
+    ("entities", "idx_entities_tenant", "idx_entities_zone"),
+    ("entities", "idx_entities_tenant_type", "idx_entities_zone_type"),
+    ("relationships", "idx_relationships_tenant", "idx_relationships_zone"),
+)
+_UNIQUE_RENAMES = (("entities", "uq_entity_tenant_name", "uq_entity_zone_name"),)
+
+
+def _inspector() -> sa.Inspector:
+    return sa.inspect(op.get_bind())
+
+
+def _columns(table_name: str) -> dict[str, Any]:
+    inspector = _inspector()
+    if table_name not in inspector.get_table_names():
+        return {}
+    return {column["name"]: column for column in inspector.get_columns(table_name)}
+
+
+def _index_names(table_name: str) -> set[str]:
+    if not _columns(table_name):
+        return set()
+    return {
+        name
+        for index in _inspector().get_indexes(table_name)
+        if isinstance((name := index.get("name")), str)
+    }
+
+
+def _unique_constraint_names(table_name: str) -> set[str]:
+    if not _columns(table_name):
+        return set()
+    return {
+        name
+        for constraint in _inspector().get_unique_constraints(table_name)
+        if isinstance((name := constraint.get("name")), str)
+    }
+
+
+def _is_string_64(column: Any) -> bool:
+    column_type = column["type"]
+    return isinstance(column_type, sa.String) and column_type.length == 64
+
+
+def _quoted_identifier(identifier: str) -> str:
+    return op.get_bind().dialect.identifier_preparer.quote(identifier)
+
+
+def _reflected_name(reflected_object: Any) -> str:
+    name = reflected_object.get("name")
+    if not isinstance(name, str):
+        raise RuntimeError("reflected schema object has no usable name")
+    return name
+
+
+def _replace_sql_identifier(value: str, old_column: str, new_column: str) -> str:
+    """Replace an exact SQL identifier without rewriting literals or comments."""
+    chunks: list[str] = []
+    index = 0
+    while index < len(value):
+        if value.startswith("--", index):
+            end = value.find("\n", index)
+            if end == -1:
+                chunks.append(value[index:])
+                break
+            chunks.append(value[index:end])
+            index = end
+            continue
+
+        if value.startswith("/*", index):
+            end = index + 2
+            depth = 1
+            while end < len(value) and depth:
+                if value.startswith("/*", end):
+                    depth += 1
+                    end += 2
+                elif value.startswith("*/", end):
+                    depth -= 1
+                    end += 2
+                else:
+                    end += 1
+            chunks.append(value[index:end])
+            index = end
+            continue
+
+        character = value[index]
+        if character == "'":
+            prefix_index = index - 1
+            escape_string = (
+                prefix_index >= 0
+                and value[prefix_index] in {"E", "e"}
+                and (
+                    prefix_index == 0
+                    or not (
+                        value[prefix_index - 1] in {"_", "$"} or value[prefix_index - 1].isalnum()
+                    )
+                )
+            )
+            end = index + 1
+            while end < len(value):
+                if escape_string and value[end] == "\\":
+                    end = min(end + 2, len(value))
+                    continue
+                if value[end] != "'":
+                    end += 1
+                    continue
+                if end + 1 < len(value) and value[end + 1] == "'":
+                    end += 2
+                    continue
+                end += 1
+                break
+            chunks.append(value[index:end])
+            index = end
+            continue
+
+        if character == '"':
+            end = index + 1
+            quoted_identifier_chars: list[str] = []
+            while end < len(value):
+                if value[end] != '"':
+                    quoted_identifier_chars.append(value[end])
+                    end += 1
+                    continue
+                if end + 1 < len(value) and value[end + 1] == '"':
+                    quoted_identifier_chars.append('"')
+                    end += 2
+                    continue
+                end += 1
+                break
+            if end <= len(value) and "".join(quoted_identifier_chars) == old_column:
+                chunks.append(f'"{new_column.replace(chr(34), chr(34) * 2)}"')
+            else:
+                chunks.append(value[index:end])
+            index = end
+            continue
+
+        if character == "$":
+            delimiter_match = re.match(r"\$(?:[A-Za-z_][A-Za-z0-9_]*)?\$", value[index:])
+            if delimiter_match:
+                delimiter = delimiter_match.group(0)
+                end = value.find(delimiter, index + len(delimiter))
+                if end != -1:
+                    end += len(delimiter)
+                    chunks.append(value[index:end])
+                    index = end
+                    continue
+
+        if character == "_" or character.isalpha():
+            end = index + 1
+            while end < len(value) and (value[end] in {"_", "$"} or value[end].isalnum()):
+                end += 1
+            identifier = value[index:end]
+            chunks.append(new_column if identifier == old_column else identifier)
+            index = end
+            continue
+
+        chunks.append(character)
+        index += 1
+
+    return "".join(chunks)
+
+
+def _transform_reflected_value(value: Any, old_column: str, new_column: str) -> Any:
+    if isinstance(value, sa.sql.elements.TextClause):
+        return sa.text(_replace_sql_identifier(value.text, old_column, new_column))
+    if isinstance(value, str):
+        return _replace_sql_identifier(value, old_column, new_column)
+    if isinstance(value, Mapping):
+        return {
+            _transform_reflected_value(key, old_column, new_column): _transform_reflected_value(
+                item,
+                old_column,
+                new_column,
+            )
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [_transform_reflected_value(item, old_column, new_column) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_transform_reflected_value(item, old_column, new_column) for item in value)
+    if isinstance(value, set):
+        return {_transform_reflected_value(item, old_column, new_column) for item in value}
+    if isinstance(value, frozenset):
+        return frozenset(_transform_reflected_value(item, old_column, new_column) for item in value)
+    return value
+
+
+def _reflected_value_references_identifier(value: Any, identifier: str) -> bool:
+    replacement = f"__nexus_migration_replacement_{identifier}__"
+    if isinstance(value, sa.sql.elements.TextClause):
+        return _replace_sql_identifier(value.text, identifier, replacement) != value.text
+    if isinstance(value, str):
+        return _replace_sql_identifier(value, identifier, replacement) != value
+    if isinstance(value, Mapping):
+        return any(
+            _reflected_value_references_identifier(key, identifier)
+            or _reflected_value_references_identifier(item, identifier)
+            for key, item in value.items()
+        )
+    if isinstance(value, (list, tuple, set, frozenset)):
+        return any(_reflected_value_references_identifier(item, identifier) for item in value)
+    return False
+
+
+def _reflected_object_depends_on_column(reflected_object: Any, column_name: str) -> bool:
+    return any(
+        key in reflected_object
+        and _reflected_value_references_identifier(reflected_object[key], column_name)
+        for key in (
+            "column_names",
+            "dialect_options",
+            "include_columns",
+            "expressions",
+            "column_sorting",
+        )
+    )
+
+
+def _transformed_columns(
+    reflected_object: Any,
+    old_column: str,
+    new_column: str,
+) -> tuple[str | None, ...]:
+    return tuple(
+        new_column if column_name == old_column else column_name
+        for column_name in (reflected_object.get("column_names") or ())
+    )
+
+
+def _transformed_dialect_options(
+    reflected_object: Any,
+    old_column: str,
+    new_column: str,
+) -> dict[str, Any]:
+    options = reflected_object.get("dialect_options") or {}
+    if not isinstance(options, Mapping):
+        return {}
+    return {
+        str(key): _transform_reflected_value(value, old_column, new_column)
+        for key, value in options.items()
+    }
+
+
+def _transformed_index_options(
+    reflected_index: Any,
+    old_column: str,
+    new_column: str,
+    dialect_name: str,
+) -> dict[str, Any]:
+    options = _transformed_dialect_options(reflected_index, old_column, new_column)
+    if (
+        dialect_name == "postgresql"
+        and "postgresql_include" not in options
+        and reflected_index.get("include_columns")
+    ):
+        options["postgresql_include"] = _transform_reflected_value(
+            reflected_index["include_columns"],
+            old_column,
+            new_column,
+        )
+    return options
+
+
+def _transformed_index_elements(
+    reflected_index: Any,
+    old_column: str,
+    new_column: str,
+) -> list[Any]:
+    expressions = reflected_index.get("expressions") or ()
+    if isinstance(expressions, str) or not isinstance(expressions, Sequence):
+        expressions = ()
+    sorting = _transform_reflected_value(
+        reflected_index.get("column_sorting") or {},
+        old_column,
+        new_column,
+    )
+    if not isinstance(sorting, Mapping):
+        sorting = {}
+
+    elements: list[Any] = []
+    for position, column_name in enumerate(reflected_index.get("column_names") or ()):
+        is_expression = column_name is None
+        if is_expression:
+            if position >= len(expressions) or not isinstance(expressions[position], str):
+                raise RuntimeError("reflected expression index has no usable expression")
+            element = _replace_sql_identifier(expressions[position], old_column, new_column)
+        else:
+            element = _replace_sql_identifier(column_name, old_column, new_column)
+
+        sorting_flags = sorting.get(element, ())
+        if sorting_flags:
+            sorting_sql = {
+                "asc": "ASC",
+                "desc": "DESC",
+                "nulls_first": "NULLS FIRST",
+                "nulls_last": "NULLS LAST",
+            }
+            try:
+                suffix = " ".join(sorting_sql[flag] for flag in sorting_flags)
+            except KeyError as error:
+                raise RuntimeError(
+                    f"unsupported reflected index sorting flag: {error.args[0]}"
+                ) from error
+            element = f"{element} {suffix}"
+            is_expression = True
+
+        elements.append(sa.text(element) if is_expression else element)
+    return elements
+
+
+def _signature_value(value: Any) -> str:
+    if isinstance(value, sa.sql.elements.TextClause):
+        return f"sql:{value.text}"
+    if isinstance(value, Mapping):
+        items = sorted(
+            (_signature_value(key), _signature_value(item)) for key, item in value.items()
+        )
+        return f"mapping:{items!r}"
+    if isinstance(value, (list, tuple)):
+        return f"sequence:{tuple(_signature_value(item) for item in value)!r}"
+    if isinstance(value, (set, frozenset)):
+        return f"set:{tuple(sorted(_signature_value(item) for item in value))!r}"
+    return f"{type(value).__qualname__}:{value!r}"
+
+
+def _logical_signature(
+    reflected_object: Any,
+    old_column: str,
+    new_column: str,
+    *,
+    unique: bool,
+) -> tuple[tuple[str | None, ...], bool, tuple[tuple[str, str], ...]]:
+    details: dict[str, Any] = {}
+    for key in ("dialect_options", "expressions", "include_columns", "column_sorting"):
+        if key not in reflected_object:
+            continue
+        value = reflected_object[key]
+        if isinstance(value, (Mapping, list, tuple, set, frozenset)) and not value:
+            continue
+        details[key] = _transform_reflected_value(value, old_column, new_column)
+    return (
+        _transformed_columns(reflected_object, old_column, new_column),
+        unique,
+        tuple(sorted((key, _signature_value(value)) for key, value in details.items())),
+    )
+
+
+def _legacy_dependencies(
+    table_name: str,
+    old_column: str,
+) -> tuple[list[ReflectedIndex], list[ReflectedUniqueConstraint]]:
+    """Return real indexes and unique constraints that depend on the old column."""
+    inspector = _inspector()
+    indexes_by_name: dict[str, ReflectedIndex] = {}
+    for index in inspector.get_indexes(table_name):
+        name = index.get("name")
+        if (
+            not isinstance(name, str)
+            or name in indexes_by_name
+            or not _reflected_object_depends_on_column(index, old_column)
+            # PostgreSQL exposes a unique constraint's backing index here too.
+            # The constraint owns that index, so it must never be treated as a
+            # separately droppable/recreatable index.
+            or index.get("duplicates_constraint")
+        ):
+            continue
+        indexes_by_name[name] = index
+
+    uniques_by_name: dict[str, ReflectedUniqueConstraint] = {}
+    for constraint in inspector.get_unique_constraints(table_name):
+        name = constraint.get("name")
+        if (
+            not isinstance(name, str)
+            or name in uniques_by_name
+            or not _reflected_object_depends_on_column(constraint, old_column)
+        ):
+            continue
+        uniques_by_name[name] = constraint
+
+    return list(indexes_by_name.values()), list(uniques_by_name.values())
+
+
+def _renamed_object(
+    table_name: str,
+    object_name: str,
+    renames: tuple[tuple[str, str, str], ...],
+    direction: Literal["upgrade", "downgrade"],
+) -> str:
+    for mapped_table, tenant_name, zone_name in renames:
+        if mapped_table != table_name:
+            continue
+        old_name, new_name = (
+            (tenant_name, zone_name) if direction == "upgrade" else (zone_name, tenant_name)
+        )
+        if object_name == old_name:
+            return new_name
+    return object_name
+
+
+def _merge_and_remove_old_column(
+    table_name: str,
+    old_column: str,
+    new_column: str,
+    direction: Literal["upgrade", "downgrade"],
+) -> None:
+    """Merge a partially aligned table without rebuilding it on SQLite."""
+    legacy_indexes, legacy_uniques = _legacy_dependencies(table_name, old_column)
+    dialect_name = op.get_bind().dialect.name
+
+    if dialect_name == "sqlite" and legacy_uniques:
+        raise RuntimeError(
+            f"cannot safely remove {old_column} from {table_name} on SQLite because "
+            "a unique constraint depends on the legacy column"
+        )
+
+    quoted_table = _quoted_identifier(table_name)
+    quoted_old = _quoted_identifier(old_column)
+    quoted_new = _quoted_identifier(new_column)
+    op.execute(
+        sa.text(
+            f"UPDATE {quoted_table} SET {quoted_new} = {quoted_old} "
+            f"WHERE ({quoted_new} IS NULL OR {quoted_new} = '') "
+            f"AND {quoted_old} IS NOT NULL"
+        )
+    )
+
+    dropped_index_names = {index["name"] for index in legacy_indexes}
+    dropped_unique_names = {constraint["name"] for constraint in legacy_uniques}
+    surviving_index_names = _index_names(table_name) - dropped_index_names
+    surviving_unique_names = _unique_constraint_names(table_name) - dropped_unique_names
+    inspector = _inspector()
+    surviving_index_signatures = {
+        _logical_signature(
+            index,
+            old_column,
+            new_column,
+            unique=bool(index.get("unique", False)),
+        )
+        for index in inspector.get_indexes(table_name)
+        if index.get("name") not in dropped_index_names and not index.get("duplicates_constraint")
+    }
+    surviving_unique_signatures = {
+        _logical_signature(
+            constraint,
+            old_column,
+            new_column,
+            unique=True,
+        )
+        for constraint in inspector.get_unique_constraints(table_name)
+        if constraint.get("name") not in dropped_unique_names
+    }
+    recreated_index_names: set[str] = set()
+    recreated_unique_names: set[str] = set()
+    new_info = _columns(table_name)[new_column]
+
+    for index in legacy_indexes:
+        op.drop_index(_reflected_name(index), table_name=table_name)
+    for constraint in legacy_uniques:
+        op.drop_constraint(_reflected_name(constraint), table_name, type_="unique")
+
+    if dialect_name == "sqlite":
+        op.execute(sa.text(f"ALTER TABLE {quoted_table} DROP COLUMN {quoted_old}"))
+    else:
+        op.drop_column(table_name, old_column)
+        if not _is_string_64(new_info):
+            op.alter_column(
+                table_name,
+                new_column,
+                existing_type=new_info["type"],
+                existing_nullable=new_info["nullable"],
+                type_=sa.String(length=64),
+            )
+
+    for index in legacy_indexes:
+        index_name = _reflected_name(index)
+        target_name = _renamed_object(
+            table_name,
+            index_name,
+            _INDEX_RENAMES,
+            direction,
+        )
+        signature = _logical_signature(
+            index,
+            old_column,
+            new_column,
+            unique=bool(index.get("unique", False)),
+        )
+        if (
+            target_name in surviving_index_names
+            or target_name in recreated_index_names
+            or signature in surviving_index_signatures
+        ):
+            continue
+        op.create_index(
+            target_name,
+            table_name,
+            _transformed_index_elements(index, old_column, new_column),
+            unique=bool(index.get("unique", False)),
+            **_transformed_index_options(index, old_column, new_column, dialect_name),
+        )
+        recreated_index_names.add(target_name)
+        surviving_index_signatures.add(signature)
+
+    for constraint in legacy_uniques:
+        constraint_name = _reflected_name(constraint)
+        target_name = _renamed_object(
+            table_name,
+            constraint_name,
+            _UNIQUE_RENAMES,
+            direction,
+        )
+        signature = _logical_signature(
+            constraint,
+            old_column,
+            new_column,
+            unique=True,
+        )
+        if (
+            target_name in surviving_unique_names
+            or target_name in recreated_unique_names
+            or signature in surviving_unique_signatures
+        ):
+            continue
+        op.create_unique_constraint(
+            target_name,
+            table_name,
+            [
+                new_column if column_name == old_column else column_name
+                for column_name in constraint["column_names"]
+                if column_name is not None
+            ],
+            **_transformed_dialect_options(constraint, old_column, new_column),
+        )
+        recreated_unique_names.add(target_name)
+        surviving_unique_signatures.add(signature)
+
+
+def _assert_no_conflicting_values(table_name: str, old_column: str, new_column: str) -> None:
+    columns = _columns(table_name)
+    if old_column not in columns or new_column not in columns:
+        return
+
+    quoted_table = _quoted_identifier(table_name)
+    quoted_old = _quoted_identifier(old_column)
+    quoted_new = _quoted_identifier(new_column)
+    conflict_count = (
+        op.get_bind()
+        .execute(
+            sa.text(
+                f"SELECT COUNT(*) FROM {quoted_table} "
+                f"WHERE {quoted_new} IS NOT NULL AND {quoted_new} <> '' "
+                f"AND {quoted_old} IS NOT NULL AND {quoted_new} <> {quoted_old}"
+            )
+        )
+        .scalar_one()
+    )
+    if conflict_count:
+        raise RuntimeError(
+            f"Conflicting {old_column} and {new_column} values in {table_name}; "
+            "refusing to modify graph data"
+        )
+
+
+def _assert_sqlite_mixed_schema_is_safe(
+    table_name: str,
+    old_column: str,
+    new_column: str,
+) -> None:
+    if op.get_bind().dialect.name != "sqlite":
+        return
+    columns = _columns(table_name)
+    if old_column not in columns or new_column not in columns:
+        return
+    _, legacy_uniques = _legacy_dependencies(table_name, old_column)
+    if legacy_uniques:
+        raise RuntimeError(
+            f"cannot safely remove {old_column} from {table_name} on SQLite because "
+            "a unique constraint depends on the legacy column"
+        )
+
+
+def _preflight_alignment(old_column: str, new_column: str) -> None:
+    for table_name in _GRAPH_TABLES:
+        _assert_no_conflicting_values(table_name, old_column, new_column)
+        _assert_sqlite_mixed_schema_is_safe(table_name, old_column, new_column)
+
+
+def _align_column(
+    table_name: str,
+    old_column: str,
+    new_column: str,
+    direction: Literal["upgrade", "downgrade"],
+) -> None:
+    columns = _columns(table_name)
+    if not columns:
+        return
+
+    has_old = old_column in columns
+    has_new = new_column in columns
+    if has_old and has_new:
+        _merge_and_remove_old_column(table_name, old_column, new_column, direction)
+        return
+    if has_old:
+        old_info = columns[old_column]
+        if op.get_bind().dialect.name == "sqlite":
+            quoted_table = _quoted_identifier(table_name)
+            quoted_old = _quoted_identifier(old_column)
+            quoted_new = _quoted_identifier(new_column)
+            op.execute(
+                sa.text(f"ALTER TABLE {quoted_table} RENAME COLUMN {quoted_old} TO {quoted_new}")
+            )
+        else:
+            op.alter_column(
+                table_name,
+                old_column,
+                new_column_name=new_column,
+                existing_type=old_info["type"],
+                existing_nullable=old_info["nullable"],
+                type_=sa.String(length=64),
+            )
+        return
+    if (
+        has_new
+        and op.get_bind().dialect.name != "sqlite"
+        and not _is_string_64(columns[new_column])
+    ):
+        new_info = columns[new_column]
+        op.alter_column(
+            table_name,
+            new_column,
+            existing_type=new_info["type"],
+            existing_nullable=new_info["nullable"],
+            type_=sa.String(length=64),
+        )
+
+
+def _rename_postgresql_schema_objects(
+    direction: Literal["upgrade", "downgrade"],
+) -> None:
+    """Rename legacy PostgreSQL object names after the column rename."""
+    if op.get_bind().dialect.name != "postgresql":
+        return
+
+    for table_name, tenant_name, zone_name in _INDEX_RENAMES:
+        old_name, new_name = (
+            (tenant_name, zone_name) if direction == "upgrade" else (zone_name, tenant_name)
+        )
+        names = _index_names(table_name)
+        if old_name in names and new_name not in names:
+            op.execute(sa.text(f"ALTER INDEX {old_name} RENAME TO {new_name}"))
+
+    for table_name, tenant_name, zone_name in _UNIQUE_RENAMES:
+        old_name, new_name = (
+            (tenant_name, zone_name) if direction == "upgrade" else (zone_name, tenant_name)
+        )
+        names = _unique_constraint_names(table_name)
+        if old_name in names and new_name not in names:
+            op.execute(
+                sa.text(f"ALTER TABLE {table_name} RENAME CONSTRAINT {old_name} TO {new_name}")
+            )
+
+
+def upgrade() -> None:
+    _preflight_alignment("tenant_id", "zone_id")
+    for table_name in _GRAPH_TABLES:
+        _align_column(table_name, "tenant_id", "zone_id", "upgrade")
+    _rename_postgresql_schema_objects("upgrade")
+
+
+def downgrade() -> None:
+    _preflight_alignment("zone_id", "tenant_id")
+    for table_name in _GRAPH_TABLES:
+        _align_column(table_name, "zone_id", "tenant_id", "downgrade")
+    _rename_postgresql_schema_objects("downgrade")

--- a/docs/superpowers/plans/2026-06-28-koodle-edge-qualification-gaps.md
+++ b/docs/superpowers/plans/2026-06-28-koodle-edge-qualification-gaps.md
@@ -1,0 +1,282 @@
+# Koodle Edge Qualification Gaps Implementation Plan
+
+> **For Codex:** Execute every change test-first. Keep subsystem diffs independent,
+> run each focused suite before its commit, and never deploy or mutate Koodle production.
+
+**Goal:** Fix all eight Nexus-owned defects found while qualifying Koodle against the
+current edge image, then open one upstream draft PR against `develop`.
+
+**Architecture:** Preserve public APIs and fix each defect at its owning layer:
+anchor-aware macro expansion, finite vector results, collapse-before-gate mutation
+handling, correct HTTP/VFS adapters, request-scoped zone sessions plus schema alignment,
+and bounded lifecycle-managed cache warmup. Koodle compatibility fallbacks and
+`nexus-vfs` are excluded.
+
+**Stack:** Python 3.14, FastAPI, SQLAlchemy/Alembic, PostgreSQL + pgvector, pytest,
+Ruff, mypy, `uv`, and GitHub CLI.
+
+**Worktree:** `/Users/tafeng/.codex/worktrees/21d7/nexus-upstream-gaps`
+
+---
+
+## Task 1: Search correctness
+
+**Files:**
+
+- Modify `src/nexus/bricks/search/macro_chunk.py`
+- Modify `src/nexus/bricks/search/pg_vector_backend.py`
+- Modify `src/nexus/bricks/search/daemon.py`
+- Test `tests/unit/bricks/search/test_macro_chunk_expand.py`
+- Test `tests/unit/bricks/search/test_pg_vector_backend.py`
+- Test `tests/integration/bricks/search/test_search_mutation_flow.py`
+
+### 1.1 Macro window: RED
+
+Add one over-budget heading section with two hits near opposite ends. Expand both in a
+single call and assert each macro contains its own anchor, their texts differ, and line
+bounds match their actual windows.
+
+Run `uv run pytest tests/unit/bricks/search/test_macro_chunk_expand.py -q --override-ini='addopts='`.
+
+Expected failure: the second hit reuses the first cached macro.
+
+### 1.2 Macro window: GREEN
+
+Compute `_window_for_anchor()` before lookup and cache by
+`(path, window_lo, window_hi)`. Preserve sharing for identical actual windows and the
+best-effort exception contract. Re-run the test file.
+
+### 1.3 Pgvector: RED
+
+Add tests proving empty, all-zero, NaN, and infinity query vectors return `[]` without
+opening a connection. Add mock-row tests proving `None`, NaN, and infinity scores are
+dropped while finite scores retain ordering. Assert the SQL contains a stored halfvec
+norm guard.
+
+Run `uv run pytest tests/unit/bricks/search/test_pg_vector_backend.py -q --override-ini='addopts='`.
+
+Expected failure: invalid queries execute SQL and invalid scores reach result creation.
+
+### 1.4 Pgvector: GREEN
+
+Require every component to pass `math.isfinite()` and the query Euclidean norm to be
+strictly positive. Add `l2_norm(c.embedding) > 0` to SQL; pgvector documents this for
+`halfvec`, whose zero vectors are not valid cosine-index candidates. Build results in a
+loop that skips missing/non-finite scores. Re-run the test file.
+
+### 1.5 Mutation ordering: RED
+
+Add three cases for one `(zone_id, doc_id)` batch:
+
+1. unresolved UPSERT then DELETE keeps only DELETE and creates no retry/park;
+2. unresolved UPSERT then newer resolved UPSERT keeps only the newer event;
+3. newest unresolved UPSERT still raises the existing unresolved-mutation error.
+
+Run `uv run pytest tests/integration/bricks/search/test_search_mutation_flow.py -q --override-ini='addopts='`.
+
+Expected failure: the obsolete UPSERT is gated first.
+
+### 1.6 Mutation ordering: GREEN
+
+Resolve the raw batch, call `_collapse_resolved_mutations()`, then apply
+`_gate_unresolved()` for non-legacy consumers. Remove redundant post-resolution
+collapse at both consumer call sites. Preserve the legacy refresh delete path.
+
+### 1.7 Verify and commit
+
+Run all three search test files together, then Ruff on the six changed files. Stage
+only this task and commit `fix(search): preserve valid expansion and mutation results`.
+
+---
+
+## Task 2: Async file permission and VFS grep correctness
+
+**Files:**
+
+- Modify `src/nexus/server/api/v2/routers/async_files.py`
+- Test `src/nexus/server/api/v2/routers/tests/test_files_search.py`
+- Test `tests/integration/server/api/v2/routers/test_files_ops.py`
+- Test, if its fixtures are needed, `tests/integration/server/api/v2/routers/test_batch_write_read.py`
+
+### 2.1 Permission mapping: RED
+
+Parameterize representative read, write, list/exists, search, and bulk routes so their
+checker/NexusFS mocks raise built-in `PermissionError`. Assert HTTP 403 and preserve
+existing per-item bulk behavior. Keep the existing `NexusPermissionError` coverage.
+
+Run the two primary router test files. Expected failure: built-in permission denials
+flow through the generic HTTP 500 arm.
+
+### 2.2 Permission mapping: GREEN
+
+Use one module-level permission-exception tuple or equivalent helper in every affected
+`async_files.py` permission arm, including nested bulk handling. Preserve distinct
+invalid-path, not-found, and validation responses. Do not catch arbitrary exceptions.
+
+### 2.3 Grep semantics: RED
+
+Add tests for:
+
+- a virtual `/workspace/doc.md` read through `fs.read()`;
+- a positively resolved local physical file searched by mmap but reported by its
+  original virtual path;
+- a mixed local/virtual set merged under one global limit;
+- invalid regex returning HTTP 400 before scanning;
+- empty local mmap results not suppressing virtual scanning.
+
+Expected failure: virtual paths are passed to host mmap and return a false empty result.
+
+### 2.4 Grep semantics: GREEN
+
+Resolve virtual paths to physical paths only through a Nexus service/backend API. Send
+only positively resolved local files to `grep_files_mmap`, keep a reverse response-path
+map, and use compiled Python regex plus `fs.read()` for unresolved paths. Merge both
+lanes under one limit. Never use `Path.is_file()` on a virtual string as authority.
+
+### 2.5 Verify and commit
+
+Run the three affected router suites with `--override-ini='addopts='`, then Ruff on
+changed files. Commit `fix(api): preserve permission and virtual grep semantics`.
+
+---
+
+## Task 3: Zone sessions and graph-schema alignment
+
+**Files:**
+
+- Modify `src/nexus/server/auth/zone_routes.py`
+- Add `alembic/versions/align_graph_zone_columns.py`
+- Test `tests/e2e/server/test_zone_routes_e2e.py`
+- Test `tests/e2e/server/test_zone_deprovision_permissions_e2e.py`
+- Add `tests/migrations/test_graph_zone_column_migration.py`
+- Verify `tests/e2e/postgres/migrations/test_harness.py`
+
+### 3.1 API-key sessions: RED
+
+Build route-level apps where `request.app.state.session_factory` is valid but the
+module-global `DatabaseLocalAuth` provider is absent. Cover pure `DatabaseAPIKeyAuth`
+and chained static+database auth for create/get/list/delete. Assert no route returns 503
+after successful authentication.
+
+Run `uv run pytest tests/e2e/server/test_zone_routes_e2e.py -q --override-ini='addopts='`.
+
+Expected failure: create/get/delete fail during dependency resolution.
+
+### 3.2 API-key sessions: GREEN
+
+Make `_get_session_factory(request)` prefer `app.state.session_factory`, then unwrap
+the active app-state provider, then use the legacy local-auth and NexusFS fallbacks.
+Add `Request` to create/delete, remove their local-auth-only dependencies, and use the
+helper in create/get/list/delete. Keep authentication and authorization unchanged.
+
+### 3.3 Schema migration: RED
+
+Add a focused migration test with two preconditions: legacy graph tables containing
+`tenant_id`, and already-correct tables containing `zone_id`. Assert upgrade ends with
+`zone_id`, preserves rows, and safely avoids a second rename. Add a deprovision test
+with target/control graph and ReBAC rows; only target rows may be removed.
+
+Run the new migration test and the zone-deprovision suite. Expected failure: no
+alignment revision exists and migrated schemas reject `zone_id` cleanup SQL.
+
+### 3.4 Schema migration: GREEN
+
+Create revision `align_graph_zone_columns` with down revision
+`add_chunk_heading_prefix`. Inspect both graph tables and rename `tenant_id` to
+`zone_id` only if legacy exists and target does not. Preserve data and rename/rebuild
+tenant-named indexes and uniqueness constraints to zone-named equivalents on
+PostgreSQL. Keep `rebac_tuples.zone_id` unchanged. Support the repository's SQLite
+migration harness and PostgreSQL using guarded or dialect-specific operations.
+
+### 3.5 Verify and commit
+
+Run both zone suites, the new migration test, and
+`TestMigrationPreChecks::test_single_head_fast`. Run
+`uv run alembic -c alembic/alembic.ini heads` and require exactly
+`align_graph_zone_columns`. Run Ruff, then commit
+`fix(zones): support API key sessions and migrated graph data`.
+
+---
+
+## Task 4: Bounded lifecycle-managed startup warmup
+
+**Files:**
+
+- Modify `src/nexus/server/lifespan/permissions.py`
+- Modify `src/nexus/server/cache_warmer.py`
+- Add `tests/unit/server/test_startup_cache_warmup.py`
+- Modify `tests/e2e/server/test_cache_warmup_e2e.py`
+
+### 4.1 Startup lifecycle: RED
+
+Assert false values for `NEXUS_CACHE_WARMUP_ENABLED` create no task; default and true
+values create one tracked task; invalid numeric configuration follows the existing
+skip/log behavior. Assert `startup_permissions()` returns the task for shutdown
+cancellation/awaiting.
+
+Run `uv run pytest tests/unit/server/test_startup_cache_warmup.py -q --override-ini='addopts='`.
+
+Expected failure: the enable flag is ignored and the task is fire-and-forget.
+
+### 4.2 Startup lifecycle: GREEN
+
+Parse standard true/false values with a compatibility default of true. Return an empty
+or one-task list from `_startup_cache_warmup()` and extend the lifespan background-task
+collection. Preserve unavailable-service and invalid-config logging behavior.
+
+### 4.3 Bounded traversal: RED
+
+Use an instrumented fake tree wider/deeper than the limits. Assert discovery stops at
+`max_files`, does not list below `depth`, performs zero calls for non-positive limits,
+never calls recursive `search.glob()`, and sends only files to metadata warmup.
+
+Expected failure: current code recursively enumerates everything before slicing.
+
+### 4.4 Bounded traversal: GREEN
+
+Replace glob with a private breadth-first discovery helper using non-recursive,
+paginated listing. Queue child directories only below `depth` and stop requesting
+pages/directories as soon as `max_files` files are collected. Accept both
+`PaginatedResult` and list results for lightweight test fakes. Preserve zone/context
+propagation and content-warmup behavior.
+
+### 4.5 Verify and commit
+
+Run the new unit suite and cache warmup e2e suite, then Ruff on changed files. Commit
+`fix(startup): bound and track cache warmup`.
+
+---
+
+## Task 5: Integrated verification, reviews, and draft PR
+
+### 5.1 Scope and dependency audit
+
+Run `git status --short`, `git diff --stat origin/develop...HEAD`,
+`git diff --check origin/develop...HEAD`, and
+`git diff --name-only origin/develop...HEAD`. Restore `uv.lock` if tooling changed it
+without an intentional dependency update. Reject any Koodle, Railway, Vercel, Supabase,
+or `nexus-vfs` file.
+
+### 5.2 Combined verification
+
+Run all affected search, file-router, zone, migration, and warmup test files in one
+pytest invocation with repository `addopts` disabled. Run `ruff check`,
+`ruff format --check`, and focused mypy on all changed production Python files. Re-run
+the single-head migration pre-check.
+
+### 5.3 Two-stage review
+
+Have one reviewer compare the diff to the approved design/plan and resolve every
+missing or extra behavior. Then have a separate reviewer inspect code quality,
+lifecycle/concurrency behavior, SQL safety, migration idempotence, and test strength.
+Resolve findings and rerun affected checks.
+
+### 5.4 Freshness and publication
+
+Fetch `origin/develop`; if it advanced, rebase and rerun all affected checks. Push
+`codex/fix-edge-qualification-gaps` and open one draft PR titled
+`fix: close Koodle edge qualification gaps` against `develop`.
+
+The PR body must enumerate all eight fixes, historical links (#4354, #4352, #4398,
+#4399, #4337/#4350, #4252, #1076), exact test results, pgvector behavior, and the note
+that production was not deployed. Report the PR URL and CI state; do not merge or deploy.

--- a/docs/superpowers/plans/2026-06-29-pr4454-live-qualification-harness.md
+++ b/docs/superpowers/plans/2026-06-29-pr4454-live-qualification-harness.md
@@ -1,0 +1,399 @@
+# PR #4454 Live Qualification Harness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the two live PR #4454 qualification scripts fail on incomplete document restoration, stale owner semantics, or misleading group-permission explanations.
+
+**Architecture:** Keep all changes in the host-side validation layer. Add one pure Python predicate for exact edit restoration and extend the existing static shell-script guards so the Bash demo remains testable without a server; then confirm the same behavior against the disposable locally built Nexus stack.
+
+**Tech Stack:** Python 3.14, pytest, Bash, Nexus CLI, Docker Compose
+
+---
+
+### Task 1: Require exact fuzzy-edit restoration
+
+**Files:**
+- Create: `tests/unit/scripts/test_build_perf_e2e.py`
+- Modify: `scripts/test_build_perf_e2e.py:32-40`
+- Modify: `scripts/test_build_perf_e2e.py:287-335`
+
+- [ ] **Step 1: Write the failing unit test**
+
+Create `tests/unit/scripts/test_build_perf_e2e.py`:
+
+```python
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[3] / "scripts" / "test_build_perf_e2e.py"
+SPEC = importlib.util.spec_from_file_location("test_build_perf_e2e_script", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def test_plan_auth_restore_requires_the_complete_original_line() -> None:
+    assert MODULE._plan_auth_line_restored("# Plan\n- Configure authentication\n")
+    assert not MODULE._plan_auth_line_restored("# Plan\nConfigure authentication\n")
+    assert not MODULE._plan_auth_line_restored(
+        "# Plan\n- Configure authentication\n- Configure auth (test-edit)\n"
+    )
+```
+
+- [ ] **Step 2: Run the test and verify the red state**
+
+Run:
+
+```bash
+uv run --no-sync pytest tests/unit/scripts/test_build_perf_e2e.py -q
+```
+
+Expected: FAIL because `scripts/test_build_perf_e2e.py` has no `_plan_auth_line_restored` function.
+
+- [ ] **Step 3: Add the minimal predicate and exact restore check**
+
+Add next to the other script constants:
+
+```python
+PLAN_AUTH_ORIGINAL = "- Configure authentication"
+PLAN_AUTH_EDITED = "- Configure auth (test-edit)"
+
+
+def _plan_auth_line_restored(text: str) -> bool:
+    lines = text.splitlines()
+    return PLAN_AUTH_ORIGINAL in lines and PLAN_AUTH_EDITED not in lines
+```
+
+Change the fuzzy edit to preserve the full Markdown line:
+
+```python
+"edits": [["- Confgiure auth (test-edt)", PLAN_AUTH_ORIGINAL]],
+```
+
+Immediately after the existing `edit (fuzzy restore)` check, read the file and add a separate correctness check:
+
+```python
+step("RPC sys_read verifying fuzzy restore is exact")
+content = t.call_rpc("sys_read", {"path": "/workspace/demo/plan.md"})
+text = content.decode() if isinstance(content, bytes) else str(content)
+check(
+    "fuzzy restore preserved original line",
+    _plan_auth_line_restored(text),
+    f"original_line={PLAN_AUTH_ORIGINAL in text.splitlines()}, "
+    f"edited_line={PLAN_AUTH_EDITED in text.splitlines()}",
+)
+```
+
+- [ ] **Step 4: Run the focused test and verify green**
+
+Run:
+
+```bash
+uv run --no-sync pytest tests/unit/scripts/test_build_perf_e2e.py -q
+```
+
+Expected: `1 passed`.
+
+- [ ] **Step 5: Commit the exact-restore guard**
+
+```bash
+git add scripts/test_build_perf_e2e.py tests/unit/scripts/test_build_perf_e2e.py
+git commit -m "test(e2e): require exact fuzzy edit restoration"
+```
+
+### Task 2: Align owner expectations with the file namespace
+
+**Files:**
+- Modify: `tests/unit/scripts/test_permissions_demo_enhanced.py:46`
+- Modify: `permissions_demo_enhanced.sh:467-516`
+
+- [ ] **Step 1: Add a failing static guard**
+
+Append to `tests/unit/scripts/test_permissions_demo_enhanced.py`:
+
+```python
+def test_owner_role_requires_read_write_and_execute() -> None:
+    text = SCRIPT.read_text()
+    owner_block = text[
+        text.index('print_subsection "1.1 Understanding Permission Roles"') :
+        text.index('print_test "Verify bob (editor)')
+    ]
+
+    assert "OWNER:  read ✓  write ✓  execute ✓" in owner_block
+    assert "owners need editor/viewer role for read" not in owner_block
+    assert 'ALICE_READ=$(nexus rebac check user alice read file' in owner_block
+    assert (
+        'if echo "$ALICE_READ" | grep -q "GRANTED" '
+        '&& echo "$ALICE_WRITE" | grep -q "GRANTED" '
+        '&& echo "$ALICE_EXEC" | grep -q "GRANTED"; then'
+    ) in owner_block
+```
+
+- [ ] **Step 2: Run the test and verify the red state**
+
+```bash
+uv run --no-sync pytest \
+  tests/unit/scripts/test_permissions_demo_enhanced.py::test_owner_role_requires_read_write_and_execute \
+  -q
+```
+
+Expected: FAIL because the demo still says owner read is denied and does not include read in its success condition.
+
+- [ ] **Step 3: Update the owner narrative and assertion**
+
+Replace the owner description with:
+
+```bash
+echo "    OWNER:  read ✓  write ✓  execute ✓  (full control)"
+```
+
+Remove the sentence that owners need an editor/viewer role. Read all three decisions before the condition:
+
+```bash
+ALICE_READ=$(nexus rebac check user alice read file $DEMO_BASE/test-file.txt 2>&1)
+ALICE_WRITE=$(nexus rebac check user alice write file $DEMO_BASE/test-file.txt 2>&1)
+ALICE_EXEC=$(nexus rebac check user alice execute file $DEMO_BASE/test-file.txt 2>&1)
+```
+
+Require all three grants and include all three observed decisions in the failure:
+
+```bash
+if echo "$ALICE_READ" | grep -q "GRANTED" && echo "$ALICE_WRITE" | grep -q "GRANTED" && echo "$ALICE_EXEC" | grep -q "GRANTED"; then
+    print_success "✅ Owner has read + write + execute"
+else
+    print_error "Owner permissions incorrect! read=$(echo "$ALICE_READ"|grep -oE 'GRANTED|DENIED'|head -1) write=$(echo "$ALICE_WRITE"|grep -oE 'GRANTED|DENIED'|head -1) execute=$(echo "$ALICE_EXEC"|grep -oE 'GRANTED|DENIED'|head -1)"
+fi
+```
+
+- [ ] **Step 4: Run the focused test and Bash syntax check**
+
+```bash
+uv run --no-sync pytest \
+  tests/unit/scripts/test_permissions_demo_enhanced.py::test_owner_role_requires_read_write_and_execute \
+  -q
+bash -n permissions_demo_enhanced.sh
+```
+
+Expected: `1 passed`; Bash exits `0`.
+
+- [ ] **Step 5: Commit the owner semantics guard**
+
+```bash
+git add permissions_demo_enhanced.sh tests/unit/scripts/test_permissions_demo_enhanced.py
+git commit -m "test(rebac): require current owner semantics"
+```
+
+### Task 3: Make the group explanation actionable
+
+**Files:**
+- Modify: `tests/unit/scripts/test_permissions_demo_enhanced.py:60`
+- Modify: `permissions_demo_enhanced.sh:612-624`
+
+- [ ] **Step 1: Add a failing explanation guard**
+
+Append to `tests/unit/scripts/test_permissions_demo_enhanced.py`:
+
+```python
+def test_group_explanation_targets_and_requires_the_granted_parent() -> None:
+    text = SCRIPT.read_text()
+    explain_block = text[
+        text.index('log_step "rebac check user bob write file $DEMO_BASE') :
+        text.index('print_subsection "2.4 PROVE group composition')
+    ]
+
+    assert (
+        'EXPLAIN_OUT=$(nexus rebac explain user bob write file $DEMO_BASE 2>&1) '
+        '&& EXPLAIN_RC=0 || EXPLAIN_RC=$?'
+    ) in explain_block
+    assert (
+        '[ "$EXPLAIN_RC" -eq 0 ] && echo "$EXPLAIN_OUT" | grep -q "GRANTED"'
+    ) in explain_block
+    assert "Group explanation failed" in explain_block
+    assert "$DEMO_BASE/team-file.txt" not in explain_block
+```
+
+- [ ] **Step 2: Run the test and verify the red state**
+
+```bash
+uv run --no-sync pytest \
+  tests/unit/scripts/test_permissions_demo_enhanced.py::test_group_explanation_targets_and_requires_the_granted_parent \
+  -q
+```
+
+Expected: FAIL because the demo explains the child path, discards failure, and never checks `GRANTED`.
+
+- [ ] **Step 3: Capture and assert the parent explanation**
+
+Replace the unguarded explanation command with:
+
+```bash
+log_step "rebac explain bob write on $DEMO_BASE"
+EXPLAIN_OUT=$(nexus rebac explain user bob write file $DEMO_BASE 2>&1) && EXPLAIN_RC=0 || EXPLAIN_RC=$?
+echo "$EXPLAIN_OUT" | head -5
+if [ "$EXPLAIN_RC" -eq 0 ] && echo "$EXPLAIN_OUT" | grep -q "GRANTED"; then
+    print_success "✅ Group permission explanation is granted"
+else
+    print_error "Group explanation failed (exit=$EXPLAIN_RC): $(echo "$EXPLAIN_OUT" | head -3)"
+fi
+```
+
+- [ ] **Step 4: Run the complete focused unit suite**
+
+```bash
+uv run --no-sync pytest \
+  tests/unit/scripts/test_build_perf_e2e.py \
+  tests/unit/scripts/test_permissions_demo_enhanced.py \
+  -q
+bash -n permissions_demo_enhanced.sh
+uv run --no-sync ruff check \
+  scripts/test_build_perf_e2e.py \
+  tests/unit/scripts/test_build_perf_e2e.py \
+  tests/unit/scripts/test_permissions_demo_enhanced.py
+```
+
+Expected: all focused tests pass; Bash and Ruff exit `0`.
+
+- [ ] **Step 5: Commit the explanation guard**
+
+```bash
+git add permissions_demo_enhanced.sh tests/unit/scripts/test_permissions_demo_enhanced.py
+git commit -m "test(rebac): require granted group explanation"
+```
+
+### Task 4: Re-run both requested scripts against the built PR image
+
+**Files:**
+- Read: `/tmp/nexus-pr4454-e2e.dWZeQ2/nexus.yaml`
+- Read: `/tmp/nexus-pr4454-e2e.dWZeQ2/nexus-data/.state.json`
+- Produce: `/tmp/nexus-pr4454-e2e.dWZeQ2/build-perf-e2e-fixed.log`
+- Produce: `/tmp/nexus-pr4454-e2e.dWZeQ2/permissions-demo-fixed.log`
+
+- [ ] **Step 1: Confirm the disposable stack and reset its demo data**
+
+Run from `/tmp/nexus-pr4454-e2e.dWZeQ2`:
+
+```bash
+REPO=/Users/tafeng/.codex/worktrees/21d7/nexus-upstream-gaps
+CLI="$REPO/.venv/bin/nexus"
+unset NEXUS_URL NEXUS_API_KEY NEXUS_GRPC_HOST NEXUS_GRPC_PORT \
+  NEXUS_APPROVALS_GRPC_PORT NEXUS_DATABASE_URL DATABASE_URL NEXUS_PROFILE \
+  NEXUS_IMAGE_REF NEXUS_IMAGE_TAG NEXUS_DATA_DIR
+eval "$("$CLI" env)"
+"$CLI" status --json
+"$CLI" demo init --reset
+```
+
+Expected: status identifies the healthy local server and reseeding exits `0`.
+
+- [ ] **Step 2: Run the corrected performance/correctness E2E**
+
+Run without printing either key:
+
+```bash
+PY="$REPO/.venv/bin/python"
+export NEXUS_DEMO_USER_KEY="$("$PY" -c \
+  'import json; print(json.load(open("nexus-data/.demo-manifest.json"))["identity_keys"]["demo_user"]["api_key"])')"
+export NEXUS_CLI="$CLI"
+"$PY" "$REPO/scripts/test_build_perf_e2e.py" \
+  > build-perf-e2e-fixed.log 2>&1
+grep -E '^RESULTS:|RPC latency|HERB hit rate' build-perf-e2e-fixed.log
+```
+
+Expected: `RESULTS: 26 passed, 0 failed`, HERB at least `7/8`, and RPC p50 below `50 ms`.
+
+- [ ] **Step 3: Reset again and run the corrected strict permissions demo**
+
+```bash
+"$CLI" demo init --reset
+eval "$("$CLI" env)"
+export NEXUS_DATABASE_URL="$DATABASE_URL"
+export PATH="$REPO/.venv/bin:$PATH"
+KEEP=0 \
+NEXUS_DEMO_PYTHON_BIN="$REPO/.venv/bin/python" \
+NEXUS_DEMO_STRICT_PERF=1 \
+NEXUS_DEMO_LATENCY_MEDIAN_MS_MAX=300 \
+"$REPO/permissions_demo_enhanced.sh" \
+  > permissions-demo-fixed.log 2>&1
+```
+
+Expected: exit `0`, final `All tests passed!`, all five benchmark rows say `PASS`, and median latency is below `300 ms`.
+
+- [ ] **Step 4: Verify the corrected positive-path output**
+
+```bash
+python3 - <<'PY'
+from pathlib import Path
+import re
+
+text = Path("permissions-demo-fixed.log").read_text(errors="replace")
+text = re.sub(r"\x1b\[[0-9;]*m", "", text)
+assert "Owner has read + write + execute" in text
+assert "Group permission explanation is granted" in text
+assert "Group explanation failed" not in text
+assert "All tests passed!" in text
+PY
+```
+
+Expected: exit `0`.
+
+### Task 5: Final verification and PR update
+
+**Files:**
+- Verify: all files changed since `origin/develop`
+
+- [ ] **Step 1: Run repository hygiene checks**
+
+```bash
+git diff --check origin/develop...HEAD
+git status --short --branch
+```
+
+Expected: no whitespace errors; only intended uncommitted plan state, if any.
+
+- [ ] **Step 2: Commit the implementation plan if still uncommitted**
+
+```bash
+git add docs/superpowers/plans/2026-06-29-pr4454-live-qualification-harness.md
+git commit -m "docs: plan live qualification harness fixes"
+```
+
+- [ ] **Step 3: Re-run the focused tests from the final committed tree**
+
+```bash
+uv run --no-sync pytest \
+  tests/unit/scripts/test_build_perf_e2e.py \
+  tests/unit/scripts/test_permissions_demo_enhanced.py \
+  -q
+bash -n permissions_demo_enhanced.sh
+uv run --no-sync ruff check \
+  scripts/test_build_perf_e2e.py \
+  tests/unit/scripts/test_build_perf_e2e.py \
+  tests/unit/scripts/test_permissions_demo_enhanced.py
+git diff --check origin/develop...HEAD
+```
+
+Expected: every command exits `0`.
+
+- [ ] **Step 4: Push the branch and confirm PR state**
+
+```bash
+git push origin codex/fix-edge-qualification-gaps
+gh pr checks 4454 --repo nexi-lab/nexus --watch
+gh pr view 4454 --repo nexi-lab/nexus \
+  --json isDraft,state,mergeable,mergeStateStatus,reviewDecision,headRefOid
+```
+
+Expected: push succeeds, required checks pass, the PR head matches local `HEAD`, and the only remaining merge gate is required review if `reviewDecision` remains `REVIEW_REQUIRED`.
+
+- [ ] **Step 5: Stop the disposable stack after all reruns**
+
+Run from `/tmp/nexus-pr4454-e2e.dWZeQ2`:
+
+```bash
+REPO=/Users/tafeng/.codex/worktrees/21d7/nexus-upstream-gaps
+"$REPO/.venv/bin/nexus" down
+```
+
+Expected: the `nexus-c26ab29d` containers and network stop without touching unrelated Compose projects or production services.

--- a/docs/superpowers/specs/2026-06-28-koodle-edge-qualification-gaps-design.md
+++ b/docs/superpowers/specs/2026-06-28-koodle-edge-qualification-gaps-design.md
@@ -1,0 +1,184 @@
+# Koodle edge qualification gaps — upstream Nexus fixes
+
+- **Date**: 2026-06-28
+- **Base**: `nexi-lab/nexus@0e7d247064af51486bd4b402383a834567f5fa65`
+- **Status**: design approved by requester (all validated upstream gaps in one PR)
+- **Deployment constraint**: do not modify or deploy Koodle production Railway
+
+## Context
+
+Koodle was qualified locally against the published Nexus edge image that corresponds
+to the base commit above. Browser- and API-backed validation exposed eight defects
+whose root causes are in Nexus rather than Koodle or `nexus-vfs`. The Koodle wrapper
+contains temporary compatibility patches, but those should not become the permanent
+implementation.
+
+The objective is one upstream draft PR against `develop`, organized as independent
+commits so maintainers can review each subsystem separately. The original `~/nexus`
+checkout is dirty and remains untouched; work is isolated in a dedicated worktree.
+
+## Approaches considered
+
+### A. One comprehensive PR with subsystem commits — selected
+
+Fix all eight validated gaps in one draft PR, split into search, file API,
+zone/schema, and startup-lifecycle commits. This gives Koodle one upstream revision to
+qualify before deployment and keeps each concern independently reviewable. The tradeoff
+is a broader PR.
+
+### B. Three or four independent PRs
+
+Split search, file/HTTP, zone/schema, and startup performance into separate PRs. This
+reduces review surface per PR but creates multiple merge and image-publication gates
+before Koodle can deploy a single known-good Nexus version.
+
+### C. Correctness-only release blocker
+
+Fix the seven correctness/API defects and defer startup warmup. This is the smallest
+release-blocker diff, but it leaves the observed large-namespace startup performance
+regression unresolved and does not satisfy the request to fix all validated gaps.
+
+## Scope
+
+### 1. Search correctness
+
+#### Macro expansion cache anchors
+
+`expand_results()` currently caches a macro by `(path, section_lo, section_hi)`, even
+though an over-budget macro window is also a function of the hit anchor. Two distant
+hits in one large section can therefore receive the same macro, and the later result
+may not contain its own matched chunk.
+
+Compute the anchor-specific window first and cache the stitched result by its actual
+`(path, window_lo, window_hi)` bounds. Every expanded hit must contain its own anchor.
+This is a corrective follow-up to #4398/#4399; it does not change search ranking or
+the opt-in `expand=macro` contract.
+
+#### Finite pgvector scores
+
+Cosine similarity is undefined for a zero-norm vector. Reject empty, zero-norm, and
+non-finite query vectors before SQL. Exclude zero-norm stored embeddings in the query
+where the pgvector/PostgreSQL function is available, and defensively discard database
+rows whose score is `NULL` or non-finite before constructing a result. The HTTP
+serialization boundary must never emit `NaN`, infinity, or an accidental `null`
+score for a semantic result.
+
+#### Collapse mutations before unresolved gating
+
+The mutation resolver currently applies retry/parking to an unresolved UPSERT before
+collapsing later events for the same `(zone_id, doc_id)`. Resolve the batch, collapse
+it to the newest mutation per document, then apply the unresolved gate. A later DELETE
+or resolved UPSERT must supersede an obsolete unresolved write; the newest unresolved
+UPSERT must continue to block under the existing bounded-retry contract from #4337.
+
+### 2. File API correctness and UX
+
+#### Permission denials map to HTTP 403
+
+The active ReBAC checker raises Python's built-in `PermissionError`, while the async
+file router generally catches only `NexusPermissionError`; the generic arm turns a
+normal authorization denial into HTTP 500. Treat both exception types as permission
+denials in every affected async file route, while preserving any existing
+`AccessDeniedError` handling and bulk-result semantics. This closes the still-valid
+behavior recorded in #4354 without masking unrelated exceptions.
+
+#### Grep reads virtual files through NexusFS
+
+`GET /api/v2/files/grep` passes Nexus virtual paths directly to the host mmap helper.
+The helper returns an empty list on host `OSError`, which is incorrectly interpreted
+as a successful no-match and suppresses the VFS fallback.
+
+Use mmap only for paths that Nexus positively resolves to local physical files. Keep
+a virtual-to-physical mapping so response paths remain virtual, and run the VFS read
+fallback for unresolved or non-local paths. Mixed local and virtual working sets must
+search both sources, respect the global limit, and preserve invalid-regex HTTP 400
+behavior. A coincidental host path with the same string as a virtual path must not be
+treated as authoritative.
+
+### 3. Zone API and schema correctness
+
+#### Request-scoped session resolution
+
+Zone create/get/delete endpoints depend on the module-global `DatabaseLocalAuth`
+provider, so pure database API-key and chained-auth deployments authenticate and then
+fail dependency resolution with 503. Remove that local-auth-only dependency. Resolve
+the session factory from `request.app.state.session_factory` first, followed by the
+active app-state provider and legacy NexusFS/local-auth fallbacks. List/create/get/
+delete then share one request-scoped database-session path.
+
+#### Align migrated graph columns with the ORM
+
+The graph-table migration created `entities.tenant_id` and
+`relationships.tenant_id`, while the current ORM and finalizer use `zone_id`. Add an
+idempotent Alembic migration that renames legacy `tenant_id` columns to `zone_id` while
+preserving data, indexes, and uniqueness constraints. It must be safe for databases
+whose columns are already correct. `rebac_tuples.zone_id` remains unchanged.
+
+Zone deprovision tests will seed target-zone and control-zone graph/ReBAC records and
+prove only the target zone is removed. The temporary Koodle query rewrite to
+`tenant_id` is not copied upstream because it would preserve the schema split.
+
+### 4. Bounded startup cache warmup
+
+Startup currently schedules warmup unconditionally; `CacheWarmer` recursively globs
+the entire namespace and only then slices to `max_files`, while depth values of two or
+greater all become `**/*`. On large workspaces this produces an avoidable full scan.
+
+Honor `NEXUS_CACHE_WARMUP_ENABLED` (default remains enabled for compatibility), parse
+standard true/false values, and skip task creation when disabled. Replace the
+full-tree glob with bounded paginated listing/traversal that stops at both configured
+depth and file count. Return the created task through the lifespan background-task
+list so shutdown cancellation and task exceptions follow the existing lifecycle
+contract. Invalid non-positive limits should perform no scan.
+
+The implementation must bound discovery work rather than merely truncate the final
+result. Tests will use an instrumented fake listing service to assert that traversal
+does not request additional pages/directories after the cap is reached.
+
+## Testing strategy
+
+Each production change is test-driven: add the regression, observe it fail against
+the base commit, then implement the narrow fix.
+
+1. Unit tests for anchor-specific macro windows and finite pgvector inputs/results.
+2. Mutation-flow tests for superseding DELETE, superseding resolved UPSERT, and newest
+   unresolved UPSERT behavior.
+3. Router tests using the real built-in `PermissionError`, plus VFS-only, local-only,
+   and mixed-path grep cases.
+4. Zone endpoint tests with database API-key and chained auth, and migration-backed
+   PostgreSQL coverage for legacy and already-renamed graph schemas.
+5. Warmup tests for disabled startup, max-file early stop, depth enforcement, task
+   tracking, failure observation, and shutdown cancellation.
+6. Focused lint/type checks, the affected unit/integration/e2e suites, Alembic upgrade
+   checks, and final diff review. No production deploy is part of validation.
+
+## PR organization
+
+The draft PR targets `develop` and uses four focused implementation commits after this
+design/plan documentation:
+
+1. search expansion, vector-score, and mutation ordering fixes;
+2. async file permission and VFS grep fixes;
+3. zone session resolution and graph-schema migration;
+4. bounded, configurable startup warmup.
+
+The PR body will include the exact base/image qualification context, linked historical
+issues/PRs, regression commands, and a deployment note that Koodle should consume a
+new edge digest only after upstream CI and local qualification pass.
+
+## Out of scope
+
+- Koodle SDK schema fields and `macroText ?? chunkText` context assembly from Koodle
+  #1431; those remain Koodle-owned and require Nexus #4399 or newer.
+- Koodle-side nullable-score compatibility and agent fallback behavior after the
+  upstream server stops producing non-finite scores.
+- Changes to `nexus-vfs`; none of the validated root causes are in that repository.
+- Any production Railway, Vercel, or Supabase mutation or deployment.
+
+## Success criteria
+
+1. All eight regressions fail on the base behavior and pass with the patch.
+2. Existing focused test suites, lint, and type checks remain green.
+3. No unrelated files from the dirty `~/nexus` checkout enter the branch.
+4. A draft PR is open against `nexi-lab/nexus:develop` with CI-visible commits and
+   no production deployment.

--- a/docs/superpowers/specs/2026-06-29-pr4454-live-qualification-harness-design.md
+++ b/docs/superpowers/specs/2026-06-29-pr4454-live-qualification-harness-design.md
@@ -1,0 +1,96 @@
+# PR #4454 Live Qualification Harness Design
+
+## Context
+
+PR #4454 passed a disposable `nexus up --build` qualification run, the full
+build/performance E2E, and the enhanced ReBAC permissions demo. The live run
+also exposed three false-confidence or misleading-output gaps in the host-side
+validation scripts:
+
+1. `scripts/test_build_perf_e2e.py` reports that its fuzzy edit restored
+   `plan.md`, but the replacement drops the Markdown list marker.
+2. `permissions_demo_enhanced.sh` documents owners as unable to read and does
+   not fail when owner read is denied, while the current file namespace grants
+   owners read, write, and execute.
+3. The permissions demo asks `rebac explain` about a child file without a
+   ReBAC parent tuple, prints a red denial, and then reports the parent-based
+   real-I/O test as successful. The explanation should target and assert the
+   parent resource whose group permission is under test.
+
+## Goal
+
+Make the two live qualification scripts fail when these expectations regress
+and keep their output consistent with the behavior they claim to validate.
+
+## Scope
+
+Modify only:
+
+- `scripts/test_build_perf_e2e.py`
+- `permissions_demo_enhanced.sh`
+- focused tests under `tests/unit/scripts/`
+
+No Nexus server, ReBAC engine, API, schema, dependency, image, or Koodle code
+changes are included. The live server behavior already produced the correct
+authorization and mutation results.
+
+## Design
+
+### Exact fuzzy-edit restoration
+
+The performance E2E will preserve the complete Markdown line, including the
+leading list marker, when performing its intentionally misspelled fuzzy
+restore. It will read the file after the restore and add an explicit check that
+the original line is present and the temporary edited line is absent. A small
+pure predicate will make this requirement directly unit-testable without a
+running stack.
+
+### Current owner semantics
+
+The permissions demo will describe an owner as having read, write, and execute,
+matching `DEFAULT_FILE_NAMESPACE`. Its owner assertion will require all three
+decisions to be granted. A denial of any one permission will increment the
+existing failure counter and make the script exit nonzero.
+
+### Actionable group explanation
+
+The group-composition section will run `rebac explain` on the parent directory
+that has the userset permission. The command output will be captured and
+required to contain `GRANTED`; a denial or command failure will increment the
+existing failure counter. Child-path inheritance remains covered separately by
+the real file-I/O assertion.
+
+## Testing Strategy
+
+Follow red-green TDD for each behavior:
+
+1. Add a focused Python unit test proving that a missing Markdown list marker
+   is not accepted as an exact restore; run it and observe the expected failure.
+2. Add static shell-script guards requiring owner read/write/execute and a
+   gated parent-resource explanation; run them and observe the expected
+   failures.
+3. Implement the smallest script changes that satisfy the tests.
+4. Run the focused unit tests and formatting/lint checks.
+5. Reuse the disposable locally built PR stack, reset/reseed the demo corpus,
+   and rerun both requested scripts. Require zero failed checks, strict ReBAC
+   median latency below 300 ms, and no misleading red denial in the positive
+   explanation section.
+6. Run `git diff --check` and confirm the branch contains only the approved
+   harness/spec changes beyond the existing PR.
+
+## Operational Safety
+
+All live reruns stay on the disposable local stack and database at ports
+`50780-50784`. No Railway, Vercel, Supabase, Koodle production, or shared Nexus
+database is used. The permissions demo remains restricted to the disposable
+database because its cleanup performs broad ReBAC tuple deletion.
+
+## Acceptance Criteria
+
+- The fuzzy restore leaves `plan.md` exactly formatted and is verified by a
+  post-restore read.
+- Owner read, write, and execute are all mandatory in the permissions demo.
+- The positive group explanation is `GRANTED` and failure-counted otherwise.
+- Focused unit tests pass after demonstrating the expected red state first.
+- Both live scripts pass again against the locally built PR image.
+- No production environment or dependency version is changed.

--- a/docs/surface-coverage/api-rpc-surface-coverage.yaml
+++ b/docs/surface-coverage/api-rpc-surface-coverage.yaml
@@ -950,7 +950,7 @@ operations:
   transports:
     http:
       name: POST /batch/read
-      source: src/nexus/server/api/v2/routers/async_files.py:1963
+      source: src/nexus/server/api/v2/routers/async_files.py:1996
   profiles:
     lite: supported
     sandbox: unavailable
@@ -969,7 +969,7 @@ operations:
   transports:
     http:
       name: POST /batch/write
-      source: src/nexus/server/api/v2/routers/async_files.py:1914
+      source: src/nexus/server/api/v2/routers/async_files.py:1947
   profiles:
     lite: supported
     sandbox: unavailable
@@ -988,7 +988,7 @@ operations:
   transports:
     http:
       name: POST /copy
-      source: src/nexus/server/api/v2/routers/async_files.py:2139
+      source: src/nexus/server/api/v2/routers/async_files.py:2172
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1007,7 +1007,7 @@ operations:
   transports:
     http:
       name: POST /copy-bulk
-      source: src/nexus/server/api/v2/routers/async_files.py:2238
+      source: src/nexus/server/api/v2/routers/async_files.py:2271
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1026,7 +1026,7 @@ operations:
   transports:
     http:
       name: DELETE /delete
-      source: src/nexus/server/api/v2/routers/async_files.py:1445
+      source: src/nexus/server/api/v2/routers/async_files.py:1478
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1044,7 +1044,7 @@ operations:
   transports:
     http:
       name: GET /exists
-      source: src/nexus/server/api/v2/routers/async_files.py:1521
+      source: src/nexus/server/api/v2/routers/async_files.py:1554
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1062,7 +1062,7 @@ operations:
   transports:
     http:
       name: GET /glob
-      source: src/nexus/server/api/v2/routers/async_files.py:2315
+      source: src/nexus/server/api/v2/routers/async_files.py:2348
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1080,7 +1080,7 @@ operations:
   transports:
     http:
       name: GET /grep
-      source: src/nexus/server/api/v2/routers/async_files.py:2366
+      source: src/nexus/server/api/v2/routers/async_files.py:2399
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1099,7 +1099,7 @@ operations:
   transports:
     http:
       name: GET /list
-      source: src/nexus/server/api/v2/routers/async_files.py:1550
+      source: src/nexus/server/api/v2/routers/async_files.py:1583
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1117,7 +1117,7 @@ operations:
   transports:
     http:
       name: GET /md-structure
-      source: src/nexus/server/api/v2/routers/async_files.py:1347
+      source: src/nexus/server/api/v2/routers/async_files.py:1380
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1135,7 +1135,7 @@ operations:
   transports:
     http:
       name: GET /metadata
-      source: src/nexus/server/api/v2/routers/async_files.py:1826
+      source: src/nexus/server/api/v2/routers/async_files.py:1859
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1153,7 +1153,7 @@ operations:
   transports:
     http:
       name: POST /mkdir
-      source: src/nexus/server/api/v2/routers/async_files.py:1788
+      source: src/nexus/server/api/v2/routers/async_files.py:1821
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1171,7 +1171,7 @@ operations:
   transports:
     http:
       name: GET /read
-      source: src/nexus/server/api/v2/routers/async_files.py:823
+      source: src/nexus/server/api/v2/routers/async_files.py:847
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1189,7 +1189,7 @@ operations:
   transports:
     http:
       name: GET /read-url
-      source: src/nexus/server/api/v2/routers/async_files.py:1192
+      source: src/nexus/server/api/v2/routers/async_files.py:1216
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1208,7 +1208,7 @@ operations:
   transports:
     http:
       name: POST /rename
-      source: src/nexus/server/api/v2/routers/async_files.py:2101
+      source: src/nexus/server/api/v2/routers/async_files.py:2134
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1226,7 +1226,7 @@ operations:
   transports:
     http:
       name: POST /rename-batch
-      source: src/nexus/server/api/v2/routers/async_files.py:2196
+      source: src/nexus/server/api/v2/routers/async_files.py:2229
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1244,7 +1244,7 @@ operations:
   transports:
     http:
       name: GET /stream
-      source: src/nexus/server/api/v2/routers/async_files.py:2037
+      source: src/nexus/server/api/v2/routers/async_files.py:2070
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1262,7 +1262,7 @@ operations:
   transports:
     http:
       name: POST /write
-      source: src/nexus/server/api/v2/routers/async_files.py:623
+      source: src/nexus/server/api/v2/routers/async_files.py:647
   profiles:
     lite: supported
     sandbox: unavailable
@@ -9899,7 +9899,7 @@ operations:
   transports:
     http:
       name: GET /api/zones/{zone_id}
-      source: src/nexus/server/auth/zone_routes.py:248
+      source: src/nexus/server/auth/zone_routes.py:265
   profiles:
     lite: supported
     sandbox: supported

--- a/permissions_demo_enhanced.sh
+++ b/permissions_demo_enhanced.sh
@@ -611,8 +611,14 @@ BOB_GROUP_WRITE=$(nexus rebac check user bob write file $DEMO_BASE 2>&1)
 echo "    bob write on $DEMO_BASE: $(echo "$BOB_GROUP_WRITE" | grep -oE 'GRANTED|DENIED' | head -1)" >&2
 if echo "$BOB_GROUP_WRITE" | grep -q "GRANTED"; then
     print_success "✅ Bob has access via group:project1-editors#member"
-    log_step "rebac explain bob write on team-file.txt"
-    nexus rebac explain user bob write file $DEMO_BASE/team-file.txt 2>/dev/null | head -5 || true
+    log_step "rebac explain bob write on $DEMO_BASE"
+    EXPLAIN_OUT=$(nexus rebac explain user bob write file $DEMO_BASE 2>&1) && EXPLAIN_RC=0 || EXPLAIN_RC=$?
+    echo "$EXPLAIN_OUT" | head -5
+    if [ "$EXPLAIN_RC" -eq 0 ] && echo "$EXPLAIN_OUT" | grep -q "GRANTED"; then
+        print_success "✅ Group permission explanation is granted"
+    else
+        print_error "Group explanation failed (exit=$EXPLAIN_RC): $(echo "$EXPLAIN_OUT" | head -3)"
+    fi
 else
     print_error "Group membership not working! output: $(echo "$BOB_GROUP_WRITE" | head -3)"
 fi

--- a/permissions_demo_enhanced.sh
+++ b/permissions_demo_enhanced.sh
@@ -466,11 +466,9 @@ print_success "Admin has ownership of $DEMO_BASE"
 
 print_subsection "1.1 Understanding Permission Roles"
 echo "  NOTE: In this ReBAC implementation:"
-echo "    OWNER:  read ✗  write ✓  execute ✓  (can write & manage, but not read!)"
+echo "    OWNER:  read ✓  write ✓  execute ✓  (full control)"
 echo "    EDITOR: read ✓  write ✓  execute ✗  (can read & write, but can't manage)"
 echo "    VIEWER: read ✓  write ✗  execute ✗  (read-only)"
-echo ""
-echo "  This is the actual behavior - owners need editor/viewer role for read!"
 echo ""
 
 log_step "create API keys for alice, bob, charlie in zone=default"
@@ -497,22 +495,18 @@ nexus rebac create user bob direct_editor file $DEMO_BASE/test-file.txt
 echo "    → nexus rebac create user charlie direct_viewer file $DEMO_BASE/test-file.txt" >&2
 nexus rebac create user charlie direct_viewer file $DEMO_BASE/test-file.txt
 
-print_test "Verify alice (owner) has write+execute (but NOT read in this model)"
-log_step "rebac check alice write/execute on test-file.txt (expect GRANTED)"
+print_test "Verify alice (owner) has read+write+execute"
+log_step "rebac check alice read/write/execute on test-file.txt (expect GRANTED)"
+ALICE_READ=$(nexus rebac check user alice read file $DEMO_BASE/test-file.txt 2>&1)
 ALICE_WRITE=$(nexus rebac check user alice write file $DEMO_BASE/test-file.txt 2>&1)
 ALICE_EXEC=$(nexus rebac check user alice execute file $DEMO_BASE/test-file.txt 2>&1)
+echo "    alice read:    $(echo "$ALICE_READ" | grep -oE 'GRANTED|DENIED' | head -1)" >&2
 echo "    alice write:   $(echo "$ALICE_WRITE" | grep -oE 'GRANTED|DENIED' | head -1)" >&2
 echo "    alice execute: $(echo "$ALICE_EXEC" | grep -oE 'GRANTED|DENIED' | head -1)" >&2
-if echo "$ALICE_WRITE" | grep -q "GRANTED" && echo "$ALICE_EXEC" | grep -q "GRANTED"; then
-    print_success "✅ Owner has write + execute (as expected in this ReBAC model)"
-
-    ALICE_READ=$(nexus rebac check user alice read file $DEMO_BASE/test-file.txt 2>&1)
-    echo "    alice read: $(echo "$ALICE_READ" | grep -oE 'GRANTED|DENIED' | head -1)" >&2
-    if echo "$ALICE_READ" | grep -q "DENIED"; then
-        print_info "Note: Owner does NOT have read (needs editor/viewer role for that)"
-    fi
+if echo "$ALICE_READ" | grep -q "GRANTED" && echo "$ALICE_WRITE" | grep -q "GRANTED" && echo "$ALICE_EXEC" | grep -q "GRANTED"; then
+    print_success "✅ Owner has read + write + execute"
 else
-    print_error "Owner permissions incorrect! write=$(echo "$ALICE_WRITE"|grep -oE 'GRANTED|DENIED'|head -1) execute=$(echo "$ALICE_EXEC"|grep -oE 'GRANTED|DENIED'|head -1)"
+    print_error "Owner permissions incorrect! read=$(echo "$ALICE_READ" | grep -oE 'GRANTED|DENIED' | head -1) write=$(echo "$ALICE_WRITE" | grep -oE 'GRANTED|DENIED' | head -1) execute=$(echo "$ALICE_EXEC" | grep -oE 'GRANTED|DENIED' | head -1)"
 fi
 
 print_test "Verify bob (editor) has read+write but NOT execute"

--- a/scripts/test_build_perf_e2e.py
+++ b/scripts/test_build_perf_e2e.py
@@ -31,6 +31,8 @@ USER_KEY = os.environ.get("NEXUS_DEMO_USER_KEY", "")
 GRPC_PORT = os.environ.get("NEXUS_GRPC_PORT", "2029")
 HERB_SEARCH_PATH = "/workspace/demo/herb"
 AUTO_INDEX_MARKER = "zephyr marker"
+PLAN_AUTH_ORIGINAL = "- Configure authentication"
+PLAN_AUTH_EDITED = "- Configure auth (test-edit)"
 
 passed = 0
 failed = 0
@@ -67,6 +69,11 @@ def check(name: str, condition: bool, detail: str = "") -> None:
             msg += f" — {detail}"
         print(msg, flush=True)
     results.append((name, condition, detail))
+
+
+def _plan_auth_line_restored(text: str) -> bool:
+    lines = text.splitlines()
+    return PLAN_AUTH_ORIGINAL in lines and PLAN_AUTH_EDITED not in lines
 
 
 def _status_json_reachable(stdout: str) -> tuple[bool, str]:
@@ -321,7 +328,7 @@ def main() -> None:
         "edit",
         {
             "path": "/workspace/demo/plan.md",
-            "edits": [["Confgiure auth (test-edt)", "Configure authentication"]],
+            "edits": [["- Confgiure auth (test-edt)", PLAN_AUTH_ORIGINAL]],
             "fuzzy_threshold": 0.7,
         },
     )
@@ -330,6 +337,16 @@ def main() -> None:
         "edit (fuzzy restore)",
         result.get("success") and result.get("applied_count") == 1,
         str(result),
+    )
+    step("RPC sys_read verifying fuzzy restore is exact")
+    content = t.call_rpc("sys_read", {"path": "/workspace/demo/plan.md"})
+    text = content.decode() if isinstance(content, bytes) else str(content)
+    lines = text.splitlines()
+    check(
+        "fuzzy restore preserved original line",
+        _plan_auth_line_restored(text),
+        f"original exact line={PLAN_AUTH_ORIGINAL in lines}, "
+        f"edited exact line={PLAN_AUTH_EDITED in lines}",
     )
 
     step("RPC edit OCC conflict (expect exception)")

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -3815,7 +3815,23 @@ class SearchDaemon:
             # Fallback delete-propagation path: resolves DELETE events only
             # (always content_resolved) — the gate has nothing to do.
             return resolved
-        return await self._gate_unresolved(consumer_name, resolved)
+        collapsed = self._collapse_resolved_mutations(resolved)
+        retained_event_ids = {mutation.event.event_id for mutation in collapsed}
+        discarded_event_ids = list(
+            dict.fromkeys(
+                mutation.event.event_id
+                for mutation in resolved
+                if mutation.event.event_id not in retained_event_ids
+            )
+        )
+        if discarded_event_ids:
+            # Persist the durable cleanup before dropping in-memory retry state.
+            # If persistence fails, the exception keeps the batch checkpoint from
+            # advancing past a parked record that still needs operator attention.
+            await self._park_store.remove(consumer_name, discarded_event_ids)
+            for event_id in discarded_event_ids:
+                self._unresolved_attempts.pop((consumer_name, event_id), None)
+        return await self._gate_unresolved(consumer_name, collapsed)
 
     async def _gate_unresolved(
         self,
@@ -3943,7 +3959,7 @@ class SearchDaemon:
         embedding_active = (
             self._indexing_pipeline is not None and self._embedding_provider is not None
         )
-        resolved = self._collapse_resolved_mutations(await self._resolve_mutations("fts", events))
+        resolved = await self._resolve_mutations("fts", events)
         for mutation in resolved:
             is_delete_shaped = mutation.event.op == SearchMutationOp.DELETE or (
                 mutation.event.op == SearchMutationOp.UPSERT and mutation.content == ""
@@ -4000,9 +4016,7 @@ class SearchDaemon:
     async def _consume_embedding_mutations(self, events: list[SearchMutationEvent]) -> None:
         if self._indexing_pipeline is None or self._embedding_provider is None:
             return
-        resolved = self._collapse_resolved_mutations(
-            await self._resolve_mutations("embedding", events)
-        )
+        resolved = await self._resolve_mutations("embedding", events)
         for mutation in resolved:
             # Codex review R10 #1 (high): treat resolved-empty UPSERTs
             # as DELETEs (real truncation). Combined with the explicit

--- a/src/nexus/bricks/search/macro_chunk.py
+++ b/src/nexus/bricks/search/macro_chunk.py
@@ -186,10 +186,9 @@ async def expand_results(
         if not by_index or r.chunk_index not in by_index:
             continue  # gap — leave chunk_text as-is
         try:
-            s_lo, s_hi = _section_bounds(by_index, r.chunk_index)
-            key = (r.path, s_lo, s_hi)
+            w_lo, w_hi = _window_for_anchor(by_index, r.chunk_index, cfg, _is_code_path(r.path))
+            key = (r.path, w_lo, w_hi)
             if key not in section_cache:
-                w_lo, w_hi = _window_for_anchor(by_index, r.chunk_index, cfg, _is_code_path(r.path))
                 section_cache[key] = _stitch(by_index, w_lo, w_hi)
             text, ls, le = section_cache[key]
             r.macro_text = text

--- a/src/nexus/bricks/search/pg_vector_backend.py
+++ b/src/nexus/bricks/search/pg_vector_backend.py
@@ -17,6 +17,7 @@ protocol shape so isinstance() checks pass immediately.
 
 from __future__ import annotations
 
+import math
 from collections.abc import Sequence
 from typing import Any
 
@@ -25,6 +26,8 @@ from sqlalchemy.ext.asyncio import AsyncEngine
 
 from nexus.bricks.search.macro_chunk import ChunkRow
 from nexus.bricks.search.results import BaseSearchResult
+
+_EMBEDDING_DIMENSION = 1536
 
 # ---------------------------------------------------------------------------
 # SQL template
@@ -43,6 +46,7 @@ _SEMANTIC_SQL = text("""
     FROM document_chunks c
     JOIN file_paths fp ON c.path_id = fp.path_id
     WHERE c.embedding IS NOT NULL
+      AND l2_norm(c.embedding) > 0
       AND fp.zone_id = :zone_id
       AND fp.virtual_path LIKE :prefix || '%'
       AND fp.deleted_at IS NULL
@@ -163,11 +167,11 @@ class PgVectorBackend:
             (nearest neighbours first). ``vector_score`` is populated with the
             cosine similarity (1 − distance).
         """
-        # Empty-vector guard: pgvector rejects ``CAST('[]' AS halfvec)`` with
-        # ``zero-length vector not allowed`` (and a 1536-dim halfvec can't
-        # accept a 0-length input regardless). Fail fast so callers that
-        # forgot to embed the query get an empty list rather than a 500.
-        if not query_vector:
+        if len(query_vector) != _EMBEDDING_DIMENSION:
+            return []
+        if any(not math.isfinite(component) for component in query_vector):
+            return []
+        if math.sqrt(sum(component * component for component in query_vector)) <= 0:
             return []
         # pgvector expects '[0.1,0.2,...]' string for halfvec CAST.
         qvec_str = str(list(query_vector))
@@ -189,17 +193,25 @@ class PgVectorBackend:
                 .all()
             )
 
-        return [
-            BaseSearchResult(
-                path=r["path"],
-                chunk_text=r["chunk_text"],
-                score=float(r["score"]),
-                chunk_index=int(r["chunk_index"]),
-                vector_score=float(r["score"]),
-                zone_id=zone_id,
+        results: list[BaseSearchResult] = []
+        for r in rows:
+            score = r["score"]
+            if score is None:
+                continue
+            score_float = float(score)
+            if not math.isfinite(score_float):
+                continue
+            results.append(
+                BaseSearchResult(
+                    path=r["path"],
+                    chunk_text=r["chunk_text"],
+                    score=score_float,
+                    chunk_index=int(r["chunk_index"]),
+                    vector_score=score_float,
+                    zone_id=zone_id,
+                )
             )
-            for r in rows
-        ]
+        return results
 
     # -------------------------------------------------------------------------
     # Neighbor fetch — NeighborFetcher protocol (macro-chunk expansion, T6)

--- a/src/nexus/server/api/v2/routers/async_files.py
+++ b/src/nexus/server/api/v2/routers/async_files.py
@@ -18,7 +18,6 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from fastapi.responses import Response, StreamingResponse
 from pydantic import BaseModel, Field, field_validator
 
-from nexus._rust_compat import grep_files_mmap
 from nexus.bricks.search.primitives.glob_helpers import glob_filter
 from nexus.bricks.snapshot.errors import TransactionConflictError as _TransactionConflictError
 from nexus.contracts.exceptions import (
@@ -40,6 +39,7 @@ from nexus.server.zone_execution import run_zone_scoped
 
 logger = logging.getLogger(__name__)
 T = TypeVar("T")
+_PERMISSION_ERRORS = (NexusPermissionError, AccessDeniedError, PermissionError)
 
 
 def _gate_zone(
@@ -199,6 +199,30 @@ async def _maybe_await(value: Any) -> Any:
     if hasattr(value, "__await__"):
         return await value
     return value
+
+
+async def _call_sync_or_async(callable_obj: Any, /, *args: Any, **kwargs: Any) -> Any:
+    """Call VFS APIs without running synchronous I/O on the request event loop."""
+    if inspect.iscoroutinefunction(callable_obj) or inspect.iscoroutinefunction(
+        type(callable_obj).__call__
+    ):
+        return await callable_obj(*args, **kwargs)
+
+    value = await asyncio.to_thread(callable_obj, *args, **kwargs)
+    return await _maybe_await(value)
+
+
+def _entry_path(entry: Any) -> str | None:
+    if isinstance(entry, str):
+        return entry
+    if isinstance(entry, dict):
+        return entry.get("path") or entry.get("name")
+    return getattr(entry, "path", None) or getattr(entry, "name", None)
+
+
+async def _read_grep_file(fs: Any, virtual_path: str, context: Any) -> Any:
+    """Read a virtual grep candidate without blocking the request event loop."""
+    return await _call_sync_or_async(fs.read, virtual_path, context=context)
 
 
 def _encode_read_payload(
@@ -806,7 +830,7 @@ def create_async_files_router(
 
         except HTTPException:
             raise
-        except NexusPermissionError as e:
+        except _PERMISSION_ERRORS as e:
             raise HTTPException(status_code=403, detail=str(e)) from e
         except InvalidPathError as e:
             raise HTTPException(status_code=400, detail=str(e)) from e
@@ -943,7 +967,7 @@ def create_async_files_router(
                     if not _skip_access:
                         try:
                             _accessible = fs.access(path, context=context)
-                        except NexusPermissionError as e:
+                        except _PERMISSION_ERRORS as e:
                             raise HTTPException(status_code=403, detail=str(e)) from e
                         if not _accessible:
                             raise NexusFileNotFoundError(path)
@@ -1179,7 +1203,7 @@ def create_async_files_router(
         except AuthenticationError:
             # Preserve structured re-auth signal (see /list handler above).
             raise
-        except NexusPermissionError as e:
+        except _PERMISSION_ERRORS as e:
             raise HTTPException(status_code=403, detail=str(e)) from e
         except NexusFileNotFoundError as e:
             raise HTTPException(status_code=404, detail=str(e)) from e
@@ -1232,7 +1256,9 @@ def create_async_files_router(
 
         async def _work() -> Response:
             fs = await _get_fs()
-            meta = fs.sys_stat(path, context=context)  # raises -> 403 if denied
+            meta = await _call_sync_or_async(
+                fs.sys_stat, path, context=context
+            )  # raises -> 403 if denied
             if meta is None:
                 # sys_stat returns None when the VFS cannot resolve the path to an
                 # object. Fail closed: never mint a bearer S3/R2 URL for a key we
@@ -1318,6 +1344,8 @@ def create_async_files_router(
 
             try:
                 signed = signer(rel, expires_in=ttl, method="GET", context=context)
+            except _PERMISSION_ERRORS:
+                raise
             except Exception as e:
                 logger.exception(f"read-url signing error: {e}")
                 raise HTTPException(status_code=500, detail=f"signing failed: {e}") from e
@@ -1342,7 +1370,12 @@ def create_async_files_router(
         # path/query zone is rejected (400) before any stat/sign, and the stat +
         # mount resolution + signing all run in the resolved target zone — so an
         # out-of-band storage URL can't be minted across a tenant boundary.
-        return await _run_for_context(context, {"path": path, "zone": zone}, _work)
+        try:
+            return await _run_for_context(context, {"path": path, "zone": zone}, _work)
+        except HTTPException:
+            raise
+        except _PERMISSION_ERRORS as e:
+            raise HTTPException(status_code=403, detail=str(e)) from e
 
     @router.get("/md-structure")
     async def md_structure(
@@ -1381,7 +1414,7 @@ def create_async_files_router(
             return await _run_for_context(context, {"path": path}, _work)
         except HTTPException:
             raise
-        except NexusPermissionError as e:
+        except _PERMISSION_ERRORS as e:
             raise HTTPException(status_code=403, detail=str(e)) from e
         except NexusFileNotFoundError as e:
             raise HTTPException(status_code=404, detail=str(e)) from e
@@ -1506,7 +1539,7 @@ def create_async_files_router(
 
             return await _run_for_context(context, {"path": path, "zone": zone}, _work)
 
-        except NexusPermissionError as e:
+        except _PERMISSION_ERRORS as e:
             raise HTTPException(status_code=403, detail=str(e)) from e
         except NexusFileNotFoundError as e:
             raise HTTPException(status_code=404, detail=str(e)) from e
@@ -1539,7 +1572,7 @@ def create_async_files_router(
 
             return await _run_for_context(context, {"path": path, "zone": zone}, _work)
 
-        except NexusPermissionError as e:
+        except _PERMISSION_ERRORS as e:
             raise HTTPException(status_code=403, detail=str(e)) from e
         except InvalidPathError as e:
             raise HTTPException(status_code=400, detail=str(e)) from e
@@ -1775,7 +1808,7 @@ def create_async_files_router(
             # fields clients need for re-auth.  Wrapping as 500 would
             # drop the signal.
             raise
-        except NexusPermissionError as e:
+        except _PERMISSION_ERRORS as e:
             raise HTTPException(status_code=403, detail=str(e)) from e
         except NexusFileNotFoundError as e:
             raise HTTPException(status_code=404, detail=str(e)) from e
@@ -1811,7 +1844,7 @@ def create_async_files_router(
                 _work,
             )
 
-        except NexusPermissionError as e:
+        except _PERMISSION_ERRORS as e:
             raise HTTPException(status_code=403, detail=str(e)) from e
         except FileExistsError as e:
             raise HTTPException(status_code=409, detail=str(e)) from e
@@ -1850,7 +1883,7 @@ def create_async_files_router(
         except AuthenticationError:
             # Preserve structured re-auth signal (see /list and /read handlers).
             raise
-        except NexusPermissionError as e:
+        except _PERMISSION_ERRORS as e:
             raise HTTPException(status_code=403, detail=str(e)) from e
         except NexusFileNotFoundError as e:
             raise HTTPException(status_code=404, detail=str(e)) from e
@@ -1903,7 +1936,7 @@ def create_async_files_router(
                 _work,
             )
 
-        except NexusPermissionError as e:
+        except _PERMISSION_ERRORS as e:
             raise HTTPException(status_code=403, detail=str(e)) from e
         except InvalidPathError as e:
             raise HTTPException(status_code=400, detail=str(e)) from e
@@ -1952,7 +1985,7 @@ def create_async_files_router(
                 )
 
             return await _run_for_context(context, request, _work)
-        except (NexusPermissionError, AccessDeniedError) as e:
+        except _PERMISSION_ERRORS as e:
             raise HTTPException(status_code=403, detail=str(e)) from e
         except InvalidPathError as e:
             raise HTTPException(status_code=400, detail=str(e)) from e
@@ -2018,7 +2051,7 @@ def create_async_files_router(
             return await _run_for_context(context, request, _work)
         except NexusFileNotFoundError as e:
             raise HTTPException(status_code=404, detail=str(e)) from e
-        except (NexusPermissionError, AccessDeniedError) as e:
+        except _PERMISSION_ERRORS as e:
             raise HTTPException(status_code=403, detail=str(e)) from e
         except InvalidPathError as e:
             raise HTTPException(status_code=400, detail=str(e)) from e
@@ -2086,7 +2119,7 @@ def create_async_files_router(
 
             return await _run_for_context(context, {"path": path}, _work)
 
-        except NexusPermissionError as e:
+        except _PERMISSION_ERRORS as e:
             raise HTTPException(status_code=403, detail=str(e)) from e
         except NexusFileNotFoundError as e:
             raise HTTPException(status_code=404, detail=str(e)) from e
@@ -2124,7 +2157,7 @@ def create_async_files_router(
 
             return await _run_for_context(context, request, _work)
 
-        except NexusPermissionError as e:
+        except _PERMISSION_ERRORS as e:
             raise HTTPException(status_code=403, detail=str(e)) from e
         except NexusFileNotFoundError as e:
             raise HTTPException(status_code=404, detail=str(e)) from e
@@ -2181,7 +2214,7 @@ def create_async_files_router(
 
             return await _run_for_context(context, request, _work)
 
-        except NexusPermissionError as e:
+        except _PERMISSION_ERRORS as e:
             raise HTTPException(status_code=403, detail=str(e)) from e
         except NexusFileNotFoundError as e:
             raise HTTPException(status_code=404, detail=str(e)) from e
@@ -2227,7 +2260,7 @@ def create_async_files_router(
 
             return await _run_for_context(context, request, _work)
 
-        except NexusPermissionError as e:
+        except _PERMISSION_ERRORS as e:
             raise HTTPException(status_code=403, detail=str(e)) from e
         except InvalidPathError as e:
             raise HTTPException(status_code=400, detail=str(e)) from e
@@ -2304,7 +2337,7 @@ def create_async_files_router(
 
             return await _run_for_context(context, request, _work)
 
-        except NexusPermissionError as e:
+        except _PERMISSION_ERRORS as e:
             raise HTTPException(status_code=403, detail=str(e)) from e
         except InvalidPathError as e:
             raise HTTPException(status_code=400, detail=str(e)) from e
@@ -2330,10 +2363,10 @@ def create_async_files_router(
             async def _work() -> GlobResponse:
                 fs = await _get_fs()
 
-                # List all files under the base path
-                # sys_readdir is async — call directly, not via to_thread
-                all_paths = await _maybe_await(
-                    fs.sys_readdir(path, recursive=True, context=context)
+                # List all files without blocking the zone runner when a
+                # synchronous NexusFS implementation performs recursive I/O.
+                all_paths = await _call_sync_or_async(
+                    fs.sys_readdir, path, recursive=True, context=context
                 )
 
                 # Apply glob pattern filter
@@ -2355,7 +2388,7 @@ def create_async_files_router(
 
             return await _run_for_context(context, {"path": path}, _work)
 
-        except NexusPermissionError as e:
+        except _PERMISSION_ERRORS as e:
             raise HTTPException(status_code=403, detail=str(e)) from e
         except InvalidPathError as e:
             raise HTTPException(status_code=400, detail=str(e)) from e
@@ -2384,37 +2417,60 @@ def create_async_files_router(
             async def _work() -> GrepResponse:
                 fs = await _get_fs()
 
-                # List all files under the base path
-                # sys_readdir is async — call directly, not via to_thread
-                all_paths = await _maybe_await(
-                    fs.sys_readdir(path, recursive=True, context=context)
-                )
+                flags = re.IGNORECASE if ignore_case else 0
+                try:
+                    compiled = re.compile(pattern, flags)
+                except re.error as e:
+                    raise HTTPException(
+                        status_code=400, detail=f"Invalid regex pattern: {e}"
+                    ) from e
 
-                # Try Rust mmap grep first
-                results = await asyncio.to_thread(
-                    grep_files_mmap,
-                    pattern,
-                    all_paths,
-                    ignore_case=ignore_case,
-                    max_results=limit,
+                all_paths = await _call_sync_or_async(
+                    fs.sys_readdir, path, recursive=True, context=context
                 )
+                virtual_paths: list[str] = []
+                for entry in all_paths:
+                    entry_path = _entry_path(entry)
+                    if entry_path:
+                        virtual_paths.append(entry_path)
 
-                # Fallback to Python re if Rust is unavailable
-                if results is None:
-                    flags = re.IGNORECASE if ignore_case else 0
+                results: list[dict[str, Any]] = []
+                used_search_service = False
+                service_lookup = getattr(fs, "service", None)
+                if callable(service_lookup):
                     try:
-                        compiled = re.compile(pattern, flags)
-                    except re.error as e:
-                        raise HTTPException(
-                            status_code=400, detail=f"Invalid regex pattern: {e}"
-                        ) from e
+                        search = service_lookup("search")
+                    except _PERMISSION_ERRORS:
+                        raise
+                    except Exception:
+                        logger.debug("Search service lookup failed", exc_info=True)
+                    else:
+                        if search is not None:
+                            try:
+                                service_results = await _maybe_await(
+                                    search.grep(
+                                        pattern=pattern,
+                                        path=path,
+                                        ignore_case=ignore_case,
+                                        max_results=limit,
+                                        files=virtual_paths,
+                                        context=context,
+                                    )
+                                )
+                                if service_results is not None:
+                                    results = list(service_results)[:limit]
+                                    used_search_service = True
+                            except _PERMISSION_ERRORS:
+                                raise
+                            except Exception:
+                                logger.debug("Search service grep failed", exc_info=True)
 
-                    results = []
-                    for file_path in all_paths:
+                if not used_search_service:
+                    for file_path in virtual_paths:
                         if len(results) >= limit:
                             break
                         try:
-                            content = fs.read(file_path, context=context)
+                            content = await _read_grep_file(fs, file_path, context)
                             if isinstance(content, bytes):
                                 content = content.decode("utf-8", errors="replace")
                             elif isinstance(content, dict):
@@ -2434,11 +2490,31 @@ def create_async_files_router(
                                     )
                                     if len(results) >= limit:
                                         break
+                        except _PERMISSION_ERRORS:
+                            raise
                         except Exception:
-                            # Skip files that can't be read (binary, permissions, etc.)
+                            # Skip non-permission failures for individual files.
                             continue
 
-                total = len(results)
+                normalized_results: list[dict[str, Any]] = []
+                for result in results[:limit]:
+                    content = str(result.get("content", ""))
+                    match_text = result.get("match")
+                    if match_text is None:
+                        derived_match = compiled.search(content)
+                        if derived_match is None:
+                            continue
+                        match_text = derived_match.group(0)
+                    normalized_results.append(
+                        {
+                            "file": str(result.get("file", "")),
+                            "line": int(result.get("line", 0)),
+                            "content": content,
+                            "match": str(match_text),
+                        }
+                    )
+
+                total = len(normalized_results)
                 truncated = total >= limit
                 matches = [
                     GrepMatch(
@@ -2447,7 +2523,7 @@ def create_async_files_router(
                         content=r["content"],
                         match=r["match"],
                     )
-                    for r in results[:limit]
+                    for r in normalized_results
                 ]
 
                 return GrepResponse(
@@ -2462,7 +2538,7 @@ def create_async_files_router(
 
         except HTTPException:
             raise
-        except NexusPermissionError as e:
+        except _PERMISSION_ERRORS as e:
             raise HTTPException(status_code=403, detail=str(e)) from e
         except InvalidPathError as e:
             raise HTTPException(status_code=400, detail=str(e)) from e

--- a/src/nexus/server/api/v2/routers/tests/test_files_search.py
+++ b/src/nexus/server/api/v2/routers/tests/test_files_search.py
@@ -1,11 +1,16 @@
 """Tests for GET /glob and GET /grep file search endpoints."""
 
-from unittest.mock import MagicMock, patch
+import threading
+from pathlib import Path
+from typing import Any, cast
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from nexus._rust_compat import grep_files_mmap
+from nexus.contracts.exceptions import AccessDeniedError, NexusPermissionError
 from nexus.server.api.v2.routers.async_files import create_async_files_router
 from nexus.server.dependencies import get_auth_result
 
@@ -34,6 +39,7 @@ def mock_fs() -> MagicMock:
         return contents.get(path, b"")
 
     fs.read.side_effect = _read
+    fs.service.return_value = None
     return fs
 
 
@@ -150,12 +156,55 @@ class TestGlobEndpoint:
         resp = client.get("/glob", params={"pattern": "*.py", "path": "/secret"})
         assert resp.status_code == 403
 
+    def test_glob_builtin_permission_error(self, client: TestClient, mock_fs: MagicMock) -> None:
+        """Built-in PermissionError on readdir returns 403."""
+        mock_fs.sys_readdir.side_effect = PermissionError("Access denied")
+
+        resp = client.get("/glob", params={"pattern": "*.py", "path": "/secret"})
+        assert resp.status_code == 403
+
     def test_glob_internal_error(self, client: TestClient, mock_fs: MagicMock) -> None:
         """Unexpected error returns 500."""
         mock_fs.sys_readdir.side_effect = RuntimeError("disk failure")
 
         resp = client.get("/glob", params={"pattern": "*.py"})
         assert resp.status_code == 500
+
+    @patch("nexus.server.api.v2.routers.async_files.glob_filter")
+    def test_glob_sync_readdir_runs_off_event_loop(
+        self,
+        mock_glob_filter: MagicMock,
+        client: TestClient,
+        mock_fs: MagicMock,
+    ) -> None:
+        """Recursive synchronous listings do not block the zone event loop."""
+        event_loop_threads: list[int] = []
+        listing_threads: list[int] = []
+
+        def _readdir(*_args: object, **_kwargs: object) -> list[str]:
+            listing_threads.append(threading.get_ident())
+            return ["/remote.txt"]
+
+        async def _auth_result() -> dict[str, object]:
+            event_loop_threads.append(threading.get_ident())
+            return {
+                "authenticated": True,
+                "user_id": "test-user",
+                "groups": [],
+                "zone_id": "root",
+                "is_admin": False,
+            }
+
+        mock_fs.sys_readdir.side_effect = _readdir
+        mock_glob_filter.return_value = ["/remote.txt"]
+        cast(FastAPI, client.app).dependency_overrides[get_auth_result] = _auth_result
+
+        resp = client.get("/glob", params={"pattern": "*.txt"})
+
+        assert resp.status_code == 200
+        assert listing_threads
+        assert event_loop_threads
+        assert listing_threads[0] != event_loop_threads[0]
 
 
 # =============================================================================
@@ -171,13 +220,185 @@ class TestGrepEndpoint:
         resp = client.get("/grep")
         assert resp.status_code == 422
 
-    @patch("nexus.server.api.v2.routers.async_files.grep_files_mmap")
-    def test_grep_happy_path_rust(self, mock_grep: MagicMock, client: TestClient) -> None:
-        """Grep returns matches from Rust mmap grep."""
-        mock_grep.return_value = [
-            {"file": "/src/main.py", "line": 1, "content": "import os", "match": "import"},
-            {"file": "/src/utils.py", "line": 1, "content": "import sys", "match": "import"},
+    def test_grep_derives_match_from_real_mmap_service_result(
+        self,
+        client: TestClient,
+        mock_fs: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Real mmap output without ``match`` remains a valid API result."""
+        virtual_path = "/src/main.py"
+        local_path = tmp_path / "main.py"
+        local_path.write_text("before\nimport os\nafter\n", encoding="utf-8")
+
+        class ProductionShapedSearchService:
+            async def grep(self, **kwargs: Any) -> list[dict[str, Any]]:
+                assert kwargs["files"] == [virtual_path]
+                results = grep_files_mmap(
+                    str(kwargs["pattern"]),
+                    [str(local_path)],
+                    ignore_case=bool(kwargs["ignore_case"]),
+                    max_results=int(kwargs["max_results"]),
+                )
+                for result in results:
+                    result["file"] = virtual_path
+                return results
+
+        mock_fs.sys_readdir.return_value = [virtual_path]
+        mock_fs.service.return_value = ProductionShapedSearchService()
+
+        resp = client.get("/grep", params={"pattern": r"imp\w+", "limit": 5})
+
+        assert resp.status_code == 200
+        assert resp.json()["matches"] == [
+            {
+                "file": virtual_path,
+                "line": 2,
+                "content": "import os",
+                "match": "import",
+            }
         ]
+
+    def test_grep_delegates_virtual_working_set_context_and_limit(
+        self,
+        client: TestClient,
+        mock_fs: MagicMock,
+    ) -> None:
+        """The router delegates virtual candidates to SearchService."""
+        virtual_paths = ["/src/main.py", "/connector/remote.py"]
+        search = MagicMock()
+        search.grep = AsyncMock(
+            return_value=[
+                {
+                    "file": "/connector/remote.py",
+                    "line": 3,
+                    "content": "prefix needle suffix",
+                    "match": "needle",
+                }
+            ]
+        )
+        mock_fs.sys_readdir.return_value = virtual_paths
+        mock_fs.service.return_value = search
+
+        resp = client.get("/grep", params={"pattern": "needle", "limit": 7})
+
+        assert resp.status_code == 200
+        assert resp.json()["matches"][0]["file"] == "/connector/remote.py"
+        search.grep.assert_awaited_once()
+        kwargs = search.grep.await_args.kwargs
+        assert kwargs["files"] == virtual_paths
+        assert kwargs["max_results"] == 7
+        assert kwargs["context"].zone_id == "root"
+
+    def test_grep_virtual_host_looking_path_never_uses_host_path_authority(
+        self,
+        client: TestClient,
+        mock_fs: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """A connector key that names a real host file remains virtual."""
+        host_looking_key = str(tmp_path / "remote-key.txt")
+        (tmp_path / "remote-key.txt").write_text("host-only needle\n", encoding="utf-8")
+        search = MagicMock()
+        search.grep = AsyncMock(return_value=[])
+        mock_fs.sys_readdir.return_value = [host_looking_key]
+        mock_fs.service.return_value = search
+
+        with patch("pathlib.Path.is_file", side_effect=AssertionError("host path probe")):
+            resp = client.get("/grep", params={"pattern": "needle"})
+
+        assert resp.status_code == 200
+        assert resp.json()["matches"] == []
+        assert search.grep.await_args.kwargs["files"] == [host_looking_key]
+        mock_fs.read.assert_not_called()
+
+    def test_grep_sync_vfs_listing_and_read_run_off_event_loop(
+        self,
+        client: TestClient,
+        mock_fs: MagicMock,
+    ) -> None:
+        """Synchronous VFS listing and reads do not block the request event loop."""
+        event_loop_threads: list[int] = []
+        listing_threads: list[int] = []
+        read_threads: list[int] = []
+
+        def _readdir(*_args: object, **_kwargs: object) -> list[str]:
+            listing_threads.append(threading.get_ident())
+            return ["/remote.txt"]
+
+        def _read(*_args: object, **_kwargs: object) -> bytes:
+            read_threads.append(threading.get_ident())
+            return b"needle\n"
+
+        def _service(*_args: object, **_kwargs: object) -> None:
+            event_loop_threads.append(threading.get_ident())
+
+        mock_fs.sys_readdir.side_effect = _readdir
+        mock_fs.read.side_effect = _read
+        mock_fs.service.side_effect = _service
+
+        resp = client.get("/grep", params={"pattern": "needle"})
+
+        assert resp.status_code == 200
+        assert resp.json()["total"] == 1
+        assert listing_threads[0] != event_loop_threads[0]
+        assert read_threads[0] != event_loop_threads[0]
+
+    def test_grep_async_vfs_listing_is_awaited(
+        self,
+        client: TestClient,
+        mock_fs: MagicMock,
+    ) -> None:
+        """A native async recursive listing is awaited."""
+        mock_fs.sys_readdir = AsyncMock(return_value=["/remote.txt"])
+        mock_fs.read.side_effect = None
+        mock_fs.read.return_value = b"needle\n"
+
+        resp = client.get("/grep", params={"pattern": "needle"})
+
+        assert resp.status_code == 200
+        assert resp.json()["total"] == 1
+        mock_fs.sys_readdir.assert_awaited_once()
+
+    def test_grep_async_vfs_read_is_awaited(
+        self,
+        client: TestClient,
+        mock_fs: MagicMock,
+    ) -> None:
+        """A native async VFS reader is awaited on fallback."""
+        mock_fs.sys_readdir.return_value = ["/remote.txt"]
+        mock_fs.read = AsyncMock(return_value=b"needle\n")
+
+        resp = client.get("/grep", params={"pattern": "needle"})
+
+        assert resp.status_code == 200
+        assert resp.json()["total"] == 1
+        mock_fs.read.assert_awaited_once()
+
+    def test_grep_happy_path_search_service(
+        self,
+        client: TestClient,
+        mock_fs: MagicMock,
+    ) -> None:
+        """Grep returns virtual-path matches from SearchService."""
+        search = MagicMock()
+        search.grep = AsyncMock(
+            return_value=[
+                {
+                    "file": "/src/main.py",
+                    "line": 1,
+                    "content": "import os",
+                    "match": "import",
+                },
+                {
+                    "file": "/src/utils.py",
+                    "line": 1,
+                    "content": "import sys",
+                    "match": "import",
+                },
+            ]
+        )
+        mock_fs.service.return_value = search
 
         resp = client.get("/grep", params={"pattern": "import"})
         assert resp.status_code == 200
@@ -193,26 +414,41 @@ class TestGrepEndpoint:
         assert data["pattern"] == "import"
         assert data["base_path"] == "/"
 
-    @patch("nexus.server.api.v2.routers.async_files.grep_files_mmap")
-    def test_grep_with_ignore_case(self, mock_grep: MagicMock, client: TestClient) -> None:
-        """ignore_case parameter is forwarded to grep_files_mmap."""
-        mock_grep.return_value = []
+    def test_grep_with_ignore_case(
+        self,
+        client: TestClient,
+        mock_fs: MagicMock,
+    ) -> None:
+        """ignore_case parameter is forwarded to SearchService."""
+        search = MagicMock()
+        search.grep = AsyncMock(return_value=[])
+        mock_fs.service.return_value = search
 
         resp = client.get("/grep", params={"pattern": "README", "ignore_case": "true"})
         assert resp.status_code == 200
 
-        # Verify ignore_case was passed as True
-        mock_grep.assert_called_once()
-        call_args = mock_grep.call_args
-        assert call_args.kwargs["ignore_case"] is True
+        search.grep.assert_awaited_once()
+        assert search.grep.await_args.kwargs["ignore_case"] is True
 
-    @patch("nexus.server.api.v2.routers.async_files.grep_files_mmap")
-    def test_grep_truncation(self, mock_grep: MagicMock, client: TestClient) -> None:
-        """When Rust returns limit results, truncated=True."""
-        mock_grep.return_value = [
-            {"file": f"/file{i}.py", "line": 1, "content": "match", "match": "match"}
-            for i in range(10)
-        ]
+    def test_grep_truncation(
+        self,
+        client: TestClient,
+        mock_fs: MagicMock,
+    ) -> None:
+        """When SearchService returns limit results, truncated=True."""
+        search = MagicMock()
+        search.grep = AsyncMock(
+            return_value=[
+                {
+                    "file": f"/file{i}.py",
+                    "line": 1,
+                    "content": "match",
+                    "match": "match",
+                }
+                for i in range(10)
+            ]
+        )
+        mock_fs.service.return_value = search
 
         resp = client.get("/grep", params={"pattern": "match", "limit": 10})
         assert resp.status_code == 200
@@ -222,11 +458,8 @@ class TestGrepEndpoint:
         assert data["total"] == 10
         assert data["truncated"] is True
 
-    @patch("nexus.server.api.v2.routers.async_files.grep_files_mmap")
-    def test_grep_python_fallback(self, mock_grep: MagicMock, client: TestClient) -> None:
-        """When Rust grep returns None, falls back to Python re."""
-        mock_grep.return_value = None  # Rust unavailable
-
+    def test_grep_python_fallback(self, client: TestClient) -> None:
+        """Virtual paths are searched through fs.read() without SearchService."""
         resp = client.get("/grep", params={"pattern": "import"})
         assert resp.status_code == 200
 
@@ -237,21 +470,78 @@ class TestGrepEndpoint:
         assert "/src/main.py" in files_matched
         assert "/src/utils.py" in files_matched
 
-    @patch("nexus.server.api.v2.routers.async_files.grep_files_mmap")
-    def test_grep_python_fallback_invalid_regex(
-        self, mock_grep: MagicMock, client: TestClient
+    def test_grep_preserves_service_mixed_results_under_global_limit(
+        self,
+        client: TestClient,
+        mock_fs: MagicMock,
     ) -> None:
-        """Invalid regex pattern returns 400 in Python fallback path."""
-        mock_grep.return_value = None  # Rust unavailable, trigger Python fallback
+        """SearchService's merged lanes stay virtual and share one limit."""
+        search = MagicMock()
+        search.grep = AsyncMock(
+            return_value=[
+                {
+                    "file": "/local.py",
+                    "line": 1,
+                    "content": "import local",
+                    "match": "service-local",
+                },
+                {
+                    "file": "/virtual.py",
+                    "line": 1,
+                    "content": "import virtual",
+                    "match": "service-virtual",
+                },
+            ]
+        )
+        mock_fs.sys_readdir.return_value = ["/local.py", "/virtual.py"]
+        mock_fs.service.return_value = search
 
+        resp = client.get("/grep", params={"pattern": "import", "limit": 2})
+        assert resp.status_code == 200
+
+        data = resp.json()
+        assert [match["file"] for match in data["matches"]] == ["/local.py", "/virtual.py"]
+        assert [match["match"] for match in data["matches"]] == [
+            "service-local",
+            "service-virtual",
+        ]
+        assert search.grep.await_args.kwargs["max_results"] == 2
+        mock_fs.read.assert_not_called()
+
+    def test_grep_empty_service_results_are_valid_without_fallback(
+        self,
+        client: TestClient,
+        mock_fs: MagicMock,
+    ) -> None:
+        """An empty SearchService response does not trigger a second scan."""
+        search = MagicMock()
+        search.grep = AsyncMock(return_value=[])
+        mock_fs.sys_readdir.return_value = ["/virtual.py"]
+        mock_fs.read.return_value = b"needle virtual\n"
+        mock_fs.service.return_value = search
+
+        resp = client.get("/grep", params={"pattern": "needle"})
+        assert resp.status_code == 200
+
+        data = resp.json()
+        assert data["matches"] == []
+        mock_fs.read.assert_not_called()
+
+    def test_grep_python_fallback_invalid_regex(
+        self, client: TestClient, mock_fs: MagicMock
+    ) -> None:
+        """Invalid regex pattern returns 400 before listing or searching."""
         resp = client.get("/grep", params={"pattern": "[invalid"})
         assert resp.status_code == 400
         assert "Invalid regex" in resp.json()["detail"]
+        mock_fs.sys_readdir.assert_not_called()
+        mock_fs.service.assert_not_called()
 
-    @patch("nexus.server.api.v2.routers.async_files.grep_files_mmap")
-    def test_grep_no_matches(self, mock_grep: MagicMock, client: TestClient) -> None:
+    def test_grep_no_matches(self, client: TestClient, mock_fs: MagicMock) -> None:
         """Grep with no matches returns empty list."""
-        mock_grep.return_value = []
+        search = MagicMock()
+        search.grep = AsyncMock(return_value=[])
+        mock_fs.service.return_value = search
 
         resp = client.get("/grep", params={"pattern": "nonexistent_string_xyz"})
         assert resp.status_code == 200
@@ -260,6 +550,7 @@ class TestGrepEndpoint:
         assert data["matches"] == []
         assert data["total"] == 0
         assert data["truncated"] is False
+        mock_fs.read.assert_not_called()
 
     def test_grep_limit_max_validation(self, client: TestClient) -> None:
         """Limit exceeding 1000 returns 422."""
@@ -282,6 +573,98 @@ class TestGrepEndpoint:
         resp = client.get("/grep", params={"pattern": "test", "path": "/secret"})
         assert resp.status_code == 403
 
+    def test_grep_builtin_permission_error(self, client: TestClient, mock_fs: MagicMock) -> None:
+        """Built-in PermissionError on readdir returns 403."""
+        mock_fs.sys_readdir.side_effect = PermissionError("Access denied")
+
+        resp = client.get("/grep", params={"pattern": "test", "path": "/secret"})
+        assert resp.status_code == 403
+
+    @pytest.mark.parametrize(
+        "error",
+        [
+            PermissionError("Access denied"),
+            NexusPermissionError(path="/secret.txt", message="Access denied"),
+            AccessDeniedError(message="Access denied", path="/secret.txt"),
+        ],
+        ids=["builtin", "nexus", "namespace"],
+    )
+    def test_grep_virtual_read_permission_errors_return_403(
+        self,
+        client: TestClient,
+        mock_fs: MagicMock,
+        error: Exception,
+    ) -> None:
+        """Permission failures while reading a virtual file are not skipped."""
+        mock_fs.sys_readdir.return_value = ["/secret.txt"]
+        mock_fs.read.side_effect = error
+
+        resp = client.get("/grep", params={"pattern": "secret", "path": "/"})
+
+        assert resp.status_code == 403
+
+    @pytest.mark.parametrize(
+        "error",
+        [
+            PermissionError("Access denied"),
+            NexusPermissionError(path="/secret.txt", message="Access denied"),
+            AccessDeniedError(message="Access denied", path="/secret.txt"),
+        ],
+        ids=["builtin", "nexus", "namespace"],
+    )
+    def test_grep_search_service_permission_errors_return_403(
+        self,
+        client: TestClient,
+        mock_fs: MagicMock,
+        error: Exception,
+    ) -> None:
+        """Authorization failures from SearchService are not swallowed."""
+        search = MagicMock()
+        search.grep = AsyncMock(side_effect=error)
+        mock_fs.sys_readdir.return_value = ["/secret.txt"]
+        mock_fs.service.return_value = search
+
+        resp = client.get("/grep", params={"pattern": "secret", "path": "/"})
+
+        assert resp.status_code == 403
+        mock_fs.read.assert_not_called()
+
+    def test_grep_search_service_non_permission_error_uses_virtual_read(
+        self,
+        client: TestClient,
+        mock_fs: MagicMock,
+    ) -> None:
+        """Ordinary SearchService failures preserve the VFS fallback."""
+        search = MagicMock()
+        search.grep = AsyncMock(side_effect=RuntimeError("search unavailable"))
+        mock_fs.sys_readdir.return_value = ["/src/main.py"]
+        mock_fs.service.return_value = search
+
+        resp = client.get("/grep", params={"pattern": "import", "path": "/"})
+
+        assert resp.status_code == 200
+        assert [match["file"] for match in resp.json()["matches"]] == ["/src/main.py"]
+
+    def test_grep_virtual_read_non_permission_error_skips_only_failed_file(
+        self,
+        client: TestClient,
+        mock_fs: MagicMock,
+    ) -> None:
+        """An ordinary read failure does not suppress later valid matches."""
+        mock_fs.sys_readdir.return_value = ["/broken.txt", "/src/main.py"]
+
+        def _read(path: str, **_kwargs: object) -> bytes:
+            if path == "/broken.txt":
+                raise RuntimeError("unreadable")
+            return b"import os\n"
+
+        mock_fs.read.side_effect = _read
+
+        resp = client.get("/grep", params={"pattern": "import", "path": "/"})
+
+        assert resp.status_code == 200
+        assert [match["file"] for match in resp.json()["matches"]] == ["/src/main.py"]
+
     def test_grep_internal_error(self, client: TestClient, mock_fs: MagicMock) -> None:
         """Unexpected error returns 500."""
         mock_fs.sys_readdir.side_effect = RuntimeError("disk failure")
@@ -289,12 +672,11 @@ class TestGrepEndpoint:
         resp = client.get("/grep", params={"pattern": "test"})
         assert resp.status_code == 500
 
-    @patch("nexus.server.api.v2.routers.async_files.grep_files_mmap")
-    def test_grep_with_custom_base_path(
-        self, mock_grep: MagicMock, client: TestClient, mock_fs: MagicMock
-    ) -> None:
-        """Grep passes base path to sys_readdir."""
-        mock_grep.return_value = []
+    def test_grep_with_custom_base_path(self, client: TestClient, mock_fs: MagicMock) -> None:
+        """Grep passes base path to readdir and SearchService."""
+        search = MagicMock()
+        search.grep = AsyncMock(return_value=[])
+        mock_fs.service.return_value = search
 
         resp = client.get("/grep", params={"pattern": "test", "path": "/src"})
         assert resp.status_code == 200
@@ -306,3 +688,4 @@ class TestGrepEndpoint:
             or call_args[1].get("path") == "/src"
             or call_args[0] == ("/src",)
         )
+        assert search.grep.await_args.kwargs["path"] == "/src"

--- a/src/nexus/server/api/v2/routers/tests/test_read_url.py
+++ b/src/nexus/server/api/v2/routers/tests/test_read_url.py
@@ -7,12 +7,16 @@ storage. nexus stays out of the byte path.
 
 from __future__ import annotations
 
+import threading
+from collections.abc import Callable
+from typing import cast
 from unittest.mock import MagicMock
 
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from nexus.contracts.exceptions import AccessDeniedError, NexusPermissionError
 from nexus.server.api.v2.routers.async_files import create_async_files_router
 from nexus.server.dependencies import get_auth_result
 
@@ -42,6 +46,22 @@ class _PlainBackend:
     """A non-S3 backend with NO generate_signed_url (e.g. local)."""
 
 
+class _DenyingSignableBackend:
+    """S3-shaped signer that denies URL generation."""
+
+    def __init__(self, error: Exception) -> None:
+        self.error = error
+
+    def generate_signed_url(
+        self,
+        path: str,  # noqa: ARG002
+        expires_in: int = 3600,  # noqa: ARG002
+        method: str = "GET",  # noqa: ARG002
+        context: object = None,  # noqa: ARG002
+    ) -> dict[str, object]:
+        raise self.error
+
+
 class _GcsLikeBackend:
     """A signing backend whose generate_signed_url has NO ``method`` param (like
     PathGCSBackend). read-url must 409 it, not call it into a TypeError -> 500."""
@@ -58,9 +78,16 @@ class _GcsLikeBackend:
 _DEFAULT_STAT = {"content_id": "abc123", "size": 12, "is_directory": False}
 
 
-def _make_client(mounts: dict[str, object], stat_result: object = _DEFAULT_STAT) -> TestClient:
+def _make_client(
+    mounts: dict[str, object],
+    stat_result: object = _DEFAULT_STAT,
+    *,
+    stat_error: Exception | Callable[..., object] | None = None,
+    raise_server_exceptions: bool = True,
+) -> TestClient:
     fs = MagicMock()
     fs.sys_stat.return_value = stat_result
+    fs.sys_stat.side_effect = stat_error
     # The endpoint resolves the owning mount via this dict.
     fs._mounted_backend_instances = mounts
 
@@ -73,7 +100,7 @@ def _make_client(mounts: dict[str, object], stat_result: object = _DEFAULT_STAT)
         "zone_id": "root",
         "is_admin": True,
     }
-    return TestClient(app)
+    return TestClient(app, raise_server_exceptions=raise_server_exceptions)
 
 
 @pytest.fixture()
@@ -95,6 +122,36 @@ def test_read_url_s3_mount_returns_presigned_url(s3_backend: _SignableBackend) -
     assert body["path"] == "/workspace/demo/file.md"
     # Path handed to the backend is mount-relative (mount prefix stripped).
     assert s3_backend.calls == [("demo/file.md", 120, "GET")]
+
+
+def test_read_url_sync_stat_runs_off_event_loop(s3_backend: _SignableBackend) -> None:
+    """A synchronous authorization stat does not block the zone event loop."""
+    event_loop_threads: list[int] = []
+    stat_threads: list[int] = []
+
+    def _stat(*_args: object, **_kwargs: object) -> object:
+        stat_threads.append(threading.get_ident())
+        return _DEFAULT_STAT
+
+    async def _auth_result() -> dict[str, object]:
+        event_loop_threads.append(threading.get_ident())
+        return {
+            "authenticated": True,
+            "user_id": "alice",
+            "groups": [],
+            "zone_id": "root",
+            "is_admin": True,
+        }
+
+    client = _make_client({"/workspace": s3_backend}, stat_error=_stat)
+    cast(FastAPI, client.app).dependency_overrides[get_auth_result] = _auth_result
+
+    resp = client.get("/read-url", params={"path": "/workspace/demo/file.md"})
+
+    assert resp.status_code == 200
+    assert stat_threads
+    assert event_loop_threads
+    assert stat_threads[0] != event_loop_threads[0]
 
 
 def test_read_url_longest_mount_prefix_wins() -> None:
@@ -154,6 +211,47 @@ def test_read_url_stat_none_returns_404_without_signing(s3_backend: _SignableBac
 
     assert resp.status_code == 404
     assert s3_backend.calls == []  # signer must not have been called
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        PermissionError("Access denied"),
+        NexusPermissionError(path="/workspace/secret.txt", message="Access denied"),
+        AccessDeniedError(message="Access denied", path="/workspace/secret.txt"),
+    ],
+    ids=["builtin", "rebac", "namespace"],
+)
+def test_read_url_permission_errors_return_403(error: Exception) -> None:
+    client = _make_client(
+        {"/workspace": _SignableBackend()},
+        stat_error=error,
+        raise_server_exceptions=False,
+    )
+
+    resp = client.get("/read-url", params={"path": "/workspace/secret.txt"})
+
+    assert resp.status_code == 403
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        PermissionError("Access denied"),
+        NexusPermissionError(path="secret.txt", message="Access denied"),
+        AccessDeniedError(message="Access denied", path="secret.txt"),
+    ],
+    ids=["builtin", "rebac", "namespace"],
+)
+def test_read_url_signer_permission_errors_return_403(error: Exception) -> None:
+    client = _make_client(
+        {"/workspace": _DenyingSignableBackend(error)},
+        raise_server_exceptions=False,
+    )
+
+    resp = client.get("/read-url", params={"path": "/workspace/secret.txt"})
+
+    assert resp.status_code == 403
 
 
 def test_read_url_method_less_signer_returns_409() -> None:

--- a/src/nexus/server/auth/zone_routes.py
+++ b/src/nexus/server/auth/zone_routes.py
@@ -13,7 +13,6 @@ from fastapi import APIRouter, Depends, HTTPException, Request, status
 from pydantic import BaseModel, Field
 from sqlalchemy import func, select, text
 
-from nexus.bricks.auth.providers.database_local import DatabaseLocalAuth
 from nexus.bricks.auth.zone_helpers import (
     create_zone,
     normalize_to_slug,
@@ -106,25 +105,42 @@ def _trigger_federation_remove_zone(nx: Any, zone_id: str) -> bool:
 
 
 def _inline_zone_finalizer_deletes(session: Any, zone_id: str) -> None:
-    """Run the three zone-scoped DELETEs that previously lived in the K8s-
-    finalizer-pattern services (SearchZoneFinalizer for entities +
-    relationships, ReBACZoneFinalizer for rebac_tuples).
+    """Delete zone graph data and every ReBAC tuple that references the zone.
 
-    Inlined here as part of the K8s-finalizer abstraction simplification
-    (PR 7b).  No FK constraints exist between these tables and ``zones``;
-    orphan rows only waste storage.  Idempotent — running this twice for
-    the same zone is harmless.
+    Graph dependents are removed explicitly before their entities so cleanup
+    remains correct when SQLite foreign-key enforcement is disabled. ReBAC
+    cleanup includes tuple ownership and cross-zone subject/object references.
+    Every statement is idempotent, so retrying cleanup is harmless.
     """
+    session.execute(
+        text(
+            "DELETE FROM entity_mentions WHERE entity_id IN ("
+            "SELECT entity_id FROM entities WHERE zone_id = :zid)"
+        ),
+        {"zid": zone_id},
+    )
+    session.execute(
+        text(
+            "DELETE FROM relationships "
+            "WHERE zone_id = :zid "
+            "OR source_entity_id IN ("
+            "SELECT entity_id FROM entities WHERE zone_id = :zid) "
+            "OR target_entity_id IN ("
+            "SELECT entity_id FROM entities WHERE zone_id = :zid)"
+        ),
+        {"zid": zone_id},
+    )
     session.execute(
         text("DELETE FROM entities WHERE zone_id = :zid"),
         {"zid": zone_id},
     )
     session.execute(
-        text("DELETE FROM relationships WHERE zone_id = :zid"),
-        {"zid": zone_id},
-    )
-    session.execute(
-        text("DELETE FROM rebac_tuples WHERE zone_id = :zid"),
+        text(
+            "DELETE FROM rebac_tuples "
+            "WHERE zone_id = :zid "
+            "OR subject_zone_id = :zid "
+            "OR object_zone_id = :zid"
+        ),
         {"zid": zone_id},
     )
 
@@ -158,18 +174,18 @@ def _zone_to_response(zone: ZoneModel) -> ZoneResponse:
 
 @router.post("", response_model=ZoneResponse, status_code=status.HTTP_201_CREATED)
 async def create_zone_endpoint(
-    request: CreateZoneRequest,
+    zone_request: CreateZoneRequest,
+    request: Request,
     auth_result: dict[str, Any] = Depends(require_auth),
-    auth: DatabaseLocalAuth = Depends(get_auth_provider),
 ) -> ZoneResponse:
     """Create a new zone.
 
     The authenticated user will be added as owner of the new zone.
 
     Args:
-        request: Zone creation request
+        zone_request: Zone creation request body
+        request: FastAPI request used to resolve the app-scoped DB session
         auth_result: Authenticated identity (JWT, API key, or static admin key)
-        auth: Authentication provider for DB session access
 
     Returns:
         Created zone information
@@ -181,20 +197,21 @@ async def create_zone_endpoint(
     """
     user_id = auth_result["subject_id"]
 
-    with auth.session_factory() as session:
+    session_factory = _get_session_factory(request)
+    with session_factory() as session:
         # Determine zone_id
-        if request.zone_id:
+        if zone_request.zone_id:
             # Validate provided zone_id
-            is_valid, error_msg = validate_zone_id(request.zone_id)
+            is_valid, error_msg = validate_zone_id(zone_request.zone_id)
             if not is_valid:
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
                     detail=error_msg,
                 )
-            zone_id = request.zone_id
+            zone_id = zone_request.zone_id
         else:
             # Generate zone_id from name
-            suggested_slug = normalize_to_slug(request.name)
+            suggested_slug = normalize_to_slug(zone_request.name)
             zone_id = suggest_zone_id(suggested_slug, session)
 
         # Create zone
@@ -202,9 +219,9 @@ async def create_zone_endpoint(
             zone = create_zone(
                 session=session,
                 zone_id=zone_id,
-                name=request.name,
-                domain=request.domain,
-                description=request.description,
+                name=zone_request.name,
+                domain=zone_request.domain,
+                description=zone_request.description,
             )
 
             # Add authenticated user as zone owner via ReBAC
@@ -250,7 +267,6 @@ async def get_zone(
     zone_id: str,
     request: Request,
     auth_result: dict[str, Any] = Depends(require_auth),
-    auth: DatabaseLocalAuth = Depends(get_auth_provider),
 ) -> ZoneResponse:
     """Get zone information by ID.
 
@@ -259,9 +275,8 @@ async def get_zone(
 
     Args:
         zone_id: Zone identifier
-        request: FastAPI request (for ``app.state.policy_gate`` lookup)
+        request: FastAPI request for policy-gate and DB-session lookup
         auth_result: Authenticated identity (JWT, API key, or static admin key)
-        auth: Authentication provider for DB session access
 
     Returns:
         Zone information
@@ -275,7 +290,8 @@ async def get_zone(
     user_id = auth_result["subject_id"]
     is_admin = auth_result.get("is_admin", False)
 
-    with auth.session_factory() as session:
+    session_factory = _get_session_factory(request)
+    with session_factory() as session:
         # Check zone access (admins can access any zone)
         nx = get_nexus_instance()
         rebac_mgr = nx.service("rebac_manager") if (nx and hasattr(nx, "service")) else None
@@ -390,11 +406,26 @@ async def _zone_access_approved_via_gate(
 
 
 def _get_session_factory(request: Request) -> Any:
-    """Get a DB session factory from auth provider or NexusFS."""
-    # Try auth provider first
+    """Resolve the app-scoped, provider-backed, or NexusFS DB session factory."""
+    sf = getattr(request.app.state, "session_factory", None)
+    if sf is not None:
+        return sf
+
+    provider = getattr(request.app.state, "auth_provider", None)
+    sf = getattr(provider, "session_factory", None)
+    if sf is not None:
+        return sf
+    for attr in ("providers", "_providers"):
+        for child in getattr(provider, attr, ()) or ():
+            sf = getattr(child, "session_factory", None)
+            if sf is not None:
+                return sf
+
     try:
         auth = get_auth_provider()
-        return auth.session_factory
+        sf = getattr(auth, "session_factory", None)
+        if sf is not None:
+            return sf
     except HTTPException:
         pass
     # Fallback: NexusFS.SessionLocal
@@ -418,8 +449,7 @@ async def list_zones(
     """List zones the authenticated user belongs to.
 
     Global admins can see all zones. Regular users only see zones
-    they are members of. Works with both DatabaseLocalAuth and
-    API key authentication.
+    they are members of. Works with JWT and API-key authentication.
 
     Args:
         auth_result: Authenticated identity (JWT, API key, or static admin key)
@@ -522,8 +552,8 @@ class ZoneDeprovisionResponse(BaseModel):
 )
 async def delete_zone_endpoint(
     zone_id: str,
+    request: Request,
     auth_result: dict[str, Any] = Depends(require_auth),
-    auth: DatabaseLocalAuth = Depends(get_auth_provider),
 ) -> ZoneDeprovisionResponse:
     """Delete (deprovision) a zone.
 
@@ -544,8 +574,8 @@ async def delete_zone_endpoint(
 
     Args:
         zone_id: Zone identifier
+        request: FastAPI request used to resolve the app-scoped DB session
         auth_result: Authenticated identity (JWT, API key, or static admin key)
-        auth: Authentication provider for DB session access
 
     Raises:
         403: User is not zone owner or global admin, or zone is ROOT_ZONE_ID
@@ -572,7 +602,8 @@ async def delete_zone_endpoint(
 
     nx = get_nexus_instance()
 
-    with auth.session_factory() as session:
+    session_factory = _get_session_factory(request)
+    with session_factory() as session:
         if not is_admin:
             # Require zone *owner* (not mere member) for destructive operations
             rebac_mgr = nx.service("rebac_manager") if (nx and hasattr(nx, "service")) else None

--- a/src/nexus/server/cache_warmer.py
+++ b/src/nexus/server/cache_warmer.py
@@ -25,10 +25,13 @@ import asyncio
 import logging
 import threading
 import time
+from collections import deque
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from nexus.contracts.constants import ROOT_ZONE_ID
+from nexus.contracts.metadata import DT_DIR, DT_MOUNT, DT_REG
+from nexus.core.pagination import PaginatedResult
 from nexus.server.zone_execution import run_zone_scoped
 
 if TYPE_CHECKING:
@@ -36,6 +39,11 @@ if TYPE_CHECKING:
     from nexus.storage.local_disk_cache import LocalDiskCache
 
 logger = logging.getLogger(__name__)
+
+_DISCOVERY_PAGE_SIZE = 256
+_DISCOVERY_ENTRY_MULTIPLIER = 16
+_DISCOVERY_LISTING_MULTIPLIER = 4
+_DISCOVERY_MIN_LISTINGS = 4
 
 # =============================================================================
 # Configuration
@@ -520,18 +528,13 @@ class CacheWarmer:
                 f"include_content={include_content}, max_files={max_files}"
             )
 
-            # Get files using glob
-            pattern = self._build_glob_pattern(path, depth)
-            search = self._nexus.service("search")
-            assert search is not None, "SearchService required for cache warmup"
-            files = search.glob(pattern, path="/", context=context)
-            files = files[:max_files]
+            files = await self._discover_files_for_warmup(path, depth, max_files, context)
 
             logger.info(f"[WARMUP] Found {len(files)} files to warm")
 
             # Parallel metadata warmup
             metadata_tasks = [self._warmup_metadata(f, zone_id, context) for f in files]
-            await asyncio.gather(*metadata_tasks, return_exceptions=True)
+            metadata_results = await asyncio.gather(*metadata_tasks, return_exceptions=True)
 
             # Content warmup for small files if requested
             if include_content:
@@ -543,7 +546,7 @@ class CacheWarmer:
                 await asyncio.gather(*content_tasks, return_exceptions=True)
 
             self._current_stats.duration_seconds = time.time() - start_time
-            self._current_stats.files_warmed = len(files)
+            self._current_stats.files_warmed = sum(result is True for result in metadata_results)
 
             logger.info(f"[WARMUP] Directory warmup complete: {self._current_stats.to_dict()}")
 
@@ -556,6 +559,103 @@ class CacheWarmer:
 
         finally:
             self._is_warming = False
+
+    async def _discover_files_for_warmup(
+        self,
+        path: str,
+        depth: int,
+        max_files: int,
+        context: Any | None,
+    ) -> list[str]:
+        """Discover files with bounded non-recursive directory listing."""
+        if max_files <= 0 or depth <= 0:
+            return []
+
+        files: list[str] = []
+        queue: deque[tuple[str, int]] = deque([(path or "/", 1)])
+        entry_budget = max(_DISCOVERY_PAGE_SIZE, max_files * _DISCOVERY_ENTRY_MULTIPLIER)
+        minimum_pages = (entry_budget + _DISCOVERY_PAGE_SIZE - 1) // _DISCOVERY_PAGE_SIZE
+        listing_budget = max(
+            _DISCOVERY_MIN_LISTINGS,
+            minimum_pages * _DISCOVERY_LISTING_MULTIPLIER,
+        )
+        entries_examined = 0
+        listings = 0
+
+        while (
+            queue
+            and len(files) < max_files
+            and entries_examined < entry_budget
+            and listings < listing_budget
+        ):
+            current_path, current_depth = queue.popleft()
+            cursor: str | None = None
+
+            while (
+                len(files) < max_files
+                and entries_examined < entry_budget
+                and listings < listing_budget
+            ):
+                limit = min(_DISCOVERY_PAGE_SIZE, entry_budget - entries_examined)
+                result = await asyncio.to_thread(
+                    self._nexus.sys_readdir,
+                    current_path,
+                    recursive=False,
+                    details=True,
+                    limit=limit,
+                    cursor=cursor,
+                    context=context,
+                )
+                listings += 1
+                entries, cursor, has_more = self._coerce_readdir_page(result)
+
+                for entry in entries[: entry_budget - entries_examined]:
+                    entries_examined += 1
+                    entry_path, entry_type = self._entry_path_and_type(entry)
+                    if not entry_path or entry_path == current_path:
+                        continue
+                    if entry_type in (DT_DIR, DT_MOUNT):
+                        if current_depth < depth:
+                            queue.append((entry_path, current_depth + 1))
+                        continue
+                    if entry_type == DT_REG:
+                        files.append(entry_path)
+                        if len(files) >= max_files:
+                            break
+
+                if not has_more or cursor is None:
+                    break
+
+        if queue and len(files) < max_files:
+            logger.info(
+                "[WARMUP] Discovery budget reached after %d entries and %d listings",
+                entries_examined,
+                listings,
+            )
+
+        return files
+
+    @staticmethod
+    def _coerce_readdir_page(result: Any) -> tuple[list[Any], str | None, bool]:
+        if isinstance(result, PaginatedResult):
+            return result.items, result.next_cursor, result.has_more
+        if isinstance(result, dict) and "items" in result:
+            return (
+                list(result.get("items") or []),
+                result.get("next_cursor"),
+                bool(result.get("has_more")),
+            )
+        return list(result or []), None, False
+
+    @staticmethod
+    def _entry_path_and_type(entry: Any) -> tuple[str | None, int | None]:
+        if isinstance(entry, dict):
+            return entry.get("path") or entry.get("name"), entry.get("entry_type")
+        if isinstance(entry, tuple) and len(entry) >= 2:
+            return entry[0], entry[1]
+        return getattr(entry, "path", None) or getattr(entry, "name", None), getattr(
+            entry, "entry_type", None
+        )
 
     async def warmup_from_history(
         self,
@@ -770,7 +870,7 @@ class CacheWarmer:
 
             # Warm metadata
             metadata_tasks = [self._warmup_metadata(p, zone_id, context) for p in paths]
-            await asyncio.gather(*metadata_tasks, return_exceptions=True)
+            metadata_results = await asyncio.gather(*metadata_tasks, return_exceptions=True)
 
             # Warm content if requested
             if include_content:
@@ -781,7 +881,7 @@ class CacheWarmer:
                 await asyncio.gather(*content_tasks, return_exceptions=True)
 
             self._current_stats.duration_seconds = time.time() - start_time
-            self._current_stats.files_warmed = len(paths)
+            self._current_stats.files_warmed = sum(result is True for result in metadata_results)
 
             return self._current_stats
 
@@ -807,26 +907,23 @@ class CacheWarmer:
         self,
         path: str,
         _zone_id: str,
-        _context: Any | None,
-    ) -> None:
+        context: Any | None,
+    ) -> bool:
         """Warm metadata cache for a single file."""
         async with self._semaphore:
             try:
-                # Check if file exists (warms exists cache)
-                exists = self._nexus.access(path)
-                if not exists:
+                metadata = await asyncio.to_thread(self._nexus.sys_stat, path, context=context)
+                if metadata is None:
                     self._current_stats.skipped += 1
-                    return
+                    return False
 
-                # Get metadata (warms path cache)
-                # This internally triggers the metadata cache
-                metadata = self._nexus.metadata.get(path)
-                if metadata:
-                    self._current_stats.metadata_warmed += 1
+                self._current_stats.metadata_warmed += 1
+                return True
 
             except Exception as e:
                 logger.debug(f"[WARMUP] Metadata warmup failed for {path}: {e}")
                 self._current_stats.errors += 1
+                return False
 
     async def _warmup_content(
         self,
@@ -850,9 +947,13 @@ class CacheWarmer:
                     # ``content_id``, which is the canonical identifier the L2
                     # cache keys on.
                     if self._local_disk_cache and isinstance(content, bytes):
-                        metadata = self._nexus.metadata.get(path)
-                        if metadata and metadata.content_id:
-                            content_id = metadata.content_id
+                        metadata = await asyncio.to_thread(
+                            self._nexus.sys_stat,
+                            path,
+                            context=context,
+                        )
+                        content_id = self._metadata_field(metadata, "content_id")
+                        if content_id:
                             self._local_disk_cache.put(
                                 content_id,
                                 content,
@@ -874,13 +975,26 @@ class CacheWarmer:
 
         for path in paths:
             try:
-                metadata = self._nexus.metadata.get(path)
-                if metadata and metadata.size and metadata.size < threshold:
+                metadata = await asyncio.to_thread(
+                    self._nexus.sys_stat,
+                    path,
+                    context=_context,
+                )
+                size = self._metadata_field(metadata, "size")
+                if size is not None and size < threshold:
                     small_files.append(path)
             except Exception as e:
                 logger.debug("Failed to check metadata for path %s: %s", path, e)
 
         return small_files
+
+    @staticmethod
+    def _metadata_field(metadata: Any, field: str) -> Any:
+        if metadata is None:
+            return None
+        if isinstance(metadata, dict):
+            return metadata.get(field)
+        return getattr(metadata, field, None)
 
     async def _warmup_permission_check(
         self,

--- a/src/nexus/server/lifespan/permissions.py
+++ b/src/nexus/server/lifespan/permissions.py
@@ -36,7 +36,7 @@ async def startup_permissions(app: "FastAPI", svc: "LifespanServices") -> list[a
     await _startup_durable_invalidation(app, svc)  # Issue #3396
     bg_tasks.extend(await _startup_tiger_cache(app, svc))
     bg_tasks.extend(_startup_backfill(app, svc))
-    _startup_cache_warmup(app, svc)
+    bg_tasks.extend(_startup_cache_warmup(app, svc))
     await _startup_circuit_breaker(app, svc)
 
     return bg_tasks
@@ -446,12 +446,16 @@ def _startup_backfill(_app: "FastAPI", svc: "LifespanServices") -> list[asyncio.
     return bg_tasks
 
 
-def _startup_cache_warmup(_app: "FastAPI", svc: "LifespanServices") -> None:
+def _startup_cache_warmup(_app: "FastAPI", svc: "LifespanServices") -> list[asyncio.Task]:
     """File cache warmup on server startup (Issue #1076)."""
     if not svc.nexus_fs:
-        return
+        return []
 
     try:
+        if not _parse_cache_warmup_enabled():
+            logger.info("[WARMUP] Server startup warmup disabled")
+            return []
+
         warmup_max_files = int(os.getenv("NEXUS_CACHE_WARMUP_MAX_FILES", "1000"))
         warmup_depth = int(os.getenv("NEXUS_CACHE_WARMUP_DEPTH", "2"))
         _nexus_fs_warmup = svc.nexus_fs  # Capture for closure
@@ -477,14 +481,43 @@ def _startup_cache_warmup(_app: "FastAPI", svc: "LifespanServices") -> None:
                 stats.metadata_warmed,
             )
 
-        asyncio.create_task(_warmup_file_cache())
+        task = asyncio.create_task(_warmup_file_cache())
+        task.add_done_callback(_observe_cache_warmup_task)
         logger.info(
             "[WARMUP] Server startup warmup started (max_files=%d, depth=%d)",
             warmup_max_files,
             warmup_depth,
         )
+        return [task]
+    except (ValueError, TypeError) as e:
+        logger.warning("[WARMUP] Server startup warmup skipped due to invalid config: %s", e)
+        return []
     except Exception as e:
         logger.debug("[WARMUP] Server startup warmup skipped: %s", e)
+        return []
+
+
+def _observe_cache_warmup_task(task: asyncio.Future[None]) -> None:
+    try:
+        task.result()
+    except asyncio.CancelledError:
+        logger.debug("[WARMUP] Server startup warmup cancelled")
+    except Exception:
+        logger.exception("[WARMUP] Server startup warmup failed")
+
+
+def _parse_cache_warmup_enabled() -> bool:
+    raw = os.getenv("NEXUS_CACHE_WARMUP_ENABLED")
+    if raw is None:
+        return True
+
+    value = raw.strip().lower()
+    if value in {"1", "true", "t", "yes", "y", "on"}:
+        return True
+    if value in {"0", "false", "f", "no", "n", "off"}:
+        return False
+
+    raise ValueError(f"invalid NEXUS_CACHE_WARMUP_ENABLED={raw!r}")
 
 
 async def _startup_circuit_breaker(app: "FastAPI", svc: "LifespanServices") -> None:

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -175,8 +175,10 @@ def nexus_server(isolated_db, tmp_path):
         env=env,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-        # Use process group so we can kill all child processes
-        preexec_fn=os.setsid if sys.platform != "win32" else None,
+        # Use a process group so cleanup can terminate all children.  Python's
+        # native flag performs setsid safely in the child; preexec_fn can
+        # deadlock when pytest has already started background threads.
+        start_new_session=sys.platform != "win32",
     )
 
     # Event-driven readiness: drain stdout/stderr in background threads and

--- a/tests/e2e/server/test_cache_warmup_e2e.py
+++ b/tests/e2e/server/test_cache_warmup_e2e.py
@@ -12,6 +12,13 @@ Run with:
 
 import pytest
 
+AUTH_HEADERS = {"Authorization": "Bearer test-e2e-api-key-12345"}
+
+
+@pytest.fixture(autouse=True)
+def _authenticate_test_app(test_app):
+    test_app.headers.update(AUTH_HEADERS)
+
 
 class TestCacheWarmupAPI:
     """End-to-end tests for Cache Warmup API endpoints."""
@@ -79,6 +86,8 @@ class TestCacheWarmupAPI:
 
         assert data["status"] == "completed"
         assert "files_warmed" in data
+        assert data["files_warmed"] >= 2
+        assert data["metadata_warmed"] >= 2
         assert "duration_seconds" in data
         assert data["duration_seconds"] >= 0
 
@@ -111,7 +120,9 @@ class TestCacheWarmupAPI:
 
         assert data["status"] == "completed"
         assert "content_warmed" in data
+        assert data["content_warmed"] >= 1
         assert "bytes_warmed" in data
+        assert data["bytes_warmed"] > 0
 
     @pytest.mark.asyncio
     async def test_cache_warmup_requires_path_or_user(self, test_app):

--- a/tests/e2e/server/test_zone_deprovision_permissions_e2e.py
+++ b/tests/e2e/server/test_zone_deprovision_permissions_e2e.py
@@ -100,7 +100,7 @@ async def app_with_auth():
 
     client = TestClient(app)
 
-    yield {"client": client, "nx": nx}
+    yield {"client": client, "nx": nx, "session_factory": SessionLocal}
 
     # Cleanup
     nx.close()
@@ -186,10 +186,10 @@ class TestZonePermissions:
     """Verify ReBAC permissions on zone endpoints."""
 
     def test_unauthenticated_delete_returns_error(self, app_with_auth):
-        """DELETE without token → 422 (missing header)."""
+        """DELETE without token → 401 from the unified auth dependency."""
         client = app_with_auth["client"]
         resp = client.delete("/api/zones/perm-test-zone")
-        assert resp.status_code == 422
+        assert resp.status_code == 401
 
     def test_outsider_cannot_get_zone(self, app_with_auth, outsider_token, zone_id):
         """Non-member cannot GET a zone they don't belong to."""
@@ -313,6 +313,160 @@ class TestDeprovisionLifecycle:
             data = get_resp.json()
             assert data["phase"] in ("Terminating", "Terminated")
             assert data["is_active"] is False
+
+    def test_deprovision_removes_only_target_zone_graph_and_rebac_rows(
+        self,
+        app_with_auth,
+        owner_token,
+    ):
+        """Finalizer deletes all target references and preserves control rows."""
+        from sqlalchemy import text
+
+        client = app_with_auth["client"]
+        session_factory = app_with_auth["session_factory"]
+        headers = {"Authorization": f"Bearer {owner_token}"}
+        target_zone = "cleanup-target-zone"
+        control_zone = "cleanup-control-zone"
+
+        for zone_id, name in (
+            (target_zone, "Cleanup Target"),
+            (control_zone, "Cleanup Control"),
+        ):
+            response = client.post(
+                "/api/zones",
+                json={"name": name, "zone_id": zone_id},
+                headers=headers,
+            )
+            assert response.status_code == 201, response.text
+
+        with session_factory() as session:
+            # This regression must exercise the explicit cleanup statements,
+            # not SQLite's optional ON DELETE CASCADE behavior.
+            assert session.execute(text("PRAGMA foreign_keys")).scalar_one() == 0
+
+            for prefix, zone_id in (("target", target_zone), ("control", control_zone)):
+                session.execute(
+                    text(
+                        "INSERT INTO entities ("
+                        "entity_id, zone_id, canonical_name, entity_type, merge_count, "
+                        "created_at, updated_at) VALUES ("
+                        ":source_id, :zone_id, :source_name, 'CONCEPT', 1, "
+                        "CURRENT_TIMESTAMP, CURRENT_TIMESTAMP), ("
+                        ":target_id, :zone_id, :target_name, 'CONCEPT', 1, "
+                        "CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"
+                    ),
+                    {
+                        "source_id": f"{prefix}-source",
+                        "target_id": f"{prefix}-target",
+                        "zone_id": zone_id,
+                        "source_name": f"{prefix} source",
+                        "target_name": f"{prefix} target",
+                    },
+                )
+                session.execute(
+                    text(
+                        "INSERT INTO relationships ("
+                        "relationship_id, zone_id, source_entity_id, target_entity_id, "
+                        "relationship_type, weight, confidence, created_at) VALUES ("
+                        ":relationship_id, :zone_id, :source_id, :target_id, "
+                        "'RELATES_TO', 1.0, 1.0, CURRENT_TIMESTAMP)"
+                    ),
+                    {
+                        "relationship_id": f"{prefix}-relationship",
+                        "zone_id": zone_id,
+                        "source_id": f"{prefix}-source",
+                        "target_id": f"{prefix}-target",
+                    },
+                )
+                session.execute(
+                    text(
+                        "INSERT INTO entity_mentions ("
+                        "mention_id, entity_id, confidence, mention_text, created_at) VALUES ("
+                        ":mention_id, :entity_id, 1.0, :mention_text, CURRENT_TIMESTAMP)"
+                    ),
+                    {
+                        "mention_id": f"{prefix}-mention",
+                        "entity_id": f"{prefix}-source",
+                        "mention_text": f"{prefix} mention",
+                    },
+                )
+
+            for tuple_id, tuple_zone, subject_zone, object_zone in (
+                ("target-owned-tuple", target_zone, target_zone, target_zone),
+                ("target-subject-cross-tuple", control_zone, target_zone, control_zone),
+                ("target-object-cross-tuple", control_zone, control_zone, target_zone),
+                ("control-tuple", control_zone, control_zone, control_zone),
+            ):
+                session.execute(
+                    text(
+                        "INSERT INTO rebac_tuples ("
+                        "tuple_id, zone_id, subject_zone_id, object_zone_id, subject_type, "
+                        "subject_id, relation, object_type, object_id, created_at) VALUES ("
+                        ":tuple_id, :tuple_zone, :subject_zone, :object_zone, 'user', "
+                        ":subject_id, 'viewer', 'zone', :object_id, CURRENT_TIMESTAMP)"
+                    ),
+                    {
+                        "tuple_id": tuple_id,
+                        "tuple_zone": tuple_zone,
+                        "subject_zone": subject_zone,
+                        "object_zone": object_zone,
+                        "subject_id": f"{tuple_id}-subject",
+                        "object_id": f"{tuple_id}-object",
+                    },
+                )
+            session.commit()
+
+        delete_response = client.delete(f"/api/zones/{target_zone}", headers=headers)
+        assert delete_response.status_code == 202, delete_response.text
+
+        with session_factory() as session:
+            target_entity_count = session.execute(
+                text("SELECT COUNT(*) FROM entities WHERE zone_id = :zone_id"),
+                {"zone_id": target_zone},
+            ).scalar_one()
+            control_entity_count = session.execute(
+                text("SELECT COUNT(*) FROM entities WHERE zone_id = :zone_id"),
+                {"zone_id": control_zone},
+            ).scalar_one()
+            assert target_entity_count == 0
+            assert control_entity_count == 2
+
+            target_relationship_count = session.execute(
+                text("SELECT COUNT(*) FROM relationships WHERE zone_id = :zone_id"),
+                {"zone_id": target_zone},
+            ).scalar_one()
+            control_relationship_count = session.execute(
+                text("SELECT COUNT(*) FROM relationships WHERE zone_id = :zone_id"),
+                {"zone_id": control_zone},
+            ).scalar_one()
+            assert target_relationship_count == 0
+            assert control_relationship_count == 1
+
+            target_mention_count = session.execute(
+                text("SELECT COUNT(*) FROM entity_mentions WHERE mention_id = :mention_id"),
+                {"mention_id": "target-mention"},
+            ).scalar_one()
+            control_mention_count = session.execute(
+                text("SELECT COUNT(*) FROM entity_mentions WHERE mention_id = :mention_id"),
+                {"mention_id": "control-mention"},
+            ).scalar_one()
+
+            target_tuple_reference_count = session.execute(
+                text(
+                    "SELECT COUNT(*) FROM rebac_tuples "
+                    "WHERE zone_id = :zone_id "
+                    "OR subject_zone_id = :zone_id "
+                    "OR object_zone_id = :zone_id"
+                ),
+                {"zone_id": target_zone},
+            ).scalar_one()
+            control_tuple_count = session.execute(
+                text("SELECT COUNT(*) FROM rebac_tuples WHERE tuple_id = :tuple_id"),
+                {"tuple_id": "control-tuple"},
+            ).scalar_one()
+            assert (target_mention_count, target_tuple_reference_count) == (0, 0)
+            assert control_mention_count == 1
+            assert control_tuple_count == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/e2e/server/test_zone_routes_e2e.py
+++ b/tests/e2e/server/test_zone_routes_e2e.py
@@ -8,14 +8,26 @@ Tests the security fixes for zone endpoints:
 Run with: PYTHONPATH=src python -m pytest tests/e2e/test_zone_routes_e2e.py -v
 """
 
+from types import SimpleNamespace
+
 import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from nexus.bricks.auth.providers.database_key import DatabaseAPIKeyAuth
+from nexus.server.auth.factory import create_auth_provider
+from nexus.server.auth.zone_routes import router as zone_router
+from nexus.storage.models._base import Base
 
 
 class TestZoneRoutesAuthentication:
     """Test authentication requirements for zone routes."""
 
     def test_create_zone_requires_auth(self, test_app):
-        """Test that creating a zone without auth returns 401/422."""
+        """Test that creating a zone without auth returns 401."""
         response = test_app.post(
             "/api/zones",
             json={
@@ -23,27 +35,116 @@ class TestZoneRoutesAuthentication:
                 "zone_id": "test-zone",
             },
         )
-        # Should require authentication
-        # 422 = missing Authorization header (FastAPI validation)
-        # 401 = invalid/missing token
-        # 503 = auth provider not configured (acceptable in minimal test setup)
-        assert response.status_code in (401, 422, 503), (
-            f"Got {response.status_code}: {response.text}"
-        )
+        assert response.status_code == 401, f"Got {response.status_code}: {response.text}"
 
     def test_get_zone_requires_auth(self, test_app):
-        """Test that getting a zone without auth returns 401/422."""
+        """Test that getting a zone without auth returns 401."""
         response = test_app.get("/api/zones/some-zone")
-        assert response.status_code in (401, 422, 503), (
-            f"Got {response.status_code}: {response.text}"
-        )
+        assert response.status_code == 401, f"Got {response.status_code}: {response.text}"
 
     def test_list_zones_requires_auth(self, test_app):
-        """Test that listing zones without auth returns 401/422."""
+        """Test that listing zones without auth returns 401."""
         response = test_app.get("/api/zones")
-        assert response.status_code in (401, 422, 503), (
-            f"Got {response.status_code}: {response.text}"
+        assert response.status_code == 401, f"Got {response.status_code}: {response.text}"
+
+
+@pytest.fixture(params=("database", "static-database-chain"))
+def api_key_zone_app(request, monkeypatch):
+    """Build an isolated zone router with real API-key authentication."""
+    from nexus.server.auth import auth_routes
+
+    monkeypatch.setattr(auth_routes, "_auth_provider", None)
+    monkeypatch.setattr(auth_routes, "_nexus_fs_instance", None)
+
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    session_factory = sessionmaker(bind=engine)
+    record_store = SimpleNamespace(session_factory=session_factory)
+
+    subject_id = f"{request.param}-admin"
+    with session_factory() as session:
+        _key_id, api_key = DatabaseAPIKeyAuth.create_key(
+            session,
+            user_id=subject_id,
+            subject_id=subject_id,
+            name=f"zone route {request.param} admin",
+            is_admin=True,
         )
+        session.commit()
+
+    if request.param == "database":
+        auth_provider = DatabaseAPIKeyAuth(record_store)
+    else:
+        auth_provider = create_auth_provider(
+            "static",
+            auth_config={
+                "api_keys": {
+                    "sk-static-zone-route-admin-key": {
+                        "subject_type": "user",
+                        "subject_id": "static-admin",
+                        "is_admin": True,
+                    }
+                }
+            },
+            record_store=record_store,
+        )
+        assert auth_provider is not None
+
+    app = FastAPI()
+    app.state.auth_provider = auth_provider
+    app.state.session_factory = session_factory
+    app.include_router(zone_router)
+
+    with TestClient(app) as client:
+        yield {
+            "client": client,
+            "api_key": api_key,
+            "provider_kind": request.param,
+            "session_factory": session_factory,
+        }
+
+    auth_provider.close()
+    engine.dispose()
+
+
+def test_api_key_providers_support_full_zone_lifecycle_without_local_auth(
+    api_key_zone_app,
+) -> None:
+    """Pure and chained API-key providers use app-state sessions on every route."""
+    from nexus.server.auth import auth_routes
+
+    client = api_key_zone_app["client"]
+    api_key = api_key_zone_app["api_key"]
+    provider_kind = api_key_zone_app["provider_kind"]
+    zone_id = f"route-{provider_kind}"
+    headers = {"Authorization": f"Bearer {api_key}"}
+
+    assert auth_routes._auth_provider is None
+    assert callable(api_key_zone_app["session_factory"])
+
+    create_response = client.post(
+        "/api/zones",
+        json={"name": f"Route {provider_kind}", "zone_id": zone_id},
+        headers=headers,
+    )
+    assert create_response.status_code == 201, create_response.text
+    assert create_response.json()["zone_id"] == zone_id
+
+    get_response = client.get(f"/api/zones/{zone_id}", headers=headers)
+    assert get_response.status_code == 200, get_response.text
+    assert get_response.json()["zone_id"] == zone_id
+
+    list_response = client.get("/api/zones", headers=headers)
+    assert list_response.status_code == 200, list_response.text
+    assert zone_id in {zone["zone_id"] for zone in list_response.json()["zones"]}
+
+    delete_response = client.delete(f"/api/zones/{zone_id}", headers=headers)
+    assert delete_response.status_code == 202, delete_response.text
+    assert delete_response.json()["zone_id"] == zone_id
 
 
 class TestZoneRoutesWithAuth:

--- a/tests/integration/bricks/search/test_search_mutation_flow.py
+++ b/tests/integration/bricks/search/test_search_mutation_flow.py
@@ -8,6 +8,8 @@ import pytest
 
 from nexus.bricks.search.daemon import SearchDaemon
 from nexus.bricks.search.mutation_events import SearchMutationEvent, SearchMutationOp
+from nexus.bricks.search.mutation_parking import ParkedEvent, UnresolvedMutationError
+from nexus.bricks.search.mutation_resolver import ResolvedMutation
 from nexus.contracts.constants import ROOT_ZONE_ID
 
 
@@ -232,6 +234,167 @@ def _make_session_factory(rows: list[tuple[str, str, str]]):
         return _FakeSession()
 
     return _factory
+
+
+def _event(event_id: str, op: SearchMutationOp, sequence: int) -> SearchMutationEvent:
+    return SearchMutationEvent(
+        event_id=event_id,
+        operation_id=event_id,
+        op=op,
+        path="/docs/readme.md",
+        zone_id=ROOT_ZONE_ID,
+        timestamp=datetime.now(UTC).replace(tzinfo=None),
+        sequence_number=sequence,
+    )
+
+
+def _mutation(
+    event: SearchMutationEvent,
+    *,
+    content: str | None,
+    content_resolved: bool,
+) -> ResolvedMutation:
+    return ResolvedMutation(
+        event=event,
+        zone_id=ROOT_ZONE_ID,
+        virtual_path="/docs/readme.md",
+        path_id="pid-1",
+        doc_id="/docs/readme.md",
+        content=content,
+        content_resolved=content_resolved,
+        failure_kind=None if content_resolved else "transient",
+        failure_detail=None if content_resolved else "reader unavailable",
+    )
+
+
+@pytest.mark.asyncio
+async def test_resolve_mutations_collapses_delete_before_unresolved_gate() -> None:
+    daemon = SearchDaemon()
+    stale_upsert = _event("evt-upsert", SearchMutationOp.UPSERT, 1)
+    newest_delete = _event("evt-delete", SearchMutationOp.DELETE, 2)
+    daemon._unresolved_attempts[("fts", stale_upsert.event_id)] = 7
+    daemon._mutation_resolver = SimpleNamespace(
+        resolve_batch=AsyncMock(
+            return_value=[
+                _mutation(stale_upsert, content=None, content_resolved=False),
+                _mutation(newest_delete, content=None, content_resolved=True),
+            ]
+        )
+    )
+
+    resolved = await daemon._resolve_mutations("fts", [stale_upsert, newest_delete])
+
+    assert [mutation.event.event_id for mutation in resolved] == ["evt-delete"]
+    assert not daemon._unresolved_attempts
+
+
+@pytest.mark.asyncio
+async def test_resolve_mutations_collapses_newer_resolved_upsert_before_gate() -> None:
+    daemon = SearchDaemon()
+    stale_upsert = _event("evt-stale", SearchMutationOp.UPSERT, 1)
+    newest_upsert = _event("evt-new", SearchMutationOp.UPSERT, 2)
+    daemon._unresolved_attempts[("embedding", stale_upsert.event_id)] = 7
+    daemon._mutation_resolver = SimpleNamespace(
+        resolve_batch=AsyncMock(
+            return_value=[
+                _mutation(stale_upsert, content=None, content_resolved=False),
+                _mutation(newest_upsert, content="fresh", content_resolved=True),
+            ]
+        )
+    )
+
+    resolved = await daemon._resolve_mutations("embedding", [stale_upsert, newest_upsert])
+
+    assert [mutation.event.event_id for mutation in resolved] == ["evt-new"]
+    assert resolved[0].content == "fresh"
+    assert not daemon._unresolved_attempts
+
+
+@pytest.mark.asyncio
+async def test_resolve_mutations_removes_collapsed_parked_event() -> None:
+    settings_store = _SettingsStore()
+    daemon = SearchDaemon(settings_store=settings_store)
+    stale_upsert = _event("evt-parked", SearchMutationOp.UPSERT, 1)
+    newest_delete = _event("evt-delete", SearchMutationOp.DELETE, 2)
+    stale_mutation = _mutation(stale_upsert, content=None, content_resolved=False)
+    await daemon._park_store.park(
+        ParkedEvent.from_mutation(
+            "fts",
+            stale_mutation,
+            kind="transient",
+            detail="reader unavailable",
+            attempts=3,
+        )
+    )
+    daemon._mutation_resolver = SimpleNamespace(
+        resolve_batch=AsyncMock(
+            return_value=[
+                stale_mutation,
+                _mutation(newest_delete, content=None, content_resolved=True),
+            ]
+        )
+    )
+
+    resolved = await daemon._resolve_mutations("fts", [stale_upsert, newest_delete])
+
+    assert [mutation.event.event_id for mutation in resolved] == ["evt-delete"]
+    assert not daemon._park_store.contains("fts", stale_upsert.event_id)
+
+
+@pytest.mark.asyncio
+async def test_resolve_mutations_propagates_collapsed_park_removal_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings_store = _SettingsStore()
+    daemon = SearchDaemon(settings_store=settings_store)
+    stale_upsert = _event("evt-parked", SearchMutationOp.UPSERT, 1)
+    newest_delete = _event("evt-delete", SearchMutationOp.DELETE, 2)
+    stale_mutation = _mutation(stale_upsert, content=None, content_resolved=False)
+    await daemon._park_store.park(
+        ParkedEvent.from_mutation(
+            "fts",
+            stale_mutation,
+            kind="transient",
+            detail="reader unavailable",
+            attempts=3,
+        )
+    )
+    remove = AsyncMock(side_effect=OSError("park persistence failed"))
+    monkeypatch.setattr(daemon._park_store, "remove", remove)
+    daemon._mutation_resolver = SimpleNamespace(
+        resolve_batch=AsyncMock(
+            return_value=[
+                stale_mutation,
+                _mutation(newest_delete, content=None, content_resolved=True),
+            ]
+        )
+    )
+
+    with pytest.raises(OSError, match="park persistence failed"):
+        await daemon._resolve_mutations("fts", [stale_upsert, newest_delete])
+
+    assert daemon._park_store.contains("fts", stale_upsert.event_id)
+
+
+@pytest.mark.asyncio
+async def test_resolve_mutations_keeps_newest_unresolved_upsert_blocking() -> None:
+    daemon = SearchDaemon()
+    resolved_upsert = _event("evt-resolved", SearchMutationOp.UPSERT, 1)
+    newest_unresolved = _event("evt-unresolved", SearchMutationOp.UPSERT, 2)
+    daemon._unresolved_attempts[("fts", newest_unresolved.event_id)] = 4
+    daemon._mutation_resolver = SimpleNamespace(
+        resolve_batch=AsyncMock(
+            return_value=[
+                _mutation(resolved_upsert, content="old", content_resolved=True),
+                _mutation(newest_unresolved, content=None, content_resolved=False),
+            ]
+        )
+    )
+
+    with pytest.raises(UnresolvedMutationError):
+        await daemon._resolve_mutations("fts", [resolved_upsert, newest_unresolved])
+
+    assert daemon._unresolved_attempts[("fts", newest_unresolved.event_id)] == 5
 
 
 @pytest.mark.asyncio

--- a/tests/migrations/test_graph_zone_column_migration.py
+++ b/tests/migrations/test_graph_zone_column_migration.py
@@ -1,0 +1,671 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import Mock
+
+import pytest
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from sqlalchemy import Connection, String, create_engine, inspect, text
+from sqlalchemy.engine.interfaces import ReflectedColumn
+
+
+def _load_revision() -> ModuleType:
+    revision_path = (
+        Path(__file__).resolve().parents[2] / "alembic" / "versions" / "align_graph_zone_columns.py"
+    )
+    spec = importlib.util.spec_from_file_location("align_graph_zone_columns", revision_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+REVISION = _load_revision()
+
+
+def _run_revision(conn: Connection, direction: str = "upgrade") -> None:
+    context = MigrationContext.configure(conn)
+    with Operations.context(context):
+        getattr(REVISION, direction)()
+
+
+def _column_map(conn: Connection, table_name: str) -> dict[str, ReflectedColumn]:
+    return {column["name"]: column for column in inspect(conn).get_columns(table_name)}
+
+
+def _create_rebac_sentinel(conn: Connection) -> None:
+    conn.execute(
+        text(
+            "CREATE TABLE rebac_tuples ("
+            "tuple_id VARCHAR(36) PRIMARY KEY, zone_id VARCHAR(255) NOT NULL)"
+        )
+    )
+    conn.execute(
+        text("INSERT INTO rebac_tuples (tuple_id, zone_id) VALUES ('tuple-1', 'control-zone')")
+    )
+
+
+def test_upgrade_executes_revision_and_preserves_legacy_graph_data(tmp_path: Path) -> None:
+    engine = create_engine(f"sqlite:///{tmp_path / 'legacy.db'}")
+    with engine.begin() as conn:
+        conn.exec_driver_sql("PRAGMA foreign_keys=ON")
+        conn.execute(
+            text(
+                "CREATE TABLE entities ("
+                "entity_id VARCHAR(36) PRIMARY KEY, "
+                "tenant_id VARCHAR(255) NOT NULL, canonical_name VARCHAR(512) NOT NULL)"
+            )
+        )
+        conn.execute(
+            text(
+                "CREATE TABLE relationships ("
+                "relationship_id VARCHAR(36) PRIMARY KEY, tenant_id VARCHAR(255) NOT NULL, "
+                "source_entity_id VARCHAR(36) NOT NULL "
+                "REFERENCES entities(entity_id) ON DELETE CASCADE, "
+                "target_entity_id VARCHAR(36) NOT NULL "
+                "REFERENCES entities(entity_id) ON DELETE CASCADE)"
+            )
+        )
+        conn.execute(
+            text(
+                "CREATE TABLE entity_mentions ("
+                "mention_id VARCHAR(36) PRIMARY KEY, entity_id VARCHAR(36) NOT NULL "
+                "REFERENCES entities(entity_id) ON DELETE CASCADE)"
+            )
+        )
+        conn.execute(
+            text(
+                "INSERT INTO entities (entity_id, tenant_id, canonical_name) "
+                "VALUES ('e1', 'legacy-zone', 'Legacy Entity'), "
+                "('e2', 'legacy-zone', 'Second Entity')"
+            )
+        )
+        conn.execute(
+            text(
+                "INSERT INTO relationships "
+                "(relationship_id, tenant_id, source_entity_id, target_entity_id) "
+                "VALUES ('r1', 'legacy-zone', 'e1', 'e2')"
+            )
+        )
+        conn.execute(
+            text("INSERT INTO entity_mentions (mention_id, entity_id) VALUES ('m1', 'e1')")
+        )
+        _create_rebac_sentinel(conn)
+
+        _run_revision(conn)
+
+        entity_columns = _column_map(conn, "entities")
+        relationship_columns = _column_map(conn, "relationships")
+        assert "tenant_id" not in entity_columns
+        assert "tenant_id" not in relationship_columns
+        # SQLite does not enforce VARCHAR lengths. Keeping the original type lets
+        # the revision use its native, FK-safe column rename instead of rebuilding
+        # a referenced parent table merely to change 255 to 64.
+        assert getattr(entity_columns["zone_id"]["type"], "length", None) == 255
+        assert getattr(relationship_columns["zone_id"]["type"], "length", None) == 255
+        assert [
+            tuple(row)
+            for row in conn.execute(
+                text("SELECT entity_id, zone_id FROM entities ORDER BY entity_id")
+            )
+        ] == [("e1", "legacy-zone"), ("e2", "legacy-zone")]
+        assert conn.execute(text("SELECT zone_id FROM relationships")).scalar_one() == "legacy-zone"
+        assert conn.execute(
+            text("SELECT relationship_id, source_entity_id, target_entity_id FROM relationships")
+        ).one() == ("r1", "e1", "e2")
+        assert conn.execute(text("SELECT mention_id, entity_id FROM entity_mentions")).one() == (
+            "m1",
+            "e1",
+        )
+        assert conn.exec_driver_sql("PRAGMA foreign_key_check").all() == []
+        assert conn.execute(text("SELECT * FROM rebac_tuples")).one() == (
+            "tuple-1",
+            "control-zone",
+        )
+
+
+def test_upgrade_is_idempotent_for_already_aligned_tables(tmp_path: Path) -> None:
+    engine = create_engine(f"sqlite:///{tmp_path / 'aligned.db'}")
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                "CREATE TABLE entities ("
+                "entity_id VARCHAR(36) PRIMARY KEY, "
+                "zone_id VARCHAR(255) NOT NULL, canonical_name VARCHAR(512) NOT NULL)"
+            )
+        )
+        conn.execute(
+            text(
+                "CREATE TABLE relationships ("
+                "relationship_id VARCHAR(36) PRIMARY KEY, zone_id VARCHAR(255) NOT NULL)"
+            )
+        )
+        conn.execute(
+            text(
+                "INSERT INTO entities (entity_id, zone_id, canonical_name) "
+                "VALUES ('e1', 'aligned-zone', 'Aligned Entity')"
+            )
+        )
+        _create_rebac_sentinel(conn)
+
+        _run_revision(conn)
+        _run_revision(conn)
+
+        assert getattr(_column_map(conn, "entities")["zone_id"]["type"], "length", None) == 255
+        assert getattr(_column_map(conn, "relationships")["zone_id"]["type"], "length", None) == 255
+        assert conn.execute(text("SELECT zone_id FROM entities")).scalar_one() == "aligned-zone"
+        assert conn.execute(text("SELECT * FROM rebac_tuples")).one() == (
+            "tuple-1",
+            "control-zone",
+        )
+
+
+def test_upgrade_merges_partially_aligned_columns_before_dropping_legacy(
+    tmp_path: Path,
+) -> None:
+    engine = create_engine(f"sqlite:///{tmp_path / 'partial.db'}")
+    with engine.begin() as conn:
+        for table_name, id_column in (
+            ("entities", "entity_id"),
+            ("relationships", "relationship_id"),
+        ):
+            conn.execute(
+                text(
+                    f"CREATE TABLE {table_name} ("
+                    f"{id_column} VARCHAR(36) PRIMARY KEY, "
+                    "tenant_id VARCHAR(64), zone_id VARCHAR(255))"
+                )
+            )
+            conn.execute(
+                text(
+                    f"INSERT INTO {table_name} ({id_column}, tenant_id, zone_id) VALUES "
+                    "('null-zone', 'legacy-null', NULL), "
+                    "('empty-zone', 'legacy-empty', ''), "
+                    "('kept-zone', 'already-aligned', 'already-aligned')"
+                )
+            )
+        _create_rebac_sentinel(conn)
+
+        _run_revision(conn)
+
+        for table_name in ("entities", "relationships"):
+            columns = _column_map(conn, table_name)
+            assert "tenant_id" not in columns
+            assert getattr(columns["zone_id"]["type"], "length", None) == 255
+            assert conn.execute(
+                text(f"SELECT zone_id FROM {table_name} ORDER BY rowid")
+            ).scalars().all() == ["legacy-null", "legacy-empty", "already-aligned"]
+        assert conn.execute(text("SELECT * FROM rebac_tuples")).one() == (
+            "tuple-1",
+            "control-zone",
+        )
+
+
+def test_upgrade_fails_closed_for_unsafe_sqlite_mixed_unique_constraints(tmp_path: Path) -> None:
+    engine = create_engine(f"sqlite:///{tmp_path / 'partial-dependencies.db'}")
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                "CREATE TABLE entities ("
+                "entity_id VARCHAR(36) PRIMARY KEY, tenant_id VARCHAR(64), "
+                "zone_id VARCHAR(64), canonical_name VARCHAR(512) NOT NULL, "
+                "entity_type VARCHAR(64), "
+                "CONSTRAINT uq_entity_tenant_name UNIQUE (tenant_id, canonical_name))"
+            )
+        )
+        conn.execute(text("CREATE INDEX idx_entities_tenant ON entities (tenant_id)"))
+        conn.execute(
+            text("CREATE INDEX idx_entities_tenant_type ON entities (tenant_id, entity_type)")
+        )
+        conn.execute(
+            text(
+                "CREATE TABLE relationships ("
+                "relationship_id VARCHAR(36) PRIMARY KEY, tenant_id VARCHAR(64), "
+                "zone_id VARCHAR(64), source_entity_id VARCHAR(36) NOT NULL, "
+                "target_entity_id VARCHAR(36) NOT NULL, relationship_type VARCHAR(64) NOT NULL, "
+                "CONSTRAINT uq_relationship_tuple UNIQUE ("
+                "tenant_id, source_entity_id, target_entity_id, relationship_type))"
+            )
+        )
+        conn.execute(text("CREATE INDEX idx_relationships_tenant ON relationships (tenant_id)"))
+
+        with pytest.raises(
+            RuntimeError,
+            match="cannot safely remove tenant_id.*entities.*SQLite.*unique constraint",
+        ):
+            _run_revision(conn)
+
+        assert set(_column_map(conn, "entities")) >= {"tenant_id", "zone_id"}
+        assert set(_column_map(conn, "relationships")) >= {"tenant_id", "zone_id"}
+        assert "idx_entities_tenant" in {
+            index["name"] for index in inspect(conn).get_indexes("entities")
+        }
+        assert "uq_entity_tenant_name" in {
+            constraint["name"] for constraint in inspect(conn).get_unique_constraints("entities")
+        }
+
+
+def test_upgrade_rejects_conflicting_mixed_rows_before_modifying_any_table(
+    tmp_path: Path,
+) -> None:
+    engine = create_engine(f"sqlite:///{tmp_path / 'conflicting.db'}")
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                "CREATE TABLE entities ("
+                "entity_id VARCHAR(36) PRIMARY KEY, tenant_id VARCHAR(64) NOT NULL)"
+            )
+        )
+        conn.execute(
+            text(
+                "CREATE TABLE relationships ("
+                "relationship_id VARCHAR(36) PRIMARY KEY, tenant_id VARCHAR(64), "
+                "zone_id VARCHAR(64))"
+            )
+        )
+        conn.execute(text("INSERT INTO entities VALUES ('e1', 'legacy-zone')"))
+        conn.execute(
+            text("INSERT INTO relationships VALUES ('r1', 'legacy-zone', 'different-zone')")
+        )
+
+        with pytest.raises(
+            RuntimeError,
+            match=(
+                "Conflicting tenant_id and zone_id values in relationships; "
+                "refusing to modify graph data"
+            ),
+        ):
+            _run_revision(conn)
+
+        assert set(_column_map(conn, "entities")) >= {"tenant_id"}
+        assert "zone_id" not in _column_map(conn, "entities")
+        assert set(_column_map(conn, "relationships")) >= {"tenant_id", "zone_id"}
+        assert conn.execute(text("SELECT * FROM entities")).one() == ("e1", "legacy-zone")
+        assert conn.execute(text("SELECT * FROM relationships")).one() == (
+            "r1",
+            "legacy-zone",
+            "different-zone",
+        )
+
+
+def test_postgresql_mixed_reflection_filters_constraint_indexes_and_duplicates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    inspector = Mock()
+    inspector.get_indexes.return_value = [
+        {
+            "name": "uq_entity_tenant_name",
+            "column_names": ["tenant_id", "canonical_name"],
+            "unique": True,
+            "duplicates_constraint": "uq_entity_tenant_name",
+        },
+        {"name": "idx_entities_tenant", "column_names": ["tenant_id"], "unique": False},
+        {"name": "idx_entities_tenant", "column_names": ["tenant_id"], "unique": False},
+    ]
+    inspector.get_unique_constraints.return_value = [
+        {
+            "name": "uq_entity_tenant_name",
+            "column_names": ["tenant_id", "canonical_name"],
+        },
+        {
+            "name": "uq_entity_tenant_name",
+            "column_names": ["tenant_id", "canonical_name"],
+        },
+    ]
+    monkeypatch.setattr(REVISION, "_inspector", lambda: inspector)
+
+    indexes, unique_constraints = REVISION._legacy_dependencies("entities", "tenant_id")
+
+    assert [index["name"] for index in indexes] == ["idx_entities_tenant"]
+    assert [constraint["name"] for constraint in unique_constraints] == ["uq_entity_tenant_name"]
+
+
+@pytest.mark.parametrize(
+    "dependency_metadata",
+    [
+        {"dialect_options": {"postgresql_where": "tenant_id IS NOT NULL"}},
+        {"include_columns": ["tenant_id"]},
+        {"expressions": ["lower(tenant_id)"]},
+        {"column_sorting": {"tenant_id": ("desc",)}},
+    ],
+)
+def test_postgresql_reflection_detects_old_column_in_index_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+    dependency_metadata: dict[str, object],
+) -> None:
+    inspector = Mock()
+    inspector.get_indexes.return_value = [
+        {
+            "name": "idx_metadata_dependency",
+            "column_names": ["entity_type"],
+            "unique": False,
+            **dependency_metadata,
+        }
+    ]
+    inspector.get_unique_constraints.return_value = []
+    monkeypatch.setattr(REVISION, "_inspector", lambda: inspector)
+
+    indexes, _ = REVISION._legacy_dependencies("entities", "tenant_id")
+
+    assert [index["name"] for index in indexes] == ["idx_metadata_dependency"]
+
+
+def test_reflected_sql_identifier_transform_preserves_string_literals() -> None:
+    predicate = (
+        '"tenant_id" IS NOT NULL AND tenant_id <> marker '
+        "AND marker <> 'tenant_id' AND note <> 'tenant_id''s value'"
+    )
+
+    transformed = REVISION._transform_reflected_value(predicate, "tenant_id", "zone_id")
+
+    assert transformed == (
+        '"zone_id" IS NOT NULL AND zone_id <> marker '
+        "AND marker <> 'tenant_id' AND note <> 'tenant_id''s value'"
+    )
+
+
+@pytest.mark.parametrize("escape_prefix", ["E", "e"])
+def test_reflected_sql_identifier_transform_preserves_postgresql_escape_strings(
+    escape_prefix: str,
+) -> None:
+    predicate = (
+        rf"note = {escape_prefix}'tenant_id\' tenant_id' "
+        "AND tenant_id IS NOT NULL"
+    )
+
+    transformed = REVISION._transform_reflected_value(predicate, "tenant_id", "zone_id")
+
+    assert transformed == (
+        rf"note = {escape_prefix}'tenant_id\' tenant_id' "
+        "AND zone_id IS NOT NULL"
+    )
+
+
+def _run_mocked_postgresql_mixed_merge(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    indexes: list[dict[str, object]],
+    unique_constraints: list[dict[str, object]],
+) -> tuple[Mock, Mock]:
+    inspector = Mock()
+    inspector.get_table_names.return_value = ["entities"]
+    inspector.get_columns.return_value = [
+        {"name": "tenant_id", "type": String(64), "nullable": True},
+        {"name": "zone_id", "type": String(64), "nullable": True},
+    ]
+    inspector.get_indexes.return_value = indexes
+    inspector.get_unique_constraints.return_value = unique_constraints
+
+    bind = Mock()
+    bind.dialect.name = "postgresql"
+    bind.dialect.identifier_preparer.quote.side_effect = lambda identifier: identifier
+    monkeypatch.setattr(REVISION, "_inspector", lambda: inspector)
+    monkeypatch.setattr(REVISION.op, "get_bind", lambda: bind)
+    monkeypatch.setattr(REVISION.op, "execute", Mock())
+    monkeypatch.setattr(REVISION.op, "drop_index", Mock())
+    monkeypatch.setattr(REVISION.op, "drop_constraint", Mock())
+    monkeypatch.setattr(REVISION.op, "drop_column", Mock())
+    created_indexes = Mock()
+    created_unique_constraints = Mock()
+    monkeypatch.setattr(REVISION.op, "create_index", created_indexes)
+    monkeypatch.setattr(
+        REVISION.op,
+        "create_unique_constraint",
+        created_unique_constraints,
+    )
+
+    REVISION._merge_and_remove_old_column(
+        "entities",
+        "tenant_id",
+        "zone_id",
+        "upgrade",
+    )
+
+    return created_indexes, created_unique_constraints
+
+
+def test_postgresql_mixed_merge_skips_custom_name_logical_duplicates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    created_indexes, created_unique_constraints = _run_mocked_postgresql_mixed_merge(
+        monkeypatch,
+        indexes=[
+            {
+                "name": "existing_zone_lookup",
+                "column_names": ["zone_id", "entity_type"],
+                "unique": False,
+            },
+            {
+                "name": "legacy_custom_lookup",
+                "column_names": ["tenant_id", "entity_type"],
+                "unique": False,
+            },
+        ],
+        unique_constraints=[
+            {
+                "name": "existing_zone_unique",
+                "column_names": ["zone_id", "canonical_name"],
+            },
+            {
+                "name": "legacy_custom_unique",
+                "column_names": ["tenant_id", "canonical_name"],
+            },
+        ],
+    )
+
+    created_indexes.assert_not_called()
+    created_unique_constraints.assert_not_called()
+
+
+def test_postgresql_mixed_merge_preserves_distinct_partial_index_predicate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    created_indexes, _ = _run_mocked_postgresql_mixed_merge(
+        monkeypatch,
+        indexes=[
+            {
+                "name": "existing_zone_partial",
+                "column_names": ["zone_id", "entity_type"],
+                "unique": False,
+                "dialect_options": {"postgresql_where": "deleted_at IS NULL"},
+            },
+            {
+                "name": "legacy_tenant_partial",
+                "column_names": ["tenant_id", "entity_type"],
+                "unique": False,
+                "dialect_options": {"postgresql_where": "tenant_id IS NOT NULL"},
+            },
+            {
+                "name": "legacy_tenant_partial_copy",
+                "column_names": ["tenant_id", "entity_type"],
+                "unique": False,
+                "dialect_options": {"postgresql_where": "tenant_id IS NOT NULL"},
+            },
+        ],
+        unique_constraints=[],
+    )
+
+    created_indexes.assert_called_once_with(
+        "legacy_tenant_partial",
+        "entities",
+        ["zone_id", "entity_type"],
+        unique=False,
+        postgresql_where="zone_id IS NOT NULL",
+    )
+
+
+def test_postgresql_mixed_merge_recreates_predicate_only_dependency(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    created_indexes, _ = _run_mocked_postgresql_mixed_merge(
+        monkeypatch,
+        indexes=[
+            {
+                "name": "idx_entity_type_for_tenant",
+                "column_names": ["entity_type"],
+                "unique": False,
+                "dialect_options": {
+                    "postgresql_where": "tenant_id IS NOT NULL AND marker <> 'tenant_id'"
+                },
+            }
+        ],
+        unique_constraints=[],
+    )
+
+    created_indexes.assert_called_once_with(
+        "idx_entity_type_for_tenant",
+        "entities",
+        ["entity_type"],
+        unique=False,
+        postgresql_where="zone_id IS NOT NULL AND marker <> 'tenant_id'",
+    )
+
+
+def test_postgresql_mixed_merge_recreates_reflected_expression_index(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    created_indexes, _ = _run_mocked_postgresql_mixed_merge(
+        monkeypatch,
+        indexes=[
+            {
+                "name": "idx_lower_tenant",
+                "column_names": [None],
+                "expressions": ["lower(tenant_id)"],
+                "unique": False,
+            }
+        ],
+        unique_constraints=[],
+    )
+
+    created_indexes.assert_called_once()
+    index_name, table_name, elements = created_indexes.call_args.args
+    assert index_name == "idx_lower_tenant"
+    assert table_name == "entities"
+    assert len(elements) == 1
+    assert isinstance(elements[0], type(text("")))
+    assert str(elements[0]) == "lower(zone_id)"
+    assert created_indexes.call_args.kwargs == {"unique": False}
+
+
+def test_downgrade_symmetrically_restores_tenant_columns(tmp_path: Path) -> None:
+    engine = create_engine(f"sqlite:///{tmp_path / 'downgrade.db'}")
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                "CREATE TABLE entities ("
+                "entity_id VARCHAR(36) PRIMARY KEY, zone_id VARCHAR(255) NOT NULL)"
+            )
+        )
+        conn.execute(
+            text(
+                "CREATE TABLE relationships ("
+                "relationship_id VARCHAR(36) PRIMARY KEY, zone_id VARCHAR(255) NOT NULL)"
+            )
+        )
+        conn.execute(text("INSERT INTO entities VALUES ('e1', 'zone-to-restore')"))
+
+        _run_revision(conn, "downgrade")
+
+        assert "zone_id" not in _column_map(conn, "entities")
+        assert getattr(_column_map(conn, "entities")["tenant_id"]["type"], "length", None) == 255
+        assert conn.execute(text("SELECT tenant_id FROM entities")).scalar_one() == (
+            "zone-to-restore"
+        )
+
+
+@pytest.mark.parametrize(
+    ("direction", "old_names", "expected_fragments"),
+    [
+        (
+            "upgrade",
+            {
+                "indexes": {
+                    "entities": {"idx_entities_tenant", "idx_entities_tenant_type"},
+                    "relationships": {"idx_relationships_tenant"},
+                },
+                "constraints": {"entities": {"uq_entity_tenant_name"}},
+            },
+            (
+                "ALTER INDEX idx_entities_tenant RENAME TO idx_entities_zone",
+                "ALTER INDEX idx_entities_tenant_type RENAME TO idx_entities_zone_type",
+                "ALTER INDEX idx_relationships_tenant RENAME TO idx_relationships_zone",
+                "ALTER TABLE entities RENAME CONSTRAINT uq_entity_tenant_name TO uq_entity_zone_name",
+            ),
+        ),
+        (
+            "downgrade",
+            {
+                "indexes": {
+                    "entities": {"idx_entities_zone", "idx_entities_zone_type"},
+                    "relationships": {"idx_relationships_zone"},
+                },
+                "constraints": {"entities": {"uq_entity_zone_name"}},
+            },
+            (
+                "ALTER INDEX idx_entities_zone RENAME TO idx_entities_tenant",
+                "ALTER INDEX idx_entities_zone_type RENAME TO idx_entities_tenant_type",
+                "ALTER INDEX idx_relationships_zone RENAME TO idx_relationships_tenant",
+                "ALTER TABLE entities RENAME CONSTRAINT uq_entity_zone_name TO uq_entity_tenant_name",
+            ),
+        ),
+    ],
+)
+def test_postgresql_schema_object_renames_are_guarded_and_symmetric(
+    monkeypatch: pytest.MonkeyPatch,
+    direction: str,
+    old_names: dict[str, dict[str, set[str]]],
+    expected_fragments: tuple[str, ...],
+) -> None:
+    executed: list[str] = []
+    bind = Mock()
+    bind.dialect.name = "postgresql"
+    monkeypatch.setattr(REVISION.op, "get_bind", lambda: bind)
+    monkeypatch.setattr(
+        REVISION,
+        "_index_names",
+        lambda table_name: old_names["indexes"].get(table_name, set()),
+    )
+    monkeypatch.setattr(
+        REVISION,
+        "_unique_constraint_names",
+        lambda table_name: old_names["constraints"].get(table_name, set()),
+    )
+    monkeypatch.setattr(REVISION.op, "execute", lambda statement: executed.append(str(statement)))
+
+    REVISION._rename_postgresql_schema_objects(direction=direction)
+
+    assert executed == list(expected_fragments)
+
+
+def test_postgresql_schema_object_renames_skip_existing_targets(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executed: list[str] = []
+    bind = Mock()
+    bind.dialect.name = "postgresql"
+    monkeypatch.setattr(REVISION.op, "get_bind", lambda: bind)
+    monkeypatch.setattr(
+        REVISION,
+        "_index_names",
+        lambda _table_name: {
+            "idx_entities_tenant",
+            "idx_entities_zone",
+            "idx_entities_tenant_type",
+            "idx_entities_zone_type",
+            "idx_relationships_tenant",
+            "idx_relationships_zone",
+        },
+    )
+    monkeypatch.setattr(
+        REVISION,
+        "_unique_constraint_names",
+        lambda _table_name: {"uq_entity_tenant_name", "uq_entity_zone_name"},
+    )
+    monkeypatch.setattr(REVISION.op, "execute", lambda statement: executed.append(str(statement)))
+
+    REVISION._rename_postgresql_schema_objects(direction="upgrade")
+
+    assert executed == []

--- a/tests/unit/bricks/search/test_macro_chunk_expand.py
+++ b/tests/unit/bricks/search/test_macro_chunk_expand.py
@@ -63,6 +63,23 @@ async def test_expand_single_batched_fetch_and_section_dedup():
 
 
 @pytest.mark.asyncio
+async def test_expand_over_budget_section_uses_anchor_specific_window():
+    rows = [
+        _row(i, heading="A", tokens=100, text=f"chunk-{i}", ls=i + 1, le=i + 1) for i in range(12)
+    ]
+    fetcher = _FakeFetcher(rows)
+    res = [_Result("/a.md", 1), _Result("/a.md", 10)]
+
+    out = await expand_results(res, fetcher, ExpansionConfig(token_budget=300, window=12))
+
+    assert "chunk-1" in out[0].macro_text
+    assert "chunk-10" in out[1].macro_text
+    assert out[0].macro_text != out[1].macro_text
+    assert (out[0].macro_line_start, out[0].macro_line_end) == (1, 3)
+    assert (out[1].macro_line_start, out[1].macro_line_end) == (10, 12)
+
+
+@pytest.mark.asyncio
 async def test_expand_missing_anchor_leaves_result_untouched():
     fetcher = _FakeFetcher([])  # eventual-consistency gap: nothing returned
     res = [_Result("/a.md", 5)]

--- a/tests/unit/bricks/search/test_pg_vector_backend.py
+++ b/tests/unit/bricks/search/test_pg_vector_backend.py
@@ -185,6 +185,112 @@ def test_satisfies_protocol():
     assert isinstance(b, SearchBackend)
 
 
+class _MockRows:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def mappings(self):
+        return self
+
+    def all(self):
+        return self._rows
+
+
+class _MockConnection:
+    def __init__(self, engine):
+        self._engine = engine
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_exc_info):
+        return False
+
+    async def execute(self, statement, params):
+        self._engine.statements.append(str(statement))
+        self._engine.params.append(params)
+        return _MockRows(self._engine.rows)
+
+
+class _MockEngine:
+    def __init__(self, rows=None):
+        self.rows = rows or []
+        self.connect_count = 0
+        self.statements = []
+        self.params = []
+
+    def connect(self):
+        self.connect_count += 1
+        return _MockConnection(self)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "query_vector",
+    [
+        [],
+        [0.0] * 1536,
+        [float("nan")] + [0.0] * 1535,
+        [float("inf")] + [0.0] * 1535,
+        [float("-inf")] + [0.0] * 1535,
+    ],
+)
+async def test_semantic_search_rejects_invalid_query_vectors_without_connection(query_vector):
+    engine = _MockEngine()
+    backend = PgVectorBackend(engine=engine)
+
+    assert await backend.semantic_search(query_vector, "/", k=10, zone_id="z") == []
+    assert engine.connect_count == 0
+
+
+@pytest.mark.asyncio
+async def test_semantic_search_rejects_wrong_dimension_without_connection():
+    engine = _MockEngine()
+    backend = PgVectorBackend(engine=engine)
+
+    assert await backend.semantic_search([1.0] * 1535, "/", k=10, zone_id="z") == []
+    assert engine.connect_count == 0
+
+
+@pytest.mark.asyncio
+async def test_semantic_search_filters_non_finite_scores_and_guards_stored_norm():
+    engine = _MockEngine(
+        rows=[
+            {
+                "path": "/z/good.txt",
+                "chunk_text": "good",
+                "score": 0.75,
+                "chunk_index": 1,
+            },
+            {
+                "path": "/z/null.txt",
+                "chunk_text": "null",
+                "score": None,
+                "chunk_index": 2,
+            },
+            {
+                "path": "/z/nan.txt",
+                "chunk_text": "nan",
+                "score": float("nan"),
+                "chunk_index": 3,
+            },
+            {
+                "path": "/z/inf.txt",
+                "chunk_text": "inf",
+                "score": float("inf"),
+                "chunk_index": 4,
+            },
+        ]
+    )
+    backend = PgVectorBackend(engine=engine)
+
+    hits = await backend.semantic_search([1.0] + [0.0] * 1535, "/z/", k=10, zone_id="z")
+
+    assert [hit.path for hit in hits] == ["/z/good.txt"]
+    assert hits[0].score == 0.75
+    assert "l2_norm(c.embedding) > 0" in engine.statements[0]
+
+
 @pytest.mark.asyncio
 async def test_semantic_search_orders_by_cosine(
     backend: PgVectorBackend, postgres_engine_clean: AsyncEngine

--- a/tests/unit/scripts/test_build_perf_e2e.py
+++ b/tests/unit/scripts/test_build_perf_e2e.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[3] / "scripts" / "test_build_perf_e2e.py"
+SPEC = importlib.util.spec_from_file_location("test_build_perf_e2e_script", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def test_plan_auth_restore_requires_the_complete_original_line() -> None:
+    assert MODULE._plan_auth_line_restored("# Plan\n- Configure authentication\n")
+    assert not MODULE._plan_auth_line_restored("# Plan\nConfigure authentication\n")
+    assert not MODULE._plan_auth_line_restored(
+        "# Plan\n- Configure authentication\n- Configure auth (test-edit)\n"
+    )

--- a/tests/unit/scripts/test_permissions_demo_enhanced.py
+++ b/tests/unit/scripts/test_permissions_demo_enhanced.py
@@ -61,3 +61,19 @@ def test_owner_role_requires_read_write_and_execute() -> None:
         '&& echo "$ALICE_WRITE" | grep -q "GRANTED" '
         '&& echo "$ALICE_EXEC" | grep -q "GRANTED"; then'
     ) in owner_block
+
+
+def test_group_explanation_targets_and_requires_the_granted_parent() -> None:
+    text = SCRIPT.read_text()
+    explain_block = text[
+        text.index('log_step "rebac check user bob write file $DEMO_BASE') : text.index(
+            'print_subsection "2.4 PROVE group composition'
+        )
+    ]
+    assert (
+        "EXPLAIN_OUT=$(nexus rebac explain user bob write file $DEMO_BASE 2>&1) "
+        "&& EXPLAIN_RC=0 || EXPLAIN_RC=$?"
+    ) in explain_block
+    assert ('[ "$EXPLAIN_RC" -eq 0 ] && echo "$EXPLAIN_OUT" | grep -q "GRANTED"') in explain_block
+    assert 'print_error "Group explanation failed' in explain_block
+    assert "$DEMO_BASE/team-file.txt" not in explain_block

--- a/tests/unit/scripts/test_permissions_demo_enhanced.py
+++ b/tests/unit/scripts/test_permissions_demo_enhanced.py
@@ -43,3 +43,21 @@ def test_tuple_id_capture_filters_log_noise_to_uuid_only() -> None:
     assert "grep -Eo" in tuple_block
     assert "[0-9a-fA-F]{8}" in tuple_block
     assert "tail -1" in tuple_block
+
+
+def test_owner_role_requires_read_write_and_execute() -> None:
+    text = SCRIPT.read_text()
+    owner_block = text[
+        text.index('print_subsection "1.1 Understanding Permission Roles"') : text.index(
+            'print_test "Verify bob (editor)'
+        )
+    ]
+
+    assert "OWNER:  read ✓  write ✓  execute ✓" in owner_block
+    assert "owners need editor/viewer role for read" not in owner_block
+    assert "ALICE_READ=$(nexus rebac check user alice read file" in owner_block
+    assert (
+        'if echo "$ALICE_READ" | grep -q "GRANTED" '
+        '&& echo "$ALICE_WRITE" | grep -q "GRANTED" '
+        '&& echo "$ALICE_EXEC" | grep -q "GRANTED"; then'
+    ) in owner_block

--- a/tests/unit/server/test_startup_cache_warmup.py
+++ b/tests/unit/server/test_startup_cache_warmup.py
@@ -1,0 +1,431 @@
+import asyncio
+import logging
+import threading
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from nexus.contracts.metadata import DT_DIR, DT_REG
+from nexus.core.pagination import PaginatedResult
+from nexus.server.cache_warmer import CacheWarmer, WarmupConfig
+from nexus.server.lifespan import permissions
+
+
+class _FakeNexusFS:
+    def __init__(self, pages: dict[tuple[str, str | None], PaginatedResult | list[dict]]):
+        self.pages = pages
+        self.readdir_calls: list[dict] = []
+
+    def service(self, name: str):
+        raise AssertionError(f"unexpected service lookup: {name}")
+
+    def sys_readdir(
+        self,
+        path: str,
+        *,
+        recursive: bool,
+        details: bool,
+        limit: int,
+        cursor: str | None,
+        context,
+    ):
+        self.readdir_calls.append(
+            {
+                "path": path,
+                "recursive": recursive,
+                "details": details,
+                "limit": limit,
+                "cursor": cursor,
+                "context": context,
+            }
+        )
+        return self.pages.get((path, cursor), [])
+
+
+class _StatNexusFS(_FakeNexusFS):
+    def __init__(self, pages, stats, contents=None):
+        super().__init__(pages)
+        self.stats = stats
+        self.contents = contents or {}
+        self.stat_calls: list[dict] = []
+
+    def sys_stat(self, path: str, *, context):
+        self.stat_calls.append(
+            {
+                "path": path,
+                "context": context,
+                "thread_id": threading.get_ident(),
+            }
+        )
+        result = self.stats.get(path)
+        if isinstance(result, BaseException):
+            raise result
+        return result
+
+    def sys_read(self, path: str, *, context):
+        return self.contents[path]
+
+
+class _DoneTask:
+    def __init__(self, error: BaseException | None = None):
+        self.error = error
+        self.callback = None
+
+    def add_done_callback(self, callback):
+        self.callback = callback
+
+    def result(self):
+        if self.error is not None:
+            raise self.error
+        return None
+
+
+class _RecordingDiskCache:
+    def __init__(self):
+        self.put_calls: list[tuple[str, bytes, str]] = []
+
+    def put(self, content_id: str, content: bytes, *, zone_id: str):
+        self.put_calls.append((content_id, content, zone_id))
+
+
+def _entry(path: str, entry_type: int) -> dict:
+    return {"path": path, "entry_type": entry_type, "size": 0, "content_id": ""}
+
+
+def test_startup_cache_warmup_disabled_creates_no_task(monkeypatch):
+    monkeypatch.setenv("NEXUS_CACHE_WARMUP_ENABLED", "false")
+    created = []
+
+    def _create_task(coro):
+        coro.close()
+        created.append(coro)
+        return object()
+
+    monkeypatch.setattr(asyncio, "create_task", _create_task)
+
+    tasks = permissions._startup_cache_warmup(  # noqa: SLF001
+        SimpleNamespace(),
+        SimpleNamespace(nexus_fs=object()),
+    )
+
+    assert tasks == []
+    assert created == []
+
+
+@pytest.mark.parametrize("enabled", [None, "true", "1", "yes"])
+def test_startup_cache_warmup_returns_tracked_task(monkeypatch, enabled):
+    if enabled is None:
+        monkeypatch.delenv("NEXUS_CACHE_WARMUP_ENABLED", raising=False)
+    else:
+        monkeypatch.setenv("NEXUS_CACHE_WARMUP_ENABLED", enabled)
+    sentinel = _DoneTask()
+
+    def _create_task(coro):
+        coro.close()
+        return sentinel
+
+    monkeypatch.setattr(asyncio, "create_task", _create_task)
+
+    tasks = permissions._startup_cache_warmup(  # noqa: SLF001
+        SimpleNamespace(),
+        SimpleNamespace(nexus_fs=object()),
+    )
+
+    assert tasks == [sentinel]
+
+
+def test_startup_cache_warmup_invalid_config_skips(monkeypatch):
+    monkeypatch.setenv("NEXUS_CACHE_WARMUP_MAX_FILES", "not-an-int")
+
+    tasks = permissions._startup_cache_warmup(  # noqa: SLF001
+        SimpleNamespace(),
+        SimpleNamespace(nexus_fs=object()),
+    )
+
+    assert tasks == []
+
+
+def test_startup_cache_warmup_observes_background_failure(monkeypatch, caplog):
+    task = _DoneTask(RuntimeError("warmup exploded"))
+
+    def _create_task(coro):
+        coro.close()
+        return task
+
+    monkeypatch.setattr(asyncio, "create_task", _create_task)
+
+    tasks = permissions._startup_cache_warmup(  # noqa: SLF001
+        SimpleNamespace(),
+        SimpleNamespace(nexus_fs=object()),
+    )
+
+    assert tasks == [task]
+    assert task.callback is not None
+    with caplog.at_level(logging.ERROR, logger=permissions.__name__):
+        task.callback(task)
+    assert "Server startup warmup failed" in caplog.text
+    assert "warmup exploded" in caplog.text
+
+
+def test_startup_cache_warmup_cancellation_is_not_logged_as_error(monkeypatch, caplog):
+    task = _DoneTask(asyncio.CancelledError())
+
+    def _create_task(coro):
+        coro.close()
+        return task
+
+    monkeypatch.setattr(asyncio, "create_task", _create_task)
+
+    permissions._startup_cache_warmup(  # noqa: SLF001
+        SimpleNamespace(),
+        SimpleNamespace(nexus_fs=object()),
+    )
+
+    assert task.callback is not None
+    with caplog.at_level(logging.ERROR, logger=permissions.__name__):
+        task.callback(task)
+    assert caplog.records == []
+
+
+@pytest.mark.asyncio
+async def test_startup_permissions_returns_cache_warmup_task(monkeypatch):
+    sentinel = object()
+
+    monkeypatch.setattr(permissions, "_seed_root_zone", lambda svc: None)
+    monkeypatch.setattr(permissions, "_startup_async_rebac", AsyncMock())
+    monkeypatch.setattr(permissions, "_startup_cache_brick", AsyncMock())
+    monkeypatch.setattr(permissions, "_startup_durable_invalidation", AsyncMock())
+    monkeypatch.setattr(permissions, "_startup_tiger_cache", AsyncMock(return_value=[]))
+    monkeypatch.setattr(permissions, "_startup_backfill", lambda app, svc: [])
+    monkeypatch.setattr(permissions, "_startup_cache_warmup", lambda app, svc: [sentinel])
+    monkeypatch.setattr(permissions, "_startup_circuit_breaker", AsyncMock())
+
+    tasks = await permissions.startup_permissions(SimpleNamespace(), SimpleNamespace())
+
+    assert tasks == [sentinel]
+
+
+@pytest.mark.asyncio
+async def test_cache_warmup_uses_bounded_paginated_readdir():
+    pages = {
+        ("/", None): PaginatedResult(
+            items=[_entry("/dir", DT_DIR), _entry("/a.txt", DT_REG)],
+            next_cursor="/a.txt",
+            has_more=True,
+        ),
+        ("/", "/a.txt"): PaginatedResult(
+            items=[_entry("/b.txt", DT_REG), _entry("/c.txt", DT_REG)],
+            next_cursor=None,
+            has_more=False,
+        ),
+        ("/dir", None): [_entry("/dir/should-not-list.txt", DT_REG)],
+    }
+    nexus = _FakeNexusFS(pages)
+    warmer = CacheWarmer(nexus, config=WarmupConfig(max_files=2, depth=2))
+    warmer._warmup_metadata = AsyncMock(return_value=True)  # noqa: SLF001
+
+    stats = await warmer._warmup_directory_on_current_loop(  # noqa: SLF001
+        "/",
+        max_files=2,
+        depth=2,
+        context={"zone_id": "root"},
+    )
+
+    assert stats.files_warmed == 2
+    assert [call.args[2] for call in warmer._warmup_metadata.await_args_list] == [
+        {"zone_id": "root"},
+        {"zone_id": "root"},
+    ]
+    assert [call.args[0] for call in warmer._warmup_metadata.await_args_list] == [
+        "/a.txt",
+        "/b.txt",
+    ]
+    assert all(call["recursive"] is False for call in nexus.readdir_calls)
+    assert "/dir" not in [call["path"] for call in nexus.readdir_calls]
+
+
+@pytest.mark.asyncio
+async def test_cache_warmup_respects_depth_and_non_positive_limit():
+    nexus = _FakeNexusFS(
+        {
+            ("/", None): [
+                _entry("/dir", DT_DIR),
+                _entry("/root.txt", DT_REG),
+            ],
+            ("/dir", None): [_entry("/dir/nested.txt", DT_REG)],
+        }
+    )
+    warmer = CacheWarmer(nexus, config=WarmupConfig(max_files=10, depth=1))
+    warmer._warmup_metadata = AsyncMock()  # noqa: SLF001
+
+    await warmer._warmup_directory_on_current_loop("/", max_files=10, depth=1)  # noqa: SLF001
+
+    assert [call.args[0] for call in warmer._warmup_metadata.await_args_list] == ["/root.txt"]
+    assert [call["path"] for call in nexus.readdir_calls] == ["/"]
+
+    nexus_zero = _FakeNexusFS({})
+    zero_warmer = CacheWarmer(nexus_zero, config=WarmupConfig(max_files=0, depth=2))
+
+    zero_stats = await zero_warmer._warmup_directory_on_current_loop(  # noqa: SLF001
+        "/",
+        max_files=0,
+        depth=2,
+    )
+
+    assert zero_stats.files_warmed == 0
+    assert nexus_zero.readdir_calls == []
+
+
+@pytest.mark.asyncio
+async def test_cache_warmup_uses_real_sys_stat_off_loop_and_counts_successes():
+    context = {"zone_id": "root", "user_id": "warmup"}
+    pages = {
+        ("/", None): [
+            _entry("/ok.txt", DT_REG),
+            _entry("/missing.txt", DT_REG),
+            _entry("/denied.txt", DT_REG),
+        ]
+    }
+    nexus = _StatNexusFS(
+        pages,
+        {
+            "/ok.txt": {"path": "/ok.txt", "size": 3, "content_id": "ok"},
+            "/missing.txt": None,
+            "/denied.txt": PermissionError("denied"),
+        },
+    )
+    warmer = CacheWarmer(nexus, config=WarmupConfig(max_files=3, depth=1))
+    event_loop_thread = threading.get_ident()
+
+    stats = await warmer._warmup_directory_on_current_loop(  # noqa: SLF001
+        "/",
+        max_files=3,
+        depth=1,
+        context=context,
+    )
+
+    assert sorted(call["path"] for call in nexus.stat_calls) == [
+        "/denied.txt",
+        "/missing.txt",
+        "/ok.txt",
+    ]
+    assert all(call["context"] is context for call in nexus.stat_calls)
+    assert all(call["thread_id"] != event_loop_thread for call in nexus.stat_calls)
+    assert stats.metadata_warmed == 1
+    assert stats.files_warmed == 1
+    assert stats.skipped == 1
+    assert stats.errors == 1
+
+
+@pytest.mark.asyncio
+async def test_cache_warmup_supports_dict_and_object_metadata_fields():
+    nexus = _StatNexusFS(
+        {},
+        {
+            "/empty.txt": {"size": 0},
+            "/small.txt": SimpleNamespace(size=12),
+            "/large.txt": {"size": 4096},
+            "/dict-content.txt": {"content_id": "dict-content"},
+            "/object-content.txt": SimpleNamespace(content_id="object-content"),
+        },
+        {
+            "/dict-content.txt": b"dict",
+            "/object-content.txt": b"object",
+        },
+    )
+    disk_cache = _RecordingDiskCache()
+    warmer = CacheWarmer(
+        nexus,
+        config=WarmupConfig(small_file_threshold_kb=1),
+        local_disk_cache=disk_cache,
+    )
+
+    small_files = await warmer._filter_small_files(  # noqa: SLF001
+        ["/empty.txt", "/small.txt", "/large.txt"],
+        {"zone_id": "root"},
+    )
+    await warmer._warmup_content(  # noqa: SLF001
+        "/dict-content.txt",
+        "root",
+        {"zone_id": "root"},
+    )
+    await warmer._warmup_content(  # noqa: SLF001
+        "/object-content.txt",
+        "root",
+        {"zone_id": "root"},
+    )
+
+    assert small_files == ["/empty.txt", "/small.txt"]
+    assert disk_cache.put_calls == [
+        ("dict-content", b"dict", "root"),
+        ("object-content", b"object", "root"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_cache_warmup_caps_directory_only_paginated_discovery():
+    class _DirectoryOnlyNexus(_FakeNexusFS):
+        def __init__(self):
+            super().__init__({})
+            self.entries_returned = 0
+
+        def sys_readdir(
+            self,
+            path: str,
+            *,
+            recursive: bool,
+            details: bool,
+            limit: int,
+            cursor: str | None,
+            context,
+        ):
+            if path == "/":
+                start = int(cursor or 0)
+                remaining = max(0, 32 - start)
+                count = min(limit, remaining)
+                next_offset = start + count
+                items = [_entry(f"/dir-{i}", DT_DIR) for i in range(start, next_offset)]
+                next_cursor = str(next_offset) if next_offset < 32 else None
+                has_more = next_offset < 32
+            elif path.count("/") < 8:
+                count = 1
+                items = [_entry(f"{path}/child", DT_DIR)]
+                next_cursor = None
+                has_more = False
+            else:
+                count = 0
+                items = []
+                next_cursor = None
+                has_more = False
+            self.entries_returned += count
+            self.readdir_calls.append(
+                {
+                    "path": path,
+                    "recursive": recursive,
+                    "details": details,
+                    "limit": limit,
+                    "cursor": cursor,
+                    "context": context,
+                }
+            )
+            return PaginatedResult(
+                items=items,
+                next_cursor=next_cursor,
+                has_more=has_more,
+            )
+
+    nexus = _DirectoryOnlyNexus()
+    warmer = CacheWarmer(nexus, config=WarmupConfig(max_files=1, depth=32))
+
+    files = await warmer._discover_files_for_warmup(  # noqa: SLF001
+        "/",
+        depth=32,
+        max_files=1,
+        context={"zone_id": "root"},
+    )
+
+    assert files == []
+    assert nexus.readdir_calls[0]["limit"] == 256
+    assert len(nexus.readdir_calls) <= 4
+    assert nexus.entries_returned <= 256

--- a/tests/unit/server/test_startup_cache_warmup.py
+++ b/tests/unit/server/test_startup_cache_warmup.py
@@ -185,7 +185,7 @@ def test_startup_cache_warmup_cancellation_is_not_logged_as_error(monkeypatch, c
     assert task.callback is not None
     with caplog.at_level(logging.ERROR, logger=permissions.__name__):
         task.callback(task)
-    assert caplog.records == []
+    assert not any(record.levelno >= logging.ERROR for record in caplog.records)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Harden search qualification: anchor macro-chunk caches to the real window, reject invalid pgvector embeddings/scores, and durably clear collapsed mutation events.
- Preserve VFS/API semantics: map permission failures consistently, keep grep on virtual paths through SearchService, and offload synchronous recursive listings, reads, and read-url stats from request loops while still awaiting native async implementations.
- Make zone lifecycle safe for API-key auth and schema upgrades: use request-scoped session factories, remove all target-zone graph/ReBAC dependents, and migrate `tenant_id` to `zone_id` without losing SQLite foreign-key data or collapsing distinct PostgreSQL indexes/constraints.
- Bound and observe startup cache warmup: paginated BFS discovery, separate listing/entry budgets, real metadata stats, tracked task failures, and truthful warmup counters.
- Prevent threaded E2E runs from deadlocking in `subprocess.Popen` by replacing unsafe `preexec_fn=os.setsid` with `start_new_session` in the shared server fixture.

## Why

Koodle's latest-Nexus qualification exposed correctness, authorization, performance, migration-safety, and lifecycle gaps across the runtime paths it depends on. These are upstream Nexus fixes; they are not changes to `nexus-vfs` or Koodle application code.

The E2E harness fix was found during final validation: the shared fixture could fork after pytest started threads and block forever before exec. `start_new_session` preserves process-group cleanup without running Python in the forked child.

Related Nexus work: #4354, #4352, #4398, #4399, #4337, #4350, #4252, #1076.

Koodle issue [DeepBuildAI/koodle#1431](https://github.com/DeepBuildAI/koodle/issues/1431) still requires its SDK/query/context changes and a Nexus image containing #4399. This PR hardens the upstream build that should be qualified before that deployment; it does not deploy anything.

## User and operator impact

- Search expansion and mutation retries no longer return stale, invalid, or repeatedly parked work.
- Virtual connector grep stays permission-aware and avoids blocking per-zone request loops on synchronous I/O.
- API-key-authenticated zone CRUD works without global local-auth state.
- Existing graph data survives the zone-column migration, and deprovisioning removes target-zone graph/ReBAC dependents without deleting control-zone rows.
- Startup warmup has deterministic breadth limits and observable failures instead of unbounded traversal or silent background-task exceptions.
- Repeated daemon-backed E2E tests launch reliably in a threaded pytest process.

## Validation

- `201 passed, 7 skipped` across the 12 affected search/API/zone/migration/warmup suites on the rebased branch (`169.99s`).
- `58 passed` for complete glob/grep/read-url router files after the sync/async dispatch fix.
- `10 passed` for daemon-backed cache-warmup E2E after the process-launch fix (`191.79s`).
- Alembic reports exactly one head: `align_graph_zone_columns (knowledge_platform) (head)`.
- `pytest-alembic` single-head precheck: `1 passed`.
- Ruff check passed; Ruff format reports 19 files formatted; mypy reports no issues in 8 changed production files.
- CRLF-aware `git diff --check` passed; `uv.lock` is unchanged.
- Independent final review approved the corrected async, migration, authorization, cleanup, and warmup paths.

## Deployment

No Railway, Vercel, Supabase, Koodle production, or other production environment was changed. Keep this PR draft until CI and maintainer review complete; deploy only an image built from the merged commit.

## Final local image qualification

- Built this PR locally with `nexus up --build` and ran a disposable demo stack; no production services were touched.
- `scripts/test_build_perf_e2e.py`: **26 passed, 0 failed**; HERB retrieval 8/8; direct RPC p50/p95 5.2/47.5 ms; exact fuzzy restore, auto-index, and stale-delete checks passed.
- `permissions_demo_enhanced.sh` in strict mode: owner/group/tenant/cache/rename checks passed; all 5 decision rows passed across 100 checks; latency median/p95/p99/max 71.86/128.83/191.90/191.90 ms.
- Hardened both host-side qualification scripts so exact document restoration, current owner semantics, and a granted parent group explanation are failure-counted. Focused unit checks: 7 passed; Bash, Ruff, format, and final review passed.
- Removed the disposable containers, network, volumes, image, and raw local credentials after validation.
