### PR TITLE
docs(runbook) + chore(deps): reflect + pin nexus-vfs peer-identity closure (PR #111)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=3c8e6f36221161592325af000d126050ab97b0b3#3c8e6f36221161592325af000d126050ab97b0b3"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=e3b1f890152e044d3da14f20f5ce5b166f631aad#e3b1f890152e044d3da14f20f5ce5b166f631aad"
 dependencies = [
  "ahash",
  "base64",
@@ -550,7 +550,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=3c8e6f36221161592325af000d126050ab97b0b3#3c8e6f36221161592325af000d126050ab97b0b3"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=e3b1f890152e044d3da14f20f5ce5b166f631aad#e3b1f890152e044d3da14f20f5ce5b166f631aad"
 dependencies = [
  "parking_lot",
  "serde",
@@ -1343,7 +1343,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=3c8e6f36221161592325af000d126050ab97b0b3#3c8e6f36221161592325af000d126050ab97b0b3"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=e3b1f890152e044d3da14f20f5ce5b166f631aad#e3b1f890152e044d3da14f20f5ce5b166f631aad"
 dependencies = [
  "ahash",
  "base64",
@@ -1394,7 +1394,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=3c8e6f36221161592325af000d126050ab97b0b3#3c8e6f36221161592325af000d126050ab97b0b3"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=e3b1f890152e044d3da14f20f5ce5b166f631aad#e3b1f890152e044d3da14f20f5ce5b166f631aad"
 dependencies = [
  "ahash",
  "base64",
@@ -1589,7 +1589,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=3c8e6f36221161592325af000d126050ab97b0b3#3c8e6f36221161592325af000d126050ab97b0b3"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=e3b1f890152e044d3da14f20f5ce5b166f631aad#e3b1f890152e044d3da14f20f5ce5b166f631aad"
 
 [[package]]
 name = "nexus-vault"
@@ -2163,9 +2163,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc_version"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,8 +30,17 @@ exclude = ["nexus-fuse"]
 [workspace.dependencies]
 # Kernel-tier crates from nexus-vfs (external git dependency).
 # SSOT: https://github.com/nexi-lab/nexus-vfs
-# Pinned at the nexus-vfs commit that landed PR #106 + #107 + #108 + #109 + #110
-# (3c8e6f362, 2026-07-03): PR #110 closes the user-observable peer-identity
+# Pinned at the nexus-vfs commit that landed PR #106 + #107 + #108 + #109 + #110 + #111
+# (e3b1f8901, 2026-07-03): PR #111 completes the audit PR #110 began —
+# 11 additional tracing sites where the field name was ambiguous
+# (`peer = <u64>`, `leader = <u64>`, `node_id = <peer.node_id>`) all
+# renamed to the disambiguated `peer_node_id` / `leader_node_id` +
+# paired `_addr` field where NodeAddress is in scope.  A source-tree
+# regression test walks `rust/raft/src/` at test time and rejects the
+# retired shapes, closing the audit-methodology gap that let #110's
+# manual grep miss these — a future contributor reintroducing
+# `peer = target_id` gets red CI on their PR before merge.
+# PR #110 closes the user-observable peer-identity
 # leak class (6 commits): joiner seed_peers log emits bare host:port;
 # SOLO invariant + non-resumable recovery errors use operator peer form;
 # tracing/message-format node_id renamed to local_node_id / peer_node_id
@@ -167,13 +176,13 @@ exclude = ["nexus-fuse"]
 #
 # Bump alongside the rest of nexus-vfs updates when a downstream
 # change needs newer kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "3c8e6f36221161592325af000d126050ab97b0b3" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "3c8e6f36221161592325af000d126050ab97b0b3" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "3c8e6f36221161592325af000d126050ab97b0b3" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "3c8e6f36221161592325af000d126050ab97b0b3", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "3c8e6f36221161592325af000d126050ab97b0b3", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "3c8e6f36221161592325af000d126050ab97b0b3", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "3c8e6f36221161592325af000d126050ab97b0b3" }
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "e3b1f890152e044d3da14f20f5ce5b166f631aad" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "e3b1f890152e044d3da14f20f5ce5b166f631aad" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "e3b1f890152e044d3da14f20f5ce5b166f631aad" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "e3b1f890152e044d3da14f20f5ce5b166f631aad", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "e3b1f890152e044d3da14f20f5ce5b166f631aad", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "e3b1f890152e044d3da14f20f5ce5b166f631aad", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "e3b1f890152e044d3da14f20f5ce5b166f631aad" }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ENV CARGO_NET_RETRY=10 \
     CARGO_HTTP_TIMEOUT=120
 # Override for edge/CI or a different pin: --build-arg NEXUS_VFS_REV=<sha|tag>
-ARG NEXUS_VFS_REV=3c8e6f36221161592325af000d126050ab97b0b3
+ARG NEXUS_VFS_REV=e3b1f890152e044d3da14f20f5ce5b166f631aad
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,id=cargo-install-${TARGETARCH},target=/root/.cargo/target \

--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir --no-deps --prefix=/install .
 # enforces agreement) — an unpinned install tracks nexus-vfs HEAD and
 # ships an untested kernel (#4343). --locked honors the source tree's
 # Cargo.lock.
-ARG NEXUS_VFS_REV=3c8e6f36221161592325af000d126050ab97b0b3
+ARG NEXUS_VFS_REV=e3b1f890152e044d3da14f20f5ce5b166f631aad
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-cluster nexus-cluster
 
 # -- Runtime stage --

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -25,7 +25,7 @@ WORKDIR /build
 # (CI preflight enforces agreement) — an unpinned install tracks HEAD
 # and can skew the raft contract against the cluster/witness images.
 # --locked honors the source tree's Cargo.lock.
-ARG NEXUS_VFS_REV=3c8e6f36221161592325af000d126050ab97b0b3
+ARG NEXUS_VFS_REV=e3b1f890152e044d3da14f20f5ce5b166f631aad
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexus-raft-server raft
 
 # ---------- Production image ----------

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=3c8e6f36221161592325af000d126050ab97b0b3
+ARG NEXUS_VFS_REV=e3b1f890152e044d3da14f20f5ce5b166f631aad
 RUN cargo install \
     --locked \
     --git https://github.com/nexi-lab/nexus-vfs \

--- a/docs/architecture/federation-cross-machine-runbook.md
+++ b/docs/architecture/federation-cross-machine-runbook.md
@@ -211,7 +211,7 @@ target/release/nexusd-cluster \
 Wait for:
 
 ```
-Zone 'root' registered (node_id=<A_node_id>, peers=1)
+Zone 'root' registered (local_node_id=<A_node_id>, peers=1)
 Zone 'sharedzone' registered ...
 install_mount_apply_cb: slot set parent_zone_id=root
 install_mount_apply_cb: slot set parent_zone_id=sharedzone
@@ -219,7 +219,7 @@ wire_mount: installing distributed locks bound to ROOT zone parent_zone=root mou
 Static topology applied: 1 mounts via raft consensus
 ```
 
-The `Static topology applied` line should land within ~400 ms of `Zone 'root' registered` on a healthy 1-voter founder.  If it takes ~10 s and you see a `Forward to leader failed leader=<A_node_id>` warning in between, you're running a pre-nexus-vfs-#25 binary — rebuild.
+The `Static topology applied` line should land within ~400 ms of `Zone 'root' registered` on a healthy 1-voter founder.  If it takes ~10 s and you see a `Forward to leader failed leader_node_id=<...> leader_addr=<host:port>` warning in between, you're running a pre-nexus-vfs-#25 binary — rebuild.  (Field name convention: `local_node_id` = this daemon; `peer_node_id` / `leader_node_id` = a remote node; `_addr` fields carry the directly pingable `host:port`.  If you see a bare `node_id=<u64>` or `peer=<u64>` in a log line, you're on a pre-#110 binary.)
 
 **3b. Joiner (machine B, first boot)**
 
@@ -563,7 +563,8 @@ It walks every zone subdirectory, reads ConfState + HardState + log indices dire
 | `Zone 'root' registered (peers=1)` then silence | JoinZone went to self or founder unreachable | Check founder is listening on `:2126`; set `NEXUS_HOSTNAME` to the Tailscale IP |
 | `peer list contains self ...` | Self listed in `--peers` | Remove your own IP from `--peers` (PR #4014's other-only contract) |
 | `to_commit X is out of range [last_index 0]` | Stale raft state from a previous session | Wipe data dir on both sides, restart fresh |
-| `not leader, leader hint: None` | Quorum not formed | Ensure both daemons running and connected |
+| `not leader, leader hint: None` | Quorum not formed OR leader address not yet learned | Ensure both daemons running and connected; on cold-boot expect ~1 election cycle before the hint resolves |
+| `not leader, leader hint: Some("<host:port>")` | Local node is a follower; leader is at that address | Retarget the failing operation at the leader (`nexusd-cluster` propose paths auto-forward; direct RPC clients should follow the hint) |
 | `Clamping inbound raft commit hint` | Follower has empty log, leader sending heartbeats | Normal during catch-up; wait for InstallSnapshot |
 | `Cannot start a runtime from within a runtime` | Old pre-#4011 binary | Rebuild against current main |
 | `Cannot drop a runtime in a context where blocking is not allowed` in `run_join` | Pre-nexus-vfs-#23 binary; `zm.mount` called directly from async | Rebuild against current nexus-vfs main |


### PR DESCRIPTION
## Summary

Companion to nexus-vfs PR #111 (merged as \`e3b1f8901\`).  Two commits:

- **\`docs(runbook): reflect local_node_id / peer_node_id / leader_node_id + leader_addr rename\`** — updates \`federation-cross-machine-runbook.md\` to reflect the boot-log line rename (\`Zone 'root' registered (local_node_id=...)\`), the forward-to-leader troubleshooting example (now shows \`leader_node_id=<...> leader_addr=<host:port>\`), and adds a new raft-troubleshooting table row for the \`not leader, leader hint: Some("<host:port>")\` case that PR #110 introduced.
- **\`chore(deps): bump nexus-vfs pin to e3b1f8901 (PR #111 audit closure)\`** — Cargo.toml + Cargo.lock + all Dockerfiles (main + minimal + raft-server + raft-witness).

## What PR #111 shipped

Four commits (~120 LOC net) on nexus-vfs main-after-#110, all green CI:

1. \`refactor(raft): forward_to_leader tracing — leader → leader_node_id + adds leader_addr\` — 2 sites in node.rs.
2. \`refactor(raft): transport_loop tracing — peer → peer_node_id + peer_addr where scoped\` — 8 sites.
3. \`refactor(raft): 4 more ambiguous node_id tracing sites → peer_node_id + peer_addr\` — 1 site in node.rs conf_change + 3 in transport/server.rs join handlers.
4. \`test(raft): source-scan regression pin — bans ambiguous identity fields in tracing\` — walks \`rust/raft/src/\` at test time, rejects retired shapes.

Combined with the existing \`NotLeader Display\` test from PR #110, the leak class is now closed at BOTH the tracing-authoring layer AND the Display-materialization layer.  A future contributor reintroducing \`peer = target_id\` sees red CI on their PR before merge.

No wire-format changes.  Kernel syscall ABI unchanged; plugin ABI unchanged; raft Command contracts unchanged.

## Verification

- \`cargo check --workspace\` green locally with the new pin.
- Runbook text changes are examples-only; no code changes to test.

## Test plan

- [ ] CI: Federation E2E (Docker) green (parses the boot-log line via \`_NODE_ID_LOG_RE\` — that regex was updated in PR #4470 to match \`local_node_id=\` shape from PR #110).
- [ ] CI: cc-tasks-share E2E (Docker) green
- [ ] CI: nexusd-cluster Smoke green
- [ ] CI: Rust Lint and Test green
- [ ] All standard pre-commit / lint / typecheck gates green

Ref: nexus-vfs PR #111, PR #110, memory \`feedback_user_observable_field_naming\`.