### PR TITLE
feat: NFS localhost mount fallback for macOS (FUSE-T broken on Tahoe)

### DIFF
--- a/.github/workflows/fuse-plugin-macos-nfs-e2e.yml
+++ b/.github/workflows/fuse-plugin-macos-nfs-e2e.yml
@@ -79,6 +79,13 @@ jobs:
         with:
           shared-key: fuse-plugin-macos-nfs-e2e
 
+      # macFUSE provides libfuse3 headers needed to compile the fuser
+      # crate.  Even though this E2E exercises the NFS fallback (not
+      # fuser), the fuse-plugin cdylib links both paths in one binary.
+      - name: Install macFUSE (libfuse3 build dependency)
+        if: steps.changes.outputs.run == 'true'
+        run: brew install --cask macfuse
+
       # protobuf-build 0.14.1 hard-codes `major == 3 && minor >= 1` in
       # its version check.  Newer protoc (v27+) uses a different major
       # version scheme.  The bundled protoc fallback also fails on

--- a/.github/workflows/fuse-plugin-macos-nfs-e2e.yml
+++ b/.github/workflows/fuse-plugin-macos-nfs-e2e.yml
@@ -1,0 +1,217 @@
+name: FUSE Plugin macOS NFS E2E
+
+# Runs `tests/e2e/macos/test_fuse_plugin_nfs_e2e.py` against a real NFS
+# localhost mount on a `macos-latest` runner.
+#
+# When FUSE-T is broken on macOS (Tahoe: go-nfsv4 panic, SMB EOF, FSKit
+# entitlement missing), the FUSE plugin falls back to an in-process
+# NFSv3 server mounted via `mount_nfs`.  This suite exercises that
+# fallback path.
+#
+# Flow: build nexusd-cluster + plugin → spawn cluster with NFS fallback
+# active → pytest workflows with gRPC cross-check → teardown.
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main, develop]
+    paths:
+      - 'rust/services/fuse-plugin/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'tests/e2e/macos/**'
+      - '.github/workflows/fuse-plugin-macos-nfs-e2e.yml'
+  pull_request:
+    branches: [main, develop]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  fuse-plugin-macos-nfs-e2e:
+    name: FUSE Plugin macOS NFS E2E
+    runs-on: macos-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect macOS-NFS-relevant changes
+        id: changes
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git fetch --no-tags --prune origin "${{ github.base_ref }}"
+          git diff --name-only "origin/${{ github.base_ref }}"...HEAD > /tmp/changed_files.txt
+          cat /tmp/changed_files.txt
+          if grep -Eq '^(rust/services/fuse-plugin/|Cargo\.toml$|Cargo\.lock$|tests/e2e/macos/)' /tmp/changed_files.txt; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Skip — no relevant changes
+        if: steps.changes.outputs.run != 'true'
+        run: |
+          echo "No FUSE-plugin-relevant macOS changes; skipping."
+
+      - name: Install Rust toolchain
+        if: steps.changes.outputs.run == 'true'
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache: false
+
+      - name: Install Python 3.14
+        if: steps.changes.outputs.run == 'true'
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.14'
+
+      - name: Rust cache
+        if: steps.changes.outputs.run == 'true'
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: fuse-plugin-macos-nfs-e2e
+
+      - name: Read NEXUS_VFS_REV from Cargo.toml
+        if: steps.changes.outputs.run == 'true'
+        id: vfs_rev
+        run: |
+          sha=$(grep -oP '(?<=rev = ")[a-f0-9]{40}' Cargo.toml | sort -u | head -1)
+          if [ -z "$sha" ]; then
+            # macOS grep doesn't support -P; fallback to sed.
+            sha=$(sed -n 's/.*rev = "\([a-f0-9]\{40\}\)".*/\1/p' Cargo.toml | sort -u | head -1)
+          fi
+          if [ -z "$sha" ]; then
+            echo "::error::Could not parse nexus-vfs SHA from Cargo.toml"
+            exit 1
+          fi
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+
+      - name: Install nexusd-cluster from nexus-vfs (pinned)
+        if: steps.changes.outputs.run == 'true'
+        env:
+          REV: ${{ steps.vfs_rev.outputs.sha }}
+        run: |
+          set -euo pipefail
+          cargo install --locked \
+            --git https://github.com/nexi-lab/nexus-vfs \
+            --rev "$REV" \
+            --bin nexusd-cluster nexus-cluster
+
+      - name: Build + sign FUSE plugin dylib
+        if: steps.changes.outputs.run == 'true'
+        env:
+          PLUGIN_SIGNING_PRIVKEY: ${{ secrets.PLUGIN_SIGNING_PRIVKEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "$PLUGIN_SIGNING_PRIVKEY" ]; then
+            echo "::error::PLUGIN_SIGNING_PRIVKEY secret is not available"
+            exit 1
+          fi
+          cargo build --release -p nexus-fuse-plugin
+          pip install --quiet cryptography
+          python scripts/sign_plugin.py \
+            target/release/libnexus_fuse_plugin.dylib
+
+      - name: Prepare plugin dir + mount point
+        if: steps.changes.outputs.run == 'true'
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.nexus/plugins
+          cp target/release/libnexus_fuse_plugin.dylib ~/.nexus/plugins/
+          cp target/release/libnexus_fuse_plugin.dylib.sig ~/.nexus/plugins/
+          mkdir -p /tmp/nexus-nfs-e2e
+
+      - name: "Run FUSE plugin macOS NFS E2E (daemon + tests)"
+        if: steps.changes.outputs.run == 'true'
+        env:
+          NEXUS_FUSE_MACOS_NFS_E2E: "1"
+          NEXUS_CLUSTER_GRPC: "127.0.0.1:2126"
+          NEXUS_FUSE_MOUNT_POINT: "/tmp/nexus-nfs-e2e"
+          NEXUS_FUSE_VFS_ROOT: "/"
+          NEXUS_BIND_ADDR: "0.0.0.0:2126"
+          NEXUS_NO_TLS: "true"
+          NEXUS_BOOTSTRAP_MODE: "dynamic"
+        run: |
+          set -euo pipefail
+          DATADIR="$HOME/.nexus/data"
+          PLUGINDIR="$HOME/.nexus/plugins"
+          mkdir -p "$DATADIR"
+
+          # Spawn daemon in background.
+          nexusd-cluster \
+            --plugin-dir "$PLUGINDIR" \
+            --bind-addr "0.0.0.0:2126" \
+            --data-dir "$DATADIR" \
+            --no-tls \
+            --bootstrap-mode dynamic \
+            > nexusd.log 2> nexusd.err.log &
+          DAEMON_PID=$!
+          echo "nexusd-cluster started, pid=$DAEMON_PID"
+
+          # Wait for gRPC + NFS mount ready.
+          READY=false
+          for i in $(seq 1 90); do
+            GRPC_OK=false
+            if nc -z 127.0.0.1 2126 2>/dev/null; then
+              GRPC_OK=true
+            fi
+            MOUNT_OK=false
+            if mount | grep -q "/tmp/nexus-nfs-e2e"; then
+              MOUNT_OK=true
+            fi
+            if [ "$GRPC_OK" = "true" ] && [ "$MOUNT_OK" = "true" ]; then
+              echo "Cluster healthy (gRPC + NFS mount) after ${i}s"
+              READY=true
+              break
+            fi
+            if [ $((i % 10)) -eq 1 ]; then
+              ALIVE=$(kill -0 "$DAEMON_PID" 2>/dev/null && echo "yes" || echo "no")
+              echo "iter=$i grpcOK=$GRPC_OK mountOK=$MOUNT_OK alive=$ALIVE"
+            fi
+            sleep 2
+          done
+
+          TEST_RC=1
+          if [ "$READY" = "true" ]; then
+            pip install -e ".[test]"
+            python -m pytest tests/e2e/macos/test_fuse_plugin_nfs_e2e.py -v --no-header -o "addopts=" && TEST_RC=0 || TEST_RC=$?
+          else
+            echo "::error::Timed out waiting for cluster ready (180s)"
+            echo "=== mount output ==="
+            mount
+            echo "=== daemon alive? ==="
+            kill -0 "$DAEMON_PID" 2>/dev/null && echo "yes" || echo "no (exited)"
+          fi
+
+          # Teardown.
+          kill "$DAEMON_PID" 2>/dev/null || true
+          wait "$DAEMON_PID" 2>/dev/null || true
+
+          echo "=== nexusd.log (last 100 lines) ==="
+          tail -100 nexusd.log 2>/dev/null || true
+          echo "=== nexusd.err.log (last 100 lines) ==="
+          tail -100 nexusd.err.log 2>/dev/null || true
+
+          # Unmount if still mounted.
+          umount /tmp/nexus-nfs-e2e 2>/dev/null || true
+
+          exit $TEST_RC
+
+      - name: Upload daemon logs as artifact
+        if: always() && steps.changes.outputs.run == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: nexusd-nfs-logs-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            nexusd.log
+            nexusd.err.log
+          if-no-files-found: warn
+          retention-days: 14

--- a/.github/workflows/fuse-plugin-macos-nfs-e2e.yml
+++ b/.github/workflows/fuse-plugin-macos-nfs-e2e.yml
@@ -81,7 +81,9 @@ jobs:
 
       - name: Install protobuf compiler
         if: steps.changes.outputs.run == 'true'
-        run: brew install protobuf
+        uses: arduino/setup-protoc@v3
+        with:
+          version: '27.x'
 
       - name: Read NEXUS_VFS_REV from Cargo.toml
         if: steps.changes.outputs.run == 'true'

--- a/.github/workflows/fuse-plugin-macos-nfs-e2e.yml
+++ b/.github/workflows/fuse-plugin-macos-nfs-e2e.yml
@@ -79,6 +79,10 @@ jobs:
         with:
           shared-key: fuse-plugin-macos-nfs-e2e
 
+      - name: Install protobuf compiler
+        if: steps.changes.outputs.run == 'true'
+        run: brew install protobuf
+
       - name: Read NEXUS_VFS_REV from Cargo.toml
         if: steps.changes.outputs.run == 'true'
         id: vfs_rev

--- a/.github/workflows/fuse-plugin-macos-nfs-e2e.yml
+++ b/.github/workflows/fuse-plugin-macos-nfs-e2e.yml
@@ -79,11 +79,21 @@ jobs:
         with:
           shared-key: fuse-plugin-macos-nfs-e2e
 
-      - name: Install protobuf compiler
+      # protobuf-build 0.14.1 hard-codes `major == 3 && minor >= 1` in
+      # its version check.  Newer protoc (v27+) uses a different major
+      # version scheme.  The bundled protoc fallback also fails on
+      # macOS aarch64 (no match in the OS/arch table).  Fix: install
+      # protoc 3.x and point PROTOC to it.
+      - name: Install protoc 3.x (protobuf-build compatible)
         if: steps.changes.outputs.run == 'true'
-        uses: arduino/setup-protoc@v3
-        with:
-          version: '27.x'
+        run: |
+          set -euo pipefail
+          # Download protoc 3.25.1 for macOS (universal binary).
+          curl -fsSL -o /tmp/protoc.zip \
+            "https://github.com/protocolbuffers/protobuf/releases/download/v25.1/protoc-25.1-osx-universal_binary.zip"
+          sudo unzip -o /tmp/protoc.zip -d /usr/local bin/protoc
+          protoc --version
+          echo "PROTOC=/usr/local/bin/protoc" >> "$GITHUB_ENV"
 
       - name: Read NEXUS_VFS_REV from Cargo.toml
         if: steps.changes.outputs.run == 'true'

--- a/.github/workflows/fuse-plugin-macos-nfs-e2e.yml
+++ b/.github/workflows/fuse-plugin-macos-nfs-e2e.yml
@@ -88,9 +88,10 @@ jobs:
         if: steps.changes.outputs.run == 'true'
         run: |
           set -euo pipefail
-          # Download protoc 3.25.1 for macOS (universal binary).
+          # Download protoc 3.21.12 (last release with 3.x version output).
+          # protoc v22+ changed versioning to drop the 3. prefix.
           curl -fsSL -o /tmp/protoc.zip \
-            "https://github.com/protocolbuffers/protobuf/releases/download/v25.1/protoc-25.1-osx-universal_binary.zip"
+            "https://github.com/protocolbuffers/protobuf/releases/download/v21.12/protoc-21.12-osx-universal_binary.zip"
           sudo unzip -o /tmp/protoc.zip -d /usr/local bin/protoc
           protoc --version
           echo "PROTOC=/usr/local/bin/protoc" >> "$GITHUB_ENV"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -824,6 +824,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1551,10 +1561,13 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 name = "nexus-fuse-plugin"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "fuser",
  "libc",
  "nexus-plugin-abi",
+ "nfsserve",
  "tempfile",
+ "tokio",
  "tracing",
  "widestring",
  "windows-sys 0.52.0",
@@ -1599,6 +1612,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "nfsserve"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1424b6d88c60a091931392970999ea3ceab132d968e6a5545c770fad5b97d7"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "byteorder",
+ "filetime",
+ "num-derive",
+ "num-traits",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "nix"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1635,6 +1664,17 @@ name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "num-traits"

--- a/rust/services/fuse-plugin/Cargo.toml
+++ b/rust/services/fuse-plugin/Cargo.toml
@@ -45,6 +45,11 @@ fuser = "0.17"
 # the brew formula ships both.  Linking libfuse3 covers both paths.
 [target.'cfg(target_os = "macos")'.dependencies]
 fuser = { version = "0.17", features = ["libfuse3"] }
+# NFS localhost fallback — when FUSE-T is broken or missing on macOS,
+# we run an in-process NFSv3 server and let the native NFS client mount.
+nfsserve = "0.11"
+async-trait = "0.1"
+tokio = { version = "1", features = ["net", "rt", "rt-multi-thread", "sync", "macros", "io-util"] }
 
 # `winfsp` is the Rust binding around the WinFsp Windows user-space
 # filesystem framework.  Different trait shape from fuser
@@ -60,6 +65,8 @@ fuser = { version = "0.17", features = ["libfuse3"] }
 # touching /Library/Filesystems on the developer's host. macOS-only
 # because that's the only target where `fuse_t_detect` compiles.
 tempfile = "3"
+# NFS integration tests need a tokio runtime for async NFSFileSystem methods.
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winfsp = "0.13"

--- a/rust/services/fuse-plugin/src/fs_nfs.rs
+++ b/rust/services/fuse-plugin/src/fs_nfs.rs
@@ -1,0 +1,416 @@
+//! `NexusNfs` — `nfsserve::vfs::NFSFileSystem` impl that translates
+//! NFSv3 ops into Nexus kernel syscalls via the `KernelHandle` callback
+//! table.  macOS fallback path when FUSE-T is broken or missing.
+//!
+//! ## Why NFS localhost
+//!
+//! FUSE-T 1.2.7 is broken on macOS 26 (Tahoe): the go-nfsv4 backend
+//! panics on every mount, SMB backend EOF's, and the FSKit backend is
+//! blocked by a missing Apple entitlement.  FUSE-T is closed-source so
+//! we can't fix it.  Instead we run an in-process NFSv3 server on
+//! localhost and let macOS's native NFS client (`mount_nfs`) do the
+//! mount — zero third-party runtime dependency.
+//!
+//! ## Architecture
+//!
+//! Same `KernelHandle` + `PathIndex` as the fuser path.  The NFS
+//! server (nfsserve crate, MIT, HuggingFace-proven) runs in a tokio
+//! runtime spawned by `spawn_nfs_mount`.  All NFS ops translate to the
+//! same `kernel_callbacks::sys_*` wrappers that fuser uses.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Mutex;
+use std::time::SystemTime;
+
+use async_trait::async_trait;
+use nfsserve::nfs::{
+    fattr3, fileid3, filename3, ftype3, nfspath3, nfsstat3, nfstime3, sattr3, specdata3,
+};
+use nfsserve::tcp::{NFSTcp, NFSTcpListener};
+use nfsserve::vfs::{DirEntry, NFSFileSystem, ReadDirResult, VFSCapabilities};
+
+use nexus_plugin_abi::KernelHandle;
+
+use crate::kernel_callbacks::{self, parse_readdir, parse_stat, DT_DIR, DT_MOUNT};
+use crate::path_index::{join_path, PathIndex};
+
+/// Root inode — matches fuser's `INodeNo::ROOT.0` so PathIndex seeds
+/// identically regardless of which adapter creates it.
+const NFS_ROOT_ID: fileid3 = 1;
+
+/// NFS filesystem backed by Nexus kernel syscalls.
+pub struct NexusNfs {
+    kernel: KernelHandle,
+    paths: Mutex<PathIndex>,
+    next_inode: AtomicU64,
+}
+
+// SAFETY: KernelHandle is a bag of function pointers + an opaque ptr
+// documented to be valid for the plugin's lifetime.  The NFS server's
+// Arc<NexusNfs> is dropped before the plugin (spawn_nfs_mount's handle
+// is stored in FusePlugin, which the loader drops before reclaiming
+// the kernel).  All mutable state is behind Mutex/Atomic.
+unsafe impl Send for NexusNfs {}
+unsafe impl Sync for NexusNfs {}
+
+impl NexusNfs {
+    pub fn new(kernel: KernelHandle, vfs_root: String) -> Self {
+        Self {
+            kernel,
+            paths: Mutex::new(PathIndex::with_root(NFS_ROOT_ID, vfs_root)),
+            next_inode: AtomicU64::new(NFS_ROOT_ID + 1),
+        }
+    }
+
+    fn path_for(&self, id: fileid3) -> Option<String> {
+        self.paths.lock().unwrap().path_for(id)
+    }
+
+    fn inode_for(&self, path: &str) -> fileid3 {
+        self.paths
+            .lock()
+            .unwrap()
+            .lookup_or_register(path, || self.next_inode.fetch_add(1, Ordering::Relaxed))
+    }
+
+    /// Build an `fattr3` from a kernel `sys_stat` JSON result.
+    fn make_fattr(&self, id: fileid3, stat_json: &str) -> Result<fattr3, nfsstat3> {
+        let (size, entry_type) = parse_stat(stat_json).ok_or(nfsstat3::NFS3ERR_IO)?;
+        let is_dir = entry_type == DT_DIR || entry_type == DT_MOUNT;
+        let now = nfs_now();
+        Ok(fattr3 {
+            ftype: if is_dir { ftype3::NF3DIR } else { ftype3::NF3REG },
+            mode: if is_dir { 0o755 } else { 0o644 },
+            nlink: if is_dir { 2 } else { 1 },
+            uid: unsafe { libc::getuid() },
+            gid: unsafe { libc::getgid() },
+            size,
+            used: size,
+            rdev: specdata3 {
+                specdata1: 0,
+                specdata2: 0,
+            },
+            fsid: 0,
+            fileid: id,
+            atime: now,
+            mtime: now,
+            ctime: now,
+        })
+    }
+
+    /// Stat a path and return its fattr3.
+    fn stat_fattr(&self, id: fileid3, path: &str) -> Result<fattr3, nfsstat3> {
+        let json = kernel_callbacks::sys_stat(&self.kernel, path)
+            .map_err(|_| nfsstat3::NFS3ERR_NOENT)?;
+        self.make_fattr(id, &json)
+    }
+}
+
+fn nfs_now() -> nfstime3 {
+    let dur = SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default();
+    nfstime3 {
+        seconds: dur.as_secs() as u32,
+        nseconds: dur.subsec_nanos(),
+    }
+}
+
+#[async_trait]
+impl NFSFileSystem for NexusNfs {
+    fn root_dir(&self) -> fileid3 {
+        NFS_ROOT_ID
+    }
+
+    fn capabilities(&self) -> VFSCapabilities {
+        VFSCapabilities::ReadWrite
+    }
+
+    async fn lookup(&self, dirid: fileid3, filename: &filename3) -> Result<fileid3, nfsstat3> {
+        let parent = self.path_for(dirid).ok_or(nfsstat3::NFS3ERR_NOENT)?;
+        let name = std::str::from_utf8(filename).map_err(|_| nfsstat3::NFS3ERR_INVAL)?;
+        let path = join_path(&parent, name);
+        // Stat first — only allocate inode on positive hit.
+        kernel_callbacks::sys_stat(&self.kernel, &path).map_err(|_| nfsstat3::NFS3ERR_NOENT)?;
+        Ok(self.inode_for(&path))
+    }
+
+    async fn getattr(&self, id: fileid3) -> Result<fattr3, nfsstat3> {
+        let path = self.path_for(id).ok_or(nfsstat3::NFS3ERR_NOENT)?;
+        self.stat_fattr(id, &path)
+    }
+
+    async fn setattr(&self, _id: fileid3, _setattr: sattr3) -> Result<fattr3, nfsstat3> {
+        Err(nfsstat3::NFS3ERR_NOENT)
+    }
+
+    async fn read(
+        &self,
+        id: fileid3,
+        offset: u64,
+        count: u32,
+    ) -> Result<(Vec<u8>, bool), nfsstat3> {
+        let path = self.path_for(id).ok_or(nfsstat3::NFS3ERR_NOENT)?;
+        let full = kernel_callbacks::sys_read(&self.kernel, &path)
+            .map_err(|_| nfsstat3::NFS3ERR_NOENT)?;
+        let start = offset as usize;
+        if start >= full.len() {
+            return Ok((vec![], true));
+        }
+        let end = (start + count as usize).min(full.len());
+        let eof = end >= full.len();
+        Ok((full[start..end].to_vec(), eof))
+    }
+
+    async fn write(&self, id: fileid3, offset: u64, data: &[u8]) -> Result<fattr3, nfsstat3> {
+        if offset != 0 {
+            return Err(nfsstat3::NFS3ERR_IO);
+        }
+        let path = self.path_for(id).ok_or(nfsstat3::NFS3ERR_NOENT)?;
+        kernel_callbacks::sys_write(&self.kernel, &path, data)
+            .map_err(|_| nfsstat3::NFS3ERR_IO)?;
+        self.stat_fattr(id, &path)
+    }
+
+    async fn create(
+        &self,
+        dirid: fileid3,
+        filename: &filename3,
+        _attr: sattr3,
+    ) -> Result<(fileid3, fattr3), nfsstat3> {
+        let parent = self.path_for(dirid).ok_or(nfsstat3::NFS3ERR_NOENT)?;
+        let name = std::str::from_utf8(filename).map_err(|_| nfsstat3::NFS3ERR_INVAL)?;
+        let path = join_path(&parent, name);
+        kernel_callbacks::sys_write(&self.kernel, &path, &[])
+            .map_err(|_| nfsstat3::NFS3ERR_IO)?;
+        let id = self.inode_for(&path);
+        let attr = self.stat_fattr(id, &path)?;
+        Ok((id, attr))
+    }
+
+    async fn create_exclusive(
+        &self,
+        dirid: fileid3,
+        filename: &filename3,
+    ) -> Result<fileid3, nfsstat3> {
+        let parent = self.path_for(dirid).ok_or(nfsstat3::NFS3ERR_NOENT)?;
+        let name = std::str::from_utf8(filename).map_err(|_| nfsstat3::NFS3ERR_INVAL)?;
+        let path = join_path(&parent, name);
+        // Check existence first.
+        if kernel_callbacks::sys_stat(&self.kernel, &path).is_ok() {
+            return Err(nfsstat3::NFS3ERR_EXIST);
+        }
+        kernel_callbacks::sys_write(&self.kernel, &path, &[])
+            .map_err(|_| nfsstat3::NFS3ERR_IO)?;
+        Ok(self.inode_for(&path))
+    }
+
+    async fn mkdir(
+        &self,
+        dirid: fileid3,
+        dirname: &filename3,
+    ) -> Result<(fileid3, fattr3), nfsstat3> {
+        let parent = self.path_for(dirid).ok_or(nfsstat3::NFS3ERR_NOENT)?;
+        let name = std::str::from_utf8(dirname).map_err(|_| nfsstat3::NFS3ERR_INVAL)?;
+        let path = join_path(&parent, name);
+        kernel_callbacks::sys_mkdir(&self.kernel, &path).map_err(|_| nfsstat3::NFS3ERR_IO)?;
+        let id = self.inode_for(&path);
+        let attr = self.stat_fattr(id, &path)?;
+        Ok((id, attr))
+    }
+
+    async fn remove(&self, dirid: fileid3, filename: &filename3) -> Result<(), nfsstat3> {
+        let parent = self.path_for(dirid).ok_or(nfsstat3::NFS3ERR_NOENT)?;
+        let name = std::str::from_utf8(filename).map_err(|_| nfsstat3::NFS3ERR_INVAL)?;
+        let path = join_path(&parent, name);
+        // Try unlink first (file), fall back to rmdir (directory).
+        if kernel_callbacks::sys_unlink(&self.kernel, &path).is_err() {
+            kernel_callbacks::sys_rmdir(&self.kernel, &path)
+                .map_err(|_| nfsstat3::NFS3ERR_IO)?;
+        }
+        self.paths.lock().unwrap().forget(&path);
+        Ok(())
+    }
+
+    async fn rename(
+        &self,
+        from_dirid: fileid3,
+        from_filename: &filename3,
+        to_dirid: fileid3,
+        to_filename: &filename3,
+    ) -> Result<(), nfsstat3> {
+        let from_parent = self.path_for(from_dirid).ok_or(nfsstat3::NFS3ERR_NOENT)?;
+        let to_parent = self.path_for(to_dirid).ok_or(nfsstat3::NFS3ERR_NOENT)?;
+        let from_name =
+            std::str::from_utf8(from_filename).map_err(|_| nfsstat3::NFS3ERR_INVAL)?;
+        let to_name = std::str::from_utf8(to_filename).map_err(|_| nfsstat3::NFS3ERR_INVAL)?;
+        let old_path = join_path(&from_parent, from_name);
+        let new_path = join_path(&to_parent, to_name);
+        kernel_callbacks::sys_rename(&self.kernel, &old_path, &new_path)
+            .map_err(|_| nfsstat3::NFS3ERR_IO)?;
+        self.paths.lock().unwrap().rename(&old_path, &new_path);
+        Ok(())
+    }
+
+    async fn readdir(
+        &self,
+        dirid: fileid3,
+        start_after: fileid3,
+        max_entries: usize,
+    ) -> Result<ReadDirResult, nfsstat3> {
+        let parent_path = self.path_for(dirid).ok_or(nfsstat3::NFS3ERR_NOENT)?;
+        let json = kernel_callbacks::sys_readdir(&self.kernel, &parent_path)
+            .map_err(|_| nfsstat3::NFS3ERR_IO)?;
+        let entries = parse_readdir(&json);
+
+        let mut result_entries = Vec::new();
+        let mut past_start = start_after == 0;
+
+        for (name, entry_type) in &entries {
+            let child_path = join_path(&parent_path, name);
+            let child_id = self.inode_for(&child_path);
+
+            if !past_start {
+                if child_id == start_after {
+                    past_start = true;
+                }
+                continue;
+            }
+
+            let is_dir = *entry_type == DT_DIR || *entry_type == DT_MOUNT;
+            let now = nfs_now();
+            result_entries.push(DirEntry {
+                fileid: child_id,
+                name: name.as_bytes().into(),
+                attr: fattr3 {
+                    ftype: if is_dir { ftype3::NF3DIR } else { ftype3::NF3REG },
+                    mode: if is_dir { 0o755 } else { 0o644 },
+                    nlink: if is_dir { 2 } else { 1 },
+                    uid: unsafe { libc::getuid() },
+                    gid: unsafe { libc::getgid() },
+                    size: 0,
+                    used: 0,
+                    rdev: specdata3 {
+                        specdata1: 0,
+                        specdata2: 0,
+                    },
+                    fsid: 0,
+                    fileid: child_id,
+                    atime: now,
+                    mtime: now,
+                    ctime: now,
+                },
+            });
+
+            if result_entries.len() >= max_entries {
+                break;
+            }
+        }
+
+        let end = result_entries.len() < max_entries;
+        Ok(ReadDirResult {
+            entries: result_entries,
+            end,
+        })
+    }
+
+    async fn symlink(
+        &self,
+        _dirid: fileid3,
+        _linkname: &filename3,
+        _symlink: &nfspath3,
+        _attr: &sattr3,
+    ) -> Result<(fileid3, fattr3), nfsstat3> {
+        Err(nfsstat3::NFS3ERR_NOENT)
+    }
+
+    async fn readlink(&self, _id: fileid3) -> Result<nfspath3, nfsstat3> {
+        Err(nfsstat3::NFS3ERR_NOENT)
+    }
+}
+
+// ── NFS mount lifecycle ────────────────────────────────────────────
+
+/// Handle returned by `spawn_nfs_mount` — dropping it shuts down the
+/// NFS server and unmounts the mount point.
+pub struct NfsMountHandle {
+    /// Port the NFS server is listening on.
+    port: u16,
+    /// Mount point path on the host filesystem.
+    mount_point: String,
+    /// Tokio runtime driving the NFS server.  Dropping it stops all
+    /// spawned tasks (the `handle_forever` loop + connections).
+    _runtime: tokio::runtime::Runtime,
+}
+
+impl Drop for NfsMountHandle {
+    fn drop(&mut self) {
+        // Best-effort unmount — `umount` may fail if the mount was
+        // already torn down (e.g. `diskutil unmount` from Finder).
+        let _ = std::process::Command::new("/sbin/umount")
+            .arg(&self.mount_point)
+            .output();
+    }
+}
+
+impl NfsMountHandle {
+    pub fn port(&self) -> u16 {
+        self.port
+    }
+}
+
+/// Bind an NFS server on localhost, mount it at `mount_point`, and
+/// return the handle.  The NFS server runs in a dedicated tokio
+/// runtime so it doesn't interfere with fuser's thread model.
+pub fn spawn_nfs_mount(
+    nfs_fs: NexusNfs,
+    mount_point: &str,
+) -> Result<NfsMountHandle, Box<dyn std::error::Error>> {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .enable_all()
+        .thread_name("nexus-nfs")
+        .build()?;
+
+    let (port, listener) = rt.block_on(async {
+        let listener = NFSTcpListener::bind("127.0.0.1:0", nfs_fs).await?;
+        let port = listener.get_listen_port();
+        Ok::<_, std::io::Error>((port, listener))
+    })?;
+
+    // Spawn the NFS server loop — runs forever until the runtime is
+    // dropped.
+    rt.spawn(async move {
+        if let Err(e) = listener.handle_forever().await {
+            eprintln!("[nexus-fuse-plugin] NFS server error: {e}");
+        }
+    });
+
+    // Mount via macOS native `mount_nfs`.  Options:
+    //   nolocks  — no NLM (kernel doesn't support locking)
+    //   vers=3   — NFSv3 (nfsserve speaks v3)
+    //   tcp      — TCP transport
+    //   port=P   — NFS server port
+    //   mountport=P — mount daemon port (same, nfsserve handles both)
+    let mount_output = std::process::Command::new("/sbin/mount_nfs")
+        .args([
+            "-o",
+            &format!(
+                "nolocks,noresvport,vers=3,tcp,port={port},mountport={port}"
+            ),
+            "localhost:/",
+            mount_point,
+        ])
+        .output()?;
+
+    if !mount_output.status.success() {
+        let stderr = String::from_utf8_lossy(&mount_output.stderr);
+        return Err(format!("mount_nfs failed: {stderr}").into());
+    }
+
+    Ok(NfsMountHandle {
+        port,
+        mount_point: mount_point.to_string(),
+        _runtime: rt,
+    })
+}

--- a/rust/services/fuse-plugin/src/fs_nfs.rs
+++ b/rust/services/fuse-plugin/src/fs_nfs.rs
@@ -79,7 +79,11 @@ impl NexusNfs {
         let is_dir = entry_type == DT_DIR || entry_type == DT_MOUNT;
         let now = nfs_now();
         Ok(fattr3 {
-            ftype: if is_dir { ftype3::NF3DIR } else { ftype3::NF3REG },
+            ftype: if is_dir {
+                ftype3::NF3DIR
+            } else {
+                ftype3::NF3REG
+            },
             mode: if is_dir { 0o755 } else { 0o644 },
             nlink: if is_dir { 2 } else { 1 },
             uid: unsafe { libc::getuid() },
@@ -100,8 +104,8 @@ impl NexusNfs {
 
     /// Stat a path and return its fattr3.
     fn stat_fattr(&self, id: fileid3, path: &str) -> Result<fattr3, nfsstat3> {
-        let json = kernel_callbacks::sys_stat(&self.kernel, path)
-            .map_err(|_| nfsstat3::NFS3ERR_NOENT)?;
+        let json =
+            kernel_callbacks::sys_stat(&self.kernel, path).map_err(|_| nfsstat3::NFS3ERR_NOENT)?;
         self.make_fattr(id, &json)
     }
 }
@@ -151,8 +155,8 @@ impl NFSFileSystem for NexusNfs {
         count: u32,
     ) -> Result<(Vec<u8>, bool), nfsstat3> {
         let path = self.path_for(id).ok_or(nfsstat3::NFS3ERR_NOENT)?;
-        let full = kernel_callbacks::sys_read(&self.kernel, &path)
-            .map_err(|_| nfsstat3::NFS3ERR_NOENT)?;
+        let full =
+            kernel_callbacks::sys_read(&self.kernel, &path).map_err(|_| nfsstat3::NFS3ERR_NOENT)?;
         let start = offset as usize;
         if start >= full.len() {
             return Ok((vec![], true));
@@ -167,8 +171,7 @@ impl NFSFileSystem for NexusNfs {
             return Err(nfsstat3::NFS3ERR_IO);
         }
         let path = self.path_for(id).ok_or(nfsstat3::NFS3ERR_NOENT)?;
-        kernel_callbacks::sys_write(&self.kernel, &path, data)
-            .map_err(|_| nfsstat3::NFS3ERR_IO)?;
+        kernel_callbacks::sys_write(&self.kernel, &path, data).map_err(|_| nfsstat3::NFS3ERR_IO)?;
         self.stat_fattr(id, &path)
     }
 
@@ -181,8 +184,7 @@ impl NFSFileSystem for NexusNfs {
         let parent = self.path_for(dirid).ok_or(nfsstat3::NFS3ERR_NOENT)?;
         let name = std::str::from_utf8(filename).map_err(|_| nfsstat3::NFS3ERR_INVAL)?;
         let path = join_path(&parent, name);
-        kernel_callbacks::sys_write(&self.kernel, &path, &[])
-            .map_err(|_| nfsstat3::NFS3ERR_IO)?;
+        kernel_callbacks::sys_write(&self.kernel, &path, &[]).map_err(|_| nfsstat3::NFS3ERR_IO)?;
         let id = self.inode_for(&path);
         let attr = self.stat_fattr(id, &path)?;
         Ok((id, attr))
@@ -200,8 +202,7 @@ impl NFSFileSystem for NexusNfs {
         if kernel_callbacks::sys_stat(&self.kernel, &path).is_ok() {
             return Err(nfsstat3::NFS3ERR_EXIST);
         }
-        kernel_callbacks::sys_write(&self.kernel, &path, &[])
-            .map_err(|_| nfsstat3::NFS3ERR_IO)?;
+        kernel_callbacks::sys_write(&self.kernel, &path, &[]).map_err(|_| nfsstat3::NFS3ERR_IO)?;
         Ok(self.inode_for(&path))
     }
 
@@ -225,8 +226,7 @@ impl NFSFileSystem for NexusNfs {
         let path = join_path(&parent, name);
         // Try unlink first (file), fall back to rmdir (directory).
         if kernel_callbacks::sys_unlink(&self.kernel, &path).is_err() {
-            kernel_callbacks::sys_rmdir(&self.kernel, &path)
-                .map_err(|_| nfsstat3::NFS3ERR_IO)?;
+            kernel_callbacks::sys_rmdir(&self.kernel, &path).map_err(|_| nfsstat3::NFS3ERR_IO)?;
         }
         self.paths.lock().unwrap().forget(&path);
         Ok(())
@@ -241,8 +241,7 @@ impl NFSFileSystem for NexusNfs {
     ) -> Result<(), nfsstat3> {
         let from_parent = self.path_for(from_dirid).ok_or(nfsstat3::NFS3ERR_NOENT)?;
         let to_parent = self.path_for(to_dirid).ok_or(nfsstat3::NFS3ERR_NOENT)?;
-        let from_name =
-            std::str::from_utf8(from_filename).map_err(|_| nfsstat3::NFS3ERR_INVAL)?;
+        let from_name = std::str::from_utf8(from_filename).map_err(|_| nfsstat3::NFS3ERR_INVAL)?;
         let to_name = std::str::from_utf8(to_filename).map_err(|_| nfsstat3::NFS3ERR_INVAL)?;
         let old_path = join_path(&from_parent, from_name);
         let new_path = join_path(&to_parent, to_name);
@@ -283,7 +282,11 @@ impl NFSFileSystem for NexusNfs {
                 fileid: child_id,
                 name: name.as_bytes().into(),
                 attr: fattr3 {
-                    ftype: if is_dir { ftype3::NF3DIR } else { ftype3::NF3REG },
+                    ftype: if is_dir {
+                        ftype3::NF3DIR
+                    } else {
+                        ftype3::NF3REG
+                    },
                     mode: if is_dir { 0o755 } else { 0o644 },
                     nlink: if is_dir { 2 } else { 1 },
                     uid: unsafe { libc::getuid() },
@@ -395,9 +398,7 @@ pub fn spawn_nfs_mount(
     let mount_output = std::process::Command::new("/sbin/mount_nfs")
         .args([
             "-o",
-            &format!(
-                "nolocks,noresvport,vers=3,tcp,port={port},mountport={port}"
-            ),
+            &format!("nolocks,noresvport,vers=3,tcp,port={port},mountport={port}"),
             "localhost:/",
             mount_point,
         ])

--- a/rust/services/fuse-plugin/src/lib.rs
+++ b/rust/services/fuse-plugin/src/lib.rs
@@ -63,6 +63,9 @@ mod path_index;
 mod fs;
 
 #[cfg(target_os = "macos")]
+pub mod fs_nfs;
+
+#[cfg(target_os = "macos")]
 mod fuse_t_detect;
 
 #[cfg(target_os = "windows")]
@@ -94,6 +97,11 @@ struct FusePlugin {
     /// a free-form message.
     #[cfg(target_os = "macos")]
     prereq_missing: Mutex<Option<&'static str>>,
+    /// NFS localhost mount handle — populated when the fuser mount fails
+    /// on macOS and the NFS fallback succeeds.  Dropping the handle
+    /// unmounts and shuts down the NFS server.
+    #[cfg(target_os = "macos")]
+    nfs_handle: Mutex<Option<fs_nfs::NfsMountHandle>>,
     #[cfg(target_os = "windows")]
     host: Mutex<
         Option<winfsp::host::FileSystemHost<fs_winfsp::NexusWinFsp, winfsp::host::CoarseGuard>>,
@@ -107,6 +115,8 @@ impl FusePlugin {
             session: Mutex::new(None),
             #[cfg(target_os = "macos")]
             prereq_missing: Mutex::new(None),
+            #[cfg(target_os = "macos")]
+            nfs_handle: Mutex::new(None),
             #[cfg(target_os = "windows")]
             host: Mutex::new(None),
         }
@@ -165,7 +175,7 @@ fn create_fuse_plugin(_kernel: &KernelHandle) -> Box<FusePlugin> {
             // plugin instance (destroy joins the worker thread before
             // dropping the box).
             let kernel_clone = unsafe { kernel_handle_clone(_kernel) };
-            let fs = fs::NexusFs::new(kernel_clone, vfs_root);
+            let fs = fs::NexusFs::new(kernel_clone, vfs_root.clone());
 
             // Default fuser::Config is sufficient for cc-tasks-share's
             // flat-file read/write workflow.  Operators who need uid/gid
@@ -190,13 +200,61 @@ fn create_fuse_plugin(_kernel: &KernelHandle) -> Box<FusePlugin> {
                     *plugin.session.lock().unwrap() = Some(session);
                 }
                 Err(e) => {
-                    eprintln!("[nexus-fuse-plugin] mount FAILED at {mount_point}: {e}");
-                    tracing::error!(
-                        target: "nexus::fuse",
-                        mount_point = %mount_point,
-                        error = %e,
-                        "FUSE mount failed; plugin will report status=unmounted"
-                    );
+                    // On macOS, fuser mount failure is expected when
+                    // FUSE-T is broken (macOS 26 Tahoe).  Fall back to
+                    // an in-process NFSv3 localhost server mounted via
+                    // the native `mount_nfs` binary.
+                    #[cfg(target_os = "macos")]
+                    {
+                        eprintln!(
+                            "[nexus-fuse-plugin] fuser mount failed ({e}), falling back to NFS localhost"
+                        );
+                        tracing::warn!(
+                            target: "nexus::fuse",
+                            mount_point = %mount_point,
+                            error = %e,
+                            "fuser mount failed; attempting NFS localhost fallback"
+                        );
+                        let kernel_nfs = unsafe { kernel_handle_clone(_kernel) };
+                        let nfs_fs = fs_nfs::NexusNfs::new(kernel_nfs, vfs_root.clone());
+                        match fs_nfs::spawn_nfs_mount(nfs_fs, &mount_point) {
+                            Ok(handle) => {
+                                eprintln!(
+                                    "[nexus-fuse-plugin] NFS mount OK at {mount_point} (port {})",
+                                    handle.port()
+                                );
+                                tracing::info!(
+                                    target: "nexus::fuse",
+                                    mount_point = %mount_point,
+                                    port = handle.port(),
+                                    "NFS localhost fallback mounted"
+                                );
+                                *plugin.nfs_handle.lock().unwrap() = Some(handle);
+                            }
+                            Err(nfs_err) => {
+                                eprintln!(
+                                    "[nexus-fuse-plugin] NFS fallback also failed: {nfs_err}"
+                                );
+                                tracing::error!(
+                                    target: "nexus::fuse",
+                                    mount_point = %mount_point,
+                                    fuser_error = %e,
+                                    nfs_error = %nfs_err,
+                                    "Both fuser and NFS mounts failed"
+                                );
+                            }
+                        }
+                    }
+                    #[cfg(not(target_os = "macos"))]
+                    {
+                        eprintln!("[nexus-fuse-plugin] mount FAILED at {mount_point}: {e}");
+                        tracing::error!(
+                            target: "nexus::fuse",
+                            mount_point = %mount_point,
+                            error = %e,
+                            "FUSE mount failed; plugin will report status=unmounted"
+                        );
+                    }
                 }
             }
         } else {
@@ -369,12 +427,18 @@ fn dispatch_fuse(svc: &FusePlugin, method: &str, _payload: &[u8]) -> Result<Vec<
             }
             #[cfg(any(target_os = "linux", target_os = "macos"))]
             {
-                let mounted = svc.session.lock().unwrap().is_some();
-                Ok(if mounted {
-                    b"mounted".to_vec()
-                } else {
-                    b"unmounted".to_vec()
-                })
+                let fuse_mounted = svc.session.lock().unwrap().is_some();
+                if fuse_mounted {
+                    return Ok(b"mounted".to_vec());
+                }
+                #[cfg(target_os = "macos")]
+                {
+                    let nfs_mounted = svc.nfs_handle.lock().unwrap().is_some();
+                    if nfs_mounted {
+                        return Ok(b"mounted-nfs".to_vec());
+                    }
+                }
+                Ok(b"unmounted".to_vec())
             }
             #[cfg(not(any(target_os = "linux", target_os = "macos")))]
             {
@@ -390,10 +454,19 @@ fn dispatch_fuse(svc: &FusePlugin, method: &str, _payload: &[u8]) -> Result<Vec<
                     // Dropping the BackgroundSession sends the unmount
                     // ioctl and joins the worker thread.
                     drop(session);
-                    Ok(b"ok".to_vec())
-                } else {
-                    Ok(b"not-mounted".to_vec())
+                    return Ok(b"ok".to_vec());
                 }
+                #[cfg(target_os = "macos")]
+                {
+                    let nfs = svc.nfs_handle.lock().unwrap().take();
+                    if nfs.is_some() {
+                        // Dropping NfsMountHandle runs `umount` and
+                        // stops the tokio runtime.
+                        drop(nfs);
+                        return Ok(b"ok".to_vec());
+                    }
+                }
+                Ok(b"not-mounted".to_vec())
             }
             #[cfg(not(any(target_os = "linux", target_os = "macos")))]
             {

--- a/rust/services/fuse-plugin/tests/nfs_integration.rs
+++ b/rust/services/fuse-plugin/tests/nfs_integration.rs
@@ -1,0 +1,584 @@
+//! Integration test for `NexusNfs` — exercises the `NFSFileSystem` trait
+//! implementation against a mock `KernelHandle` that stores files in an
+//! in-memory HashMap.
+//!
+//! This verifies the full path: NFS method → kernel_callbacks wrapper →
+//! C ABI callback → mock storage → response parsing, without needing
+//! a real NFS mount (which requires OS-level privileges tested in CI).
+
+#![cfg(target_os = "macos")]
+
+use std::collections::HashMap;
+use std::ffi::{c_char, c_void, CStr};
+use std::sync::Mutex;
+
+use nexus_plugin_abi::KernelHandle;
+
+use nexus_fuse_plugin::fs_nfs::NexusNfs;
+use nfsserve::nfs::{ftype3, nfsstat3};
+use nfsserve::vfs::{NFSFileSystem, VFSCapabilities};
+
+/// Helper: compare nfsstat3 variants (the crate doesn't derive PartialEq).
+fn is_nfs_err(err: nfsstat3, expected: nfsstat3) -> bool {
+    // Both are #[repr(u32)] — compare via discriminant.
+    (err as u32) == (expected as u32)
+}
+
+/// Helper: compare ftype3 variants.
+fn is_ftype(ft: ftype3, expected: ftype3) -> bool {
+    (ft as u32) == (expected as u32)
+}
+
+// ── Mock in-memory kernel ──────────────────────────────────────────
+
+/// A simple in-memory filesystem for testing.  Entries are either
+/// directories (data=None) or files (data=Some(bytes)).
+struct MockEntry {
+    is_dir: bool,
+    data: Vec<u8>,
+}
+
+struct MockKernel {
+    entries: Mutex<HashMap<String, MockEntry>>,
+}
+
+impl MockKernel {
+    fn new() -> Self {
+        let mut entries = HashMap::new();
+        entries.insert(
+            "/".to_string(),
+            MockEntry {
+                is_dir: true,
+                data: vec![],
+            },
+        );
+        Self {
+            entries: Mutex::new(entries),
+        }
+    }
+}
+
+// Per-test mock kernel.  Each test gets a fresh MockKernel stored in
+// a Box, with the raw pointer passed as `kernel_ptr` in KernelHandle.
+// The C ABI callbacks cast `kernel_ptr` back to `&MockKernel`.
+
+fn new_mock_box() -> Box<MockKernel> {
+    Box::new(MockKernel::new())
+}
+
+// ── C ABI callback implementations ────────────────────────────────
+
+/// Helper: allocate a buffer on the heap and write it to out_buf/out_len.
+/// The plugin calls `nexus_free` on this — but in tests we leak it
+/// (the test process exits anyway). To match the real contract,
+/// we use Box::into_raw.
+unsafe fn write_out(out_buf: *mut *mut u8, out_len: *mut usize, data: &[u8]) {
+    let boxed = data.to_vec().into_boxed_slice();
+    *out_len = boxed.len();
+    *out_buf = Box::into_raw(boxed) as *mut u8;
+}
+
+unsafe extern "C" fn mock_sys_stat(
+    kernel: *const c_void,
+    path: *const c_char,
+    out_buf: *mut *mut u8,
+    out_len: *mut usize,
+) -> i32 {
+    let mock = &*(kernel as *const MockKernel);
+    let path_str = CStr::from_ptr(path).to_str().unwrap();
+    let entries = mock.entries.lock().unwrap();
+    match entries.get(path_str) {
+        Some(entry) => {
+            let entry_type = if entry.is_dir { 1u64 } else { 0u64 };
+            let json = format!(
+                r#"{{"path":"{}","entry_type":{},"size":{},"zone_id":"root"}}"#,
+                path_str,
+                entry_type,
+                entry.data.len()
+            );
+            write_out(out_buf, out_len, json.as_bytes());
+            0
+        }
+        None => -1, // NotFound
+    }
+}
+
+unsafe extern "C" fn mock_sys_read(
+    kernel: *const c_void,
+    path: *const c_char,
+    out_buf: *mut *mut u8,
+    out_len: *mut usize,
+) -> i32 {
+    let mock = &*(kernel as *const MockKernel);
+    let path_str = CStr::from_ptr(path).to_str().unwrap();
+    let entries = mock.entries.lock().unwrap();
+    match entries.get(path_str) {
+        Some(entry) if !entry.is_dir => {
+            write_out(out_buf, out_len, &entry.data);
+            0
+        }
+        _ => -1,
+    }
+}
+
+unsafe extern "C" fn mock_sys_write(
+    kernel: *const c_void,
+    path: *const c_char,
+    data: *const u8,
+    data_len: usize,
+) -> i32 {
+    let mock = &*(kernel as *const MockKernel);
+    let path_str = CStr::from_ptr(path).to_str().unwrap();
+    let content = std::slice::from_raw_parts(data, data_len).to_vec();
+    let mut entries = mock.entries.lock().unwrap();
+    entries.insert(
+        path_str.to_string(),
+        MockEntry {
+            is_dir: false,
+            data: content,
+        },
+    );
+    0
+}
+
+unsafe extern "C" fn mock_sys_readdir(
+    kernel: *const c_void,
+    parent_path: *const c_char,
+    out_buf: *mut *mut u8,
+    out_len: *mut usize,
+) -> i32 {
+    let mock = &*(kernel as *const MockKernel);
+    let parent = CStr::from_ptr(parent_path).to_str().unwrap();
+    let entries = mock.entries.lock().unwrap();
+    if !entries.contains_key(parent) {
+        return -1;
+    }
+    let prefix = if parent == "/" {
+        "/".to_string()
+    } else {
+        format!("{}/", parent)
+    };
+    let mut children = Vec::new();
+    for (path, entry) in entries.iter() {
+        if path == parent {
+            continue;
+        }
+        if let Some(name) = path.strip_prefix(&prefix) {
+            if !name.contains('/') {
+                let entry_type = if entry.is_dir { 1 } else { 0 };
+                children.push(format!(
+                    r#"{{"name":"{}","entry_type":{}}}"#,
+                    name, entry_type
+                ));
+            }
+        }
+    }
+    let json = format!("[{}]", children.join(","));
+    write_out(out_buf, out_len, json.as_bytes());
+    0
+}
+
+unsafe extern "C" fn mock_sys_unlink(
+    kernel: *const c_void,
+    path: *const c_char,
+) -> i32 {
+    let mock = &*(kernel as *const MockKernel);
+    let path_str = CStr::from_ptr(path).to_str().unwrap();
+    let mut entries = mock.entries.lock().unwrap();
+    match entries.remove(path_str) {
+        Some(_) => 0,
+        None => -1,
+    }
+}
+
+unsafe extern "C" fn mock_sys_mkdir(
+    kernel: *const c_void,
+    path: *const c_char,
+) -> i32 {
+    let mock = &*(kernel as *const MockKernel);
+    let path_str = CStr::from_ptr(path).to_str().unwrap();
+    let mut entries = mock.entries.lock().unwrap();
+    if entries.contains_key(path_str) {
+        return -3; // EEXIST
+    }
+    entries.insert(
+        path_str.to_string(),
+        MockEntry {
+            is_dir: true,
+            data: vec![],
+        },
+    );
+    0
+}
+
+unsafe extern "C" fn mock_sys_rmdir(
+    kernel: *const c_void,
+    path: *const c_char,
+) -> i32 {
+    let mock = &*(kernel as *const MockKernel);
+    let path_str = CStr::from_ptr(path).to_str().unwrap();
+    let mut entries = mock.entries.lock().unwrap();
+    match entries.remove(path_str) {
+        Some(e) if e.is_dir => 0,
+        Some(e) => {
+            entries.insert(path_str.to_string(), e);
+            -2
+        }
+        None => -1,
+    }
+}
+
+unsafe extern "C" fn mock_sys_rename(
+    kernel: *const c_void,
+    old_path: *const c_char,
+    new_path: *const c_char,
+) -> i32 {
+    let mock = &*(kernel as *const MockKernel);
+    let old = CStr::from_ptr(old_path).to_str().unwrap();
+    let new = CStr::from_ptr(new_path).to_str().unwrap();
+    let mut entries = mock.entries.lock().unwrap();
+    match entries.remove(old) {
+        Some(entry) => {
+            entries.insert(new.to_string(), entry);
+            0
+        }
+        None => -1,
+    }
+}
+
+unsafe extern "C" fn mock_sys_stat_batch(
+    _kernel: *const c_void,
+    _paths_json: *const c_char,
+    out_buf: *mut *mut u8,
+    out_len: *mut usize,
+) -> i32 {
+    // Stub — not used by NFS adapter.
+    write_out(out_buf, out_len, b"[]");
+    0
+}
+
+fn mock_kernel_handle(mock: &MockKernel) -> KernelHandle {
+    KernelHandle {
+        sys_read: mock_sys_read,
+        sys_write: mock_sys_write,
+        sys_stat: mock_sys_stat,
+        sys_readdir: mock_sys_readdir,
+        sys_unlink: mock_sys_unlink,
+        sys_mkdir: mock_sys_mkdir,
+        sys_rmdir: mock_sys_rmdir,
+        sys_rename: mock_sys_rename,
+        sys_stat_batch: mock_sys_stat_batch,
+        kernel_ptr: mock as *const MockKernel as *const c_void,
+    }
+}
+
+// ── Test helpers ───────────────────────────────────────────────────
+
+/// Each test gets its own mock + NexusNfs so tests can run in parallel.
+/// The Box<MockKernel> must be kept alive for the duration of the test.
+fn make_nfs() -> (Box<MockKernel>, NexusNfs) {
+    let mock = new_mock_box();
+    let handle = mock_kernel_handle(&mock);
+    let nfs = NexusNfs::new(handle, "/".to_string());
+    (mock, nfs)
+}
+
+// ── Tests ──────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn root_dir_returns_1() {
+    let (_mock, nfs) = make_nfs();
+    assert_eq!(nfs.root_dir(), 1);
+}
+
+#[tokio::test]
+async fn capabilities_returns_readwrite() {
+    let (_mock, nfs) = make_nfs();
+    assert!(matches!(nfs.capabilities(), VFSCapabilities::ReadWrite));
+}
+
+#[tokio::test]
+async fn getattr_root_is_directory() {
+    let (_mock, nfs) = make_nfs();
+    let attr = nfs.getattr(nfs.root_dir()).await.unwrap();
+    assert!(is_ftype(attr.ftype, ftype3::NF3DIR));
+    assert_eq!(attr.fileid, 1);
+}
+
+#[tokio::test]
+async fn lookup_nonexistent_returns_noent() {
+    let (_mock, nfs) = make_nfs();
+    let err = nfs
+        .lookup(nfs.root_dir(), &"nonexistent".as_bytes().into())
+        .await
+        .unwrap_err();
+    assert!(is_nfs_err(err, nfsstat3::NFS3ERR_NOENT));
+}
+
+#[tokio::test]
+async fn create_and_read_file() {
+    let (_mock, nfs) = make_nfs();
+    let root = nfs.root_dir();
+    let filename: nfsserve::nfs::filename3 = "hello.txt".as_bytes().into();
+
+    // Create.
+    let (fid, attr) = nfs
+        .create(root, &filename, Default::default())
+        .await
+        .unwrap();
+    assert!(fid > 0);
+    assert!(is_ftype(attr.ftype, ftype3::NF3REG));
+    assert_eq!(attr.size, 0); // empty file
+
+    // Write content.
+    let content = b"hello world";
+    let write_attr = nfs.write(fid, 0, content).await.unwrap();
+    assert_eq!(write_attr.size, content.len() as u64);
+
+    // Read back.
+    let (data, eof) = nfs.read(fid, 0, 1024).await.unwrap();
+    assert_eq!(data, content);
+    assert!(eof);
+
+    // Partial read.
+    let (data, eof) = nfs.read(fid, 6, 5).await.unwrap();
+    assert_eq!(data, b"world");
+    assert!(eof);
+}
+
+#[tokio::test]
+async fn mkdir_and_readdir() {
+    let (_mock, nfs) = make_nfs();
+    let root = nfs.root_dir();
+
+    // Create a subdirectory.
+    let dirname: nfsserve::nfs::filename3 = "subdir".as_bytes().into();
+    let (dir_id, dir_attr) = nfs.mkdir(root, &dirname).await.unwrap();
+    assert!(dir_id > 0);
+    assert!(is_ftype(dir_attr.ftype, ftype3::NF3DIR));
+
+    // Create a file in root.
+    let filename: nfsserve::nfs::filename3 = "file.txt".as_bytes().into();
+    nfs.create(root, &filename, Default::default())
+        .await
+        .unwrap();
+
+    // Readdir root — should contain both.
+    let result = nfs.readdir(root, 0, 100).await.unwrap();
+    let names: Vec<String> = result
+        .entries
+        .iter()
+        .map(|e| String::from_utf8_lossy(&e.name).to_string())
+        .collect();
+    assert!(names.contains(&"subdir".to_string()), "missing subdir in {names:?}");
+    assert!(names.contains(&"file.txt".to_string()), "missing file.txt in {names:?}");
+    assert!(result.end);
+}
+
+#[tokio::test]
+async fn lookup_returns_stable_inode() {
+    let (_mock, nfs) = make_nfs();
+    let root = nfs.root_dir();
+    let filename: nfsserve::nfs::filename3 = "stable.txt".as_bytes().into();
+
+    nfs.create(root, &filename, Default::default())
+        .await
+        .unwrap();
+
+    let id1 = nfs.lookup(root, &filename).await.unwrap();
+    let id2 = nfs.lookup(root, &filename).await.unwrap();
+    assert_eq!(id1, id2, "lookup must return stable inode for same path");
+}
+
+#[tokio::test]
+async fn rename_preserves_content() {
+    let (_mock, nfs) = make_nfs();
+    let root = nfs.root_dir();
+
+    let old_name: nfsserve::nfs::filename3 = "old.txt".as_bytes().into();
+    let new_name: nfsserve::nfs::filename3 = "new.txt".as_bytes().into();
+
+    // Create and write.
+    let (fid, _) = nfs
+        .create(root, &old_name, Default::default())
+        .await
+        .unwrap();
+    let content = b"rename me";
+    nfs.write(fid, 0, content).await.unwrap();
+
+    // Rename.
+    nfs.rename(root, &old_name, root, &new_name).await.unwrap();
+
+    // Old is gone.
+    let err = nfs.lookup(root, &old_name).await.unwrap_err();
+    assert!(is_nfs_err(err, nfsstat3::NFS3ERR_NOENT));
+
+    // New has the content.
+    let new_id = nfs.lookup(root, &new_name).await.unwrap();
+    let (data, _) = nfs.read(new_id, 0, 1024).await.unwrap();
+    assert_eq!(data, content);
+}
+
+#[tokio::test]
+async fn remove_deletes_file() {
+    let (_mock, nfs) = make_nfs();
+    let root = nfs.root_dir();
+    let filename: nfsserve::nfs::filename3 = "doomed.txt".as_bytes().into();
+
+    nfs.create(root, &filename, Default::default())
+        .await
+        .unwrap();
+
+    // File exists.
+    nfs.lookup(root, &filename).await.unwrap();
+
+    // Remove.
+    nfs.remove(root, &filename).await.unwrap();
+
+    // Gone.
+    let err = nfs.lookup(root, &filename).await.unwrap_err();
+    assert!(is_nfs_err(err, nfsstat3::NFS3ERR_NOENT));
+}
+
+#[tokio::test]
+async fn create_exclusive_fails_on_existing() {
+    let (_mock, nfs) = make_nfs();
+    let root = nfs.root_dir();
+    let filename: nfsserve::nfs::filename3 = "exists.txt".as_bytes().into();
+
+    nfs.create(root, &filename, Default::default())
+        .await
+        .unwrap();
+
+    let err = nfs.create_exclusive(root, &filename).await.unwrap_err();
+    assert!(is_nfs_err(err, nfsstat3::NFS3ERR_EXIST));
+}
+
+#[tokio::test]
+async fn readdir_pagination_with_start_after() {
+    let (_mock, nfs) = make_nfs();
+    let root = nfs.root_dir();
+
+    // Create 5 files.
+    for i in 0..5 {
+        let name: nfsserve::nfs::filename3 =
+            format!("file-{i}.txt").as_bytes().into();
+        nfs.create(root, &name, Default::default()).await.unwrap();
+    }
+
+    // Read all.
+    let all = nfs.readdir(root, 0, 100).await.unwrap();
+    assert_eq!(all.entries.len(), 5);
+
+    // Paginate: first 2.
+    let page1 = nfs.readdir(root, 0, 2).await.unwrap();
+    assert_eq!(page1.entries.len(), 2);
+    assert!(!page1.end);
+
+    // Next page starting after last entry of page1.
+    let last_id = page1.entries.last().unwrap().fileid;
+    let page2 = nfs.readdir(root, last_id, 100).await.unwrap();
+    assert_eq!(page2.entries.len(), 3);
+    assert!(page2.end);
+}
+
+#[tokio::test]
+async fn symlink_and_readlink_unsupported() {
+    let (_mock, nfs) = make_nfs();
+    let err = nfs
+        .symlink(
+            nfs.root_dir(),
+            &"link".as_bytes().into(),
+            &"/target".as_bytes().into(),
+            &Default::default(),
+        )
+        .await
+        .unwrap_err();
+    assert!(is_nfs_err(err, nfsstat3::NFS3ERR_NOENT));
+
+    let err = nfs.readlink(999).await.unwrap_err();
+    assert!(is_nfs_err(err, nfsstat3::NFS3ERR_NOENT));
+}
+
+#[tokio::test]
+async fn write_at_nonzero_offset_returns_io() {
+    let (_mock, nfs) = make_nfs();
+    let root = nfs.root_dir();
+    let filename: nfsserve::nfs::filename3 = "offset.txt".as_bytes().into();
+
+    let (fid, _) = nfs
+        .create(root, &filename, Default::default())
+        .await
+        .unwrap();
+
+    let err = nfs.write(fid, 10, b"data").await.unwrap_err();
+    assert!(is_nfs_err(err, nfsstat3::NFS3ERR_IO));
+}
+
+#[tokio::test]
+async fn read_past_eof_returns_empty() {
+    let (_mock, nfs) = make_nfs();
+    let root = nfs.root_dir();
+    let filename: nfsserve::nfs::filename3 = "small.txt".as_bytes().into();
+
+    let (fid, _) = nfs
+        .create(root, &filename, Default::default())
+        .await
+        .unwrap();
+    nfs.write(fid, 0, b"hi").await.unwrap();
+
+    let (data, eof) = nfs.read(fid, 100, 50).await.unwrap();
+    assert!(data.is_empty());
+    assert!(eof);
+}
+
+/// Workflow test: full session lifecycle mirroring the pytest E2E.
+/// mkdir → write N files → readdir → read each → unlink each → rmdir.
+#[tokio::test]
+async fn workflow_session_lifecycle() {
+    let (_mock, nfs) = make_nfs();
+    let root = nfs.root_dir();
+
+    // Step 1: mkdir.
+    let sess_name: nfsserve::nfs::filename3 = "session".as_bytes().into();
+    let (sess_id, _) = nfs.mkdir(root, &sess_name).await.unwrap();
+
+    // Step 2: write 3 task files.
+    let tasks = vec![
+        ("task-001.json", r#"{"id":1,"title":"PR"}"#),
+        ("task-002.json", r#"{"id":2,"title":"review"}"#),
+        ("task-003.json", r#"{"id":3,"title":"smoke"}"#),
+    ];
+    let mut task_ids = Vec::new();
+    for (name, payload) in &tasks {
+        let fname: nfsserve::nfs::filename3 = name.as_bytes().into();
+        let (fid, _) = nfs.create(sess_id, &fname, Default::default()).await.unwrap();
+        nfs.write(fid, 0, payload.as_bytes()).await.unwrap();
+        task_ids.push(fid);
+    }
+
+    // Step 3: readdir session — all 3 present.
+    let listing = nfs.readdir(sess_id, 0, 100).await.unwrap();
+    assert_eq!(listing.entries.len(), 3);
+
+    // Step 4: read each back — byte exact.
+    for (i, (_, payload)) in tasks.iter().enumerate() {
+        let (data, _) = nfs.read(task_ids[i], 0, 4096).await.unwrap();
+        assert_eq!(
+            String::from_utf8_lossy(&data),
+            *payload,
+            "file {i} content mismatch"
+        );
+    }
+
+    // Step 5: unlink each.
+    for (name, _) in &tasks {
+        let fname: nfsserve::nfs::filename3 = name.as_bytes().into();
+        nfs.remove(sess_id, &fname).await.unwrap();
+    }
+
+    // Step 6: rmdir session.
+    nfs.remove(root, &"session".as_bytes().into()).await.unwrap();
+    let err = nfs.lookup(root, &sess_name).await.unwrap_err();
+    assert!(is_nfs_err(err, nfsstat3::NFS3ERR_NOENT));
+}

--- a/rust/services/fuse-plugin/tests/nfs_integration.rs
+++ b/rust/services/fuse-plugin/tests/nfs_integration.rs
@@ -178,10 +178,7 @@ unsafe extern "C" fn mock_sys_readdir(
     0
 }
 
-unsafe extern "C" fn mock_sys_unlink(
-    kernel: *const c_void,
-    path: *const c_char,
-) -> i32 {
+unsafe extern "C" fn mock_sys_unlink(kernel: *const c_void, path: *const c_char) -> i32 {
     let mock = &*(kernel as *const MockKernel);
     let path_str = CStr::from_ptr(path).to_str().unwrap();
     let mut entries = mock.entries.lock().unwrap();
@@ -191,10 +188,7 @@ unsafe extern "C" fn mock_sys_unlink(
     }
 }
 
-unsafe extern "C" fn mock_sys_mkdir(
-    kernel: *const c_void,
-    path: *const c_char,
-) -> i32 {
+unsafe extern "C" fn mock_sys_mkdir(kernel: *const c_void, path: *const c_char) -> i32 {
     let mock = &*(kernel as *const MockKernel);
     let path_str = CStr::from_ptr(path).to_str().unwrap();
     let mut entries = mock.entries.lock().unwrap();
@@ -211,10 +205,7 @@ unsafe extern "C" fn mock_sys_mkdir(
     0
 }
 
-unsafe extern "C" fn mock_sys_rmdir(
-    kernel: *const c_void,
-    path: *const c_char,
-) -> i32 {
+unsafe extern "C" fn mock_sys_rmdir(kernel: *const c_void, path: *const c_char) -> i32 {
     let mock = &*(kernel as *const MockKernel);
     let path_str = CStr::from_ptr(path).to_str().unwrap();
     let mut entries = mock.entries.lock().unwrap();
@@ -370,8 +361,14 @@ async fn mkdir_and_readdir() {
         .iter()
         .map(|e| String::from_utf8_lossy(&e.name).to_string())
         .collect();
-    assert!(names.contains(&"subdir".to_string()), "missing subdir in {names:?}");
-    assert!(names.contains(&"file.txt".to_string()), "missing file.txt in {names:?}");
+    assert!(
+        names.contains(&"subdir".to_string()),
+        "missing subdir in {names:?}"
+    );
+    assert!(
+        names.contains(&"file.txt".to_string()),
+        "missing file.txt in {names:?}"
+    );
     assert!(result.end);
 }
 
@@ -461,8 +458,7 @@ async fn readdir_pagination_with_start_after() {
 
     // Create 5 files.
     for i in 0..5 {
-        let name: nfsserve::nfs::filename3 =
-            format!("file-{i}.txt").as_bytes().into();
+        let name: nfsserve::nfs::filename3 = format!("file-{i}.txt").as_bytes().into();
         nfs.create(root, &name, Default::default()).await.unwrap();
     }
 
@@ -552,7 +548,10 @@ async fn workflow_session_lifecycle() {
     let mut task_ids = Vec::new();
     for (name, payload) in &tasks {
         let fname: nfsserve::nfs::filename3 = name.as_bytes().into();
-        let (fid, _) = nfs.create(sess_id, &fname, Default::default()).await.unwrap();
+        let (fid, _) = nfs
+            .create(sess_id, &fname, Default::default())
+            .await
+            .unwrap();
         nfs.write(fid, 0, payload.as_bytes()).await.unwrap();
         task_ids.push(fid);
     }
@@ -578,7 +577,9 @@ async fn workflow_session_lifecycle() {
     }
 
     // Step 6: rmdir session.
-    nfs.remove(root, &"session".as_bytes().into()).await.unwrap();
+    nfs.remove(root, &"session".as_bytes().into())
+        .await
+        .unwrap();
     let err = nfs.lookup(root, &sess_name).await.unwrap_err();
     assert!(is_nfs_err(err, nfsstat3::NFS3ERR_NOENT));
 }

--- a/tests/e2e/macos/test_fuse_plugin_nfs_e2e.py
+++ b/tests/e2e/macos/test_fuse_plugin_nfs_e2e.py
@@ -1,0 +1,405 @@
+"""FUSE plugin macOS NFS E2E — real NFS localhost mount, real user workflows, gRPC cross-check.
+
+When FUSE-T is broken (macOS 26 Tahoe: go-nfsv4 panic, SMB EOF, FSKit
+entitlement missing), the FUSE plugin falls back to an in-process NFSv3
+localhost server mounted via macOS native ``mount_nfs``.  This suite
+exercises that fallback path end-to-end: real ``nexusd-cluster`` → real
+NFS mount → real shell commands → gRPC ``vfs_stat`` / ``vfs_read``
+kernel-side cross-check at every step.
+
+## Why workflows, not single ops
+
+Per the integration-test-generator pattern: 1-step "did mkdir work?"
+tests don't catch state-machine bugs — they look green until the
+next op trips on the missed update.  3+ step workflows like
+"create session → write tasks → list → cleanup" exercise the
+PathIndex remap, readdir pagination, and NFS dentry caching in the
+same call chain a real operator hits.
+
+## Workflow inventory
+
+* **Session lifecycle** — ``mkdir sess; write N tasks; ls; cat each; rm all; rmdir``
+  — exercises sys_mkdir → sys_write (N×) → sys_readdir → sys_read (N×)
+  → sys_unlink (N×) → sys_rmdir.  Mirrors the real CC ``cc tasks list``
+  end-to-end shape.
+
+* **Mid-session rename** — ``write task; mv to new name; verify old
+  gone + new present + content preserved`` — exercises sys_rename +
+  PathIndex remap.
+
+* **Cross-layer write integrity** — ``write via mount; vfs_read via
+  gRPC; verify byte-exact`` — independent kernel-side check.  Catches a
+  plugin that silently drops writes (mount-side ``cat`` would still pass
+  via NFS attribute cache, gRPC sees the truth).
+
+## Test data isolation
+
+Every workflow creates its own session directory under a fresh
+``uuid4`` name.  Cleanup runs in ``try / finally``.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import time
+import uuid
+from dataclasses import dataclass
+
+import pytest
+
+if os.environ.get("NEXUS_FUSE_MACOS_NFS_E2E") != "1":
+    pytest.skip(
+        "FUSE plugin macOS NFS E2E — requires the .github workflow's "
+        "harness to set NEXUS_FUSE_MACOS_NFS_E2E=1 + spawn nexusd-cluster "
+        "with the FUSE plugin loaded and NFS fallback active at the "
+        "configured mount point (see .github/workflows/fuse-plugin-macos-nfs-e2e.yml).",
+        allow_module_level=True,
+    )
+
+
+@dataclass(frozen=True)
+class Topology:
+    cluster_grpc: str
+    mount_point: str
+
+    def mount_path(self, relpath: str) -> str:
+        rel = relpath.lstrip("/")
+        return os.path.join(self.mount_point, rel) if rel else self.mount_point
+
+    def vfs_path(self, relpath: str) -> str:
+        if not relpath.startswith("/"):
+            relpath = "/" + relpath
+        return relpath
+
+
+@pytest.fixture(scope="module")
+def topology() -> Topology:
+    return Topology(
+        cluster_grpc=os.environ.get("NEXUS_CLUSTER_GRPC", "127.0.0.1:2126"),
+        mount_point=os.environ.get("NEXUS_FUSE_MOUNT_POINT", "/tmp/nexus-nfs-e2e").rstrip("/"),
+    )
+
+
+@pytest.fixture()
+def session_name() -> str:
+    return f"sess-{uuid.uuid4().hex[:8]}"
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Command helpers
+# ─────────────────────────────────────────────────────────────────────
+
+
+def _sh(
+    args: list[str], *, check: bool = True, timeout: float = 30
+) -> subprocess.CompletedProcess[str]:
+    """Run a shell command — the operator-level path."""
+    return subprocess.run(
+        args,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=check,
+    )
+
+
+def _write_file(path: str, payload: str) -> None:
+    """Write ``payload`` byte-exact to ``path`` through Python's
+    ``open()``.  The path lives on an NFS-mounted directory so the
+    underlying write syscall fires the NFS WRITE RPC → plugin's
+    ``write`` callback — same code path a real tool hits."""
+    with open(path, "w", encoding="utf-8", newline="") as f:
+        f.write(payload)
+
+
+def _vfs_stat(grpc_target: str, path: str) -> dict:
+    from tests.e2e.docker import runbook_helpers
+
+    return runbook_helpers.vfs_stat(grpc_target, path)
+
+
+def _vfs_read(grpc_target: str, path: str) -> dict:
+    from tests.e2e.docker import runbook_helpers
+
+    return runbook_helpers.vfs_read(grpc_target, path)
+
+
+def _decode_content(read_result: dict) -> bytes:
+    from tests.e2e.docker import runbook_helpers
+
+    return runbook_helpers.decode_content(read_result)
+
+
+def _wait_path_via_grpc(
+    topology: Topology,
+    path: str,
+    *,
+    expect_found: bool,
+    timeout: float = 10.0,
+) -> dict:
+    deadline = time.monotonic() + timeout
+    last: dict = {}
+    while time.monotonic() < deadline:
+        last = _vfs_stat(topology.cluster_grpc, path)
+        if "error" not in last and last["result"]["found"] == expect_found:
+            return last
+        time.sleep(0.1)
+    pytest.fail(
+        f"vfs_stat({path}) never reached expected found={expect_found} "
+        f"within {timeout}s — last result: {last}"
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Sanity — proves the harness is healthy enough to trust the
+# workflow tests below.
+# ─────────────────────────────────────────────────────────────────────
+
+
+class TestSanity:
+    def test_grpc_port_responds(self, topology: Topology) -> None:
+        result = _vfs_stat(topology.cluster_grpc, "/")
+        assert "error" not in result, f"gRPC vfs_stat(/) failed: {result}"
+        assert result["result"]["found"], "/ must exist on a fresh cluster"
+
+    def test_nfs_mount_reachable(self, topology: Topology) -> None:
+        """Prove the NFS mount is live.  ``os.path.isdir`` fires a
+        GETATTR NFS RPC which exercises the full NFS server → plugin →
+        kernel path.  Unlike ``mount | grep``, this actually proves
+        data flows end-to-end."""
+        assert os.path.isdir(topology.mount_point), (
+            f"NFS mount at {topology.mount_point} is not reachable as a directory. "
+            f"Likely causes: NFS server failed to bind, mount_nfs failed, "
+            f"or the cluster's FUSE plugin didn't fall back to NFS."
+        )
+
+    def test_mount_shows_nfs_type(self, topology: Topology) -> None:
+        """Verify ``mount`` output confirms NFS mount type — proves
+        the fallback path was taken (not FUSE-T)."""
+        result = _sh(["mount"], check=False)
+        mount_entry = [ln for ln in result.stdout.splitlines() if topology.mount_point in ln]
+        assert mount_entry, (
+            f"No mount entry found for {topology.mount_point}.\nFull mount output:\n{result.stdout}"
+        )
+        assert any("nfs" in entry.lower() for entry in mount_entry), (
+            f"Mount at {topology.mount_point} exists but is not NFS type.\n"
+            f"Entry: {mount_entry[0]}\n"
+            f"Expected NFS localhost fallback, got something else."
+        )
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Workflow 1 — Session lifecycle.
+#
+#    mkdir sess           → sys_mkdir
+#    write N tasks        → N × sys_write
+#    ls sess              → sys_readdir
+#    cat each task        → N × sys_read
+#    rm each task         → N × sys_unlink
+#    rmdir sess           → sys_rmdir
+# ─────────────────────────────────────────────────────────────────────
+
+
+class TestSessionLifecycle:
+    def test_create_session_write_read_cleanup(self, topology: Topology, session_name: str) -> None:
+        sess_rel = f".claude/tasks/{session_name}"
+        sess_mount = topology.mount_path(sess_rel)
+        task_payloads = {
+            "task-001.json": '{"id":1,"status":"todo","title":"draft PR"}',
+            "task-002.json": '{"id":2,"status":"todo","title":"review #4450"}',
+            "task-003.json": '{"id":3,"status":"todo","title":"smoke Mac NFS"}',
+        }
+        try:
+            # Step 1: mkdir session dir — sys_mkdir.
+            os.makedirs(sess_mount, exist_ok=True)
+            stat = _wait_path_via_grpc(topology, topology.vfs_path(sess_rel), expect_found=True)
+            assert stat["result"]["isDirectory"], f"session dir not seen as dir by kernel: {stat}"
+
+            # Step 2: write N tasks — N × sys_write.
+            for name, payload in task_payloads.items():
+                rel = f"{sess_rel}/{name}"
+                _write_file(topology.mount_path(rel), payload)
+                kernel_stat = _wait_path_via_grpc(
+                    topology, topology.vfs_path(rel), expect_found=True
+                )
+                assert kernel_stat["result"]["size"] > 0, (
+                    f"sys_write(`{rel}`) reported success but kernel sees "
+                    f"size=0; NFS write callback dropped bytes"
+                )
+
+            # Step 3: ls session — sys_readdir.
+            listing = os.listdir(sess_mount)
+            seen_names = set(listing)
+            assert set(task_payloads) <= seen_names, (
+                f"readdir missed tasks; expected superset of {set(task_payloads)}, got {seen_names}"
+            )
+
+            # Step 4: read each task back — N × sys_read.
+            # Compare byte-exact through gRPC vfs_read (the SSOT).
+            for name, payload in task_payloads.items():
+                read = _vfs_read(
+                    topology.cluster_grpc,
+                    topology.vfs_path(f"{sess_rel}/{name}"),
+                )
+                assert "error" not in read, f"vfs_read({name}) failed: {read}"
+                body = _decode_content(read).decode("utf-8", errors="replace")
+                assert payload in body, (
+                    f"vfs_read({name}) body did not contain expected payload\n"
+                    f"  expected substring: {payload!r}\n"
+                    f"  actual body:        {body!r}"
+                )
+
+            # Step 5: unlink each task — N × sys_unlink.
+            for name in task_payloads:
+                os.remove(topology.mount_path(f"{sess_rel}/{name}"))
+                _wait_path_via_grpc(
+                    topology,
+                    topology.vfs_path(f"{sess_rel}/{name}"),
+                    expect_found=False,
+                )
+
+            # Step 6: rmdir session — sys_rmdir.
+            os.rmdir(sess_mount)
+            _wait_path_via_grpc(topology, topology.vfs_path(sess_rel), expect_found=False)
+        finally:
+            _sh(["rm", "-rf", sess_mount], check=False, timeout=10)
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Workflow 2 — Mid-session rename.
+#
+#    mkdir sess               → sys_mkdir
+#    write task               → sys_write
+#    cross-check size kernel  → vfs_stat
+#    rename task              → sys_rename
+#    verify old absent        → vfs_stat (expect_found=False)
+#    verify new present       → vfs_stat (expect_found=True)
+#    read new byte-exact      → vfs_read
+# ─────────────────────────────────────────────────────────────────────
+
+
+class TestMidSessionRename:
+    def test_rename_preserves_content_and_remaps_inode(
+        self, topology: Topology, session_name: str
+    ) -> None:
+        sess_rel = f".claude/tasks/{session_name}"
+        sess_mount = topology.mount_path(sess_rel)
+        old_rel = f"{sess_rel}/draft.json"
+        new_rel = f"{sess_rel}/in-progress.json"
+        payload = '{"title":"draft to in-progress","content":"WIP"}'
+
+        try:
+            # Step 1+2: create sess + initial task.
+            os.makedirs(sess_mount, exist_ok=True)
+            _write_file(topology.mount_path(old_rel), payload)
+
+            # Step 3: kernel-side check.
+            stat = _wait_path_via_grpc(topology, topology.vfs_path(old_rel), expect_found=True)
+            old_size = stat["result"]["size"]
+            assert old_size > 0, "precondition: draft.json must have bytes before rename"
+
+            # Step 4: rename through the mount — sys_rename.
+            os.rename(
+                topology.mount_path(old_rel),
+                topology.mount_path(new_rel),
+            )
+
+            # Step 5+6: cross-check both sides of the rename.
+            _wait_path_via_grpc(topology, topology.vfs_path(old_rel), expect_found=False)
+            new_stat = _wait_path_via_grpc(topology, topology.vfs_path(new_rel), expect_found=True)
+            assert new_stat["result"]["size"] == old_size, (
+                f"rename moved metadata but lost bytes\n"
+                f"  old size: {old_size}\n"
+                f"  new size: {new_stat['result']['size']}"
+            )
+
+            # Step 7: byte-exact read of the new path through gRPC.
+            read = _vfs_read(topology.cluster_grpc, topology.vfs_path(new_rel))
+            assert "error" not in read, f"vfs_read after rename failed: {read}"
+            body = _decode_content(read).decode("utf-8", errors="replace")
+            assert payload in body, (
+                f"rename preserved metadata but bytes diverged\n"
+                f"  expected substring: {payload!r}\n"
+                f"  actual body:        {body!r}"
+            )
+        finally:
+            _sh(["rm", "-rf", sess_mount], check=False, timeout=10)
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Workflow 3 — Cross-layer write integrity.
+# ─────────────────────────────────────────────────────────────────────
+
+
+class TestCrossLayerWriteIntegrity:
+    def test_mount_write_visible_through_grpc(self, topology: Topology, session_name: str) -> None:
+        sess_rel = f".claude/tasks/{session_name}"
+        sess_mount = topology.mount_path(sess_rel)
+        file_rel = f"{sess_rel}/cross-layer.json"
+        payload = '{"verification":"mount→kernel→read should round-trip byte-exact"}'
+
+        try:
+            # Step 1: setup parent.
+            os.makedirs(sess_mount, exist_ok=True)
+
+            # Step 2: write through the NFS mount.
+            _write_file(topology.mount_path(file_rel), payload)
+
+            # Step 3: kernel-side stat check.
+            stat = _wait_path_via_grpc(topology, topology.vfs_path(file_rel), expect_found=True)
+            assert stat["result"]["size"] > 0, (
+                f"plugin reported sys_write success but kernel sees size=0\n  vfs_stat: {stat}"
+            )
+
+            # Step 4: kernel-side byte-exact read — the SSOT.
+            read = _vfs_read(topology.cluster_grpc, topology.vfs_path(file_rel))
+            assert "error" not in read, f"vfs_read failed: {read}"
+            body = _decode_content(read).decode("utf-8", errors="replace")
+            assert payload in body, (
+                f"vfs_read body did not contain mount-side payload\n"
+                f"  expected substring: {payload!r}\n"
+                f"  actual body:        {body!r}"
+            )
+        finally:
+            _sh(["rm", "-rf", sess_mount], check=False, timeout=10)
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Workflow 4 — NFS-specific: cat through shell (not Python open).
+#
+# NFS has its own attribute caching layer that differs from FUSE-T's
+# kernel_cache.  A bug where the NFS server returns stale fattr3 or
+# wrong file size would make `cat` return truncated/wrong data while
+# Python's open() (which went through NFS LOOKUP + READ in a different
+# call sequence) might still work.  This workflow exercises the exact
+# shell pipeline an operator uses.
+# ─────────────────────────────────────────────────────────────────────
+
+
+class TestShellRoundTrip:
+    def test_cat_returns_written_content(self, topology: Topology, session_name: str) -> None:
+        sess_rel = f".claude/tasks/{session_name}"
+        sess_mount = topology.mount_path(sess_rel)
+        file_rel = f"{sess_rel}/shell-test.json"
+        payload = '{"shell":"cat should return this exact string"}'
+
+        try:
+            os.makedirs(sess_mount, exist_ok=True)
+            _write_file(topology.mount_path(file_rel), payload)
+
+            # Read back via shell `cat` — the real operator path.
+            result = _sh(["cat", topology.mount_path(file_rel)])
+            assert payload in result.stdout, (
+                f"cat output did not contain expected payload\n"
+                f"  expected substring: {payload!r}\n"
+                f"  actual stdout:      {result.stdout!r}"
+            )
+
+            # Also verify ls sees the file in the directory listing.
+            ls_result = _sh(["ls", sess_mount])
+            assert "shell-test.json" in ls_result.stdout, (
+                f"ls did not list shell-test.json\n  ls output: {ls_result.stdout!r}"
+            )
+        finally:
+            _sh(["rm", "-rf", sess_mount], check=False, timeout=10)


### PR DESCRIPTION
## Summary

- Replace broken FUSE-T dependency on macOS 26 Tahoe with in-process NFSv3 localhost server (`nfsserve` crate, MIT, HuggingFace-proven)
- On macOS, when `fuser::spawn_mount2` fails, plugin falls back to NFS: binds on `127.0.0.1:0`, mounts via native `mount_nfs` — zero third-party runtime
- Same `KernelHandle` + `PathIndex` as fuser path — all 15 NFS methods delegate to identical C ABI callbacks

## Files changed

| File | What |
|---|---|
| `rust/services/fuse-plugin/src/fs_nfs.rs` | **New** — `NFSFileSystem` impl, `NfsMountHandle` lifecycle, `spawn_nfs_mount()` |
| `rust/services/fuse-plugin/src/lib.rs` | NFS fallback on fuser failure, `nfs_handle` field, `mounted-nfs` status |
| `rust/services/fuse-plugin/Cargo.toml` | macOS deps: `nfsserve 0.11`, `async-trait`, `tokio` |
| `rust/services/fuse-plugin/tests/nfs_integration.rs` | 15 Rust integration tests with mock KernelHandle (parallel-safe) |
| `tests/e2e/macos/test_fuse_plugin_nfs_e2e.py` | pytest E2E: 4 workflow classes mirroring Windows WinFsp E2E pattern |
| `.github/workflows/fuse-plugin-macos-nfs-e2e.yml` | CI workflow on `macos-latest` with gRPC cross-check |

## Test plan

- [x] `cargo build -p nexus-fuse-plugin` — compiles with nfsserve on macOS
- [x] `cargo test -p nexus-fuse-plugin` — 37 tests pass (22 existing + 15 new NFS integration)
- [ ] CI: `fuse-plugin-macos-nfs-e2e` workflow runs on macos-latest runner
- [ ] Manual: start nexusd-cluster → fuser fails → NFS fallback mounts → `ls`/`cat`/write through mount

🤖 Generated with [Claude Code](https://claude.com/claude-code)