### PR TITLE
test(e2e): cc-tasks peer-shared Docker E2E — regression pin for production Win↔Mac topology

### DIFF
--- a/.github/workflows/cc-tasks-peer-shared-e2e.yml
+++ b/.github/workflows/cc-tasks-peer-shared-e2e.yml
@@ -1,0 +1,165 @@
+name: cc-tasks-peer-shared E2E
+
+# Runs `tests/e2e/docker/test_cc_tasks_peer_shared_e2e.py` against the
+# founder + joiner cluster in
+# `dockerfiles/docker-compose.cc-tasks-peer-shared.yml`.  This is the
+# peer-shared companion to `cc-tasks-share-e2e.yml`: SAME plugin stack,
+# but LocalConnector mounted at the SAME VFS path (`/shared/cc-tasks`)
+# on both nodes — the production Win↔Mac shape.
+#
+# The namespaced suite (`cc-tasks-share-e2e.yml`) covers historical
+# `/shared/cc-tasks/<hostname>` topology.  Both shapes exercise
+# DT_MOUNT idempotency + raft-replicated metastore, but only this suite
+# exercises the same-VFS-path rebind semantics.
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main, develop]
+    paths:
+      - 'dockerfiles/Dockerfile.local-connector-plugin'
+      - 'dockerfiles/docker-compose.cc-tasks-peer-shared.yml'
+      - 'dockerfiles/Dockerfile.nexusd-cluster'
+      - 'dockerfiles/Dockerfile.federation-test'
+      - 'rust/backends/local-connector/**'
+      - 'rust/services/fuse-plugin/**'
+      - 'rust/plugin-abi/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'tests/e2e/docker/test_cc_tasks_peer_shared_e2e.py'
+      - 'tests/e2e/docker/cc_tasks_share_helpers.py'
+      - 'tests/e2e/docker/runbook_helpers.py'
+      - '.github/workflows/cc-tasks-peer-shared-e2e.yml'
+  pull_request:
+    branches: [main, develop]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  cc-tasks-peer-shared-e2e:
+    name: cc-tasks-peer-shared E2E (Docker)
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect cc-tasks-peer-shared-relevant changes
+        id: changes
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git fetch --no-tags --prune origin "${{ github.base_ref }}"
+          git diff --name-only "origin/${{ github.base_ref }}"...HEAD > /tmp/changed_files.txt
+          cat /tmp/changed_files.txt
+          if grep -Eq '^(dockerfiles/(Dockerfile\.(local-connector-plugin|nexusd-cluster|federation-test)|docker-compose\.cc-tasks-peer-shared\.yml)|rust/(backends/local-connector|services/fuse-plugin|plugin-abi)/|Cargo\.toml$|Cargo\.lock$|tests/e2e/docker/(test_cc_tasks_peer_shared_e2e|cc_tasks_share_helpers|runbook_helpers)\.py$)' /tmp/changed_files.txt; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Skip cc-tasks-peer-shared E2E
+        if: steps.changes.outputs.run != 'true'
+        run: |
+          echo "No cc-tasks-peer-shared-relevant files changed; reporting required check without running suite."
+
+      - name: Set up Docker Buildx
+        if: steps.changes.outputs.run == 'true'
+        uses: docker/setup-buildx-action@v3
+
+      - name: Read NEXUS_VFS_REV from Cargo.toml
+        if: steps.changes.outputs.run == 'true'
+        id: vfs_rev
+        run: |
+          sha=$(grep -oP '(?<=rev = ")[a-f0-9]{40}' Cargo.toml | sort -u | head -1)
+          if [ -z "$sha" ]; then
+            echo "::error::Could not parse nexus-vfs SHA from Cargo.toml"
+            exit 1
+          fi
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+          echo "Resolved nexus-vfs SHA: $sha"
+
+      - name: Checkout nexus-vfs source at pinned SHA
+        if: steps.changes.outputs.run == 'true'
+        uses: actions/checkout@v4
+        with:
+          repository: nexi-lab/nexus-vfs
+          ref: ${{ steps.vfs_rev.outputs.sha }}
+          path: nexus-vfs-src
+          fetch-depth: 1
+
+      - name: Build nexusd-cluster image
+        if: steps.changes.outputs.run == 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: dockerfiles/Dockerfile.nexusd-cluster
+          build-contexts: |
+            nexus-vfs-src=nexus-vfs-src
+          load: true
+          tags: nexusd-cluster:latest
+          cache-from: type=gha,scope=cc-tasks-peer-shared-cluster
+          cache-to: type=gha,scope=cc-tasks-peer-shared-cluster,mode=max
+
+      - name: Build local-connector-plugin + federation-test images
+        if: steps.changes.outputs.run == 'true'
+        env:
+          BUILDX_BUILDER: default
+          PLUGIN_SIGNING_PRIVKEY: ${{ secrets.PLUGIN_SIGNING_PRIVKEY }}
+        run: |
+          if [ -z "$PLUGIN_SIGNING_PRIVKEY" ]; then
+            echo "::error::PLUGIN_SIGNING_PRIVKEY secret is not available — cannot sign the local-connector plugin (kernel refuses unsigned plugins)."
+            exit 1
+          fi
+          docker compose -f dockerfiles/docker-compose.cc-tasks-peer-shared.yml build \
+            founder joiner test
+
+      - name: Start cc-tasks-peer-shared cluster
+        if: steps.changes.outputs.run == 'true'
+        run: |
+          docker compose -f dockerfiles/docker-compose.cc-tasks-peer-shared.yml up -d founder joiner
+          docker compose -f dockerfiles/docker-compose.cc-tasks-peer-shared.yml ps
+
+      - name: Wait for founder + joiner healthy
+        if: steps.changes.outputs.run == 'true'
+        run: |
+          deadline=$((SECONDS + 180))
+          while [ $SECONDS -lt $deadline ]; do
+            if docker exec nexus-cc-tasks-ps-founder bash -c 'timeout 1 bash -c "</dev/tcp/localhost/2126" 2>/dev/null' && \
+               docker exec nexus-cc-tasks-ps-joiner bash -c 'timeout 1 bash -c "</dev/tcp/localhost/2126" 2>/dev/null'; then
+              echo "Founder + joiner healthy (gRPC 2126 reachable on both) after ${SECONDS}s"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "::error::Timed out waiting for cluster ready (180s)"
+          docker compose -f dockerfiles/docker-compose.cc-tasks-peer-shared.yml logs --tail=300
+          exit 1
+
+      - name: Run cc-tasks-peer-shared E2E tests
+        if: steps.changes.outputs.run == 'true'
+        run: |
+          docker compose -f dockerfiles/docker-compose.cc-tasks-peer-shared.yml \
+            run --rm test
+
+      - name: Dump container logs on failure
+        if: failure() && steps.changes.outputs.run == 'true'
+        run: |
+          for c in nexus-cc-tasks-ps-founder nexus-cc-tasks-ps-joiner; do
+            echo "::group::$c"
+            docker logs "$c" --tail=400 2>&1 || echo "(no logs)"
+            echo "::endgroup::"
+          done
+
+      - name: Tear down
+        if: always() && steps.changes.outputs.run == 'true'
+        run: |
+          docker compose -f dockerfiles/docker-compose.cc-tasks-peer-shared.yml down -v --remove-orphans || true

