### PR TITLE
chore(deps): bump nexus-vfs pin -> d7cc21d69b (Phase E DT_MOUNT harvest)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=4aad3ff3e26ed36e2927e8c791ff78c3c3079224#4aad3ff3e26ed36e2927e8c791ff78c3c3079224"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=d7cc21d69bae292fb452166cf6ad72c2db5fea02#d7cc21d69bae292fb452166cf6ad72c2db5fea02"
 dependencies = [
  "ahash",
  "base64",
@@ -550,7 +550,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=4aad3ff3e26ed36e2927e8c791ff78c3c3079224#4aad3ff3e26ed36e2927e8c791ff78c3c3079224"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=d7cc21d69bae292fb452166cf6ad72c2db5fea02#d7cc21d69bae292fb452166cf6ad72c2db5fea02"
 dependencies = [
  "parking_lot",
  "serde",
@@ -1343,7 +1343,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=4aad3ff3e26ed36e2927e8c791ff78c3c3079224#4aad3ff3e26ed36e2927e8c791ff78c3c3079224"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=d7cc21d69bae292fb452166cf6ad72c2db5fea02#d7cc21d69bae292fb452166cf6ad72c2db5fea02"
 dependencies = [
  "ahash",
  "base64",
@@ -1394,7 +1394,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=4aad3ff3e26ed36e2927e8c791ff78c3c3079224#4aad3ff3e26ed36e2927e8c791ff78c3c3079224"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=d7cc21d69bae292fb452166cf6ad72c2db5fea02#d7cc21d69bae292fb452166cf6ad72c2db5fea02"
 dependencies = [
  "ahash",
  "base64",
@@ -1589,7 +1589,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=4aad3ff3e26ed36e2927e8c791ff78c3c3079224#4aad3ff3e26ed36e2927e8c791ff78c3c3079224"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=d7cc21d69bae292fb452166cf6ad72c2db5fea02#d7cc21d69bae292fb452166cf6ad72c2db5fea02"
 
 [[package]]
 name = "nexus-vault"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ exclude = ["nexus-fuse"]
 # Kernel-tier crates from nexus-vfs (external git dependency).
 # SSOT: https://github.com/nexi-lab/nexus-vfs
 # Pinned at the nexus-vfs commit that landed PR #113 -- S3 unified bring-up
-# (Phase A + B + C + D) on top of PR #106..#112 (4aad3ff3e2, 2026-07-05):
+# (Phase A + B + C + D + E) on top of PR #106..#112 (d7cc21d69b, 2026-07-05):
 # PR #112 lands two bootstrap-safety fixes:
 #   (1) split-brain guard — run_daemon refuses `bootstrap_static_async` when
 #       `identity.json` already lists persisted peers.  Prevents the
@@ -197,13 +197,13 @@ exclude = ["nexus-fuse"]
 #
 # Bump alongside the rest of nexus-vfs updates when a downstream
 # change needs newer kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "4aad3ff3e26ed36e2927e8c791ff78c3c3079224" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "4aad3ff3e26ed36e2927e8c791ff78c3c3079224" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "4aad3ff3e26ed36e2927e8c791ff78c3c3079224" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "4aad3ff3e26ed36e2927e8c791ff78c3c3079224", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "4aad3ff3e26ed36e2927e8c791ff78c3c3079224", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "4aad3ff3e26ed36e2927e8c791ff78c3c3079224", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "4aad3ff3e26ed36e2927e8c791ff78c3c3079224" }
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "d7cc21d69bae292fb452166cf6ad72c2db5fea02" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "d7cc21d69bae292fb452166cf6ad72c2db5fea02" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "d7cc21d69bae292fb452166cf6ad72c2db5fea02" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "d7cc21d69bae292fb452166cf6ad72c2db5fea02", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "d7cc21d69bae292fb452166cf6ad72c2db5fea02", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "d7cc21d69bae292fb452166cf6ad72c2db5fea02", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "d7cc21d69bae292fb452166cf6ad72c2db5fea02" }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ENV CARGO_NET_RETRY=10 \
     CARGO_HTTP_TIMEOUT=120
 # Override for edge/CI or a different pin: --build-arg NEXUS_VFS_REV=<sha|tag>
-ARG NEXUS_VFS_REV=4aad3ff3e26ed36e2927e8c791ff78c3c3079224
+ARG NEXUS_VFS_REV=d7cc21d69bae292fb452166cf6ad72c2db5fea02
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,id=cargo-install-${TARGETARCH},target=/root/.cargo/target \

--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir --no-deps --prefix=/install .
 # enforces agreement) — an unpinned install tracks nexus-vfs HEAD and
 # ships an untested kernel (#4343). --locked honors the source tree's
 # Cargo.lock.
-ARG NEXUS_VFS_REV=4aad3ff3e26ed36e2927e8c791ff78c3c3079224
+ARG NEXUS_VFS_REV=d7cc21d69bae292fb452166cf6ad72c2db5fea02
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-cluster nexus-cluster
 
 # -- Runtime stage --

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -25,7 +25,7 @@ WORKDIR /build
 # (CI preflight enforces agreement) — an unpinned install tracks HEAD
 # and can skew the raft contract against the cluster/witness images.
 # --locked honors the source tree's Cargo.lock.
-ARG NEXUS_VFS_REV=4aad3ff3e26ed36e2927e8c791ff78c3c3079224
+ARG NEXUS_VFS_REV=d7cc21d69bae292fb452166cf6ad72c2db5fea02
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexus-raft-server raft
 
 # ---------- Production image ----------

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=4aad3ff3e26ed36e2927e8c791ff78c3c3079224
+ARG NEXUS_VFS_REV=d7cc21d69bae292fb452166cf6ad72c2db5fea02
 RUN cargo install \
     --locked \
     --git https://github.com/nexi-lab/nexus-vfs \


### PR DESCRIPTION
Follow-up pin bump on top of PR #4480.  Picks up nexus-vfs #116 (Phase E — DT_MOUNT SSOT harvest for DiscoverZones restart survival). All 7 nexus-vfs crates + 4 Dockerfile SHA syncs. cargo check --workspace clean.