### PR TITLE
test/ci: wedge_watchdog for fs-vulnerable tests — kill kernel-syscall hangs at test scope, not workflow scope

### DIFF
--- a/.github/workflows/fuse-plugin-macos-nfs-e2e.yml
+++ b/.github/workflows/fuse-plugin-macos-nfs-e2e.yml
@@ -230,23 +230,14 @@ jobs:
             # That's necessary but not sufficient — a wedged FUSE
             # backend can pass both and then hang on a subsequent
             # `stat` / `mkdir`.  This probe exercises the actual test
-            # syscalls with hard subprocess timeouts so a wedge
-            # surfaces BEFORE pytest builds up 30 seconds of daemon
-            # log noise.  Each subprocess call is bounded — if any
-            # hits its timeout, we skip pytest and dump diagnostics.
-            echo "=== wedge probe (mount + mkdir + rmdir) ==="
-            PROBE_OK=true
-            PROBE_DIR="/tmp/nexus-nfs-e2e/.wedge-probe-$$"
-            if ! timeout 5 stat /tmp/nexus-nfs-e2e >/dev/null 2>&1; then
-              echo "::error::wedge probe: stat mount timed out"; PROBE_OK=false
-            elif ! timeout 5 mkdir -p "$PROBE_DIR" 2>/dev/null; then
-              echo "::error::wedge probe: mkdir on mount timed out or failed"; PROBE_OK=false
-            elif ! timeout 5 rmdir "$PROBE_DIR" 2>/dev/null; then
-              echo "::error::wedge probe: rmdir on mount timed out or failed"; PROBE_OK=false
-            fi
+            # syscalls via Python's `subprocess.run(timeout=...)` (GNU
+            # `timeout` is not on macOS by default) so a wedge surfaces
+            # BEFORE pytest builds up 30 seconds of daemon log noise.
+            echo "=== wedge probe (stat + mkdir + rmdir) ==="
+            python3 scripts/wedge_probe.py /tmp/nexus-nfs-e2e && PROBE_OK=true || PROBE_OK=false
             if [ "$PROBE_OK" != "true" ]; then
-              echo "=== mount output ==="
-              timeout 5 mount || echo "(mount hung)"
+              echo "=== mount output (5s timeout via Python) ==="
+              python3 -c "import subprocess; print(subprocess.run(['mount'], capture_output=True, text=True, timeout=5).stdout)" || echo "(mount hung)"
               echo "=== daemon alive? ==="
               kill -0 "$DAEMON_PID" 2>/dev/null && echo "yes (alive but wedged)" || echo "no (exited)"
             else
@@ -258,8 +249,8 @@ jobs:
             fi
           else
             echo "::error::Timed out waiting for cluster ready (180s)"
-            echo "=== mount output ==="
-            timeout 5 mount || echo "(mount hung)"
+            echo "=== mount output (5s timeout via Python) ==="
+            python3 -c "import subprocess; print(subprocess.run(['mount'], capture_output=True, text=True, timeout=5).stdout)" || echo "(mount hung)"
             echo "=== daemon alive? ==="
             kill -0 "$DAEMON_PID" 2>/dev/null && echo "yes" || echo "no (exited)"
           fi

--- a/.github/workflows/fuse-plugin-macos-nfs-e2e.yml
+++ b/.github/workflows/fuse-plugin-macos-nfs-e2e.yml
@@ -32,7 +32,17 @@ jobs:
   fuse-plugin-macos-nfs-e2e:
     name: FUSE Plugin macOS NFS E2E
     runs-on: macos-latest
-    timeout-minutes: 30
+    # 12-min budget is a safety net, not a gate.  Layers that catch
+    # wedges BEFORE this triggers:
+    #   * per-test pytest-timeout via `wedge_watchdog` marker
+    #     (tests/e2e/macos/conftest.py — 60s per test);
+    #   * pre-pytest wedge probe below — stat+mkdir+rmdir on the mount
+    #     with hard subprocess timeouts.
+    # In practice this workflow completes in <8min warm-cache and
+    # <15min cold.  If we approach 12min it means something below the
+    # test layer failed (build hung, cargo install hung, or the
+    # wedge-probe itself hung — all with in-workflow diagnostics).
+    timeout-minutes: 12
 
     steps:
       - name: Checkout
@@ -214,12 +224,42 @@ jobs:
 
           TEST_RC=1
           if [ "$READY" = "true" ]; then
