### PR TITLE
chore: bump nexus-vfs pin to the auth-identity foundation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=8180374c81a7fb08eda293a3f97fcbc965be0dc0#8180374c81a7fb08eda293a3f97fcbc965be0dc0"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=79b6798f87f237d282410838f21f28019a6e9bef#79b6798f87f237d282410838f21f28019a6e9bef"
 dependencies = [
  "ahash",
  "base64",
@@ -550,7 +550,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=8180374c81a7fb08eda293a3f97fcbc965be0dc0#8180374c81a7fb08eda293a3f97fcbc965be0dc0"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=79b6798f87f237d282410838f21f28019a6e9bef#79b6798f87f237d282410838f21f28019a6e9bef"
 dependencies = [
  "parking_lot",
  "serde",
@@ -1334,7 +1334,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=8180374c81a7fb08eda293a3f97fcbc965be0dc0#8180374c81a7fb08eda293a3f97fcbc965be0dc0"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=79b6798f87f237d282410838f21f28019a6e9bef#79b6798f87f237d282410838f21f28019a6e9bef"
 dependencies = [
  "ahash",
  "base64",
@@ -1385,7 +1385,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=8180374c81a7fb08eda293a3f97fcbc965be0dc0#8180374c81a7fb08eda293a3f97fcbc965be0dc0"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=79b6798f87f237d282410838f21f28019a6e9bef#79b6798f87f237d282410838f21f28019a6e9bef"
 dependencies = [
  "ahash",
  "base64",
@@ -1580,7 +1580,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=8180374c81a7fb08eda293a3f97fcbc965be0dc0#8180374c81a7fb08eda293a3f97fcbc965be0dc0"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=79b6798f87f237d282410838f21f28019a6e9bef#79b6798f87f237d282410838f21f28019a6e9bef"
 
 [[package]]
 name = "nexus-vault"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -209,13 +209,13 @@ exclude = ["nexus-fuse"]
 #
 # Bump alongside the rest of nexus-vfs updates when a downstream
 # change needs newer kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "8180374c81a7fb08eda293a3f97fcbc965be0dc0" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "8180374c81a7fb08eda293a3f97fcbc965be0dc0" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "8180374c81a7fb08eda293a3f97fcbc965be0dc0" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "8180374c81a7fb08eda293a3f97fcbc965be0dc0", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "8180374c81a7fb08eda293a3f97fcbc965be0dc0", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "8180374c81a7fb08eda293a3f97fcbc965be0dc0", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "8180374c81a7fb08eda293a3f97fcbc965be0dc0" }
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "79b6798f87f237d282410838f21f28019a6e9bef" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "79b6798f87f237d282410838f21f28019a6e9bef" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "79b6798f87f237d282410838f21f28019a6e9bef" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "79b6798f87f237d282410838f21f28019a6e9bef", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "79b6798f87f237d282410838f21f28019a6e9bef", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "79b6798f87f237d282410838f21f28019a6e9bef", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "79b6798f87f237d282410838f21f28019a6e9bef" }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ENV CARGO_NET_RETRY=10 \
     CARGO_HTTP_TIMEOUT=120
 # Override for edge/CI or a different pin: --build-arg NEXUS_VFS_REV=<sha|tag>
-ARG NEXUS_VFS_REV=8180374c81a7fb08eda293a3f97fcbc965be0dc0
+ARG NEXUS_VFS_REV=79b6798f87f237d282410838f21f28019a6e9bef
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,id=cargo-install-${TARGETARCH},target=/root/.cargo/target \

--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir --no-deps --prefix=/install .
 # enforces agreement) — an unpinned install tracks nexus-vfs HEAD and
 # ships an untested kernel (#4343). --locked honors the source tree's
 # Cargo.lock.
-ARG NEXUS_VFS_REV=8180374c81a7fb08eda293a3f97fcbc965be0dc0
+ARG NEXUS_VFS_REV=79b6798f87f237d282410838f21f28019a6e9bef
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-cluster nexus-cluster
 
 # -- Runtime stage --

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -25,7 +25,7 @@ WORKDIR /build
 # (CI preflight enforces agreement) — an unpinned install tracks HEAD
 # and can skew the raft contract against the cluster/witness images.
 # --locked honors the source tree's Cargo.lock.
-ARG NEXUS_VFS_REV=8180374c81a7fb08eda293a3f97fcbc965be0dc0
+ARG NEXUS_VFS_REV=79b6798f87f237d282410838f21f28019a6e9bef
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexus-raft-server raft
 
 # ---------- Production image ----------

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=8180374c81a7fb08eda293a3f97fcbc965be0dc0
+ARG NEXUS_VFS_REV=79b6798f87f237d282410838f21f28019a6e9bef
 RUN cargo install \
     --locked \
     --git https://github.com/nexi-lab/nexus-vfs \


### PR DESCRIPTION
Picks up [nexus-vfs#141](https://github.com/nexi-lab/nexus-vfs/pull/141) — the identity plumbing under A2A:

- `AuthProvider::resolve(&AuthCredentials { token, peer })` — providers can now see the mTLS peer identity that mTLS already verified and the handler was discarding.
- Replicated credential store: a dedicated raft tree (`TREE_AUTH_KEYS`) + `PutAuthKey`/`DeleteAuthKey`, so revocation propagates. Verified over a real two-node cluster.
- `AuthKeyStore` (Control-Plane HAL §3.B.3) — the seam a services-tier provider reads through, since `services ⊥ raft` bars it from naming raft types.
- `ProcfsRegistry` (§4.6) + the admin-gated, read-only `/__sys__/auth/keys/` view.

**No behaviour change in this repo.** `NoAuth` is still the only provider, and no gate is turned on.

The pin is what unblocks the next piece: `ApiKeyAuthProvider`, the `sk-` HMAC policy that turns a credential into an identity (the PAM/`sshd` analogue). It is a services-tier policy, so it lands here rather than in nexus-vfs, and injects into the kernel-tier `Arc<dyn AuthProvider>` slot at the composition root.

Workspace builds clean and the Rust test suites pass against the new rev — no nexus-side `AuthProvider` implementor was caught by the widened signature.