### PR TITLE
chore(deps): nexus-vfs pin bump + identity.json E2E pin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=291f5fa72104a02d95a099818376d3f267e094b6#291f5fa72104a02d95a099818376d3f267e094b6"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=a52f130157995e00428d5b72c2f6eeb944d1e531#a52f130157995e00428d5b72c2f6eeb944d1e531"
 dependencies = [
  "ahash",
  "base64",
@@ -550,7 +550,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=291f5fa72104a02d95a099818376d3f267e094b6#291f5fa72104a02d95a099818376d3f267e094b6"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=a52f130157995e00428d5b72c2f6eeb944d1e531#a52f130157995e00428d5b72c2f6eeb944d1e531"
 dependencies = [
  "parking_lot",
  "serde",
@@ -1334,7 +1334,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=291f5fa72104a02d95a099818376d3f267e094b6#291f5fa72104a02d95a099818376d3f267e094b6"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=a52f130157995e00428d5b72c2f6eeb944d1e531#a52f130157995e00428d5b72c2f6eeb944d1e531"
 dependencies = [
  "ahash",
  "base64",
@@ -1385,7 +1385,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=291f5fa72104a02d95a099818376d3f267e094b6#291f5fa72104a02d95a099818376d3f267e094b6"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=a52f130157995e00428d5b72c2f6eeb944d1e531#a52f130157995e00428d5b72c2f6eeb944d1e531"
 dependencies = [
  "ahash",
  "base64",
@@ -1580,7 +1580,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=291f5fa72104a02d95a099818376d3f267e094b6#291f5fa72104a02d95a099818376d3f267e094b6"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=a52f130157995e00428d5b72c2f6eeb944d1e531#a52f130157995e00428d5b72c2f6eeb944d1e531"
 
 [[package]]
 name = "nexus-vault"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=a52f130157995e00428d5b72c2f6eeb944d1e531#a52f130157995e00428d5b72c2f6eeb944d1e531"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=46c61f7855f418bd28a58d9ac4e32612c0d21d8f#46c61f7855f418bd28a58d9ac4e32612c0d21d8f"
 dependencies = [
  "ahash",
  "base64",
@@ -550,7 +550,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=a52f130157995e00428d5b72c2f6eeb944d1e531#a52f130157995e00428d5b72c2f6eeb944d1e531"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=46c61f7855f418bd28a58d9ac4e32612c0d21d8f#46c61f7855f418bd28a58d9ac4e32612c0d21d8f"
 dependencies = [
  "parking_lot",
  "serde",
@@ -1334,7 +1334,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=a52f130157995e00428d5b72c2f6eeb944d1e531#a52f130157995e00428d5b72c2f6eeb944d1e531"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=46c61f7855f418bd28a58d9ac4e32612c0d21d8f#46c61f7855f418bd28a58d9ac4e32612c0d21d8f"
 dependencies = [
  "ahash",
  "base64",
@@ -1385,7 +1385,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=a52f130157995e00428d5b72c2f6eeb944d1e531#a52f130157995e00428d5b72c2f6eeb944d1e531"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=46c61f7855f418bd28a58d9ac4e32612c0d21d8f#46c61f7855f418bd28a58d9ac4e32612c0d21d8f"
 dependencies = [
  "ahash",
  "base64",
@@ -1580,7 +1580,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=a52f130157995e00428d5b72c2f6eeb944d1e531#a52f130157995e00428d5b72c2f6eeb944d1e531"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=46c61f7855f418bd28a58d9ac4e32612c0d21d8f#46c61f7855f418bd28a58d9ac4e32612c0d21d8f"
 
 [[package]]
 name = "nexus-vault"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,12 +30,17 @@ exclude = ["nexus-fuse"]
 [workspace.dependencies]
 # Kernel-tier crates from nexus-vfs (external git dependency).
 # SSOT: https://github.com/nexi-lab/nexus-vfs
-# Pinned at the nexus-vfs commit that landed PR #105
-# (291f5fa72, 2026-07-01): sys_readdir observation stamps
-# `size = backend.stat().size` for DT_REG entries (was hard-
-# coded 0), so POSIX `read()` / `cat` — which consult
-# `stat.st_size` for read length — return actual bytes on
-# observed rows instead of empty.  Cumulative stack:
+# Pinned at the nexus-vfs commit that landed PR #106
+# (a52f13015, 2026-07-02): identity.json persists the raft
+# transport peer address book at platform-native user-data path
+# (%LOCALAPPDATA%\Nexus, ~/Library/Application Support/Nexus,
+# $XDG_DATA_HOME/nexus).  Boot merges CLI --peers with the
+# persisted list, `nexusd-cluster join` sidecar records the
+# leader --peer-addr so subsequent restarts (with NEXUS_PEERS
+# unset per the entrypoint) still have a transport seed.
+# node_id lifecycle unchanged — stays at <data_dir>/.node_id
+# under the rotate-on-wipe PR #3996 opaque-ID contract.
+# Cumulative stack:
 # PR #98 (uniform local-first sys_write), PR #99 (KernelBlobFetcher
 # federation cache SSOT-symmetric fix), PR #100 (runtime trust
 # dir + SSOT allowlist), PR #101 (--advertise-addr decoupled from
@@ -124,13 +129,13 @@ exclude = ["nexus-fuse"]
 #
 # Bump alongside the rest of nexus-vfs updates when a downstream
 # change needs newer kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "291f5fa72104a02d95a099818376d3f267e094b6" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "291f5fa72104a02d95a099818376d3f267e094b6" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "291f5fa72104a02d95a099818376d3f267e094b6" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "291f5fa72104a02d95a099818376d3f267e094b6", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "291f5fa72104a02d95a099818376d3f267e094b6", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "291f5fa72104a02d95a099818376d3f267e094b6", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "291f5fa72104a02d95a099818376d3f267e094b6" }
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "a52f130157995e00428d5b72c2f6eeb944d1e531" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "a52f130157995e00428d5b72c2f6eeb944d1e531" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "a52f130157995e00428d5b72c2f6eeb944d1e531" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "a52f130157995e00428d5b72c2f6eeb944d1e531", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "a52f130157995e00428d5b72c2f6eeb944d1e531", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "a52f130157995e00428d5b72c2f6eeb944d1e531", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "a52f130157995e00428d5b72c2f6eeb944d1e531" }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,8 +30,8 @@ exclude = ["nexus-fuse"]
 [workspace.dependencies]
 # Kernel-tier crates from nexus-vfs (external git dependency).
 # SSOT: https://github.com/nexi-lab/nexus-vfs
-# Pinned at the nexus-vfs commit that landed PR #106
-# (a52f13015, 2026-07-02): identity.json persists the raft
+# Pinned at the nexus-vfs commit that landed PR #106 + #107
+# (46c61f785, 2026-07-02): PR #106 identity.json persists the raft
 # transport peer address book at platform-native user-data path
 # (%LOCALAPPDATA%\Nexus, ~/Library/Application Support/Nexus,
 # $XDG_DATA_HOME/nexus).  Boot merges CLI --peers with the
@@ -40,6 +40,13 @@ exclude = ["nexus-fuse"]
 # unset per the entrypoint) still have a transport seed.
 # node_id lifecycle unchanged — stays at <data_dir>/.node_id
 # under the rotate-on-wipe PR #3996 opaque-ID contract.
+# PR #107 (fix): identity peers are transport-only, not bootstrap —
+# `ZoneManagerBundle::peer_addrs` reflects CLI --peers only, so
+# root's per-node SOLO invariant guard in `bootstrap_or_join_zone`
+# does not fire on joiner restart after `nexusd-cluster join`
+# recorded a leader address to identity.  Identity's persisted
+# peer list still seeds `ZoneManager`'s transport peer map (i.e.
+# reconnect hint for federation raft messages).
 # Cumulative stack:
 # PR #98 (uniform local-first sys_write), PR #99 (KernelBlobFetcher
 # federation cache SSOT-symmetric fix), PR #100 (runtime trust
@@ -129,13 +136,13 @@ exclude = ["nexus-fuse"]
 #
 # Bump alongside the rest of nexus-vfs updates when a downstream
 # change needs newer kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "a52f130157995e00428d5b72c2f6eeb944d1e531" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "a52f130157995e00428d5b72c2f6eeb944d1e531" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "a52f130157995e00428d5b72c2f6eeb944d1e531" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "a52f130157995e00428d5b72c2f6eeb944d1e531", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "a52f130157995e00428d5b72c2f6eeb944d1e531", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "a52f130157995e00428d5b72c2f6eeb944d1e531", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "a52f130157995e00428d5b72c2f6eeb944d1e531" }
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "46c61f7855f418bd28a58d9ac4e32612c0d21d8f" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "46c61f7855f418bd28a58d9ac4e32612c0d21d8f" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "46c61f7855f418bd28a58d9ac4e32612c0d21d8f" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "46c61f7855f418bd28a58d9ac4e32612c0d21d8f", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "46c61f7855f418bd28a58d9ac4e32612c0d21d8f", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "46c61f7855f418bd28a58d9ac4e32612c0d21d8f", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "46c61f7855f418bd28a58d9ac4e32612c0d21d8f" }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ENV CARGO_NET_RETRY=10 \
     CARGO_HTTP_TIMEOUT=120
 # Override for edge/CI or a different pin: --build-arg NEXUS_VFS_REV=<sha|tag>
-ARG NEXUS_VFS_REV=291f5fa72104a02d95a099818376d3f267e094b6
+ARG NEXUS_VFS_REV=a52f130157995e00428d5b72c2f6eeb944d1e531
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,id=cargo-install-${TARGETARCH},target=/root/.cargo/target \

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ENV CARGO_NET_RETRY=10 \
     CARGO_HTTP_TIMEOUT=120
 # Override for edge/CI or a different pin: --build-arg NEXUS_VFS_REV=<sha|tag>
-ARG NEXUS_VFS_REV=a52f130157995e00428d5b72c2f6eeb944d1e531
+ARG NEXUS_VFS_REV=46c61f7855f418bd28a58d9ac4e32612c0d21d8f
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,id=cargo-install-${TARGETARCH},target=/root/.cargo/target \

--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir --no-deps --prefix=/install .
 # enforces agreement) — an unpinned install tracks nexus-vfs HEAD and
 # ships an untested kernel (#4343). --locked honors the source tree's
 # Cargo.lock.
-ARG NEXUS_VFS_REV=291f5fa72104a02d95a099818376d3f267e094b6
+ARG NEXUS_VFS_REV=a52f130157995e00428d5b72c2f6eeb944d1e531
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-cluster nexus-cluster
 
 # -- Runtime stage --

--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir --no-deps --prefix=/install .
 # enforces agreement) — an unpinned install tracks nexus-vfs HEAD and
 # ships an untested kernel (#4343). --locked honors the source tree's
 # Cargo.lock.
-ARG NEXUS_VFS_REV=a52f130157995e00428d5b72c2f6eeb944d1e531
+ARG NEXUS_VFS_REV=46c61f7855f418bd28a58d9ac4e32612c0d21d8f
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-cluster nexus-cluster
 
 # -- Runtime stage --

--- a/dockerfiles/Dockerfile.nexusd-cluster
+++ b/dockerfiles/Dockerfile.nexusd-cluster
@@ -62,8 +62,15 @@ RUN apt-get update && \
 COPY --from=builder /usr/local/cargo/bin/nexusd-cluster /usr/local/bin/
 
 # Non-root runtime user
+#
+# Pre-creates BOTH `/app/data` (raft state cache) AND `/app/identity`
+# (node-bound peer address book from nexus-vfs PR #106) so downstream
+# compose stacks that mount named volumes at either path inherit the
+# `nexus:nexus` ownership.  Without pre-creation, Docker mounts the
+# volume as root-owned and the `nexus` user hits `Permission denied`
+# on the first `identity::persist_peers` write.
 RUN useradd -r -m -u 1000 -s /bin/bash nexus && \
-    mkdir -p /app/data && \
+    mkdir -p /app/data /app/identity && \
     chown -R nexus:nexus /app
 
 USER nexus

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -25,7 +25,7 @@ WORKDIR /build
 # (CI preflight enforces agreement) — an unpinned install tracks HEAD
 # and can skew the raft contract against the cluster/witness images.
 # --locked honors the source tree's Cargo.lock.
-ARG NEXUS_VFS_REV=a52f130157995e00428d5b72c2f6eeb944d1e531
+ARG NEXUS_VFS_REV=46c61f7855f418bd28a58d9ac4e32612c0d21d8f
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexus-raft-server raft
 
 # ---------- Production image ----------

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -25,7 +25,7 @@ WORKDIR /build
 # (CI preflight enforces agreement) — an unpinned install tracks HEAD
 # and can skew the raft contract against the cluster/witness images.
 # --locked honors the source tree's Cargo.lock.
-ARG NEXUS_VFS_REV=291f5fa72104a02d95a099818376d3f267e094b6
+ARG NEXUS_VFS_REV=a52f130157995e00428d5b72c2f6eeb944d1e531
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexus-raft-server raft
 
 # ---------- Production image ----------

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=291f5fa72104a02d95a099818376d3f267e094b6
+ARG NEXUS_VFS_REV=a52f130157995e00428d5b72c2f6eeb944d1e531
 RUN cargo install \
     --locked \
     --git https://github.com/nexi-lab/nexus-vfs \

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=a52f130157995e00428d5b72c2f6eeb944d1e531
+ARG NEXUS_VFS_REV=46c61f7855f418bd28a58d9ac4e32612c0d21d8f
 RUN cargo install \
     --locked \
     --git https://github.com/nexi-lab/nexus-vfs \

--- a/dockerfiles/docker-compose.cc-tasks-share.yml
+++ b/dockerfiles/docker-compose.cc-tasks-share.yml
@@ -163,6 +163,15 @@ services:
       NEXUS_BIND_ADDR: 0.0.0.0:2126
       NEXUS_ADVERTISE_ADDR: joiner:2126
       NEXUS_DATA_DIR: /app/data
+      # `identity.json` (nexus-vfs PR #106) — node-bound peer address
+      # book that survives `<NEXUS_DATA_DIR>` cleanup.  Volume-mounted
+      # SEPARATELY from `NEXUS_DATA_DIR` so a data-volume wipe scenario
+      # does not lose the persisted `--peer-addr` the sidecar just
+      # recorded.  Shared with the `nexusd-cluster join` sidecar (see
+      # `runbook_helpers.run_nexusd_cluster_join`) so the sidecar's
+      # post-JoinZone `identity::persist_peers` lands here where the
+      # main daemon's next boot loads it.
+      NEXUS_IDENTITY_DIR: /app/identity
       NEXUS_NO_TLS: "true"
       # Joiner does NOT set FEDERATION_ZONES at first boot — the test
       # fixture's `nexusd-cluster join` CLI seeds sharedzone's
@@ -175,6 +184,7 @@ services:
       RUST_LOG: info,nexus_raft=info
     volumes:
       - cc_tasks_joiner_data:/app/data
+      - cc_tasks_joiner_identity:/app/identity
       - cc_tasks_joiner_hostfs:/host/tasks
     networks:
       - nexus-cc-tasks-net
@@ -262,5 +272,11 @@ volumes:
     name: nexus-cc-tasks-founder-hostfs
   cc_tasks_joiner_data:
     name: nexus-cc-tasks-joiner-data
+  # `identity.json` (nexus-vfs PR #106) — cache-loss-safe peer address
+  # book, mounted at `/app/identity` on both the joiner service AND the
+  # transient `nexusd-cluster join` sidecar so the sidecar's post-JoinZone
+  # `identity::persist_peers` write persists across the sidecar's exit.
+  cc_tasks_joiner_identity:
+    name: nexus-cc-tasks-joiner-identity
   cc_tasks_joiner_hostfs:
     name: nexus-cc-tasks-joiner-hostfs

--- a/tests/e2e/docker/runbook_helpers.py
+++ b/tests/e2e/docker/runbook_helpers.py
@@ -683,6 +683,8 @@ def run_nexusd_cluster_join(
     cluster_image: str | None = None,
     network: str | None = None,
     data_dir: str = "/app/data",
+    identity_volume: str | None = None,
+    identity_dir: str = "/app/identity",
     timeout: float = 120,
     as_role: str = "voter",
 ) -> subprocess.CompletedProcess:
@@ -728,23 +730,36 @@ def run_nexusd_cluster_join(
         hostname,
         "-v",
         f"{target_volume}:{data_dir}",
-        # Override the image's `ENTRYPOINT ["nexusd-cluster"]` so we
-        # can pass `join` as the subcommand instead of an arg.
-        "--entrypoint",
-        "nexusd-cluster",
-        image,
-        "join",
-        f"{founder_node_id}@{founder_addr}",
-        zone_id,
-        local_path,
-        "--data-dir",
-        data_dir,
-        "--no-tls",
-        "--hostname",
-        hostname,
-        "--as",
-        as_role,
     ]
+    # `identity_volume` mounts the same host volume the target daemon
+    # uses for its `NEXUS_IDENTITY_DIR` so the sidecar's post-JoinZone
+    # `identity::persist_peers` write persists across the sidecar's
+    # exit and the target daemon reads it on its next boot.  Without
+    # this mount the sidecar writes to its own transient fs and every
+    # restart of the target daemon loses the leader peer address.
+    if identity_volume is not None:
+        cmd.extend(["-v", f"{identity_volume}:{identity_dir}"])
+        cmd.extend(["-e", f"NEXUS_IDENTITY_DIR={identity_dir}"])
+    cmd.extend(
+        [
+            # Override the image's `ENTRYPOINT ["nexusd-cluster"]` so we
+            # can pass `join` as the subcommand instead of an arg.
+            "--entrypoint",
+            "nexusd-cluster",
+            image,
+            "join",
+            f"{founder_node_id}@{founder_addr}",
+            zone_id,
+            local_path,
+            "--data-dir",
+            data_dir,
+            "--no-tls",
+            "--hostname",
+            hostname,
+            "--as",
+            as_role,
+        ]
+    )
     return subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
 
 

--- a/tests/e2e/docker/runbook_helpers.py
+++ b/tests/e2e/docker/runbook_helpers.py
@@ -377,7 +377,9 @@ def wait_healthy(grpc_addrs: Iterable[str], timeout: float = HEALTH_TIMEOUT) -> 
 
     Hard-fails on timeout — runbook tests cannot proceed past boot if
     a voter isn't reachable; silent skip would mask a real cluster
-    boot regression.
+    boot regression.  On timeout, dumps container logs so CI
+    transcripts carry the daemon's own boot log without needing a
+    re-run with manual diagnostics.
     """
     deadline = time.time() + timeout
     for addr in grpc_addrs:
@@ -387,7 +389,20 @@ def wait_healthy(grpc_addrs: Iterable[str], timeout: float = HEALTH_TIMEOUT) -> 
                 break
             time.sleep(2)
         else:
-            pytest.fail(f"Timed out waiting for {addr} to become healthy")
+            host = addr.split(":", 1)[0]
+            candidates = [host, f"nexus-cc-tasks-{host}", f"nexus-runbook-{host}"]
+            log_dump = ""
+            for container in candidates:
+                try:
+                    logs = docker_logs(container, tail=200)
+                except subprocess.SubprocessError:
+                    continue
+                if logs:
+                    log_dump = f"\n--- {container} (tail 200) ---\n{logs}"
+                    break
+            pytest.fail(
+                f"Timed out waiting for {addr} to become healthy{log_dump or ' (no container logs)'}"
+            )
 
 
 def uid() -> str:

--- a/tests/e2e/docker/test_cc_tasks_share_e2e.py
+++ b/tests/e2e/docker/test_cc_tasks_share_e2e.py
@@ -34,6 +34,7 @@ suite is green; this E2E is the regression guard before that smoke.
 from __future__ import annotations
 
 import concurrent.futures
+import json
 import os
 import subprocess
 import time
@@ -521,6 +522,11 @@ def joined_cluster(topology: CcTasksTopology) -> dict:
                 "NEXUS_CLUSTER_IMAGE", "nexus-local-connector-plugin:latest"
             ),
             network=os.environ.get("NEXUS_CC_TASKS_NETWORK", "nexus-cc-tasks-net"),
+            # nexus-vfs PR #106 — sidecar shares the joiner's identity
+            # volume so `identity::persist_peers` after JoinZone lands
+            # where the main daemon's next boot loads it.  Volume name
+            # matches the compose file's `cc_tasks_joiner_identity`.
+            identity_volume=f"{topology.joiner_container}-identity",
         )
     finally:
         runbook_helpers.docker_start(topology.joiner_container)
@@ -1899,3 +1905,102 @@ class TestSysReaddirObservation:
                 ["rm", "-rf", f"/host/tasks/{session}"],
                 check=False,
             )
+
+
+class TestIdentityPeerPersistence:
+    """Pin nexus-vfs PR #106's identity.json peer-address persistence.
+
+    Regression-protects the S3 cache-loss-recovery foundation: the
+    ``nexusd-cluster join`` sidecar records the leader ``--peer-addr``
+    into ``identity.json`` after JoinZone so subsequent daemon
+    restarts (with ``NEXUS_PEERS`` unset per the entrypoint's
+    ``MODE=restart`` branch) still have a transport-layer seed for
+    the founder.
+
+    Without this pin, silent regressions in ``run_join``'s
+    ``identity::persist_peers`` call, or in ``open_zone_manager``'s
+    identity load, would surface only as "operator wiped data_dir +
+    can't remember peers = daemon stuck" in production — the exact
+    scenario S3 is meant to prevent.
+    """
+
+    def test_joiner_identity_json_contains_founder_peer_after_join(
+        self,
+        topology: CcTasksTopology,
+        joined_cluster: dict,
+    ) -> None:
+        # ── Step 1: joined_cluster fixture (setup) ──────────────────
+        #
+        # The fixture ran the runbook §3b offline
+        # `nexusd-cluster join <founder_id>@founder:2126 sharedzone
+        # /shared` sidecar against the joiner's data + identity
+        # volumes.  Under nexus-vfs PR #106 that CLI call MUST have
+        # invoked `identity::persist_peers` after the JoinZone RPC
+        # committed the AddNode ConfChange.  Fixture also restarted
+        # the joiner daemon, whose `open_zone_manager` boot path
+        # separately calls `identity::load` + `persist_peers` on the
+        # CLI peer set — the persisted union survives across both.
+        founder_node_id = joined_cluster["founder_node_id"]
+
+        # ── Step 2: read joiner's identity.json (the causal output) ─
+        #
+        # The compose mounts `cc_tasks_joiner_identity` at
+        # `/app/identity` on the joiner service AND on the sidecar,
+        # matching `NEXUS_IDENTITY_DIR`.  A container-level `cat`
+        # avoids depending on the joiner's Python runtime being
+        # importable — this test is a substrate-level regression
+        # pin, not a service-tier flow.
+        cat_result = runbook_helpers.docker_exec(
+            topology.joiner_container,
+            ["cat", "/app/identity/identity.json"],
+        )
+        assert cat_result.rc == 0, (
+            f"joiner's /app/identity/identity.json missing (rc={cat_result.rc}). "
+            f"Either the compose volume mount or the sidecar's "
+            f"`identity::persist_peers` write is broken. "
+            f"stderr={cat_result.stderr!r}"
+        )
+        try:
+            identity = json.loads(cat_result.stdout)
+        except json.JSONDecodeError as e:
+            pytest.fail(
+                f"joiner's /app/identity/identity.json is not valid JSON "
+                f"({e}). The sidecar's `identity::persist_peers` either "
+                f"failed to write or wrote a schema this test does not "
+                f"understand. Raw content: {cat_result.stdout!r}"
+            )
+
+        # ── Step 3: schema + persisted-peer content assertions ──────
+        #
+        # Schema version pinned by `SCHEMA_VERSION` in
+        # `rust/raft/src/identity.rs`; a mismatch means either an
+        # intentional schema bump (update this test) or an accidental
+        # rollback (fix the code).  The peer entry must be present
+        # exactly as `NodeAddress::to_raft_peer_str()` renders it —
+        # `<node_id>@<host>:<port>` — because that's how
+        # `NodeAddress::parse_peer_list` at boot expects to consume
+        # it.
+        assert identity.get("schema_version") == 1, (
+            f"identity schema_version mismatch: expected 1, got "
+            f"{identity.get('schema_version')!r}. Full identity: {identity!r}"
+        )
+        peers = identity.get("peers")
+        assert isinstance(peers, list), (
+            f"identity.peers must be a list, got {type(peers).__name__}: {peers!r}"
+        )
+        # `founder_node_id` is the u64 raft ID minted at founder's
+        # first boot (`read_or_mint_node_id` — the SSOT for this
+        # value).  The sidecar was invoked with
+        # `<founder_id>@founder:2126`, so identity's peer entry MUST
+        # reference the same id AND the founder container's raft
+        # endpoint hostname:port.  This proves
+        # `identity::persist_peers` received the exact peer string
+        # the sidecar's CLI parsed — no silent truncation or
+        # substitution somewhere in the path.
+        founder_peer = f"{founder_node_id}@{topology.founder_grpc}"
+        assert founder_peer in peers, (
+            f"identity.peers does not contain the founder peer "
+            f"{founder_peer!r}. The sidecar's `identity::persist_peers` "
+            f"either did not run, wrote to the wrong path, or wrote a "
+            f"different peer string. Full identity.peers={peers!r}"
+        )


### PR DESCRIPTION
## Summary

Companion PR to nexus-vfs #106 (identity.json peer address book).
Bumps the pin + adds the substrate-level regression pin so a future
regression in `run_join::identity::persist_peers` or
`open_zone_manager::identity::load` surfaces in CI instead of
production.

## Pin bump

- `nexus-vfs` → `a52f13015` (PR #106)
- Cargo.toml + Cargo.lock + Dockerfile + Dockerfile.raft-server +
  Dockerfile.raft-witness + Dockerfile.minimal + auto-plugin-release.yml

## E2E regression pin

`TestIdentityPeerPersistence::test_joiner_identity_json_contains_founder_peer_after_join`

- 3-step causal chain per integration-test-generator standards:
  1. `joined_cluster` fixture → sidecar `nexusd-cluster join
     <founder_id>@founder:2126 sharedzone /shared` writes to
     joiner's identity volume.
  2. `docker exec joiner cat /app/identity/identity.json`.
  3. Assert `schema_version == 1` + peers list contains
     `<founder_node_id>@founder:2126` (exact
     `NodeAddress::to_raft_peer_str()` output).
- Would catch: `persist_peers` no-op regression, wrong-path load,
  schema drift, silent truncation.

## Infrastructure

- `docker-compose.cc-tasks-share.yml`: adds
  `NEXUS_IDENTITY_DIR=/app/identity` env + dedicated
  `cc_tasks_joiner_identity` volume on the joiner service.
- `runbook_helpers.run_nexusd_cluster_join`: new optional
  `identity_volume` + `identity_dir` params so the transient
  sidecar container mounts the same volume + gets the same
  `NEXUS_IDENTITY_DIR` env as the target daemon.  Backward-compat:
  omit both to skip the identity mount (existing federation-runbook
  tests unaffected).
- `joined_cluster` fixture passes the identity volume through.

## Test plan

- [x] `cargo check --workspace` on new pin — clean
- [ ] Docker E2E `test_cc_tasks_share_e2e.py::TestIdentityPeerPersistence`
  runs in CI (cc-tasks-share workflow)
- [ ] All other existing tests continue to pass — the sidecar's
  `identity_volume` param is optional and defaults skip identity
  mount, so federation-runbook + audit suites are unaffected