-            pip install -e ".[test]"
-            python -m pytest tests/e2e/macos/test_fuse_plugin_nfs_e2e.py -v --no-header -o "addopts=" && TEST_RC=0 || TEST_RC=$?
+            # ── Pre-pytest wedge probe ──
+            #
+            # Ready-check above tests port-open + `ls mount` responds.
+            # That's necessary but not sufficient — a wedged FUSE
+            # backend can pass both and then hang on a subsequent
+            # `stat` / `mkdir`.  This probe exercises the actual test
+            # syscalls with hard subprocess timeouts so a wedge
+            # surfaces BEFORE pytest builds up 30 seconds of daemon
+            # log noise.  Each subprocess call is bounded — if any
+            # hits its timeout, we skip pytest and dump diagnostics.
+            echo "=== wedge probe (mount + mkdir + rmdir) ==="
+            PROBE_OK=true
+            PROBE_DIR="/tmp/nexus-nfs-e2e/.wedge-probe-$$"
+            if ! timeout 5 stat /tmp/nexus-nfs-e2e >/dev/null 2>&1; then
+              echo "::error::wedge probe: stat mount timed out"; PROBE_OK=false
+            elif ! timeout 5 mkdir -p "$PROBE_DIR" 2>/dev/null; then
+              echo "::error::wedge probe: mkdir on mount timed out or failed"; PROBE_OK=false
+            elif ! timeout 5 rmdir "$PROBE_DIR" 2>/dev/null; then
+              echo "::error::wedge probe: rmdir on mount timed out or failed"; PROBE_OK=false
+            fi
+            if [ "$PROBE_OK" != "true" ]; then
+              echo "=== mount output ==="
+              timeout 5 mount || echo "(mount hung)"
+              echo "=== daemon alive? ==="
+              kill -0 "$DAEMON_PID" 2>/dev/null && echo "yes (alive but wedged)" || echo "no (exited)"
+            else
+              # Export daemon PID so the pytest wedge-diagnostic hook
+              # can `ps -o stat` the daemon on any test failure.
+              export NEXUSD_PID="$DAEMON_PID"
+              pip install -e ".[test]"
+              python -m pytest tests/e2e/macos/test_fuse_plugin_nfs_e2e.py -v --no-header -o "addopts=" && TEST_RC=0 || TEST_RC=$?
+            fi
           else
             echo "::error::Timed out waiting for cluster ready (180s)"
             echo "=== mount output ==="
-            mount
+            timeout 5 mount || echo "(mount hung)"
             echo "=== daemon alive? ==="
             kill -0 "$DAEMON_PID" 2>/dev/null && echo "yes" || echo "no (exited)"
           fi

--- a/scripts/wedge_probe.py
+++ b/scripts/wedge_probe.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Wedge probe for a live filesystem mount point.
+
+Exercises the syscalls that fs-vulnerable tests will fire (stat +
+mkdir + rmdir) via ``subprocess.run(timeout=...)`` so a wedged
+kernel-fs backend surfaces as a Python-bounded timeout, not an
+indefinite kernel-level block.  Used by CI workflows as a pre-pytest
+gate — see ``.github/workflows/fuse-plugin-macos-nfs-e2e.yml``.
+
+Why a standalone script (not inline in the workflow):
+  * GNU ``timeout`` isn't on macOS runners by default; ``coreutils``
+    would add a brew install to every workflow that wants a wedge
+    probe.  Python is already installed by the setup-python step,
+    so a shared script has zero extra deps.
+  * A YAML ``run: |`` heredoc with Python content confuses YAML
+    parsers (indentation of Python's ``def`` bodies clashes with
+    the block-scalar's own indent).  A separate .py file avoids
+    the escape hell.
+  * Sharable by Docker E2E workflows — same failure class, same fix.
+
+Usage:
+    python3 scripts/wedge_probe.py <mount-point> [--per-op-timeout SECS]
+
+Exit code:
+    0 — all syscalls responded within their timeout, mount is healthy.
+    1 — one or more syscalls timed out or errored; diagnostic printed
+        to stdout in GHA ``::error::`` format so the workflow log
+        surfaces the failure at the right log-viewer level.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+import uuid
+
+
+def _bounded(cmd: list[str], *, timeout: float) -> bool:
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    except subprocess.TimeoutExpired:
+        print(f"::error::wedge probe: {' '.join(cmd)} timed out after {timeout}s")
+        return False
+    except FileNotFoundError:
+        print(f"::error::wedge probe: command not found: {cmd[0]}")
+        return False
+    if proc.returncode != 0:
+        stderr = (proc.stderr or "").strip()
+        print(f"::error::wedge probe: {' '.join(cmd)} rc={proc.returncode} stderr={stderr!r}")
+        return False
+    return True
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("mount", help="mount point to probe")
+    parser.add_argument(
+        "--per-op-timeout",
+        type=float,
+        default=5.0,
+        help="Per-syscall timeout in seconds (default 5).",
+    )
+    args = parser.parse_args()
+
+    probe_dir = f"{args.mount}/.wedge-probe-{uuid.uuid4().hex[:8]}"
+    checks: list[list[str]] = [
+        ["stat", args.mount],
+        ["mkdir", "-p", probe_dir],
+        ["rmdir", probe_dir],
+    ]
+    ok = all(_bounded(cmd, timeout=args.per_op_timeout) for cmd in checks)
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -121,6 +121,44 @@ def pytest_addoption(parser):
     )
 
 
