### PR TITLE
fix(fuse-plugin): implement WinFsp overwrite disposition — fix §3g task update

### DIFF
--- a/rust/services/fuse-plugin/src/fs_winfsp.rs
+++ b/rust/services/fuse-plugin/src/fs_winfsp.rs
@@ -391,6 +391,37 @@ impl FileSystemContext for NexusWinFsp {
         })
     }
 
+    /// Overwrite (truncate) an EXISTING file — WinFsp's CREATE_ALWAYS /
+    /// FILE_OVERWRITE(_IF) / FILE_SUPERSEDE disposition on a file that
+    /// already exists (e.g. `open(path, "w")`, `writeFile`, CC's
+    /// `TaskUpdate`). The `FileSystemContext` trait default returns
+    /// `STATUS_INVALID_DEVICE_REQUEST`, so without this override every
+    /// truncating open of an existing file failed — a §3g regression that
+    /// §3f never exposed (CC wrote the raw host dir natively, not FUSE).
+    ///
+    /// The kernel's `sys_write` is whole-file (O_TRUNC) rewrite semantics,
+    /// so truncation is an empty-payload write — the exact pattern
+    /// `create` uses for a fresh file; the subsequent `write` handler then
+    /// replaces the content at offset 0. Kernel syscall surface unchanged.
+    fn overwrite(
+        &self,
+        context: &Self::FileContext,
+        _file_attributes: FILE_FLAGS_AND_ATTRIBUTES,
+        _replace_file_attributes: bool,
+        _allocation_size: u64,
+        _extra_buffer: Option<&[u8]>,
+        file_info: &mut FileInfo,
+    ) -> Result<(), FspError> {
+        winfsp_diag!("overwrite path={}", context.path);
+        if context.is_dir {
+            return Err(FspError::NTSTATUS(STATUS_NOT_A_DIRECTORY));
+        }
+        kernel_callbacks::sys_write(&self.kernel, &context.path, &[])
+            .map_err(|e| FspError::NTSTATUS(errno_to_status(e)))?;
+        Self::populate_file_info(file_info, 0, false);
+        Ok(())
+    }
+
     fn get_file_info(
         &self,
         context: &Self::FileContext,

--- a/tests/e2e/windows/test_fuse_plugin_winfsp_e2e.py
+++ b/tests/e2e/windows/test_fuse_plugin_winfsp_e2e.py
@@ -358,6 +358,58 @@ class TestSessionLifecycle:
 # ─────────────────────────────────────────────────────────────────────
 
 
+class TestOverwriteExistingFile:
+    """Rewrite an EXISTING file through the WinFsp mount — CC's `TaskUpdate`
+    workflow (a task's `.json` is overwritten in place as its status
+    changes).
+
+    Regression guard for the §3g overwrite gap: WinFsp routes
+    ``open(path, "w")`` / CREATE_ALWAYS on an *existing* file to the
+    ``FileSystemContext::overwrite`` disposition, whose trait default is
+    ``STATUS_INVALID_DEVICE_REQUEST``.  Without the plugin's ``overwrite``
+    override every task UPDATE failed (the create → read → delete lifecycle
+    above masked it — nothing rewrote a file that already existed).  §3f
+    never exposed this because CC wrote the raw host dir natively, not
+    through FUSE.
+    """
+
+    def test_overwrite_existing_task_replaces_content(
+        self, topology: Topology, session_name: str
+    ) -> None:
+        sess_rel = f".claude/tasks/{session_name}"
+        rel = f"{sess_rel}/task-upd.json"
+        mount = topology.mount_path(rel)
+        vfs = topology.vfs_path(rel)
+        v1 = '{"id":7,"status":"todo","title":"v1"}'
+        v2 = '{"id":7,"status":"done","title":"v2-updated-and-longer"}'
+        try:
+            _cmd(["mkdir", topology.mount_path(sess_rel)])
+            # Create the file (fresh write — the create disposition).
+            _write_file(mount, v1)
+            first = _vfs_read(topology.cluster_grpc, vfs)
+            assert "error" not in first, f"initial vfs_read failed: {first}"
+            assert v1 in _decode_content(first).decode("utf-8", errors="replace")
+
+            # OVERWRITE the existing file — `open(path,"w")` on a file that
+            # already exists.  This is the op that returned EINVAL before
+            # the `overwrite` handler existed.
+            _write_file(mount, v2)
+            _wait_path_via_grpc(topology, vfs, expect_found=True)
+
+            # The kernel SSOT must now hold v2 and NONE of v1 (whole-file
+            # rewrite, not append).
+            second = _vfs_read(topology.cluster_grpc, vfs)
+            assert "error" not in second, f"post-overwrite vfs_read failed: {second}"
+            body = _decode_content(second).decode("utf-8", errors="replace")
+            assert v2 in body, f"overwrite did not replace content — expected {v2!r}, got {body!r}"
+            assert '"title":"v1"' not in body, f"stale v1 content survived the overwrite: {body!r}"
+        finally:
+            try:
+                os.remove(mount)
+            except OSError:
+                pass
+
+
 class TestMidSessionRename:
     def test_rename_preserves_content_and_remaps_inode(
         self, topology: Topology, session_name: str


### PR DESCRIPTION
## Bug (found live during the §3g cutover)

Overwriting an **existing** file through the WinFsp mount failed with `STATUS_INVALID_DEVICE_REQUEST`. WinFsp routes `open(path, "w")` / `CREATE_ALWAYS` on a file that already exists to `FileSystemContext::overwrite`, whose winfsp-rs trait **default returns an error** — and `fs_winfsp.rs` never overrode it. So CC's **`TaskUpdate`** (rewrites a task `.json` in place) was broken under §3g on Windows. `TaskCreate` (new file) + reads were fine.

§3f never exposed this: CC wrote the **raw host dir natively**, bypassing FUSE. §3g makes the FUSE mount the **sole** I/O path, so every WinFsp disposition must be mapped — same "§3f masked it, §3g exposes it" pattern as the read-path finding.

## Fix (frontend adapter only — kernel untouched)

Implement `overwrite` in `fs_winfsp.rs`. The kernel's `sys_write` is already whole-file (`O_TRUNC`) rewrite semantics, so `overwrite` = an empty-payload truncate write (mirrors `create`'s fresh-file branch); the subsequent `write` handler replaces content at offset 0. No new imports, no kernel syscall-surface change.

Verified against the bar: simplest correct location (frontend adapter owns OS-op→syscall mapping, SRP, orthogonal to `create`/`write`), reuses existing `sys_write` (DRY, content SSOT unchanged), no boundary leak, non-hot-path, no raft interaction beyond the existing write path.

## Validation

- `clippy --release -D warnings` + `fmt` clean.
- **Live-verified Win**: `open('w')` on an existing task file now replaces content byte-exact; the harness `TaskUpdate` (which failed EISDIR/EINVAL before) succeeds.
- **New regression E2E** (`TestOverwriteExistingFile`) in the CI `windows-latest` WinFsp suite: create → overwrite-in-place → assert the kernel SSOT (`vfs_read`) holds the new content and none of the stale content. This is precisely the coverage that was missing (the lifecycle test only did create/read/delete, never a rewrite).

## Follow-up (separate)

Symmetric check on Mac's `fs_nfs.rs` (FUSE-T/fuser routes truncate via `setattr(size=0)`, likely already covered — confirming with the Mac side).