### PR TITLE
docs(architecture): visual HTML+mermaid federation runbook (§3g)

### DIFF
--- a/docs/architecture/federation-architecture.html
+++ b/docs/architecture/federation-architecture.html
@@ -1,0 +1,294 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Nexus Cross-Machine Federation — Architecture &amp; §3g Runbook</title>
+<style>
+  :root {
+    --bg: #0f1420; --panel: #161d2c; --ink: #e6edf6; --muted: #9fb0c8;
+    --accent: #5aa0ff; --good: #4cd08a; --warn: #f2b366; --bad: #ff6b6b;
+    --line: #263349; --code-bg: #0b0f18;
+  }
+  @media (prefers-color-scheme: light) {
+    :root {
+      --bg: #f6f8fc; --panel: #ffffff; --ink: #16202e; --muted: #55647a;
+      --accent: #1f6feb; --good: #1a7f4b; --warn: #b26a00; --bad: #c62828;
+      --line: #dce4ef; --code-bg: #eef2f8;
+    }
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; background: var(--bg); color: var(--ink);
+    font: 16px/1.65 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    -webkit-font-smoothing: antialiased;
+  }
+  .wrap { max-width: 1040px; margin: 0 auto; padding: 40px 22px 96px; }
+  header.hero {
+    padding: 30px 30px 26px; border: 1px solid var(--line); border-radius: 16px;
+    background: linear-gradient(180deg, var(--panel), transparent);
+    margin-bottom: 34px;
+  }
+  header.hero h1 { margin: 0 0 8px; font-size: 30px; line-height: 1.2; letter-spacing: -0.02em; }
+  header.hero p { margin: 0; color: var(--muted); font-size: 16px; }
+  .pills { margin-top: 16px; display: flex; flex-wrap: wrap; gap: 8px; }
+  .pill { font-size: 12.5px; padding: 4px 11px; border-radius: 999px; border: 1px solid var(--line); color: var(--muted); background: var(--code-bg); }
+  .pill b { color: var(--accent); font-weight: 600; }
+  h2 { font-size: 22px; margin: 46px 0 10px; letter-spacing: -0.01em; padding-bottom: 8px; border-bottom: 1px solid var(--line); }
+  h3 { font-size: 17px; margin: 26px 0 6px; color: var(--ink); }
+  p { margin: 10px 0; }
+  .muted { color: var(--muted); }
+  code { font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace; font-size: 13.5px; background: var(--code-bg); padding: 1px 6px; border-radius: 5px; border: 1px solid var(--line); }
+  .card { border: 1px solid var(--line); border-radius: 14px; background: var(--panel); padding: 8px 18px 14px; margin: 18px 0; }
+  .grid2 { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+  @media (max-width: 780px) { .grid2 { grid-template-columns: 1fr; } }
+  .callout { border-left: 3px solid var(--accent); background: var(--code-bg); padding: 12px 16px; border-radius: 0 10px 10px 0; margin: 16px 0; }
+  .callout.good { border-color: var(--good); }
+  .callout.warn { border-color: var(--warn); }
+  .callout .tag { font-size: 12px; font-weight: 700; text-transform: uppercase; letter-spacing: .04em; }
+  .callout.good .tag { color: var(--good); } .callout.warn .tag { color: var(--warn); } .callout .tag { color: var(--accent); }
+  table { width: 100%; border-collapse: collapse; margin: 14px 0; font-size: 14.5px; }
+  th, td { text-align: left; padding: 9px 12px; border-bottom: 1px solid var(--line); vertical-align: top; }
+  th { color: var(--muted); font-weight: 600; font-size: 13px; text-transform: uppercase; letter-spacing: .03em; }
+  td code { font-size: 12.5px; }
+  .diagram { overflow-x: auto; margin: 6px 0; }
+  pre.mermaid { background: none; border: none; text-align: center; padding: 18px 0; visibility: hidden; }
+  pre.mermaid[data-processed] { visibility: visible; }
+  .toc { columns: 2; column-gap: 26px; font-size: 14.5px; }
+  @media (max-width: 620px) { .toc { columns: 1; } }
+  .toc a { color: var(--accent); text-decoration: none; }
+  .toc a:hover { text-decoration: underline; }
+  footer { margin-top: 60px; padding-top: 18px; border-top: 1px solid var(--line); color: var(--muted); font-size: 13.5px; }
+  .ok { color: var(--good); } .no { color: var(--bad); }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <header class="hero">
+    <h1>Nexus Cross-Machine Federation</h1>
+    <p>Architecture &amp; operational runbook for the Win↔Mac <b>cc-tasks-share</b> substrate — the §3g <em>read&nbsp;⊥&nbsp;cache&nbsp;⊥&nbsp;materialize</em> model. A visual companion to <code>docs/architecture/federation-cross-machine-runbook.md</code>.</p>
+    <div class="pills">
+      <span class="pill"><b>Topology</b> 2-node raft (Win founder + Mac joiner)</span>
+      <span class="pill"><b>Transport</b> Tailscale / Headscale (DERP fallback)</span>
+      <span class="pill"><b>Mount</b> FUSE at the CC task path (§3g)</span>
+      <span class="pill"><b>State</b> live-verified Win↔Mac</span>
+    </div>
+  </header>
+
+  <div class="card">
+    <h3 style="margin-top:14px">Contents</h3>
+    <div class="toc">
+      <p><a href="#topology">1 · Topology at a glance</a></p>
+      <p><a href="#layers">2 · The layer stack on each node</a></p>
+      <p><a href="#3g">3 · §3f → §3g: read ⊥ cache ⊥ materialize</a></p>
+      <p><a href="#read">4 · Cross-node READ flow</a></p>
+      <p><a href="#write">5 · WRITE / UPDATE flow</a></p>
+      <p><a href="#raft">6 · Raft membership &amp; the DT_MOUNT deadlock fix</a></p>
+      <p><a href="#cutover">7 · The one-time §3f→§3g cutover</a></p>
+      <p><a href="#invariants">8 · Invariants &amp; hard-won lessons</a></p>
+    </div>
+  </div>
+
+  <h2 id="topology">1 · Topology at a glance</h2>
+  <p>Two machines share one federated zone (<code>sharedzone</code>) over a raft cluster. Each runs a single <code>nexusd-cluster</code> daemon that hosts the kernel, the raft transport, and two plugins: a <b>LocalConnector</b> (backing store) and a <b>FUSE</b> mount (the surface Claude Code reads/writes). Claude Code's task list is routed to a per-machine path that <em>is</em> the FUSE mount — so every task read/write flows through the kernel.</p>
+  <div class="diagram">
+  <pre class="mermaid">
+flowchart LR
+    subgraph WIN["🪟 Windows — FOUNDER (100.64.0.27)"]
+        CCW["Claude Code<br/>TaskCreate / List / Update"]
+        FUSEW["FUSE mount (WinFsp)<br/>~/.claude/tasks/nexus-project"]
+        KW["nexusd-cluster<br/>kernel + raft voter"]
+        LCW["LocalConnector<br/>~/.claude/tasks.local/nexus-project"]
+        CCW <--> FUSEW <--> KW <--> LCW
+    end
+    subgraph MAC["🍎 macOS — JOINER (100.64.0.21)"]
+        CCM["Claude Code<br/>TaskCreate / List / Update"]
+        FUSEM["FUSE mount (FUSE-T/NFS)<br/>~/.claude/tasks/nexus-project"]
+        KM["nexusd-cluster<br/>kernel + raft voter"]
+        LCM["LocalConnector<br/>~/.claude/tasks.local/nexus-project"]
+        CCM <--> FUSEM <--> KM <--> LCM
+    end
+    KW <-->|"raft consensus · ReadBlob RPC<br/>Tailscale / DERP relay"| KM
+    style WIN fill:#1b2740,stroke:#5aa0ff
+    style MAC fill:#1b2740,stroke:#4cd08a
+  </pre>
+  </div>
+  <p class="muted">The merged view is symmetric: each node mounts its LocalConnector into <code>sharedzone</code> at the <em>same</em> VFS path, so <code>ls</code> on either FUSE mount returns the <b>union</b> of both machines' tasks.</p>
+
+  <h2 id="layers">2 · The layer stack on each node</h2>
+  <p>A single daemon, three tiers. The kernel exposes a stable syscall surface; plugins are C-ABI cdylibs that adapt an OS-level interface to those syscalls. The whole point of §3g is that the <b>FUSE plugin is the sole I/O path</b> for cc-tasks — so its adapter must faithfully map every file op onto the kernel.</p>
+  <div class="diagram">
+  <pre class="mermaid">
+flowchart TB
+    OS["OS file op<br/>(ls / cat / open(w) / rm)"] --> FP
+    subgraph FP["FUSE plugin — frontend adapter (per platform)"]
+      direction LR
+      W["fs_winfsp.rs<br/>WinFsp dispositions"]
+      N["fs_nfs.rs<br/>NFS / FUSE-T ops"]
+    end
+    FP -->|"C-ABI KernelHandle"| SYS
+    subgraph SYS["Kernel — syscall surface (SSOT, ABI-stable)"]
+      direction LR
+      R["sys_read"]
+      WR["sys_write<br/>(whole-file O_TRUNC)"]
+      RD["sys_readdir"]
+      ST["sys_stat"]
+    end
+    SYS --> RT["VFS router → route()"]
+    RT --> MS["ZoneMetaStore<br/>(raft-replicated rows)"]
+    RT --> BK["LocalConnector backend<br/>(host fs = tasks.local)"]
+    RT -.->|"local miss + last_writer=peer"| TRF["try_remote_fetch → peer ReadBlob"]
+    style SYS fill:#12233b,stroke:#5aa0ff
+    style FP fill:#1c2233,stroke:#9fb0c8
+  </pre>
+  </div>
+  <div class="callout"><span class="tag">Design rule</span> — Adapters map OS ops → syscalls; they never change the kernel ABI. Every fix this cycle lived in a plugin adapter or a kernel <em>idempotency</em> check — the syscall surface stayed frozen.</div>
+
+  <h2 id="3g">3 · §3f → §3g: read ⊥ cache ⊥ materialize</h2>
+  <p>The old §3f model made cross-node reads work by <b>materializing</b> peer bytes onto local disk (a hot-path cache-back after every fetch) and having Claude Code read that raw dir directly. That conflated three orthogonal concerns. §3g decouples them: Claude Code reads <em>through</em> the FUSE mount, and peer content is fetched <b>on demand</b>, never cached back.</p>
+  <div class="grid2">
+    <div class="card">
+      <h3>§3f (superseded)</h3>
+      <div class="diagram"><pre class="mermaid">
+flowchart TB
+    CC1["CC reads RAW dir<br/>~/.claude/tasks/…"] --> D1["local disk"]
+    RF1["cross-node read"] -->|"cache-back<br/>write_content"| D1
+    D1 -.->|"peer bytes<br/>materialized"| CC1
+    style D1 fill:#3a2a1a,stroke:#f2b366
+      </pre></div>
+      <p class="muted"><span class="no">✗</span> read = cache = materialize (coupled). Peer files land on local disk. Masked real gaps in the FUSE path.</p>
+    </div>
+    <div class="card">
+      <h3>§3g (current)</h3>
+      <div class="diagram"><pre class="mermaid">
+flowchart TB
+    CC2["CC reads THROUGH FUSE<br/>(mount = CC path)"] --> K2["kernel sys_read"]
+    K2 -->|"local miss"| RF2["try_remote_fetch<br/>(on demand)"]
+    RF2 -->|"bytes, NOT stored"| CC2
+    LR2["tasks.local<br/>(own files only)"] --> K2
+    style RF2 fill:#1a3a2a,stroke:#4cd08a
+      </pre></div>
+      <p class="muted"><span class="ok">✓</span> read ⊥ cache ⊥ materialize. Merged view = raft-replicated rows + per-read fetch. Nothing shadow-copied.</p>
+    </div>
+  </div>
+  <div class="callout good"><span class="tag">Why it's correct</span> — cc-tasks is append-only with raft-replicated metadata rows, so no failover content cache is needed. A real read-through cache, if ever required, belongs in a dedicated <code>CacheStore</code>, not inlined on the read hot path.</div>
+
+  <h2 id="read">4 · Cross-node READ flow</h2>
+  <p>When one node reads a task owned by the other, the kernel routes by <code>last_writer_address</code> to the owner's co-located <code>ReadBlob</code> RPC and streams the bytes back — no local materialization.</p>
+  <div class="diagram">
+  <pre class="mermaid">
+sequenceDiagram
+    autonumber
+    participant U as OS (cat)
+    participant F as FUSE plugin
+    participant K as Kernel (sys_read)
+    participant M as ZoneMetaStore
+    participant B as Local backend
+    participant P as Peer ReadBlob (owner)
+    U->>F: read(/…/peer-task.json)
+    F->>K: sys_read(path)
+    K->>M: get(path)  ·  row: last_writer = PEER
+    K->>B: read_content(path)
+    B-->>K: MISS (not local)
+    K->>P: try_remote_fetch(origin=peer, key)
+    P-->>K: bytes (current content)
+    K-->>F: bytes  (NOT cached back)
+    F-->>U: content ✓
+    Note over K,B: no write_content — read ⊥ materialize
+  </pre>
+  </div>
+  <div class="callout warn"><span class="tag">Hard invariant</span> — on-demand read requires <code>last_writer_address</code> to point at a node that <em>actually holds</em> the content. A row claiming <code>last_writer=self</code> with no local bytes is an <b>orphan</b> — unreadable under §3g (§3f hid this by materializing). Orphans are a cutover artifact, not a steady-state occurrence for append-only + FUSE-mediated cc-tasks.</div>
+
+  <h2 id="write">5 · WRITE / UPDATE flow</h2>
+  <p>A write (create <em>or</em> overwrite) commits to the local backend and proposes a metastore row stamped <code>last_writer=self</code>; raft replicates the row so the peer sees the entry and fetches fresh bytes on its next read. <b>Overwrite</b> (Claude Code's <code>TaskUpdate</code>) was the subtle one: WinFsp routes <code>open(path,"w")</code> on an existing file to a distinct <code>overwrite</code> disposition, and NFS to <code>setattr(size=0)</code> — both had to be wired to the kernel's whole-file rewrite.</p>
+  <div class="diagram">
+  <pre class="mermaid">
+sequenceDiagram
+    autonumber
+    participant U as OS (open "w")
+    participant F as FUSE plugin
+    participant K as Kernel
+    participant B as Local backend
+    participant R as Raft (sharedzone)
+    U->>F: create OR overwrite(existing)
+    alt existing file (TaskUpdate)
+        F->>K: sys_write(path, &[])  ·  truncate
+    end
+    U->>F: write(new content)
+    F->>K: sys_write(path, content)
+    K->>B: write_content (whole-file)
+    K->>R: metastore.put(row: last_writer=self, new content_id/size)
+    R-->>K: committed (replicated)
+    K-->>F: ok
+    Note over R: peer now sees the row → reads v2 on demand
+  </pre>
+  </div>
+  <div class="callout"><span class="tag">The overwrite fix</span> — the frontend adapters lacked the truncate-overwrite disposition, so <code>TaskUpdate</code> failed under §3g (§3f wrote the raw dir natively, never through FUSE). Fixed identically on both platforms: <em>truncate = empty whole-file write</em> — kernel untouched.</div>
+
+  <h2 id="raft">6 · Raft membership &amp; the DT_MOUNT deadlock fix</h2>
+  <p>A 2-voter cluster needs <b>majority = 2</b> for any write. Restarting both nodes at once used to deadlock: each daemon <em>fail-loud'd</em> installing its <code>--mount-driver</code> because that unconditionally <code>propose</code>d the DT_MOUNT row (a raft write needing a leader) — and neither had a leader yet. The fix is a raft-contract idempotency: on resume the row is already committed, so read it with a <b>leader-free local read</b> and skip the propose.</p>
+  <div class="diagram">
+  <pre class="mermaid">
+stateDiagram-v2
+    [*] --> Booting
+    Booting --> ReplayLog: read persisted raft log (leader-free)
+    ReplayLog --> RowExists: DT_MOUNT already committed?
+    RowExists --> WireLocal: YES → skip propose, wire backend
+    RowExists --> Propose: NO (genuinely new) → propose (needs leader)
+    WireLocal --> Serving: daemon stays up ✓
+    Propose --> Serving: leader present (founder bootstrap)
+    Propose --> FailLoud: no leader (transient)
+    Serving --> QuorumForms: peer connects → elect leader
+    note right of RowExists
+      get-before-put:
+      never re-propose committed state
+    end note
+    note right of FailLoud
+      old bug: both nodes here
+      at once → mutual deadlock
+    end note
+  </pre>
+  </div>
+  <div class="callout"><span class="tag">Raft contract</span> — never re-propose already-committed state; use leader-free reads for existing state. N=2 has no fault tolerance (both must be up) — an odd N≥3 with a witness removes the &ldquo;both required&rdquo; cliff.</div>
+
+  <h2 id="cutover">7 · The one-time §3f→§3g cutover</h2>
+  <p>Flipping the live CC task dir into a FUSE mount is hard to reverse, so the launcher performs a single, safe migration: move (never delete) existing task files into the LocalConnector backend, then mount over the emptied leaf. Guarded by <code>NEXUS_3G_CUTOVER</code> so an incidental restart can't fire it.</p>
+  <div class="diagram">
+  <pre class="mermaid">
+flowchart LR
+    A["~/.claude/tasks/nexus-project<br/>(real dir, §3f)"] -->|"MOVE, no delete"| B["~/.claude/tasks.local/nexus-project<br/>(LocalConnector backend)"]
+    A -->|"emptied leaf"| C{"rmdir ok?"}
+    C -->|"yes"| D["FUSE mounts here<br/>= CC read path (§3g)"]
+    C -->|"name collision"| E["refuse loudly<br/>(resolve by hand)"]
+    style D fill:#1a3a2a,stroke:#4cd08a
+    style E fill:#3a1a1a,stroke:#ff6b6b
+  </pre>
+  </div>
+
+  <h2 id="invariants">8 · Invariants &amp; hard-won lessons</h2>
+  <table>
+    <tr><th>Invariant / lesson</th><th>Why it matters</th></tr>
+    <tr><td><b>read ⊥ cache ⊥ materialize</b></td><td>The read hot path returns peer bytes; it does not write them back. Caching, if needed, is a separate concern (CacheStore).</td></tr>
+    <tr><td><b><code>last_writer</code> must hold the content</b></td><td>On-demand read routes by owner; a row whose owner lacks the bytes is an unreadable orphan.</td></tr>
+    <tr><td><b>Never re-propose committed state</b></td><td>Idempotent DT_MOUNT install; leader-free reads on resume — the raft-contract fix for the 2-voter cold-start deadlock.</td></tr>
+    <tr><td><b>FUSE is the sole I/O path (§3g)</b></td><td>So the frontend adapter's file-op contract must be complete on <em>every</em> platform — and CI-guarded by a real CRUD E2E.</td></tr>
+    <tr><td><b>Docker-green ≠ live-green</b></td><td>The on-demand read and both overwrite gaps were invisible to Docker (libfuse3) and only surfaced on live WinFsp / FUSE-T. Live cross-machine verification is the real gate.</td></tr>
+    <tr><td><b>Kernel ABI stays frozen</b></td><td>Every fix was a plugin adapter or a kernel idempotency check — the syscall surface was never touched.</td></tr>
+  </table>
+  <div class="callout good"><span class="tag">Live-verified</span> — cross-node read (bidirectional), cross-machine update propagation (Win overwrite → raft row → Mac on-demand fetch → new content, no materialization), 2-node cold-start recovery, and full CRUD through both FUSE frontends.</div>
+
+  <footer>
+    Source of truth: <code>nexi-lab/nexus · docs/architecture/federation-cross-machine-runbook.md</code> (detailed operational steps) + this visual companion.
+    Published to ShareOne via the <em>remote-URL</em> mechanism — edits land by merging the source file; ShareOne re-fetches automatically.
+  </footer>
+
+</div>
+
+<script type="module">
+  import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
+  const dark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+  mermaid.initialize({ startOnLoad: true, theme: dark ? 'dark' : 'default', look: 'handDrawn', fontFamily: 'inherit' });
+</script>
+</body>
+</html>


### PR DESCRIPTION
Diagrams-first HTML companion to `federation-cross-machine-runbook.md` — topology, per-node layer stack, §3f→§3g read⊥cache⊥materialize comparison, cross-node read + write/update sequence diagrams, the 2-voter DT_MOUNT-deadlock state diagram, and the cutover flow (Mermaid). Intended for ShareOne publish via the remote-URL mechanism (edits land by merge; ShareOne auto-refetches).