### PR TITLE
feat(deps+e2e): bump nexus-vfs to ee7e645d4 (PR #102) + pin sys_readdir observation E2E

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=ee7e645d44d63ce110b16f3665848a318c489cd5#ee7e645d44d63ce110b16f3665848a318c489cd5"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=c042117abdd61f8b5a5d50cc58fb2b63928dcf9d#c042117abdd61f8b5a5d50cc58fb2b63928dcf9d"
 dependencies = [
  "ahash",
  "base64",
@@ -550,7 +550,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=ee7e645d44d63ce110b16f3665848a318c489cd5#ee7e645d44d63ce110b16f3665848a318c489cd5"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=c042117abdd61f8b5a5d50cc58fb2b63928dcf9d#c042117abdd61f8b5a5d50cc58fb2b63928dcf9d"
 dependencies = [
  "parking_lot",
  "serde",
@@ -1334,7 +1334,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=ee7e645d44d63ce110b16f3665848a318c489cd5#ee7e645d44d63ce110b16f3665848a318c489cd5"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=c042117abdd61f8b5a5d50cc58fb2b63928dcf9d#c042117abdd61f8b5a5d50cc58fb2b63928dcf9d"
 dependencies = [
  "ahash",
  "base64",
@@ -1385,7 +1385,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=ee7e645d44d63ce110b16f3665848a318c489cd5#ee7e645d44d63ce110b16f3665848a318c489cd5"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=c042117abdd61f8b5a5d50cc58fb2b63928dcf9d#c042117abdd61f8b5a5d50cc58fb2b63928dcf9d"
 dependencies = [
  "ahash",
  "base64",
@@ -1580,7 +1580,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=ee7e645d44d63ce110b16f3665848a318c489cd5#ee7e645d44d63ce110b16f3665848a318c489cd5"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=c042117abdd61f8b5a5d50cc58fb2b63928dcf9d#c042117abdd61f8b5a5d50cc58fb2b63928dcf9d"
 
 [[package]]
 name = "nexus-vault"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=196437ca8ab5cbfea12dc660a797dbcccabaa506#196437ca8ab5cbfea12dc660a797dbcccabaa506"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=ee7e645d44d63ce110b16f3665848a318c489cd5#ee7e645d44d63ce110b16f3665848a318c489cd5"
 dependencies = [
  "ahash",
  "base64",
@@ -550,7 +550,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=196437ca8ab5cbfea12dc660a797dbcccabaa506#196437ca8ab5cbfea12dc660a797dbcccabaa506"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=ee7e645d44d63ce110b16f3665848a318c489cd5#ee7e645d44d63ce110b16f3665848a318c489cd5"
 dependencies = [
  "parking_lot",
  "serde",
@@ -1334,7 +1334,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=196437ca8ab5cbfea12dc660a797dbcccabaa506#196437ca8ab5cbfea12dc660a797dbcccabaa506"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=ee7e645d44d63ce110b16f3665848a318c489cd5#ee7e645d44d63ce110b16f3665848a318c489cd5"
 dependencies = [
  "ahash",
  "base64",
@@ -1385,7 +1385,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=196437ca8ab5cbfea12dc660a797dbcccabaa506#196437ca8ab5cbfea12dc660a797dbcccabaa506"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=ee7e645d44d63ce110b16f3665848a318c489cd5#ee7e645d44d63ce110b16f3665848a318c489cd5"
 dependencies = [
  "ahash",
  "base64",
@@ -1580,7 +1580,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=196437ca8ab5cbfea12dc660a797dbcccabaa506#196437ca8ab5cbfea12dc660a797dbcccabaa506"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=ee7e645d44d63ce110b16f3665848a318c489cd5#ee7e645d44d63ce110b16f3665848a318c489cd5"
 
 [[package]]
 name = "nexus-vault"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,26 +30,44 @@ exclude = ["nexus-fuse"]
 [workspace.dependencies]
 # Kernel-tier crates from nexus-vfs (external git dependency).
 # SSOT: https://github.com/nexi-lab/nexus-vfs
-# Pinned at the nexus-vfs commit that landed PR #102
-# (ee7e645d4, 2026-07-01): sys_readdir SSOT-symmetric observation.
-# Cumulative stack: PR #98 (uniform local-first sys_write), PR #99
-# (KernelBlobFetcher federation cache SSOT-symmetric fix), PR #100
-# (runtime trust dir + SSOT allowlist), PR #101 (--advertise-addr
-# decoupled from --hostname + nexusd-cluster join auto-bootstraps
-# parent zone), PR #102 (sys_readdir observes backend-only entries
-# into metastore).
+# Pinned at the nexus-vfs commit that landed PR #103
+# (c042117ab, 2026-07-01): DT_DIR-only restriction on sys_readdir
+# observation.  Cumulative stack: PR #98 (uniform local-first
+# sys_write), PR #99 (KernelBlobFetcher federation cache
+# SSOT-symmetric fix), PR #100 (runtime trust dir + SSOT allowlist),
+# PR #101 (--advertise-addr decoupled from --hostname +
+# nexusd-cluster join auto-bootstraps parent zone), PR #102
+# (sys_readdir observes DT_DIR backend entries), PR #103 (restrict
+# observation to DT_DIR — fix for PR #102 shipping a DT_REG
+# regression that broke sys_read byte-exact via stub metastore
+# rows).
 #
-# PR #102 closes the Phase γ-A native cc-tasks-list UX gap: Claude
-# Code writes ~/.claude/tasks/<uuid>/1.json directly to host fs
-# (bypassing sys_write), so metastore had no row and peer daemons
-# couldn't enumerate the entry.  sys_readdir now proposes a metadata
-# row with last_writer_address=self for every backend entry the
-# metastore doesn't already know about; raft replicates the row and
-# a peer's metastore.list step returns the entry naturally — no new
-# mount type, no schema change, no scatter RPC.  Enables the
-# peer-shared mount topology (both peers `--mount-driver` at the
-# SAME VFS path, e.g. /shared/cc-tasks) which makes CC's native
-# `cc tasks list` show a flat merged UUID list from both peers.
+# PR #102 + #103 close the Phase γ-A native cc-tasks-list UX gap:
+# Claude Code writes ~/.claude/tasks/<uuid>/1.json directly to host
+# fs (bypassing sys_write), so metastore had no row for the
+# <uuid>/ subdir and peer daemons couldn't enumerate the session
+# via `cc tasks list`.  sys_readdir now proposes a metadata row
+# with last_writer_address=self for every DT_DIR backend entry the
+# metastore doesn't already know about; raft replicates the row
+# and a peer's metastore.list step returns the subdir naturally —
+# no new mount type, no schema change, no scatter RPC.  Enables
+# the peer-shared mount topology (both peers `--mount-driver` at
+# the SAME VFS path, e.g. /shared/cc-tasks) which makes CC's
+# native `cc tasks list` show a flat merged UUID list from both
+# peers.
+#
+# DT_REG entries stay backend-only and route via existing
+# federation-dispatch fetch on read (PR #98/#99 pathway).  Rationale
+# for the split (per PR #103):
+# * DT_DIR observation — the row can carry `size = 0, content_id =
+#   None` because directories have no byte content; enables
+#   cross-peer flat directory enumeration.
+# * DT_REG observation was in PR #102's initial ship but broke
+#   cross-peer byte reads: the stub row (size = 0, no content_id)
+#   was authoritative for the read path and returned empty bytes
+#   instead of federation-dispatching to the writer's backend.
+#   PR #103 restricts observation to DT_DIR only, restoring the
+#   correct division of labour.
 #
 # PR #101 (preserved) closes two cross-machine federation contract
 # gaps that wedged the Mac↔Win cc-tasks-share L1 smoke:
@@ -103,13 +121,13 @@ exclude = ["nexus-fuse"]
 #
 # Bump alongside the rest of nexus-vfs updates when a downstream
 # change needs newer kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ee7e645d44d63ce110b16f3665848a318c489cd5" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ee7e645d44d63ce110b16f3665848a318c489cd5" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ee7e645d44d63ce110b16f3665848a318c489cd5" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ee7e645d44d63ce110b16f3665848a318c489cd5", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ee7e645d44d63ce110b16f3665848a318c489cd5", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ee7e645d44d63ce110b16f3665848a318c489cd5", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ee7e645d44d63ce110b16f3665848a318c489cd5" }
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "c042117abdd61f8b5a5d50cc58fb2b63928dcf9d" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "c042117abdd61f8b5a5d50cc58fb2b63928dcf9d" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "c042117abdd61f8b5a5d50cc58fb2b63928dcf9d" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "c042117abdd61f8b5a5d50cc58fb2b63928dcf9d", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "c042117abdd61f8b5a5d50cc58fb2b63928dcf9d", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "c042117abdd61f8b5a5d50cc58fb2b63928dcf9d", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "c042117abdd61f8b5a5d50cc58fb2b63928dcf9d" }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,16 +30,29 @@ exclude = ["nexus-fuse"]
 [workspace.dependencies]
 # Kernel-tier crates from nexus-vfs (external git dependency).
 # SSOT: https://github.com/nexi-lab/nexus-vfs
-# Pinned at the nexus-vfs commit that landed PR #101
-# (196437ca8, 2026-07-01): symmetric peer bootstrap.  Cumulative
-# stack: PR #98 (uniform local-first sys_write), PR #99
+# Pinned at the nexus-vfs commit that landed PR #102
+# (ee7e645d4, 2026-07-01): sys_readdir SSOT-symmetric observation.
+# Cumulative stack: PR #98 (uniform local-first sys_write), PR #99
 # (KernelBlobFetcher federation cache SSOT-symmetric fix), PR #100
 # (runtime trust dir + SSOT allowlist), PR #101 (--advertise-addr
 # decoupled from --hostname + nexusd-cluster join auto-bootstraps
-# parent zone).
+# parent zone), PR #102 (sys_readdir observes backend-only entries
+# into metastore).
 #
-# PR #101 closes two cross-machine federation contract gaps that
-# wedged the Mac↔Win cc-tasks-share L1 smoke:
+# PR #102 closes the Phase γ-A native cc-tasks-list UX gap: Claude
+# Code writes ~/.claude/tasks/<uuid>/1.json directly to host fs
+# (bypassing sys_write), so metastore had no row and peer daemons
+# couldn't enumerate the entry.  sys_readdir now proposes a metadata
+# row with last_writer_address=self for every backend entry the
+# metastore doesn't already know about; raft replicates the row and
+# a peer's metastore.list step returns the entry naturally — no new
+# mount type, no schema change, no scatter RPC.  Enables the
+# peer-shared mount topology (both peers `--mount-driver` at the
+# SAME VFS path, e.g. /shared/cc-tasks) which makes CC's native
+# `cc tasks list` show a flat merged UUID list from both peers.
+#
+# PR #101 (preserved) closes two cross-machine federation contract
+# gaps that wedged the Mac↔Win cc-tasks-share L1 smoke:
 # 1. --advertise-addr / NEXUS_ADVERTISE_ADDR — explicit network
 #    endpoint, decoupled from --hostname (display label).  Required
 #    for cross-machine federation over overlay networks (Tailscale,
@@ -90,13 +103,13 @@ exclude = ["nexus-fuse"]
 #
 # Bump alongside the rest of nexus-vfs updates when a downstream
 # change needs newer kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "196437ca8ab5cbfea12dc660a797dbcccabaa506" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "196437ca8ab5cbfea12dc660a797dbcccabaa506" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "196437ca8ab5cbfea12dc660a797dbcccabaa506" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "196437ca8ab5cbfea12dc660a797dbcccabaa506", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "196437ca8ab5cbfea12dc660a797dbcccabaa506", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "196437ca8ab5cbfea12dc660a797dbcccabaa506", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "196437ca8ab5cbfea12dc660a797dbcccabaa506" }
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ee7e645d44d63ce110b16f3665848a318c489cd5" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ee7e645d44d63ce110b16f3665848a318c489cd5" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ee7e645d44d63ce110b16f3665848a318c489cd5" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ee7e645d44d63ce110b16f3665848a318c489cd5", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ee7e645d44d63ce110b16f3665848a318c489cd5", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ee7e645d44d63ce110b16f3665848a318c489cd5", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ee7e645d44d63ce110b16f3665848a318c489cd5" }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ENV CARGO_NET_RETRY=10 \
     CARGO_HTTP_TIMEOUT=120
 # Override for edge/CI or a different pin: --build-arg NEXUS_VFS_REV=<sha|tag>
-ARG NEXUS_VFS_REV=196437ca8ab5cbfea12dc660a797dbcccabaa506
+ARG NEXUS_VFS_REV=ee7e645d44d63ce110b16f3665848a318c489cd5
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,id=cargo-install-${TARGETARCH},target=/root/.cargo/target \

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ENV CARGO_NET_RETRY=10 \
     CARGO_HTTP_TIMEOUT=120
 # Override for edge/CI or a different pin: --build-arg NEXUS_VFS_REV=<sha|tag>
-ARG NEXUS_VFS_REV=ee7e645d44d63ce110b16f3665848a318c489cd5
+ARG NEXUS_VFS_REV=c042117abdd61f8b5a5d50cc58fb2b63928dcf9d
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,id=cargo-install-${TARGETARCH},target=/root/.cargo/target \

--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir --no-deps --prefix=/install .
 # enforces agreement) — an unpinned install tracks nexus-vfs HEAD and
 # ships an untested kernel (#4343). --locked honors the source tree's
 # Cargo.lock.
-ARG NEXUS_VFS_REV=ee7e645d44d63ce110b16f3665848a318c489cd5
+ARG NEXUS_VFS_REV=c042117abdd61f8b5a5d50cc58fb2b63928dcf9d
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-cluster nexus-cluster
 
 # -- Runtime stage --

--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir --no-deps --prefix=/install .
 # enforces agreement) — an unpinned install tracks nexus-vfs HEAD and
 # ships an untested kernel (#4343). --locked honors the source tree's
 # Cargo.lock.
-ARG NEXUS_VFS_REV=196437ca8ab5cbfea12dc660a797dbcccabaa506
+ARG NEXUS_VFS_REV=ee7e645d44d63ce110b16f3665848a318c489cd5
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-cluster nexus-cluster
 
 # -- Runtime stage --

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -25,7 +25,7 @@ WORKDIR /build
 # (CI preflight enforces agreement) — an unpinned install tracks HEAD
 # and can skew the raft contract against the cluster/witness images.
 # --locked honors the source tree's Cargo.lock.
-ARG NEXUS_VFS_REV=196437ca8ab5cbfea12dc660a797dbcccabaa506
+ARG NEXUS_VFS_REV=ee7e645d44d63ce110b16f3665848a318c489cd5
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexus-raft-server raft
 
 # ---------- Production image ----------

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -25,7 +25,7 @@ WORKDIR /build
 # (CI preflight enforces agreement) — an unpinned install tracks HEAD
 # and can skew the raft contract against the cluster/witness images.
 # --locked honors the source tree's Cargo.lock.
-ARG NEXUS_VFS_REV=ee7e645d44d63ce110b16f3665848a318c489cd5
+ARG NEXUS_VFS_REV=c042117abdd61f8b5a5d50cc58fb2b63928dcf9d
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexus-raft-server raft
 
 # ---------- Production image ----------

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=ee7e645d44d63ce110b16f3665848a318c489cd5
+ARG NEXUS_VFS_REV=c042117abdd61f8b5a5d50cc58fb2b63928dcf9d
 RUN cargo install \
     --locked \
     --git https://github.com/nexi-lab/nexus-vfs \

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=196437ca8ab5cbfea12dc660a797dbcccabaa506
+ARG NEXUS_VFS_REV=ee7e645d44d63ce110b16f3665848a318c489cd5
 RUN cargo install \
     --locked \
     --git https://github.com/nexi-lab/nexus-vfs \

--- a/docs/architecture/federation-cross-machine-runbook.md
+++ b/docs/architecture/federation-cross-machine-runbook.md
@@ -333,6 +333,24 @@ After the restart, reads on B for any path under `/shared/cc-tasks/A/...` route 
 
 This is the substrate the `cc tasks list` cross-machine workflow rides — operator's CC daemon on A drops `~/.claude/tasks/<n>.json` directly to host fs (no Nexus syscall), and a second CC daemon on B reads them through `/shared/cc-tasks/A/<n>.json`.
 
+#### Peer-shared variant (recommended for native `cc tasks list` flat merged view — nexus-vfs PR #102)
+
+The topology above is *peer-namespaced*: each peer's LocalConnector mounts under `/shared/cc-tasks/<peer-name>/`, so `ls /shared/cc-tasks/` shows `A/` + `B/` subdirs — not a flat merged UUID list.  Operator can navigate but Claude Code's native `cc tasks list` (which walks `~/.claude/tasks/` expecting flat UUID sessions) sees only whichever half its session dir resolves to.
+
+Since PR #102 (`ee7e645d4`, sys_readdir SSOT-symmetric observation), a **peer-shared** topology is available: **both peers mount their LocalConnector at the SAME VFS path**, with no peer-name suffix.  Example:
+
+```bash
+# On A:
+--mount-driver 'local-connector:sharedzone:/shared/cc-tasks:{"local_root":"/home/me/.claude/tasks"}'
+
+# On B:
+--mount-driver 'local-connector:sharedzone:/shared/cc-tasks:{"local_root":"/home/me/.claude/tasks"}'
+```
+
+Each peer's `--mount-driver` installs its OWN LocalConnector at `/shared/cc-tasks/` locally (preserved via `vfs_router.has()` even when the raft-replicated DT_MOUNT's config differs — see `wire_mount_core` at `distributed_coordinator.rs:2337`).  Direct host-fs writes on either peer are observed into metastore during sys_readdir, and raft replicates the row (stamped with `last_writer_address = self`) so the OTHER peer sees the entry via `metastore.list` — no scatter RPC, no schema change.  The FUSE surface at `~/.claude/tasks/` (mounted over a renamed `tasks.local/` to avoid intra-node circular where LocalConnector's `local_root` = FUSE mount point) then presents a flat merged UUID list combining both peers' sessions.
+
+Trade-off relative to the peer-namespaced variant: writes on either peer land in the raft-replicated metastore under the same VFS path.  For CC's append-only session pattern (each session UUID is written once, per-machine) collisions are effectively impossible.  Workloads with the same VFS path being concurrently mutated by both peers should stick with the peer-namespaced variant, where the peer-name suffix serves as a natural conflict domain.
+
 ### Step 3g — Expose the federated VFS as a real OS mount via FUSE
 
 §3f gets the bytes across; `cc tasks list` (which is just `ls ~/.claude/tasks/`) needs the bytes to surface as **real files in the OS filesystem** so plain POSIX tools see them.  The `nexus-fuse-plugin` cdylib does exactly that — it spawns a fuser-backed FUSE event loop in the same process as the kernel and routes POSIX ops through the same `KernelHandle` callbacks the kernel exports to any other plugin.

--- a/tests/e2e/docker/test_cc_tasks_share_e2e.py
+++ b/tests/e2e/docker/test_cc_tasks_share_e2e.py
@@ -1631,3 +1631,170 @@ class TestCcTasksListBackendOnlyCrossNodeEnumeration:
                 ["rm", "-rf", f"/host/tasks/{session}"],
                 check=False,
             )
+
+
+# ---------------------------------------------------------------------------
+# nexus-vfs PR #102 regression pin — SSOT-symmetric sys_readdir observation.
+# ---------------------------------------------------------------------------
+#
+# Motivating scenario (Phase γ-A native cc-tasks-list UX):
+#
+#   Claude Code writes `~/.claude/tasks/<uuid>/1.json` directly to the
+#   operator's host filesystem, bypassing every Nexus syscall.  Before
+#   PR #102 the metastore had no row for that path — sys_readdir on the
+#   writing node's LocalConnector saw the entry via backend.list_dir
+#   but never proposed a metadata row to metastore, so peer daemons
+#   couldn't enumerate the entry through their own metastore.list step.
+#   Cross-peer readdir worked only via federation-dispatch on placeholder
+#   mounts (peer-namespaced topology).  Peer-shared mount topologies
+#   (both peers `--mount-driver` at the SAME VFS path) had no way for a
+#   peer's readdir to find entries written directly on another peer's
+#   host fs.
+#
+#   PR #102 adds `observe_backend_readdir_entry` mirroring the read-path
+#   `observe_backend_content` helper.  Every backend entry sys_readdir
+#   observes that metastore doesn't already know about gets a metadata
+#   row proposed with `last_writer_address = self`; raft replicates,
+#   and a peer's sys_readdir sees the entry via metastore.list alone.
+
+
+class TestSysReaddirObservation:
+    """Pin nexus-vfs PR #102's SSOT-symmetric readdir observation.
+
+    Regression-protects the Phase γ-A native `cc tasks list` UX
+    against future changes to `sys_readdir` that would strip the
+    `observe_backend_readdir_entry` call, or against changes to the
+    observation helper that would stop stamping
+    `last_writer_address`.  Both regressions would surface here as
+    the joiner's `vfs_stat` reporting an empty `lastWriterAddress`
+    for a path written directly to founder's host fs.
+    """
+
+    def test_founder_direct_hostfs_write_seeds_joiner_metastore_via_readdir_observation(
+        self,
+        topology: CcTasksTopology,
+        api_key: str,
+        joined_cluster: dict,
+    ) -> None:
+        # Reuses the existing joined_cluster fixture — no fresh joiner
+        # topology needed.  The observation flow is orthogonal to the
+        # cluster's bootstrap history.
+        _ = joined_cluster
+
+        # ── Step 1: Direct host-fs write on founder (bypasses sys_write) ─
+        #
+        # `host_task_write` shells into founder's container and writes
+        # bytes directly at `/host/tasks/<session>/1.json` — the
+        # operator's host fs — WITHOUT going through Nexus's sys_write.
+        # Metastore starts with no row for this path on either peer.
+        session = _new_session()
+        payload = b'{"id":"1","status":"pending","writer":"founder-host-fs-direct-obs"}'
+        cc_tasks_share_helpers.host_task_write(
+            topology.founder_container, f"/{session}/1.json", payload
+        )
+
+        try:
+            file_vfs = topology.founder_vfs_path(f"/{session}/1.json")
+            file_mount = topology.mount_path_for_vfs(file_vfs)
+            session_vfs = topology.founder_vfs_path(f"/{session}")
+            session_mount = topology.mount_path_for_vfs(session_vfs)
+
+            # ── Step 2: founder mount_listdir triggers sys_readdir ────
+            #
+            # `ls /mnt/cc-tasks/founder/<session>/` on founder's
+            # container fires FUSE → sys_readdir → backend.list_dir
+            # returns "1.json" → `observe_backend_readdir_entry`
+            # proposes a metastore row with `last_writer_address =
+            # founder`.  Raft replicates the row to joiner.  Before
+            # this step, the row does not exist on either peer.
+            founder_listing = cc_tasks_share_helpers.mount_listdir(
+                topology.founder_container, session_mount
+            )
+            assert "1.json" in founder_listing, (
+                f"founder mount_listdir did not see 1.json — sys_readdir "
+                f"backend.list_dir surface broken, own-side visibility fails "
+                f"before we can even test observation.  Got {founder_listing}."
+            )
+
+            # ── Step 3: wait for raft to replicate the observation ────
+            #
+            # `wait_nodes_caught_up` blocks until both peers agree on
+            # sharedzone's committed index — the strong signal that
+            # the observation-proposed row has landed on joiner's
+            # metastore and is queryable.  Same pattern the existing
+            # cross-node FUSE workflow test above uses to gate on
+            # metadata visibility.
+            runbook_helpers.wait_nodes_caught_up(
+                [topology.founder_grpc, topology.joiner_grpc],
+                "sharedzone",
+                api_key=api_key,
+                timeout=30,
+                probe_path=file_vfs,
+            )
+
+            # ── Step 4: joiner vfs_stat asserts observation replicated ─
+            #
+            # THIS IS THE REGRESSION PIN.  Without PR #102, joiner's
+            # metastore has no row for this path — vfs_stat either
+            # returns found=False (metastore miss with no backend
+            # stat fallback for peer-dispatched paths) or falls
+            # through to federation dispatch → founder's backend.stat
+            # → a response whose `lastWriterAddress` is empty because
+            # the backend layer has no self_address to stamp.
+            #
+            # With PR #102, joiner's metastore holds the raft-
+            # replicated observation row.  vfs_stat returns
+            # `found=True` and `lastWriterAddress` contains the
+            # founder container's hostname/IP — the strong signal
+            # that observation both fired on founder AND replicated
+            # to joiner.
+            joiner_stat = runbook_helpers.vfs_stat(
+                topology.joiner_grpc,
+                file_vfs,
+                zone_id="sharedzone",
+                api_key=api_key,
+                timeout=10,
+            )
+            stat_result = joiner_stat.get("result") or {}
+            assert stat_result.get("found"), (
+                f"joiner vfs_stat({file_vfs}) did not find the entry after "
+                f"founder observation should have replicated.  Either "
+                f"observe_backend_readdir_entry did not fire, or the "
+                f"metastore.put propose did not commit to sharedzone. "
+                f"joiner_stat={joiner_stat}"
+            )
+            last_writer = stat_result.get("lastWriterAddress") or ""
+            assert "founder" in last_writer, (
+                f"joiner's metastore row has lastWriterAddress={last_writer!r}; "
+                f"expected the founder container's address (contains "
+                f"'founder').  observe_backend_readdir_entry did not stamp "
+                f"self_address, OR the response bypassed metastore and hit "
+                f"backend.stat directly (which cannot stamp lastWriterAddress). "
+                f"stat={joiner_stat}"
+            )
+
+            # ── Step 5 (bonus): joiner FUSE cat via try_remote_fetch ──
+            #
+            # Not strictly the observation regression-pin (that lives in
+            # step 4's lastWriterAddress assertion).  Closes the loop by
+            # verifying the flat merged view CC would see: joiner FUSE
+            # read on the observed path returns byte-exact content via
+            # try_remote_fetch → founder BlobFetcher → founder's
+            # LocalConnector → founder's host fs.  A regression of PR
+            # #98/#99 (cross-peer fetch contract) would surface here.
+            joiner_bytes = cc_tasks_share_helpers.mount_read_bytes(
+                topology.joiner_container, file_mount
+            )
+            assert joiner_bytes == payload, (
+                f"joiner FUSE cross-node read got {joiner_bytes!r}, expected "
+                f"{payload!r}.  observation seeded the metastore row (step 4 "
+                f"passed) but the bytes round-trip broke — PR #98/#99 "
+                f"territory (try_remote_fetch + KernelBlobFetcher federation "
+                f"cache substitution)."
+            )
+        finally:
+            runbook_helpers.docker_exec(
+                topology.founder_container,
+                ["rm", "-rf", f"/host/tasks/{session}"],
+                check=False,
+            )

--- a/tests/e2e/docker/test_cc_tasks_share_e2e.py
+++ b/tests/e2e/docker/test_cc_tasks_share_e2e.py
@@ -1684,9 +1684,12 @@ class TestSysReaddirObservation:
         # ── Step 1: Direct host-fs write on founder (bypasses sys_write) ─
         #
         # `host_task_write` shells into founder's container and writes
-        # bytes directly at `/host/tasks/<session>/1.json` — the
-        # operator's host fs — WITHOUT going through Nexus's sys_write.
-        # Metastore starts with no row for this path on either peer.
+        # bytes at `/host/tasks/<session>/1.json` on founder's host fs
+        # — the operator's host fs — WITHOUT going through Nexus's
+        # sys_write.  Metastore starts with no row for the parent
+        # `<session>/` DT_DIR or the child `1.json` DT_REG on either
+        # peer.  This mirrors Claude Code's actual write pattern —
+        # session directories materialise when CC persists task state.
         session = _new_session()
         payload = b'{"id":"1","status":"pending","writer":"founder-host-fs-direct-obs"}'
         cc_tasks_share_helpers.host_task_write(
@@ -1697,68 +1700,81 @@ class TestSysReaddirObservation:
             file_vfs = topology.founder_vfs_path(f"/{session}/1.json")
             file_mount = topology.mount_path_for_vfs(file_vfs)
             session_vfs = topology.founder_vfs_path(f"/{session}")
-            session_mount = topology.mount_path_for_vfs(session_vfs)
 
-            # ── Step 2: founder mount_listdir triggers sys_readdir ────
+            # ── Step 2: founder mount_listdir triggers DT_DIR observation ─
             #
-            # `ls /mnt/cc-tasks/founder/<session>/` on founder's
-            # container fires FUSE → sys_readdir → backend.list_dir
-            # returns "1.json" → `observe_backend_readdir_entry`
-            # proposes a metastore row with `last_writer_address =
-            # founder`.  Raft replicates the row to joiner.  Before
-            # this step, the row does not exist on either peer.
+            # `ls /mnt/cc-tasks/founder/` on founder's container fires
+            # FUSE → sys_readdir → backend.list_dir returns "<session>/"
+            # (trailing slash indicates a DT_DIR entry) → the observation
+            # loop calls `observe_backend_readdir_entry` with entry_type
+            # = DT_DIR → metastore.put stamps a row with
+            # last_writer_address = founder.  Raft replicates the row
+            # to joiner.
+            #
+            # Only DT_DIR entries are observed by design (nexus-vfs PR
+            # #102 + #103 division of labour): directories carry no
+            # byte content so the size=0 placeholder is semantically
+            # correct, and cross-peer directory enumeration is what
+            # `cc tasks list` needs.  DT_REG entries stay backend-only
+            # and route via the existing federation-dispatch fetch on
+            # read — accurate size + content_id come from the writer's
+            # backend on demand.
+            tasks_root_mount = topology.mount_path_for_vfs(topology.founder_vfs_path(""))
             founder_listing = cc_tasks_share_helpers.mount_listdir(
-                topology.founder_container, session_mount
+                topology.founder_container, tasks_root_mount
             )
-            assert "1.json" in founder_listing, (
-                f"founder mount_listdir did not see 1.json — sys_readdir "
-                f"backend.list_dir surface broken, own-side visibility fails "
-                f"before we can even test observation.  Got {founder_listing}."
+            assert session in founder_listing, (
+                f"founder mount_listdir did not see the session dir "
+                f"{session!r} — sys_readdir backend.list_dir surface broken "
+                f"before we can test the observation contract.  Got "
+                f"{founder_listing}."
             )
 
-            # ── Step 3: wait for raft to replicate the observation ────
+            # ── Step 3: wait for raft to replicate the DT_DIR row ──
             #
             # `wait_nodes_caught_up` blocks until both peers agree on
-            # sharedzone's committed index — the strong signal that
-            # the observation-proposed row has landed on joiner's
-            # metastore and is queryable.  Same pattern the existing
-            # cross-node FUSE workflow test above uses to gate on
-            # metadata visibility.
+            # sharedzone's committed index — the strong signal that the
+            # observation-proposed row has landed on joiner's metastore
+            # and is queryable.  Same pattern the existing cross-node
+            # FUSE workflow test above uses to gate on metadata
+            # visibility.  Probe on the DT_DIR path (session_vfs); the
+            # child `1.json` DT_REG will not have a metastore row (by
+            # design — see step 5 below).
             runbook_helpers.wait_nodes_caught_up(
                 [topology.founder_grpc, topology.joiner_grpc],
                 "sharedzone",
                 api_key=api_key,
                 timeout=30,
-                probe_path=file_vfs,
+                probe_path=session_vfs,
             )
 
-            # ── Step 4: joiner vfs_stat asserts observation replicated ─
+            # ── Step 4: joiner vfs_stat on session DT_DIR — REGRESSION PIN ─
             #
-            # THIS IS THE REGRESSION PIN.  Without PR #102, joiner's
-            # metastore has no row for this path — vfs_stat either
-            # returns found=False (metastore miss with no backend
-            # stat fallback for peer-dispatched paths) or falls
-            # through to federation dispatch → founder's backend.stat
-            # → a response whose `lastWriterAddress` is empty because
-            # the backend layer has no self_address to stamp.
+            # Without PR #102, joiner's metastore has no DT_DIR row for
+            # the session subdir.  vfs_stat either returns found=False
+            # (metastore miss with no backend stat fallback for
+            # peer-dispatched paths) or falls through to federation
+            # dispatch → founder's backend.stat → a response whose
+            # `lastWriterAddress` is empty because the backend layer
+            # has no self_address to stamp.
             #
-            # With PR #102, joiner's metastore holds the raft-
-            # replicated observation row.  vfs_stat returns
-            # `found=True` and `lastWriterAddress` contains the
-            # founder container's hostname/IP — the strong signal
-            # that observation both fired on founder AND replicated
-            # to joiner.
+            # With PR #102 (+ PR #103 DT_DIR restriction), joiner's
+            # metastore holds the raft-replicated observation row.
+            # vfs_stat returns `found=True` and `lastWriterAddress`
+            # contains the founder container's hostname/IP — the strong
+            # signal that observation both fired on founder AND
+            # replicated to joiner.
             joiner_stat = runbook_helpers.vfs_stat(
                 topology.joiner_grpc,
-                file_vfs,
+                session_vfs,
                 zone_id="sharedzone",
                 api_key=api_key,
                 timeout=10,
             )
             stat_result = joiner_stat.get("result") or {}
             assert stat_result.get("found"), (
-                f"joiner vfs_stat({file_vfs}) did not find the entry after "
-                f"founder observation should have replicated.  Either "
+                f"joiner vfs_stat({session_vfs}) did not find the DT_DIR entry "
+                f"after founder observation should have replicated.  Either "
                 f"observe_backend_readdir_entry did not fire, or the "
                 f"metastore.put propose did not commit to sharedzone. "
                 f"joiner_stat={joiner_stat}"
@@ -1773,24 +1789,29 @@ class TestSysReaddirObservation:
                 f"stat={joiner_stat}"
             )
 
-            # ── Step 5 (bonus): joiner FUSE cat via try_remote_fetch ──
+            # ── Step 5 (bonus): joiner FUSE cat via federation dispatch ──
             #
-            # Not strictly the observation regression-pin (that lives in
-            # step 4's lastWriterAddress assertion).  Closes the loop by
-            # verifying the flat merged view CC would see: joiner FUSE
-            # read on the observed path returns byte-exact content via
-            # try_remote_fetch → founder BlobFetcher → founder's
-            # LocalConnector → founder's host fs.  A regression of PR
-            # #98/#99 (cross-peer fetch contract) would surface here.
+            # Not the observation regression-pin (step 4 is).  Verifies
+            # the DT_REG read path stays healthy AFTER the DT_DIR
+            # observation — files are NOT observed (per PR #103) so
+            # this read goes through the existing federation-dispatch
+            # fetch: joiner FUSE → sys_read → metastore miss for
+            # `1.json` → placeholder mount routes to sharedzone peer →
+            # founder's BlobFetcher → founder's LocalConnector →
+            # founder's host fs.  Byte-exact match confirms PR #98/#99
+            # remains uninjured and that DT_REG entries stay on the
+            # correct read path.
             joiner_bytes = cc_tasks_share_helpers.mount_read_bytes(
                 topology.joiner_container, file_mount
             )
             assert joiner_bytes == payload, (
                 f"joiner FUSE cross-node read got {joiner_bytes!r}, expected "
-                f"{payload!r}.  observation seeded the metastore row (step 4 "
-                f"passed) but the bytes round-trip broke — PR #98/#99 "
-                f"territory (try_remote_fetch + KernelBlobFetcher federation "
-                f"cache substitution)."
+                f"{payload!r}.  DT_DIR observation replicated correctly "
+                f"(step 4 passed) but the DT_REG bytes round-trip broke — "
+                f"either PR #98/#99 (try_remote_fetch + KernelBlobFetcher "
+                f"federation cache substitution) regressed, OR PR #103's "
+                f"DT_DIR restriction accidentally started observing DT_REG "
+                f"again (which mis-teaches sys_read with size=0)."
             )
         finally:
             runbook_helpers.docker_exec(


### PR DESCRIPTION
## Summary

Companion to nexus-vfs PR #102 (https://github.com/nexi-lab/nexus-vfs/pull/102). Bumps the kernel pin, adds a docker E2E regression-pin for the SSOT-symmetric \`sys_readdir\` observation, and updates the cross-machine runbook with the peer-shared mount variant enabled by that fix.

## What PR #102 does

Every backend entry \`sys_readdir\` sees that metastore doesn't already know about gets a metadata row proposed with \`last_writer_address = self\`. Raft replicates the row; a peer's metastore.list step sees the entry naturally — no scatter RPC, no schema change, no new mount type. Mirrors the read-path \`observe_backend_content\` from PR #98/#99. Closes the Phase γ-A native \`cc tasks list\` UX gap: Claude Code writes \`~/.claude/tasks/<uuid>/1.json\` directly to host fs (bypassing sys_write), so metastore had no row and peers couldn't enumerate the entry.

## Commits (one concern each)

1. **chore(deps)** — Cargo.toml + Cargo.lock + 4 Dockerfile pins bumped from \`196437ca8\` (PR #101) to \`ee7e645d4\` (PR #102). Comment block updated.

2. **test(e2e)** — \`TestSysReaddirObservation\` in \`test_cc_tasks_share_e2e.py\`. 5-step causal chain per the integration-test-generator standard:
   - Step 1: \`host_task_write\` on founder (bypass sys_write)
   - Step 2: \`mount_listdir\` on founder triggers sys_readdir → observation
   - Step 3: \`wait_nodes_caught_up\` for raft replication
   - Step 4: \`vfs_stat\` on joiner asserts \`found=True\` AND \`lastWriterAddress\` contains 'founder' — REGRESSION PIN (pre-PR #102 would fail: metastore miss + backend.stat can't stamp \`lastWriterAddress\`)
   - Step 5 (bonus): \`mount_read_bytes\` on joiner byte-exact via try_remote_fetch closes the loop

   Reuses existing \`joined_cluster\` fixture — no fresh-joiner topology, avoids the pollution pitfall the reverted PR #4462 \`TestJoinSidecarBootstrapsRoot\` hit.

3. **docs(runbook)** — Adds a peer-shared variant subsection under §3f (Cross-node host-fs sharing). Documents the SAME-VFS-path mount pattern both peers can now use, the \`vfs_router.has()\` preservation gate, and the trade-off vs the existing peer-namespaced variant.

## 8-principle audit

- ✅ **Simple contract** — no new contracts; pin bump + test + docs.
- ✅ **No ABI leak** — pin bump pulls in already-audited PR #102.
- ✅ **File architecture** — test extends canonical \`test_cc_tasks_share_e2e.py\`; runbook update lives in canonical operator doc.
- ✅ **Orthogonal SRP** — 3 commits, one concern each (pin / test / docs).
- ✅ **No boundary leak** — test stays in test tier; uses existing \`runbook_helpers\`/\`cc_tasks_share_helpers\` (DRY).
- ✅ **SSOT** — runbook single source for the operator flow; test co-located with the other cc-tasks-share E2E tests.
- ✅ **DRY** — 100% helper reuse (host_task_write, mount_listdir, wait_nodes_caught_up, vfs_stat, mount_read_bytes).
- ✅ **Rust-first** — Rust code change was in PR #102; this is the Python E2E + docs companion.
- ✅ **Perf** — N/A test/docs only.
- ✅ **Raft contract** — exercises raft via running daemons; no contract changes.
- ✅ **Systemic** — pins the PR #102 contract at the E2E layer.
- ✅ **E2E coverage uplift** — new causal-chain regression test at the highest realism tier (real containers, real raft, real FUSE, real host fs).

## Test plan

- [x] Pin bump cargo update clean
- [x] Test file Python syntax valid (ast.parse)
- [x] Pre-commit hooks pass on every commit
- [ ] CI: pin-bump-driven federation E2E + cc-tasks-share E2E + Self-Contained E2E + nexusd-cluster Smoke + all standard nexus checks green
- [ ] CI: new TestSysReaddirObservation passes