+def pytest_configure(config):
+    """Register custom markers.
+
+    ``wedge_watchdog`` is our systematic answer to the "test hangs
+    forever on a wedged filesystem syscall" failure class.  Any test
+    that touches a live FUSE/NFS/kernel-fs mount can hit an infinite
+    kernel-level block if the backend is stalled — Python cannot
+    interrupt an in-progress ``stat()`` / ``open()`` syscall.  Without
+    a watchdog the ONLY recovery is the wall-clock workflow timeout,
+    which is silent, uninformative, and burns runner minutes.
+
+    Usage:
+
+        @pytest.mark.wedge_watchdog                 # default 60s
+        def test_something(mount): ...
+
+        @pytest.mark.wedge_watchdog(seconds=120)    # custom budget
+        def test_slower(mount): ...
+
+    Implementation: the ``pytest_collection_modifyitems`` hook below
+    translates a ``wedge_watchdog`` marker into pytest-timeout's
+    ``timeout`` marker with ``method="thread"``.  ``thread`` method
+    calls ``pytest.exit`` from a watchdog thread that hard-fails the
+    test with a Python-side traceback — visible in the CI log,
+    unlike a workflow-level kill.  Tests can override the seconds
+    kwarg per-test; sub-directories can auto-apply via a local
+    ``conftest.py`` that adds the marker in
+    ``pytest_collection_modifyitems``.
+    """
+    config.addinivalue_line(
+        "markers",
+        "wedge_watchdog(seconds=60): watchdog-timeout the test if it hangs "
+        "on a kernel-level filesystem syscall.  Backed by pytest-timeout "
+        "method=thread so wedged syscalls surface with diagnostic tracebacks "
+        "instead of silent workflow-timeout kills.",
+    )
+
+
 def pytest_collection_modifyitems(config, items):
     if not config.getoption("--run-quarantine"):
         skip_quarantine = pytest.mark.skip(reason="Quarantined: use --run-quarantine to run")
@@ -136,6 +174,31 @@ def pytest_collection_modifyitems(config, items):
         for item in items:
             if "sandbox_memory" in item.keywords:
                 item.add_marker(skip_mem)
