### PR TITLE
feat(services): transport-observer — data-privacy warning on relay-transported cross-node reads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=79b367d19ce91b00801b8854ff8463683791c03f#79b367d19ce91b00801b8854ff8463683791c03f"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=82d5fc2f015b3cb7c9af48d0b2839d8b9f4e6529#82d5fc2f015b3cb7c9af48d0b2839d8b9f4e6529"
 dependencies = [
  "ahash",
  "base64",
@@ -550,7 +550,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=79b367d19ce91b00801b8854ff8463683791c03f#79b367d19ce91b00801b8854ff8463683791c03f"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=82d5fc2f015b3cb7c9af48d0b2839d8b9f4e6529#82d5fc2f015b3cb7c9af48d0b2839d8b9f4e6529"
 dependencies = [
  "parking_lot",
  "serde",
@@ -1334,7 +1334,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=79b367d19ce91b00801b8854ff8463683791c03f#79b367d19ce91b00801b8854ff8463683791c03f"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=82d5fc2f015b3cb7c9af48d0b2839d8b9f4e6529#82d5fc2f015b3cb7c9af48d0b2839d8b9f4e6529"
 dependencies = [
  "ahash",
  "base64",
@@ -1385,7 +1385,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=79b367d19ce91b00801b8854ff8463683791c03f#79b367d19ce91b00801b8854ff8463683791c03f"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=82d5fc2f015b3cb7c9af48d0b2839d8b9f4e6529#82d5fc2f015b3cb7c9af48d0b2839d8b9f4e6529"
 dependencies = [
  "ahash",
  "base64",
@@ -1580,7 +1580,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=79b367d19ce91b00801b8854ff8463683791c03f#79b367d19ce91b00801b8854ff8463683791c03f"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=82d5fc2f015b3cb7c9af48d0b2839d8b9f4e6529#82d5fc2f015b3cb7c9af48d0b2839d8b9f4e6529"
 
 [[package]]
 name = "nexus-vault"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -200,13 +200,13 @@ exclude = ["nexus-fuse"]
 #
 # Bump alongside the rest of nexus-vfs updates when a downstream
 # change needs newer kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "79b367d19ce91b00801b8854ff8463683791c03f" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "79b367d19ce91b00801b8854ff8463683791c03f" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "79b367d19ce91b00801b8854ff8463683791c03f" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "79b367d19ce91b00801b8854ff8463683791c03f", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "79b367d19ce91b00801b8854ff8463683791c03f", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "79b367d19ce91b00801b8854ff8463683791c03f", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "79b367d19ce91b00801b8854ff8463683791c03f" }
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "82d5fc2f015b3cb7c9af48d0b2839d8b9f4e6529" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "82d5fc2f015b3cb7c9af48d0b2839d8b9f4e6529" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "82d5fc2f015b3cb7c9af48d0b2839d8b9f4e6529" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "82d5fc2f015b3cb7c9af48d0b2839d8b9f4e6529", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "82d5fc2f015b3cb7c9af48d0b2839d8b9f4e6529", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "82d5fc2f015b3cb7c9af48d0b2839d8b9f4e6529", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "82d5fc2f015b3cb7c9af48d0b2839d8b9f4e6529" }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ENV CARGO_NET_RETRY=10 \
     CARGO_HTTP_TIMEOUT=120
 # Override for edge/CI or a different pin: --build-arg NEXUS_VFS_REV=<sha|tag>
-ARG NEXUS_VFS_REV=79b367d19ce91b00801b8854ff8463683791c03f
+ARG NEXUS_VFS_REV=82d5fc2f015b3cb7c9af48d0b2839d8b9f4e6529
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,id=cargo-install-${TARGETARCH},target=/root/.cargo/target \

--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir --no-deps --prefix=/install .
 # enforces agreement) — an unpinned install tracks nexus-vfs HEAD and
 # ships an untested kernel (#4343). --locked honors the source tree's
 # Cargo.lock.
-ARG NEXUS_VFS_REV=79b367d19ce91b00801b8854ff8463683791c03f
+ARG NEXUS_VFS_REV=82d5fc2f015b3cb7c9af48d0b2839d8b9f4e6529
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-cluster nexus-cluster
 
 # -- Runtime stage --

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -25,7 +25,7 @@ WORKDIR /build
 # (CI preflight enforces agreement) — an unpinned install tracks HEAD
 # and can skew the raft contract against the cluster/witness images.
 # --locked honors the source tree's Cargo.lock.
-ARG NEXUS_VFS_REV=79b367d19ce91b00801b8854ff8463683791c03f
+ARG NEXUS_VFS_REV=82d5fc2f015b3cb7c9af48d0b2839d8b9f4e6529
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexus-raft-server raft
 
 # ---------- Production image ----------

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=79b367d19ce91b00801b8854ff8463683791c03f
+ARG NEXUS_VFS_REV=82d5fc2f015b3cb7c9af48d0b2839d8b9f4e6529
 RUN cargo install \
     --locked \
     --git https://github.com/nexi-lab/nexus-vfs \

--- a/rust/services/Cargo.toml
+++ b/rust/services/Cargo.toml
@@ -14,6 +14,15 @@ default = []
 # Per-service features.  Each gates one `pub mod` line in lib.rs so
 # slim Rust binaries (nexus-cluster) link only the services they want.
 service-audit = []
+# TransportObserverService — data-privacy warning when cross-node
+# `sys_read` (via `try_remote_fetch`) bytes traverse a relay hop
+# instead of a direct P2P transport.  Filters
+# `FileEventType::RemoteFetch` (nexus-vfs PR #121) and classifies
+# each event's opaque `remote_addr` via a substrate-specific
+# resolver (Tailscale today; the trait accepts plug-in resolvers
+# for future substrates).  Warn / metric emission only; no I/O
+# refusal on the sys_read hot path.
+service-transport-observer = []
 service-agents = []
 service-managed-agent = []
 service-acp = []

--- a/rust/services/src/lib.rs
+++ b/rust/services/src/lib.rs
@@ -82,3 +82,11 @@ pub mod password_vault;
 // mount with PasswordVaultService. Loaded as part of the vault cdylib plugin.
 #[cfg(feature = "service-generic-secrets")]
 pub mod generic_secrets;
+// TransportObserverService — data-privacy warning + metric on cross-node
+// `sys_read` (via `try_remote_fetch`) events whose current network path
+// traverses a relay hop instead of a direct P2P transport. Filters
+// `FileEventType::RemoteFetch` (nexus-vfs PR #121) and classifies each
+// event's opaque `remote_addr` through a substrate-specific resolver
+// (Tailscale today; trait accepts alternate substrate resolvers).
+#[cfg(feature = "service-transport-observer")]
+pub mod transport_observer;

--- a/rust/services/src/transport_observer/mod.rs
+++ b/rust/services/src/transport_observer/mod.rs
@@ -1,0 +1,644 @@
+//! TransportObserverService — data-privacy warning on cross-node reads
+//! that traverse a relay hop instead of a direct P2P transport.
+//!
+//! ## Motivation
+//!
+//! Nexus is a distributed VFS.  Cross-node reads (`sys_read` via
+//! `try_remote_fetch`) travel over whichever substrate the operator
+//! configured — today Tailscale-over-WireGuard, tomorrow possibly other
+//! overlay networks or direct SSH tunnels.  Tailscale's design falls
+//! back to a **DERP relay** when direct NAT-punch fails; the operator
+//! wants to know when their bytes are transiting a third-party relay
+//! (data-privacy concern — the WireGuard encryption still applies, but
+//! traffic patterns / SPOF / lag / SLA changes are visible signals).
+//!
+//! ## Design
+//!
+//! `TransportObserverService` implements the kernel's existing
+//! [`MutationObserver`] trait, filtering on
+//! [`FileEventType::RemoteFetch`] events (nexus-vfs PR #121).  For each
+//! such event it consults a [`TransportPathResolver`] — an abstract
+//! substrate-lookup — to classify the current path to `remote_addr` as
+//! [`TransportPath::Direct`], [`TransportPath::Relay`], or
+//! [`TransportPath::Unknown`].  Relay classification emits a warning
+//! (`tracing::warn!`) and increments an atomic counter that operators
+//! can scrape via any future metrics endpoint.
+//!
+//! ### Layering discipline
+//!
+//! The kernel emits `RemoteFetch` events with `remote_addr` as an
+//! **opaque string** — kernel knows nothing about Tailscale.  This
+//! service owns Tailscale semantics via the concrete
+//! [`TailscaleResolver`] impl of the [`TransportPathResolver`] trait.
+//! Alternative substrates (Nebula, WireGuard mesh without Tailscale,
+//! WebRTC, S3-tier tracking) plug in via alternate resolvers — same
+//! service, swap the resolver.
+
+use std::collections::HashMap;
+use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use parking_lot::RwLock;
+
+use kernel::core::dispatch::{FileEvent, FileEventType, MutationObserver};
+
+/// Classification of the network path an opaque remote address is
+/// currently reachable through.  Consumer of the substrate lookup.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum TransportPath {
+    /// Direct P2P transport (e.g. Tailscale WireGuard direct).  No
+    /// third-party relay involved.  Ideal for data-privacy.
+    Direct,
+    /// Bytes route through a third-party relay (e.g. Tailscale DERP).
+    /// `via` names the relay for operator diagnostics.
+    Relay { via: String },
+    /// Substrate has no information about this address (peer not in
+    /// the tailnet, resolver failed, tailscale CLI absent, etc.).
+    /// Treated as "not proven direct" — the observer emits a warning
+    /// under the `Warn` policy just like a relay, since we can't
+    /// certify privacy.
+    Unknown,
+}
+
+/// Substrate-specific transport-path lookup.  The kernel emits opaque
+/// `remote_addr` strings; concrete impls interpret them (a Tailscale
+/// resolver keys on `"host:port"` where host is a `100.64.0.x` IP; a
+/// future S3 resolver keys on bucket names; etc.).
+pub trait TransportPathResolver: Send + Sync {
+    /// Classify the current network path to `remote_addr`.  Called on
+    /// every `RemoteFetch` event inline on the sys_read caller thread
+    /// (see nexus-vfs `kernel/observability.rs::dispatch_observers`),
+    /// so implementations MUST stay fast: cache aggressively (RwLock +
+    /// pre-computed map) and never issue I/O in the resolver body.
+    /// Network fetches / RPCs belong on a background poller thread
+    /// that populates the cache the resolver reads from.
+    fn resolve(&self, remote_addr: &str) -> TransportPath;
+}
+
+/// Operator-selectable behaviour when a `RemoteFetch` event's path is
+/// classified as Relay or Unknown (not proven direct).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TransportPolicy {
+    /// Warn (log + metric) on relay/unknown paths; allow the read.
+    /// Fail-open — the read already returned data by the time the
+    /// observer fires (post-mutation dispatch is fire-and-forget).
+    Warn,
+    /// Never emit warnings; silently accept every path.  Use when
+    /// operator has other observability and doesn't want log noise.
+    AllowAll,
+}
+
+/// Cached tailscale-status snapshot keyed by peer `100.64.0.x` IP
+/// (without port).  Populated by [`TailscaleResolver::refresh`] on the
+/// background poller thread; read lock-free-ish via `RwLock` on the
+/// observer thread.
+type PathMap = HashMap<String, TransportPath>;
+
+/// Concrete [`TransportPathResolver`] impl for Tailscale.  Polls
+/// `tailscale status --json` at construction and every
+/// `refresh_interval`, populating an internal cache indexed by peer
+/// tailnet IP.
+///
+/// **Threading model**: the periodic refresh runs on a dedicated OS
+/// thread (not tokio — this crate targets both async and sync
+/// consumers).  30s cadence matches Tailscale's own endpoint-change
+/// notification interval closely enough that operators won't observe
+/// stale classifications for realistic connection lifetimes.
+pub struct TailscaleResolver {
+    cache: Arc<RwLock<PathMap>>,
+}
+
+impl TailscaleResolver {
+    /// Spawn the poller and return a resolver.  Caller must hold the
+    /// returned [`Arc`] for the lifetime of the daemon — dropping the
+    /// last strong reference stops the poller.
+    pub fn spawn(refresh_interval: Duration) -> Arc<Self> {
+        let resolver = Arc::new(Self {
+            cache: Arc::new(RwLock::new(PathMap::new())),
+        });
+        Self::spawn_poller(Arc::clone(&resolver.cache), refresh_interval);
+        // Prime the cache once synchronously so early reads don't see
+        // an empty map for the first refresh_interval.
+        Self::refresh_cache(&resolver.cache, None);
+        resolver
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_static_status(status_json: String) -> Arc<Self> {
+        let resolver = Arc::new(Self {
+            cache: Arc::new(RwLock::new(PathMap::new())),
+        });
+        Self::refresh_cache(&resolver.cache, Some(&status_json));
+        resolver
+    }
+
+    fn spawn_poller(cache: Arc<RwLock<PathMap>>, refresh_interval: Duration) {
+        std::thread::Builder::new()
+            .name("transport-observer/tailscale-poller".into())
+            .spawn(move || {
+                // Weak downgrade so poller exits when observer service drops.
+                let weak = Arc::downgrade(&cache);
+                loop {
+                    std::thread::sleep(refresh_interval);
+                    let Some(strong) = weak.upgrade() else {
+                        break;
+                    };
+                    Self::refresh_cache(&strong, None);
+                }
+            })
+            .ok();
+    }
+
+    fn refresh_cache(cache: &RwLock<PathMap>, override_json: Option<&str>) {
+        let json = match override_json {
+            Some(s) => s.to_string(),
+            None => match Self::query_tailscale_status() {
+                Ok(s) => s,
+                Err(_) => return, // silent — offline / not-installed is normal
+            },
+        };
+        let map = Self::parse_status_json(&json);
+        *cache.write() = map;
+    }
+
+    fn query_tailscale_status() -> Result<String, String> {
+        let out = Command::new("tailscale")
+            .args(["status", "--json"])
+            .output()
+            .map_err(|e| format!("spawn tailscale: {e}"))?;
+        if !out.status.success() {
+            return Err(format!("tailscale exit {:?}", out.status.code()));
+        }
+        String::from_utf8(out.stdout).map_err(|e| format!("utf8: {e}"))
+    }
+
+    /// Parse `tailscale status --json` output into a peer-IP → path map.
+    ///
+    /// Tailscale's schema per peer under `.Peer`:
+    /// - `TailscaleIPs: [String]` — the `100.64.0.x` addresses
+    /// - `Relay: String` — DERP relay name (empty when direct)
+    /// - `CurAddr: String` — current direct endpoint (empty when relay)
+    ///
+    /// Interpretation: `CurAddr` non-empty ⇒ Direct.  Otherwise `Relay`
+    /// non-empty ⇒ Relay { via }.  Both empty ⇒ Unknown (not yet
+    /// connected or offline).
+    fn parse_status_json(json: &str) -> PathMap {
+        let mut map = PathMap::new();
+        let Ok(v): Result<serde_json::Value, _> = serde_json::from_str(json) else {
+            return map;
+        };
+        let Some(peers) = v.get("Peer").and_then(|p| p.as_object()) else {
+            return map;
+        };
+        for (_key, peer) in peers.iter() {
+            let ips = peer
+                .get("TailscaleIPs")
+                .and_then(|v| v.as_array())
+                .cloned()
+                .unwrap_or_default();
+            let cur_addr = peer
+                .get("CurAddr")
+                .and_then(|v| v.as_str())
+                .unwrap_or_default();
+            let relay = peer
+                .get("Relay")
+                .and_then(|v| v.as_str())
+                .unwrap_or_default();
+            let path = if !cur_addr.is_empty() {
+                TransportPath::Direct
+            } else if !relay.is_empty() {
+                TransportPath::Relay {
+                    via: relay.to_string(),
+                }
+            } else {
+                TransportPath::Unknown
+            };
+            for ip in ips {
+                if let Some(ip_str) = ip.as_str() {
+                    map.insert(ip_str.to_string(), path.clone());
+                }
+            }
+        }
+        map
+    }
+}
+
+impl TransportPathResolver for TailscaleResolver {
+    fn resolve(&self, remote_addr: &str) -> TransportPath {
+        // Kernel stamps `remote_addr` as the operator-facing "host:port"
+        // form; strip the port for tailscale IP lookup.
+        let host = remote_addr.rsplit_once(':').map_or(remote_addr, |(h, _)| h);
+        // Strip leading "http://" / "https://" if the substrate stamped
+        // a URL (raft transport uses URL form for gRPC endpoints).
+        let host = host
+            .trim_start_matches("http://")
+            .trim_start_matches("https://");
+        self.cache
+            .read()
+            .get(host)
+            .cloned()
+            .unwrap_or(TransportPath::Unknown)
+    }
+}
+
+/// TransportObserverService — the actual [`MutationObserver`] plugged
+/// into kernel dispatch.  Filters `RemoteFetch` events and produces a
+/// warning per configured policy.
+pub struct TransportObserverService {
+    resolver: Arc<dyn TransportPathResolver>,
+    policy: TransportPolicy,
+    warn_count: AtomicU64,
+    direct_count: AtomicU64,
+    unknown_count: AtomicU64,
+}
+
+impl TransportObserverService {
+    /// Wire the service with a policy and a substrate-specific
+    /// resolver.  Caller registers via `Kernel::register_service_observer`.
+    pub fn new(resolver: Arc<dyn TransportPathResolver>, policy: TransportPolicy) -> Self {
+        Self {
+            resolver,
+            policy,
+            warn_count: AtomicU64::new(0),
+            direct_count: AtomicU64::new(0),
+            unknown_count: AtomicU64::new(0),
+        }
+    }
+
+    /// Number of RemoteFetch events classified as Relay whose warning
+    /// fired (post-policy).  Exposed for Prometheus-scrape callers.
+    pub fn relay_warn_count(&self) -> u64 {
+        self.warn_count.load(Ordering::Relaxed)
+    }
+
+    /// Number of RemoteFetch events classified as Direct.  Ratio with
+    /// [`relay_warn_count`] answers "what fraction of my data traffic
+    /// was point-to-point?"
+    pub fn direct_count(&self) -> u64 {
+        self.direct_count.load(Ordering::Relaxed)
+    }
+
+    /// Number of RemoteFetch events where the resolver returned
+    /// Unknown (peer not in tailnet, cache miss, tailscale absent).
+    pub fn unknown_count(&self) -> u64 {
+        self.unknown_count.load(Ordering::Relaxed)
+    }
+}
+
+impl MutationObserver for TransportObserverService {
+    fn on_mutation(&self, event: &FileEvent) {
+        if event.event_type != FileEventType::RemoteFetch {
+            return;
+        }
+        let remote_addr = match event.remote_addr() {
+            Some(addr) if !addr.is_empty() => addr,
+            _ => return,
+        };
+        let path = self.resolver.resolve(remote_addr);
+        match &path {
+            TransportPath::Direct => {
+                self.direct_count.fetch_add(1, Ordering::Relaxed);
+            }
+            TransportPath::Relay { via } => {
+                self.warn_count.fetch_add(1, Ordering::Relaxed);
+                if self.policy == TransportPolicy::Warn {
+                    tracing::warn!(
+                        target: "transport_observer",
+                        remote_addr = %remote_addr,
+                        via = %via,
+                        path = %event.path(),
+                        bytes = event.size().unwrap_or(0),
+                        "distributed-VFS remote-fetch traversed relay — data-privacy caution",
+                    );
+                }
+            }
+            TransportPath::Unknown => {
+                self.unknown_count.fetch_add(1, Ordering::Relaxed);
+                if self.policy == TransportPolicy::Warn {
+                    tracing::warn!(
+                        target: "transport_observer",
+                        remote_addr = %remote_addr,
+                        path = %event.path(),
+                        bytes = event.size().unwrap_or(0),
+                        "distributed-VFS remote-fetch path unclassified (substrate lookup returned Unknown)",
+                    );
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Deterministic resolver for unit tests — no OS deps.
+    struct StaticResolver(HashMap<String, TransportPath>);
+
+    impl TransportPathResolver for StaticResolver {
+        fn resolve(&self, addr: &str) -> TransportPath {
+            let host = addr
+                .rsplit_once(':')
+                .map_or(addr, |(h, _)| h)
+                .trim_start_matches("http://")
+                .trim_start_matches("https://");
+            self.0.get(host).cloned().unwrap_or(TransportPath::Unknown)
+        }
+    }
+
+    fn make_event(remote_addr: &str, bytes: u64) -> FileEvent {
+        FileEvent::remote_fetch("/shared/x.json", remote_addr, bytes)
+    }
+
+    #[test]
+    fn ignores_non_remote_fetch_events() {
+        // Verifies event-type discrimination — a service registered on
+        // the general observer stream must reject other event types
+        // silently (no counter change, no warning).  Uses `with_zone`
+        // (public ctor) with FileWrite; even though remote_addr is
+        // unpopulated, we never reach the resolver because event_type
+        // filters out.
+        let mut map = HashMap::new();
+        map.insert("100.64.0.21".to_string(), TransportPath::Direct);
+        let svc =
+            TransportObserverService::new(Arc::new(StaticResolver(map)), TransportPolicy::Warn);
+        let event = FileEvent::with_zone(FileEventType::FileWrite, "/w.json", "root");
+        svc.on_mutation(&event);
+        assert_eq!(svc.direct_count(), 0);
+        assert_eq!(svc.relay_warn_count(), 0);
+        assert_eq!(svc.unknown_count(), 0);
+    }
+
+    #[test]
+    fn direct_path_counts_but_does_not_warn() {
+        let mut map = HashMap::new();
+        map.insert("100.64.0.21".to_string(), TransportPath::Direct);
+        let svc =
+            TransportObserverService::new(Arc::new(StaticResolver(map)), TransportPolicy::Warn);
+        svc.on_mutation(&make_event("100.64.0.21:2126", 4096));
+        assert_eq!(svc.direct_count(), 1);
+        assert_eq!(svc.relay_warn_count(), 0);
+        assert_eq!(svc.unknown_count(), 0);
+    }
+
+    #[test]
+    fn relay_path_increments_warn_counter() {
+        let mut map = HashMap::new();
+        map.insert(
+            "100.64.0.21".to_string(),
+            TransportPath::Relay {
+                via: "headscale".to_string(),
+            },
+        );
+        let svc =
+            TransportObserverService::new(Arc::new(StaticResolver(map)), TransportPolicy::Warn);
+        svc.on_mutation(&make_event("100.64.0.21:2126", 4096));
+        assert_eq!(svc.relay_warn_count(), 1);
+        assert_eq!(svc.direct_count(), 0);
+    }
+
+    #[test]
+    fn unknown_path_increments_unknown_counter() {
+        // Peer not in the tailnet cache — treated as unknown, warned
+        // under Warn policy (we can't certify direct).
+        let svc = TransportObserverService::new(
+            Arc::new(StaticResolver(HashMap::new())),
+            TransportPolicy::Warn,
+        );
+        svc.on_mutation(&make_event("192.0.2.5:2126", 512));
+        assert_eq!(svc.unknown_count(), 1);
+        assert_eq!(svc.direct_count(), 0);
+        assert_eq!(svc.relay_warn_count(), 0);
+    }
+
+    #[test]
+    fn allow_all_policy_still_counts_but_stays_silent() {
+        // Counters must still increment under AllowAll so operators
+        // that use metrics-only observability still get data.  Only
+        // the log emission is gated.
+        let mut map = HashMap::new();
+        map.insert(
+            "100.64.0.21".to_string(),
+            TransportPath::Relay {
+                via: "derp".to_string(),
+            },
+        );
+        let svc =
+            TransportObserverService::new(Arc::new(StaticResolver(map)), TransportPolicy::AllowAll);
+        svc.on_mutation(&make_event("100.64.0.21:2126", 8192));
+        assert_eq!(svc.relay_warn_count(), 1);
+    }
+
+    #[test]
+    fn resolver_strips_port_and_url_prefix() {
+        // Kernel may stamp `remote_addr` as either bare `IP:port` (from
+        // raft peer table) or `http://IP:port` (from gRPC transport
+        // endpoint form).  Both must resolve to the same tailnet IP.
+        let mut map = HashMap::new();
+        map.insert("100.64.0.21".to_string(), TransportPath::Direct);
+        let resolver = StaticResolver(map);
+        assert_eq!(resolver.resolve("100.64.0.21:2126"), TransportPath::Direct);
+        assert_eq!(
+            resolver.resolve("http://100.64.0.21:2126"),
+            TransportPath::Direct
+        );
+        assert_eq!(
+            resolver.resolve("https://100.64.0.21:2126"),
+            TransportPath::Direct
+        );
+    }
+
+    #[test]
+    fn tailscale_resolver_parses_direct_and_relay() {
+        // Fixture matches the shape of `tailscale status --json` on a
+        // live tailnet with one direct peer and one DERP-relayed peer.
+        let json = r#"{
+            "Peer": {
+                "nodekey:aaaa": {
+                    "TailscaleIPs": ["100.64.0.21"],
+                    "CurAddr": "192.168.1.3:41641",
+                    "Relay": "headscale"
+                },
+                "nodekey:bbbb": {
+                    "TailscaleIPs": ["100.64.0.22"],
+                    "CurAddr": "",
+                    "Relay": "headscale"
+                },
+                "nodekey:cccc": {
+                    "TailscaleIPs": ["100.64.0.23"],
+                    "CurAddr": "",
+                    "Relay": ""
+                }
+            }
+        }"#;
+        let resolver = TailscaleResolver::with_static_status(json.to_string());
+        assert_eq!(
+            resolver.resolve("100.64.0.21:2126"),
+            TransportPath::Direct,
+            "peer with CurAddr must classify as Direct"
+        );
+        assert_eq!(
+            resolver.resolve("http://100.64.0.22:2126"),
+            TransportPath::Relay {
+                via: "headscale".to_string()
+            },
+            "peer without CurAddr but with Relay must classify as Relay",
+        );
+        assert_eq!(
+            resolver.resolve("100.64.0.23:2126"),
+            TransportPath::Unknown,
+            "peer with neither CurAddr nor Relay must classify as Unknown",
+        );
+        assert_eq!(
+            resolver.resolve("100.64.0.99:2126"),
+            TransportPath::Unknown,
+            "peer not in the tailnet must classify as Unknown",
+        );
+    }
+
+    #[test]
+    fn tailscale_resolver_survives_malformed_json() {
+        // `tailscale status --json` output can vary across versions;
+        // parser must not panic on unexpected shapes.
+        let resolver = TailscaleResolver::with_static_status("not json".to_string());
+        assert_eq!(resolver.resolve("100.64.0.21:2126"), TransportPath::Unknown);
+    }
+
+    // ── Multi-step workflow tests (mirror the ../.claude/skills/
+    //    integration-test-generator standard: sequential steps with
+    //    data-flow between them, not independent operations) ──
+
+    #[test]
+    fn workflow_operator_boot_and_sees_mixed_direct_and_relay_traffic() {
+        // Simulates a full operator workflow:
+        //   1. Boot: Tailscale reports one peer direct, one via DERP relay
+        //      (typical mixed home-LAN + mobile-hotspot scenario).
+        //   2. Cross-node reads happen — several direct-peer fetches, one
+        //      relay-peer fetch, one unknown-peer fetch.
+        //   3. Operator queries counters — must reflect exact per-path totals.
+        // This mirrors what the operator sees in real production, and
+        // catches integration bugs unit tests miss (e.g. resolver caching
+        // the wrong peer, counter aliasing between paths).
+        let json = r#"{
+            "Peer": {
+                "nk:aaa": {
+                    "TailscaleIPs": ["100.64.0.21"],
+                    "CurAddr": "192.168.1.3:41641",
+                    "Relay": "headscale"
+                },
+                "nk:bbb": {
+                    "TailscaleIPs": ["100.64.0.22"],
+                    "CurAddr": "",
+                    "Relay": "headscale"
+                }
+            }
+        }"#;
+        let resolver = TailscaleResolver::with_static_status(json.to_string());
+        let svc = TransportObserverService::new(resolver, TransportPolicy::Warn);
+
+        // Direct peer — 3 fetches
+        for _ in 0..3 {
+            svc.on_mutation(&make_event("100.64.0.21:2126", 1024));
+        }
+        // Relay peer — 1 fetch (this is the operator-visible warning)
+        svc.on_mutation(&make_event("100.64.0.22:2126", 2048));
+        // Unknown peer (not in tailnet) — 2 fetches
+        for _ in 0..2 {
+            svc.on_mutation(&make_event("100.64.0.99:2126", 512));
+        }
+
+        assert_eq!(svc.direct_count(), 3, "3 direct fetches");
+        assert_eq!(svc.relay_warn_count(), 1, "1 relay warn");
+        assert_eq!(svc.unknown_count(), 2, "2 unknown-peer fetches");
+    }
+
+    #[test]
+    fn workflow_concurrent_events_produce_correct_counter_totals() {
+        // The kernel's `dispatch_observers` runs on a ThreadPool — the
+        // observer's `on_mutation` MUST tolerate concurrent invocation
+        // without lost counter increments (atomic ordering) or
+        // interior-mutability panics.  Simulate: 8 threads × 100 events
+        // each = 800 total events, all Direct.  Final `direct_count()`
+        // must equal 800.  Regression guard for accidentally introducing
+        // a Mutex or non-atomic counter later.
+        let mut map = HashMap::new();
+        map.insert("100.64.0.21".to_string(), TransportPath::Direct);
+        let svc = Arc::new(TransportObserverService::new(
+            Arc::new(StaticResolver(map)),
+            TransportPolicy::AllowAll,
+        ));
+
+        let mut handles = Vec::new();
+        for _ in 0..8 {
+            let svc = Arc::clone(&svc);
+            handles.push(std::thread::spawn(move || {
+                for _ in 0..100 {
+                    svc.on_mutation(&make_event("100.64.0.21:2126", 128));
+                }
+            }));
+        }
+        for h in handles {
+            h.join().expect("thread panic");
+        }
+
+        assert_eq!(
+            svc.direct_count(),
+            800,
+            "concurrent dispatch must not lose or double-count events",
+        );
+        assert_eq!(svc.relay_warn_count(), 0);
+        assert_eq!(svc.unknown_count(), 0);
+    }
+
+    #[test]
+    fn workflow_tailscale_status_refresh_updates_classification() {
+        // Simulates the operator's home-LAN → mobile-hotspot transition
+        // that motivated this service in the first place:
+        //   1. Initial state: peer is direct (both on same LAN).
+        //   2. Peer moves to mobile hotspot; tailscale reclassifies to relay.
+        //   3. Subsequent reads must classify as relay, not stale-direct.
+        // This is the "SPOF/lag concerns become visible" workflow the
+        // service exists to signal.
+        let initial_json = r#"{"Peer":{"nk:x":{
+            "TailscaleIPs":["100.64.0.21"],
+            "CurAddr":"192.168.1.3:41641",
+            "Relay":""
+        }}}"#;
+        let resolver = TailscaleResolver::with_static_status(initial_json.to_string());
+        assert_eq!(
+            resolver.resolve("100.64.0.21:2126"),
+            TransportPath::Direct,
+            "initial state — LAN direct",
+        );
+
+        // Peer switches network — tailscale refreshes status.
+        let after_hotspot_json = r#"{"Peer":{"nk:x":{
+            "TailscaleIPs":["100.64.0.21"],
+            "CurAddr":"",
+            "Relay":"headscale"
+        }}}"#;
+        TailscaleResolver::refresh_cache(&resolver.cache, Some(after_hotspot_json));
+
+        assert_eq!(
+            resolver.resolve("100.64.0.21:2126"),
+            TransportPath::Relay {
+                via: "headscale".to_string()
+            },
+            "after hotspot transition — must reclassify to relay",
+        );
+
+        // Wire through observer — the reclassification must reach the
+        // service's counters on subsequent events (not stuck on cached
+        // Direct verdict).
+        let svc = TransportObserverService::new(resolver, TransportPolicy::Warn);
+        svc.on_mutation(&make_event("100.64.0.21:2126", 4096));
+        assert_eq!(svc.relay_warn_count(), 1);
+        assert_eq!(
+            svc.direct_count(),
+            0,
+            "must not classify as Direct post-refresh"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

New `services::transport_observer` module — implements the kernel's existing `MutationObserver` trait, filters `FileEventType::RemoteFetch` events (nexus-vfs PR #121), and classifies each event's opaque `remote_addr` through a substrate-specific `TransportPathResolver` into `Direct | Relay { via } | Unknown`. Fires a `tracing::warn!` when a cross-node read's current network path traverses a third-party relay hop instead of a direct P2P transport (data-privacy signal per elfenlieds7's original design intent).

