### PR TITLE
chore(pins): bump nexus-vfs to 3b00f9ae (metadata-sync on-access seed)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=218213dadbc6ca662284a81562b83617f42f1a95#218213dadbc6ca662284a81562b83617f42f1a95"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=a84b4b120cf08deaa45517a65afdfb5e7a01ee0c#a84b4b120cf08deaa45517a65afdfb5e7a01ee0c"
 dependencies = [
  "ahash",
  "base64",
@@ -550,7 +550,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=218213dadbc6ca662284a81562b83617f42f1a95#218213dadbc6ca662284a81562b83617f42f1a95"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=a84b4b120cf08deaa45517a65afdfb5e7a01ee0c#a84b4b120cf08deaa45517a65afdfb5e7a01ee0c"
 dependencies = [
  "parking_lot",
  "serde",
@@ -1334,7 +1334,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=218213dadbc6ca662284a81562b83617f42f1a95#218213dadbc6ca662284a81562b83617f42f1a95"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=a84b4b120cf08deaa45517a65afdfb5e7a01ee0c#a84b4b120cf08deaa45517a65afdfb5e7a01ee0c"
 dependencies = [
  "ahash",
  "base64",
@@ -1385,7 +1385,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=218213dadbc6ca662284a81562b83617f42f1a95#218213dadbc6ca662284a81562b83617f42f1a95"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=a84b4b120cf08deaa45517a65afdfb5e7a01ee0c#a84b4b120cf08deaa45517a65afdfb5e7a01ee0c"
 dependencies = [
  "ahash",
  "base64",
@@ -1580,7 +1580,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=218213dadbc6ca662284a81562b83617f42f1a95#218213dadbc6ca662284a81562b83617f42f1a95"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=a84b4b120cf08deaa45517a65afdfb5e7a01ee0c#a84b4b120cf08deaa45517a65afdfb5e7a01ee0c"
 
 [[package]]
 name = "nexus-vault"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=a84b4b120cf08deaa45517a65afdfb5e7a01ee0c#a84b4b120cf08deaa45517a65afdfb5e7a01ee0c"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=46d312212ab6e2d2520dc9e3b289dc28901ee5af#46d312212ab6e2d2520dc9e3b289dc28901ee5af"
 dependencies = [
  "ahash",
  "base64",
@@ -550,7 +550,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=a84b4b120cf08deaa45517a65afdfb5e7a01ee0c#a84b4b120cf08deaa45517a65afdfb5e7a01ee0c"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=46d312212ab6e2d2520dc9e3b289dc28901ee5af#46d312212ab6e2d2520dc9e3b289dc28901ee5af"
 dependencies = [
  "parking_lot",
  "serde",
@@ -1334,7 +1334,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=a84b4b120cf08deaa45517a65afdfb5e7a01ee0c#a84b4b120cf08deaa45517a65afdfb5e7a01ee0c"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=46d312212ab6e2d2520dc9e3b289dc28901ee5af#46d312212ab6e2d2520dc9e3b289dc28901ee5af"
 dependencies = [
  "ahash",
  "base64",
@@ -1385,7 +1385,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=a84b4b120cf08deaa45517a65afdfb5e7a01ee0c#a84b4b120cf08deaa45517a65afdfb5e7a01ee0c"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=46d312212ab6e2d2520dc9e3b289dc28901ee5af#46d312212ab6e2d2520dc9e3b289dc28901ee5af"
 dependencies = [
  "ahash",
  "base64",
@@ -1580,7 +1580,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=a84b4b120cf08deaa45517a65afdfb5e7a01ee0c#a84b4b120cf08deaa45517a65afdfb5e7a01ee0c"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=46d312212ab6e2d2520dc9e3b289dc28901ee5af#46d312212ab6e2d2520dc9e3b289dc28901ee5af"
 
 [[package]]
 name = "nexus-vault"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=46d312212ab6e2d2520dc9e3b289dc28901ee5af#46d312212ab6e2d2520dc9e3b289dc28901ee5af"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=3b00f9ae81728f38f95f516eae1c6486c7f6cfba#3b00f9ae81728f38f95f516eae1c6486c7f6cfba"
 dependencies = [
  "ahash",
  "base64",
@@ -550,7 +550,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=46d312212ab6e2d2520dc9e3b289dc28901ee5af#46d312212ab6e2d2520dc9e3b289dc28901ee5af"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=3b00f9ae81728f38f95f516eae1c6486c7f6cfba#3b00f9ae81728f38f95f516eae1c6486c7f6cfba"
 dependencies = [
  "parking_lot",
  "serde",
@@ -1334,7 +1334,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=46d312212ab6e2d2520dc9e3b289dc28901ee5af#46d312212ab6e2d2520dc9e3b289dc28901ee5af"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=3b00f9ae81728f38f95f516eae1c6486c7f6cfba#3b00f9ae81728f38f95f516eae1c6486c7f6cfba"
 dependencies = [
  "ahash",
  "base64",
@@ -1385,7 +1385,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=46d312212ab6e2d2520dc9e3b289dc28901ee5af#46d312212ab6e2d2520dc9e3b289dc28901ee5af"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=3b00f9ae81728f38f95f516eae1c6486c7f6cfba#3b00f9ae81728f38f95f516eae1c6486c7f6cfba"
 dependencies = [
  "ahash",
  "base64",
@@ -1580,7 +1580,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=46d312212ab6e2d2520dc9e3b289dc28901ee5af#46d312212ab6e2d2520dc9e3b289dc28901ee5af"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=3b00f9ae81728f38f95f516eae1c6486c7f6cfba#3b00f9ae81728f38f95f516eae1c6486c7f6cfba"
 
 [[package]]
 name = "nexus-vault"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -200,13 +200,13 @@ exclude = ["nexus-fuse"]
 #
 # Bump alongside the rest of nexus-vfs updates when a downstream
 # change needs newer kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "a84b4b120cf08deaa45517a65afdfb5e7a01ee0c" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "a84b4b120cf08deaa45517a65afdfb5e7a01ee0c" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "a84b4b120cf08deaa45517a65afdfb5e7a01ee0c" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "a84b4b120cf08deaa45517a65afdfb5e7a01ee0c", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "a84b4b120cf08deaa45517a65afdfb5e7a01ee0c", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "a84b4b120cf08deaa45517a65afdfb5e7a01ee0c", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "a84b4b120cf08deaa45517a65afdfb5e7a01ee0c" }
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "46d312212ab6e2d2520dc9e3b289dc28901ee5af" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "46d312212ab6e2d2520dc9e3b289dc28901ee5af" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "46d312212ab6e2d2520dc9e3b289dc28901ee5af" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "46d312212ab6e2d2520dc9e3b289dc28901ee5af", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "46d312212ab6e2d2520dc9e3b289dc28901ee5af", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "46d312212ab6e2d2520dc9e3b289dc28901ee5af", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "46d312212ab6e2d2520dc9e3b289dc28901ee5af" }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -200,13 +200,13 @@ exclude = ["nexus-fuse"]
 #
 # Bump alongside the rest of nexus-vfs updates when a downstream
 # change needs newer kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "218213dadbc6ca662284a81562b83617f42f1a95" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "218213dadbc6ca662284a81562b83617f42f1a95" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "218213dadbc6ca662284a81562b83617f42f1a95" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "218213dadbc6ca662284a81562b83617f42f1a95", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "218213dadbc6ca662284a81562b83617f42f1a95", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "218213dadbc6ca662284a81562b83617f42f1a95", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "218213dadbc6ca662284a81562b83617f42f1a95" }
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "a84b4b120cf08deaa45517a65afdfb5e7a01ee0c" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "a84b4b120cf08deaa45517a65afdfb5e7a01ee0c" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "a84b4b120cf08deaa45517a65afdfb5e7a01ee0c" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "a84b4b120cf08deaa45517a65afdfb5e7a01ee0c", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "a84b4b120cf08deaa45517a65afdfb5e7a01ee0c", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "a84b4b120cf08deaa45517a65afdfb5e7a01ee0c", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "a84b4b120cf08deaa45517a65afdfb5e7a01ee0c" }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -200,13 +200,13 @@ exclude = ["nexus-fuse"]
 #
 # Bump alongside the rest of nexus-vfs updates when a downstream
 # change needs newer kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "46d312212ab6e2d2520dc9e3b289dc28901ee5af" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "46d312212ab6e2d2520dc9e3b289dc28901ee5af" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "46d312212ab6e2d2520dc9e3b289dc28901ee5af" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "46d312212ab6e2d2520dc9e3b289dc28901ee5af", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "46d312212ab6e2d2520dc9e3b289dc28901ee5af", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "46d312212ab6e2d2520dc9e3b289dc28901ee5af", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "46d312212ab6e2d2520dc9e3b289dc28901ee5af" }
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "3b00f9ae81728f38f95f516eae1c6486c7f6cfba" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "3b00f9ae81728f38f95f516eae1c6486c7f6cfba" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "3b00f9ae81728f38f95f516eae1c6486c7f6cfba" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "3b00f9ae81728f38f95f516eae1c6486c7f6cfba", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "3b00f9ae81728f38f95f516eae1c6486c7f6cfba", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "3b00f9ae81728f38f95f516eae1c6486c7f6cfba", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "3b00f9ae81728f38f95f516eae1c6486c7f6cfba" }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ENV CARGO_NET_RETRY=10 \
     CARGO_HTTP_TIMEOUT=120
 # Override for edge/CI or a different pin: --build-arg NEXUS_VFS_REV=<sha|tag>
-ARG NEXUS_VFS_REV=a84b4b120cf08deaa45517a65afdfb5e7a01ee0c
+ARG NEXUS_VFS_REV=46d312212ab6e2d2520dc9e3b289dc28901ee5af
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,id=cargo-install-${TARGETARCH},target=/root/.cargo/target \

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ENV CARGO_NET_RETRY=10 \
     CARGO_HTTP_TIMEOUT=120
 # Override for edge/CI or a different pin: --build-arg NEXUS_VFS_REV=<sha|tag>
-ARG NEXUS_VFS_REV=46d312212ab6e2d2520dc9e3b289dc28901ee5af
+ARG NEXUS_VFS_REV=3b00f9ae81728f38f95f516eae1c6486c7f6cfba
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,id=cargo-install-${TARGETARCH},target=/root/.cargo/target \

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ENV CARGO_NET_RETRY=10 \
     CARGO_HTTP_TIMEOUT=120
 # Override for edge/CI or a different pin: --build-arg NEXUS_VFS_REV=<sha|tag>
-ARG NEXUS_VFS_REV=218213dadbc6ca662284a81562b83617f42f1a95
+ARG NEXUS_VFS_REV=a84b4b120cf08deaa45517a65afdfb5e7a01ee0c
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,id=cargo-install-${TARGETARCH},target=/root/.cargo/target \

--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir --no-deps --prefix=/install .
 # enforces agreement) — an unpinned install tracks nexus-vfs HEAD and
 # ships an untested kernel (#4343). --locked honors the source tree's
 # Cargo.lock.
-ARG NEXUS_VFS_REV=46d312212ab6e2d2520dc9e3b289dc28901ee5af
+ARG NEXUS_VFS_REV=3b00f9ae81728f38f95f516eae1c6486c7f6cfba
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-cluster nexus-cluster
 
 # -- Runtime stage --

--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir --no-deps --prefix=/install .
 # enforces agreement) — an unpinned install tracks nexus-vfs HEAD and
 # ships an untested kernel (#4343). --locked honors the source tree's
 # Cargo.lock.
-ARG NEXUS_VFS_REV=a84b4b120cf08deaa45517a65afdfb5e7a01ee0c
+ARG NEXUS_VFS_REV=46d312212ab6e2d2520dc9e3b289dc28901ee5af
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-cluster nexus-cluster
 
 # -- Runtime stage --

--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir --no-deps --prefix=/install .
 # enforces agreement) — an unpinned install tracks nexus-vfs HEAD and
 # ships an untested kernel (#4343). --locked honors the source tree's
 # Cargo.lock.
-ARG NEXUS_VFS_REV=218213dadbc6ca662284a81562b83617f42f1a95
+ARG NEXUS_VFS_REV=a84b4b120cf08deaa45517a65afdfb5e7a01ee0c
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-cluster nexus-cluster
 
 # -- Runtime stage --

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -25,7 +25,7 @@ WORKDIR /build
 # (CI preflight enforces agreement) — an unpinned install tracks HEAD
 # and can skew the raft contract against the cluster/witness images.
 # --locked honors the source tree's Cargo.lock.
-ARG NEXUS_VFS_REV=46d312212ab6e2d2520dc9e3b289dc28901ee5af
+ARG NEXUS_VFS_REV=3b00f9ae81728f38f95f516eae1c6486c7f6cfba
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexus-raft-server raft
 
 # ---------- Production image ----------

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -25,7 +25,7 @@ WORKDIR /build
 # (CI preflight enforces agreement) — an unpinned install tracks HEAD
 # and can skew the raft contract against the cluster/witness images.
 # --locked honors the source tree's Cargo.lock.
-ARG NEXUS_VFS_REV=a84b4b120cf08deaa45517a65afdfb5e7a01ee0c
+ARG NEXUS_VFS_REV=46d312212ab6e2d2520dc9e3b289dc28901ee5af
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexus-raft-server raft
 
 # ---------- Production image ----------

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -25,7 +25,7 @@ WORKDIR /build
 # (CI preflight enforces agreement) — an unpinned install tracks HEAD
 # and can skew the raft contract against the cluster/witness images.
 # --locked honors the source tree's Cargo.lock.
-ARG NEXUS_VFS_REV=218213dadbc6ca662284a81562b83617f42f1a95
+ARG NEXUS_VFS_REV=a84b4b120cf08deaa45517a65afdfb5e7a01ee0c
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexus-raft-server raft
 
 # ---------- Production image ----------

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=a84b4b120cf08deaa45517a65afdfb5e7a01ee0c
+ARG NEXUS_VFS_REV=46d312212ab6e2d2520dc9e3b289dc28901ee5af
 RUN cargo install \
     --locked \
     --git https://github.com/nexi-lab/nexus-vfs \

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=218213dadbc6ca662284a81562b83617f42f1a95
+ARG NEXUS_VFS_REV=a84b4b120cf08deaa45517a65afdfb5e7a01ee0c
 RUN cargo install \
     --locked \
     --git https://github.com/nexi-lab/nexus-vfs \

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=46d312212ab6e2d2520dc9e3b289dc28901ee5af
+ARG NEXUS_VFS_REV=3b00f9ae81728f38f95f516eae1c6486c7f6cfba
 RUN cargo install \
     --locked \
     --git https://github.com/nexi-lab/nexus-vfs \


### PR DESCRIPTION
Bumps the nexus-vfs kernel-tier pin from `218213d` to `a84b4b120` (nexus-vfs main after PR #132).

## What it picks up
PR #132's **metadata-sync cutover**: a kernel-side generic reconcile (`core/metadata_sync.rs`) that keeps the metastore authoritative for out-of-band backend content (e.g. cc writing task JSON directly to the LocalConnector host dir), replacing the deleted lazy cold-discovery chain (sys_read fan_out + readdir observe + readdir peer-fanout). Off-by-default opt-in via `Kernel::arm_metadata_sync`. Plus the `extensions/` regroup and the #131 revert.

## Why safe for nexus
- **Additive + kernel-internal** — no nexus code references the moved (`kernel::llm_streaming` → `kernel::extensions::llm_streaming`) or deleted (`ObserverBackend`/`as_observer`) symbols (grep-verified).
- `cargo check --workspace` clean against the new rev.

## Changed
- `Cargo.toml` — 7 kernel-tier pins (contracts, lib, transport, backends, kernel, raft, nexus-plugin-abi)
- `Cargo.lock` — regenerated
- 4 Dockerfiles — `NEXUS_VFS_REV`

The metadata-sync fix ships in the nexus-vfs `nexusd-cluster` binary (what cc-tasks-share runs); this bump keeps the nexus repo's kernel-tier deps in sync.