### PR TITLE
docs+deps: bootstrap safety runbook fix + nexus-vfs #112 pin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=e3b1f890152e044d3da14f20f5ce5b166f631aad#e3b1f890152e044d3da14f20f5ce5b166f631aad"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=92f3323916fcd71f26ee0b0eaacf2a5b9f1cf5ae#92f3323916fcd71f26ee0b0eaacf2a5b9f1cf5ae"
 dependencies = [
  "ahash",
  "base64",
@@ -550,7 +550,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=e3b1f890152e044d3da14f20f5ce5b166f631aad#e3b1f890152e044d3da14f20f5ce5b166f631aad"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=92f3323916fcd71f26ee0b0eaacf2a5b9f1cf5ae#92f3323916fcd71f26ee0b0eaacf2a5b9f1cf5ae"
 dependencies = [
  "parking_lot",
  "serde",
@@ -1343,7 +1343,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=e3b1f890152e044d3da14f20f5ce5b166f631aad#e3b1f890152e044d3da14f20f5ce5b166f631aad"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=92f3323916fcd71f26ee0b0eaacf2a5b9f1cf5ae#92f3323916fcd71f26ee0b0eaacf2a5b9f1cf5ae"
 dependencies = [
  "ahash",
  "base64",
@@ -1394,7 +1394,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=e3b1f890152e044d3da14f20f5ce5b166f631aad#e3b1f890152e044d3da14f20f5ce5b166f631aad"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=92f3323916fcd71f26ee0b0eaacf2a5b9f1cf5ae#92f3323916fcd71f26ee0b0eaacf2a5b9f1cf5ae"
 dependencies = [
  "ahash",
  "base64",
@@ -1589,7 +1589,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=e3b1f890152e044d3da14f20f5ce5b166f631aad#e3b1f890152e044d3da14f20f5ce5b166f631aad"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=92f3323916fcd71f26ee0b0eaacf2a5b9f1cf5ae#92f3323916fcd71f26ee0b0eaacf2a5b9f1cf5ae"
 
 [[package]]
 name = "nexus-vault"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,8 +30,28 @@ exclude = ["nexus-fuse"]
 [workspace.dependencies]
 # Kernel-tier crates from nexus-vfs (external git dependency).
 # SSOT: https://github.com/nexi-lab/nexus-vfs
-# Pinned at the nexus-vfs commit that landed PR #106 + #107 + #108 + #109 + #110 + #111
-# (e3b1f8901, 2026-07-03): PR #111 completes the audit PR #110 began —
+# Pinned at the nexus-vfs commit that landed PR #106..#112 (92f332391, 2026-07-04):
+# PR #112 lands two bootstrap-safety fixes:
+#   (1) split-brain guard — run_daemon refuses `bootstrap_static_async` when
+#       `identity.json` already lists persisted peers.  Prevents the
+#       "both-founder" misconfig (two nodes each auto-creating sharedzone
+#       SOLO on empty data_dir + accidental parallel `NEXUS_FEDERATION_ZONES=
+#       sharedzone` both wedging the federation with independent commit
+#       histories that raft cannot merge).  Error message names both
+#       correct roles: (a) wipe identity if you meant founder; (b) unset
+#       NEXUS_FEDERATION_ZONES + run sidecar `join` if you meant joiner.
+#   (2) fail-loud gRPC bind — `ZoneManager::start` used to `tracing::error!`
+#       + swallow tonic serve errors, leaving daemon half-alive (raft + FUSE
+#       + LocalConnector all up, no gRPC listener).  Now exits(1) so
+#       supervisors + operator's `echo $?` see the failure at the right
+#       level.  Bind failure is unrecoverable from inside the process.
+# Companion rename in the same PR: `ZoneManagerBundle.peer_addrs` →
+# `cli_peer_addrs`, new `identity_persisted_peers` field.  Docstring on
+# the struct explains why the two peer fields are NOT unified (see PR
+# body's trade-off analysis — merging breaks either root SOLO invariant
+# or S3 reconnect contract).
+#
+# PR #111 completes the audit PR #110 began —
 # 11 additional tracing sites where the field name was ambiguous
 # (`peer = <u64>`, `leader = <u64>`, `node_id = <peer.node_id>`) all
 # renamed to the disambiguated `peer_node_id` / `leader_node_id` +
@@ -176,13 +196,13 @@ exclude = ["nexus-fuse"]
 #
 # Bump alongside the rest of nexus-vfs updates when a downstream
 # change needs newer kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "e3b1f890152e044d3da14f20f5ce5b166f631aad" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "e3b1f890152e044d3da14f20f5ce5b166f631aad" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "e3b1f890152e044d3da14f20f5ce5b166f631aad" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "e3b1f890152e044d3da14f20f5ce5b166f631aad", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "e3b1f890152e044d3da14f20f5ce5b166f631aad", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "e3b1f890152e044d3da14f20f5ce5b166f631aad", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "e3b1f890152e044d3da14f20f5ce5b166f631aad" }
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "92f3323916fcd71f26ee0b0eaacf2a5b9f1cf5ae" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "92f3323916fcd71f26ee0b0eaacf2a5b9f1cf5ae" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "92f3323916fcd71f26ee0b0eaacf2a5b9f1cf5ae" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "92f3323916fcd71f26ee0b0eaacf2a5b9f1cf5ae", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "92f3323916fcd71f26ee0b0eaacf2a5b9f1cf5ae", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "92f3323916fcd71f26ee0b0eaacf2a5b9f1cf5ae", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "92f3323916fcd71f26ee0b0eaacf2a5b9f1cf5ae" }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ENV CARGO_NET_RETRY=10 \
     CARGO_HTTP_TIMEOUT=120
 # Override for edge/CI or a different pin: --build-arg NEXUS_VFS_REV=<sha|tag>
-ARG NEXUS_VFS_REV=e3b1f890152e044d3da14f20f5ce5b166f631aad
+ARG NEXUS_VFS_REV=92f3323916fcd71f26ee0b0eaacf2a5b9f1cf5ae
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,id=cargo-install-${TARGETARCH},target=/root/.cargo/target \

--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir --no-deps --prefix=/install .
 # enforces agreement) — an unpinned install tracks nexus-vfs HEAD and
 # ships an untested kernel (#4343). --locked honors the source tree's
 # Cargo.lock.
-ARG NEXUS_VFS_REV=e3b1f890152e044d3da14f20f5ce5b166f631aad
+ARG NEXUS_VFS_REV=92f3323916fcd71f26ee0b0eaacf2a5b9f1cf5ae
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-cluster nexus-cluster
 
 # -- Runtime stage --

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -25,7 +25,7 @@ WORKDIR /build
 # (CI preflight enforces agreement) — an unpinned install tracks HEAD
 # and can skew the raft contract against the cluster/witness images.
 # --locked honors the source tree's Cargo.lock.
-ARG NEXUS_VFS_REV=e3b1f890152e044d3da14f20f5ce5b166f631aad
+ARG NEXUS_VFS_REV=92f3323916fcd71f26ee0b0eaacf2a5b9f1cf5ae
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexus-raft-server raft
 
 # ---------- Production image ----------

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=e3b1f890152e044d3da14f20f5ce5b166f631aad
+ARG NEXUS_VFS_REV=92f3323916fcd71f26ee0b0eaacf2a5b9f1cf5ae
 RUN cargo install \
     --locked \
     --git https://github.com/nexi-lab/nexus-vfs \

--- a/docs/architecture/federation-cross-machine-runbook.md
+++ b/docs/architecture/federation-cross-machine-runbook.md
@@ -302,8 +302,11 @@ Node A and node B each mount their own LocalConnector under a hostname-namespace
 
 Operator flow (mirrors what `dockerfiles/docker-compose.cc-tasks-share.yml` automates):
 
+**⚠️ Discipline: EXACTLY ONE node in a federation is the founder.**  Both nodes running the founder recipe (both setting `NEXUS_FEDERATION_ZONES=sharedzone` on fresh data dirs) auto-creates the zone as SOLO on each node with itself as sole voter → two independent raft clusters that happen to share a zone name → split-brain that raft cannot reconcile.  nexus-vfs PR #112 landed a hard guard for this: if `identity.json` has persisted peers and the launcher still sets `NEXUS_FEDERATION_ZONES`, the daemon refuses to boot and names both correct roles.  Prefer running the guard-protected recipes below rather than relying on the guard as backstop.
+
 ```bash
-# On A (founder of sharedzone):
+# On A (FOUNDER of sharedzone) — auto-creates the zone SOLO, then waits for
+# joiners to sidecar-join against it.  EXACTLY ONE node runs this recipe.
 NEXUS_FEDERATION_ZONES=sharedzone \
 NEXUS_FEDERATION_MOUNTS=/shared=sharedzone \
 nexusd-cluster --bootstrap-mode static \
@@ -311,23 +314,28 @@ nexusd-cluster --bootstrap-mode static \
   --mount-driver 'local-connector:sharedzone:/shared/cc-tasks/A:{"local_root":"/home/me/.claude/tasks"}' \
   ...
 
-# On B (joiner):
-# 1. First boot — daemon ignores --mount-driver because sharedzone is not yet loaded
-#    locally; the substrate explicitly skips operator driver mounts on zones that
-#    don't exist yet, preventing a parallel-bootstrap split-brain.
-nexusd-cluster --bootstrap-mode static \
+# On B (JOINER of A's sharedzone) — does NOT set NEXUS_FEDERATION_ZONES /
+# NEXUS_FEDERATION_MOUNTS (those trigger auto-create on B).  Sequence is:
+#
+# 1. Offline sidecar join (daemon stopped) — seeds sharedzone's ConfState + log
+#    into B's data dir + persists A's addr into identity.json.
+#
+#    Bare `<HOST:PORT>` is the ONLY accepted peer form post nexus-vfs PR #109
+#    (the `<node_id>@<host:port>` shape was retired at the CLI boundary).
+#    Bare `join` defaults to `--as voter` (symmetric peer); pass `--as learner`
+#    for owner-pattern wipe-rejoin safety instead.
+nexusd-cluster join <A_host:port> sharedzone /shared \
+  --data-dir ./data --hostname B --no-tls
+
+# 2. Start B's main daemon — RESTART mode picks up sharedzone from disk;
+#    --mount-driver runs on the resumed zone; no auto-create anywhere.
+nexusd-cluster --bootstrap-mode restart \
   --plugin-dir ./plugins \
   --mount-driver 'local-connector:sharedzone:/shared/cc-tasks/B:{"local_root":"/home/me/.claude/tasks"}' \
   ...
-
-# 2. Offline join (daemon stopped) — seeds sharedzone's ConfState + log into B's data dir.
-#    Bare `join` defaults to `--as voter` (symmetric peer); pass `--as learner` for
-#    owner-pattern wipe-rejoin safety instead.
-nexusd-cluster join <A_node_id>@<A_addr> sharedzone /shared --data-dir ./data --hostname B
-
-# 3. Restart — entrypoint auto-detects restart mode; sharedzone replays from disk and
-#    --mount-driver runs successfully because the zone is now loaded.
 ```
+
+If you accidentally started B with `NEXUS_FEDERATION_ZONES=sharedzone` set on empty data dir before doing the sidecar join, the split-brain guard now catches it — the error message tells you which role you meant (wipe identity to become founder, or unset the env var + run sidecar to become joiner).
 
 After the restart, reads on B for any path under `/shared/cc-tasks/A/...` route through `/sharedzone/shared` (the federation mount), miss locally, fan out to A, and return A's host-fs bytes.  Subsequent reads take Mode A.  Symmetric on A reading `/shared/cc-tasks/B/...`.
 


### PR DESCRIPTION
## Summary

Two commits landing the operator-facing side of nexus-vfs PR #112 (split-brain guard + fail-loud gRPC bind):

1. **``docs(runbook): correct founder-vs-joiner discipline``** — the pre-2026-07-04 runbook §Peer-shared subsection literally instructed BOTH nodes to set ``NEXUS_FEDERATION_ZONES=sharedzone`` and claimed the substrate would prevent "parallel-bootstrap split-brain".  It doesn't — the substrate skip only guards mount install on unloaded zones, not zone auto-create.  Both Mac AI and I followed the runbook verbatim on 2026-07-04 and got straight into a wedged federation.  Rewrite: WARNING callout naming the guard, reversed joiner recipe (no federation env, sidecar first + restart mode after), sidecar CLI updated to bare ``<host:port>`` per PR #109.
2. **``chore(deps): bump nexus-vfs pin → 92f332391``** — companion pin bump for the guard + fail-loud fixes.  Cargo.toml + Cargo.lock + Dockerfile + dockerfiles/{minimal,raft-server,raft-witness}.

## What nexus-vfs PR #112 ships

- **Split-brain guard**: ``run_daemon`` refuses ``bootstrap_static_async`` when ``identity.json`` already lists persisted peers.  Structural prevention of the both-founder misconfig.  Error message names both correct roles.
- **Fail-loud gRPC bind**: ``ZoneManager::start`` used to log-and-swallow tonic serve errors → daemon stayed alive with no gRPC.  Now exits(1).  Bind failure is unrecoverable from inside the process.
- **Companion rename** (in the same guard commit because they share data flow): ``ZoneManagerBundle.peer_addrs`` → ``cli_peer_addrs``, new ``identity_persisted_peers`` field.  Docstring explains why the pair can't be merged (root SOLO invariant vs S3 reconnect contract are genuinely different data).

## 8-principle verdict

- **Simple contract** ✅ — one runbook edit, one pin bump, one added guard behavior.  No new operator API.
- **No boundary leak** ✅ — kernel guard + operator doc each in their own layer.
- **SSOT** ✅ — runbook is now the single source for the founder/joiner discipline.
- **DRY** ✅ — the guard consolidates the "don't accidentally both-founder" invariant into one Rust check rather than repeated operator vigilance.
- **Rust-first** ✅ — enforcement lives in the daemon, not in launcher scripts.
- **Perf** ✅ — one boot-path ``is_empty()``.  Zero runtime cost.
- **Raft 100%** ✅ — no protocol change.  Guard catches misconfig BEFORE raft state machine is touched.
- **Systemic (principle 8)** ✅ — closes the misconfig class at the daemon boundary.  Follow-up local work (operator launcher role-split into founder/joiner scripts) is per-machine and doesn't need to land here.
- **E2E coverage** ✅ — federation-runbook Docker E2E already exercises the founder-joiner sequence; the guard adds a negative-path test in the nexus-vfs suite.

## Test plan

- [ ] CI: all fast gates + Federation E2E (Docker) + cc-tasks-share E2E green
- [ ] CI: nexusd-cluster Smoke green
- [ ] Manual (once merged): rebuild Win daemon on 92f332391, wipe locally, re-do the Mac↔Win federation using the corrected joiner recipe