### PR TITLE
chore(deps): bump nexus-vfs pin -> 3c7eeb6021 (Phase G) + retire --bootstrap-mode

### DIFF
--- a/.github/workflows/fuse-plugin-macos-nfs-e2e.yml
+++ b/.github/workflows/fuse-plugin-macos-nfs-e2e.yml
@@ -175,22 +175,21 @@ jobs:
           NEXUS_FUSE_VFS_ROOT: "/"
           NEXUS_BIND_ADDR: "0.0.0.0:2126"
           NEXUS_NO_TLS: "true"
-          NEXUS_BOOTSTRAP_MODE: "dynamic"
         run: |
           set -euo pipefail
           DATADIR="$HOME/.nexus/data"
           PLUGINDIR="$HOME/.nexus/plugins"
           mkdir -p "$DATADIR"
 
-          # Spawn daemon in background.  Tee stderr so startup progress
-          # is visible in the CI log during the wait loop (nexusd-cluster
-          # logs to stderr via tracing).
+          # Phase G (nexus-vfs #118): no --bootstrap-mode; empty
+          # data_dir + no peers + no federation env => row 2
+          # (RootlessDynamic).  Runtime API drives zone formation
+          # via the plugin.
           nexusd-cluster \
             --plugin-dir "$PLUGINDIR" \
             --bind-addr "0.0.0.0:2126" \
             --data-dir "$DATADIR" \
             --no-tls \
-            --bootstrap-mode dynamic \
             > nexusd.log 2> >(tee nexusd.err.log) &
           DAEMON_PID=$!
           echo "nexusd-cluster started, pid=$DAEMON_PID"

--- a/.github/workflows/fuse-plugin-windows-e2e.yml
+++ b/.github/workflows/fuse-plugin-windows-e2e.yml
@@ -243,18 +243,18 @@ jobs:
           $env:NEXUS_BIND_ADDR = "0.0.0.0:2126"
           $env:NEXUS_NO_TLS = "true"
           $env:NEXUS_DATA_DIR = $datadir
-          $env:NEXUS_BOOTSTRAP_MODE = "dynamic"
 
-          # Spawn daemon as child of THIS pwsh — it lives until we
-          # stop it (or until this pwsh exits at end of step, which
-          # is also when teardown runs).
+          # Phase G (nexus-vfs #118): no --bootstrap-mode; the fresh
+          # empty data_dir + empty peers + no federation env = row 2
+          # (RootlessDynamic).  Runtime API drives zone formation
+          # (which is exactly what this FUSE plugin E2E does via
+          # the plugin's own runtime create_zone calls).
           $proc = Start-Process -FilePath nexusd-cluster `
             -ArgumentList @(
               "--plugin-dir", $plugindir,
               "--bind-addr", "0.0.0.0:2126",
               "--data-dir", $datadir,
-              "--no-tls",
-              "--bootstrap-mode", "dynamic"
+              "--no-tls"
             ) `
             -RedirectStandardOutput nexusd.log `
             -RedirectStandardError nexusd.err.log `

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -716,12 +716,12 @@ jobs:
         if: needs.detect-changes.outputs.code_changed == 'true'
         run: |
           DATA_DIR=$(mktemp -d)
-          # Smoke uses static + empty peers → single-node default
-          # (creates own root 1-voter zone).  --bootstrap-mode is
-          # required since BootstrapMode validator landed.
+          # Smoke: empty peers + no federation env + empty data_dir
+          # → Phase G row 2 (RootlessDynamic).  Daemon comes up
+          # rootless; that is exactly what this smoke exercises
+          # (gRPC + tracing + tokio runtime start-and-shutdown).
           RUST_LOG=info nexusd-cluster \
