### PR TITLE
docs: normalize gig table to 50h/month

### DIFF
--- a/docs/architecture/p2p-task-settlement-zh.html
+++ b/docs/architecture/p2p-task-settlement-zh.html
@@ -713,37 +713,37 @@ sequenceDiagram
 </div>
 
 <h3>3. 大学生竞品零工收入</h3>
-<p>我们的目标市场（大学生）有多种零工选择。微任务结算必须在<strong>总价值</strong>（现金 + AI 使用权）上具有竞争力，而不仅仅是时薪。</p>
+<p>我们的目标市场（大学生）有多种零工选择。微任务结算必须在<strong>总价值</strong>（现金 + AI 使用权）上具有竞争力，而不仅仅是时薪。所有月收入统一按 <strong>50 小时/月</strong>（每天 2-3 小时 &times; 20 天，典型的学生兼职工时）折算。</p>
 <table>
-  <tr><th>零工类型</th><th>时薪</th><th>月收入（估算）</th><th>备注</th></tr>
-  <tr><td>一对一家教</td><td>&#165;40 &ndash; 200/小时</td><td>&#165;2,000 &ndash; 8,000</td><td>时薪最高，但需学科专业知识 + 时间安排。因城市而异（一线城市 &#165;60-300）。</td></tr>
-  <tr><td>外卖骑手（兼职）</td><td>&#165;20 &ndash; 30/小时</td><td>&#165;2,000 &ndash; 4,000</td><td>体力劳动，受天气影响。全职骑手平均 &#165;7,500/月。</td></tr>
-  <tr><td>游戏陪玩</td><td>&#165;10 &ndash; 30/小时（平台价）</td><td>&#165;1,000 &ndash; 5,000</td><td>填充率低（约 40%）。头部 &#165;25,000+/月。价格较 2023 峰值腰斩（&#165;80-90/局 &rarr; &#165;40-45/局）。</td></tr>
-  <tr><td>兼职客服</td><td>&#165;15 &ndash; 25/小时</td><td>&#165;2,000 &ndash; 4,000</td><td>时间灵活，与微任务最为相似。</td></tr>
-  <tr><td>数据标注平台</td><td>&#165;15 &ndash; 25/小时</td><td>&#165;1,000 &ndash; 3,000</td><td>数字化、灵活，但单调且利润率持续下降。</td></tr>
+  <tr><th>零工类型</th><th>时薪</th><th>月收入 @50h</th><th>备注</th></tr>
+  <tr><td>一对一家教</td><td>&#165;40 &ndash; 200/小时</td><td>&#165;2,000 &ndash; 10,000</td><td>时薪最高，但需学科专业知识 + 时间安排。因城市而异（一线城市 &#165;60-300）。实际难以填满 50h/月 &mdash; 通常 2-3 个学生 &times; 2h/周。</td></tr>
+  <tr><td>外卖骑手（兼职）</td><td>&#165;20 &ndash; 30/小时</td><td>&#165;1,000 &ndash; 1,500</td><td>体力劳动，受天气影响。50h 容易填满但辛苦。全职骑手（200h/月）平均 &#165;7,500/月。</td></tr>
+  <tr><td>游戏陪玩</td><td>&#165;10 &ndash; 30/小时（平台价）</td><td>&#165;200 &ndash; 600</td><td>填充率约 40% &mdash; 50h 中仅 20h 有报酬。价格较 2023 峰值腰斩。高填充率头部玩家收入远高于此。</td></tr>
+  <tr><td>兼职客服</td><td>&#165;15 &ndash; 25/小时</td><td>&#165;750 &ndash; 1,250</td><td>时间灵活，与微任务最为相似。50h 容易填满。</td></tr>
+  <tr><td>数据标注平台</td><td>&#165;15 &ndash; 25/小时</td><td>&#165;750 &ndash; 1,250</td><td>数字化、灵活，但单调且利润率持续下降。</td></tr>
   <tr style="background:var(--card)">
-    <td><strong>我们的场景 C：抖音微任务（纯现金，无 AI）</strong></td>
+    <td><strong>我们的场景 C：抖音微任务（无 AI）</strong></td>
     <td><strong>&#165;6 &ndash; 15/小时</strong></td>
