### PR TITLE
chore(deps): bump nexus-vfs pin to 542a11ee (federation HAL collapse + architecture lint)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=051bc598439d2cb801e2dc0c282407a4dbd158a0#051bc598439d2cb801e2dc0c282407a4dbd158a0"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=542a11ee4ff9a2c2f96c9e61f2a86ec528a9ab23#542a11ee4ff9a2c2f96c9e61f2a86ec528a9ab23"
 dependencies = [
  "ahash",
  "base64",
@@ -550,7 +550,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=051bc598439d2cb801e2dc0c282407a4dbd158a0#051bc598439d2cb801e2dc0c282407a4dbd158a0"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=542a11ee4ff9a2c2f96c9e61f2a86ec528a9ab23#542a11ee4ff9a2c2f96c9e61f2a86ec528a9ab23"
 dependencies = [
  "parking_lot",
  "serde",
@@ -1333,7 +1333,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=051bc598439d2cb801e2dc0c282407a4dbd158a0#051bc598439d2cb801e2dc0c282407a4dbd158a0"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=542a11ee4ff9a2c2f96c9e61f2a86ec528a9ab23#542a11ee4ff9a2c2f96c9e61f2a86ec528a9ab23"
 dependencies = [
  "ahash",
  "base64",
@@ -1384,7 +1384,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=051bc598439d2cb801e2dc0c282407a4dbd158a0#051bc598439d2cb801e2dc0c282407a4dbd158a0"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=542a11ee4ff9a2c2f96c9e61f2a86ec528a9ab23#542a11ee4ff9a2c2f96c9e61f2a86ec528a9ab23"
 dependencies = [
  "ahash",
  "base64",
@@ -1576,7 +1576,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=051bc598439d2cb801e2dc0c282407a4dbd158a0#051bc598439d2cb801e2dc0c282407a4dbd158a0"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=542a11ee4ff9a2c2f96c9e61f2a86ec528a9ab23#542a11ee4ff9a2c2f96c9e61f2a86ec528a9ab23"
 
 [[package]]
 name = "nexus-vault"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,22 +30,49 @@ exclude = ["nexus-fuse"]
 [workspace.dependencies]
 # Kernel-tier crates from nexus-vfs (external git dependency).
 # SSOT: https://github.com/nexi-lab/nexus-vfs
-# Pinned at the nexus-vfs main commit that landed PR #94
-# (051bc598, merged 2026-06-29): warn-loud diagnostics on the
-# three silent-failure paths of `dispatch_federation_peer`
-# (target_zone_id=None / zone_peers empty / all peers RPC failed).
-# Pure observability — no contract change.  Drives the Federation
-# E2E + cc-tasks-share E2E suites against the new logs so the
-# Mac↔Win Direction-A re-investigation has ground-truth signals.
-# Bump alongside the rest of nexus-vfs updates when a downstream
+# Pinned at the nexus-vfs main commit that landed PRs #96 + #97
+# (542a11ee, merged 2026-06-29): Federation HAL collapse.  The
+# `FederationPeerClient` HAL trait + Kernel slot are deleted;
+# the 9 per-syscall peer_* RPCs (read/write/stat/list_dir/
+# delete_file/rmdir/mkdir/rename/setattr) are absorbed into the
+# single `DistributedCoordinator` trait (§3.B.1 HAL).  Kernel
+# syscall sites reach the SSOT peer through
+# `RouteResult::supplement_*` / `via_federation_*` behavior
+# methods — `is_federation_peer_mount()` is now a one-place
+# predicate inside RouteResult's own module.  `FederationPeerBackend`
+# (dead ObjectStore impl, wrong storage pillar) deleted alongside.
+# PR #94's three warn-loud observability paths
+# (target_zone_id=None / zone_peers empty / all peers RPC failed)
+# preserved verbatim and moved from kernel into
+# `RaftDistributedCoordinator::dispatch_to_peers` (its natural
+# home — that's where `zone_peers` SSOT lives).
+#
+# Companion architecture fix (#97) lands
+# `FederationWriteOutcome` (named 3-variant enum for the sys_write
+# three-state need) in its correct home `kernel/src/federation/
+# route_outcomes.rs` rather than `core/vfs_router.rs` (where
+# §4 says only kernel primitives belong), and adds a new
+# `.github/workflows/kernel-architecture.yml` CI gate that
+# enforces §3 tier-directory file allowlists + §6.1 crate
+# dependency edges so future placement errors fail at PR-review
+# time with a clear error citing the architecture doc.
+#
+# Syscall ABI / plugin ABI / raft `Command` contracts unchanged
+# across both PRs.  +16 new behavioral pins in nexus-vfs
+# (7 dispatch loop + 9 RouteResult methods).  Drives the Federation
+# E2E + cc-tasks-share E2E + Self-Contained E2E (PR #92-class
+# regression catcher) suites against the collapsed dispatch path
+# so any kernel-side regression surfaces before the Mac↔Win
+# Direction-A re-investigation lands its eventual fix.  Bump
+# alongside the rest of nexus-vfs updates when a downstream
 # change needs newer kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "051bc598439d2cb801e2dc0c282407a4dbd158a0" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "051bc598439d2cb801e2dc0c282407a4dbd158a0" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "051bc598439d2cb801e2dc0c282407a4dbd158a0" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "051bc598439d2cb801e2dc0c282407a4dbd158a0", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "051bc598439d2cb801e2dc0c282407a4dbd158a0", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "051bc598439d2cb801e2dc0c282407a4dbd158a0", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "051bc598439d2cb801e2dc0c282407a4dbd158a0" }
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "542a11ee4ff9a2c2f96c9e61f2a86ec528a9ab23" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "542a11ee4ff9a2c2f96c9e61f2a86ec528a9ab23" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "542a11ee4ff9a2c2f96c9e61f2a86ec528a9ab23" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "542a11ee4ff9a2c2f96c9e61f2a86ec528a9ab23", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "542a11ee4ff9a2c2f96c9e61f2a86ec528a9ab23", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "542a11ee4ff9a2c2f96c9e61f2a86ec528a9ab23", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "542a11ee4ff9a2c2f96c9e61f2a86ec528a9ab23" }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ENV CARGO_NET_RETRY=10 \
     CARGO_HTTP_TIMEOUT=120
 # Override for edge/CI or a different pin: --build-arg NEXUS_VFS_REV=<sha|tag>
-ARG NEXUS_VFS_REV=051bc598439d2cb801e2dc0c282407a4dbd158a0
+ARG NEXUS_VFS_REV=542a11ee4ff9a2c2f96c9e61f2a86ec528a9ab23
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,id=cargo-install-${TARGETARCH},target=/root/.cargo/target \

--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir --no-deps --prefix=/install .
 # enforces agreement) — an unpinned install tracks nexus-vfs HEAD and
 # ships an untested kernel (#4343). --locked honors the source tree's
 # Cargo.lock.
-ARG NEXUS_VFS_REV=051bc598439d2cb801e2dc0c282407a4dbd158a0
+ARG NEXUS_VFS_REV=542a11ee4ff9a2c2f96c9e61f2a86ec528a9ab23
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-cluster nexus-cluster
 
 # -- Runtime stage --

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -25,7 +25,7 @@ WORKDIR /build
 # (CI preflight enforces agreement) — an unpinned install tracks HEAD
 # and can skew the raft contract against the cluster/witness images.
 # --locked honors the source tree's Cargo.lock.
-ARG NEXUS_VFS_REV=051bc598439d2cb801e2dc0c282407a4dbd158a0
+ARG NEXUS_VFS_REV=542a11ee4ff9a2c2f96c9e61f2a86ec528a9ab23
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexus-raft-server raft
 
 # ---------- Production image ----------

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=051bc598439d2cb801e2dc0c282407a4dbd158a0
+ARG NEXUS_VFS_REV=542a11ee4ff9a2c2f96c9e61f2a86ec528a9ab23
 RUN cargo install \
     --locked \
     --git https://github.com/nexi-lab/nexus-vfs \


### PR DESCRIPTION
## Summary

Bumps nexus-vfs from **051bc598** (PR #94 — federation dispatch observability) to **542a11ee** (post-#96 + #97 — kernel federation HAL collapse + architecture lint).

### nexus-vfs #96 — kernel federation HAL collapse

The single biggest concern of the federation refactor cycle. Federation was modelled as two parallel HAL traits (`FederationPeerClient` per-syscall typed RPCs + `DistributedCoordinator` zone management). Collapsed into **one** HAL — `DistributedCoordinator` carries 9 `peer_*` methods (`read` / `write` / `stat` / `list_dir` / `delete_file` / `rmdir` / `mkdir` / `rename` / `setattr`); the `federation_peer_client` Kernel slot is deleted.

- Syscall sites in `io.rs` / `kernel/mod.rs` reach the SSOT peer through `RouteResult::supplement_*` / `via_federation_*` behavior methods rather than naming the coordinator directly — `is_federation_peer_mount()` is a one-place predicate encapsulated inside RouteResult.
- `FederationPeerBackend` (dead `ObjectStore` impl, wrong storage pillar) deleted alongside.
- PR #94's three warn-loud observability paths (`target_zone_id=None` / `zone_peers empty` / `all peers RPC failed`) preserved verbatim and moved into `RaftDistributedCoordinator::dispatch_to_peers` (its natural home — that's where `zone_peers` SSOT lives).

### nexus-vfs #97 — architecture fix + new CI gate

The `FederationWriteOutcome` enum (named 3-variant outcome for the `sys_write` three-state need that previously landed as `Option<Option<WriteResult>>`) initially placed in `core/vfs_router.rs`. Per `docs/KERNEL-ARCHITECTURE.md` §3/§4 it belongs in `kernel/src/federation/route_outcomes.rs` (federation-domain types live in `federation/`, `core/` is for §4 kernel primitives). Moved + re-exported from `federation/mod.rs`.

Companion **`.github/workflows/kernel-architecture.yml`** CI gate enforces:
- §3 tier-directory file allowlists (abc/, hal/, core/, federation/)
- §6.1 crate dep edges (`kernel` ⊥ `raft/transport/backends/services`, `lib` ⊥ all peer crates, peer-orthogonality)

Errors cite the exact `KERNEL-ARCHITECTURE.md` section + tell the contributor where the offending type/dep should go. This is the gate that would have caught the original placement error at PR-review time rather than after merge.

## Contracts unchanged

- Syscall ABI ✅
- Plugin / driver ABI ✅
- Raft `Command` / snapshot / apply / ConfState contracts ✅

## +16 new behavioral pins
- 7 dispatch-loop pins (raft crate)
- 9 RouteResult method pins (kernel crate)

## Test plan

- [ ] Federation E2E (Docker)
- [ ] cc-tasks-share E2E (Docker)
- [ ] E2E Tests (Self-Contained) — the suite that caught the PR #92-class wrong-tier regression
- [ ] nexusd-cluster Smoke Test
- [ ] FUSE Plugin Windows E2E
- [ ] Standard CI battery (cargo check / clippy / fmt / Rust Lint and Test / Lint and Type Check / per-Python-version tests / boundary checks)
- [ ] 4 vault-plugin builds (linux/mac-arm64/mac-x86/win)

Admin-merge once green per `feedback_admin_merge_self_approve`.