### PR TITLE
fix(fuse-plugin): NFS stale mount cleanup + DRY fallback + post-mount probe

### DIFF
--- a/.github/workflows/fuse-plugin-macos-nfs-e2e.yml
+++ b/.github/workflows/fuse-plugin-macos-nfs-e2e.yml
@@ -254,17 +254,26 @@ jobs:
             kill -0 "$DAEMON_PID" 2>/dev/null && echo "yes" || echo "no (exited)"
           fi
 
-          # Teardown.
+          # Teardown — force-unmount BEFORE killing daemon so the NFS
+          # server's tokio runtime doesn't block on active connections.
+          umount -f /tmp/nexus-nfs-e2e 2>/dev/null || true
+
+          # SIGTERM first, then SIGKILL after 5s grace period.
+          # `wait` can hang indefinitely if the NFS server's tokio
+          # runtime has active connections; the SIGKILL ensures we
+          # never exceed the job timeout on teardown.
           kill "$DAEMON_PID" 2>/dev/null || true
+          for i in $(seq 1 10); do
+            kill -0 "$DAEMON_PID" 2>/dev/null || break
+            sleep 0.5
+          done
+          kill -9 "$DAEMON_PID" 2>/dev/null || true
           wait "$DAEMON_PID" 2>/dev/null || true
 
           echo "=== nexusd.log (last 100 lines) ==="
           tail -100 nexusd.log 2>/dev/null || true
           echo "=== nexusd.err.log (last 100 lines) ==="
           tail -100 nexusd.err.log 2>/dev/null || true
-
-          # Unmount if still mounted.
-          umount /tmp/nexus-nfs-e2e 2>/dev/null || true
 
           exit $TEST_RC
 

--- a/rust/services/fuse-plugin/src/fs_nfs.rs
+++ b/rust/services/fuse-plugin/src/fs_nfs.rs
@@ -393,9 +393,7 @@ fn cleanup_stale_nfs_mount(mount_point: &str) {
                         let stale_path = &after_on[..paren_idx];
                         // Don't re-unmount what we already did above
                         if stale_path != mount_point {
-                            eprintln!(
-                                "[nexus-fuse-plugin] cleaning stale NFS mount: {stale_path}"
-                            );
+                            eprintln!("[nexus-fuse-plugin] cleaning stale NFS mount: {stale_path}");
                             let _ = std::process::Command::new("/sbin/umount")
                                 .args(["-f", stale_path])
                                 .output();

--- a/rust/services/fuse-plugin/src/fs_nfs.rs
+++ b/rust/services/fuse-plugin/src/fs_nfs.rs
@@ -102,6 +102,33 @@ impl NexusNfs {
         })
     }
 
