### PR TITLE
chore(deps): nexus-vfs pin bump — retire operator id@host:port form (#109)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=1ec7f7620d0a94d409a0c2298b51db55c4a6396b#1ec7f7620d0a94d409a0c2298b51db55c4a6396b"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=d7bb896e22788ebf02868c2dec01249d7040763d#d7bb896e22788ebf02868c2dec01249d7040763d"
 dependencies = [
  "ahash",
  "base64",
@@ -550,7 +550,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=1ec7f7620d0a94d409a0c2298b51db55c4a6396b#1ec7f7620d0a94d409a0c2298b51db55c4a6396b"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=d7bb896e22788ebf02868c2dec01249d7040763d#d7bb896e22788ebf02868c2dec01249d7040763d"
 dependencies = [
  "parking_lot",
  "serde",
@@ -1334,7 +1334,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=1ec7f7620d0a94d409a0c2298b51db55c4a6396b#1ec7f7620d0a94d409a0c2298b51db55c4a6396b"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=d7bb896e22788ebf02868c2dec01249d7040763d#d7bb896e22788ebf02868c2dec01249d7040763d"
 dependencies = [
  "ahash",
  "base64",
@@ -1385,7 +1385,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=1ec7f7620d0a94d409a0c2298b51db55c4a6396b#1ec7f7620d0a94d409a0c2298b51db55c4a6396b"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=d7bb896e22788ebf02868c2dec01249d7040763d#d7bb896e22788ebf02868c2dec01249d7040763d"
 dependencies = [
  "ahash",
  "base64",
@@ -1580,7 +1580,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=1ec7f7620d0a94d409a0c2298b51db55c4a6396b#1ec7f7620d0a94d409a0c2298b51db55c4a6396b"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=d7bb896e22788ebf02868c2dec01249d7040763d#d7bb896e22788ebf02868c2dec01249d7040763d"
 
 [[package]]
 name = "nexus-vault"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,8 +30,20 @@ exclude = ["nexus-fuse"]
 [workspace.dependencies]
 # Kernel-tier crates from nexus-vfs (external git dependency).
 # SSOT: https://github.com/nexi-lab/nexus-vfs
-# Pinned at the nexus-vfs commit that landed PR #106 + #107 + #108
-# (1ec7f7620, 2026-07-02): PR #108 extends the try_remote_fetch
+# Pinned at the nexus-vfs commit that landed PR #106 + #107 + #108 + #109
+# (d7bb896e2, 2026-07-02): PR #109 retires the legacy `<id>@host:port`
+# peer address form at the operator boundary via an SRP split —
+# `PeerAddress::parse_operator_addr` (used by --peers, NEXUS_PEERS,
+# `nexusd-cluster join <peer_addr>`, identity.json load) hard-rejects
+# `@` with a migration message; `PeerAddress::parse` (raft-internal
+# round-trip: create_zone address-book keying, founder self-registration,
+# ConfChange context) keeps the dual-form accept for the authoritative-id
+# round-trips it relies on.  Identity persistence uses `to_operator_str`
+# (bare `host:port`) so subsequent cold-boot load never trips the
+# id-prefix rejection.  Operators no longer sync opaque node_ids between
+# peers — `nexusd-cluster join <host:port> <zone> <path>` is the ONE
+# accepted shape.
+# PR #108 extends the try_remote_fetch
 # "sender dispatches, remote handles" pattern from sys_read to
 # sys_readdir.  Direction B of the peer-shared topology (Mac lists
 # Win's session UUID Mac has never observed) now returns peer-side
@@ -145,13 +157,13 @@ exclude = ["nexus-fuse"]
 #
 # Bump alongside the rest of nexus-vfs updates when a downstream
 # change needs newer kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "1ec7f7620d0a94d409a0c2298b51db55c4a6396b" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "1ec7f7620d0a94d409a0c2298b51db55c4a6396b" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "1ec7f7620d0a94d409a0c2298b51db55c4a6396b" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "1ec7f7620d0a94d409a0c2298b51db55c4a6396b", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "1ec7f7620d0a94d409a0c2298b51db55c4a6396b", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "1ec7f7620d0a94d409a0c2298b51db55c4a6396b", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "1ec7f7620d0a94d409a0c2298b51db55c4a6396b" }
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "d7bb896e22788ebf02868c2dec01249d7040763d" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "d7bb896e22788ebf02868c2dec01249d7040763d" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "d7bb896e22788ebf02868c2dec01249d7040763d" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "d7bb896e22788ebf02868c2dec01249d7040763d", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "d7bb896e22788ebf02868c2dec01249d7040763d", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "d7bb896e22788ebf02868c2dec01249d7040763d", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "d7bb896e22788ebf02868c2dec01249d7040763d" }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ENV CARGO_NET_RETRY=10 \
     CARGO_HTTP_TIMEOUT=120
 # Override for edge/CI or a different pin: --build-arg NEXUS_VFS_REV=<sha|tag>
-ARG NEXUS_VFS_REV=1ec7f7620d0a94d409a0c2298b51db55c4a6396b
+ARG NEXUS_VFS_REV=d7bb896e22788ebf02868c2dec01249d7040763d
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,id=cargo-install-${TARGETARCH},target=/root/.cargo/target \

--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir --no-deps --prefix=/install .
 # enforces agreement) — an unpinned install tracks nexus-vfs HEAD and
 # ships an untested kernel (#4343). --locked honors the source tree's
 # Cargo.lock.
-ARG NEXUS_VFS_REV=1ec7f7620d0a94d409a0c2298b51db55c4a6396b
+ARG NEXUS_VFS_REV=d7bb896e22788ebf02868c2dec01249d7040763d
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-cluster nexus-cluster
 
 # -- Runtime stage --

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -25,7 +25,7 @@ WORKDIR /build
 # (CI preflight enforces agreement) — an unpinned install tracks HEAD
 # and can skew the raft contract against the cluster/witness images.
 # --locked honors the source tree's Cargo.lock.
-ARG NEXUS_VFS_REV=1ec7f7620d0a94d409a0c2298b51db55c4a6396b
+ARG NEXUS_VFS_REV=d7bb896e22788ebf02868c2dec01249d7040763d
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexus-raft-server raft
 
 # ---------- Production image ----------

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=1ec7f7620d0a94d409a0c2298b51db55c4a6396b
+ARG NEXUS_VFS_REV=d7bb896e22788ebf02868c2dec01249d7040763d
 RUN cargo install \
     --locked \
     --git https://github.com/nexi-lab/nexus-vfs \

--- a/tests/e2e/docker/runbook_helpers.py
+++ b/tests/e2e/docker/runbook_helpers.py
@@ -763,7 +763,12 @@ def run_nexusd_cluster_join(
             "nexusd-cluster",
             image,
             "join",
-            f"{founder_node_id}@{founder_addr}",
+            # Bare `host:port` is the ONLY accepted operator-facing
+            # form post nexus-vfs #109.  `founder_node_id` is unused
+            # by the CLI (kept as a keyword arg for source-diff-
+            # compat; the daemon learns founder's real id from the
+            # first inbound raft message via `learn_peer_address`).
+            founder_addr,
             zone_id,
             local_path,
             "--data-dir",

--- a/tests/e2e/docker/test_cc_tasks_share_e2e.py
+++ b/tests/e2e/docker/test_cc_tasks_share_e2e.py
@@ -1975,11 +1975,14 @@ class TestIdentityPeerPersistence:
         # Schema version pinned by `SCHEMA_VERSION` in
         # `rust/raft/src/identity.rs`; a mismatch means either an
         # intentional schema bump (update this test) or an accidental
-        # rollback (fix the code).  The peer entry must be present
-        # exactly as `NodeAddress::to_raft_peer_str()` renders it —
-        # `<node_id>@<host>:<port>` — because that's how
-        # `NodeAddress::parse_peer_list` at boot expects to consume
-        # it.
+        # rollback (fix the code).  Identity peer entries are the
+        # operator-facing `host:port` shape post nexus-vfs #109 —
+        # `NodeAddress::to_operator_str` serializes without the
+        # `<node_id>@` prefix so subsequent cold-boot load through
+        # `parse_operator_addr` never trips the id-prefix rejection.
+        # The daemon still learns the founder's real node_id at
+        # runtime via `learn_peer_address` on the first inbound raft
+        # message — it never needs to be encoded in the address book.
         assert identity.get("schema_version") == 1, (
             f"identity schema_version mismatch: expected 1, got "
             f"{identity.get('schema_version')!r}. Full identity: {identity!r}"
@@ -1988,19 +1991,17 @@ class TestIdentityPeerPersistence:
         assert isinstance(peers, list), (
             f"identity.peers must be a list, got {type(peers).__name__}: {peers!r}"
         )
-        # `founder_node_id` is the u64 raft ID minted at founder's
-        # first boot (`read_or_mint_node_id` — the SSOT for this
-        # value).  The sidecar was invoked with
-        # `<founder_id>@founder:2126`, so identity's peer entry MUST
-        # reference the same id AND the founder container's raft
-        # endpoint hostname:port.  This proves
-        # `identity::persist_peers` received the exact peer string
-        # the sidecar's CLI parsed — no silent truncation or
-        # substitution somewhere in the path.
-        founder_peer = f"{founder_node_id}@{topology.founder_grpc}"
+        # Founder peer entry = bare `host:port` (topology.founder_grpc).
+        # `founder_node_id` is still fetched via `joined_cluster` above
+        # so a schema regression that ever re-introduces id encoding
+        # surfaces here as an inequality (kept in the debug output for
+        # diagnosis, not part of the expected value).
+        _ = founder_node_id
+        founder_peer = topology.founder_grpc
         assert founder_peer in peers, (
             f"identity.peers does not contain the founder peer "
             f"{founder_peer!r}. The sidecar's `identity::persist_peers` "
             f"either did not run, wrote to the wrong path, or wrote a "
-            f"different peer string. Full identity.peers={peers!r}"
+            f"different peer string.  Full identity.peers={peers!r} "
+            f"(founder_node_id={founder_node_id})"
         )


### PR DESCRIPTION
## Summary

Pin bump for nexus-vfs #109 — operator-facing `<id>@host:port` peer
address form retired via an SRP split of `PeerAddress::parse`.  No
downstream code touched: internal raft round-trip through
`to_raft_peer_str`/`parse` stays intact; operator surface goes through
`parse_operator_addr` which hard-rejects `@` with a migration message.

## Operator migration

- `NEXUS_PEERS=1@nexus-1:2126` → `NEXUS_PEERS=nexus-1:2126`
- `nexusd-cluster join 2@bob:2126 sharedzone /shared` →
  `nexusd-cluster join bob:2126 sharedzone /shared`
- `identity.json` entries are re-serialized in bare form on the next
  identity persist call (which fires on any successful `nexusd-cluster
  join` sidecar or main-daemon boot with `--peers` provided).

## Test plan

- [x] `cargo check --workspace` clean on new pin
- [ ] All existing CI checks pass — no behaviour change on any
      downstream code path.  The split is entry-point / doc work at
      the peer parse layer + a companion strict variant used by CLI
      + env parsing.  Docker E2E paths (federation-runbook,
      cc-tasks-share) already use bare `host:port` shapes so the new
      strict variant is a no-op there.

## Follow-up

Once Mac AI is unpaused, the `nexusd-cluster join <host:port>` shape
they'll invoke against Win exercises this exact path end-to-end via
Tailscale — that's the ultimate acceptance for the operator UX.