### PR TITLE
chore(deps): bump nexus-vfs pin → 79b367d19 (Phase H — learner rejoins as learner)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=3c7eeb6021d40192c5a8f538b8097ecb0f374304#3c7eeb6021d40192c5a8f538b8097ecb0f374304"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=79b367d19ce91b00801b8854ff8463683791c03f#79b367d19ce91b00801b8854ff8463683791c03f"
 dependencies = [
  "ahash",
  "base64",
@@ -289,7 +289,7 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -550,7 +550,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=3c7eeb6021d40192c5a8f538b8097ecb0f374304#3c7eeb6021d40192c5a8f538b8097ecb0f374304"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=79b367d19ce91b00801b8854ff8463683791c03f#79b367d19ce91b00801b8854ff8463683791c03f"
 dependencies = [
  "parking_lot",
  "serde",
@@ -1259,7 +1259,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -1315,15 +1315,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "itertools"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1343,7 +1334,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=3c7eeb6021d40192c5a8f538b8097ecb0f374304#3c7eeb6021d40192c5a8f538b8097ecb0f374304"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=79b367d19ce91b00801b8854ff8463683791c03f#79b367d19ce91b00801b8854ff8463683791c03f"
 dependencies = [
  "ahash",
  "base64",
@@ -1394,7 +1385,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=3c7eeb6021d40192c5a8f538b8097ecb0f374304#3c7eeb6021d40192c5a8f538b8097ecb0f374304"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=79b367d19ce91b00801b8854ff8463683791c03f#79b367d19ce91b00801b8854ff8463683791c03f"
 dependencies = [
  "ahash",
  "base64",
@@ -1589,7 +1580,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=3c7eeb6021d40192c5a8f538b8097ecb0f374304#3c7eeb6021d40192c5a8f538b8097ecb0f374304"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=79b367d19ce91b00801b8854ff8463683791c03f#79b367d19ce91b00801b8854ff8463683791c03f"
 
 [[package]]
 name = "nexus-vault"
@@ -1896,7 +1887,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools",
  "log",
  "multimap",
  "petgraph",
@@ -1917,7 +1908,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools",
  "proc-macro2",
  "quote",
  "syn",
@@ -3042,7 +3033,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
  "windows-collections",
- "windows-core 0.61.2",
+ "windows-core",
  "windows-future",
  "windows-link 0.1.3",
  "windows-numerics",
@@ -3054,7 +3045,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -3066,21 +3057,8 @@ dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-link 0.1.3",
- "windows-result 0.3.4",
- "windows-strings 0.4.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
@@ -3089,7 +3067,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
  "windows-link 0.1.3",
  "windows-threading",
 ]
@@ -3134,7 +3112,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
  "windows-link 0.1.3",
 ]
 
@@ -3148,30 +3126,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-result"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
-dependencies = [
- "windows-link 0.2.1",
-]
-
-[[package]]
 name = "windows-strings"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
-dependencies = [
- "windows-link 0.2.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,8 +30,11 @@ exclude = ["nexus-fuse"]
 [workspace.dependencies]
 # Kernel-tier crates from nexus-vfs (external git dependency).
 # SSOT: https://github.com/nexi-lab/nexus-vfs
-# Pinned at the nexus-vfs commit that landed PR #113 -- S3 unified bring-up
-# (Phase A-G — bootstrap-mode retired) on top of PR #106..#112 (3c7eeb6021, 2026-07-05):
+# Pinned at the nexus-vfs commit that landed PR #120 -- S3 Phase H (respect
+# identity.zones[].as_role on Row 4 rejoin; wiped learner rejoins as learner,
+# not voter — closes the silent-SSOT-violation that was inflating voter set
+# on every wipe cycle) on top of PR #113 -- Phase A-G unified bring-up
+# (2026-07-05):
 # PR #112 lands two bootstrap-safety fixes:
 #   (1) split-brain guard — run_daemon refuses `bootstrap_static_async` when
 #       `identity.json` already lists persisted peers.  Prevents the
@@ -197,13 +200,13 @@ exclude = ["nexus-fuse"]
 #
 # Bump alongside the rest of nexus-vfs updates when a downstream
 # change needs newer kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "3c7eeb6021d40192c5a8f538b8097ecb0f374304" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "3c7eeb6021d40192c5a8f538b8097ecb0f374304" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "3c7eeb6021d40192c5a8f538b8097ecb0f374304" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "3c7eeb6021d40192c5a8f538b8097ecb0f374304", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "3c7eeb6021d40192c5a8f538b8097ecb0f374304", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "3c7eeb6021d40192c5a8f538b8097ecb0f374304", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "3c7eeb6021d40192c5a8f538b8097ecb0f374304" }
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "79b367d19ce91b00801b8854ff8463683791c03f" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "79b367d19ce91b00801b8854ff8463683791c03f" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "79b367d19ce91b00801b8854ff8463683791c03f" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "79b367d19ce91b00801b8854ff8463683791c03f", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "79b367d19ce91b00801b8854ff8463683791c03f", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "79b367d19ce91b00801b8854ff8463683791c03f", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "79b367d19ce91b00801b8854ff8463683791c03f" }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ENV CARGO_NET_RETRY=10 \
     CARGO_HTTP_TIMEOUT=120
 # Override for edge/CI or a different pin: --build-arg NEXUS_VFS_REV=<sha|tag>
-ARG NEXUS_VFS_REV=3c7eeb6021d40192c5a8f538b8097ecb0f374304
+ARG NEXUS_VFS_REV=79b367d19ce91b00801b8854ff8463683791c03f
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,id=cargo-install-${TARGETARCH},target=/root/.cargo/target \

--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir --no-deps --prefix=/install .
 # enforces agreement) — an unpinned install tracks nexus-vfs HEAD and
 # ships an untested kernel (#4343). --locked honors the source tree's
 # Cargo.lock.
-ARG NEXUS_VFS_REV=3c7eeb6021d40192c5a8f538b8097ecb0f374304
+ARG NEXUS_VFS_REV=79b367d19ce91b00801b8854ff8463683791c03f
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-cluster nexus-cluster
 
 # -- Runtime stage --

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -25,7 +25,7 @@ WORKDIR /build
 # (CI preflight enforces agreement) — an unpinned install tracks HEAD
 # and can skew the raft contract against the cluster/witness images.
 # --locked honors the source tree's Cargo.lock.
-ARG NEXUS_VFS_REV=3c7eeb6021d40192c5a8f538b8097ecb0f374304
+ARG NEXUS_VFS_REV=79b367d19ce91b00801b8854ff8463683791c03f
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexus-raft-server raft
 
 # ---------- Production image ----------

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=3c7eeb6021d40192c5a8f538b8097ecb0f374304
+ARG NEXUS_VFS_REV=79b367d19ce91b00801b8854ff8463683791c03f
 RUN cargo install \
     --locked \
     --git https://github.com/nexi-lab/nexus-vfs \


### PR DESCRIPTION
## Summary

Pin bump to pick up **nexus-vfs PR #120 (Phase H)**: `identity.zones[].as_role` is now respected on Row 4 rejoin of the daemon federation branch. A wiped-then-restored **learner** rejoins as `AddLearnerNode` (preserving the 1-voter+N-learners S3 topology) instead of silently upgrading to `AddNode` (voter) on every wipe cycle.

## Why it matters

Before Phase H, every wipe cycle of a learner silently inflated the voter set. Over a few wipes a healthy 1-voter+N-learners topology drifted toward all-voters, eventually wedging on the voter-wipe-rejoin trap documented in `docs/federation-architecture.md § 6.3.1` (also touched up in PR #119).

## Boundary

Nexus service-tier surface unchanged. The daemon-boot decision layer lives entirely in `nexus_raft::bootstrap`. No operator env var / CLI arg changed — runbook + docker-compose recipes stay valid.

## Files

- `Cargo.toml` — 7 kernel-tier crate revs
- `Cargo.lock` — 5 crate revs (transport is workspace-local, not nexus-vfs)
- `Dockerfile` + `dockerfiles/Dockerfile.{minimal,raft-server,raft-witness}` — `NEXUS_VFS_REV` ARG

## Test plan

- [x] cargo fetch resolves both nexus-vfs deps + workspace clean
- [ ] CI green (cargo check + clippy + test + Docker builds + E2E)