### PR TITLE
fix(fuse-plugin): implement NFS setattr truncate for file overwrite

### DIFF
--- a/rust/services/fuse-plugin/src/fs_nfs.rs
+++ b/rust/services/fuse-plugin/src/fs_nfs.rs
@@ -199,8 +199,15 @@ impl NFSFileSystem for NexusNfs {
         }
     }
 
-    async fn setattr(&self, _id: fileid3, _setattr: sattr3) -> Result<fattr3, nfsstat3> {
-        Err(nfsstat3::NFS3ERR_NOENT)
+    async fn setattr(&self, id: fileid3, setattr: sattr3) -> Result<fattr3, nfsstat3> {
+        let path = self.path_for(id).ok_or(nfsstat3::NFS3ERR_NOENT)?;
+        // Handle truncate (size=0): shell `>` redirect and open(O_TRUNC)
+        // send setattr(size=0) before writing new content.
+        if let nfsserve::nfs::set_size3::size(0) = setattr.size {
+            kernel_callbacks::sys_write(&self.kernel, &path, &[])
+                .map_err(|_| nfsstat3::NFS3ERR_IO)?;
+        }
+        self.stat_fattr(id, &path)
     }
 
     async fn read(


### PR DESCRIPTION
## Summary

Symmetric fix to #4498 (WinFsp overwrite). Shell redirects (`echo v2 > file`) and `open(O_TRUNC)` send NFS `setattr(size=0)` before writing new content. The NFS adapter returned `NFS3ERR_NOENT` unconditionally from `setattr`, breaking CC TaskUpdate which overwrites existing task JSON files.

Fix: handle `setattr size=0` → `sys_write(path, &[])` truncate. Kernel untouched.

## Test plan

- [x] All 40 tests pass (22 unit + 18 integration)
- [x] Local live test: `echo v1 > f; echo v2 > f; cat f` → shows v2
- [ ] CI green