--- a/dockerfiles/docker-compose.cc-tasks-peer-shared.yml
+++ b/dockerfiles/docker-compose.cc-tasks-peer-shared.yml
@@ -1,0 +1,194 @@
+# cc-tasks-peer-shared E2E — peer-shared mount topology
+# =========================================================================
+# Companion to `docker-compose.cc-tasks-share.yml` — SAME plugin stack,
+# SAME network topology, but the LocalConnector mount driver points at
+# `/shared/cc-tasks` (no `/founder` / `/joiner` suffix) on BOTH nodes.
+# Each side's LocalConnector reads its own container-local `/host/tasks/`;
+# sys_readdir observation writes into sharedzone metastore; raft
+# replicates; the merged view surfaces via `metastore.list` on either
+# node's FUSE mount.
+#
+# This is the production Win↔Mac shape (per `start-founder.sh` and
+# `federation-cross-machine-runbook.md`).  The namespaced companion
+# (`docker-compose.cc-tasks-share.yml`) covers the historical
+# `/shared/cc-tasks/<hostname>` shape used by earlier smoke workflows.
+# Both shapes exercise DT_MOUNT idempotency + raft-replicated metastore,
+# but only this one exercises the same-VFS-path rebind semantics that
+# make `cc tasks list` a flat merged UUID list on both peers.
+#
+# Distinct container / volume / network / name so this compose can run
+# alongside the namespaced compose without conflict.
+#
+# Usage:
+#   docker compose -f dockerfiles/docker-compose.cc-tasks-peer-shared.yml up -d founder joiner
+#   docker compose -f dockerfiles/docker-compose.cc-tasks-peer-shared.yml run --rm test
+#   docker compose -f dockerfiles/docker-compose.cc-tasks-peer-shared.yml down -v
+
+x-fuse-runtime: &fuse-runtime
+  privileged: true
+  devices:
+    - /dev/fuse
+  cap_add:
+    - SYS_ADMIN
+  security_opt:
+    - apparmor:unconfined
+
+x-bootstrap-entrypoint: &bootstrap-entrypoint
+  entrypoint:
+    - /bin/bash
+    - -c
+    - |
+      set -e
+      DATA_DIR="${NEXUS_DATA_DIR:-/app/data}"
+      if [ -f "$$DATA_DIR/.node_id" ]; then
+        MODE=restart
+        unset NEXUS_FEDERATION_ZONES NEXUS_FEDERATION_MOUNTS NEXUS_PEERS NEXUS_BOOTSTRAP_NEW
+      else
+        MODE=static
+      fi
+      exec nexusd-cluster \
+        --bind-addr "$${NEXUS_BIND_ADDR:-0.0.0.0:2126}" \
+        --data-dir "$$DATA_DIR" \
+        --no-tls \
+        --plugin-dir /plugins \
+        --mount-driver "$$NEXUS_MOUNT_DRIVER" \
+        --bootstrap-mode "$$MODE"
+  command: []
+
+services:
+  founder:
+    <<: [*bootstrap-entrypoint, *fuse-runtime]
+    build:
+      context: ..
+      dockerfile: dockerfiles/Dockerfile.local-connector-plugin
+      secrets:
+        - plugin_signing_key
+    image: nexus-local-connector-plugin:latest
+    container_name: nexus-cc-tasks-ps-founder
+    hostname: founder
+    environment:
+      NEXUS_HOSTNAME: founder
+      NEXUS_BIND_ADDR: 0.0.0.0:2126
+      NEXUS_ADVERTISE_ADDR: founder:2126
+      NEXUS_DATA_DIR: /app/data
+      NEXUS_NO_TLS: "true"
+      NEXUS_FEDERATION_ZONES: sharedzone
+      NEXUS_FEDERATION_MOUNTS: /shared=sharedzone
+      # Peer-shared: SAME VFS path on both nodes.  Each side's
+      # LocalConnector points at its own container-local `/host/tasks/`;
+      # sys_readdir observation replicates the entry list via sharedzone
+      # metastore so both sides get the merged view.
+      NEXUS_MOUNT_DRIVER: 'local-connector:sharedzone:/shared/cc-tasks:{"local_root":"/host/tasks"}'
+      NEXUS_FUSE_MOUNT_POINT: /mnt/cc-tasks
+      NEXUS_FUSE_VFS_ROOT: /shared/cc-tasks
+      RUST_LOG: info,nexus_raft=info
+    volumes:
+      - cc_tasks_ps_founder_data:/app/data
+      - cc_tasks_ps_founder_hostfs:/host/tasks
+    networks:
+      - nexus-cc-tasks-ps-net
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - >
+          timeout 1 bash -c '</dev/tcp/localhost/2126' 2>/dev/null &&
+          grep -qE ' /mnt/cc-tasks fuse' /proc/mounts
+      interval: 5s
+      timeout: 5s
+      retries: 24
+      start_period: 30s
+
+  joiner:
+    <<: [*bootstrap-entrypoint, *fuse-runtime]
+    image: nexus-local-connector-plugin:latest
+    container_name: nexus-cc-tasks-ps-joiner
+    hostname: joiner
+    environment:
+      NEXUS_HOSTNAME: joiner
+      NEXUS_BIND_ADDR: 0.0.0.0:2126
+      NEXUS_ADVERTISE_ADDR: joiner:2126
+      NEXUS_DATA_DIR: /app/data
+      NEXUS_IDENTITY_DIR: /app/identity
+      NEXUS_NO_TLS: "true"
+      # Joiner: SAME VFS path as founder — the peer-shared shape.
+      NEXUS_MOUNT_DRIVER: 'local-connector:sharedzone:/shared/cc-tasks:{"local_root":"/host/tasks"}'
+      NEXUS_FUSE_MOUNT_POINT: /mnt/cc-tasks
+      NEXUS_FUSE_VFS_ROOT: /shared/cc-tasks
+      RUST_LOG: info,nexus_raft=info
+    volumes:
+      - cc_tasks_ps_joiner_data:/app/data
+      - cc_tasks_ps_joiner_identity:/app/identity
+      - cc_tasks_ps_joiner_hostfs:/host/tasks
+    networks:
+      - nexus-cc-tasks-ps-net
+    depends_on:
+      founder:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "timeout 1 bash -c '</dev/tcp/localhost/2126' 2>/dev/null || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 24
+      start_period: 30s
+
+  test:
+    build:
+      context: ..
+      dockerfile: dockerfiles/Dockerfile.federation-test
+    image: nexus-federation-test:latest
+    container_name: nexus-cc-tasks-ps-test
+    profiles:
+      - run
+    depends_on:
+      founder:
+        condition: service_healthy
+      joiner:
+        condition: service_healthy
+    user: "0:0"
+    volumes:
+      - ..:/workspace:ro
+      - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      NEXUS_CC_TASKS_PEER_SHARED_E2E: "1"
+      NEXUS_FOUNDER_GRPC: founder:2126
+      NEXUS_JOINER_GRPC: joiner:2126
+      NEXUS_FOUNDER_CONTAINER: nexus-cc-tasks-ps-founder
+      NEXUS_JOINER_CONTAINER: nexus-cc-tasks-ps-joiner
+      NEXUS_CLUSTER_IMAGE: nexus-local-connector-plugin:latest
+      NEXUS_CC_TASKS_NETWORK: nexus-cc-tasks-ps-net
+      NEXUS_LOCAL_CONNECTOR_ZONE: sharedzone
+      # Peer-shared: both sides mount at the SAME VFS root.  Tests
+      # exercise merged-view + cross-node byte-exact behavior at this
+      # shared path, not per-node namespaced subtrees.
+      NEXUS_LOCAL_CONNECTOR_VFS_ROOT: /shared/cc-tasks
+      NEXUS_FUSE_MOUNT_POINT: /mnt/cc-tasks
+    networks:
+      - nexus-cc-tasks-ps-net
+    command:
+      - pytest
+      - tests/e2e/docker/test_cc_tasks_peer_shared_e2e.py
+      - -v
+      - --no-header
+      - -o
+      - addopts=
+
+networks:
+  nexus-cc-tasks-ps-net:
+    name: nexus-cc-tasks-ps-net
+    driver: bridge
+
+secrets:
+  plugin_signing_key:
+    environment: PLUGIN_SIGNING_PRIVKEY
+
+volumes:
+  cc_tasks_ps_founder_data:
+    name: nexus-cc-tasks-ps-founder-data
+  cc_tasks_ps_founder_hostfs:
+    name: nexus-cc-tasks-ps-founder-hostfs
+  cc_tasks_ps_joiner_data:
+    name: nexus-cc-tasks-ps-joiner-data
+  cc_tasks_ps_joiner_identity:
+    name: nexus-cc-tasks-ps-joiner-identity
+  cc_tasks_ps_joiner_hostfs:
+    name: nexus-cc-tasks-ps-joiner-hostfs

