### PR TITLE
refactor(cc-tasks): §3g FUSE-at-CC-path — decouple read ⊥ cache ⊥ materialize [DO NOT MERGE: temp pin + live cutover]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=3b00f9ae81728f38f95f516eae1c6486c7f6cfba#3b00f9ae81728f38f95f516eae1c6486c7f6cfba"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=1e528d3aca6643489f9073d3f66a349d4dc41a77#1e528d3aca6643489f9073d3f66a349d4dc41a77"
 dependencies = [
  "ahash",
  "base64",
@@ -550,7 +550,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=3b00f9ae81728f38f95f516eae1c6486c7f6cfba#3b00f9ae81728f38f95f516eae1c6486c7f6cfba"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=1e528d3aca6643489f9073d3f66a349d4dc41a77#1e528d3aca6643489f9073d3f66a349d4dc41a77"
 dependencies = [
  "parking_lot",
  "serde",
@@ -1334,7 +1334,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=3b00f9ae81728f38f95f516eae1c6486c7f6cfba#3b00f9ae81728f38f95f516eae1c6486c7f6cfba"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=1e528d3aca6643489f9073d3f66a349d4dc41a77#1e528d3aca6643489f9073d3f66a349d4dc41a77"
 dependencies = [
  "ahash",
  "base64",
@@ -1385,7 +1385,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=3b00f9ae81728f38f95f516eae1c6486c7f6cfba#3b00f9ae81728f38f95f516eae1c6486c7f6cfba"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=1e528d3aca6643489f9073d3f66a349d4dc41a77#1e528d3aca6643489f9073d3f66a349d4dc41a77"
 dependencies = [
  "ahash",
  "base64",
@@ -1580,7 +1580,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=3b00f9ae81728f38f95f516eae1c6486c7f6cfba#3b00f9ae81728f38f95f516eae1c6486c7f6cfba"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=1e528d3aca6643489f9073d3f66a349d4dc41a77#1e528d3aca6643489f9073d3f66a349d4dc41a77"
 
 [[package]]
 name = "nexus-vault"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=1e528d3aca6643489f9073d3f66a349d4dc41a77#1e528d3aca6643489f9073d3f66a349d4dc41a77"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=8180374c81a7fb08eda293a3f97fcbc965be0dc0#8180374c81a7fb08eda293a3f97fcbc965be0dc0"
 dependencies = [
  "ahash",
  "base64",
@@ -550,7 +550,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=1e528d3aca6643489f9073d3f66a349d4dc41a77#1e528d3aca6643489f9073d3f66a349d4dc41a77"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=8180374c81a7fb08eda293a3f97fcbc965be0dc0#8180374c81a7fb08eda293a3f97fcbc965be0dc0"
 dependencies = [
  "parking_lot",
  "serde",
@@ -1334,7 +1334,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=1e528d3aca6643489f9073d3f66a349d4dc41a77#1e528d3aca6643489f9073d3f66a349d4dc41a77"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=8180374c81a7fb08eda293a3f97fcbc965be0dc0#8180374c81a7fb08eda293a3f97fcbc965be0dc0"
 dependencies = [
  "ahash",
  "base64",
@@ -1385,7 +1385,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=1e528d3aca6643489f9073d3f66a349d4dc41a77#1e528d3aca6643489f9073d3f66a349d4dc41a77"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=8180374c81a7fb08eda293a3f97fcbc965be0dc0#8180374c81a7fb08eda293a3f97fcbc965be0dc0"
 dependencies = [
  "ahash",
  "base64",
@@ -1580,7 +1580,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=1e528d3aca6643489f9073d3f66a349d4dc41a77#1e528d3aca6643489f9073d3f66a349d4dc41a77"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=8180374c81a7fb08eda293a3f97fcbc965be0dc0#8180374c81a7fb08eda293a3f97fcbc965be0dc0"
 
 [[package]]
 name = "nexus-vault"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,13 +31,15 @@ exclude = ["nexus-fuse"]
 # Kernel-tier crates from nexus-vfs (external git dependency).
 # SSOT: https://github.com/nexi-lab/nexus-vfs
 #
-# ⚠️ TEMP VALIDATION PIN — points at the UNMERGED nexus-vfs branch
-# `refactor/read-path-decouple-remove-cacheback` (PR #138) so the
-# cc-tasks-peer-shared Docker E2E in this PR builds the read-⊥-cache-⊥-
-# materialize kernel and its new anti-materialization guard passes.
-# BEFORE MERGING this nexus PR: re-pin to the merged nexus-vfs main SHA.
+# Pinned at merged nexus-vfs main after PR #139 (dlc: idempotent DT_MOUNT
+# install — fixes the 2-voter cold-start `not leader` deadlock via
+# get-before-put; live-verified Win↔Mac) and PR #138 (read ⊥ cache ⊥
+# materialize — drop the try_remote_fetch cache-back so cross-node reads
+# are on-demand under §3g; + surface previously-swallowed cross-node fetch
+# errors). Both raft-contract-correct; cc-tasks §3g cross-node read
+# validated bidirectionally live.
 #
-# Pinned at the nexus-vfs commit that landed PR #120 -- S3 Phase H (respect
+# Earlier: PR #120 -- S3 Phase H (respect
 # identity.zones[].as_role on Row 4 rejoin; wiped learner rejoins as learner,
 # not voter — closes the silent-SSOT-violation that was inflating voter set
 # on every wipe cycle) on top of PR #113 -- Phase A-G unified bring-up
@@ -207,13 +209,13 @@ exclude = ["nexus-fuse"]
 #
 # Bump alongside the rest of nexus-vfs updates when a downstream
 # change needs newer kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "1e528d3aca6643489f9073d3f66a349d4dc41a77" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "1e528d3aca6643489f9073d3f66a349d4dc41a77" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "1e528d3aca6643489f9073d3f66a349d4dc41a77" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "1e528d3aca6643489f9073d3f66a349d4dc41a77", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "1e528d3aca6643489f9073d3f66a349d4dc41a77", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "1e528d3aca6643489f9073d3f66a349d4dc41a77", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "1e528d3aca6643489f9073d3f66a349d4dc41a77" }
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "8180374c81a7fb08eda293a3f97fcbc965be0dc0" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "8180374c81a7fb08eda293a3f97fcbc965be0dc0" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "8180374c81a7fb08eda293a3f97fcbc965be0dc0" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "8180374c81a7fb08eda293a3f97fcbc965be0dc0", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "8180374c81a7fb08eda293a3f97fcbc965be0dc0", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "8180374c81a7fb08eda293a3f97fcbc965be0dc0", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "8180374c81a7fb08eda293a3f97fcbc965be0dc0" }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,13 @@ exclude = ["nexus-fuse"]
 [workspace.dependencies]
 # Kernel-tier crates from nexus-vfs (external git dependency).
 # SSOT: https://github.com/nexi-lab/nexus-vfs
+#
+# ⚠️ TEMP VALIDATION PIN — points at the UNMERGED nexus-vfs branch
+# `refactor/read-path-decouple-remove-cacheback` (PR #138) so the
+# cc-tasks-peer-shared Docker E2E in this PR builds the read-⊥-cache-⊥-
+# materialize kernel and its new anti-materialization guard passes.
+# BEFORE MERGING this nexus PR: re-pin to the merged nexus-vfs main SHA.
+#
 # Pinned at the nexus-vfs commit that landed PR #120 -- S3 Phase H (respect
 # identity.zones[].as_role on Row 4 rejoin; wiped learner rejoins as learner,
 # not voter — closes the silent-SSOT-violation that was inflating voter set
@@ -200,13 +207,13 @@ exclude = ["nexus-fuse"]
 #
 # Bump alongside the rest of nexus-vfs updates when a downstream
 # change needs newer kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "3b00f9ae81728f38f95f516eae1c6486c7f6cfba" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "3b00f9ae81728f38f95f516eae1c6486c7f6cfba" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "3b00f9ae81728f38f95f516eae1c6486c7f6cfba" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "3b00f9ae81728f38f95f516eae1c6486c7f6cfba", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "3b00f9ae81728f38f95f516eae1c6486c7f6cfba", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "3b00f9ae81728f38f95f516eae1c6486c7f6cfba", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "3b00f9ae81728f38f95f516eae1c6486c7f6cfba" }
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "1e528d3aca6643489f9073d3f66a349d4dc41a77" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "1e528d3aca6643489f9073d3f66a349d4dc41a77" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "1e528d3aca6643489f9073d3f66a349d4dc41a77" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "1e528d3aca6643489f9073d3f66a349d4dc41a77", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "1e528d3aca6643489f9073d3f66a349d4dc41a77", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "1e528d3aca6643489f9073d3f66a349d4dc41a77", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "1e528d3aca6643489f9073d3f66a349d4dc41a77" }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ENV CARGO_NET_RETRY=10 \
     CARGO_HTTP_TIMEOUT=120
 # Override for edge/CI or a different pin: --build-arg NEXUS_VFS_REV=<sha|tag>
-ARG NEXUS_VFS_REV=1e528d3aca6643489f9073d3f66a349d4dc41a77
+ARG NEXUS_VFS_REV=8180374c81a7fb08eda293a3f97fcbc965be0dc0
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,id=cargo-install-${TARGETARCH},target=/root/.cargo/target \

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ENV CARGO_NET_RETRY=10 \
     CARGO_HTTP_TIMEOUT=120
 # Override for edge/CI or a different pin: --build-arg NEXUS_VFS_REV=<sha|tag>
-ARG NEXUS_VFS_REV=3b00f9ae81728f38f95f516eae1c6486c7f6cfba
+ARG NEXUS_VFS_REV=1e528d3aca6643489f9073d3f66a349d4dc41a77
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,id=cargo-install-${TARGETARCH},target=/root/.cargo/target \

--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir --no-deps --prefix=/install .
 # enforces agreement) — an unpinned install tracks nexus-vfs HEAD and
 # ships an untested kernel (#4343). --locked honors the source tree's
 # Cargo.lock.
-ARG NEXUS_VFS_REV=3b00f9ae81728f38f95f516eae1c6486c7f6cfba
+ARG NEXUS_VFS_REV=1e528d3aca6643489f9073d3f66a349d4dc41a77
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-cluster nexus-cluster
 
 # -- Runtime stage --

--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir --no-deps --prefix=/install .
 # enforces agreement) — an unpinned install tracks nexus-vfs HEAD and
 # ships an untested kernel (#4343). --locked honors the source tree's
 # Cargo.lock.
-ARG NEXUS_VFS_REV=1e528d3aca6643489f9073d3f66a349d4dc41a77
+ARG NEXUS_VFS_REV=8180374c81a7fb08eda293a3f97fcbc965be0dc0
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-cluster nexus-cluster
 
 # -- Runtime stage --

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -25,7 +25,7 @@ WORKDIR /build
 # (CI preflight enforces agreement) — an unpinned install tracks HEAD
 # and can skew the raft contract against the cluster/witness images.
 # --locked honors the source tree's Cargo.lock.
-ARG NEXUS_VFS_REV=1e528d3aca6643489f9073d3f66a349d4dc41a77
+ARG NEXUS_VFS_REV=8180374c81a7fb08eda293a3f97fcbc965be0dc0
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexus-raft-server raft
 
 # ---------- Production image ----------

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -25,7 +25,7 @@ WORKDIR /build
 # (CI preflight enforces agreement) — an unpinned install tracks HEAD
 # and can skew the raft contract against the cluster/witness images.
 # --locked honors the source tree's Cargo.lock.
-ARG NEXUS_VFS_REV=3b00f9ae81728f38f95f516eae1c6486c7f6cfba
+ARG NEXUS_VFS_REV=1e528d3aca6643489f9073d3f66a349d4dc41a77
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexus-raft-server raft
 
 # ---------- Production image ----------

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=1e528d3aca6643489f9073d3f66a349d4dc41a77
+ARG NEXUS_VFS_REV=8180374c81a7fb08eda293a3f97fcbc965be0dc0
 RUN cargo install \
     --locked \
     --git https://github.com/nexi-lab/nexus-vfs \

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=3b00f9ae81728f38f95f516eae1c6486c7f6cfba
+ARG NEXUS_VFS_REV=1e528d3aca6643489f9073d3f66a349d4dc41a77
 RUN cargo install \
     --locked \
     --git https://github.com/nexi-lab/nexus-vfs \

--- a/docs/architecture/federation-cross-machine-runbook.md
+++ b/docs/architecture/federation-cross-machine-runbook.md
@@ -1,6 +1,6 @@
 # Cross-Machine Federation over Tailscale/Headscale — Complete Runbook
 
-**Status:** verified end-to-end Mac↔Win — same-LAN **and cross-LAN over the Headscale DERP relay** (2026-07-10).  L1 cross-node read is byte-exact both directions; the §3f peer-shared named-list variant delivers a bidirectionally-materialised merged view CC's native `TaskGet` / `TaskList` reads directly; a peer's out-of-band writes are stamped `last_writer` and become cross-node-visible **synchronously on `readdir`** (metadata-sync on-access seed, nexus-vfs #133 — no wait for the reconcile tick).  On a relayed path the `transport_observer` service logs a data-privacy caution per cross-node fetch.  Additional machines onboard with the Row-3 joiner recipe and self-verify via the relay-free [Step 5 CRUD handshake](#step-5--crud-handshake-no-human-relay).
+**Status:** verified end-to-end Mac↔Win — same-LAN **and cross-LAN over the Headscale DERP relay** (2026-07-10).  L1 cross-node read is byte-exact both directions; the §3g peer-shared named-list variant (CC reads **through** the FUSE mount at its task-list path) delivers a merged view CC's native `TaskGet` / `TaskList` reads directly, with peer content fetched **on demand per read** (no local materialization); a peer's out-of-band writes are stamped `last_writer` and become cross-node-visible **synchronously on `readdir`** (metadata-sync on-access seed, nexus-vfs #133 — no wait for the reconcile tick).  On a relayed path the `transport_observer` service logs a data-privacy caution per cross-node fetch.  Additional machines onboard with the Row-3 joiner recipe and self-verify via the relay-free [Step 5 CRUD handshake](#step-5--crud-handshake-no-human-relay).
 
 > **Doc SSOT.**  This file supersedes nexi-lab/nexus discussion #2596 ("Cross-Machine Federation over Tailscale/Headscale — Complete Runbook").  That discussion is now closed and should be removed; new content for this surface goes here.
 
@@ -378,7 +378,7 @@ The CI regression for this surface lives in `tests/e2e/docker/test_cc_tasks_shar
 
 ### Step 3f — Cross-node host-fs sharing (cc-tasks-share-style)
 
-Node A and node B each mount their own LocalConnector under a hostname-namespaced path inside the same federated zone.  Reads on B for a path under A's mount resolve to A's host fs without manual sync.  A's **metadata-sync** keeps A's metastore authoritative for its own out-of-band content — an initial walk at mount, a synchronous **on-access seed** on every `sys_readdir`, and a periodic reconcile backstop (nexus-vfs #133; see `KERNEL-ARCHITECTURE.md §4.5` and `docs/observer-backend-contract.md`).  Raft replicates each row stamped `last_writer_address = A`, so B's metastore already carries the entry; B's read then routes via `try_remote_fetch` keyed on `last_writer_address` to fetch A's bytes (and caches them locally).  There is **no read-miss fan-out** — the lazy cold-discovery path was removed in the metadata-sync cutover (nexus-vfs #132/#133); the metastore is the single source of truth for cross-node existence.
+Node A and node B each mount their own LocalConnector under a hostname-namespaced path inside the same federated zone.  Reads on B for a path under A's mount resolve to A's host fs without manual sync.  A's **metadata-sync** keeps A's metastore authoritative for its own out-of-band content — an initial walk at mount, a synchronous **on-access seed** on every `sys_readdir`, and a periodic reconcile backstop (nexus-vfs #133; see `KERNEL-ARCHITECTURE.md §4.5` and `docs/observer-backend-contract.md`).  Raft replicates each row stamped `last_writer_address = A`, so B's metastore already carries the entry; B's read then routes via `try_remote_fetch` keyed on `last_writer_address` to fetch A's bytes on demand (a pure read — no local cache-back).  There is **no read-miss fan-out** — the lazy cold-discovery path was removed in the metadata-sync cutover (nexus-vfs #132/#133); the metastore is the single source of truth for cross-node existence.
 
 Operator flow (mirrors what `dockerfiles/docker-compose.cc-tasks-share.yml` automates):
 
@@ -409,7 +409,7 @@ nexusd-cluster \
 
 If you accidentally started B with `NEXUS_FEDERATION_ZONES=sharedzone` set on empty data dir before doing the sidecar join, the split-brain guard now catches it — the error message tells you which role you meant (wipe identity to become founder, or unset the env var + run sidecar to become joiner).
 
-After the restart, reads on B for any path under `/shared/cc-tasks/A/...` route through `/sharedzone/shared` (the federation mount).  A's metadata-sync has already published the entry's row to the replicated metastore (`last_writer_address = A`), so B's read resolves the origin locally and issues a single `try_remote_fetch` to A that returns A's host-fs bytes (then caches them locally).  Symmetric on A reading `/shared/cc-tasks/B/...`.
+After the restart, reads on B for any path under `/shared/cc-tasks/A/...` route through `/sharedzone/shared` (the federation mount).  A's metadata-sync has already published the entry's row to the replicated metastore (`last_writer_address = A`), so B's read resolves the origin locally and issues a single `try_remote_fetch` to A that returns A's host-fs bytes on demand (no local cache-back).  Symmetric on A reading `/shared/cc-tasks/B/...`.
 
 This is the substrate the `cc tasks list` cross-machine workflow rides — operator's CC daemon on A drops `~/.claude/tasks/<n>.json` directly to host fs (no Nexus syscall), and a second CC daemon on B reads them through `/shared/cc-tasks/A/<n>.json`.
 
@@ -431,34 +431,34 @@ Each peer's `--mount-driver` installs its OWN LocalConnector at `/shared/cc-task
 
 Trade-off relative to the peer-namespaced variant: writes on either peer land in the raft-replicated metastore under the same VFS path.  For CC's append-only session pattern (each session UUID is written once, per-machine) collisions are effectively impossible.  Workloads with the same VFS path being concurrently mutated by both peers should stick with the peer-namespaced variant, where the peer-name suffix serves as a natural conflict domain.
 
-##### Named-list scope — no rename dance required
+##### Named-list scope — §3g FUSE-at-CC-path (read ⊥ cache ⊥ materialize)
 
-When the shared task list is CC's named-list scope (`CLAUDE_CODE_TASK_LIST_ID=<name>` in `.claude/settings.local.json`'s `env` field routes `TaskCreate`/`TaskList` to `~/.claude/tasks/<name>/*.json` instead of session-uuid subdirs), the peer-shared shape simplifies further: **the LocalConnector's `local_root` IS the CC task-list dir itself**, and no §3g rename dance is needed.
+When the shared task list is CC's named-list scope (`CLAUDE_CODE_TASK_LIST_ID=<name>` in `.claude/settings.local.json`'s `env` field routes `TaskCreate`/`TaskList` to `~/.claude/tasks/<name>/*.json` instead of session-uuid subdirs), CC reads its task list **through the FUSE mount**.  The FUSE mount point IS `~/.claude/tasks/<name>` itself; the LocalConnector's `local_root` is a renamed sibling `~/.claude/tasks.local/<name>` that holds only *this* machine's own task files.  This is the same rename that the workspace-scope peer-shared variant uses to avoid the intra-node circular (`local_root == FUSE mount point`) — the named-list scope follows it too.
 
-Recipe (Win↔Mac cross-machine, per elfenlieds7 dispatcher-worker-merger workflow):
+Recipe (Win↔Mac cross-machine, per elfenlieds7 dispatcher-worker-merger workflow; automated by `start-common.sh`):
 
 ```bash
-# On BOTH nodes (same VFS path, per-node local_root)
---mount-driver 'local-connector:sharedzone:/shared/tasks-nexus-project:{"local_root":"'"$HOME"'/.claude/tasks/nexus-project"}'
+# On BOTH nodes: LocalConnector backs a renamed sibling; the FUSE mount = the CC path.
+--mount-driver 'local-connector:sharedzone:/shared/tasks-nexus-project:{"local_root":"'"$HOME"'/.claude/tasks.local/nexus-project"}'
+export NEXUS_FUSE_MOUNT_POINT="$HOME/.claude/tasks/nexus-project"   # = CC's read path
+export NEXUS_FUSE_VFS_ROOT=/shared/tasks-nexus-project
 ```
 
 Behavior after each node's daemon comes up:
 
-1. Each side's LocalConnector observes its own local `~/.claude/tasks/nexus-project/*.json` via `sys_readdir` → metastore.put (raft-replicated with `last_writer_address=self`).
-2. Cross-node reads (`ls`, `cat`, CC's `TaskGet`) on the merged view route through `sys_read` → `try_remote_fetch` (kernel/src/kernel/io.rs:522-598) → peer's LocalConnector → bytes come back.
-3. **Read-triggered local materialization**: `try_remote_fetch` caches the fetched blob back to the reader's local backend via `route.backend.write_content(...)` (io.rs:594-597) — critical for failover per its docstring.  Consequence: after any FUSE `ls`/`cat` on the merged view, the remote entries appear as **real files on the reader's local disk** at `~/.claude/tasks/<name>/`.  CC's native `TaskList`/`TaskGet` then sees the union directly — no shadow-mount, no `tasks.local/` rename.
+1. Each side's LocalConnector observes its own local `~/.claude/tasks.local/nexus-project/*.json` via `sys_readdir` → `metastore.put` (raft-replicated with `last_writer_address=self`).
+2. CC's `TaskList`/`TaskGet` (and plain `ls`/`cat`) read **through the FUSE mount** at `~/.claude/tasks/nexus-project`.  A `readdir` returns the merged union directly from the raft-replicated metastore rows; a `read` of a peer-owned entry routes `sys_read` → `try_remote_fetch` (`kernel/src/kernel/io.rs`, `Kernel::try_remote_fetch`) → the peer's LocalConnector → bytes come back on demand.
+3. **No local materialization.**  The read is pure: `try_remote_fetch` returns the peer bytes without writing them back to the reader's disk.  Peer entries never appear as real files in the reader's `tasks.local/` backend — they exist only in the replicated metastore and are fetched per-read.  The merged view needs no content replication: readdir rows raft-replicate, content is fetched on access.  This §3g invariant is regression-guarded by the peer-shared Docker E2E (`tests/e2e/docker/test_cc_tasks_peer_shared_e2e.py`), which asserts a cross-node FUSE read does **not** materialize the peer's file in the reader's host dir.
 
-Verified bidirectionally Win↔Mac 2026-07-06 via `comm -13 <(ls ~/.claude/tasks/nexus-project/ | sort) <(ls "$NEXUS_FUSE_MOUNT_POINT/" | sort)` on both sides = empty (local disk ≡ FUSE mount).  Regression-guarded by the peer-shared Docker E2E suite (`tests/e2e/docker/test_cc_tasks_peer_shared_e2e.py`).
-
-Compared to the workspace-scope pattern in §3g, the named-list variant sidesteps the intra-node circular (`local_root == FUSE mount point`) by decoupling the CC task-dir from the FUSE mount point entirely: LocalConnector reads/writes `~/.claude/tasks/<name>/`, the FUSE plugin surfaces the union at `~/.claude-federated/tasks/<name>/`, and CC's task-list env var pins its native reads to the LocalConnector-managed dir where materialization has already landed.
+> **Superseded §3f note (historical — do not reintroduce).**  An earlier variant pointed the LocalConnector's `local_root` at the CC path directly (`~/.claude/tasks/<name>`), with CC reading that raw dir and bypassing FUSE.  It worked only because `try_remote_fetch` cached every fetched blob back into the local backend, *materializing* peer entries into the raw dir so CC's native reads saw them.  That hot-path cache-back conflated read/cache/materialize and justified itself with a `TestLeaderFailover::test_failover_and_recovery` that never existed in the tree.  It was deleted in favor of §3g; cc-tasks is append-only with raft-replicated rows, so no failover content cache is needed.  Do not point a LocalConnector `local_root` at a raw CC read path again.
 
 ##### Caveats for named-list scope
 
-Two limitations that don't affect the workspace-scope pattern in §3g surface for the named-list variant:
+Two CC-internals limitations, independent of the §3g substrate:
 
-1. **CC uses monotonic integer task IDs, not UUIDs.**  Each machine's CC mints the next ID via a local `.highwatermark` file, so two workers that both call `TaskCreate` before federation replicates will independently mint the SAME integer ID with DIFFERENT contents.  After replication, each side keeps its own `<id>.json` (the local write, present before the raft entry arrived, wins on that side).  The workspace-scope pattern in §3g sidesteps this by naming session dirs with UUIDs; the named-list variant reintroduces the collision risk because integer IDs are dense and independently assigned.  Mitigation: for workflows with two writers concurrently creating tasks, use the peer-namespaced variant (§3f above the peer-shared subsection) — the `/<peer-name>/` suffix serves as a natural conflict domain.  Or run one machine as the sole task-list writer and treat the other as read-only.
+1. **CC uses monotonic integer task IDs, not UUIDs.**  Each machine's CC mints the next ID via a local `.highwatermark` file, so two workers that both call `TaskCreate` before federation replicates will independently mint the SAME integer ID with DIFFERENT contents.  After replication, each side keeps its own `<id>.json` (the local write, present before the raft entry arrived, wins on that side).  (The workspace-scope pattern names session dirs with UUIDs and sidesteps this; the named-list scope's dense, independently-assigned integer IDs reintroduce the collision risk.)  Mitigation: for workflows with two writers concurrently creating tasks, use the peer-namespaced variant (§3f above the peer-shared subsection) — the `/<peer-name>/` suffix serves as a natural conflict domain.  Or run one machine as the sole task-list writer and treat the other as read-only.
 
-2. **CC caches the task list in-memory per session.**  `TaskList` and `TaskGet` read `~/.claude/tasks/<name>/` on demand, but a running CC session may hold a stale count from an earlier read.  Federation-materialized files that appeared after CC started are on disk but not always in CC's rendered view — verify with `ls ~/.claude/tasks/<name>/*.json | wc -l` against what `TaskList` shows.  If the counts differ, the CC session's task-list index is stale (not a federation sync gap).  This is a CC-internals limitation, not fixable in nexus code.
+2. **CC caches the task list in-memory per session.**  `TaskList` and `TaskGet` read `~/.claude/tasks/<name>/` on demand, but a running CC session may hold a stale count from an earlier read.  Federation entries that appeared through the FUSE mount after CC started are visible via `ls` but not always in CC's rendered view — verify with `ls ~/.claude/tasks/<name>/*.json | wc -l` against what `TaskList` shows.  If the counts differ, the CC session's task-list index is stale (not a federation sync gap).  This is a CC-internals limitation, not fixable in nexus code.
 
 ### Step 3g — Expose the federated VFS as a real OS mount via FUSE
 
@@ -605,16 +605,16 @@ Expected:
 
 ### Step 5 — CRUD handshake (no human relay)
 
-Step 4 is a low-level grpcurl smoke an operator drives on one machine.  Step 5 is the **onboarding acceptance gate**: once §3f (peer-shared named-list) and §3g (FUSE) are up on every node, each machine confirms it is fully federated **by itself, through the shared task list** — no operator shuttling messages between machines.  This is how a freshly-added Nth node and the existing nodes "shake hands."
+Step 4 is a low-level grpcurl smoke an operator drives on one machine.  Step 5 is the **onboarding acceptance gate**: once the §3g peer-shared named-list mount (FUSE at the CC task-list path) is up on every node, each machine confirms it is fully federated **by itself, through the shared task list** — no operator shuttling messages between machines.  This is how a freshly-added Nth node and the existing nodes "shake hands."
 
-Assumes every node runs the §3f peer-shared named-list recipe at the **same** VFS path `/shared/tasks-nexus-project`, FUSE-mounted at `~/.claude-federated/tasks/nexus-project`, with `local_root = ~/.claude/tasks/nexus-project`.
+Assumes every node runs the §3g peer-shared named-list recipe at the **same** VFS path `/shared/tasks-nexus-project`, FUSE-mounted at the CC task-list path `~/.claude/tasks/nexus-project`, with `local_root = ~/.claude/tasks.local/nexus-project` (the LocalConnector backend holding this machine's own markers).
 
 **1. Announce yourself.**  Drop a uniquely-named marker into your connector root (direct host write, no syscall), then `ls` the FUSE mount so the on-access seed publishes its row (`last_writer = you`) and raft replicates it:
 
 ```bash
 NODE=win3                                    # your node's short name — must be unique
-CONN=~/.claude/tasks/nexus-project
-FUSE=~/.claude-federated/tasks/nexus-project
+CONN=~/.claude/tasks.local/nexus-project      # LocalConnector backend (your own markers)
+FUSE=~/.claude/tasks/nexus-project            # FUSE mount = CC's read path (merged view)
 printf '{"probe":"%s","ts":"%s"}' "$NODE" "$(date -u +%FT%TZ)" > "$CONN/zz-node-$NODE.json"
 ls "$FUSE" >/dev/null                         # fire the readdir seed
 ```

--- a/tests/e2e/docker/cc_tasks_share_helpers.py
+++ b/tests/e2e/docker/cc_tasks_share_helpers.py
@@ -171,6 +171,26 @@ def host_task_ensure_dir(container: str, relpath: str) -> None:
     runbook_helpers.docker_exec(container, ["mkdir", "-p", _host_path(relpath)], check=True)
 
 
+def host_path_exists(container: str, relpath: str) -> bool:
+    """``test -e /host/tasks/<relpath>`` on ``<container>`` — the reader's
+    raw LocalConnector backend dir.
+
+    Backs the §3g read-⊥-materialize guard: after a cross-node read that
+    goes *through the FUSE mount*, the peer's bytes must NOT have been
+    written back as a real file in the reader's own host dir.  Returns
+    ``True`` iff the path physically exists on the reader's LocalConnector
+    backend.  On the pre-decouple kernel (``try_remote_fetch`` cache-back)
+    this returned ``True`` for a freshly-read peer file; post-decouple it
+    must be ``False``.
+    """
+    proc = subprocess.run(
+        ["docker", "exec", container, "test", "-e", _host_path(relpath)],
+        capture_output=True,
+        timeout=10,
+    )
+    return proc.returncode == 0
+
+
 def host_task_symlink(container: str, link_relpath: str, target_relpath: str) -> None:
     """Create ``link_relpath`` -> ``target_relpath`` inside ``/host/tasks``.
 

--- a/tests/e2e/docker/test_cc_tasks_peer_shared_e2e.py
+++ b/tests/e2e/docker/test_cc_tasks_peer_shared_e2e.py
@@ -259,7 +259,8 @@ class TestPeerSharedMergedView:
 # Workflow 2: cross-node byte-exact reads via try_remote_fetch.
 # ---------------------------------------------------------------------------
 class TestPeerSharedCrossNodeByteExact:
-    """Each side reads OTHER's file byte-exact via try_remote_fetch.
+    """Each side reads OTHER's file byte-exact via try_remote_fetch, and
+    the read does NOT materialize the peer's bytes on the reader's disk.
 
     Peer-shared invariant: when node A's FUSE cat lands on a path whose
     metastore row's `last_writer_address` is node B, try_remote_fetch
@@ -268,10 +269,21 @@ class TestPeerSharedCrossNodeByteExact:
     for founder→joiner + joiner→founder read; the differentiator here
     is that both writes target the SAME VFS subtree.
 
-    Three steps:
+    §3g read-⊥-materialize invariant: reads go THROUGH the FUSE mount
+    (`/mnt/cc-tasks`), which is a distinct path from each node's raw
+    LocalConnector backend dir (`/host/tasks`).  `try_remote_fetch`
+    returns the peer bytes on demand and writes nothing back locally, so
+    after a cross-node read the peer's file must be absent from the
+    reader's own host dir.  (On the pre-decouple kernel the hot-path
+    cache-back materialized it there — that behaviour is what this guard
+    now forbids.)  The merged view needs no such materialization: readdir
+    rows raft-replicate, content is fetched per-read.
+
+    Four steps:
       1. Each side writes to host fs + triggers observation.
       2. Founder cats joiner's file via FUSE → byte-exact from joiner.
       3. Joiner cats founder's file via FUSE → byte-exact from founder.
+      4. Neither peer file materialized in the reader's raw host dir.
     """
 
     def test_each_side_reads_other_side_bytes_via_peer_fetch(
@@ -333,6 +345,28 @@ class TestPeerSharedCrossNodeByteExact:
                 founder_file_on_joiner,
                 founder_bytes,
                 "joiner never got founder's bytes via peer-fetch",
+            )
+
+            # Step 4: §3g read-⊥-materialize guard.  Both cross-node reads
+            # above completed (byte-exact) through the FUSE mount.  On the
+            # decoupled kernel `try_remote_fetch` writes nothing back, so
+            # the peer's file must NOT exist in the reader's raw host dir.
+            # The reader wrote only its OWN session there; the peer's
+            # session appearing on local disk would mean the hot-path
+            # cache-back is still materializing (pre-decouple regression).
+            assert not cc_tasks_share_helpers.host_path_exists(
+                topology.founder_container, f"/{joiner_sess}/b.json"
+            ), (
+                "joiner's file was materialized in founder's raw host dir after a "
+                "cross-node FUSE read — the read-path cache-back is back (read ⊥ "
+                "materialize violated)"
+            )
+            assert not cc_tasks_share_helpers.host_path_exists(
+                topology.joiner_container, f"/{founder_sess}/a.json"
+            ), (
+                "founder's file was materialized in joiner's raw host dir after a "
+                "cross-node FUSE read — the read-path cache-back is back (read ⊥ "
+                "materialize violated)"
             )
         finally:
             runbook_helpers.docker_exec(


### PR DESCRIPTION
**⚠️ DRAFT — do not merge.** Two gates: (1) carries a TEMP validation pin to the unmerged nexus-vfs PR #138 (re-pin to merged main SHA first); (2) lands atomically with the coordinated live Win↔Mac §3g cutover.

Paired with **nexus-vfs #138** (deletes the read-path cache-back). Together they systematize the read-path materialization special-case: cc-tasks migrates to §3g (FUSE mounted AT the CC path → reads on demand) so the raw-dir materialization dependency disappears, then the hot-path `write_content` is gone.

## Changes

- **`tests/e2e/docker/test_cc_tasks_peer_shared_e2e.py` + `cc_tasks_share_helpers.py`** — new `host_path_exists` helper + a §3g read-⊥-materialize guard: after each side reads the OTHER's file through the FUSE mount, the peer's file must NOT exist in the reader's raw LocalConnector backend dir. Deterministic: fails on the old (materializing) kernel, passes on the decoupled kernel.
- **`docs/architecture/federation-cross-machine-runbook.md`** — §3g becomes the documented cc-tasks default (FUSE mount = CC path; `local_root` = renamed `tasks.local/` sibling; reads on demand, no materialization). The raw-dir §3f variant is demoted to a labelled "do not reintroduce" historical note; stale `io.rs:594-597` refs and the false "critical for failover" claim removed; Step 5 handshake + status header repointed.
- **`Cargo.toml` / `Cargo.lock`** — TEMP validation pin (see above).

## Not in this PR (local / gated)

- `start-common.sh` (gitignored local launcher) carries the §3g repoint behind an `NEXUS_3G_CUTOVER` flag defaulting to the current live §3f — applied at the coordinated live cutover, not here.

## Validation

- `py_compile` clean; runbook self-consistent (no stale `.claude-federated` / io.rs line refs).
- The cc-tasks-peer-shared Docker E2E (this PR's CI, against the #138 kernel via the temp pin) is the infra acceptance gate.
- Live Win↔Mac §3g re-verification with the Mac AI (cross-machine-bug-workflow) precedes admin-merge.