### PR TITLE
chore(deps): bump nexus-vfs pin -> d286686c4 (unified bring-up)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=92f3323916fcd71f26ee0b0eaacf2a5b9f1cf5ae#92f3323916fcd71f26ee0b0eaacf2a5b9f1cf5ae"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=d286686c4b2ce9f3173e244d55d7b60841af72e4#d286686c4b2ce9f3173e244d55d7b60841af72e4"
 dependencies = [
  "ahash",
  "base64",
@@ -550,7 +550,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=92f3323916fcd71f26ee0b0eaacf2a5b9f1cf5ae#92f3323916fcd71f26ee0b0eaacf2a5b9f1cf5ae"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=d286686c4b2ce9f3173e244d55d7b60841af72e4#d286686c4b2ce9f3173e244d55d7b60841af72e4"
 dependencies = [
  "parking_lot",
  "serde",
@@ -1343,7 +1343,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=92f3323916fcd71f26ee0b0eaacf2a5b9f1cf5ae#92f3323916fcd71f26ee0b0eaacf2a5b9f1cf5ae"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=d286686c4b2ce9f3173e244d55d7b60841af72e4#d286686c4b2ce9f3173e244d55d7b60841af72e4"
 dependencies = [
  "ahash",
  "base64",
@@ -1394,7 +1394,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=92f3323916fcd71f26ee0b0eaacf2a5b9f1cf5ae#92f3323916fcd71f26ee0b0eaacf2a5b9f1cf5ae"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=d286686c4b2ce9f3173e244d55d7b60841af72e4#d286686c4b2ce9f3173e244d55d7b60841af72e4"
 dependencies = [
  "ahash",
  "base64",
@@ -1589,7 +1589,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=92f3323916fcd71f26ee0b0eaacf2a5b9f1cf5ae#92f3323916fcd71f26ee0b0eaacf2a5b9f1cf5ae"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=d286686c4b2ce9f3173e244d55d7b60841af72e4#d286686c4b2ce9f3173e244d55d7b60841af72e4"
 
 [[package]]
 name = "nexus-vault"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,8 @@ exclude = ["nexus-fuse"]
 [workspace.dependencies]
 # Kernel-tier crates from nexus-vfs (external git dependency).
 # SSOT: https://github.com/nexi-lab/nexus-vfs
-# Pinned at the nexus-vfs commit that landed PR #106..#112 (92f332391, 2026-07-04):
+# Pinned at the nexus-vfs commit that landed PR #113 -- S3 unified bring-up
+# (Phase A + B) on top of PR #106..#112 (d286686c4, 2026-07-05):
 # PR #112 lands two bootstrap-safety fixes:
 #   (1) split-brain guard — run_daemon refuses `bootstrap_static_async` when
 #       `identity.json` already lists persisted peers.  Prevents the
@@ -196,13 +197,13 @@ exclude = ["nexus-fuse"]
 #
 # Bump alongside the rest of nexus-vfs updates when a downstream
 # change needs newer kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "92f3323916fcd71f26ee0b0eaacf2a5b9f1cf5ae" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "92f3323916fcd71f26ee0b0eaacf2a5b9f1cf5ae" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "92f3323916fcd71f26ee0b0eaacf2a5b9f1cf5ae" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "92f3323916fcd71f26ee0b0eaacf2a5b9f1cf5ae", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "92f3323916fcd71f26ee0b0eaacf2a5b9f1cf5ae", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "92f3323916fcd71f26ee0b0eaacf2a5b9f1cf5ae", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "92f3323916fcd71f26ee0b0eaacf2a5b9f1cf5ae" }
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "d286686c4b2ce9f3173e244d55d7b60841af72e4" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "d286686c4b2ce9f3173e244d55d7b60841af72e4" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "d286686c4b2ce9f3173e244d55d7b60841af72e4" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "d286686c4b2ce9f3173e244d55d7b60841af72e4", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "d286686c4b2ce9f3173e244d55d7b60841af72e4", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "d286686c4b2ce9f3173e244d55d7b60841af72e4", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "d286686c4b2ce9f3173e244d55d7b60841af72e4" }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ENV CARGO_NET_RETRY=10 \
     CARGO_HTTP_TIMEOUT=120
 # Override for edge/CI or a different pin: --build-arg NEXUS_VFS_REV=<sha|tag>
-ARG NEXUS_VFS_REV=92f3323916fcd71f26ee0b0eaacf2a5b9f1cf5ae
+ARG NEXUS_VFS_REV=d286686c4b2ce9f3173e244d55d7b60841af72e4
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,id=cargo-install-${TARGETARCH},target=/root/.cargo/target \

--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir --no-deps --prefix=/install .
 # enforces agreement) — an unpinned install tracks nexus-vfs HEAD and
 # ships an untested kernel (#4343). --locked honors the source tree's
 # Cargo.lock.
-ARG NEXUS_VFS_REV=92f3323916fcd71f26ee0b0eaacf2a5b9f1cf5ae
+ARG NEXUS_VFS_REV=d286686c4b2ce9f3173e244d55d7b60841af72e4
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-cluster nexus-cluster
 
 # -- Runtime stage --

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -25,7 +25,7 @@ WORKDIR /build
 # (CI preflight enforces agreement) — an unpinned install tracks HEAD
 # and can skew the raft contract against the cluster/witness images.
 # --locked honors the source tree's Cargo.lock.
-ARG NEXUS_VFS_REV=92f3323916fcd71f26ee0b0eaacf2a5b9f1cf5ae
+ARG NEXUS_VFS_REV=d286686c4b2ce9f3173e244d55d7b60841af72e4
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexus-raft-server raft
 
 # ---------- Production image ----------

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=92f3323916fcd71f26ee0b0eaacf2a5b9f1cf5ae
+ARG NEXUS_VFS_REV=d286686c4b2ce9f3173e244d55d7b60841af72e4
 RUN cargo install \
     --locked \
     --git https://github.com/nexi-lab/nexus-vfs \

--- a/docs/architecture/federation-cross-machine-runbook.md
+++ b/docs/architecture/federation-cross-machine-runbook.md
@@ -182,6 +182,37 @@ Windows extra: open a Developer Command Prompt for VS Build Tools first so `cl.e
 
 ### Step 3 — Bootstrap the cluster
 
+#### S3 unified bring-up (nexus-vfs #113, 2026-07-05)
+
+Since nexus-vfs PR #113 the daemon reads `(identity.peers, --peers,
+NEXUS_FEDERATION_ZONES)` at boot and dispatches deterministically:
+
+| # | identity.peers | CLI --peers | NEXUS_FEDERATION_ZONES | Action |
+|---|---|---|---|---|
+| 1 | empty | empty | set | Founder — auto-create SOLO |
+| 2 | empty | empty | unset | Rootless (daemon up, no zone auto-boot) |
+| 3 | empty | non-empty | unset | Fresh joiner — Phase B: no auto-JoinZone, use `join` sidecar for the first join |
+| 4 | non-empty | any | unset | **Returning joiner — auto-rejoins zones from `identity.zones`** (Phase B) |
+| 5 | non-empty | any | set | **FAIL LOUD** — split-brain trap (this node already knows peers) |
+| 6 | empty | non-empty | set | **FAIL LOUD** — ambiguous ("I'm a founder, but here are my peers") |
+
+**Operator implications**
+
+* Rows 5 + 6 are the two both-founder split-brain configurations we
+  hit in the field on 2026-07-04.  The daemon refuses to boot on
+  either, with an operator-actionable hint.  Match your launcher to
+  ROW 1 (founder) or ROW 3/4 (joiner) — never both.
+* Row 4 replaces the two-step "start daemon in restart mode + hope
+  ConfState is there" flow.  A joiner that has completed at least
+  one JoinZone against a federation zone gets an `identity.zones`
+  entry via the ConfChange apply callback; a subsequent boot with a
+  wiped `data_dir` (identity survives at the platform-native path
+  — `%LOCALAPPDATA%\Nexus\identity.json` on Windows, `~/Library/
+  Application Support/Nexus/identity.json` on macOS) auto-rejoins
+  without operator intervention.
+* Voter wipe-rejoin is still on the follow-up list — see
+  `docs/federation-architecture.md` § 6.3.1 in nexus-vfs.
+
 Key contract rules:
 
 * **`--bootstrap-mode` is required when federation is in play** (PR #4028).  Pass `static` for env-driven topology (`NEXUS_FEDERATION_*` carry the cluster shape, used across first boot and subsequent container restarts), `restart` for operator-managed resume where persisted ConfState is the source of truth (no env needed), `dynamic` for runtime-API-driven setups.

--- a/tests/e2e/docker/test_cc_tasks_share_e2e.py
+++ b/tests/e2e/docker/test_cc_tasks_share_e2e.py
@@ -1983,8 +1983,14 @@ class TestIdentityPeerPersistence:
         # The daemon still learns the founder's real node_id at
         # runtime via `learn_peer_address` on the first inbound raft
         # message — it never needs to be encoded in the address book.
-        assert identity.get("schema_version") == 1, (
-            f"identity schema_version mismatch: expected 1, got "
+        #
+        # nexus-vfs #113 (S3 Phase B, 2026-07-05) bumped the schema to
+        # v2 to add a `zones` per-zone membership snapshot populated
+        # by the ConfChange apply callback.  v1 files still load
+        # (backward-compat covered by `v1_file_loads_with_empty_zones_
+        # and_reports_on_disk_version` on the Rust side).
+        assert identity.get("schema_version") == 2, (
+            f"identity schema_version mismatch: expected 2, got "
             f"{identity.get('schema_version')!r}. Full identity: {identity!r}"
         )
         peers = identity.get("peers")


### PR DESCRIPTION
## Summary

Bump nexus-vfs pin to d286686c4 to pick up PR #113 (S3 unified
bring-up Phase A + identity zones mirror Phase B).

## Changes

- 7 nexus-vfs crate revs in Cargo.toml + Cargo.lock
- 4 Dockerfile NEXUS_VFS_REV pin syncs (Dockerfile, Dockerfile.minimal,
  Dockerfile.raft-server, Dockerfile.raft-witness)
- Runbook: compact S3 unified bring-up decision matrix in Step 3
  Bootstrap.  Documents the 6-row matrix, points out rows 5+6 fail-
  loud on both-founder misconfigurations, and highlights row 4 auto-
  rejoin from identity.zones (Phase B).

## Test plan

- [x] cargo check --workspace clean
- [x] cargo update -> new pin resolved
- [ ] CI green (cargo build, docker builds)
- [ ] Local Win daemon rebuild + smoke test with unified bring-up