+    /// Synthetic directory attr for the root when the VFS path isn't
+    /// mounted yet.  The NFS MOUNT RPC calls `getattr(root)` — if this
+    /// returns NOENT the mount fails.  Returning a minimal empty dir
+    /// lets the mount succeed; real content appears once the
+    /// mount-driver wires the path.
+    fn synthetic_dir_attr(&self, id: fileid3) -> fattr3 {
+        let now = nfs_now();
+        fattr3 {
+            ftype: ftype3::NF3DIR,
+            mode: 0o755,
+            nlink: 2,
+            uid: unsafe { libc::getuid() },
+            gid: unsafe { libc::getgid() },
+            size: 0,
+            used: 0,
+            rdev: specdata3 {
+                specdata1: 0,
+                specdata2: 0,
+            },
+            fsid: 0,
+            fileid: id,
+            atime: now,
+            mtime: now,
+            ctime: now,
+        }
+    }
+
     /// Stat a path and return its fattr3.
     fn stat_fattr(&self, id: fileid3, path: &str) -> Result<fattr3, nfsstat3> {
         let json =
@@ -141,7 +168,17 @@ impl NFSFileSystem for NexusNfs {
 
     async fn getattr(&self, id: fileid3) -> Result<fattr3, nfsstat3> {
         let path = self.path_for(id).ok_or(nfsstat3::NFS3ERR_NOENT)?;
-        self.stat_fattr(id, &path)
+        match self.stat_fattr(id, &path) {
+            Ok(attr) => Ok(attr),
+            Err(_) if id == NFS_ROOT_ID => {
+                // VFS root path may not exist yet (mount-driver loads
+                // after the fuse plugin).  Return a synthetic empty
+                // directory so the NFS MOUNT RPC succeeds; real
+                // content appears once the mount-driver wires the path.
+                Ok(self.synthetic_dir_attr(id))
+            }
+            Err(e) => Err(e),
+        }
     }
 
     async fn setattr(&self, _id: fileid3, _setattr: sattr3) -> Result<fattr3, nfsstat3> {
@@ -258,8 +295,17 @@ impl NFSFileSystem for NexusNfs {
         max_entries: usize,
     ) -> Result<ReadDirResult, nfsstat3> {
         let parent_path = self.path_for(dirid).ok_or(nfsstat3::NFS3ERR_NOENT)?;
-        let json = kernel_callbacks::sys_readdir(&self.kernel, &parent_path)
-            .map_err(|_| nfsstat3::NFS3ERR_IO)?;
+        let json = match kernel_callbacks::sys_readdir(&self.kernel, &parent_path) {
+            Ok(j) => j,
+            Err(_) if dirid == NFS_ROOT_ID => {
+                // VFS root not mounted yet — return empty listing.
+                return Ok(ReadDirResult {
+                    entries: vec![],
+                    end: true,
+                });
+            }
+            Err(_) => return Err(nfsstat3::NFS3ERR_IO),
+        };
         let entries = parse_readdir(&json);
 
         let mut result_entries = Vec::new();

--- a/rust/services/fuse-plugin/src/fs_nfs.rs
+++ b/rust/services/fuse-plugin/src/fs_nfs.rs
@@ -348,10 +348,12 @@ pub struct NfsMountHandle {
 
 impl Drop for NfsMountHandle {
     fn drop(&mut self) {
-        // Best-effort unmount — `umount` may fail if the mount was
-        // already torn down (e.g. `diskutil unmount` from Finder).
+        // Best-effort force-unmount — `-f` is essential on macOS
+        // because a normal unmount can hang if any process has an
+        // open fd on the mount.  May fail if the mount was already
+        // torn down (e.g. `diskutil unmount` from Finder).
         let _ = std::process::Command::new("/sbin/umount")
-            .arg(&self.mount_point)
+            .args(["-f", &self.mount_point])
             .output();
     }
 }
@@ -362,6 +364,49 @@ impl NfsMountHandle {
     }
 }
 
+/// Force-unmount any stale NFS mount at `mount_point`.
+///
+/// macOS allows only **one** `localhost:/` NFS mount at a time.  When
+/// the daemon is killed with SIGKILL, `Drop` doesn't run → the stale
+/// mount blocks all subsequent `mount_nfs` calls with "No such file or
+/// directory".  This function is idempotent: if there is no stale mount
+/// the `umount -f` simply fails and we ignore the error.
+fn cleanup_stale_nfs_mount(mount_point: &str) {
+    // 1. Force-unmount the target mount point (may be stale).
+    let _ = std::process::Command::new("/sbin/umount")
+        .args(["-f", mount_point])
+        .output();
+
+    // 2. Scan for any other stale nexus NFS mounts (e.g. /tmp/nexus-nfs-*)
+    //    from previously crashed daemon instances.
+    if let Ok(output) = std::process::Command::new("/sbin/mount").output() {
+        let mount_table = String::from_utf8_lossy(&output.stdout);
+        for line in mount_table.lines() {
+            // NFS mounts from us look like:
+            //   localhost:/ on /tmp/nexus-nfs-XXXX (nfs, ...)
+            //   localhost:/ on /Users/.../nexus-project (nfs, ...)
+            if line.contains("localhost:/") && line.contains("nfs") {
+                // Extract the mount path: "... on <path> (..."
+                if let Some(on_idx) = line.find(" on ") {
+                    let after_on = &line[on_idx + 4..];
+                    if let Some(paren_idx) = after_on.find(" (") {
+                        let stale_path = &after_on[..paren_idx];
+                        // Don't re-unmount what we already did above
+                        if stale_path != mount_point {
+                            eprintln!(
+                                "[nexus-fuse-plugin] cleaning stale NFS mount: {stale_path}"
+                            );
+                            let _ = std::process::Command::new("/sbin/umount")
+                                .args(["-f", stale_path])
+                                .output();
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
 /// Bind an NFS server on localhost, mount it at `mount_point`, and
 /// return the handle.  The NFS server runs in a dedicated tokio
 /// runtime so it doesn't interfere with fuser's thread model.
@@ -369,6 +414,11 @@ pub fn spawn_nfs_mount(
     nfs_fs: NexusNfs,
     mount_point: &str,
 ) -> Result<NfsMountHandle, Box<dyn std::error::Error>> {
+    // Clean up stale NFS mounts from crashed daemon instances before
+    // we bind a new NFS server.  Without this, macOS rejects the new
+    // mount_nfs with "No such file or directory".
+    cleanup_stale_nfs_mount(mount_point);
+
     let rt = tokio::runtime::Builder::new_multi_thread()
         .worker_threads(2)
         .enable_all()
@@ -378,6 +428,7 @@ pub fn spawn_nfs_mount(
     let (port, listener) = rt.block_on(async {
         let listener = NFSTcpListener::bind("127.0.0.1:0", nfs_fs).await?;
         let port = listener.get_listen_port();
+        eprintln!("[nexus-fuse-plugin] NFS server bound to 127.0.0.1:{port}");
         Ok::<_, std::io::Error>((port, listener))
     })?;
 
@@ -388,6 +439,18 @@ pub fn spawn_nfs_mount(
             eprintln!("[nexus-fuse-plugin] NFS server error: {e}");
         }
     });
+
+    // Ensure mount point directory exists.
+    std::fs::create_dir_all(mount_point)?;
+
+    // Wait for the NFS server to start accepting connections.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    while std::time::Instant::now() < deadline {
+        if std::net::TcpStream::connect(format!("127.0.0.1:{port}")).is_ok() {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
 
     // Mount via macOS native `mount_nfs`.  Options:
     //   nolocks  — no NLM (kernel doesn't support locking)

--- a/rust/services/fuse-plugin/src/lib.rs
+++ b/rust/services/fuse-plugin/src/lib.rs
@@ -212,7 +212,10 @@ fn create_fuse_plugin(_kernel: &KernelHandle) -> Box<FusePlugin> {
                     let vfs_root =
                         std::env::var("NEXUS_FUSE_VFS_ROOT").unwrap_or_else(|_| "/".to_string());
                     try_nfs_fallback(
-                        &plugin, _kernel, &mount_point, &vfs_root,
+                        &plugin,
+                        _kernel,
+                        &mount_point,
+                        &vfs_root,
                         "FUSE-T not installed",
                     );
                     if plugin.nfs_handle.lock().unwrap().is_none() {
@@ -249,7 +252,10 @@ fn create_fuse_plugin(_kernel: &KernelHandle) -> Box<FusePlugin> {
                         if !is_mount_live(&mount_point) {
                             drop(session);
                             try_nfs_fallback(
-                                &plugin, _kernel, &mount_point, &vfs_root,
+                                &plugin,
+                                _kernel,
+                                &mount_point,
+                                &vfs_root,
                                 "fuser returned Ok but mount is not live (FUSE-T silent failure)",
                             );
                             return Box::new(plugin);
@@ -267,7 +273,10 @@ fn create_fuse_plugin(_kernel: &KernelHandle) -> Box<FusePlugin> {
                     #[cfg(target_os = "macos")]
                     {
                         try_nfs_fallback(
-                            &plugin, _kernel, &mount_point, &vfs_root,
+                            &plugin,
+                            _kernel,
+                            &mount_point,
+                            &vfs_root,
                             &format!("fuser mount failed ({e})"),
                         );
                     }

--- a/rust/services/fuse-plugin/src/lib.rs
+++ b/rust/services/fuse-plugin/src/lib.rs
@@ -123,6 +123,62 @@ impl FusePlugin {
     }
 }
 
+/// Try NFS localhost fallback — single implementation shared by all
+/// macOS fallback paths (FUSE-T missing, fuser error, fuser silent fail).
+#[cfg(target_os = "macos")]
+fn try_nfs_fallback(
+    plugin: &FusePlugin,
+    kernel: &KernelHandle,
+    mount_point: &str,
+    vfs_root: &str,
+    reason: &str,
+) {
+    eprintln!("[nexus-fuse-plugin] {reason}, falling back to NFS localhost");
+    tracing::warn!(
+        target: "nexus::fuse",
+        mount_point = %mount_point,
+        reason = %reason,
+        "attempting NFS localhost fallback"
+    );
+    let kernel_nfs = unsafe { kernel_handle_clone(kernel) };
+    let nfs_fs = fs_nfs::NexusNfs::new(kernel_nfs, vfs_root.to_string());
+    match fs_nfs::spawn_nfs_mount(nfs_fs, mount_point) {
+        Ok(handle) => {
+            eprintln!(
+                "[nexus-fuse-plugin] NFS mount OK at {mount_point} (port {})",
+                handle.port()
+            );
+            tracing::info!(
+                target: "nexus::fuse",
+                mount_point = %mount_point,
+                port = handle.port(),
+                "NFS localhost fallback mounted"
+            );
+            *plugin.nfs_handle.lock().unwrap() = Some(handle);
+        }
+        Err(nfs_err) => {
+            eprintln!("[nexus-fuse-plugin] NFS fallback also failed: {nfs_err}");
+            tracing::error!(
+                target: "nexus::fuse",
+                mount_point = %mount_point,
+                nfs_error = %nfs_err,
+                "NFS fallback failed"
+            );
+        }
+    }
+}
+
+/// Check if a mount point has a live filesystem attached (macOS).
+/// Returns false if the mount point doesn't appear in `mount` output,
+/// which means FUSE-T returned Ok but silently disconnected.
+#[cfg(target_os = "macos")]
+fn is_mount_live(mount_point: &str) -> bool {
+    std::process::Command::new("/sbin/mount")
+        .output()
+        .map(|o| String::from_utf8_lossy(&o.stdout).contains(mount_point))
+        .unwrap_or(false)
+}
+
 /// Plugin-lifecycle `create`: read operator config from env, build the
 /// FUSE filesystem instance, and spawn the event loop in a background
 /// thread.  Returns the boxed `FusePlugin` even when the mount fails —
@@ -153,44 +209,14 @@ fn create_fuse_plugin(_kernel: &KernelHandle) -> Box<FusePlugin> {
             {
                 use fuse_t_detect::{is_fuse_t_installed, DetectionResult};
                 if matches!(is_fuse_t_installed(), DetectionResult::NotFound) {
-                    eprintln!(
-                        "[nexus-fuse-plugin] FUSE-T not installed; trying NFS localhost fallback"
-                    );
-                    tracing::warn!(
-                        target: "nexus::fuse",
-                        mount_point = %mount_point,
-                        "FUSE-T not installed; attempting NFS localhost fallback"
-                    );
                     let vfs_root =
                         std::env::var("NEXUS_FUSE_VFS_ROOT").unwrap_or_else(|_| "/".to_string());
-                    let kernel_nfs = unsafe { kernel_handle_clone(_kernel) };
-                    let nfs_fs = fs_nfs::NexusNfs::new(kernel_nfs, vfs_root);
-                    match fs_nfs::spawn_nfs_mount(nfs_fs, &mount_point) {
-                        Ok(handle) => {
-                            eprintln!(
-                                "[nexus-fuse-plugin] NFS mount OK at {mount_point} (port {})",
-                                handle.port()
-                            );
-                            tracing::info!(
-                                target: "nexus::fuse",
-                                mount_point = %mount_point,
-                                port = handle.port(),
-                                "NFS localhost fallback mounted (FUSE-T not installed)"
-                            );
-                            *plugin.nfs_handle.lock().unwrap() = Some(handle);
-                        }
-                        Err(nfs_err) => {
-                            eprintln!(
-                                "[nexus-fuse-plugin] NFS fallback failed: {nfs_err}; status=fuse-t-missing"
-                            );
-                            tracing::error!(
-                                target: "nexus::fuse",
-                                mount_point = %mount_point,
-                                error = %nfs_err,
-                                "NFS fallback failed; falling back to prereq_missing"
-                            );
-                            *plugin.prereq_missing.lock().unwrap() = Some("fuse-t");
-                        }
+                    try_nfs_fallback(
+                        &plugin, _kernel, &mount_point, &vfs_root,
+                        "FUSE-T not installed",
+                    );
+                    if plugin.nfs_handle.lock().unwrap().is_none() {
+                        *plugin.prereq_missing.lock().unwrap() = Some("fuse-t");
                     }
                     return Box::new(plugin);
                 }
@@ -214,13 +240,21 @@ fn create_fuse_plugin(_kernel: &KernelHandle) -> Box<FusePlugin> {
             let mount_config = fuser::Config::default();
             match fuser::spawn_mount2(fs, &mount_point, &mount_config) {
                 Ok(session) => {
-                    // eprintln complements tracing: a dlopen'd cdylib
-                    // owns a separate tracing global, so the plugin's
-                    // `tracing::info!` calls don't reach the cluster's
-                    // subscriber.  stderr lands in the daemon's stderr
-                    // regardless, which is what compose / `docker logs`
-                    // capture — the operator's only mount-status SoT
-                    // until the cluster grows a plugin-tracing bridge.
+                    // Post-mount validation: FUSE-T on macOS 26 Tahoe
+                    // returns Ok from spawn_mount2 but the mount silently
+                    // disconnects immediately (go-nfsv4 backend crash).
+                    #[cfg(target_os = "macos")]
+                    {
+                        std::thread::sleep(std::time::Duration::from_millis(500));
+                        if !is_mount_live(&mount_point) {
+                            drop(session);
+                            try_nfs_fallback(
+                                &plugin, _kernel, &mount_point, &vfs_root,
+                                "fuser returned Ok but mount is not live (FUSE-T silent failure)",
+                            );
+                            return Box::new(plugin);
+                        }
+                    }
                     eprintln!("[nexus-fuse-plugin] mount OK at {mount_point}");
                     tracing::info!(
                         target: "nexus::fuse",
@@ -230,50 +264,12 @@ fn create_fuse_plugin(_kernel: &KernelHandle) -> Box<FusePlugin> {
                     *plugin.session.lock().unwrap() = Some(session);
                 }
                 Err(e) => {
-                    // On macOS, fuser mount failure is expected when
-                    // FUSE-T is broken (macOS 26 Tahoe).  Fall back to
-                    // an in-process NFSv3 localhost server mounted via
-                    // the native `mount_nfs` binary.
                     #[cfg(target_os = "macos")]
                     {
-                        eprintln!(
-                            "[nexus-fuse-plugin] fuser mount failed ({e}), falling back to NFS localhost"
+                        try_nfs_fallback(
+                            &plugin, _kernel, &mount_point, &vfs_root,
+                            &format!("fuser mount failed ({e})"),
                         );
-                        tracing::warn!(
-                            target: "nexus::fuse",
-                            mount_point = %mount_point,
-                            error = %e,
-                            "fuser mount failed; attempting NFS localhost fallback"
-                        );
-                        let kernel_nfs = unsafe { kernel_handle_clone(_kernel) };
-                        let nfs_fs = fs_nfs::NexusNfs::new(kernel_nfs, vfs_root.clone());
-                        match fs_nfs::spawn_nfs_mount(nfs_fs, &mount_point) {
-                            Ok(handle) => {
-                                eprintln!(
-                                    "[nexus-fuse-plugin] NFS mount OK at {mount_point} (port {})",
-                                    handle.port()
-                                );
-                                tracing::info!(
-                                    target: "nexus::fuse",
-                                    mount_point = %mount_point,
-                                    port = handle.port(),
-                                    "NFS localhost fallback mounted"
-                                );
-                                *plugin.nfs_handle.lock().unwrap() = Some(handle);
-                            }
-                            Err(nfs_err) => {
-                                eprintln!(
-                                    "[nexus-fuse-plugin] NFS fallback also failed: {nfs_err}"
-                                );
-                                tracing::error!(
-                                    target: "nexus::fuse",
-                                    mount_point = %mount_point,
-                                    fuser_error = %e,
-                                    nfs_error = %nfs_err,
-                                    "Both fuser and NFS mounts failed"
-                                );
-                            }
-                        }
                     }
                     #[cfg(not(target_os = "macos"))]
                     {

--- a/rust/services/fuse-plugin/tests/nfs_integration.rs
+++ b/rust/services/fuse-plugin/tests/nfs_integration.rs
@@ -528,6 +528,50 @@ async fn read_past_eof_returns_empty() {
     assert!(eof);
 }
 
+/// When the VFS root path doesn't exist yet (mount-driver loads after
+/// fuse plugin), getattr on root must return a synthetic directory
+/// instead of NOENT — otherwise the NFS MOUNT RPC fails and mount_nfs
+/// errors with "No such file or directory".
+#[tokio::test]
+async fn getattr_root_synthetic_when_vfs_path_missing() {
+    let mock = new_mock_box();
+    let handle = mock_kernel_handle(&mock);
+    // VFS root "/not/yet/mounted" doesn't exist in the mock kernel.
+    let nfs = NexusNfs::new(handle, "/not/yet/mounted".to_string());
+
+    // Root getattr must succeed with a synthetic directory.
+    let attr = nfs.getattr(nfs.root_dir()).await.unwrap();
+    assert!(is_ftype(attr.ftype, ftype3::NF3DIR));
+    assert_eq!(attr.fileid, 1);
+    assert_eq!(attr.size, 0);
+}
+
+/// readdir on root must return empty (not error) when VFS root isn't
+/// mounted yet.
+#[tokio::test]
+async fn readdir_root_empty_when_vfs_path_missing() {
+    let mock = new_mock_box();
+    let handle = mock_kernel_handle(&mock);
+    let nfs = NexusNfs::new(handle, "/not/yet/mounted".to_string());
+
+    let result = nfs.readdir(nfs.root_dir(), 0, 100).await.unwrap();
+    assert!(result.entries.is_empty());
+    assert!(result.end);
+}
+
+/// Non-root inode getattr must still return NOENT for missing paths
+/// (only root gets the synthetic fallback).
+#[tokio::test]
+async fn getattr_nonroot_still_returns_noent_for_missing() {
+    let mock = new_mock_box();
+    let handle = mock_kernel_handle(&mock);
+    let nfs = NexusNfs::new(handle, "/not/yet/mounted".to_string());
+
+    // Inode 999 doesn't exist anywhere.
+    let err = nfs.getattr(999).await.unwrap_err();
+    assert!(is_nfs_err(err, nfsstat3::NFS3ERR_NOENT));
+}
+
 /// Workflow test: full session lifecycle mirroring the pytest E2E.
 /// mkdir → write N files → readdir → read each → unlink each → rmdir.
 #[tokio::test]


### PR DESCRIPTION
## Summary

- **Fix stale NFS mount bug**: macOS allows only one `localhost:/` NFS mount at a time. When daemon is killed with SIGKILL, `Drop` doesn't run → stale mount → all subsequent `mount_nfs` fail with "No such file or directory". Added `cleanup_stale_nfs_mount()` that force-unmounts the target mount point and scans the mount table for any other stale nexus NFS localhost mounts before binding a new server.
- **Fix NFS mount when VFS root not yet mounted**: The fuse plugin loads before the mount-driver plugin, so the VFS root path (e.g. `/shared/tasks-nexus-project`) doesn't exist yet at NFS mount time. The NFS MOUNT RPC calls `getattr(root)` which returned NOENT, causing `mount_nfs` to fail. Fixed by returning a synthetic empty directory for root when `sys_stat` fails — real content appears once the mount-driver wires the path.
- **DRY fallback**: Extracted `try_nfs_fallback()` shared by all 3 macOS fallback paths (FUSE-T missing, fuser error, fuser silent fail) — eliminates ~60 lines of duplicated NFS fallback code.
- **Post-mount probe**: Added `is_mount_live()` to detect FUSE-T silent disconnect on macOS 26 Tahoe (spawn_mount2 returns Ok but mount silently disappears).
- **Robustness**: `NfsMountHandle::Drop` now uses `umount -f` (force), `create_dir_all` before mount, TCP probe wait before `mount_nfs`.

## Test plan

- [x] All 40 tests pass (22 unit + 18 integration)
- [x] 3 new integration tests for synthetic root fallback
- [x] `cargo check -p nexus-fuse-plugin` clean
- [x] Local E2E: daemon starts → NFS mount succeeds → `ls` shows 90 task JSONs → write/read byte-exact roundtrip
- [ ] CI green on macOS NFS E2E workflow
- [ ] CI green on Rust Lint and Test

🤖 Generated with [Claude Code](https://claude.com/claude-code)