-    <td><strong>&#165;500 &ndash; 2,000</strong></td>
-    <td>&#165;0.30-0.50/任务，无 AI 每任务 3-5 分钟。低端场景。</td>
+    <td><strong>&#165;300 &ndash; 750</strong></td>
+    <td>&#165;0.30-0.50/任务，无 AI 每任务 3-5 分钟。纯现金不具竞争力。</td>
   </tr>
   <tr style="background:var(--card)">
     <td><strong>我们的场景 C：抖音（AI 提效后）</strong></td>
     <td><strong>&#165;18 &ndash; 30/小时</strong></td>
-    <td><strong>&#165;1,500 &ndash; 4,000</strong></td>
-    <td>AI 将任务时间压缩到约 1 分钟。与外卖/客服时薪持平。</td>
+    <td><strong>&#165;900 &ndash; 1,500</strong></td>
+    <td>AI 将任务时间压缩到约 1 分钟。与外卖/客服持平。</td>
   </tr>
   <tr style="background:#1a2e1a">
-    <td><strong>我们的场景 A：视频剪辑（现金，AI 辅助）</strong></td>
+    <td><strong>我们的场景 A：视频剪辑（AI 辅助）</strong></td>
     <td><strong>&#165;160 &ndash; 300/小时</strong></td>
-    <td><strong>&#165;4,000 &ndash; 10,000+</strong></td>
-    <td>&#165;80-150/视频，使用 sudowork 剪辑技能约 30 分钟完成。<strong>超越家教及所有其他兼职。</strong>最高价值场景。</td>
+    <td><strong>&#165;8,000 &ndash; 15,000</strong></td>
+    <td>&#165;80-150/视频，使用 sudowork 剪辑技能约 30 分钟完成。<strong>超越包括家教在内的所有兼职。</strong></td>
   </tr>
   <tr style="background:#1a2e1a">
     <td><strong>我们的场景 A：视频剪辑（现金 + AI 价值）</strong></td>
     <td><strong>&#165;160-300 现金 + &#165;1,600-6,000 AI 价值</strong></td>
     <td>&mdash;</td>
-    <td>在已经很高的现金时薪基础上叠加 10-20x Token 杠杆。在这个收入水平下，Token 杠杆是锦上添花，而非核心价值主张。</td>
+    <td>在已经很高的现金时薪基础上叠加 10-20x Token 杠杆。Token 杠杆是锦上添花，而非必需。</td>
   </tr>
 </table>
 <div class="warn">

--- a/docs/architecture/p2p-task-settlement.html
+++ b/docs/architecture/p2p-task-settlement.html
@@ -713,37 +713,37 @@ sequenceDiagram
 </div>
 
 <h3>3. Competing Gig Income for University Students</h3>
-<p>Our target market (university students) has multiple gig options. Task settlement must offer competitive <strong>total value</strong> (cash + AI access), not just hourly rate.</p>
+<p>Our target market (university students) has multiple gig options. Task settlement must offer competitive <strong>total value</strong> (cash + AI access), not just hourly rate. All monthly income normalized to <strong>50h/month</strong> (2-3h/day &times; 20 days, typical part-time student schedule).</p>
 <table>
