### PR TITLE
chore(deps): bump nexus-vfs to 3c8e6f362 (PR #110 peer-identity leak-class closure)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,9 +138,9 @@ checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "async-trait"
@@ -218,7 +218,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=d7bb896e22788ebf02868c2dec01249d7040763d#d7bb896e22788ebf02868c2dec01249d7040763d"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=3c8e6f36221161592325af000d126050ab97b0b3#3c8e6f36221161592325af000d126050ab97b0b3"
 dependencies = [
  "ahash",
  "base64",
@@ -289,7 +289,7 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "itertools",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -550,7 +550,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=d7bb896e22788ebf02868c2dec01249d7040763d#d7bb896e22788ebf02868c2dec01249d7040763d"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=3c8e6f36221161592325af000d126050ab97b0b3#3c8e6f36221161592325af000d126050ab97b0b3"
 dependencies = [
  "parking_lot",
  "serde",
@@ -1259,7 +1259,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -1315,6 +1315,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1334,7 +1343,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=d7bb896e22788ebf02868c2dec01249d7040763d#d7bb896e22788ebf02868c2dec01249d7040763d"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=3c8e6f36221161592325af000d126050ab97b0b3#3c8e6f36221161592325af000d126050ab97b0b3"
 dependencies = [
  "ahash",
  "base64",
@@ -1385,7 +1394,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=d7bb896e22788ebf02868c2dec01249d7040763d#d7bb896e22788ebf02868c2dec01249d7040763d"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=3c8e6f36221161592325af000d126050ab97b0b3#3c8e6f36221161592325af000d126050ab97b0b3"
 dependencies = [
  "ahash",
  "base64",
@@ -1580,7 +1589,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=d7bb896e22788ebf02868c2dec01249d7040763d#d7bb896e22788ebf02868c2dec01249d7040763d"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=3c8e6f36221161592325af000d126050ab97b0b3#3c8e6f36221161592325af000d126050ab97b0b3"
 
 [[package]]
 name = "nexus-vault"
@@ -1887,7 +1896,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph",
@@ -1908,7 +1917,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -2197,9 +2206,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
 dependencies = [
  "zeroize",
 ]
@@ -2572,9 +2581,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.51"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85c17d80feb7334b40c484e45ed1a5273dfd8bfda537c3be2e74a06a6686f327"
+checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
 dependencies = [
  "deranged",
  "num-conv",
@@ -2592,9 +2601,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.30"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcef1a61bdb119096e153208ec5cbec23944ce8bca13be5c7f60c634f7403935"
+checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
 dependencies = [
  "num-conv",
  "time-core",
@@ -3033,7 +3042,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
  "windows-collections",
- "windows-core",
+ "windows-core 0.61.2",
  "windows-future",
  "windows-link 0.1.3",
  "windows-numerics",
@@ -3045,7 +3054,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
- "windows-core",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -3057,8 +3066,21 @@ dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-link 0.1.3",
- "windows-result",
- "windows-strings",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]
@@ -3067,7 +3089,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
- "windows-core",
+ "windows-core 0.61.2",
  "windows-link 0.1.3",
  "windows-threading",
 ]
@@ -3112,7 +3134,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
- "windows-core",
+ "windows-core 0.61.2",
  "windows-link 0.1.3",
 ]
 
@@ -3126,12 +3148,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "windows-strings"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -3261,9 +3301,9 @@ dependencies = [
 
 [[package]]
 name = "xxhash-rust"
-version = "0.8.15"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
+checksum = "4d93c89cdc2d3a63c3ec48ffe926931bdc069eafa8e4402fe6d8f790c9d1e576"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,8 +30,18 @@ exclude = ["nexus-fuse"]
 [workspace.dependencies]
 # Kernel-tier crates from nexus-vfs (external git dependency).
 # SSOT: https://github.com/nexi-lab/nexus-vfs
-# Pinned at the nexus-vfs commit that landed PR #106 + #107 + #108 + #109
-# (d7bb896e2, 2026-07-02): PR #109 retires the legacy `<id>@host:port`
+# Pinned at the nexus-vfs commit that landed PR #106 + #107 + #108 + #109 + #110
+# (3c8e6f362, 2026-07-03): PR #110 closes the user-observable peer-identity
+# leak class (6 commits): joiner seed_peers log emits bare host:port;
+# SOLO invariant + non-resumable recovery errors use operator peer form;
+# tracing/message-format node_id renamed to local_node_id / peer_node_id
+# (incl. boot log `Zone 'root' registered (local_node_id=N, peers=P)`);
+# to_raft_peer_str / to_operator_str / Display docstrings codify the SRP
+# boundary; RaftError::NotLeader.leader_hint hard-renames from
+# Option<u64> to Option<String> (operator-form host:port), removing the
+# raw-id-in-Display leak at the type-system layer; unit-test regression
+# pin asserts Display never embeds a ≥10-digit bare integer.
+# PR #109 retires the legacy `<id>@host:port`
 # peer address form at the operator boundary via an SRP split —
 # `PeerAddress::parse_operator_addr` (used by --peers, NEXUS_PEERS,
 # `nexusd-cluster join <peer_addr>`, identity.json load) hard-rejects
@@ -157,13 +167,13 @@ exclude = ["nexus-fuse"]
 #
 # Bump alongside the rest of nexus-vfs updates when a downstream
 # change needs newer kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "d7bb896e22788ebf02868c2dec01249d7040763d" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "d7bb896e22788ebf02868c2dec01249d7040763d" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "d7bb896e22788ebf02868c2dec01249d7040763d" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "d7bb896e22788ebf02868c2dec01249d7040763d", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "d7bb896e22788ebf02868c2dec01249d7040763d", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "d7bb896e22788ebf02868c2dec01249d7040763d", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "d7bb896e22788ebf02868c2dec01249d7040763d" }
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "3c8e6f36221161592325af000d126050ab97b0b3" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "3c8e6f36221161592325af000d126050ab97b0b3" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "3c8e6f36221161592325af000d126050ab97b0b3" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "3c8e6f36221161592325af000d126050ab97b0b3", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "3c8e6f36221161592325af000d126050ab97b0b3", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "3c8e6f36221161592325af000d126050ab97b0b3", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "3c8e6f36221161592325af000d126050ab97b0b3" }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ENV CARGO_NET_RETRY=10 \
     CARGO_HTTP_TIMEOUT=120
 # Override for edge/CI or a different pin: --build-arg NEXUS_VFS_REV=<sha|tag>
-ARG NEXUS_VFS_REV=d7bb896e22788ebf02868c2dec01249d7040763d
+ARG NEXUS_VFS_REV=3c8e6f36221161592325af000d126050ab97b0b3
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,id=cargo-install-${TARGETARCH},target=/root/.cargo/target \

--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir --no-deps --prefix=/install .
 # enforces agreement) — an unpinned install tracks nexus-vfs HEAD and
 # ships an untested kernel (#4343). --locked honors the source tree's
 # Cargo.lock.
-ARG NEXUS_VFS_REV=d7bb896e22788ebf02868c2dec01249d7040763d
+ARG NEXUS_VFS_REV=3c8e6f36221161592325af000d126050ab97b0b3
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-cluster nexus-cluster
 
 # -- Runtime stage --

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -25,7 +25,7 @@ WORKDIR /build
 # (CI preflight enforces agreement) — an unpinned install tracks HEAD
 # and can skew the raft contract against the cluster/witness images.
 # --locked honors the source tree's Cargo.lock.
-ARG NEXUS_VFS_REV=d7bb896e22788ebf02868c2dec01249d7040763d
+ARG NEXUS_VFS_REV=3c8e6f36221161592325af000d126050ab97b0b3
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexus-raft-server raft
 
 # ---------- Production image ----------

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=d7bb896e22788ebf02868c2dec01249d7040763d
+ARG NEXUS_VFS_REV=3c8e6f36221161592325af000d126050ab97b0b3
 RUN cargo install \
     --locked \
     --git https://github.com/nexi-lab/nexus-vfs \

--- a/tests/e2e/docker/runbook_helpers.py
+++ b/tests/e2e/docker/runbook_helpers.py
@@ -658,19 +658,23 @@ def docker_logs(container: str, *, tail: int = 1000, since: str | None = None) -
     return (proc.stdout or "") + (proc.stderr or "")
 
 
-_NODE_ID_LOG_RE = re.compile(r"Zone 'root' registered \(node_id=(\d+)")
+_NODE_ID_LOG_RE = re.compile(r"Zone 'root' registered \(local_node_id=(\d+)")
 
 
 def fetch_node_id(container: str, *, timeout: float = 30) -> int:
     """Extract the daemon's opaque node_id from its boot log.
 
     Mirrors the runbook §3b operator step verbatim: "Wait for:
-    `Zone 'root' registered (node_id=<A_node_id>, peers=1)`".  That
-    log line is the user-facing contract for "what's this node's id";
-    the on-disk `.node_id` file is a Rust-internal `u64::to_le_bytes()`
-    binary detail that the runbook itself never inspects.  Reading the
-    log keeps the test aligned with the operator's vantage point and
-    insulated from persistence-format changes.
+    `Zone 'root' registered (local_node_id=<A_node_id>, peers=1)`".
+    The `local_node_id` prefix (renamed from `node_id` in the
+    peer-identity-surface refactor) disambiguates this node's own id
+    from a `peer_node_id` field that names a remote peer — the two
+    concepts previously shared the same field name and caused
+    operator/AI misdiagnosis under n>2 topologies.  The on-disk
+    `.node_id` file is a Rust-internal `u64::to_le_bytes()` binary
+    detail the runbook itself never inspects.  Reading the log keeps
+    the test aligned with the operator's vantage point and insulated
+    from persistence-format changes.
     """
     deadline = time.time() + timeout
     while time.time() < deadline:
@@ -680,8 +684,8 @@ def fetch_node_id(container: str, *, timeout: float = 30) -> int:
             return int(m.group(1))
         time.sleep(1)
     pytest.fail(
-        f"Could not find `Zone 'root' registered (node_id=...)` in "
-        f"{container} logs within {timeout}s; daemon may not have "
+        f"Could not find `Zone 'root' registered (local_node_id=...)` "
+        f"in {container} logs within {timeout}s; daemon may not have "
         f"completed root-zone bootstrap."
     )
 


### PR DESCRIPTION
## Summary

Companion to nexus-vfs PR #110 (merged as \`3c8e6f362\`).  Two concerns, two commits:

- **\`test(e2e): match renamed 'local_node_id=' boot log line\`** — updates \`runbook_helpers._NODE_ID_LOG_RE\` regex + docstrings to match the renamed boot log line \`Zone 'root' registered (local_node_id=N, peers=P)\`. The rename came from PR #110's commit 3 (concept-disambiguated \`local_node_id\` vs \`peer_node_id\` under n>2 topologies).
- **\`chore(deps): bump nexus-vfs pin to 3c8e6f362 (PR #110 peer-identity surface)\`** — Cargo.toml + Cargo.lock + all Dockerfiles (Dockerfile, Dockerfile.minimal, Dockerfile.raft-server, Dockerfile.raft-witness) to the new SHA.  Also updates the Cargo.toml pin-explanation header with the full PR #110 changelog.

## What PR #110 shipped

Six commits, ~198 LOC net on nexus-vfs (all green CI at the pinned SHA):

1. \`joiner_local_zone_peer_seeds\` log field emits bare \`host:port\` (via new _display projection; raft-internal seed list unchanged).
2. SOLO invariant, static+peers reject, and non-resumable recovery errors echo bare \`host:port\` peer form + drop the retired \`<leader_id>@<addr>\` CLI-argument shape.
3. Tracing/message-format \`node_id\` renamed to \`local_node_id\` vs \`peer_node_id\` by concept.  Includes the boot log line this PR's regex tracks.
4. \`to_raft_peer_str\` / \`to_operator_str\` / \`Display\` docstrings codify the SRP boundary.
5. \`RaftError::NotLeader.leader_hint\` hard-renames \`Option<u64>\` → \`Option<String>\` (operator-form \`host:port\`).  Removes leak class at the type-system layer.
6. Unit test asserts \`NotLeader\` Display never embeds a ≥10-digit bare integer.

No wire-format changes; kernel syscall ABI unchanged; plugin ABI unchanged; raft Command contracts unchanged.

## Verification

- \`cargo check --workspace\` green locally with the new pin.
- \`_NODE_ID_LOG_RE\` regex tested to match a synthetic post-#110 log line.
- Language-boundary grep across \`nexus/\` Python + YAML + Markdown for the retired \`node_id=\` boot log pattern: only \`runbook_helpers.py\` matched; all three sites migrated in commit 1.

## Test plan

- [ ] CI: Federation E2E (Docker) green
- [ ] CI: cc-tasks-share E2E (Docker) green
- [ ] CI: nexusd-cluster Smoke green
- [ ] CI: Self-Contained E2E green
- [ ] CI: all standard pre-commit / lint / typecheck gates green

Ref: nexus-vfs PR #110, memory \`feedback_user_observable_field_naming\` (new — captures the "don't reuse ambiguous identity field names" discipline this landing distills).