### PR TITLE
chore(deps): nexus-vfs pin bump — sys_readdir peer-shared fan-out (PR #108)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=46c61f7855f418bd28a58d9ac4e32612c0d21d8f#46c61f7855f418bd28a58d9ac4e32612c0d21d8f"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=1ec7f7620d0a94d409a0c2298b51db55c4a6396b#1ec7f7620d0a94d409a0c2298b51db55c4a6396b"
 dependencies = [
  "ahash",
  "base64",
@@ -550,7 +550,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=46c61f7855f418bd28a58d9ac4e32612c0d21d8f#46c61f7855f418bd28a58d9ac4e32612c0d21d8f"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=1ec7f7620d0a94d409a0c2298b51db55c4a6396b#1ec7f7620d0a94d409a0c2298b51db55c4a6396b"
 dependencies = [
  "parking_lot",
  "serde",
@@ -1334,7 +1334,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=46c61f7855f418bd28a58d9ac4e32612c0d21d8f#46c61f7855f418bd28a58d9ac4e32612c0d21d8f"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=1ec7f7620d0a94d409a0c2298b51db55c4a6396b#1ec7f7620d0a94d409a0c2298b51db55c4a6396b"
 dependencies = [
  "ahash",
  "base64",
@@ -1385,7 +1385,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=46c61f7855f418bd28a58d9ac4e32612c0d21d8f#46c61f7855f418bd28a58d9ac4e32612c0d21d8f"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=1ec7f7620d0a94d409a0c2298b51db55c4a6396b#1ec7f7620d0a94d409a0c2298b51db55c4a6396b"
 dependencies = [
  "ahash",
  "base64",
@@ -1580,7 +1580,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=46c61f7855f418bd28a58d9ac4e32612c0d21d8f#46c61f7855f418bd28a58d9ac4e32612c0d21d8f"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=1ec7f7620d0a94d409a0c2298b51db55c4a6396b#1ec7f7620d0a94d409a0c2298b51db55c4a6396b"
 
 [[package]]
 name = "nexus-vault"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,8 +30,17 @@ exclude = ["nexus-fuse"]
 [workspace.dependencies]
 # Kernel-tier crates from nexus-vfs (external git dependency).
 # SSOT: https://github.com/nexi-lab/nexus-vfs
-# Pinned at the nexus-vfs commit that landed PR #106 + #107
-# (46c61f785, 2026-07-02): PR #106 identity.json persists the raft
+# Pinned at the nexus-vfs commit that landed PR #106 + #107 + #108
+# (1ec7f7620, 2026-07-02): PR #108 extends the try_remote_fetch
+# "sender dispatches, remote handles" pattern from sys_read to
+# sys_readdir.  Direction B of the peer-shared topology (Mac lists
+# Win's session UUID Mac has never observed) now returns peer-side
+# entries without an operator-side warm-up ceremony.  Additive:
+# sys_readdir public API unchanged; new sys_readdir_peer_dispatch
+# variant exists for the fan-out loop guard on peer-facing gRPC
+# handlers.  ReaddirRequest gets a from_peer field (backward-compat
+# additive) so 3+ node topologies terminate at the first hop.
+# PR #106 identity.json persists the raft
 # transport peer address book at platform-native user-data path
 # (%LOCALAPPDATA%\Nexus, ~/Library/Application Support/Nexus,
 # $XDG_DATA_HOME/nexus).  Boot merges CLI --peers with the
@@ -136,13 +145,13 @@ exclude = ["nexus-fuse"]
 #
 # Bump alongside the rest of nexus-vfs updates when a downstream
 # change needs newer kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "46c61f7855f418bd28a58d9ac4e32612c0d21d8f" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "46c61f7855f418bd28a58d9ac4e32612c0d21d8f" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "46c61f7855f418bd28a58d9ac4e32612c0d21d8f" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "46c61f7855f418bd28a58d9ac4e32612c0d21d8f", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "46c61f7855f418bd28a58d9ac4e32612c0d21d8f", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "46c61f7855f418bd28a58d9ac4e32612c0d21d8f", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "46c61f7855f418bd28a58d9ac4e32612c0d21d8f" }
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "1ec7f7620d0a94d409a0c2298b51db55c4a6396b" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "1ec7f7620d0a94d409a0c2298b51db55c4a6396b" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "1ec7f7620d0a94d409a0c2298b51db55c4a6396b" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "1ec7f7620d0a94d409a0c2298b51db55c4a6396b", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "1ec7f7620d0a94d409a0c2298b51db55c4a6396b", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "1ec7f7620d0a94d409a0c2298b51db55c4a6396b", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "1ec7f7620d0a94d409a0c2298b51db55c4a6396b" }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ENV CARGO_NET_RETRY=10 \
     CARGO_HTTP_TIMEOUT=120
 # Override for edge/CI or a different pin: --build-arg NEXUS_VFS_REV=<sha|tag>
-ARG NEXUS_VFS_REV=46c61f7855f418bd28a58d9ac4e32612c0d21d8f
+ARG NEXUS_VFS_REV=1ec7f7620d0a94d409a0c2298b51db55c4a6396b
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,id=cargo-install-${TARGETARCH},target=/root/.cargo/target \

--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir --no-deps --prefix=/install .
 # enforces agreement) — an unpinned install tracks nexus-vfs HEAD and
 # ships an untested kernel (#4343). --locked honors the source tree's
 # Cargo.lock.
-ARG NEXUS_VFS_REV=46c61f7855f418bd28a58d9ac4e32612c0d21d8f
+ARG NEXUS_VFS_REV=1ec7f7620d0a94d409a0c2298b51db55c4a6396b
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-cluster nexus-cluster
 
 # -- Runtime stage --

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -25,7 +25,7 @@ WORKDIR /build
 # (CI preflight enforces agreement) — an unpinned install tracks HEAD
 # and can skew the raft contract against the cluster/witness images.
 # --locked honors the source tree's Cargo.lock.
-ARG NEXUS_VFS_REV=46c61f7855f418bd28a58d9ac4e32612c0d21d8f
+ARG NEXUS_VFS_REV=1ec7f7620d0a94d409a0c2298b51db55c4a6396b
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexus-raft-server raft
 
 # ---------- Production image ----------

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=46c61f7855f418bd28a58d9ac4e32612c0d21d8f
+ARG NEXUS_VFS_REV=1ec7f7620d0a94d409a0c2298b51db55c4a6396b
 RUN cargo install \
     --locked \
     --git https://github.com/nexi-lab/nexus-vfs \


### PR DESCRIPTION
## Summary

Companion PR to nexus-vfs #108.  Bumps the pin so downstream Docker E2E
runs against the new sys_readdir fan-out contract.  No E2E test
additions on this PR — see Test plan for the rationale.

## What changes for downstream

- `Kernel::sys_readdir(path, zone, is_admin)` — public signature
  unchanged.  Behavior on federated zones now falls back to
  `peer_list_dir` when local metastore + backend produce nothing.
- New `Kernel::sys_readdir_peer_dispatch(path, zone, is_admin)` —
  loop guard for peer-facing gRPC handlers.  Not called from
  service tier; kernel-internal use only via the readdir gRPC
  handler routing.
- Proto: `ReaddirRequest.from_peer = 4` (backward-compat additive).
  Existing service-tier callers that don't set this field default
  to `false`, preserving today's fan-out semantics.

## Regression coverage

- Existing hostname-namespaced cc-tasks-share tests
  (`TestCcTasksListBackendOnlyCrossNodeEnumeration`, etc.) exercise
  the pre-peer-shared federation-peer-mount path where the joiner
  has NO local backend at the peer's sub-path.  Under this shape,
  `via_federation_readdir` fires (backend is None) and populates
  `seen` — my new fan-out short-circuits on `!seen.is_empty()`, so
  the old path stays fully authoritative.  No regression expected.
- Kernel-level unit pins on nexus-vfs side cover the peer-shared
  Direction B fan-out contract (see nexus-vfs #108).

## Direction B Docker E2E deferred

Adding a peer-shared Direction B Docker E2E requires a compose
topology refactor (both nodes mounting at the SAME VFS path with
own LocalConnectors), which is task #45's scope in the plan.  That
change touches the compose entrypoint (multi-`--mount-driver`
support) plus adds a new test class independent of the existing
hostname-namespaced tests.  Doing it in this PR would sprawl beyond
one concern.

## Test plan

- [x] `cargo check --workspace` clean on new pin
- [ ] Existing cc-tasks-share E2E (Docker) passes — regression pin
      for hostname-namespaced fan-out path
- [ ] Federation E2E (Docker) passes
- [ ] All other CI checks green