### PR TITLE
feat(services): managed_agent migrates two hooks to handle-based enforcement

### DIFF
--- a/rust/services/src/managed_agent/mod.rs
+++ b/rust/services/src/managed_agent/mod.rs
@@ -586,10 +586,6 @@ impl ManagedAgentService<kernel::kernel::Kernel> {
         kernel
             .vfs_router_arc()
             .add_mount("/proc", "root", None, false);
-        kernel.register_native_hook(Box::new(
-            workspace_boundary_hook::WorkspaceBoundaryHook::new(),
-        ));
-        kernel.register_native_hook(Box::new(mailbox_stamping_hook::MailboxStampingHook::new()));
 
         // Holding `Arc<Kernel>` inside the service does create a
         // Kernel ↔ Service Arc cycle, but services live for process
@@ -640,6 +636,28 @@ impl ManagedAgentService<kernel::kernel::Kernel> {
 
         let svc_for_return = Arc::clone(&svc);
         kernel.register_rust_service(Self::NAME, svc as Arc<dyn RustService>, Vec::new())?;
+
+        // Register the two hooks the service owns via the enforced
+        // ownership surface — the handle binds each hook to this
+        // service's `ServiceRegistry` entry so
+        // `Kernel::unregister_service("managed_agent")` / `swap_managed_service`
+        // batch-remove them alongside the service instance.  Hooks are
+        // stateless so ordering (enlist-then-hook) has no correctness
+        // dependency; the two-step flow matches the pattern
+        // `services::audit::install_root` established: enlist the
+        // owning entity first, then plug hooks in through the handle.
+        let handle = kernel
+            .service_handle(Self::NAME)
+            .expect("just enlisted managed_agent above; handle must exist");
+        kernel.register_service_hook(
+            &handle,
+            Box::new(workspace_boundary_hook::WorkspaceBoundaryHook::new()),
+        );
+        kernel.register_service_hook(
+            &handle,
+            Box::new(mailbox_stamping_hook::MailboxStampingHook::new()),
+        );
+
         Ok(svc_for_return)
     }
 }
@@ -1012,7 +1030,6 @@ mod tests {
     mod procfs {
         use super::*;
         use kernel::core::agents::registry::AgentSignal;
-        use kernel::kernel::convenience::KernelConvenience;
         use kernel::kernel::Kernel;
         use kernel::ROOT_ZONE_ID;
 
@@ -1241,6 +1258,7 @@ mod tests {
                 request_id: "req-cross-link".into(),
                 context_zone_id: None,
                 zone_perms: vec![],
+                propagates_cross_node: false,
             };
 
             // Use UFCS through KernelAbi so we get the single-path
@@ -1299,6 +1317,7 @@ mod tests {
                 request_id: "req-stamp".into(),
                 context_zone_id: None,
                 zone_perms: vec![],
+                propagates_cross_node: false,
             };
 
             KernelAbi::sys_write(kernel.as_ref(), &shortcut, &ctx, &llm_authored, 0)

--- a/rust/services/src/managed_agent/proc_entry.rs
+++ b/rust/services/src/managed_agent/proc_entry.rs
@@ -214,7 +214,6 @@ fn create_dt_stream<K: KernelAbi>(
 mod tests {
     use super::*;
     use kernel::core::agents::registry::{AgentKind, AgentState, RepoMount};
-    use kernel::kernel::convenience::KernelConvenience;
     use kernel::kernel::Kernel;
     use kernel::ROOT_ZONE_ID;
 


### PR DESCRIPTION
## Summary

Closes the last production-callable unscoped `register_native_hook` in nexus's service tier outside the kernel-adjacent whitelist.  `services::managed_agent::install` now enlists as a Rust service first, then registers both `WorkspaceBoundaryHook` and `MailboxStampingHook` through the handle obtained from `Kernel::service_handle(Self::NAME)` — the pattern `services::audit::install_root` established in #4493.

## Coverage

**Before this PR:**
- audit — ✅ migrated in #4493
- managed_agent — ❌ 2 unscoped hooks
- matrix_adapter (test fixtures) — ❌ 2 unscoped hooks

**After this PR:**
- audit — ✅
- managed_agent — ✅ (this PR)
- matrix_adapter (test fixtures) — ⏳ deferred, see below

## What's in this PR (small, focused)

- `ManagedAgentService::install` reorders enlist-before-hook: `register_rust_service` first, `Kernel::service_handle(Self::NAME)` retrieves the handle, `register_service_hook(&handle, ...)` for each of the two hooks.  Hooks are stateless so reordering has zero correctness dependency.
- Result: `kernel.unregister_service(\"managed_agent\")` now batch-removes the service instance + `WorkspaceBoundaryHook` + `MailboxStampingHook` in one call.
- Cleanup of two pre-existing CI-lint warnings surfaced by `-D warnings`:
  - `OperationContext { ... }` struct literals in two managed_agent tests missing the `propagates_cross_node: false` field (added in the nexus-vfs pin bump, was previously silent because `--tests` wasn't run in the specific feature configuration).
  - Two dead `use kernel::kernel::convenience::KernelConvenience` imports.

## Deferred: matrix_adapter test fixtures

Two `#[cfg(test)] fn shared_kernel()` fixtures in `matrix_adapter/rooms.rs` and `matrix_adapter/sync.rs` still install `MailboxStampingHook` via unscoped `register_native_hook`.  The `service-matrix-adapter` feature has pre-existing signature drift (`sys_setattr` 17→21 args, `OperationContext` missing `propagates_cross_node`) that blocks a compile-verified migration.  No CI job or profile enables the feature, so this drift went undetected; not in scope for the hook-ownership sweep.  Follow-up: whichever PR next fixes the matrix-adapter feature also migrates its two test fixtures.

## Test plan

- [x] `cargo test -p services --features service-managed-agent managed_agent` — 58/58 pass
- [x] `cargo clippy -p services --features service-managed-agent --tests -- -D warnings` clean
- [x] `cargo fmt -p services -- --check` clean
- [ ] CI green

## Rollout position (Workstream C Phase 2)

- nexus-vfs #129 ✅ merged — kernel foundation
- nexus-vfs #130 ✅ merged — KernelAbi additions
- nexus #4493 ✅ merged — audit migration + pin bump
- **This PR** — managed_agent migration (last service-tier caller)
- Follow-up (whichever fixes matrix-adapter first) — matrix_adapter test fixtures + delete unscoped `register_native_hook` where not whitelisted