### PR TITLE
chore(deps) + test: bump nexus-vfs to PR #99 (cross-peer fetch fix) + restore cc-tasks-share E2E step 4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=511001614b2c4c0218035a7573f57c0f84d4ce02#511001614b2c4c0218035a7573f57c0f84d4ce02"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=ce1b1c88f8a0b353163ecc5f78ed19e299086cb6#ce1b1c88f8a0b353163ecc5f78ed19e299086cb6"
 dependencies = [
  "ahash",
  "base64",
@@ -550,7 +550,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=511001614b2c4c0218035a7573f57c0f84d4ce02#511001614b2c4c0218035a7573f57c0f84d4ce02"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=ce1b1c88f8a0b353163ecc5f78ed19e299086cb6#ce1b1c88f8a0b353163ecc5f78ed19e299086cb6"
 dependencies = [
  "parking_lot",
  "serde",
@@ -1343,7 +1343,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=511001614b2c4c0218035a7573f57c0f84d4ce02#511001614b2c4c0218035a7573f57c0f84d4ce02"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=ce1b1c88f8a0b353163ecc5f78ed19e299086cb6#ce1b1c88f8a0b353163ecc5f78ed19e299086cb6"
 dependencies = [
  "ahash",
  "base64",
@@ -1394,7 +1394,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=511001614b2c4c0218035a7573f57c0f84d4ce02#511001614b2c4c0218035a7573f57c0f84d4ce02"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=ce1b1c88f8a0b353163ecc5f78ed19e299086cb6#ce1b1c88f8a0b353163ecc5f78ed19e299086cb6"
 dependencies = [
  "ahash",
  "base64",
@@ -1589,7 +1589,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=511001614b2c4c0218035a7573f57c0f84d4ce02#511001614b2c4c0218035a7573f57c0f84d4ce02"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=ce1b1c88f8a0b353163ecc5f78ed19e299086cb6#ce1b1c88f8a0b353163ecc5f78ed19e299086cb6"
 
 [[package]]
 name = "nexus-vault"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=f85886b1876605e9940843fea97e55ef056ce54b#f85886b1876605e9940843fea97e55ef056ce54b"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=511001614b2c4c0218035a7573f57c0f84d4ce02#511001614b2c4c0218035a7573f57c0f84d4ce02"
 dependencies = [
  "ahash",
  "base64",
@@ -550,7 +550,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=f85886b1876605e9940843fea97e55ef056ce54b#f85886b1876605e9940843fea97e55ef056ce54b"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=511001614b2c4c0218035a7573f57c0f84d4ce02#511001614b2c4c0218035a7573f57c0f84d4ce02"
 dependencies = [
  "parking_lot",
  "serde",
@@ -1343,7 +1343,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=f85886b1876605e9940843fea97e55ef056ce54b#f85886b1876605e9940843fea97e55ef056ce54b"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=511001614b2c4c0218035a7573f57c0f84d4ce02#511001614b2c4c0218035a7573f57c0f84d4ce02"
 dependencies = [
  "ahash",
  "base64",
@@ -1394,7 +1394,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=f85886b1876605e9940843fea97e55ef056ce54b#f85886b1876605e9940843fea97e55ef056ce54b"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=511001614b2c4c0218035a7573f57c0f84d4ce02#511001614b2c4c0218035a7573f57c0f84d4ce02"
 dependencies = [
  "ahash",
  "base64",
@@ -1589,7 +1589,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=f85886b1876605e9940843fea97e55ef056ce54b#f85886b1876605e9940843fea97e55ef056ce54b"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=511001614b2c4c0218035a7573f57c0f84d4ce02#511001614b2c4c0218035a7573f57c0f84d4ce02"
 
 [[package]]
 name = "nexus-vault"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,13 +72,13 @@ exclude = ["nexus-fuse"]
 #
 # Bump alongside the rest of nexus-vfs updates when a downstream
 # change needs newer kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "511001614b2c4c0218035a7573f57c0f84d4ce02" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "511001614b2c4c0218035a7573f57c0f84d4ce02" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "511001614b2c4c0218035a7573f57c0f84d4ce02" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "511001614b2c4c0218035a7573f57c0f84d4ce02", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "511001614b2c4c0218035a7573f57c0f84d4ce02", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "511001614b2c4c0218035a7573f57c0f84d4ce02", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "511001614b2c4c0218035a7573f57c0f84d4ce02" }
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ce1b1c88f8a0b353163ecc5f78ed19e299086cb6" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ce1b1c88f8a0b353163ecc5f78ed19e299086cb6" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ce1b1c88f8a0b353163ecc5f78ed19e299086cb6" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ce1b1c88f8a0b353163ecc5f78ed19e299086cb6", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ce1b1c88f8a0b353163ecc5f78ed19e299086cb6", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ce1b1c88f8a0b353163ecc5f78ed19e299086cb6", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ce1b1c88f8a0b353163ecc5f78ed19e299086cb6" }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,13 +72,13 @@ exclude = ["nexus-fuse"]
 #
 # Bump alongside the rest of nexus-vfs updates when a downstream
 # change needs newer kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "f85886b1876605e9940843fea97e55ef056ce54b" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "f85886b1876605e9940843fea97e55ef056ce54b" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "f85886b1876605e9940843fea97e55ef056ce54b" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "f85886b1876605e9940843fea97e55ef056ce54b", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "f85886b1876605e9940843fea97e55ef056ce54b", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "f85886b1876605e9940843fea97e55ef056ce54b", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "f85886b1876605e9940843fea97e55ef056ce54b" }
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "511001614b2c4c0218035a7573f57c0f84d4ce02" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "511001614b2c4c0218035a7573f57c0f84d4ce02" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "511001614b2c4c0218035a7573f57c0f84d4ce02" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "511001614b2c4c0218035a7573f57c0f84d4ce02", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "511001614b2c4c0218035a7573f57c0f84d4ce02", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "511001614b2c4c0218035a7573f57c0f84d4ce02", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "511001614b2c4c0218035a7573f57c0f84d4ce02" }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ENV CARGO_NET_RETRY=10 \
     CARGO_HTTP_TIMEOUT=120
 # Override for edge/CI or a different pin: --build-arg NEXUS_VFS_REV=<sha|tag>
-ARG NEXUS_VFS_REV=f85886b1876605e9940843fea97e55ef056ce54b
+ARG NEXUS_VFS_REV=511001614b2c4c0218035a7573f57c0f84d4ce02
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,id=cargo-install-${TARGETARCH},target=/root/.cargo/target \

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ENV CARGO_NET_RETRY=10 \
     CARGO_HTTP_TIMEOUT=120
 # Override for edge/CI or a different pin: --build-arg NEXUS_VFS_REV=<sha|tag>
-ARG NEXUS_VFS_REV=511001614b2c4c0218035a7573f57c0f84d4ce02
+ARG NEXUS_VFS_REV=ce1b1c88f8a0b353163ecc5f78ed19e299086cb6
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,id=cargo-install-${TARGETARCH},target=/root/.cargo/target \

--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir --no-deps --prefix=/install .
 # enforces agreement) — an unpinned install tracks nexus-vfs HEAD and
 # ships an untested kernel (#4343). --locked honors the source tree's
 # Cargo.lock.
-ARG NEXUS_VFS_REV=511001614b2c4c0218035a7573f57c0f84d4ce02
+ARG NEXUS_VFS_REV=ce1b1c88f8a0b353163ecc5f78ed19e299086cb6
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-cluster nexus-cluster
 
 # -- Runtime stage --

--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir --no-deps --prefix=/install .
 # enforces agreement) — an unpinned install tracks nexus-vfs HEAD and
 # ships an untested kernel (#4343). --locked honors the source tree's
 # Cargo.lock.
-ARG NEXUS_VFS_REV=f85886b1876605e9940843fea97e55ef056ce54b
+ARG NEXUS_VFS_REV=511001614b2c4c0218035a7573f57c0f84d4ce02
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-cluster nexus-cluster
 
 # -- Runtime stage --

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -25,7 +25,7 @@ WORKDIR /build
 # (CI preflight enforces agreement) — an unpinned install tracks HEAD
 # and can skew the raft contract against the cluster/witness images.
 # --locked honors the source tree's Cargo.lock.
-ARG NEXUS_VFS_REV=511001614b2c4c0218035a7573f57c0f84d4ce02
+ARG NEXUS_VFS_REV=ce1b1c88f8a0b353163ecc5f78ed19e299086cb6
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexus-raft-server raft
 
 # ---------- Production image ----------

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -25,7 +25,7 @@ WORKDIR /build
 # (CI preflight enforces agreement) — an unpinned install tracks HEAD
 # and can skew the raft contract against the cluster/witness images.
 # --locked honors the source tree's Cargo.lock.
-ARG NEXUS_VFS_REV=f85886b1876605e9940843fea97e55ef056ce54b
+ARG NEXUS_VFS_REV=511001614b2c4c0218035a7573f57c0f84d4ce02
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexus-raft-server raft
 
 # ---------- Production image ----------

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=511001614b2c4c0218035a7573f57c0f84d4ce02
+ARG NEXUS_VFS_REV=ce1b1c88f8a0b353163ecc5f78ed19e299086cb6
 RUN cargo install \
     --locked \
     --git https://github.com/nexi-lab/nexus-vfs \

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=f85886b1876605e9940843fea97e55ef056ce54b
+ARG NEXUS_VFS_REV=511001614b2c4c0218035a7573f57c0f84d4ce02
 RUN cargo install \
     --locked \
     --git https://github.com/nexi-lab/nexus-vfs \

--- a/tests/e2e/docker/test_cc_tasks_share_e2e.py
+++ b/tests/e2e/docker/test_cc_tasks_share_e2e.py
@@ -1589,25 +1589,44 @@ class TestCcTasksListBackendOnlyCrossNodeEnumeration:
                 "stay on the joiner's federation_cache."
             )
 
-            # Step 4 (cross-peer readback) — deferred to a follow-up
-            # PR.  The end-state operator expectation is that
-            # `founder cat <joiner-written file>` returns the bytes
-            # via try_remote_fetch's last-writer-aware peer_read
-            # dispatch.  Local repro of step 4 surfaces a
-            # FUSE-lookup miss on founder even though the metastore
-            # entry must exist (joiner's own read passes through
-            # the same ZoneMetaStore raft replica) — likely a
-            # founder-side sys_stat code path that short-circuits to
-            # the LOCAL backend's physical existence check before
-            # consulting the metastore, OR a raft-apply timing
-            # window on founder that exceeds the 30s budget for the
-            # cross-mount put.
-            #
-            # Splitting the diagnosis from the contract switch keeps
-            # the PR scope tight: the contract IS correct (writer
-            # side proven by steps 1-3 + the joiner readback),
-            # cross-peer fetch is a separable concern that the next
-            # PR will close with a dedicated diagnostic harness.
+            # Step 4: founder FUSE cat returns joiner's bytes byte-
+            # exact via the last-writer-aware cross-peer fetch chain.
+            # Founder's sys_read finds the raft-replicated metastore
+            # entry with `last_writer = joiner`, misses its
+            # LocalConnector backend (joiner wrote to its own
+            # federation_cache, not founder's host fs), then
+            # `try_remote_fetch` dispatches `peer_read` to joiner.
+            # On joiner, `KernelBlobFetcher::read` (the ReadBlob
+            # handler) consults the kernel-global federation cache
+            # for placeholder-mount paths (nexus-vfs#99 SSOT-symmetric
+            # fix) and serves bytes back.  founder caches the bytes
+            # locally and returns them to the FUSE plugin → cat.
+            # Bounded wait tolerates raft-apply latency for the
+            # cross-mount put on founder.
+            deadline = time.monotonic() + 30
+            founder_bytes = b""
+            last_stderr = ""
+            while time.monotonic() < deadline:
+                proc = subprocess.run(
+                    ["docker", "exec", topology.founder_container, "cat", file_mount],
+                    capture_output=True,
+                    timeout=30,
+                )
+                if proc.returncode == 0:
+                    founder_bytes = proc.stdout
+                    if founder_bytes == payload:
+                        break
+                else:
+                    last_stderr = proc.stderr.decode(errors="replace").strip()
+                time.sleep(0.5)
+            assert founder_bytes == payload, (
+                f"founder FUSE cat got {founder_bytes!r}, expected "
+                f"{payload!r} (last_cat_stderr={last_stderr!r}). "
+                "Cross-peer fetch broken — nexus-vfs#99's "
+                "KernelBlobFetcher::read federation_cache substitution "
+                "regressed, OR try_remote_fetch's peer_read RPC fails "
+                "to reach the writer."
+            )
         finally:
             runbook_helpers.docker_exec(
                 topology.founder_container,


### PR DESCRIPTION
## Summary

Companion to nexus-vfs PR #99 which SSOT-couples the placeholder mount
entry with its parent federation gateway's metastore Arc.

- Pin bump: ``f85886b1`` → ``03599be8e``
- Restores ``test_joiner_fuse_write_lands_locally_and_founder_reads_via_peer_fetch``
  step 4 to its real assertion form: founder FUSE cat returns the
  joiner-written bytes byte-exact via try_remote_fetch's last-writer
  peer_read dispatch.

This pin catches any future regression of the SSOT-coupling between
placeholder MountEntry and its inherited ZoneMetaStore Arc — without
the coupling, joiner's metastore.put silently falls back to node-local
LocalMetaStore and the cross-peer round-trip silently breaks (the
exact failure mode nexus-vfs#99 fixes).

## Test plan

- [ ] cc-tasks-share E2E (Docker) — all 12 tests green, including the
  restored step 4 cross-peer readback assertion
- [ ] Federation E2E (Docker)
- [ ] Self-Contained E2E (the suite that caught PR #92 regression)
- [ ] nexusd-cluster Smoke Test
- [ ] All other standard nexus checks