--- a/tests/e2e/docker/test_cc_tasks_peer_shared_e2e.py
+++ b/tests/e2e/docker/test_cc_tasks_peer_shared_e2e.py
@@ -66,18 +66,31 @@ def joined_cluster(topology: CcTasksTopology) -> dict:
     then auto-replays --mount-driver on its restart.  Post-#109 the
     sidecar accepts bare `host:port` (no `<id>@` prefix).
     """
+    runbook_helpers.wait_zone_ready(topology.founder_grpc, "sharedzone")
     founder_node_id = runbook_helpers.fetch_node_id(topology.founder_container)
-    return runbook_helpers.run_nexusd_cluster_join(
-        target_container=topology.joiner_container,
-        target_volume="nexus-cc-tasks-ps-joiner-data",
-        founder_node_id=founder_node_id,
-        founder_addr="founder:2126",
-        cluster_image=os.environ.get("NEXUS_CLUSTER_IMAGE", "nexus-local-connector-plugin:latest"),
-        network=os.environ.get("NEXUS_CC_TASKS_NETWORK", "nexus-cc-tasks-ps-net"),
-        zone_id="sharedzone",
-        mount_path="/shared",
-        identity_volume="nexus-cc-tasks-ps-joiner-identity",
-    ) | {"founder_node_id": founder_node_id}
+    runbook_helpers.docker_stop(topology.joiner_container)
+    try:
+        join_proc = runbook_helpers.run_nexusd_cluster_join(
+            target_container=topology.joiner_container,
+            target_volume="nexus-cc-tasks-ps-joiner-data",
+            founder_node_id=founder_node_id,
+            founder_addr=topology.founder_grpc,
+            zone_id="sharedzone",
+            local_path="/shared",
+            hostname="joiner",
+            cluster_image=os.environ.get(
+                "NEXUS_CLUSTER_IMAGE", "nexus-local-connector-plugin:latest"
+            ),
+            network=os.environ.get("NEXUS_CC_TASKS_NETWORK", "nexus-cc-tasks-ps-net"),
+            identity_volume="nexus-cc-tasks-ps-joiner-identity",
+        )
+        assert join_proc.returncode == 0, (
+            f"nexusd-cluster join sidecar failed: rc={join_proc.returncode} "
+            f"stdout={join_proc.stdout!r} stderr={join_proc.stderr!r}"
+        )
+    finally:
+        runbook_helpers.docker_start(topology.joiner_container)
+    return {"founder_node_id": founder_node_id}
 
 
 @pytest.fixture(scope="module")

--- a/tests/e2e/docker/test_cc_tasks_peer_shared_e2e.py
+++ b/tests/e2e/docker/test_cc_tasks_peer_shared_e2e.py
@@ -1,0 +1,334 @@
+"""cc-tasks peer-shared Docker E2E — same-VFS-path merged view.
+
+Companion to ``test_cc_tasks_share_e2e.py``: SAME plugin stack (nexus-vfs
+kernel + LocalConnector driver + FUSE service), but exercises the
+**peer-shared** mount shape where BOTH nodes mount their LocalConnector
+at the SAME VFS path (``/shared/cc-tasks``, no per-hostname suffix).
+This is the production Win↔Mac topology that ``start-founder.sh`` and
+``federation-cross-machine-runbook.md`` deploy.
+
+The namespaced companion suite (``test_cc_tasks_share_e2e.py``) covers
+the historical ``/shared/cc-tasks/<hostname>`` shape.  Both shapes
+exercise DT_MOUNT idempotency + raft-replicated metastore, but only
+this suite exercises the same-VFS-path rebind semantics that make
+``cc tasks list`` a flat merged UUID list on both peers.
+
+Test workflows are 3+ steps with hard causal data flow between them.
+Each test uses uuid4-namespaced session dirs + try/finally cleanup so
+concurrent runs don't collide.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import time
+import uuid
+
+import pytest
+
+from tests.e2e.docker import cc_tasks_share_helpers, runbook_helpers
+from tests.e2e.docker.cc_tasks_share_helpers import CcTasksTopology
+
+pytestmark = [
+    pytest.mark.xdist_group("cc-tasks-peer-shared"),
+    pytest.mark.skipif(
+        os.environ.get("NEXUS_CC_TASKS_PEER_SHARED_E2E") != "1",
+        reason="cc-tasks-peer-shared E2E suite needs the "
+        "docker-compose.cc-tasks-peer-shared stack; set "
+        "NEXUS_CC_TASKS_PEER_SHARED_E2E=1 to enable "
+        "(cc-tasks-peer-shared-e2e.yml sets this automatically).",
+    ),
+]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures (module-scoped, mirror the namespaced suite)
+# ---------------------------------------------------------------------------
+@pytest.fixture(scope="module")
+def topology() -> CcTasksTopology:
+    return cc_tasks_share_helpers.topology_from_env()
+
+
+@pytest.fixture(scope="module")
+def api_key() -> str:
+    return os.environ.get("NEXUS_API_KEY", "sk-test-cc-tasks-key")
+
+
+@pytest.fixture(scope="module")
+def joined_cluster(topology: CcTasksTopology) -> dict:
+    """Bring joiner into founder's sharedzone via `nexusd-cluster join`.
+
+    Peer-shared parity with the namespaced suite: joiner's compose
+    entrypoint does NOT set FEDERATION_ZONES on first boot, so
+    `sharedzone` only lands after the sidecar's offline join writes
+    ConfState + DT_MOUNT entries into the data dir.  The main daemon
+    then auto-replays --mount-driver on its restart.  Post-#109 the
+    sidecar accepts bare `host:port` (no `<id>@` prefix).
+    """
+    founder_node_id = runbook_helpers.fetch_node_id(topology.founder_container)
+    return runbook_helpers.run_nexusd_cluster_join(
+        target_container=topology.joiner_container,
+        target_volume="nexus-cc-tasks-ps-joiner-data",
+        founder_node_id=founder_node_id,
+        founder_addr="founder:2126",
+        cluster_image=os.environ.get("NEXUS_CLUSTER_IMAGE", "nexus-local-connector-plugin:latest"),
+        network=os.environ.get("NEXUS_CC_TASKS_NETWORK", "nexus-cc-tasks-ps-net"),
+        zone_id="sharedzone",
+        mount_path="/shared",
+        identity_volume="nexus-cc-tasks-ps-joiner-identity",
+    ) | {"founder_node_id": founder_node_id}
+
+
+@pytest.fixture(scope="module")
+def ready_stack(topology: CcTasksTopology, api_key: str, joined_cluster: dict) -> None:
+    """Both nodes: gRPC + FUSE mount + sharedzone `/shared/cc-tasks` mount.
+
+    Peer-shared invariant: after join, BOTH nodes have the SAME
+    `sharedzone:/shared/cc-tasks` mount in their metastore.  Gate on
+    both sides answering vfs_stat on that shared path (not per-host
+    namespaced) — that's the differentiator vs the namespaced suite.
+    """
+    runbook_helpers.wait_healthy([topology.founder_grpc, topology.joiner_grpc])
+    _ = joined_cluster  # implicit dependency — join happens before mount asserts
+
+    for label, grpc, container in (
+        ("founder", topology.founder_grpc, topology.founder_container),
+        ("joiner", topology.joiner_grpc, topology.joiner_container),
+    ):
+        deadline = time.time() + 60
+        while time.time() < deadline:
+            stat = runbook_helpers.vfs_stat(grpc, "/shared/cc-tasks", api_key=api_key, timeout=5)
+            if (
+                "error" not in stat
+                and stat.get("result", {}).get("found")
+                and cc_tasks_share_helpers.mount_is_fuse_mountpoint(
+                    container, topology.fuse_mount_point
+                )
+            ):
+                break
+            time.sleep(0.5)
+        else:
+            pytest.fail(
+                f"{label} never reached ready state (gRPC + FUSE + "
+                f"/shared/cc-tasks mount) within 60s"
+            )
+
+
+def _new_session() -> str:
+    return f"session-{uuid.uuid4().hex[:12]}"
+
+
+def _poll_for_bytes(
+    container: str,
+    mount_path: str,
+    expected: bytes,
+    failure_prefix: str,
+    *,
+    timeout: float = 30.0,
+) -> None:
+    """Poll ``cat <mount_path>`` until it returns ``expected``.
+
+    Unlike ``cc_tasks_share_helpers.mount_read_bytes`` this tolerates
+    transient failures (path not yet observed → ENOENT, peer fetch
+    in flight → empty read).  Only a byte-exact match satisfies the
+    poll; anything else keeps waiting until the deadline elapses.
+    """
+    deadline = time.monotonic() + timeout
+    last_got: bytes | None = None
+    last_stderr = ""
+    while time.monotonic() < deadline:
+        proc = subprocess.run(
+            ["docker", "exec", container, "cat", mount_path],
+            capture_output=True,
+            timeout=30,
+        )
+        if proc.returncode == 0 and proc.stdout == expected:
+            return
+        last_got = proc.stdout
+        last_stderr = proc.stderr.decode(errors="replace")
+        time.sleep(0.5)
+    pytest.fail(
+        f"{failure_prefix} within {timeout}s (expected {expected!r}, "
+        f"last got {last_got!r}, last stderr={last_stderr!r})"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Workflow 1: merged view — each node writes to its own host fs, both
+# sides see the union via metastore observation.
+# ---------------------------------------------------------------------------
+class TestPeerSharedMergedView:
+    """Each side writes ONE session; both sides see BOTH.
+
+    Peer-shared invariant: with BOTH LocalConnectors mounted at the
+    same VFS root, sys_readdir observation writes sharedzone metastore
+    rows for every entry each side's LocalConnector.list_dir returns.
+    Raft replicates, so `ls /shared/cc-tasks/` on either side returns
+    the union — no per-hostname subtree traversal needed.
+
+    Three steps with hard causal flow:
+      1. Each side writes to its OWN host-fs `/host/tasks/<sess>/1.json`.
+      2. Trigger sys_readdir on BOTH sides (via FUSE `ls`) so observation
+         seeds metastore for each side's own entries.
+      3. Assert BOTH sessions appear in `metastore.list` on BOTH nodes.
+    """
+
+    def test_both_sides_see_merged_uuid_list(
+        self,
+        topology: CcTasksTopology,
+        api_key: str,
+        ready_stack: None,
+    ) -> None:
+        founder_sess = _new_session()
+        joiner_sess = _new_session()
+        founder_payload = b'{"id":"F","writer":"founder-host-fs","peer_shared":true}'
+        joiner_payload = b'{"id":"J","writer":"joiner-host-fs","peer_shared":true}'
+
+        # Step 1: each side writes to its own container's host fs
+        cc_tasks_share_helpers.host_task_write(
+            topology.founder_container, f"/{founder_sess}/1.json", founder_payload
+        )
+        cc_tasks_share_helpers.host_task_write(
+            topology.joiner_container, f"/{joiner_sess}/1.json", joiner_payload
+        )
+        try:
+            # Step 2: trigger sys_readdir on both sides (FUSE ls) so
+            # each side's LocalConnector.list_dir results get observed
+            # into metastore.
+            _ = cc_tasks_share_helpers.mount_listdir(
+                topology.founder_container, topology.fuse_mount_point
+            )
+            _ = cc_tasks_share_helpers.mount_listdir(
+                topology.joiner_container, topology.fuse_mount_point
+            )
+
+            # Step 3: assert both session UUIDs appear on BOTH nodes'
+            # merged view via FUSE mount.  Poll with a bounded budget —
+            # raft replication of the observation writes is ~ms but
+            # not instantaneous.
+            deadline = time.monotonic() + 30
+            while time.monotonic() < deadline:
+                founder_entries = cc_tasks_share_helpers.mount_listdir(
+                    topology.founder_container, topology.fuse_mount_point
+                )
+                joiner_entries = cc_tasks_share_helpers.mount_listdir(
+                    topology.joiner_container, topology.fuse_mount_point
+                )
+                if (
+                    founder_sess in founder_entries
+                    and joiner_sess in founder_entries
+                    and founder_sess in joiner_entries
+                    and joiner_sess in joiner_entries
+                ):
+                    break
+                time.sleep(0.5)
+            else:
+                pytest.fail(
+                    f"merged view never converged within 30s — "
+                    f"founder sees: {founder_entries}; joiner sees: {joiner_entries}; "
+                    f"expected both sides to include {founder_sess} AND {joiner_sess}"
+                )
+        finally:
+            runbook_helpers.docker_exec(
+                topology.founder_container,
+                ["rm", "-rf", f"/host/tasks/{founder_sess}"],
+                check=False,
+            )
+            runbook_helpers.docker_exec(
+                topology.joiner_container,
+                ["rm", "-rf", f"/host/tasks/{joiner_sess}"],
+                check=False,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Workflow 2: cross-node byte-exact reads via try_remote_fetch.
+# ---------------------------------------------------------------------------
+class TestPeerSharedCrossNodeByteExact:
+    """Each side reads OTHER's file byte-exact via try_remote_fetch.
+
+    Peer-shared invariant: when node A's FUSE cat lands on a path whose
+    metastore row's `last_writer_address` is node B, try_remote_fetch
+    dispatches to B's `KernelBlobFetcher::read` → B's LocalConnector →
+    B's host fs.  Same routing pattern the namespaced suite validates
+    for founder→joiner + joiner→founder read; the differentiator here
+    is that both writes target the SAME VFS subtree.
+
+    Three steps:
+      1. Each side writes to host fs + triggers observation.
+      2. Founder cats joiner's file via FUSE → byte-exact from joiner.
+      3. Joiner cats founder's file via FUSE → byte-exact from founder.
+    """
+
+    def test_each_side_reads_other_side_bytes_via_peer_fetch(
+        self,
+        topology: CcTasksTopology,
+        api_key: str,
+        ready_stack: None,
+    ) -> None:
+        founder_sess = _new_session()
+        joiner_sess = _new_session()
+        founder_bytes = b'{"writer":"founder","target":"cross-node-read"}'
+        joiner_bytes = b'{"writer":"joiner","target":"cross-node-read"}'
+
+        cc_tasks_share_helpers.host_task_write(
+            topology.founder_container, f"/{founder_sess}/a.json", founder_bytes
+        )
+        cc_tasks_share_helpers.host_task_write(
+            topology.joiner_container, f"/{joiner_sess}/b.json", joiner_bytes
+        )
+        try:
+            # Trigger observation on BOTH sides so the metastore
+            # rows exist for the cross-node reads.
+            _ = cc_tasks_share_helpers.mount_listdir(
+                topology.founder_container, topology.fuse_mount_point
+            )
+            _ = cc_tasks_share_helpers.mount_listdir(
+                topology.joiner_container, topology.fuse_mount_point
+            )
+            # Nested descent triggers each session dir's inner readdir
+            # observation — needed for the actual file entries to
+            # replicate through sharedzone metastore.
+            for grpc_pair in (
+                (topology.founder_container, founder_sess),
+                (topology.founder_container, joiner_sess),
+                (topology.joiner_container, founder_sess),
+                (topology.joiner_container, joiner_sess),
+            ):
+                cont, sess = grpc_pair
+                try:
+                    runbook_helpers.docker_exec(
+                        cont, ["ls", f"{topology.fuse_mount_point}/{sess}"], check=False
+                    )
+                except Exception:  # noqa: BLE001
+                    pass
+
+            # Step 2: founder reads joiner's file via FUSE
+            joiner_file_on_founder = f"{topology.fuse_mount_point}/{joiner_sess}/b.json"
+            _poll_for_bytes(
+                topology.founder_container,
+                joiner_file_on_founder,
+                joiner_bytes,
+                "founder never got joiner's bytes via peer-fetch",
+            )
+
+            # Step 3: joiner reads founder's file via FUSE
+            founder_file_on_joiner = f"{topology.fuse_mount_point}/{founder_sess}/a.json"
+            _poll_for_bytes(
+                topology.joiner_container,
+                founder_file_on_joiner,
+                founder_bytes,
+                "joiner never got founder's bytes via peer-fetch",
+            )
+        finally:
+            runbook_helpers.docker_exec(
+                topology.founder_container,
+                ["rm", "-rf", f"/host/tasks/{founder_sess}"],
+                check=False,
+            )
+            runbook_helpers.docker_exec(
+                topology.joiner_container,
+                ["rm", "-rf", f"/host/tasks/{joiner_sess}"],
+                check=False,
+            )


### PR DESCRIPTION
## Summary

Adds a Docker E2E regression pin for the peer-shared cc-tasks topology (task #45 follow-up).  Companion to the existing namespaced ``cc-tasks-share`` suite:

- **Namespaced** (existing): both nodes' LocalConnector mounted at ``/shared/cc-tasks/<hostname>/`` — historical shape.
- **Peer-shared** (this PR): both nodes' LocalConnector mounted at the SAME ``/shared/cc-tasks`` — the production Win↔Mac shape per ``start-founder.sh`` and ``federation-cross-machine-runbook.md``.

Both shapes exercise DT_MOUNT idempotency + raft-replicated metastore, but only peer-shared exercises the same-VFS-path rebind semantics that make ``cc tasks list`` a flat merged UUID list on both peers.

## Per-commit breakdown

| # | Commit | Concern |
|---|--------|---------|
| 1 | ``test(e2e): docker-compose for peer-shared cc-tasks topology`` | ``docker-compose.cc-tasks-peer-shared.yml`` — same plugin stack + same network model, distinct container/volume/network names to avoid conflict with namespaced compose. Only diff vs the namespaced compose is ``NEXUS_MOUNT_DRIVER`` (no per-hostname suffix). |
| 2 | ``test(e2e): peer-shared merged-view + cross-node byte-exact regression pins`` | Two workflows, each 3+ steps with hard causal data flow: merged-view (both sides see BOTH sessions), cross-node byte-exact (each side reads OTHER side's file via ``try_remote_fetch``).  UUID-namespaced session dirs + try/finally cleanup for parallelism. |
| 3 | ``ci: cc-tasks-peer-shared E2E workflow (Docker)`` | ``.github/workflows/cc-tasks-peer-shared-e2e.yml`` mirrors ``cc-tasks-share-e2e.yml`` with peer-shared compose + container-name substitutions + peer-shared change-detection regex. |

## 8-principle verdict

- **Simple contract** ✅ — test-only, no code change; reuses existing compose model + helpers.
- **SSOT** ✅ — reuses ``cc_tasks_share_helpers`` + ``runbook_helpers``; only new abstractions are the ``_poll_for_bytes`` failure-tolerant read helper (justified: existing ``mount_read_bytes`` pytest.fails on ENOENT which is normal during observation lag).
- **DRY** ✅ — new compose + workflow are direct edits of the namespaced siblings; test file mirrors ``test_cc_tasks_share_e2e.py``'s fixture pattern.
- **Rust-first** ✅ — no Rust changes.
- **Perf** ✅ — CI only; no runtime impact.
- **Raft 100%** ✅ — exercises peer-shared metastore behavior already supported by the current kernel (PR #98 uniform local-first sys_write + PR #108 sys_readdir fan-out).
- **Systemic** ✅ — fills a gap in CI coverage: the production Win↔Mac topology was previously only smoke-tested manually in ``start-founder.sh``; now every PR that touches the plugin stack sees red CI if peer-shared regresses.
- **E2E depth+coverage** ✅ — adds regression pin for the ULTIMATE goal of the whole cc-tasks-share arc (Mac↔Win merged view).

## Test plan

- [ ] CI: cc-tasks-peer-shared E2E (Docker) green on first run (cold cache ~10-15 min)
- [ ] CI: cc-tasks-share E2E (Docker) still green (unchanged; independent compose)
- [ ] CI: all fast gates + Rust checks green

Ref: task #45, memory ``project-phase-ga-win-mac-end-to-end`` (documents the production peer-shared shape this test pins).