### PR TITLE
fix(ci): auto-plugin-release — set github-actions[bot] git identity

### DIFF
--- a/.github/workflows/auto-plugin-release.yml
+++ b/.github/workflows/auto-plugin-release.yml
@@ -65,6 +65,15 @@ jobs:
         run: |
           set -euo pipefail
 
+          # Annotated tags (`git tag -a`) are commit-shaped objects that
+          # embed a tagger identity, so git refuses to create them
+          # without user.email + user.name set. `actions/checkout@v4`
+          # wires the push credential but not the identity — configure
+          # the standard github-actions[bot] identity here so this step
+          # doesn't exit 128 on the first `git tag -a` call.
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
           next_patch() {
             local prefix="$1"
             local latest


### PR DESCRIPTION
## Summary

\`Cut plugin release tags\` step of \`.github/workflows/auto-plugin-release.yml\` exited 128 on the first \`git tag -a\` call with *"Committer identity unknown"* when develop rev-bumped to nexus-vfs@\`196437ca8\` ([commit 51c367929, PR #4462](https://github.com/nexi-lab/nexus/commit/51c367929)):

```
Committer identity unknown
*** Please tell me who you are.
```

## Root cause

Annotated tags (\`git tag -a\`) are commit-shaped objects that embed a tagger identity, so git refuses to create them without \`user.email\` + \`user.name\` set. The workflow's \`actions/checkout@v4\` wires up the push credential helper but does NOT set the identity, and this workflow never ran \`git config\`.

## Fix

Set the standard \`github-actions[bot]\` identity at the top of the step before the first tag call. Same pattern used by every other auto-tag workflow (release-please, semantic-release, etc.).

## Impact of the regression

The auto-cut for \`vault-v0.5.1\` / \`fuse-v0.6.1\` / \`local-connector-v0.4.1\` didn't fire against \`196437ca8\`, so plugin releases for that nexus-vfs rev are still pinned at the previous set.

**Follow-up (post-merge):** either manually cut those three tags against develop HEAD (\`196437ca8\` is stable, no reason to hold back the plugin bumps), or let the next rev bump carry them forward (patch number skips a slot but no functional gap).

## Test plan

- [x] YAML validates
- [ ] CI green on PR
- [ ] Confirm next rev-bump merge to develop actually cuts tags (or manually verify by re-running this workflow via workflow_dispatch after adding one, once we decide on the follow-up path)