-            --no-tls --data-dir "$DATA_DIR" \
-            --bootstrap-mode static &
+            --no-tls --data-dir "$DATA_DIR" &
           PID=$!
           echo "Started nexusd-cluster (PID=$PID), waiting 5s for boot..."
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=a7a2f1aab81862daf31c390bd5345ab194279127#a7a2f1aab81862daf31c390bd5345ab194279127"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=3c7eeb6021d40192c5a8f538b8097ecb0f374304#3c7eeb6021d40192c5a8f538b8097ecb0f374304"
 dependencies = [
  "ahash",
  "base64",
@@ -550,7 +550,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=a7a2f1aab81862daf31c390bd5345ab194279127#a7a2f1aab81862daf31c390bd5345ab194279127"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=3c7eeb6021d40192c5a8f538b8097ecb0f374304#3c7eeb6021d40192c5a8f538b8097ecb0f374304"
 dependencies = [
  "parking_lot",
  "serde",
@@ -1343,7 +1343,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=a7a2f1aab81862daf31c390bd5345ab194279127#a7a2f1aab81862daf31c390bd5345ab194279127"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=3c7eeb6021d40192c5a8f538b8097ecb0f374304#3c7eeb6021d40192c5a8f538b8097ecb0f374304"
 dependencies = [
  "ahash",
  "base64",
@@ -1394,7 +1394,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=a7a2f1aab81862daf31c390bd5345ab194279127#a7a2f1aab81862daf31c390bd5345ab194279127"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=3c7eeb6021d40192c5a8f538b8097ecb0f374304#3c7eeb6021d40192c5a8f538b8097ecb0f374304"
 dependencies = [
  "ahash",
  "base64",
@@ -1589,7 +1589,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=a7a2f1aab81862daf31c390bd5345ab194279127#a7a2f1aab81862daf31c390bd5345ab194279127"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=3c7eeb6021d40192c5a8f538b8097ecb0f374304#3c7eeb6021d40192c5a8f538b8097ecb0f374304"
 
 [[package]]
 name = "nexus-vault"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ exclude = ["nexus-fuse"]
 # Kernel-tier crates from nexus-vfs (external git dependency).
 # SSOT: https://github.com/nexi-lab/nexus-vfs
 # Pinned at the nexus-vfs commit that landed PR #113 -- S3 unified bring-up
-# (Phase A-F) on top of PR #106..#112 (a7a2f1aab8, 2026-07-05):
+# (Phase A-G — bootstrap-mode retired) on top of PR #106..#112 (3c7eeb6021, 2026-07-05):
 # PR #112 lands two bootstrap-safety fixes:
 #   (1) split-brain guard — run_daemon refuses `bootstrap_static_async` when
 #       `identity.json` already lists persisted peers.  Prevents the
@@ -197,13 +197,13 @@ exclude = ["nexus-fuse"]
 #
 # Bump alongside the rest of nexus-vfs updates when a downstream
 # change needs newer kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "a7a2f1aab81862daf31c390bd5345ab194279127" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "a7a2f1aab81862daf31c390bd5345ab194279127" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "a7a2f1aab81862daf31c390bd5345ab194279127" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "a7a2f1aab81862daf31c390bd5345ab194279127", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "a7a2f1aab81862daf31c390bd5345ab194279127", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "a7a2f1aab81862daf31c390bd5345ab194279127", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "a7a2f1aab81862daf31c390bd5345ab194279127" }
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "3c7eeb6021d40192c5a8f538b8097ecb0f374304" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "3c7eeb6021d40192c5a8f538b8097ecb0f374304" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "3c7eeb6021d40192c5a8f538b8097ecb0f374304" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "3c7eeb6021d40192c5a8f538b8097ecb0f374304", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "3c7eeb6021d40192c5a8f538b8097ecb0f374304", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "3c7eeb6021d40192c5a8f538b8097ecb0f374304", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "3c7eeb6021d40192c5a8f538b8097ecb0f374304" }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ENV CARGO_NET_RETRY=10 \
     CARGO_HTTP_TIMEOUT=120
 # Override for edge/CI or a different pin: --build-arg NEXUS_VFS_REV=<sha|tag>
-ARG NEXUS_VFS_REV=a7a2f1aab81862daf31c390bd5345ab194279127
+ARG NEXUS_VFS_REV=3c7eeb6021d40192c5a8f538b8097ecb0f374304
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,id=cargo-install-${TARGETARCH},target=/root/.cargo/target \

--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir --no-deps --prefix=/install .
 # enforces agreement) — an unpinned install tracks nexus-vfs HEAD and
 # ships an untested kernel (#4343). --locked honors the source tree's
 # Cargo.lock.
-ARG NEXUS_VFS_REV=a7a2f1aab81862daf31c390bd5345ab194279127
+ARG NEXUS_VFS_REV=3c7eeb6021d40192c5a8f538b8097ecb0f374304
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-cluster nexus-cluster
 
 # -- Runtime stage --

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -25,7 +25,7 @@ WORKDIR /build
 # (CI preflight enforces agreement) — an unpinned install tracks HEAD
 # and can skew the raft contract against the cluster/witness images.
 # --locked honors the source tree's Cargo.lock.
-ARG NEXUS_VFS_REV=a7a2f1aab81862daf31c390bd5345ab194279127
+ARG NEXUS_VFS_REV=3c7eeb6021d40192c5a8f538b8097ecb0f374304
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexus-raft-server raft
 
 # ---------- Production image ----------

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=a7a2f1aab81862daf31c390bd5345ab194279127
+ARG NEXUS_VFS_REV=3c7eeb6021d40192c5a8f538b8097ecb0f374304
 RUN cargo install \
     --locked \
     --git https://github.com/nexi-lab/nexus-vfs \

--- a/dockerfiles/docker-compose.audit-node-test.yml
+++ b/dockerfiles/docker-compose.audit-node-test.yml
@@ -53,8 +53,6 @@ services:
       NEXUS_ADVERTISE_ADDR: nexus-1:2126
       NEXUS_PEERS: "nexus-2:2126,witness:2126"
       NEXUS_RAFT_TLS: "false"
-      NEXUS_BOOTSTRAP_NEW: "1"
-      NEXUS_BOOTSTRAP_MODE: "static"
       RUST_LOG: info,nexus_raft=debug
     volumes:
       - audit_nexus1_data:/app/data
@@ -81,7 +79,6 @@ services:
       NEXUS_ADVERTISE_ADDR: nexus-2:2126
       NEXUS_PEERS: "nexus-1:2126,witness:2126"
       NEXUS_RAFT_TLS: "false"
-      NEXUS_BOOTSTRAP_MODE: "static"
       RUST_LOG: info,nexus_raft=debug
     volumes:
       - audit_nexus2_data:/app/data

--- a/dockerfiles/docker-compose.cc-tasks-peer-shared.yml
+++ b/dockerfiles/docker-compose.cc-tasks-peer-shared.yml
@@ -33,6 +33,9 @@ x-fuse-runtime: &fuse-runtime
   security_opt:
     - apparmor:unconfined
 
+# S3 Phase G: `--bootstrap-mode` retired; the daemon auto-detects
+# boot semantics via `plan_boot_action`.  See the cc-tasks-share
+# compose's entrypoint anchor docstring for the full contract.
 x-bootstrap-entrypoint: &bootstrap-entrypoint
   entrypoint:
     - /bin/bash
@@ -40,19 +43,12 @@ x-bootstrap-entrypoint: &bootstrap-entrypoint
     - |
       set -e
       DATA_DIR="${NEXUS_DATA_DIR:-/app/data}"
-      if [ -f "$$DATA_DIR/.node_id" ]; then
-        MODE=restart
-        unset NEXUS_FEDERATION_ZONES NEXUS_FEDERATION_MOUNTS NEXUS_PEERS NEXUS_BOOTSTRAP_NEW
-      else
-        MODE=static
-      fi
       exec nexusd-cluster \
         --bind-addr "$${NEXUS_BIND_ADDR:-0.0.0.0:2126}" \
         --data-dir "$$DATA_DIR" \
         --no-tls \
         --plugin-dir /plugins \
-        --mount-driver "$$NEXUS_MOUNT_DRIVER" \
-        --bootstrap-mode "$$MODE"
+        --mount-driver "$$NEXUS_MOUNT_DRIVER"
   command: []
 
 services:

--- a/dockerfiles/docker-compose.cc-tasks-share.yml
+++ b/dockerfiles/docker-compose.cc-tasks-share.yml
@@ -72,10 +72,13 @@ x-fuse-runtime: &fuse-runtime
   security_opt:
     - apparmor:unconfined
 
-# Auto-detect bootstrap mode shared via YAML anchor — same pattern the
-# federation-runbook compose uses.  First boot reads the static-only
-# env (FEDERATION_ZONES / MOUNTS), persists ConfState, then restart
-# strips them so PR #4028's mode-x-env validator passes on next boot.
+# Shared entrypoint anchor.  S3 Phase G collapsed the boot-mode
+# decision into `nexus_raft::bootstrap::plan_boot_action` — the daemon
+# auto-detects restart (via `<data_dir>/root/raft/` presence),
+# fresh founder (via `NEXUS_FEDERATION_ZONES` set), fresh joiner
+# (via `--peers`), or wipe-recovery (via identity.zones populated).
+# No operator-declared `--bootstrap-mode` needed; leftover env vars
+# are advisory on restart (persisted ConfState is authoritative).
 x-bootstrap-entrypoint: &bootstrap-entrypoint
   entrypoint:
     - /bin/bash
@@ -83,19 +86,12 @@ x-bootstrap-entrypoint: &bootstrap-entrypoint
     - |
       set -e
       DATA_DIR="${NEXUS_DATA_DIR:-/app/data}"
-      if [ -f "$$DATA_DIR/.node_id" ]; then
-        MODE=restart
-        unset NEXUS_FEDERATION_ZONES NEXUS_FEDERATION_MOUNTS NEXUS_PEERS NEXUS_BOOTSTRAP_NEW
-      else
-        MODE=static
-      fi
       exec nexusd-cluster \
         --bind-addr "$${NEXUS_BIND_ADDR:-0.0.0.0:2126}" \
         --data-dir "$$DATA_DIR" \
         --no-tls \
         --plugin-dir /plugins \
-        --mount-driver "$$NEXUS_MOUNT_DRIVER" \
-        --bootstrap-mode "$$MODE"
+        --mount-driver "$$NEXUS_MOUNT_DRIVER"
   command: []
 
 services:

--- a/dockerfiles/docker-compose.federation-runbook.yml
+++ b/dockerfiles/docker-compose.federation-runbook.yml
@@ -40,11 +40,10 @@
 #     second start the data dir is no longer empty, so we must switch
 #     to `restart` — without operator intervention.
 #
-# The script derives the bootstrap mode from on-disk state, which IS
-# the runbook's mental model: "did I bootstrap before?".  Under
-# `restart` it also unsets the static-only env vars (NEXUS_FEDERATION_*,
-# NEXUS_PEERS, NEXUS_BOOTSTRAP_NEW) so the validator's mode-x-env
-# matrix check passes.
+# S3 Phase G (nexus-vfs #118): the daemon auto-detects boot semantics
+# via `plan_boot_action`; no operator declaration needed.  Row 0
+# (data_dir has persisted state) → resume from disk regardless of
+# env vars, so leftover NEXUS_FEDERATION_* on restart is harmless.
 x-runbook-entrypoint: &runbook-entrypoint
   entrypoint:
     - /bin/bash
@@ -52,17 +51,10 @@ x-runbook-entrypoint: &runbook-entrypoint
     - |
       set -e
       DATA_DIR="${NEXUS_DATA_DIR:-/app/data}"
-      if [ -f "$$DATA_DIR/.node_id" ]; then
-        MODE=restart
-        unset NEXUS_FEDERATION_ZONES NEXUS_FEDERATION_MOUNTS NEXUS_PEERS NEXUS_BOOTSTRAP_NEW
-      else
-        MODE=static
-      fi
       exec nexusd-cluster \
         --bind-addr "$${NEXUS_BIND_ADDR:-0.0.0.0:2126}" \
         --data-dir "$$DATA_DIR" \
-        --no-tls \
-        --bootstrap-mode "$$MODE"
+        --no-tls
   command: []
 
 services:
@@ -130,7 +122,6 @@ services:
       NEXUS_BIND_ADDR: 0.0.0.0:2126
       NEXUS_DATA_DIR: /home/nexus/data
       NEXUS_NO_TLS: "true"
-      NEXUS_BOOTSTRAP_MODE: static
       # Witness self-detects from NEXUS_PEERS (its own boot path keeps
       # the legacy contract — see bin/witness.rs in nexus-vfs).
       NEXUS_PEERS: founder:2126,joiner:2126,witness:2126

--- a/docs/architecture/federation-cross-machine-runbook.md
+++ b/docs/architecture/federation-cross-machine-runbook.md
@@ -243,13 +243,12 @@ NEXUS_ADVERTISE_ADDR=<B_tailscale_ip>:2126 \
     --bind-addr 0.0.0.0:2126 \
     --data-dir /tmp/nexus-fed-data \
     --peers <A_tailscale_ip>:2126 \
-    --no-tls \
-    --bootstrap-mode static
+    --no-tls
 ```
 
 Key contract rules:
 
-* **`--bootstrap-mode` is required when federation is in play** (PR #4028).  Pass `static` for env-driven topology (`NEXUS_FEDERATION_*` carry the cluster shape, used across first boot and subsequent container restarts), `restart` for operator-managed resume where persisted ConfState is the source of truth (no env needed), `dynamic` for runtime-API-driven setups.
+* **No `--bootstrap-mode` flag as of nexus-vfs PR #118 (Phase G).**  The daemon auto-detects boot semantics from `(data_dir_has_root, identity contents, --peers, NEXUS_FEDERATION_*)` via [`plan_boot_action`](../../rust/raft/src/bootstrap.rs).  Row 0 (data_dir has persisted state) → resume from disk; rows 1-6 (fresh data_dir) → matrix-driven dispatch.  Env vars on a restart boot are advisory — persisted ConfState is authoritative.
 * **`--peers` lists only the *other* machines.**  Self-listed peers are rejected at parse (PR #4014).
 * **`--advertise-addr` / `NEXUS_ADVERTISE_ADDR` is the reachable network endpoint advertised to peers** — MUST be set to the Tailscale IP (`<tailscale_ip>:<port>`) for cross-machine federation.  Decoupled from `--hostname` since nexus-vfs PR #101: `--hostname` is now display-only (ZoneManager registry label + TLS cert SANs), the network identity comes from `--advertise-addr`.  Falls back to `{hostname}:{bind_port}` if unset (single-node tests work unchanged), but cross-machine setups MUST pin `--advertise-addr` explicitly — a bare OS hostname does not resolve through the Tailscale overlay and surfaces as "ConfState install timeout" minutes after the initial JoinZone RPC succeeded.  Boot logs a warning when the resolved address looks unreachable (wildcard, loopback with peers, or bare hostname with peers configured).
 * **`NEXUS_HOSTNAME` is the display label** (post-PR #101).  Falls back to OS hostname.  Use whatever you want for log readability; the address peers actually dial comes from `NEXUS_ADVERTISE_ADDR`.
@@ -269,8 +268,7 @@ NEXUS_FEDERATION_MOUNTS=/shared=sharedzone \
 target/release/nexusd-cluster \
   --bind-addr 0.0.0.0:2126 \
   --data-dir /tmp/nexus-fed-data \
-  --no-tls \
-  --bootstrap-mode static
+  --no-tls
 ```
 
 Wait for:
@@ -327,12 +325,11 @@ target/release/nexusd-cluster \
   --bind-addr 0.0.0.0:2126 \
   --data-dir /tmp/nexus-fed-data \
   --no-tls \
-  --bootstrap-mode restart \
   > /tmp/nexus-mac.log 2>&1 &
 sleep 8
 ```
 
-Under `restart`, do **not** pass `--peers`, `--bootstrap-new`, `NEXUS_FEDERATION_ZONES`, or `NEXUS_FEDERATION_MOUNTS` — the persisted ConfState and DT_MOUNT entries are the source of truth.
+The daemon auto-detects "resume from disk" from `<data_dir>/root/raft/` presence (Phase G row 0) and treats any env vars still exported as advisory — persisted ConfState + DT_MOUNT entries are the source of truth on restart.
 
 ### Step 3e — Expose host paths via LocalConnector
 
@@ -371,30 +368,22 @@ Operator flow (mirrors what `dockerfiles/docker-compose.cc-tasks-share.yml` auto
 
 ```bash
 # On A (FOUNDER of sharedzone) — auto-creates the zone SOLO, then waits for
-# joiners to sidecar-join against it.  EXACTLY ONE node runs this recipe.
+# joiners to point at it.  EXACTLY ONE node runs this recipe.
 NEXUS_FEDERATION_ZONES=sharedzone \
 NEXUS_FEDERATION_MOUNTS=/shared=sharedzone \
-nexusd-cluster --bootstrap-mode static \
+nexusd-cluster \
   --plugin-dir ./plugins \
   --mount-driver 'local-connector:sharedzone:/shared/cc-tasks/A:{"local_root":"/home/me/.claude/tasks"}' \
   ...
 
-# On B (JOINER of A's sharedzone) — does NOT set NEXUS_FEDERATION_ZONES /
-# NEXUS_FEDERATION_MOUNTS (those trigger auto-create on B).  Sequence is:
+# On B (JOINER of A's sharedzone) — nexus-vfs PR #115 (Phase D) means
+# B just needs --peers, no offline sidecar.  DiscoverZones RPC pulls
+# A's federation mount table; B auto-JoinZones sharedzone.
 #
-# 1. Offline sidecar join (daemon stopped) — seeds sharedzone's ConfState + log
-#    into B's data dir + persists A's addr into identity.json.
-#
-#    Bare `<HOST:PORT>` is the ONLY accepted peer form post nexus-vfs PR #109
-#    (the `<node_id>@<host:port>` shape was retired at the CLI boundary).
-#    Bare `join` defaults to `--as voter` (symmetric peer); pass `--as learner`
-#    for owner-pattern wipe-rejoin safety instead.
-nexusd-cluster join <A_host:port> sharedzone /shared \
-  --data-dir ./data --hostname B --no-tls
-
-# 2. Start B's main daemon — RESTART mode picks up sharedzone from disk;
-#    --mount-driver runs on the resumed zone; no auto-create anywhere.
-nexusd-cluster --bootstrap-mode restart \
+# Subsequent boots (data_dir persisted): Phase G row 0 -- daemon
+# resumes from disk regardless of env vars.
+nexusd-cluster \
+  --peers <A_host:port> \
   --plugin-dir ./plugins \
   --mount-driver 'local-connector:sharedzone:/shared/cc-tasks/B:{"local_root":"/home/me/.claude/tasks"}' \
   ...
@@ -619,15 +608,20 @@ It walks every zone subdirectory, reads ConfState + HardState + log indices dire
 | Clash Verge blocks Tailscale | TUN mode intercepts coordination traffic | Add Headscale IP + `100.64.0.0/10` to `route-exclude-address` in the *active profile's* merge file (not just the global one) |
 | `nc -zv` to peer succeeds momentarily, then grpcurl times out | Tailscale dropped between the two; or Clash proxy remnant (`127.0.0.1:7897` enabled with nothing listening) intercepting HTTP/2 | Restart Tailscale; clean Clash proxy state (disable system proxy + clear DNS) |
 
-### Bootstrap mode (PR #4028)
+### Bootstrap
+
+nexus-vfs PR #118 (Phase G) retired the operator-declared
+`--bootstrap-mode` flag.  The daemon auto-detects boot semantics
+from `(data_dir_has_root, identity contents, --peers,
+NEXUS_FEDERATION_*)` via the [`plan_boot_action`](../../../nexus-vfs/rust/raft/src/bootstrap.rs) matrix.  Nothing to pass at the CLI beyond
+what the deployment recipe actually declares (peers if joining,
+federation env if founding).
 
 | Symptom | Cause | Fix |
 |---|---|---|
-| `NEXUS_BOOTSTRAP_MODE is required when bootstrapping federation` | Missing `--bootstrap-mode` flag | Pass `static`, `restart`, or `dynamic` |
-| `bootstrap mode = dynamic, but data dir already holds a 'root' zone` | Dynamic mode requires a fresh data dir; persisted state is reserved for static or restart | Pass `--bootstrap-mode restart` to resume persisted state, or wipe the data dir to start over |
-| `bootstrap mode = dynamic forbids NEXUS_BOOTSTRAP_NEW / NEXUS_PEERS` | Dynamic mode is runtime-API driven; cluster shape arrives via `share` / `join` RPCs, not env | Drop the env/flag, or switch to `--bootstrap-mode static` |
-| `bootstrap mode = restart, but data dir is empty` | First-time boot with `restart` | Use `static` for the first boot |
-| `bootstrap mode = restart forbids NEXUS_PEERS / --peers` | Passing peers under `restart` | Drop the flag — persisted ConfState carries the address book |
+| `split-brain guard: NEXUS_FEDERATION_ZONES is set ... but identity.json already lists peers` | Row 5 misconfig: this node has persisted peers AND you set founder env on a fresh data_dir | Either (a) FOUNDER — `rm IDENTITY_DIR/identity.json` then re-run, or (b) JOINER — unset `NEXUS_FEDERATION_*` and let identity.zones auto-rejoin |
+| `nexusd-cluster boot refused (ambiguous_fresh_founder_with_peers)` | Row 6 misconfig: `--peers` + `NEXUS_FEDERATION_ZONES` both set with empty identity | Choose one: FOUNDER (drop --peers) or JOINER (drop the ZONES env) |
+| Daemon skipped root bootstrap when you expected it to auto-create | Row 2 (RootlessDynamic) — no peers, no zones, no identity | Set `NEXUS_FEDERATION_ZONES=<zone>` to declare founder intent, or pass `--peers <addr>` to declare joiner intent |
 
 ### Raft
 
@@ -703,8 +697,8 @@ The bug-class history matters here — the same shape regressed twice during the
   * pre-nexus-vfs-#23 nested-tokio panic on the join's mount path
   * pre-nexus-vfs-#25 founder self-forward hairpin
 * nexus `tests/e2e/docker/test_federation_runbook.py::TestFounderBootstrap` — convergence budget + zero `Forward to leader failed leader=` warnings.
-* nexus `tests/e2e/docker/test_federation_runbook.py::TestRestartReplay` — `--bootstrap-mode restart` replays persisted `DT_MOUNT` entries; pre-existing files stay readable post-reboot.
+* nexus `tests/e2e/docker/test_federation_runbook.py::TestRestartReplay` — restart-from-disk (Phase G row 0) replays persisted `DT_MOUNT` entries; pre-existing files stay readable post-reboot.
 * nexus `tests/e2e/docker/test_federation_runbook.py::TestWitnessQuorumHA` — 3-voter quorum survives founder loss; ConfState recovers to 3 voters on restart.
-* nexus `tests/e2e/docker/test_federation_runbook.py::TestRunbookOperatorErgonomics` — `share --mount-at`, `--bootstrap-mode` validator, `--peers <self>` rejection.
+* nexus `tests/e2e/docker/test_federation_runbook.py::TestRunbookOperatorErgonomics` — `share --mount-at`, Phase A/G boot-decision matrix (split-brain guard, ambiguous fresh-founder guard), `--peers <self>` rejection.
 
 The Step-4 byte-exact L1 read across two real machines (Mac↔Win over Tailscale) remains a manual gate for the Tailscale-specific surface; the CI runbook tests cover the cross-process semantics in-network, but do not exercise the Tailscale path itself.

--- a/docs/surface-coverage/api-rpc-surface-coverage.yaml
+++ b/docs/surface-coverage/api-rpc-surface-coverage.yaml
@@ -445,7 +445,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.agent_registry
-      source: src/nexus/remote/kernel_client.py:1129
+      source: src/nexus/remote/kernel_client.py:1133
   profiles:
     lite: supported
     sandbox: supported
@@ -1862,7 +1862,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.close_all_pipes
-      source: src/nexus/remote/kernel_client.py:1008
+      source: src/nexus/remote/kernel_client.py:1012
   profiles:
     lite: supported
     sandbox: supported
@@ -1879,7 +1879,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.close_all_streams
-      source: src/nexus/remote/kernel_client.py:1061
+      source: src/nexus/remote/kernel_client.py:1065
   profiles:
     lite: supported
     sandbox: supported
@@ -1896,7 +1896,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.close_pipe
-      source: src/nexus/remote/kernel_client.py:998
+      source: src/nexus/remote/kernel_client.py:1002
   profiles:
     lite: supported
     sandbox: supported
@@ -1913,7 +1913,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.close_stream
-      source: src/nexus/remote/kernel_client.py:1052
+      source: src/nexus/remote/kernel_client.py:1056
   profiles:
     lite: supported
     sandbox: supported
@@ -2131,7 +2131,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.count_by_state
-      source: src/nexus/remote/kernel_client.py:1605
+      source: src/nexus/remote/kernel_client.py:1609
   profiles:
     lite: supported
     sandbox: supported
@@ -2165,7 +2165,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.create_pipe
-      source: src/nexus/remote/kernel_client.py:990
+      source: src/nexus/remote/kernel_client.py:994
   profiles:
     lite: supported
     sandbox: supported
@@ -2199,7 +2199,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.create_stream
-      source: src/nexus/remote/kernel_client.py:1015
+      source: src/nexus/remote/kernel_client.py:1019
   profiles:
     lite: supported
     sandbox: supported
@@ -2512,7 +2512,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.destroy_pipe
-      source: src/nexus/remote/kernel_client.py:994
+      source: src/nexus/remote/kernel_client.py:998
   profiles:
     lite: supported
     sandbox: supported
@@ -2529,7 +2529,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.destroy_stream
-      source: src/nexus/remote/kernel_client.py:1057
+      source: src/nexus/remote/kernel_client.py:1061
   profiles:
     lite: supported
     sandbox: supported
@@ -2635,7 +2635,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.dispatch_post_hooks
-      source: src/nexus/remote/kernel_client.py:744
+      source: src/nexus/remote/kernel_client.py:748
   profiles:
     lite: supported
     sandbox: supported
@@ -2652,7 +2652,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.dispatch_pre_hooks
-      source: src/nexus/remote/kernel_client.py:751
+      source: src/nexus/remote/kernel_client.py:755
   profiles:
     lite: supported
     sandbox: supported
@@ -2669,7 +2669,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.dispatch_pre_hooks_batch_stat
-      source: src/nexus/remote/kernel_client.py:779
+      source: src/nexus/remote/kernel_client.py:783
   profiles:
     lite: supported
     sandbox: supported
@@ -2798,7 +2798,7 @@ operations:
       source: src/nexus/core/nexus_fs_metadata.py:1335
     sdk:
       name: KernelClient.exists_batch
-      source: src/nexus/remote/kernel_client.py:805
+      source: src/nexus/remote/kernel_client.py:809
   profiles:
     lite: supported
     sandbox: supported
@@ -3884,7 +3884,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.get
-      source: src/nexus/remote/kernel_client.py:1552
+      source: src/nexus/remote/kernel_client.py:1556
   profiles:
     lite: supported
     sandbox: supported
@@ -3901,7 +3901,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.heartbeat
-      source: src/nexus/remote/kernel_client.py:1578
+      source: src/nexus/remote/kernel_client.py:1582
   profiles:
     lite: supported
     sandbox: supported
@@ -3986,7 +3986,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.register
-      source: src/nexus/remote/kernel_client.py:1513
+      source: src/nexus/remote/kernel_client.py:1517
   profiles:
     lite: supported
     sandbox: supported
@@ -4054,7 +4054,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.signal
-      source: src/nexus/remote/kernel_client.py:1555
+      source: src/nexus/remote/kernel_client.py:1559
   profiles:
     lite: supported
     sandbox: supported
@@ -4139,7 +4139,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.unregister
-      source: src/nexus/remote/kernel_client.py:1546
+      source: src/nexus/remote/kernel_client.py:1550
   profiles:
     lite: supported
     sandbox: supported
@@ -4256,7 +4256,7 @@ operations:
       source: src/nexus/core/nexus_fs_metadata.py:627
     sdk:
       name: KernelClient.get_content_id
-      source: src/nexus/remote/kernel_client.py:796
+      source: src/nexus/remote/kernel_client.py:800
   profiles:
     lite: supported
     sandbox: supported
@@ -4324,7 +4324,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.get_mount_points
-      source: src/nexus/remote/kernel_client.py:810
+      source: src/nexus/remote/kernel_client.py:814
   profiles:
     lite: supported
     sandbox: supported
@@ -4446,7 +4446,7 @@ operations:
       source: src/nexus/core/nexus_fs_metadata.py:268
     sdk:
       name: KernelClient.get_top_level_mounts
-      source: src/nexus/remote/kernel_client.py:817
+      source: src/nexus/remote/kernel_client.py:821
   profiles:
     lite: supported
     sandbox: supported
@@ -4481,7 +4481,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.get_xattr
-      source: src/nexus/remote/kernel_client.py:955
+      source: src/nexus/remote/kernel_client.py:959
   profiles:
     lite: supported
     sandbox: supported
@@ -4498,7 +4498,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.get_xattr_bulk
-      source: src/nexus/remote/kernel_client.py:976
+      source: src/nexus/remote/kernel_client.py:980
   profiles:
     lite: supported
     sandbox: supported
@@ -4703,7 +4703,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.has_pipe
-      source: src/nexus/remote/kernel_client.py:1003
+      source: src/nexus/remote/kernel_client.py:1007
   profiles:
     lite: supported
     sandbox: supported
@@ -4720,7 +4720,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.has_stream
-      source: src/nexus/remote/kernel_client.py:1019
+      source: src/nexus/remote/kernel_client.py:1023
   profiles:
     lite: supported
     sandbox: supported
@@ -4789,7 +4789,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.hook_count
-      source: src/nexus/remote/kernel_client.py:741
+      source: src/nexus/remote/kernel_client.py:745
   profiles:
     lite: supported
     sandbox: supported
@@ -4927,7 +4927,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.is_directory
-      source: src/nexus/remote/kernel_client.py:787
+      source: src/nexus/remote/kernel_client.py:791
   profiles:
     lite: supported
     sandbox: supported
@@ -5066,7 +5066,7 @@ operations:
       source: src/nexus/services/agents/agent_rpc_service.py:584
     sdk:
       name: _AgentRegistryProxy.list_agents
-      source: src/nexus/remote/kernel_client.py:1581
+      source: src/nexus/remote/kernel_client.py:1585
   profiles:
     lite: supported
     sandbox: supported
@@ -5084,7 +5084,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.list_by_priority
-      source: src/nexus/remote/kernel_client.py:1609
+      source: src/nexus/remote/kernel_client.py:1613
   profiles:
     lite: supported
     sandbox: supported
@@ -5229,7 +5229,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.list_processes
-      source: src/nexus/remote/kernel_client.py:1584
+      source: src/nexus/remote/kernel_client.py:1588
   profiles:
     lite: supported
     sandbox: supported
@@ -5660,7 +5660,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.metastore_list_paginated
-      source: src/nexus/remote/kernel_client.py:825
+      source: src/nexus/remote/kernel_client.py:829
   profiles:
     lite: supported
     sandbox: supported
@@ -6833,7 +6833,7 @@ operations:
       source: src/nexus/core/nexus_fs_content.py:1613
     sdk:
       name: KernelClient.read_batch
-      source: src/nexus/remote/kernel_client.py:639
+      source: src/nexus/remote/kernel_client.py:643
   profiles:
     lite: supported
     sandbox: supported
@@ -7164,7 +7164,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.register_external
-      source: src/nexus/remote/kernel_client.py:1516
+      source: src/nexus/remote/kernel_client.py:1520
   profiles:
     lite: supported
     sandbox: supported
@@ -7181,7 +7181,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.register_hook
-      source: src/nexus/remote/kernel_client.py:758
+      source: src/nexus/remote/kernel_client.py:762
   profiles:
     lite: supported
     sandbox: supported
@@ -7215,7 +7215,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.register_native_hook
-      source: src/nexus/remote/kernel_client.py:1096
+      source: src/nexus/remote/kernel_client.py:1100
   profiles:
     lite: supported
     sandbox: supported
@@ -8079,7 +8079,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.service_close_all
-      source: src/nexus/remote/kernel_client.py:733
+      source: src/nexus/remote/kernel_client.py:737
   profiles:
     lite: supported
     sandbox: supported
@@ -8096,7 +8096,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.service_enlist
-      source: src/nexus/remote/kernel_client.py:720
+      source: src/nexus/remote/kernel_client.py:724
   profiles:
     lite: supported
     sandbox: supported
@@ -8113,7 +8113,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.service_lookup
-      source: src/nexus/remote/kernel_client.py:708
+      source: src/nexus/remote/kernel_client.py:712
   profiles:
     lite: supported
     sandbox: supported
@@ -8130,7 +8130,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.service_mark_bootstrapped
-      source: src/nexus/remote/kernel_client.py:705
+      source: src/nexus/remote/kernel_client.py:709
   profiles:
     lite: supported
     sandbox: supported
@@ -8147,7 +8147,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.service_start_all
-      source: src/nexus/remote/kernel_client.py:702
+      source: src/nexus/remote/kernel_client.py:706
   profiles:
     lite: supported
     sandbox: supported
@@ -8164,7 +8164,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.service_stop_all
-      source: src/nexus/remote/kernel_client.py:730
+      source: src/nexus/remote/kernel_client.py:734
   profiles:
     lite: supported
     sandbox: supported
@@ -8181,7 +8181,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.service_swap
-      source: src/nexus/remote/kernel_client.py:712
+      source: src/nexus/remote/kernel_client.py:716
   profiles:
     lite: supported
     sandbox: supported
@@ -8198,7 +8198,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.service_unregister
-      source: src/nexus/remote/kernel_client.py:936
+      source: src/nexus/remote/kernel_client.py:940
   profiles:
     lite: supported
     sandbox: supported
@@ -8215,7 +8215,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.set_hook_count
-      source: src/nexus/remote/kernel_client.py:775
+      source: src/nexus/remote/kernel_client.py:779
   profiles:
     lite: supported
     sandbox: supported
@@ -8232,7 +8232,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.set_metastore_path
-      source: src/nexus/remote/kernel_client.py:1068
+      source: src/nexus/remote/kernel_client.py:1072
   profiles:
     lite: supported
     sandbox: supported
@@ -8249,7 +8249,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.set_permission_provider
-      source: src/nexus/remote/kernel_client.py:1100
+      source: src/nexus/remote/kernel_client.py:1104
   profiles:
     lite: supported
     sandbox: supported
@@ -8283,7 +8283,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.set_vfs_lock
-      source: src/nexus/remote/kernel_client.py:1092
+      source: src/nexus/remote/kernel_client.py:1096
   profiles:
     lite: supported
     sandbox: supported
@@ -8300,7 +8300,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.set_xattr
-      source: src/nexus/remote/kernel_client.py:968
+      source: src/nexus/remote/kernel_client.py:972
   profiles:
     lite: supported
     sandbox: supported
@@ -8560,7 +8560,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.stat_batch
-      source: src/nexus/remote/kernel_client.py:673
+      source: src/nexus/remote/kernel_client.py:677
   profiles:
     lite: supported
     sandbox: supported
@@ -8594,7 +8594,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.stream_collect_all
-      source: src/nexus/remote/kernel_client.py:1048
+      source: src/nexus/remote/kernel_client.py:1052
   profiles:
     lite: supported
     sandbox: supported
@@ -8628,7 +8628,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.stream_read_at
-      source: src/nexus/remote/kernel_client.py:1036
+      source: src/nexus/remote/kernel_client.py:1040
   profiles:
     lite: supported
     sandbox: supported
@@ -8645,7 +8645,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.stream_read_at_blocking
-      source: src/nexus/remote/kernel_client.py:1023
+      source: src/nexus/remote/kernel_client.py:1027
   profiles:
     lite: supported
     sandbox: supported
@@ -8662,7 +8662,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.stream_write_nowait
-      source: src/nexus/remote/kernel_client.py:1031
+      source: src/nexus/remote/kernel_client.py:1035
   profiles:
     lite: supported
     sandbox: supported
@@ -8747,7 +8747,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.sys_copy
-      source: src/nexus/remote/kernel_client.py:574
+      source: src/nexus/remote/kernel_client.py:578
   profiles:
     lite: supported
     sandbox: supported
@@ -8764,7 +8764,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.sys_lock
-      source: src/nexus/remote/kernel_client.py:610
+      source: src/nexus/remote/kernel_client.py:614
   profiles:
     lite: supported
     sandbox: supported
@@ -8781,7 +8781,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.sys_mkdir
-      source: src/nexus/remote/kernel_client.py:543
+      source: src/nexus/remote/kernel_client.py:547
   profiles:
     lite: supported
     sandbox: supported
@@ -8798,7 +8798,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.sys_read
-      source: src/nexus/remote/kernel_client.py:440
+      source: src/nexus/remote/kernel_client.py:444
   profiles:
     lite: supported
     sandbox: supported
@@ -8815,7 +8815,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.sys_read_raw
-      source: src/nexus/remote/kernel_client.py:472
+      source: src/nexus/remote/kernel_client.py:476
   profiles:
     lite: supported
     sandbox: supported
@@ -8832,7 +8832,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.sys_readdir
-      source: src/nexus/remote/kernel_client.py:594
+      source: src/nexus/remote/kernel_client.py:598
   profiles:
     lite: supported
     sandbox: supported
@@ -8849,7 +8849,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.sys_rename
-      source: src/nexus/remote/kernel_client.py:551
+      source: src/nexus/remote/kernel_client.py:555
   profiles:
     lite: supported
     sandbox: supported
@@ -8866,7 +8866,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.sys_setattr
-      source: src/nexus/remote/kernel_client.py:510
+      source: src/nexus/remote/kernel_client.py:514
   profiles:
     lite: supported
     sandbox: supported
@@ -8883,7 +8883,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.sys_stat
-      source: src/nexus/remote/kernel_client.py:493
+      source: src/nexus/remote/kernel_client.py:497
   profiles:
     lite: supported
     sandbox: supported
@@ -8900,7 +8900,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.sys_unlink
-      source: src/nexus/remote/kernel_client.py:529
+      source: src/nexus/remote/kernel_client.py:533
   profiles:
     lite: supported
     sandbox: supported
@@ -8917,7 +8917,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.sys_unlock
-      source: src/nexus/remote/kernel_client.py:633
+      source: src/nexus/remote/kernel_client.py:637
   profiles:
     lite: supported
     sandbox: supported
@@ -8937,7 +8937,7 @@ operations:
       source: src/nexus/core/nexus_fs_watch.py:26
     sdk:
       name: KernelClient.sys_watch
-      source: src/nexus/remote/kernel_client.py:688
+      source: src/nexus/remote/kernel_client.py:692
   profiles:
     lite: supported
     sandbox: supported
@@ -8954,7 +8954,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.sys_write
-      source: src/nexus/remote/kernel_client.py:477
+      source: src/nexus/remote/kernel_client.py:481
   profiles:
     lite: supported
     sandbox: supported
@@ -9039,7 +9039,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.trie_lookup
-      source: src/nexus/remote/kernel_client.py:947
+      source: src/nexus/remote/kernel_client.py:951
   profiles:
     lite: supported
     sandbox: supported
@@ -9056,7 +9056,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.trie_register
-      source: src/nexus/remote/kernel_client.py:944
+      source: src/nexus/remote/kernel_client.py:948
   profiles:
     lite: supported
     sandbox: supported
@@ -9073,7 +9073,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.trie_unregister
-      source: src/nexus/remote/kernel_client.py:950
+      source: src/nexus/remote/kernel_client.py:954
   profiles:
     lite: supported
     sandbox: supported
@@ -9449,7 +9449,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.unregister_external
-      source: src/nexus/remote/kernel_client.py:1549
+      source: src/nexus/remote/kernel_client.py:1553
   profiles:
     lite: supported
     sandbox: supported
@@ -9466,7 +9466,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.unregister_hook
-      source: src/nexus/remote/kernel_client.py:763
+      source: src/nexus/remote/kernel_client.py:767
   profiles:
     lite: supported
     sandbox: supported
@@ -9538,7 +9538,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.update_state
-      source: src/nexus/remote/kernel_client.py:1567
+      source: src/nexus/remote/kernel_client.py:1571
   profiles:
     lite: supported
     sandbox: supported
@@ -9778,7 +9778,7 @@ operations:
       source: src/nexus/core/nexus_fs_content.py:1451
     sdk:
       name: KernelClient.write_batch
-      source: src/nexus/remote/kernel_client.py:1104
+      source: src/nexus/remote/kernel_client.py:1108
   profiles:
     lite: supported
     sandbox: supported

--- a/src/nexus/remote/kernel_client.py
+++ b/src/nexus/remote/kernel_client.py
@@ -367,7 +367,11 @@ class KernelClient:
         )
         env["NEXUS_BIND_ADDR"] = self._server_address
         env["NEXUS_NO_TLS"] = "true"  # Loopback, no TLS needed.
-        env.setdefault("NEXUS_BOOTSTRAP_MODE", "dynamic")
+        # Phase G (nexus-vfs #118): daemon auto-detects boot from
+        # (data_dir, identity, --peers, NEXUS_FEDERATION_*).  Empty
+        # data_dir + no peers + no federation env => row 2
+        # (RootlessDynamic) — matches the pre-Phase-G intent of
+        # `NEXUS_BOOTSTRAP_MODE=dynamic` (runtime API drives).
 
         # Redirect stdout/stderr to temp files to avoid pipe buffer deadlock.
         # The OS pipe buffer (~65KB) fills up when the Rust binary emits

--- a/tests/e2e/docker/runbook_helpers.py
+++ b/tests/e2e/docker/runbook_helpers.py
@@ -721,8 +721,8 @@ def run_nexusd_cluster_join(
       1. `docker_stop(target_container)` — releases the redb lock.
       2. `run_nexusd_cluster_join(...)` — this function, runs join.
       3. `docker_start(target_container)` — daemon comes back up,
-         entrypoint auto-detects bootstrap-mode=restart from on-disk
-         state and replays DT_MOUNT via apply-cb (runbook §3c).
+         Phase G row 0 auto-resumes from on-disk state and replays
+         DT_MOUNT via apply-cb (runbook §3c).
 
     ``as_role`` is the operator-chosen membership role passed to
     ``nexusd-cluster join --as <role>``.  Default is ``"voter"`` to

--- a/tests/e2e/docker/test_federation_runbook.py
+++ b/tests/e2e/docker/test_federation_runbook.py
@@ -9,11 +9,11 @@ regress silently.
 
 Test methods are CLI-driven where the runbook is CLI-driven.  The
 operator flow goes through ``nexusd-cluster share`` / ``join`` /
-``--bootstrap-mode`` — *not* the legacy ``federation_share`` /
-``federation_join`` RPCs.  The legacy suite exercised only the RPC
-surface, so the CLI path (where PR #4293, nexus-vfs #23, nexus-vfs
-#25 all landed their fixes) was completely uncovered.  This file
-covers it.
+the auto-detected boot decision (Phase G retired ``--bootstrap-mode``)
+— *not* the legacy ``federation_share`` / ``federation_join`` RPCs.
+The legacy suite exercised only the RPC surface, so the CLI path
+(where PR #4293, nexus-vfs #23, nexus-vfs #25 all landed their
+fixes) was completely uncovered.  This file covers it.
 
 There are **no** ``pytest.skip`` calls.  Anything that would
 historically have skipped (method missing, CLI subcommand missing,
@@ -248,8 +248,8 @@ def joined_cluster(topology: RunbookTopology, api_key: str) -> dict:
            `nexusd-cluster join <id>@founder:2126 sharedzone /shared`
            against the joiner's data volume.  Mirrors runbook §3b's
            "daemon down, separate process against persisted data dir".
-      B-4: `docker start` joiner — auto-detect entrypoint picks
-           `--bootstrap-mode restart` from `.node_id` presence.
+      B-4: `docker start` joiner — daemon's Phase G row 0 auto-
+           detects restart-from-disk via `<data_dir>/root/raft/`.
       B-5: gate on the joiner observing sharedzone with a stable leader
            (the SSOT signal that the post-#33 founder bootstrap → joiner
            replay → AddLearnerNode-for-self path landed cleanly).
@@ -888,116 +888,15 @@ class TestRunbookOperatorErgonomics:
             f"regressed.\nstderr={combined}"
         )
 
-    def test_bootstrap_mode_required_when_federation_active(
-        self,
-        topology: RunbookTopology,
-    ) -> None:
-        """Boot daemon WITHOUT `--bootstrap-mode` while federation env
-        vars are present — must fail loud with the documented error.
-
-        Pins the PR #4028 startup validator.  We probe the validator
-        by running the binary briefly inside an existing container
-        with a scratch data-dir and the federation env vars set; the
-        binary must exit non-zero with the documented message before
-        opening any port.
-        """
-        from tests.e2e.docker.runbook_helpers import docker_exec, uid
-
-        suffix = uid()
-        scratch = f"/tmp/validator-{suffix}"
-        result = docker_exec(
-            topology.joiner_container,
-            [
-                "env",
-                f"NEXUS_DATA_DIR={scratch}",
-                "NEXUS_FEDERATION_ZONES=probe",
-                "NEXUS_FEDERATION_MOUNTS=/probe=probe",
-                "NEXUS_NO_TLS=true",
-                "timeout",
-                "5",
-                "nexusd-cluster",
-                "--bind-addr",
-                "0.0.0.0:2199",
-                "--data-dir",
-                scratch,
-                "--no-tls",
-            ],
-            timeout=20,
-        )
-        # We want a fast validator failure, not a timeout (timeout
-        # returns 124).  Either the binary exits non-zero with the
-        # documented message, or the validator was bypassed.
-        combined = result.stdout + result.stderr
-        assert result.rc != 0, (
-            "`nexusd-cluster` without --bootstrap-mode under federation "
-            "env did NOT fail — PR #4028 boot validator was bypassed."
-            f"\nstdout/stderr: {combined[-2000:]}"
-        )
-        assert "bootstrap" in combined.lower() and "mode" in combined.lower(), (
-            "validator error message does not mention bootstrap mode — "
-            "either the wrong error fired or the validator silently "
-            "succeeded.  Expected PR #4028's "
-            "`NEXUS_BOOTSTRAP_MODE is required when bootstrapping federation`."
-            f"\nstdout/stderr: {combined[-2000:]}"
-        )
-
-    def test_dynamic_mode_rejects_existing_data_dir(
-        self,
-        topology: RunbookTopology,
-    ) -> None:
-        """`--bootstrap-mode dynamic` on a data dir that already holds
-        a `root` zone must fail with the documented validator error.
-
-        Pins PR #4028's dynamic-mode state-x-flag rejection.  Dynamic
-        mode is runtime-API driven (cluster shape arrives via
-        `share` / `join` RPCs), so persisted state would conflict
-        with the model.  The validator emits
-        `bootstrap mode = dynamic, but data dir already holds a
-        'root' zone` and the binary exits before opening any port.
-
-        Probes against the joiner's existing /app/data, which has a
-        root zone from the joiner's first-boot static topology — no
-        joined_cluster fixture needed.
-        """
-        from tests.e2e.docker.runbook_helpers import docker_exec
-
-        result = docker_exec(
-            topology.joiner_container,
-            [
-                "timeout",
-                "5",
-                "nexusd-cluster",
-                "--bind-addr",
-                # Numeric port, well above the daemon's 2126 and clear
-                # of any other test probes (test_self_in_peers uses 2199).
-                "0.0.0.0:2197",
-                "--data-dir",
-                "/app/data",
-                "--no-tls",
-                "--bootstrap-mode",
-                "dynamic",
-            ],
-            timeout=20,
-        )
-        import re
-
-        # tracing's structured fields embed ANSI escape codes between
-        # every key/value when stdout is a tty (which `docker exec`
-        # makes it).  Strip them before substring checks.
-        combined = re.sub(r"\x1b\[[0-9;]*m", "", result.stdout + result.stderr)
-        lowered = combined.lower()
-        assert result.rc != 0, (
-            "`nexusd-cluster --bootstrap-mode dynamic` on a non-empty data dir "
-            "did NOT fail — PR #4028 state-x-flag validator was bypassed."
-            f"\nstdout/stderr: {combined[-2000:]}"
-        )
-        assert "dynamic" in lowered and (
-            "already" in lowered or "fresh" in lowered or "wipe" in lowered
-        ), (
-            "validator error message did not match the documented shape "
-            "(`bootstrap mode = dynamic, but data dir already holds a "
-            f"'root' zone`).\nstdout/stderr: {combined[-2000:]}"
-        )
+    # nexus-vfs PR #118 (S3 Phase G) retired --bootstrap-mode + the
+    # validate_bootstrap_mode fn.  The two tests formerly here
+    # (test_bootstrap_mode_required_when_federation_active +
+    # test_dynamic_mode_rejects_existing_data_dir) pinned a contract
+    # that no longer exists — the daemon auto-detects boot semantics
+    # from (data_dir_has_root, identity, --peers, NEXUS_FEDERATION_*)
+    # via plan_boot_action.  The row-5 / row-6 fail-loud paths that
+    # matter (both-founder split-brain, ambiguous fresh-founder) are
+    # covered by the Rust integration test test_unified_bringup.rs.
 
     def test_self_in_peers_rejected_at_parse(
         self,
@@ -1024,8 +923,6 @@ class TestRunbookOperatorErgonomics:
                 "--data-dir",
                 scratch,
                 "--no-tls",
-                "--bootstrap-mode",
-                "static",
                 "--peers",
                 # NEXUS_HOSTNAME=joiner is set in compose env, so
                 # joiner:2126 is "self" for the parse-time check.

--- a/tests/integration/test_typed_grpc_cluster.py
+++ b/tests/integration/test_typed_grpc_cluster.py
@@ -133,8 +133,6 @@ def cluster_grpc(tmp_path: Path) -> Iterator[str]:
                     candidate_addr,
                     "--data-dir",
                     str(data_dir),
-                    "--bootstrap-mode",
-                    "static",
                 ],
                 # Capture the daemon's own logs into cluster.log so a boot
                 # failure is diagnosable (the bin crate target is


### PR DESCRIPTION
Atomic Phase G rollout: pin bump + docker-compose entrypoint simplification + runbook rewrite + E2E test cleanup.  All downstream consumers of --bootstrap-mode updated in one shot.  Net -117 LOC.