-  <tr><th>Gig type</th><th>Hourly rate</th><th>Monthly income (est.)</th><th>Notes</th></tr>
-  <tr><td>One-on-one tutoring (家教)</td><td>&#165;40 &ndash; 200/h</td><td>&#165;2,000 &ndash; 8,000</td><td>Highest hourly, but requires subject expertise + scheduling. City-dependent (&#165;60-300 in tier 1).</td></tr>
-  <tr><td>Food delivery (外卖骑手, part-time)</td><td>&#165;20 &ndash; 30/h</td><td>&#165;2,000 &ndash; 4,000</td><td>Physical, weather-dependent. Full-time riders average &#165;7,500/mo.</td></tr>
-  <tr><td>Game companionship (游戏陪玩)</td><td>&#165;10 &ndash; 30/h (platform rate)</td><td>&#165;1,000 &ndash; 5,000</td><td>Low fill rate (~40%). Top performers &#165;25,000+/mo. Prices halved from 2023 peak (&#165;80-90/game &rarr; &#165;40-45/game).</td></tr>
-  <tr><td>Online customer service (兼职客服)</td><td>&#165;15 &ndash; 25/h</td><td>&#165;2,000 &ndash; 4,000</td><td>Flexible scheduling, most similar to micro-tasks.</td></tr>
-  <tr><td>Data labeling platforms</td><td>&#165;15 &ndash; 25/h</td><td>&#165;1,000 &ndash; 3,000</td><td>Digital, flexible, but monotonous and shrinking margins.</td></tr>
+  <tr><th>Gig type</th><th>Hourly rate</th><th>Monthly @50h</th><th>Notes</th></tr>
+  <tr><td>One-on-one tutoring (家教)</td><td>&#165;40 &ndash; 200/h</td><td>&#165;2,000 &ndash; 10,000</td><td>Highest hourly, but requires subject expertise + scheduling. City-dependent (&#165;60-300 in tier 1). Hard to fill 50h/mo &mdash; typically 2-3 students &times; 2h/week.</td></tr>
+  <tr><td>Food delivery (外卖骑手, part-time)</td><td>&#165;20 &ndash; 30/h</td><td>&#165;1,000 &ndash; 1,500</td><td>Physical, weather-dependent. 50h easily fillable but exhausting. Full-time riders (200h/mo) average &#165;7,500/mo.</td></tr>
+  <tr><td>Game companionship (游戏陪玩)</td><td>&#165;10 &ndash; 30/h (platform rate)</td><td>&#165;200 &ndash; 600</td><td>Fill rate ~40% &mdash; only 20h of 50h are paid. Prices halved from 2023 peak. Top performers with high fill rate earn far more.</td></tr>
+  <tr><td>Online customer service (兼职客服)</td><td>&#165;15 &ndash; 25/h</td><td>&#165;750 &ndash; 1,250</td><td>Flexible scheduling, most similar to micro-tasks. 50h easily fillable.</td></tr>
+  <tr><td>Data labeling platforms</td><td>&#165;15 &ndash; 25/h</td><td>&#165;750 &ndash; 1,250</td><td>Digital, flexible, but monotonous and shrinking margins.</td></tr>
   <tr style="background:var(--card)">
-    <td><strong>Our Scenario C: Douyin micro-tasks (cash only, no AI)</strong></td>
+    <td><strong>Our Scenario C: Douyin micro-tasks (no AI)</strong></td>
     <td><strong>&#165;6 &ndash; 15/h</strong></td>
-    <td><strong>&#165;500 &ndash; 2,000</strong></td>
-    <td>&#165;0.30-0.50/task, 3-5 min without AI. Low-end scenario.</td>
+    <td><strong>&#165;300 &ndash; 750</strong></td>
+    <td>&#165;0.30-0.50/task, 3-5 min without AI. Not competitive on cash alone.</td>
   </tr>
   <tr style="background:var(--card)">
-    <td><strong>Our Scenario C: Douyin (with AI throughput)</strong></td>
+    <td><strong>Our Scenario C: Douyin (with AI)</strong></td>
     <td><strong>&#165;18 &ndash; 30/h</strong></td>
-    <td><strong>&#165;1,500 &ndash; 4,000</strong></td>
+    <td><strong>&#165;900 &ndash; 1,500</strong></td>
     <td>AI compresses task to ~1 min. Matches delivery/customer service.</td>
   </tr>
   <tr style="background:#1a2e1a">
-    <td><strong>Our Scenario A: Video editing (cash, with AI)</strong></td>
+    <td><strong>Our Scenario A: Video editing (with AI)</strong></td>
     <td><strong>&#165;160 &ndash; 300/h</strong></td>
-    <td><strong>&#165;4,000 &ndash; 10,000+</strong></td>
-    <td>&#165;80-150/video, ~30 min with sudowork editing skill. <strong>Exceeds tutoring and all other gigs.</strong> Highest-value scenario.</td>
+    <td><strong>&#165;8,000 &ndash; 15,000</strong></td>
+    <td>&#165;80-150/video, ~30 min with sudowork editing skill. <strong>Exceeds all gigs including tutoring.</strong></td>
   </tr>
   <tr style="background:#1a2e1a">
     <td><strong>Our Scenario A: Video editing (cash + AI value)</strong></td>
     <td><strong>&#165;160-300 cash + &#165;1,600-6,000 AI value</strong></td>
     <td>&mdash;</td>
-    <td>10-20x token leverage on top of already-high cash rate. At this level, token leverage is a bonus, not the primary value proposition.</td>
+    <td>10-20x token leverage on top of already-high cash rate. Token leverage is a bonus, not required.</td>
   </tr>
 </table>
 <div class="warn">


### PR DESCRIPTION
All monthly income now calculated at 50h/month (2-3h/day × 20 days). Apple-to-apple comparison. EN + ZH.