### PR TITLE
feat(services): audit migrates to enforced hook ownership + nexus-vfs pin bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=82d5fc2f015b3cb7c9af48d0b2839d8b9f4e6529#82d5fc2f015b3cb7c9af48d0b2839d8b9f4e6529"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=218213dadbc6ca662284a81562b83617f42f1a95#218213dadbc6ca662284a81562b83617f42f1a95"
 dependencies = [
  "ahash",
  "base64",
@@ -550,7 +550,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=82d5fc2f015b3cb7c9af48d0b2839d8b9f4e6529#82d5fc2f015b3cb7c9af48d0b2839d8b9f4e6529"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=218213dadbc6ca662284a81562b83617f42f1a95#218213dadbc6ca662284a81562b83617f42f1a95"
 dependencies = [
  "parking_lot",
  "serde",
@@ -1334,7 +1334,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=82d5fc2f015b3cb7c9af48d0b2839d8b9f4e6529#82d5fc2f015b3cb7c9af48d0b2839d8b9f4e6529"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=218213dadbc6ca662284a81562b83617f42f1a95#218213dadbc6ca662284a81562b83617f42f1a95"
 dependencies = [
  "ahash",
  "base64",
@@ -1385,7 +1385,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=82d5fc2f015b3cb7c9af48d0b2839d8b9f4e6529#82d5fc2f015b3cb7c9af48d0b2839d8b9f4e6529"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=218213dadbc6ca662284a81562b83617f42f1a95#218213dadbc6ca662284a81562b83617f42f1a95"
 dependencies = [
  "ahash",
  "base64",
@@ -1580,7 +1580,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=82d5fc2f015b3cb7c9af48d0b2839d8b9f4e6529#82d5fc2f015b3cb7c9af48d0b2839d8b9f4e6529"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=218213dadbc6ca662284a81562b83617f42f1a95#218213dadbc6ca662284a81562b83617f42f1a95"
 
 [[package]]
 name = "nexus-vault"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -200,13 +200,13 @@ exclude = ["nexus-fuse"]
 #
 # Bump alongside the rest of nexus-vfs updates when a downstream
 # change needs newer kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "82d5fc2f015b3cb7c9af48d0b2839d8b9f4e6529" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "82d5fc2f015b3cb7c9af48d0b2839d8b9f4e6529" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "82d5fc2f015b3cb7c9af48d0b2839d8b9f4e6529" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "82d5fc2f015b3cb7c9af48d0b2839d8b9f4e6529", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "82d5fc2f015b3cb7c9af48d0b2839d8b9f4e6529", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "82d5fc2f015b3cb7c9af48d0b2839d8b9f4e6529", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "82d5fc2f015b3cb7c9af48d0b2839d8b9f4e6529" }
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "218213dadbc6ca662284a81562b83617f42f1a95" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "218213dadbc6ca662284a81562b83617f42f1a95" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "218213dadbc6ca662284a81562b83617f42f1a95" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "218213dadbc6ca662284a81562b83617f42f1a95", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "218213dadbc6ca662284a81562b83617f42f1a95", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "218213dadbc6ca662284a81562b83617f42f1a95", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "218213dadbc6ca662284a81562b83617f42f1a95" }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ENV CARGO_NET_RETRY=10 \
     CARGO_HTTP_TIMEOUT=120
 # Override for edge/CI or a different pin: --build-arg NEXUS_VFS_REV=<sha|tag>
-ARG NEXUS_VFS_REV=82d5fc2f015b3cb7c9af48d0b2839d8b9f4e6529
+ARG NEXUS_VFS_REV=218213dadbc6ca662284a81562b83617f42f1a95
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,id=cargo-install-${TARGETARCH},target=/root/.cargo/target \

--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir --no-deps --prefix=/install .
 # enforces agreement) — an unpinned install tracks nexus-vfs HEAD and
 # ships an untested kernel (#4343). --locked honors the source tree's
 # Cargo.lock.
-ARG NEXUS_VFS_REV=82d5fc2f015b3cb7c9af48d0b2839d8b9f4e6529
+ARG NEXUS_VFS_REV=218213dadbc6ca662284a81562b83617f42f1a95
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-cluster nexus-cluster
 
 # -- Runtime stage --

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -25,7 +25,7 @@ WORKDIR /build
 # (CI preflight enforces agreement) — an unpinned install tracks HEAD
 # and can skew the raft contract against the cluster/witness images.
 # --locked honors the source tree's Cargo.lock.
-ARG NEXUS_VFS_REV=82d5fc2f015b3cb7c9af48d0b2839d8b9f4e6529
+ARG NEXUS_VFS_REV=218213dadbc6ca662284a81562b83617f42f1a95
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexus-raft-server raft
 
 # ---------- Production image ----------

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=82d5fc2f015b3cb7c9af48d0b2839d8b9f4e6529
+ARG NEXUS_VFS_REV=218213dadbc6ca662284a81562b83617f42f1a95
 RUN cargo install \
     --locked \
     --git https://github.com/nexi-lab/nexus-vfs \

--- a/rust/services/src/audit/mod.rs
+++ b/rust/services/src/audit/mod.rs
@@ -38,6 +38,7 @@ use kernel::core::dispatch::{
     FileEvent, FileEventType, HookContext, MutationObserver, NativeInterceptHook,
 };
 use kernel::kernel::{Kernel, KernelError};
+use kernel::service_registry::ServiceHandle;
 
 /// DT_STREAM entry-type discriminant (mirrors `kernel::core::dcache::DT_STREAM`).
 const DT_STREAM: i32 = 4;
@@ -210,6 +211,12 @@ impl<K: KernelAbi> NativeInterceptHook for AuditHook<K> {
     }
 }
 
+/// Service name enlisted in `ServiceRegistry` for audit's hook-only
+/// ownership.  Public so operators + future observability surfaces
+/// (`nexus service-list`, metrics endpoints) reach for the same name
+/// audit uses at enlist time.
+pub const AUDIT_SERVICE_NAME: &str = "audit";
+
 /// Boot-time DI entry point — install an `AuditHook` for `zone_id`.
 ///
 /// Service-tier responsibility (this whole module). Three steps, each
@@ -222,16 +229,21 @@ impl<K: KernelAbi> NativeInterceptHook for AuditHook<K> {
 /// 2. `AuditHook::new(kernel, stream_path, zone_id)` — local services
 ///    concern: build the hook impl that holds an `Arc<K>` for syscall
 ///    callbacks.
-/// 3. `kernel.register_native_hook(Box::new(hook))` — install-time
-///    control plane (LSM-style); kernel records the hook in its
-///    native dispatch registry without ever knowing the concrete type.
+/// 3. `kernel.register_service_hook(handle, Box::new(hook))` — install-time
+///    control plane (LSM-style with enforced ownership); kernel records
+///    the hook in its native dispatch registry under the `handle`'s
+///    service entry so `unregister_service(AUDIT_SERVICE_NAME)`
+///    batch-removes every audit hook and observer at once.
 ///
-/// Idempotent: `sys_setattr` for an existing DT_STREAM is a no-op
-/// re-open; the `register_native_hook` side is not — calling `install`
-/// twice for the same zone double-registers the hook. Callers
-/// (typically `nexus.__init__` boot path) call this exactly once per zone.
+/// Idempotent on the `sys_setattr` side (existing DT_STREAM is a no-op
+/// re-open).  The hook-registration side is not idempotent — calling
+/// `install` twice for the same zone under the same handle double-
+/// registers the hook.  Callers (typically `install_root` +
+/// `ZoneAuditAutoWire`) guarantee once-per-zone through their own
+/// bookkeeping.
 pub fn install<K: KernelAbi>(
     kernel: Arc<K>,
+    handle: &ServiceHandle,
     zone_id: &str,
     stream_path: &str,
 ) -> Result<(), KernelError> {
@@ -241,7 +253,7 @@ pub fn install<K: KernelAbi>(
         stream_path.to_string(),
         zone_id.to_string(),
     );
-    kernel.register_native_hook(Box::new(hook));
+    kernel.register_service_hook(handle, Box::new(hook));
     Ok(())
 }
 
@@ -290,17 +302,31 @@ pub fn install_root(
     root_zone_id: &str,
     stream_path: &str,
 ) -> Result<(), KernelError> {
-    install(Arc::clone(kernel), root_zone_id, stream_path)?;
+    // Enlist audit as a hook-only service in `ServiceRegistry`.  The
+    // handle carries the identity that every subsequent
+    // `register_service_hook` / `register_service_observer` binds to,
+    // so `kernel.unregister_service(AUDIT_SERVICE_NAME)` batch-removes
+    // the root-zone hook, every per-zone hook the auto-wire installed,
+    // AND the auto-wire observer itself in one call.  Idempotent on
+    // re-enlist of the same name (returns a fresh handle to the same
+    // entry).
+    let handle = kernel
+        .enlist_hook_only_service(AUDIT_SERVICE_NAME)
+        .map_err(|e| KernelError::IOError(format!("enlist audit service: {e}")))?;
+
+    install(Arc::clone(kernel), &handle, root_zone_id, stream_path)?;
 
     let mut seeded = HashSet::new();
     seeded.insert(root_zone_id.to_string());
 
     let auto_wire = Arc::new(ZoneAuditAutoWire {
         kernel: Arc::clone(kernel),
+        handle: handle.clone(),
         installed: Mutex::new(seeded),
         stream_path: stream_path.to_string(),
     });
-    kernel.register_observer(
+    kernel.register_service_observer(
+        &handle,
         auto_wire,
         ZoneAuditAutoWire::OBSERVER_NAME.to_string(),
         FileEventType::Mount as u32,
@@ -314,6 +340,12 @@ pub fn install_root(
 /// re-mount events are no-ops.
 struct ZoneAuditAutoWire {
     kernel: Arc<Kernel>,
+    /// Cloned from the handle `install_root` obtained at enlist time.
+    /// Cheap (single `Arc<String>` bump) and shares the same
+    /// `ServiceRegistry` entry so per-zone hooks installed from
+    /// `on_mutation` batch-remove alongside the root-zone hook and the
+    /// observer when audit is unregistered.
+    handle: ServiceHandle,
     /// Zones the observer has already wired AuditHook for. The
     /// root zone is seeded into this set by [`install_root`] before
     /// the observer is registered, so a re-mount of the root zone
@@ -341,7 +373,12 @@ impl MutationObserver for ZoneAuditAutoWire {
                 return;
             }
         }
-        if let Err(e) = install(Arc::clone(&self.kernel), &zone_id, &self.stream_path) {
+        if let Err(e) = install(
+            Arc::clone(&self.kernel),
+            &self.handle,
+            &zone_id,
+            &self.stream_path,
+        ) {
             tracing::warn!(
                 zone = %zone_id,
                 error = ?e,
@@ -580,15 +617,28 @@ mod tests {
     fn dt_mount_dispatch_reaches_zone_audit_auto_wire_observer() {
         let kernel = fresh_federated_kernel();
 
+        // Enlist audit as a hook-only service so we can install hooks
+        // and observer through the enforced-ownership surface.
+        let handle = kernel
+            .enlist_hook_only_service(AUDIT_SERVICE_NAME)
+            .expect("enlist audit");
+
         // Pre-seed the audit DT_STREAM for the root zone via
         // `install` so the observer's per-zone `install` calls can
         // succeed against the federated kernel.
-        install(Arc::clone(&kernel), "root", "/__sys__/audit/traces/").expect("install root");
+        install(
+            Arc::clone(&kernel),
+            &handle,
+            "root",
+            "/__sys__/audit/traces/",
+        )
+        .expect("install root");
 
         // Construct + register the auto-wire ourselves so we can
         // inspect its `installed` HashSet after the dispatch fires.
         let auto_wire = Arc::new(ZoneAuditAutoWire {
             kernel: Arc::clone(&kernel),
+            handle: handle.clone(),
             installed: Mutex::new({
                 let mut s = HashSet::new();
                 s.insert("root".to_string());
@@ -596,7 +646,8 @@ mod tests {
             }),
             stream_path: "/__sys__/audit/traces/".to_string(),
         });
-        kernel.register_observer(
+        kernel.register_service_observer(
+            &handle,
             Arc::clone(&auto_wire) as Arc<dyn MutationObserver>,
             ZoneAuditAutoWire::OBSERVER_NAME.to_string(),
             FileEventType::Mount as u32,
@@ -729,6 +780,13 @@ mod tests {
     #[test]
     fn zone_audit_auto_wire_dedups_by_zone_id() {
         let kernel = fresh_kernel();
+        // Enlist audit so the auto-wire has a valid handle to hold —
+        // the HashSet short-circuit path never actually reaches the
+        // handle, so we could stub any name, but going through the real
+        // enlist keeps the test consistent with production shape.
+        let handle = kernel
+            .enlist_hook_only_service(AUDIT_SERVICE_NAME)
+            .expect("enlist audit");
         let mut seeded = HashSet::new();
         // Pre-seed every zone we'll fire events for — the HashSet
         // check short-circuits before install() runs, so we exercise
@@ -738,6 +796,7 @@ mod tests {
 
         let auto_wire = ZoneAuditAutoWire {
             kernel,
+            handle,
             installed: Mutex::new(seeded),
             stream_path: "/__sys__/audit/traces/".to_string(),
         };


### PR DESCRIPTION
## Summary

Migrates `services::audit` to the handle-based enforced ownership surface landed in nexus-vfs #129 + #130. Bumps the nexus-vfs pin to `218213d`.

## Contract shape

- `AUDIT_SERVICE_NAME = \"audit\"` — new public const, single source of truth for audit's `ServiceRegistry` entry name.
- `install_root` enlists audit as a hook-only service (`kernel.enlist_hook_only_service(\"audit\")`) and threads the returned `ServiceHandle` through:
  - the root-zone `install` call
  - the `ZoneAuditAutoWire` observer registration (`register_service_observer(&handle, ...)`)
  - every per-zone `install` the auto-wire fires from `on_mutation`
- `install<K: KernelAbi>` gains a `&ServiceHandle` parameter and uses `kernel.register_service_hook(handle, ...)` instead of the unscoped `register_native_hook`.
- `ZoneAuditAutoWire` stores a cloned `handle: ServiceHandle` (cheap `Arc<String>` clone) so per-zone auto-wire installs bind to the same registry entry as the root-zone install.

## Result

`kernel.unregister_service(\"audit\")` now batch-removes the root-zone AuditHook, the ZoneAuditAutoWire observer, AND every per-zone AuditHook the auto-wire installed — one call cleans up the whole audit surface. Ownership is enforceable at the type level: audit hooks bind to a handle issued by `ServiceRegistry`, not to a bare string tag.

## Pre-existing test note

`audit::tests::dt_mount_dispatch_reaches_zone_audit_auto_wire_observer` fails on develop baseline (verified via `git stash`) — the second consecutive `sys_setattr(DT_MOUNT)` under `/mnt/` hits a \"no parent route for non-root mount\" error unrelated to hook ownership. **Not addressed here**; kept for a separate targeted fix so this PR stays scoped to the migration.

Local test run (my branch):
```
running 4 tests
test audit::tests::zone_audit_auto_wire_dedups_by_zone_id ... ok
test audit::tests::install_root_against_federated_kernel_composes_root_audit_stream ... ok
test audit::tests::audit_hook_captures_sys_write_through_to_audit_stream ... ok
test audit::tests::dt_mount_dispatch_reaches_zone_audit_auto_wire_observer ... FAILED  (pre-existing)
```

## Systematic check against the review principles

- Contract: opaque handle, single accessor per role, single const name for audit's identity.
- Kernel syscall ABI untouched.
- Right file: audit's own mod.rs.
- SRP / orthogonality: `install` (per-zone hook install), `install_root` (root-zone + auto-wire), `ZoneAuditAutoWire` (per-zone auto-wire). Each has one responsibility.
- No boundary leak: the handle is opaque.
- SSOT: audit's identity is `AUDIT_SERVICE_NAME`; handle clones share one entry.
- DRY: `install` composed by `install_root` and `on_mutation` — one code path.
- Raft: untouched.
- Systematic not patch: no wrapper. Old unscoped-registration surface is retired for audit.

## Rollout

- nexus-vfs #129 (merged): `HookOnly` variant + `ServiceHandle` + handle-based `register_service_*`.
- nexus-vfs #130 (merged): expose the four methods through KernelAbi trait.
- **This PR (nexus)**: audit migrates.
- Follow-up: sweep `managed_agent`, `matrix_adapter`, dylib plugins to handle path; then delete the unscoped `register_native_hook` surface where not whitelisted.