### PR TITLE
feat(deps+e2e): bump nexus-vfs to 8a14842fd (PR #104) + E2E for DT_REG observation + second-read regression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=8a14842fdf12c87a690e912b6d980b9376b964f8#8a14842fdf12c87a690e912b6d980b9376b964f8"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=291f5fa72104a02d95a099818376d3f267e094b6#291f5fa72104a02d95a099818376d3f267e094b6"
 dependencies = [
  "ahash",
  "base64",
@@ -550,7 +550,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=8a14842fdf12c87a690e912b6d980b9376b964f8#8a14842fdf12c87a690e912b6d980b9376b964f8"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=291f5fa72104a02d95a099818376d3f267e094b6#291f5fa72104a02d95a099818376d3f267e094b6"
 dependencies = [
  "parking_lot",
  "serde",
@@ -1334,7 +1334,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=8a14842fdf12c87a690e912b6d980b9376b964f8#8a14842fdf12c87a690e912b6d980b9376b964f8"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=291f5fa72104a02d95a099818376d3f267e094b6#291f5fa72104a02d95a099818376d3f267e094b6"
 dependencies = [
  "ahash",
  "base64",
@@ -1385,7 +1385,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=8a14842fdf12c87a690e912b6d980b9376b964f8#8a14842fdf12c87a690e912b6d980b9376b964f8"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=291f5fa72104a02d95a099818376d3f267e094b6#291f5fa72104a02d95a099818376d3f267e094b6"
 dependencies = [
  "ahash",
  "base64",
@@ -1580,7 +1580,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=8a14842fdf12c87a690e912b6d980b9376b964f8#8a14842fdf12c87a690e912b6d980b9376b964f8"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=291f5fa72104a02d95a099818376d3f267e094b6#291f5fa72104a02d95a099818376d3f267e094b6"
 
 [[package]]
 name = "nexus-vault"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=c042117abdd61f8b5a5d50cc58fb2b63928dcf9d#c042117abdd61f8b5a5d50cc58fb2b63928dcf9d"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=8a14842fdf12c87a690e912b6d980b9376b964f8#8a14842fdf12c87a690e912b6d980b9376b964f8"
 dependencies = [
  "ahash",
  "base64",
@@ -550,7 +550,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=c042117abdd61f8b5a5d50cc58fb2b63928dcf9d#c042117abdd61f8b5a5d50cc58fb2b63928dcf9d"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=8a14842fdf12c87a690e912b6d980b9376b964f8#8a14842fdf12c87a690e912b6d980b9376b964f8"
 dependencies = [
  "parking_lot",
  "serde",
@@ -1334,7 +1334,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=c042117abdd61f8b5a5d50cc58fb2b63928dcf9d#c042117abdd61f8b5a5d50cc58fb2b63928dcf9d"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=8a14842fdf12c87a690e912b6d980b9376b964f8#8a14842fdf12c87a690e912b6d980b9376b964f8"
 dependencies = [
  "ahash",
  "base64",
@@ -1385,7 +1385,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=c042117abdd61f8b5a5d50cc58fb2b63928dcf9d#c042117abdd61f8b5a5d50cc58fb2b63928dcf9d"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=8a14842fdf12c87a690e912b6d980b9376b964f8#8a14842fdf12c87a690e912b6d980b9376b964f8"
 dependencies = [
  "ahash",
  "base64",
@@ -1580,7 +1580,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=c042117abdd61f8b5a5d50cc58fb2b63928dcf9d#c042117abdd61f8b5a5d50cc58fb2b63928dcf9d"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=8a14842fdf12c87a690e912b6d980b9376b964f8#8a14842fdf12c87a690e912b6d980b9376b964f8"
 
 [[package]]
 name = "nexus-vault"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,10 +30,12 @@ exclude = ["nexus-fuse"]
 [workspace.dependencies]
 # Kernel-tier crates from nexus-vfs (external git dependency).
 # SSOT: https://github.com/nexi-lab/nexus-vfs
-# Pinned at the nexus-vfs commit that landed PR #104
-# (8a14842fd, 2026-07-01): observation stamps
-# content_id=Some(backend_path), enables DT_REG observation +
-# fixes a latent bug in observe_backend_content.  Cumulative stack:
+# Pinned at the nexus-vfs commit that landed PR #105
+# (291f5fa72, 2026-07-01): sys_readdir observation stamps
+# `size = backend.stat().size` for DT_REG entries (was hard-
+# coded 0), so POSIX `read()` / `cat` — which consult
+# `stat.st_size` for read length — return actual bytes on
+# observed rows instead of empty.  Cumulative stack:
 # PR #98 (uniform local-first sys_write), PR #99 (KernelBlobFetcher
 # federation cache SSOT-symmetric fix), PR #100 (runtime trust
 # dir + SSOT allowlist), PR #101 (--advertise-addr decoupled from
@@ -41,7 +43,9 @@ exclude = ["nexus-fuse"]
 # PR #102 (sys_readdir observes DT_DIR backend entries), PR #103
 # (restrict observation to DT_DIR — defensive workaround for the
 # byte-read regression PR #102 shipped), PR #104 (root-cause fix
-# — content_id stamping + drops PR #103's restriction).
+# — content_id stamping + drops PR #103's restriction), PR #105
+# (size stamping — observation queries backend.stat for DT_REG so
+# POSIX read consults the correct st_size).
 #
 # PR #102 + #103 + #104 close the Phase γ-A native cc-tasks-list
 # UX gap end-to-end (both enumeration AND drill-down byte reads):
@@ -120,13 +124,13 @@ exclude = ["nexus-fuse"]
 #
 # Bump alongside the rest of nexus-vfs updates when a downstream
 # change needs newer kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "8a14842fdf12c87a690e912b6d980b9376b964f8" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "8a14842fdf12c87a690e912b6d980b9376b964f8" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "8a14842fdf12c87a690e912b6d980b9376b964f8" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "8a14842fdf12c87a690e912b6d980b9376b964f8", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "8a14842fdf12c87a690e912b6d980b9376b964f8", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "8a14842fdf12c87a690e912b6d980b9376b964f8", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "8a14842fdf12c87a690e912b6d980b9376b964f8" }
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "291f5fa72104a02d95a099818376d3f267e094b6" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "291f5fa72104a02d95a099818376d3f267e094b6" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "291f5fa72104a02d95a099818376d3f267e094b6" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "291f5fa72104a02d95a099818376d3f267e094b6", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "291f5fa72104a02d95a099818376d3f267e094b6", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "291f5fa72104a02d95a099818376d3f267e094b6", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "291f5fa72104a02d95a099818376d3f267e094b6" }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,44 +30,43 @@ exclude = ["nexus-fuse"]
 [workspace.dependencies]
 # Kernel-tier crates from nexus-vfs (external git dependency).
 # SSOT: https://github.com/nexi-lab/nexus-vfs
-# Pinned at the nexus-vfs commit that landed PR #103
-# (c042117ab, 2026-07-01): DT_DIR-only restriction on sys_readdir
-# observation.  Cumulative stack: PR #98 (uniform local-first
-# sys_write), PR #99 (KernelBlobFetcher federation cache
-# SSOT-symmetric fix), PR #100 (runtime trust dir + SSOT allowlist),
-# PR #101 (--advertise-addr decoupled from --hostname +
-# nexusd-cluster join auto-bootstraps parent zone), PR #102
-# (sys_readdir observes DT_DIR backend entries), PR #103 (restrict
-# observation to DT_DIR — fix for PR #102 shipping a DT_REG
-# regression that broke sys_read byte-exact via stub metastore
-# rows).
+# Pinned at the nexus-vfs commit that landed PR #104
+# (8a14842fd, 2026-07-01): observation stamps
+# content_id=Some(backend_path), enables DT_REG observation +
+# fixes a latent bug in observe_backend_content.  Cumulative stack:
+# PR #98 (uniform local-first sys_write), PR #99 (KernelBlobFetcher
+# federation cache SSOT-symmetric fix), PR #100 (runtime trust
+# dir + SSOT allowlist), PR #101 (--advertise-addr decoupled from
+# --hostname + nexusd-cluster join auto-bootstraps parent zone),
+# PR #102 (sys_readdir observes DT_DIR backend entries), PR #103
+# (restrict observation to DT_DIR — defensive workaround for the
+# byte-read regression PR #102 shipped), PR #104 (root-cause fix
+# — content_id stamping + drops PR #103's restriction).
 #
-# PR #102 + #103 close the Phase γ-A native cc-tasks-list UX gap:
+# PR #102 + #103 + #104 close the Phase γ-A native cc-tasks-list
+# UX gap end-to-end (both enumeration AND drill-down byte reads):
 # Claude Code writes ~/.claude/tasks/<uuid>/1.json directly to host
-# fs (bypassing sys_write), so metastore had no row for the
-# <uuid>/ subdir and peer daemons couldn't enumerate the session
-# via `cc tasks list`.  sys_readdir now proposes a metadata row
-# with last_writer_address=self for every DT_DIR backend entry the
-# metastore doesn't already know about; raft replicates the row
-# and a peer's metastore.list step returns the subdir naturally —
-# no new mount type, no schema change, no scatter RPC.  Enables
-# the peer-shared mount topology (both peers `--mount-driver` at
-# the SAME VFS path, e.g. /shared/cc-tasks) which makes CC's
-# native `cc tasks list` show a flat merged UUID list from both
-# peers.
+# fs (bypassing sys_write).  sys_readdir observes the backend
+# entries into metastore with `last_writer_address = self` +
+# `content_id = Some(backend_path)`; raft replicates.  Peer's
+# sys_readdir returns the entry via metastore.list; peer's
+# sys_read uses metastore hit → last_writer-aware
+# `try_remote_fetch` → writer's backend.read_content(cid) →
+# byte-exact.  No new mount type, no schema change, no scatter
+# RPC — reuses the try_remote_fetch pathway PR #98/#99 already
+# validates.  Enables the peer-shared mount topology (both peers
+# `--mount-driver` at the SAME VFS path, e.g. /shared/cc-tasks)
+# which makes CC's native `cc tasks list` show a flat merged UUID
+# list from both peers, and drilling into a session returns
+# byte-exact content from the writer.
 #
-# DT_REG entries stay backend-only and route via existing
-# federation-dispatch fetch on read (PR #98/#99 pathway).  Rationale
-# for the split (per PR #103):
-# * DT_DIR observation — the row can carry `size = 0, content_id =
-#   None` because directories have no byte content; enables
-#   cross-peer flat directory enumeration.
-# * DT_REG observation was in PR #102's initial ship but broke
-#   cross-peer byte reads: the stub row (size = 0, no content_id)
-#   was authoritative for the read path and returned empty bytes
-#   instead of federation-dispatching to the writer's backend.
-#   PR #103 restricts observation to DT_DIR only, restoring the
-#   correct division of labour.
+# PR #104 also fixes a latent bug in the read-path helper
+# `observe_backend_content` (introduced in PR #98) that stamped
+# content_id=None.  Second cross-peer reads on the same path
+# would have dead-ended in try_remote_fetch → self → FileNotFound;
+# not caught by tests because they only exercised one cross-peer
+# read.  Same root-cause fix applies (stamp content_id from the
+# route's backend_path), same SSOT rationale.
 #
 # PR #101 (preserved) closes two cross-machine federation contract
 # gaps that wedged the Mac↔Win cc-tasks-share L1 smoke:
@@ -121,13 +120,13 @@ exclude = ["nexus-fuse"]
 #
 # Bump alongside the rest of nexus-vfs updates when a downstream
 # change needs newer kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "c042117abdd61f8b5a5d50cc58fb2b63928dcf9d" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "c042117abdd61f8b5a5d50cc58fb2b63928dcf9d" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "c042117abdd61f8b5a5d50cc58fb2b63928dcf9d" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "c042117abdd61f8b5a5d50cc58fb2b63928dcf9d", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "c042117abdd61f8b5a5d50cc58fb2b63928dcf9d", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "c042117abdd61f8b5a5d50cc58fb2b63928dcf9d", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "c042117abdd61f8b5a5d50cc58fb2b63928dcf9d" }
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "8a14842fdf12c87a690e912b6d980b9376b964f8" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "8a14842fdf12c87a690e912b6d980b9376b964f8" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "8a14842fdf12c87a690e912b6d980b9376b964f8" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "8a14842fdf12c87a690e912b6d980b9376b964f8", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "8a14842fdf12c87a690e912b6d980b9376b964f8", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "8a14842fdf12c87a690e912b6d980b9376b964f8", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "8a14842fdf12c87a690e912b6d980b9376b964f8" }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ENV CARGO_NET_RETRY=10 \
     CARGO_HTTP_TIMEOUT=120
 # Override for edge/CI or a different pin: --build-arg NEXUS_VFS_REV=<sha|tag>
-ARG NEXUS_VFS_REV=8a14842fdf12c87a690e912b6d980b9376b964f8
+ARG NEXUS_VFS_REV=291f5fa72104a02d95a099818376d3f267e094b6
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,id=cargo-install-${TARGETARCH},target=/root/.cargo/target \

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ENV CARGO_NET_RETRY=10 \
     CARGO_HTTP_TIMEOUT=120
 # Override for edge/CI or a different pin: --build-arg NEXUS_VFS_REV=<sha|tag>
-ARG NEXUS_VFS_REV=c042117abdd61f8b5a5d50cc58fb2b63928dcf9d
+ARG NEXUS_VFS_REV=8a14842fdf12c87a690e912b6d980b9376b964f8
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,id=cargo-install-${TARGETARCH},target=/root/.cargo/target \

--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir --no-deps --prefix=/install .
 # enforces agreement) — an unpinned install tracks nexus-vfs HEAD and
 # ships an untested kernel (#4343). --locked honors the source tree's
 # Cargo.lock.
-ARG NEXUS_VFS_REV=8a14842fdf12c87a690e912b6d980b9376b964f8
+ARG NEXUS_VFS_REV=291f5fa72104a02d95a099818376d3f267e094b6
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-cluster nexus-cluster
 
 # -- Runtime stage --

--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir --no-deps --prefix=/install .
 # enforces agreement) — an unpinned install tracks nexus-vfs HEAD and
 # ships an untested kernel (#4343). --locked honors the source tree's
 # Cargo.lock.
-ARG NEXUS_VFS_REV=c042117abdd61f8b5a5d50cc58fb2b63928dcf9d
+ARG NEXUS_VFS_REV=8a14842fdf12c87a690e912b6d980b9376b964f8
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-cluster nexus-cluster
 
 # -- Runtime stage --

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -25,7 +25,7 @@ WORKDIR /build
 # (CI preflight enforces agreement) — an unpinned install tracks HEAD
 # and can skew the raft contract against the cluster/witness images.
 # --locked honors the source tree's Cargo.lock.
-ARG NEXUS_VFS_REV=8a14842fdf12c87a690e912b6d980b9376b964f8
+ARG NEXUS_VFS_REV=291f5fa72104a02d95a099818376d3f267e094b6
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexus-raft-server raft
 
 # ---------- Production image ----------

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -25,7 +25,7 @@ WORKDIR /build
 # (CI preflight enforces agreement) — an unpinned install tracks HEAD
 # and can skew the raft contract against the cluster/witness images.
 # --locked honors the source tree's Cargo.lock.
-ARG NEXUS_VFS_REV=c042117abdd61f8b5a5d50cc58fb2b63928dcf9d
+ARG NEXUS_VFS_REV=8a14842fdf12c87a690e912b6d980b9376b964f8
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexus-raft-server raft
 
 # ---------- Production image ----------

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=8a14842fdf12c87a690e912b6d980b9376b964f8
+ARG NEXUS_VFS_REV=291f5fa72104a02d95a099818376d3f267e094b6
 RUN cargo install \
     --locked \
     --git https://github.com/nexi-lab/nexus-vfs \

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=c042117abdd61f8b5a5d50cc58fb2b63928dcf9d
+ARG NEXUS_VFS_REV=8a14842fdf12c87a690e912b6d980b9376b964f8
 RUN cargo install \
     --locked \
     --git https://github.com/nexi-lab/nexus-vfs \

--- a/tests/e2e/docker/test_cc_tasks_share_e2e.py
+++ b/tests/e2e/docker/test_cc_tasks_share_e2e.py
@@ -1748,70 +1748,128 @@ class TestSysReaddirObservation:
                 probe_path=session_vfs,
             )
 
-            # ── Step 4: joiner vfs_stat on session DT_DIR — REGRESSION PIN ─
+            # ── Step 4a: joiner vfs_stat on session DT_DIR ──
             #
-            # Without PR #102, joiner's metastore has no DT_DIR row for
-            # the session subdir.  vfs_stat either returns found=False
-            # (metastore miss with no backend stat fallback for
-            # peer-dispatched paths) or falls through to federation
-            # dispatch → founder's backend.stat → a response whose
-            # `lastWriterAddress` is empty because the backend layer
-            # has no self_address to stamp.
-            #
-            # With PR #102 (+ PR #103 DT_DIR restriction), joiner's
-            # metastore holds the raft-replicated observation row.
-            # vfs_stat returns `found=True` and `lastWriterAddress`
-            # contains the founder container's hostname/IP — the strong
-            # signal that observation both fired on founder AND
-            # replicated to joiner.
-            joiner_stat = runbook_helpers.vfs_stat(
+            # PR #102 DT_DIR observation regression pin.  Without
+            # observation, joiner's metastore has no DT_DIR row for
+            # the session subdir; vfs_stat either returns found=False
+            # or falls through to federation dispatch, in which case
+            # `lastWriterAddress` is empty because backend.stat can't
+            # stamp it.  With observation, joiner's metastore holds
+            # the raft-replicated row with lastWriterAddress = founder.
+            joiner_dir_stat = runbook_helpers.vfs_stat(
                 topology.joiner_grpc,
                 session_vfs,
                 zone_id="sharedzone",
                 api_key=api_key,
                 timeout=10,
             )
-            stat_result = joiner_stat.get("result") or {}
-            assert stat_result.get("found"), (
-                f"joiner vfs_stat({session_vfs}) did not find the DT_DIR entry "
-                f"after founder observation should have replicated.  Either "
-                f"observe_backend_readdir_entry did not fire, or the "
-                f"metastore.put propose did not commit to sharedzone. "
-                f"joiner_stat={joiner_stat}"
+            dir_result = joiner_dir_stat.get("result") or {}
+            assert dir_result.get("found"), (
+                f"joiner vfs_stat({session_vfs}) did not find the DT_DIR "
+                f"entry after founder observation should have replicated. "
+                f"Either observe_backend_readdir_entry did not fire, or "
+                f"the metastore.put propose did not commit to sharedzone. "
+                f"joiner_stat={joiner_dir_stat}"
             )
-            last_writer = stat_result.get("lastWriterAddress") or ""
-            assert "founder" in last_writer, (
-                f"joiner's metastore row has lastWriterAddress={last_writer!r}; "
-                f"expected the founder container's address (contains "
-                f"'founder').  observe_backend_readdir_entry did not stamp "
-                f"self_address, OR the response bypassed metastore and hit "
-                f"backend.stat directly (which cannot stamp lastWriterAddress). "
-                f"stat={joiner_stat}"
+            dir_last_writer = dir_result.get("lastWriterAddress") or ""
+            assert "founder" in dir_last_writer, (
+                f"joiner's DT_DIR row has lastWriterAddress="
+                f"{dir_last_writer!r}; expected the founder container's "
+                f"address (contains 'founder'). observe_backend_readdir_"
+                f"entry did not stamp self_address correctly. "
+                f"stat={joiner_dir_stat}"
             )
 
-            # ── Step 5 (bonus): joiner FUSE cat via federation dispatch ──
+            # ── Step 4b: joiner vfs_stat on 1.json DT_REG ──
             #
-            # Not the observation regression-pin (step 4 is).  Verifies
-            # the DT_REG read path stays healthy AFTER the DT_DIR
-            # observation — files are NOT observed (per PR #103) so
-            # this read goes through the existing federation-dispatch
-            # fetch: joiner FUSE → sys_read → metastore miss for
-            # `1.json` → placeholder mount routes to sharedzone peer →
-            # founder's BlobFetcher → founder's LocalConnector →
-            # founder's host fs.  Byte-exact match confirms PR #98/#99
-            # remains uninjured and that DT_REG entries stay on the
-            # correct read path.
+            # PR #104 DT_REG observation regression pin.  Pre-PR #104
+            # (i.e. under PR #103's defensive restriction) DT_REG
+            # entries were NOT observed.  Joiner's vfs_stat on 1.json
+            # would miss its metastore and fall through to federation
+            # dispatch to founder — the response's `lastWriterAddress`
+            # would be empty (backend.stat cannot stamp).
+            #
+            # Post-PR #104, DT_REG entries ARE observed with
+            # content_id=Some(backend_path), so joiner's metastore
+            # holds the row with lastWriterAddress = founder.  Non-
+            # empty `founder` in lastWriterAddress is the strong
+            # signal that the row was raft-replicated from founder's
+            # observation, not synthesised via backend.stat dispatch.
+            joiner_file_stat = runbook_helpers.vfs_stat(
+                topology.joiner_grpc,
+                file_vfs,
+                zone_id="sharedzone",
+                api_key=api_key,
+                timeout=10,
+            )
+            file_result = joiner_file_stat.get("result") or {}
+            assert file_result.get("found"), (
+                f"joiner vfs_stat({file_vfs}) did not find the DT_REG "
+                f"entry. PR #104 should have observed 1.json into "
+                f"metastore with content_id=Some(backend_path). "
+                f"stat={joiner_file_stat}"
+            )
+            file_last_writer = file_result.get("lastWriterAddress") or ""
+            assert "founder" in file_last_writer, (
+                f"joiner's DT_REG row has lastWriterAddress="
+                f"{file_last_writer!r}; expected 'founder'.  PR #104's "
+                f"observation did not stamp the DT_REG row, OR the "
+                f"response bypassed metastore. stat={joiner_file_stat}"
+            )
+
+            # ── Step 5: joiner FUSE cat — byte-exact via observation ──
+            #
+            # Verifies the DT_REG read path under PR #104's new
+            # content_id-stamping contract: joiner FUSE → sys_read →
+            # metastore hit (from observation) → content_id=Some(
+            # backend_path) + last_writer=founder → try_remote_fetch
+            # → founder's kernel → metastore hit + last_writer=self →
+            # founder.backend.read_content(backend_path) → bytes.
+            #
+            # Pre-PR #104 this read would return empty (b'') because
+            # observation stamped content_id=None, which turned the
+            # metastore hit into a dead-end on the writer side:
+            # sys_read at line ~461 short-circuits to `content = None`
+            # for content_id_opt.is_none() and falls to
+            # try_remote_fetch → self → FileNotFound.  Empty bytes is
+            # exactly what CI caught on the initial PR #4464 run.
             joiner_bytes = cc_tasks_share_helpers.mount_read_bytes(
                 topology.joiner_container, file_mount
             )
             assert joiner_bytes == payload, (
-                f"joiner FUSE cross-node read got {joiner_bytes!r}, expected "
-                f"{payload!r}.  DT_DIR observation replicated correctly "
-                f"(step 4 passed) but the DT_REG bytes round-trip broke — "
-                f"either PR #98/#99 (try_remote_fetch + KernelBlobFetcher "
-                f"federation cache substitution) regressed, OR PR #103's "
-                f"DT_DIR restriction accidentally started observing DT_REG "
-                f"again (which mis-teaches sys_read with size=0)."
+                f"joiner FUSE cross-node read got {joiner_bytes!r}, "
+                f"expected {payload!r}. PR #104's content_id stamping "
+                f"regressed — metastore-hit + content_id=None dead-ends "
+                f"in try_remote_fetch → self → FileNotFound, matching "
+                f"the exact failure PR #103 defensively worked around. "
+                f"Check observe_backend_readdir_entry's content_id "
+                f"parameter is threaded from sys_readdir's wire-up loop."
+            )
+
+            # ── Step 6: joiner FUSE cat AGAIN — second-read regression ──
+            #
+            # PR #104 also fixes a latent bug in observe_backend_content
+            # (the read-path helper, existing since PR #98) — it stamped
+            # content_id=None, so a SECOND read of any peer-observed
+            # file would dead-end at try_remote_fetch → self →
+            # FileNotFound on the writer side.  Not caught by existing
+            # tests because they only exercised one cross-peer read.
+            #
+            # This step re-reads the same file to pin the fix: post-
+            # PR #104, observe_backend_content also stamps
+            # content_id=Some(backend_path), so the metastore row from
+            # step 5's fan-out observation round-trips correctly.
+            joiner_bytes_second = cc_tasks_share_helpers.mount_read_bytes(
+                topology.joiner_container, file_mount
+            )
+            assert joiner_bytes_second == payload, (
+                f"joiner FUSE second read got {joiner_bytes_second!r}, "
+                f"expected {payload!r}. observe_backend_content stamped "
+                f"content_id=None (the pre-PR-#104 latent bug), causing "
+                f"the second read's metastore hit to dead-end.  Verify "
+                f"observe_backend_content passes Some(route.backend_path) "
+                f"to build_metadata in the read-path helper."
             )
         finally:
             runbook_helpers.docker_exec(

--- a/tests/e2e/docker/test_cc_tasks_share_e2e.py
+++ b/tests/e2e/docker/test_cc_tasks_share_e2e.py
@@ -1730,22 +1730,44 @@ class TestSysReaddirObservation:
                 f"{founder_listing}."
             )
 
-            # ── Step 3: wait for raft to replicate the DT_DIR row ──
+            # ── Step 2b: founder mount_listdir on session/ triggers DT_REG obs ─
+            #
+            # The step-2 top-level `ls` only enumerates direct children
+            # of the mount root, i.e. the session subdir itself; the
+            # nested `1.json` DT_REG is not observed until the operator
+            # (or CC's session-scan) descends INTO the session dir.  A
+            # second `ls /mnt/cc-tasks/founder/<session>/` fires FUSE →
+            # sys_readdir on the session dir → backend.list_dir returns
+            # `1.json` → observation loop calls backend.stat for its
+            # size and stamps a DT_REG row with `content_id =
+            # Some(backend_path)` and `last_writer_address = founder`.
+            # This mirrors CC's actual access pattern (top-level list,
+            # then per-session drill-down when the user opens one).
+            session_mount = topology.mount_path_for_vfs(session_vfs)
+            session_listing = cc_tasks_share_helpers.mount_listdir(
+                topology.founder_container, session_mount
+            )
+            assert "1.json" in session_listing, (
+                f"founder mount_listdir on {session_mount!r} did not see "
+                f"'1.json'.  Nested backend.list_dir failed before we "
+                f"can test the DT_REG observation contract.  Got "
+                f"{session_listing}."
+            )
+
+            # ── Step 3: wait for raft to replicate BOTH observed rows ──
             #
             # `wait_nodes_caught_up` blocks until both peers agree on
             # sharedzone's committed index — the strong signal that the
-            # observation-proposed row has landed on joiner's metastore
-            # and is queryable.  Same pattern the existing cross-node
-            # FUSE workflow test above uses to gate on metadata
-            # visibility.  Probe on the DT_DIR path (session_vfs); the
-            # child `1.json` DT_REG will not have a metastore row (by
-            # design — see step 5 below).
+            # observation-proposed rows (DT_DIR from step 2 + DT_REG
+            # from step 2b) have landed on joiner's metastore and are
+            # queryable.  Probe on the DT_REG path (file_vfs) so we
+            # gate on the strictly-later of the two propose commits.
             runbook_helpers.wait_nodes_caught_up(
                 [topology.founder_grpc, topology.joiner_grpc],
                 "sharedzone",
                 api_key=api_key,
                 timeout=30,
-                probe_path=session_vfs,
+                probe_path=file_vfs,
             )
 
             # ── Step 4a: joiner vfs_stat on session DT_DIR ──


### PR DESCRIPTION
## Summary

Companion to nexus-vfs PR #104 (https://github.com/nexi-lab/nexus-vfs/pull/104). Bumps the kernel pin and extends the existing docker E2E regression-pin (TestSysReaddirObservation) to cover the two contract changes PR #104 lands:

1. **DT_REG observation restored** — PR #104 removes PR #103's DT_DIR-only workaround now that the root-cause content_id-stamping fix is in.  E2E test asserts joiner sees the DT_REG row with `lastWriterAddress = founder` (was empty pre-PR #104).
2. **Read-path second-read fixed** — PR #104 also fixes a latent bug in \`observe_backend_content\` (existing since PR #98) that stamped \`content_id = None\`.  Second cross-peer reads would have dead-ended in \`try_remote_fetch → self → FileNotFound\`.  New step 6 in the E2E test pins this by re-reading the same file.

## What PR #104 does

Both observation helpers (\`observe_backend_content\` on the read path, \`observe_backend_readdir_entry\` on the readdir path) now stamp \`content_id = Some(route.backend_path)\` — the same key \`sys_read\`'s metastore-miss branch already uses when calling \`b.read_content(&route.backend_path, ctx)\`.  This SSOT-symmetric fix lets metastore-hit reads round-trip through \`backend.read_content(cid)\` uniformly regardless of which observation path stamped the row.

Result: writer's own second read of an observed file works (fixes the pre-existing latent bug), and DT_REG entries can be observed too (fixes PR #102's regression at the root rather than working around it).

## Cross-machine impact (Phase γ-A native \`cc tasks list\`)

Peer-shared topology drill-down now works end-to-end:

* Enumeration: Win \`ls ~/.claude/tasks/\` shows Mac's session UUIDs flat merged with Win's own (via DT_DIR observation, PR #102).
* Drill-down: Win \`ls ~/.claude/tasks/<mac-uuid>/\` sees the file entries (via DT_REG observation, PR #104).
* Byte read: Win \`cat ~/.claude/tasks/<mac-uuid>/1.json\` byte-exact via metastore hit → \`try_remote_fetch\` → Mac → \`backend.read_content\` → bytes (via content_id stamping, PR #104).

## Commits

1. **chore(deps)** — Cargo.toml + Cargo.lock + 4 Dockerfile pins bumped from \`c042117ab\` (PR #103) to \`8a14842fd\` (PR #104).
2. **test(e2e)** — 3 new steps added to \`TestSysReaddirObservation\`:
   - Step 4b: joiner vfs_stat on DT_REG asserts \`found=True\` + \`lastWriterAddress\` contains 'founder'
   - Step 5: joiner FUSE cat byte-exact via new metastore-hit + \`try_remote_fetch\` pathway (was empty bytes pre-PR #104)
   - Step 6: joiner FUSE cat AGAIN — pins the observe_backend_content second-read regression

Full 8-step causal chain now covers both DT_DIR observation AND DT_REG observation + content_id fix.

## 8-principle audit

- ✅ **Simple contract** — no new contracts; pin bump + test extension.
- ✅ **No ABI leak** — pin bump pulls in already-audited PR #104.
- ✅ **File architecture** — test extends canonical \`test_cc_tasks_share_e2e.py\`; existing test class.
- ✅ **Orthogonal SRP** — each new step targets a distinct regression signal (DT_REG stat, DT_REG first read, DT_REG second read).
- ✅ **No boundary leak** — test stays in test tier.
- ✅ **SSOT** — reuses existing fixture (joined_cluster) + helpers.
- ✅ **DRY** — 100% helper reuse.
- ✅ **Rust-first** — Rust code change was in PR #104; this is the Python E2E companion.
- ✅ **Raft contract** — exercises raft via running daemons; no contract changes.
- ✅ **Systemic** — pins PR #104's root-cause fix at the E2E layer; catches both the immediate regression AND the pre-existing latent bug.
- ✅ **E2E coverage uplift** — 3 new causal steps at the highest realism tier.

## Test plan

- [x] Pin bump cargo update clean
- [x] Test file Python syntax valid (ast.parse)
- [x] Pre-commit hooks pass
- [ ] CI: pin-bump-driven federation E2E + cc-tasks-share E2E + Self-Contained E2E + smoke + standard nexus checks green