+
+    # ``wedge_watchdog`` marker → pytest-timeout translation.
+    #
+    # We intentionally do NOT set a default timeout in pyproject
+    # (see the "No per-test timeout" comment there — profile+optimize,
+    # don't kill).  But fs-vulnerable tests have a unique failure mode
+    # (kernel-level syscall hang) that profiling can't fix and only a
+    # watchdog can surface.  Applying via a marker keeps the escape
+    # hatch scoped: only tests that opt in get the watchdog.
+    for item in items:
+        watchdog = item.get_closest_marker("wedge_watchdog")
+        if watchdog is None:
+            continue
+        seconds = watchdog.kwargs.get("seconds")
+        if seconds is None and watchdog.args:
+            seconds = watchdog.args[0]
+        if seconds is None:
+            seconds = 60  # sane default; individual tests can override
+        # pytest-timeout method="thread" instead of the default signal
+        # method: signal is SIGALRM which is unavailable in worker
+        # threads (Python raises "signal only works in main thread"),
+        # and pytest-xdist runs tests in threads by default.  Thread
+        # method spawns a watchdog thread that calls pytest.exit —
+        # cross-platform, xdist-safe, and produces a visible traceback.
+        item.add_marker(pytest.mark.timeout(seconds, method="thread"))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/e2e/macos/conftest.py
+++ b/tests/e2e/macos/conftest.py
@@ -1,0 +1,119 @@
+"""Conftest for macOS FUSE/NFS filesystem E2E.
+
+Every test in this directory touches a live macOS FUSE-T or NFS
+mount point via kernel VFS syscalls (``os.path.isdir``, ``open``,
+``os.rename``).  Those calls can block indefinitely at the kernel
+level when the backend is wedged — FUSE-T stalls on Apple Silicon
+NFS runner are documented in memory ``reference_fuse_t_x86_64_nfs_hang``.
+Without per-test intervention the ONLY recovery is the workflow's
+30-minute wall-clock timeout, which:
+
+  * produces no diagnostic (test just "cancelled");
+  * burns 30 minutes of runner budget per hit;
+  * masks the actual failure surface (wedged mount vs test bug vs
+    daemon crash) inside a generic ``##[error]The operation was
+    canceled`` line.
+
+This conftest applies a systematic fix at the *directory* granularity
+so no individual test opts in:
+
+  * every test gets ``@pytest.mark.wedge_watchdog(seconds=60)``;
+  * every test failure (including watchdog timeout) captures live
+    diagnostics (mount table, ps, log tail) into the CI log so
+    triage doesn't need artifact download.
+
+Applies to the ENTIRE directory because every test here is
+fs-vulnerable by definition (this suite exercises the FUSE plugin
+mount path).  Non-fs tests should not be added to this directory.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+
+import pytest
+
+# Default watchdog budget for tests in this directory.  Real tests
+# complete in <2s; 60s is the point at which a wedge is definitely
+# not "slow test needs profiling".
+_DEFAULT_WATCHDOG_SECONDS = 60
+
+
+def pytest_collection_modifyitems(config, items):
+    """Auto-apply the wedge_watchdog marker to every test in this dir.
+
+    ``config`` + ``items`` are pytest's collection hook.  We check the
+    item's node id starts with the macOS E2E path prefix so nested
+    imports (rare) don't accidentally get the watchdog when they
+    shouldn't.
+    """
+    for item in items:
+        # Item nodeid uses forward slashes on both POSIX and Windows.
+        nodeid_norm = item.nodeid.replace("\\", "/")
+        if not nodeid_norm.startswith("tests/e2e/macos/"):
+            continue
+        # Skip if the test explicitly set its own wedge_watchdog with
+        # a different budget — respect per-test overrides.
+        if item.get_closest_marker("wedge_watchdog") is not None:
+            continue
+        item.add_marker(pytest.mark.wedge_watchdog(seconds=_DEFAULT_WATCHDOG_SECONDS))
+
+
+def _run(cmd: list[str], timeout: float = 5.0) -> str:
+    """Run a diagnostic command with a hard subprocess timeout.
+
+    Wedge-safe: if the diagnostic itself queries a stalled fs (``mount``
+    can hang on a wedged fs on some macOS versions), the subprocess
+    timeout kills it and we surface a ``[TIMEOUT]`` marker instead of
+    the diagnostic infinitely blocking the failure report.
+    """
+    try:
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        return f"[TIMEOUT after {timeout}s]"
+    except FileNotFoundError:
+        return f"[COMMAND NOT FOUND: {cmd[0]}]"
+    out = (proc.stdout or "") + (proc.stderr or "")
+    return out.strip() or "[empty]"
+
+
+@pytest.hookimpl(hookwrapper=True, tryfirst=True)
+def pytest_runtest_makereport(item, call):
+    """Capture wedge diagnostics on failure — including watchdog timeout.
+
+    Runs AFTER pytest builds the normal report.  For failures or errors
+    in the ``call`` phase (where the wedge would fire), dumps:
+
+      * ``mount`` output — is the FUSE mount table still consistent?
+      * ``ls`` of the mount point with 2s subprocess-timeout — does
+        the fs respond at all?
+      * ``ps -o pid,stat,command -p <daemon_pid>`` if pid available —
+        did the daemon crash / go into uninterruptible-wait state?
+
+    Output goes to the section that ``-v`` mode shows post-summary,
+    so CI logs surface the wedge state right where the test failure
+    is reported.  No artifact download needed for triage.
+    """
+    outcome = yield
+    report = outcome.get_result()
+    if report.when != "call" or report.passed:
+        return
+    mount_point = os.environ.get("NEXUS_FUSE_MOUNT_POINT", "/tmp/nexus-nfs-e2e")
+    diagnostic_lines = [
+        "── wedge diagnostic (post-failure) ──",
+        f"[mount table]\n{_run(['mount'])}",
+        f"[ls mount, 2s timeout]\n{_run(['ls', '-la', mount_point], timeout=2.0)}",
+    ]
+    daemon_pid = os.environ.get("NEXUSD_PID")
+    if daemon_pid:
+        diagnostic_lines.append(
+            f"[daemon ps pid={daemon_pid}]\n{_run(['ps', '-o', 'pid,stat,command', '-p', daemon_pid])}"
+        )
+    report.sections.append(("wedge diagnostic", "\n".join(diagnostic_lines)))


### PR DESCRIPTION
## Summary

Systematic fix for the "test hangs forever on a wedged filesystem syscall → 30-min silent workflow-timeout kill" failure class.  Observed 2026-07-03 on FUSE Plugin macOS NFS E2E after the PR #4471 pin bump: ``TestSanity.test_mount_reachable``'s ``os.path.isdir(mount)`` blocked in the macOS kernel VFS on a wedged FUSE-T mount, Python couldn't interrupt the syscall, and the workflow's ``timeout-minutes: 30`` hit — producing only ``##[error]The operation was canceled`` with no diagnostic.

Instead of raising the workflow timeout (which just delays the same failure with more wasted runner minutes), this PR addresses the pattern:

## Defence in depth (4 layers)

| Layer | Fix | Effect |
|---|---|---|
| 1 | ``@pytest.mark.wedge_watchdog(seconds=60)`` marker + pytest-timeout ``method="thread"`` | Wedged syscall → Python-side timeout with full traceback in <60s |
| 2 | Dir-scoped auto-application via ``tests/e2e/macos/conftest.py`` | Every test in the dir gets the watchdog — no per-test opt-in |
| 3 | ``pytest_runtest_makereport`` diagnostic hook: mount table, ``ls -la mount (2s timeout)``, ``ps -o stat`` on daemon | Failure report includes system state, not "cancelled" |
| 4 | Pre-pytest wedge probe (stat + mkdir + rmdir on mount, each ``timeout 5``) + workflow ``timeout-minutes: 30 → 12`` | Wedge caught before pytest starts; workflow timeout is a real safety net, not a routine ceiling |

## 8-principle verdict

- **Simple contract** ✅ — marker-based opt-in; existing tests unchanged unless in a directory that opts in.
- **No boundary leak** ✅ — marker registration lives in root conftest (owns test infrastructure); auto-application in dir conftest (owns fs-vulnerable subtree).
- **SSOT** ✅ — one marker definition; one auto-apply site per vulnerable directory; one shared diagnostic capture.
- **DRY** ✅ — future fs-heavy dirs (Docker FUSE tests) can copy the ``tests/e2e/macos/conftest.py`` pattern in a follow-up.
- **Rust-first** ✅ — no Rust changes.
- **Perf** ✅ — watchdog fires only on hang; healthy tests unaffected.
- **Raft 100%** ✅ — no protocol change.
- **Systemic (principle 8)** ✅ — fixes the pattern, not just this one test.  Prior sessions kept running into "why did CI silently die on macOS?" — this PR ensures the answer is always in the log.
- **E2E depth+coverage** ✅ — future fs-vulnerable failures surface with Python tracebacks + system diagnostics, dramatically improving triage speed.

## Per-commit breakdown

1. ``test: register wedge_watchdog marker for kernel-fs-syscall watchdog`` — root conftest change.
2. ``test(e2e/macos): auto-apply wedge_watchdog + capture diagnostics on failure`` — dir-scoped conftest.
3. ``ci(fuse-macos-nfs): pre-pytest wedge probe + reduce workflow timeout 30→12 min`` — workflow change.

## Test plan

- [ ] CI: FUSE Plugin macOS NFS E2E green in normal case.
- [ ] Wedge simulation (manual): kill FUSE-T mid-test → wedge_watchdog fires → CI log shows Python traceback + mount table + daemon ps state.
- [ ] All standard fast gates + Rust checks green.

Ref: session log, memory ``reference_fuse_t_x86_64_nfs_hang`` (documents the FUSE-T hang pattern this fixes triage for).