## Design (approved 2026-07-06 in-session)

- **Kernel stays transport-agnostic** — nexus-vfs #121 (kernel) emits `RemoteFetch` events with opaque `remote_addr`; kernel does NOT know Tailscale exists.
- **Tailscale semantics live in this service** — via concrete `TailscaleResolver` impl of the `TransportPathResolver` trait.
- **Alternative substrates plug in via new resolvers** — same service, swap the resolver. Nebula, WebRTC data channel, S3-tier tracking, etc.
- **Reuses existing hook infrastructure end-to-end** — zero new observer trait, zero new dispatch mechanism, zero new plugin ABI. Mirrors `services::audit` pattern.

## Commits

1. **chore**: bump nexus-vfs pin → `82d5fc2f0` (picks up PR #121 event type + PR #122 public accessors/ctor).
2. **feat**: `TransportObserverService` + `TailscaleResolver` + tests.

## Tests

11 unit tests covering:

**Basic classification**
- `ignores_non_remote_fetch_events` — event-type filter discipline
- `direct_path_counts_but_does_not_warn` — happy path
- `relay_path_increments_warn_counter` — data-privacy signal
- `unknown_path_increments_unknown_counter` — resolver miss → treated as not-direct
- `allow_all_policy_still_counts_but_stays_silent` — policy layering

**Parser edge cases**
- `resolver_strips_port_and_url_prefix` — bare `IP:port` vs `http://IP:port`
- `tailscale_resolver_parses_direct_and_relay` — full JSON schema
- `tailscale_resolver_survives_malformed_json` — degrades to Unknown, no panic

**Multi-step workflow tests** (per `.claude/skills/integration-test-generator` standard — sequential steps with data-flow between them):
- `workflow_operator_boot_and_sees_mixed_direct_and_relay_traffic` — boot with mixed peers → 6 events → verify per-path counter totals
- `workflow_concurrent_events_produce_correct_counter_totals` — 8 threads × 100 events, atomic-counter regression guard
- `workflow_tailscale_status_refresh_updates_classification` — LAN → hotspot transition → resolver updates → subsequent events reclassify

## Test plan

- [x] `cargo test -p services --features service-transport-observer transport_observer::` — 11/11 green
- [x] `cargo clippy -p services --features service-transport-observer --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [ ] CI green
- [ ] **Cross-machine live verification (Win↔Mac over Tailscale)** — after merge, per `feedback_cross_machine_bug_workflow` rule:
  - Build cluster binary with `--features service-transport-observer`
  - Boot both sides, wire the service in `nexusd-cluster::main.rs` (follow-up commit if needed)
  - Trigger cross-node read
  - Verify `tracing::warn` fires when Mac is on hotspot (relay path); does NOT fire when both on LAN (direct)

## Note on daemon wiring

This PR ships the **service library** — registering the observer at daemon start belongs in a small follow-up when the feature flag is proven. Existing services follow the same pattern (`services::audit::install(...)` is called explicitly by the cluster main).

## 8-principle audit (final)

| # | Principle | Verdict |
|---|---|---|
| 1 | Simple contract | ✅✅ zero new operator surface (feature-gated); zero new kernel API beyond PR #121 |
| 2 | No boundary leak | ✅✅ tailscale-specific code confined to this service; kernel + PeerClient stay transport-agnostic |
| 3 | SSOT | ✅✅ transport-path SSOT lives only in `TailscaleResolver` cache |
| 4 | DRY | ✅✅ reuses kernel's `MutationObserver + FileEvent + observer_pool` end-to-end |
| 5 | Rust-first | ✅ |
| 6 | Perf | ✅ observer fire-and-forget off hot path; tailscale query cached (30s cadence) |
| 7 | Raft contract | ✅ zero raft changes |
| 8 | Systemic | ✅✅ any future "cares about cross-node data movement" service (audit, cost tracker, forensics, alt-substrate) plugs into same trait — no core changes |