### PR TITLE
fix(fuse-plugin): NFS spawn_blocking to prevent tokio starvation

### DIFF
--- a/rust/services/fuse-plugin/src/fs_nfs.rs
+++ b/rust/services/fuse-plugin/src/fs_nfs.rs
@@ -136,10 +136,12 @@ impl NexusNfs {
         }
     }
 
-    /// Stat a path and return its fattr3.
-    fn stat_fattr(&self, id: fileid3, path: &str) -> Result<fattr3, nfsstat3> {
-        let json =
-            kernel_callbacks::sys_stat(&self.kernel, path).map_err(|_| nfsstat3::NFS3ERR_NOENT)?;
+    /// Stat a path and return its fattr3.  Runs the C FFI call on a
+    /// blocking thread so the tokio worker is not starved.
+    async fn stat_fattr_async(&self, id: fileid3, path: &str) -> Result<fattr3, nfsstat3> {
+        let json = kernel_callbacks::sys_stat_async(&self.kernel, path)
+            .await
+            .map_err(|_| nfsstat3::NFS3ERR_NOENT)?;
         self.make_fattr(id, &json)
     }
 }
@@ -169,13 +171,15 @@ impl NFSFileSystem for NexusNfs {
         let name = std::str::from_utf8(filename).map_err(|_| nfsstat3::NFS3ERR_INVAL)?;
         let path = join_path(&parent, name);
         // Stat first — only allocate inode on positive hit.
-        kernel_callbacks::sys_stat(&self.kernel, &path).map_err(|_| nfsstat3::NFS3ERR_NOENT)?;
+        kernel_callbacks::sys_stat_async(&self.kernel, &path)
+            .await
+            .map_err(|_| nfsstat3::NFS3ERR_NOENT)?;
         Ok(self.inode_for(&path))
     }
 
     async fn getattr(&self, id: fileid3) -> Result<fattr3, nfsstat3> {
         let path = self.path_for(id).ok_or(nfsstat3::NFS3ERR_NOENT)?;
-        match kernel_callbacks::sys_stat(&self.kernel, &path) {
+        match kernel_callbacks::sys_stat_async(&self.kernel, &path).await {
             Ok(json) => self.make_fattr(id, &json),
             Err(PLUGIN_RESULT_NOT_FOUND) if id == NFS_ROOT_ID => {
                 // VFS root path not mounted yet (mount-driver loads
@@ -204,10 +208,11 @@ impl NFSFileSystem for NexusNfs {
         // Handle truncate (size=0): shell `>` redirect and open(O_TRUNC)
         // send setattr(size=0) before writing new content.
         if let nfsserve::nfs::set_size3::size(0) = setattr.size {
-            kernel_callbacks::sys_write(&self.kernel, &path, &[])
+            kernel_callbacks::sys_write_async(&self.kernel, &path, &[])
+                .await
                 .map_err(|_| nfsstat3::NFS3ERR_IO)?;
         }
-        self.stat_fattr(id, &path)
+        self.stat_fattr_async(id, &path).await
     }
 
     async fn read(
@@ -217,8 +222,9 @@ impl NFSFileSystem for NexusNfs {
         count: u32,
     ) -> Result<(Vec<u8>, bool), nfsstat3> {
         let path = self.path_for(id).ok_or(nfsstat3::NFS3ERR_NOENT)?;
-        let full =
-            kernel_callbacks::sys_read(&self.kernel, &path).map_err(|_| nfsstat3::NFS3ERR_NOENT)?;
+        let full = kernel_callbacks::sys_read_async(&self.kernel, &path)
+            .await
+            .map_err(|_| nfsstat3::NFS3ERR_NOENT)?;
         let start = offset as usize;
         if start >= full.len() {
             return Ok((vec![], true));
@@ -233,8 +239,10 @@ impl NFSFileSystem for NexusNfs {
             return Err(nfsstat3::NFS3ERR_IO);
         }
         let path = self.path_for(id).ok_or(nfsstat3::NFS3ERR_NOENT)?;
-        kernel_callbacks::sys_write(&self.kernel, &path, data).map_err(|_| nfsstat3::NFS3ERR_IO)?;
-        self.stat_fattr(id, &path)
+        kernel_callbacks::sys_write_async(&self.kernel, &path, data)
+            .await
+            .map_err(|_| nfsstat3::NFS3ERR_IO)?;
+        self.stat_fattr_async(id, &path).await
     }
 
     async fn create(
@@ -246,9 +254,11 @@ impl NFSFileSystem for NexusNfs {
         let parent = self.path_for(dirid).ok_or(nfsstat3::NFS3ERR_NOENT)?;
         let name = std::str::from_utf8(filename).map_err(|_| nfsstat3::NFS3ERR_INVAL)?;
         let path = join_path(&parent, name);
-        kernel_callbacks::sys_write(&self.kernel, &path, &[]).map_err(|_| nfsstat3::NFS3ERR_IO)?;
+        kernel_callbacks::sys_write_async(&self.kernel, &path, &[])
+            .await
+            .map_err(|_| nfsstat3::NFS3ERR_IO)?;
         let id = self.inode_for(&path);
-        let attr = self.stat_fattr(id, &path)?;
+        let attr = self.stat_fattr_async(id, &path).await?;
         Ok((id, attr))
     }
 
@@ -261,10 +271,15 @@ impl NFSFileSystem for NexusNfs {
         let name = std::str::from_utf8(filename).map_err(|_| nfsstat3::NFS3ERR_INVAL)?;
         let path = join_path(&parent, name);
         // Check existence first.
-        if kernel_callbacks::sys_stat(&self.kernel, &path).is_ok() {
+        if kernel_callbacks::sys_stat_async(&self.kernel, &path)
+            .await
+            .is_ok()
+        {
             return Err(nfsstat3::NFS3ERR_EXIST);
         }
-        kernel_callbacks::sys_write(&self.kernel, &path, &[]).map_err(|_| nfsstat3::NFS3ERR_IO)?;
+        kernel_callbacks::sys_write_async(&self.kernel, &path, &[])
+            .await
+            .map_err(|_| nfsstat3::NFS3ERR_IO)?;
         Ok(self.inode_for(&path))
     }
 
@@ -276,9 +291,11 @@ impl NFSFileSystem for NexusNfs {
         let parent = self.path_for(dirid).ok_or(nfsstat3::NFS3ERR_NOENT)?;
         let name = std::str::from_utf8(dirname).map_err(|_| nfsstat3::NFS3ERR_INVAL)?;
         let path = join_path(&parent, name);
-        kernel_callbacks::sys_mkdir(&self.kernel, &path).map_err(|_| nfsstat3::NFS3ERR_IO)?;
+        kernel_callbacks::sys_mkdir_async(&self.kernel, &path)
+            .await
+            .map_err(|_| nfsstat3::NFS3ERR_IO)?;
         let id = self.inode_for(&path);
-        let attr = self.stat_fattr(id, &path)?;
+        let attr = self.stat_fattr_async(id, &path).await?;
         Ok((id, attr))
     }
 
@@ -287,8 +304,13 @@ impl NFSFileSystem for NexusNfs {
         let name = std::str::from_utf8(filename).map_err(|_| nfsstat3::NFS3ERR_INVAL)?;
         let path = join_path(&parent, name);
         // Try unlink first (file), fall back to rmdir (directory).
-        if kernel_callbacks::sys_unlink(&self.kernel, &path).is_err() {
-            kernel_callbacks::sys_rmdir(&self.kernel, &path).map_err(|_| nfsstat3::NFS3ERR_IO)?;
+        if kernel_callbacks::sys_unlink_async(&self.kernel, &path)
+            .await
+            .is_err()
+        {
+            kernel_callbacks::sys_rmdir_async(&self.kernel, &path)
+                .await
+                .map_err(|_| nfsstat3::NFS3ERR_IO)?;
         }
         self.paths.lock().unwrap().forget(&path);
         Ok(())
@@ -307,7 +329,8 @@ impl NFSFileSystem for NexusNfs {
         let to_name = std::str::from_utf8(to_filename).map_err(|_| nfsstat3::NFS3ERR_INVAL)?;
         let old_path = join_path(&from_parent, from_name);
         let new_path = join_path(&to_parent, to_name);
-        kernel_callbacks::sys_rename(&self.kernel, &old_path, &new_path)
+        kernel_callbacks::sys_rename_async(&self.kernel, &old_path, &new_path)
+            .await
             .map_err(|_| nfsstat3::NFS3ERR_IO)?;
         self.paths.lock().unwrap().rename(&old_path, &new_path);
         Ok(())
@@ -320,7 +343,7 @@ impl NFSFileSystem for NexusNfs {
         max_entries: usize,
     ) -> Result<ReadDirResult, nfsstat3> {
         let parent_path = self.path_for(dirid).ok_or(nfsstat3::NFS3ERR_NOENT)?;
-        let json = match kernel_callbacks::sys_readdir(&self.kernel, &parent_path) {
+        let json = match kernel_callbacks::sys_readdir_async(&self.kernel, &parent_path).await {
             Ok(j) => j,
             Err(PLUGIN_RESULT_NOT_FOUND) if dirid == NFS_ROOT_ID => {
                 // VFS root not mounted yet — return empty listing.
@@ -527,6 +550,12 @@ pub fn spawn_nfs_mount(
     //   tcp      — TCP transport
     //   port=P   — NFS server port
     //   mountport=P — mount daemon port (same, nfsserve handles both)
+    //
+    // NOTE: `soft,timeo=50` was considered for defense-in-depth but
+    // rejected — Raft leader election / redb compaction can exceed 5s,
+    // and `soft` turns that into EIO (data loss) instead of a retry.
+    // The `spawn_blocking` wrappers fix the root cause (tokio worker
+    // starvation) so the NFS client no longer sees "not responding".
     let mount_output = std::process::Command::new("/sbin/mount_nfs")
         .args([
             "-o",

--- a/rust/services/fuse-plugin/src/kernel_callbacks.rs
+++ b/rust/services/fuse-plugin/src/kernel_callbacks.rs
@@ -272,7 +272,7 @@ pub fn sys_rename(kernel: &KernelHandle, old_path: &str, new_path: &str) -> Resu
     Ok(())
 }
 
-// ── async wrappers (spawn_blocking) ────────────────────────────────
+// ── async wrappers (spawn_blocking, macOS NFS only) ────────────────
 //
 // Each function copies the relevant function pointer + `kernel_ptr`
 // into the closure, allocates `CString` arguments on the caller's
@@ -288,155 +288,173 @@ pub fn sys_rename(kernel: &KernelHandle, old_path: &str, new_path: &str) -> Resu
 // This prevents NFS async methods from starving the 2-thread tokio
 // runtime when kernel callbacks take > 0 time (Raft consensus,
 // redb I/O, etc.).
+//
+// Gated to macOS because the NFS adapter and tokio dep are macOS-only;
+// Linux uses fuser (sync), Windows uses WinFsp (sync).
+#[cfg(target_os = "macos")]
+pub use nfs_async::*;
 
-/// Async wrapper around [`sys_stat`] — runs the C FFI call on a
-/// blocking thread via `tokio::task::spawn_blocking`.
-pub async fn sys_stat_async(kernel: &KernelHandle, path: &str) -> Result<String, i32> {
-    let c_path = CString::new(path).map_err(|_| ERRNO_IO_RAW)?;
-    let fn_ptr = kernel.sys_stat;
-    let kptr = kernel.kernel_ptr as usize;
-    tokio::task::spawn_blocking(move || {
-        let kptr = kptr as *const std::ffi::c_void;
-        let mut out_buf: *mut u8 = std::ptr::null_mut();
-        let mut out_len: usize = 0;
-        let rc = unsafe { (fn_ptr)(kptr, c_path.as_ptr(), &mut out_buf, &mut out_len) };
-        if rc != 0 {
-            return Err(rc);
-        }
-        consume_string_out(out_buf, out_len)
-    })
-    .await
-    .unwrap_or(Err(ERRNO_IO_RAW))
-}
+#[cfg(target_os = "macos")]
+mod nfs_async {
+    use super::*;
 
-/// Async wrapper around [`sys_read`].
-pub async fn sys_read_async(kernel: &KernelHandle, path: &str) -> Result<Vec<u8>, i32> {
-    let c_path = CString::new(path).map_err(|_| ERRNO_IO_RAW)?;
-    let fn_ptr = kernel.sys_read;
-    let kptr = kernel.kernel_ptr as usize;
-    tokio::task::spawn_blocking(move || {
-        let kptr = kptr as *const std::ffi::c_void;
-        let mut out_buf: *mut u8 = std::ptr::null_mut();
-        let mut out_len: usize = 0;
-        let rc = unsafe { (fn_ptr)(kptr, c_path.as_ptr(), &mut out_buf, &mut out_len) };
-        if rc != 0 {
-            return Err(rc);
-        }
-        consume_bytes_out(out_buf, out_len)
-    })
-    .await
-    .unwrap_or(Err(ERRNO_IO_RAW))
-}
+    /// Async wrapper around [`super::sys_stat`] — runs the C FFI call on a
+    /// blocking thread via `tokio::task::spawn_blocking`.
+    pub async fn sys_stat_async(kernel: &KernelHandle, path: &str) -> Result<String, i32> {
+        let c_path = CString::new(path).map_err(|_| ERRNO_IO_RAW)?;
+        let fn_ptr = kernel.sys_stat;
+        let kptr = kernel.kernel_ptr as usize;
+        tokio::task::spawn_blocking(move || {
+            let kptr = kptr as *const std::ffi::c_void;
+            let mut out_buf: *mut u8 = std::ptr::null_mut();
+            let mut out_len: usize = 0;
+            let rc = unsafe { (fn_ptr)(kptr, c_path.as_ptr(), &mut out_buf, &mut out_len) };
+            if rc != 0 {
+                return Err(rc);
+            }
+            consume_string_out(out_buf, out_len)
+        })
+        .await
+        .unwrap_or(Err(ERRNO_IO_RAW))
+    }
 
-/// Async wrapper around [`sys_write`].
-pub async fn sys_write_async(kernel: &KernelHandle, path: &str, data: &[u8]) -> Result<(), i32> {
-    let c_path = CString::new(path).map_err(|_| ERRNO_IO_RAW)?;
-    let fn_ptr = kernel.sys_write;
-    let kptr = kernel.kernel_ptr as usize;
-    // Copy data into an owned Vec so it can move into the closure.
-    let owned_data = data.to_vec();
-    tokio::task::spawn_blocking(move || {
-        let kptr = kptr as *const std::ffi::c_void;
-        let rc = unsafe { (fn_ptr)(kptr, c_path.as_ptr(), owned_data.as_ptr(), owned_data.len()) };
-        if rc != 0 {
-            return Err(rc);
-        }
-        Ok(())
-    })
-    .await
-    .unwrap_or(Err(ERRNO_IO_RAW))
-}
+    /// Async wrapper around [`sys_read`].
+    pub async fn sys_read_async(kernel: &KernelHandle, path: &str) -> Result<Vec<u8>, i32> {
+        let c_path = CString::new(path).map_err(|_| ERRNO_IO_RAW)?;
+        let fn_ptr = kernel.sys_read;
+        let kptr = kernel.kernel_ptr as usize;
+        tokio::task::spawn_blocking(move || {
+            let kptr = kptr as *const std::ffi::c_void;
+            let mut out_buf: *mut u8 = std::ptr::null_mut();
+            let mut out_len: usize = 0;
+            let rc = unsafe { (fn_ptr)(kptr, c_path.as_ptr(), &mut out_buf, &mut out_len) };
+            if rc != 0 {
+                return Err(rc);
+            }
+            consume_bytes_out(out_buf, out_len)
+        })
+        .await
+        .unwrap_or(Err(ERRNO_IO_RAW))
+    }
 
-/// Async wrapper around [`sys_readdir`].
-pub async fn sys_readdir_async(kernel: &KernelHandle, parent_path: &str) -> Result<String, i32> {
-    let c_path = CString::new(parent_path).map_err(|_| ERRNO_IO_RAW)?;
-    let fn_ptr = kernel.sys_readdir;
-    let kptr = kernel.kernel_ptr as usize;
-    tokio::task::spawn_blocking(move || {
-        let kptr = kptr as *const std::ffi::c_void;
-        let mut out_buf: *mut u8 = std::ptr::null_mut();
-        let mut out_len: usize = 0;
-        let rc = unsafe { (fn_ptr)(kptr, c_path.as_ptr(), &mut out_buf, &mut out_len) };
-        if rc != 0 {
-            return Err(rc);
-        }
-        consume_string_out(out_buf, out_len)
-    })
-    .await
-    .unwrap_or(Err(ERRNO_IO_RAW))
-}
+    /// Async wrapper around [`sys_write`].
+    pub async fn sys_write_async(
+        kernel: &KernelHandle,
+        path: &str,
+        data: &[u8],
+    ) -> Result<(), i32> {
+        let c_path = CString::new(path).map_err(|_| ERRNO_IO_RAW)?;
+        let fn_ptr = kernel.sys_write;
+        let kptr = kernel.kernel_ptr as usize;
+        // Copy data into an owned Vec so it can move into the closure.
+        let owned_data = data.to_vec();
+        tokio::task::spawn_blocking(move || {
+            let kptr = kptr as *const std::ffi::c_void;
+            let rc =
+                unsafe { (fn_ptr)(kptr, c_path.as_ptr(), owned_data.as_ptr(), owned_data.len()) };
+            if rc != 0 {
+                return Err(rc);
+            }
+            Ok(())
+        })
+        .await
+        .unwrap_or(Err(ERRNO_IO_RAW))
+    }
 
-/// Async wrapper around [`sys_unlink`].
-pub async fn sys_unlink_async(kernel: &KernelHandle, path: &str) -> Result<(), i32> {
-    let c_path = CString::new(path).map_err(|_| ERRNO_IO_RAW)?;
-    let fn_ptr = kernel.sys_unlink;
-    let kptr = kernel.kernel_ptr as usize;
-    tokio::task::spawn_blocking(move || {
-        let kptr = kptr as *const std::ffi::c_void;
-        let rc = unsafe { (fn_ptr)(kptr, c_path.as_ptr()) };
-        if rc != 0 {
-            return Err(rc);
-        }
-        Ok(())
-    })
-    .await
-    .unwrap_or(Err(ERRNO_IO_RAW))
-}
+    /// Async wrapper around [`sys_readdir`].
+    pub async fn sys_readdir_async(
+        kernel: &KernelHandle,
+        parent_path: &str,
+    ) -> Result<String, i32> {
+        let c_path = CString::new(parent_path).map_err(|_| ERRNO_IO_RAW)?;
+        let fn_ptr = kernel.sys_readdir;
+        let kptr = kernel.kernel_ptr as usize;
+        tokio::task::spawn_blocking(move || {
+            let kptr = kptr as *const std::ffi::c_void;
+            let mut out_buf: *mut u8 = std::ptr::null_mut();
+            let mut out_len: usize = 0;
+            let rc = unsafe { (fn_ptr)(kptr, c_path.as_ptr(), &mut out_buf, &mut out_len) };
+            if rc != 0 {
+                return Err(rc);
+            }
+            consume_string_out(out_buf, out_len)
+        })
+        .await
+        .unwrap_or(Err(ERRNO_IO_RAW))
+    }
 
-/// Async wrapper around [`sys_mkdir`].
-pub async fn sys_mkdir_async(kernel: &KernelHandle, path: &str) -> Result<(), i32> {
-    let c_path = CString::new(path).map_err(|_| ERRNO_IO_RAW)?;
-    let fn_ptr = kernel.sys_mkdir;
-    let kptr = kernel.kernel_ptr as usize;
-    tokio::task::spawn_blocking(move || {
-        let kptr = kptr as *const std::ffi::c_void;
-        let rc = unsafe { (fn_ptr)(kptr, c_path.as_ptr()) };
-        if rc != 0 {
-            return Err(rc);
-        }
-        Ok(())
-    })
-    .await
-    .unwrap_or(Err(ERRNO_IO_RAW))
-}
+    /// Async wrapper around [`sys_unlink`].
+    pub async fn sys_unlink_async(kernel: &KernelHandle, path: &str) -> Result<(), i32> {
+        let c_path = CString::new(path).map_err(|_| ERRNO_IO_RAW)?;
+        let fn_ptr = kernel.sys_unlink;
+        let kptr = kernel.kernel_ptr as usize;
+        tokio::task::spawn_blocking(move || {
+            let kptr = kptr as *const std::ffi::c_void;
+            let rc = unsafe { (fn_ptr)(kptr, c_path.as_ptr()) };
+            if rc != 0 {
+                return Err(rc);
+            }
+            Ok(())
+        })
+        .await
+        .unwrap_or(Err(ERRNO_IO_RAW))
+    }
 
-/// Async wrapper around [`sys_rmdir`].
-pub async fn sys_rmdir_async(kernel: &KernelHandle, path: &str) -> Result<(), i32> {
-    let c_path = CString::new(path).map_err(|_| ERRNO_IO_RAW)?;
-    let fn_ptr = kernel.sys_rmdir;
-    let kptr = kernel.kernel_ptr as usize;
-    tokio::task::spawn_blocking(move || {
-        let kptr = kptr as *const std::ffi::c_void;
-        let rc = unsafe { (fn_ptr)(kptr, c_path.as_ptr()) };
-        if rc != 0 {
-            return Err(rc);
-        }
-        Ok(())
-    })
-    .await
-    .unwrap_or(Err(ERRNO_IO_RAW))
-}
+    /// Async wrapper around [`sys_mkdir`].
+    pub async fn sys_mkdir_async(kernel: &KernelHandle, path: &str) -> Result<(), i32> {
+        let c_path = CString::new(path).map_err(|_| ERRNO_IO_RAW)?;
+        let fn_ptr = kernel.sys_mkdir;
+        let kptr = kernel.kernel_ptr as usize;
+        tokio::task::spawn_blocking(move || {
+            let kptr = kptr as *const std::ffi::c_void;
+            let rc = unsafe { (fn_ptr)(kptr, c_path.as_ptr()) };
+            if rc != 0 {
+                return Err(rc);
+            }
+            Ok(())
+        })
+        .await
+        .unwrap_or(Err(ERRNO_IO_RAW))
+    }
 
-/// Async wrapper around [`sys_rename`].
-pub async fn sys_rename_async(
-    kernel: &KernelHandle,
-    old_path: &str,
-    new_path: &str,
-) -> Result<(), i32> {
-    let c_old = CString::new(old_path).map_err(|_| ERRNO_IO_RAW)?;
-    let c_new = CString::new(new_path).map_err(|_| ERRNO_IO_RAW)?;
-    let fn_ptr = kernel.sys_rename;
-    let kptr = kernel.kernel_ptr as usize;
-    tokio::task::spawn_blocking(move || {
-        let kptr = kptr as *const std::ffi::c_void;
-        let rc = unsafe { (fn_ptr)(kptr, c_old.as_ptr(), c_new.as_ptr()) };
-        if rc != 0 {
-            return Err(rc);
-        }
-        Ok(())
-    })
-    .await
-    .unwrap_or(Err(ERRNO_IO_RAW))
+    /// Async wrapper around [`sys_rmdir`].
+    pub async fn sys_rmdir_async(kernel: &KernelHandle, path: &str) -> Result<(), i32> {
+        let c_path = CString::new(path).map_err(|_| ERRNO_IO_RAW)?;
+        let fn_ptr = kernel.sys_rmdir;
+        let kptr = kernel.kernel_ptr as usize;
+        tokio::task::spawn_blocking(move || {
+            let kptr = kptr as *const std::ffi::c_void;
+            let rc = unsafe { (fn_ptr)(kptr, c_path.as_ptr()) };
+            if rc != 0 {
+                return Err(rc);
+            }
+            Ok(())
+        })
+        .await
+        .unwrap_or(Err(ERRNO_IO_RAW))
+    }
+
+    /// Async wrapper around [`sys_rename`].
+    pub async fn sys_rename_async(
+        kernel: &KernelHandle,
+        old_path: &str,
+        new_path: &str,
+    ) -> Result<(), i32> {
+        let c_old = CString::new(old_path).map_err(|_| ERRNO_IO_RAW)?;
+        let c_new = CString::new(new_path).map_err(|_| ERRNO_IO_RAW)?;
+        let fn_ptr = kernel.sys_rename;
+        let kptr = kernel.kernel_ptr as usize;
+        tokio::task::spawn_blocking(move || {
+            let kptr = kptr as *const std::ffi::c_void;
+            let rc = unsafe { (fn_ptr)(kptr, c_old.as_ptr(), c_new.as_ptr()) };
+            if rc != 0 {
+                return Err(rc);
+            }
+            Ok(())
+        })
+        .await
+        .unwrap_or(Err(ERRNO_IO_RAW))
+    }
 }
 
 // ── kernel-side JSON shape parsers ──────────────────────────────────

--- a/rust/services/fuse-plugin/src/kernel_callbacks.rs
+++ b/rust/services/fuse-plugin/src/kernel_callbacks.rs
@@ -329,11 +329,7 @@ pub async fn sys_read_async(kernel: &KernelHandle, path: &str) -> Result<Vec<u8>
 }
 
 /// Async wrapper around [`sys_write`].
-pub async fn sys_write_async(
-    kernel: &KernelHandle,
-    path: &str,
-    data: &[u8],
-) -> Result<(), i32> {
+pub async fn sys_write_async(kernel: &KernelHandle, path: &str, data: &[u8]) -> Result<(), i32> {
     let c_path = CString::new(path).map_err(|_| ERRNO_IO_RAW)?;
     let fn_ptr = kernel.sys_write;
     let kptr = kernel.kernel_ptr as usize;
@@ -341,8 +337,7 @@ pub async fn sys_write_async(
     let owned_data = data.to_vec();
     tokio::task::spawn_blocking(move || {
         let kptr = kptr as *const std::ffi::c_void;
-        let rc =
-            unsafe { (fn_ptr)(kptr, c_path.as_ptr(), owned_data.as_ptr(), owned_data.len()) };
+        let rc = unsafe { (fn_ptr)(kptr, c_path.as_ptr(), owned_data.as_ptr(), owned_data.len()) };
         if rc != 0 {
             return Err(rc);
         }
@@ -353,10 +348,7 @@ pub async fn sys_write_async(
 }
 
 /// Async wrapper around [`sys_readdir`].
-pub async fn sys_readdir_async(
-    kernel: &KernelHandle,
-    parent_path: &str,
-) -> Result<String, i32> {
+pub async fn sys_readdir_async(kernel: &KernelHandle, parent_path: &str) -> Result<String, i32> {
     let c_path = CString::new(parent_path).map_err(|_| ERRNO_IO_RAW)?;
     let fn_ptr = kernel.sys_readdir;
     let kptr = kernel.kernel_ptr as usize;

--- a/rust/services/fuse-plugin/src/kernel_callbacks.rs
+++ b/rust/services/fuse-plugin/src/kernel_callbacks.rs
@@ -272,6 +272,181 @@ pub fn sys_rename(kernel: &KernelHandle, old_path: &str, new_path: &str) -> Resu
     Ok(())
 }
 
+// ── async wrappers (spawn_blocking) ────────────────────────────────
+//
+// Each function copies the relevant function pointer + `kernel_ptr`
+// into the closure, allocates `CString` arguments on the caller's
+// async thread, then moves everything into `spawn_blocking` so the
+// C FFI call runs on a blocking OS thread instead of a tokio worker.
+//
+// `kernel_ptr` (`*const c_void`) is not `Send`, but `KernelHandle`
+// has `unsafe impl Send+Sync` — the kernel guarantees the pointer
+// stays valid across threads.  We cast to `usize` to satisfy
+// `spawn_blocking`'s `Send` bound, then cast back inside the
+// closure.
+//
+// This prevents NFS async methods from starving the 2-thread tokio
+// runtime when kernel callbacks take > 0 time (Raft consensus,
+// redb I/O, etc.).
+
+/// Async wrapper around [`sys_stat`] — runs the C FFI call on a
+/// blocking thread via `tokio::task::spawn_blocking`.
+pub async fn sys_stat_async(kernel: &KernelHandle, path: &str) -> Result<String, i32> {
+    let c_path = CString::new(path).map_err(|_| ERRNO_IO_RAW)?;
+    let fn_ptr = kernel.sys_stat;
+    let kptr = kernel.kernel_ptr as usize;
+    tokio::task::spawn_blocking(move || {
+        let kptr = kptr as *const std::ffi::c_void;
+        let mut out_buf: *mut u8 = std::ptr::null_mut();
+        let mut out_len: usize = 0;
+        let rc = unsafe { (fn_ptr)(kptr, c_path.as_ptr(), &mut out_buf, &mut out_len) };
+        if rc != 0 {
+            return Err(rc);
+        }
+        consume_string_out(out_buf, out_len)
+    })
+    .await
+    .unwrap_or(Err(ERRNO_IO_RAW))
+}
+
+/// Async wrapper around [`sys_read`].
+pub async fn sys_read_async(kernel: &KernelHandle, path: &str) -> Result<Vec<u8>, i32> {
+    let c_path = CString::new(path).map_err(|_| ERRNO_IO_RAW)?;
+    let fn_ptr = kernel.sys_read;
+    let kptr = kernel.kernel_ptr as usize;
+    tokio::task::spawn_blocking(move || {
+        let kptr = kptr as *const std::ffi::c_void;
+        let mut out_buf: *mut u8 = std::ptr::null_mut();
+        let mut out_len: usize = 0;
+        let rc = unsafe { (fn_ptr)(kptr, c_path.as_ptr(), &mut out_buf, &mut out_len) };
+        if rc != 0 {
+            return Err(rc);
+        }
+        consume_bytes_out(out_buf, out_len)
+    })
+    .await
+    .unwrap_or(Err(ERRNO_IO_RAW))
+}
+
+/// Async wrapper around [`sys_write`].
+pub async fn sys_write_async(
+    kernel: &KernelHandle,
+    path: &str,
+    data: &[u8],
+) -> Result<(), i32> {
+    let c_path = CString::new(path).map_err(|_| ERRNO_IO_RAW)?;
+    let fn_ptr = kernel.sys_write;
+    let kptr = kernel.kernel_ptr as usize;
+    // Copy data into an owned Vec so it can move into the closure.
+    let owned_data = data.to_vec();
+    tokio::task::spawn_blocking(move || {
+        let kptr = kptr as *const std::ffi::c_void;
+        let rc =
+            unsafe { (fn_ptr)(kptr, c_path.as_ptr(), owned_data.as_ptr(), owned_data.len()) };
+        if rc != 0 {
+            return Err(rc);
+        }
+        Ok(())
+    })
+    .await
+    .unwrap_or(Err(ERRNO_IO_RAW))
+}
+
+/// Async wrapper around [`sys_readdir`].
+pub async fn sys_readdir_async(
+    kernel: &KernelHandle,
+    parent_path: &str,
+) -> Result<String, i32> {
+    let c_path = CString::new(parent_path).map_err(|_| ERRNO_IO_RAW)?;
+    let fn_ptr = kernel.sys_readdir;
+    let kptr = kernel.kernel_ptr as usize;
+    tokio::task::spawn_blocking(move || {
+        let kptr = kptr as *const std::ffi::c_void;
+        let mut out_buf: *mut u8 = std::ptr::null_mut();
+        let mut out_len: usize = 0;
+        let rc = unsafe { (fn_ptr)(kptr, c_path.as_ptr(), &mut out_buf, &mut out_len) };
+        if rc != 0 {
+            return Err(rc);
+        }
+        consume_string_out(out_buf, out_len)
+    })
+    .await
+    .unwrap_or(Err(ERRNO_IO_RAW))
+}
+
+/// Async wrapper around [`sys_unlink`].
+pub async fn sys_unlink_async(kernel: &KernelHandle, path: &str) -> Result<(), i32> {
+    let c_path = CString::new(path).map_err(|_| ERRNO_IO_RAW)?;
+    let fn_ptr = kernel.sys_unlink;
+    let kptr = kernel.kernel_ptr as usize;
+    tokio::task::spawn_blocking(move || {
+        let kptr = kptr as *const std::ffi::c_void;
+        let rc = unsafe { (fn_ptr)(kptr, c_path.as_ptr()) };
+        if rc != 0 {
+            return Err(rc);
+        }
+        Ok(())
+    })
+    .await
+    .unwrap_or(Err(ERRNO_IO_RAW))
+}
+
+/// Async wrapper around [`sys_mkdir`].
+pub async fn sys_mkdir_async(kernel: &KernelHandle, path: &str) -> Result<(), i32> {
+    let c_path = CString::new(path).map_err(|_| ERRNO_IO_RAW)?;
+    let fn_ptr = kernel.sys_mkdir;
+    let kptr = kernel.kernel_ptr as usize;
+    tokio::task::spawn_blocking(move || {
+        let kptr = kptr as *const std::ffi::c_void;
+        let rc = unsafe { (fn_ptr)(kptr, c_path.as_ptr()) };
+        if rc != 0 {
+            return Err(rc);
+        }
+        Ok(())
+    })
+    .await
+    .unwrap_or(Err(ERRNO_IO_RAW))
+}
+
+/// Async wrapper around [`sys_rmdir`].
+pub async fn sys_rmdir_async(kernel: &KernelHandle, path: &str) -> Result<(), i32> {
+    let c_path = CString::new(path).map_err(|_| ERRNO_IO_RAW)?;
+    let fn_ptr = kernel.sys_rmdir;
+    let kptr = kernel.kernel_ptr as usize;
+    tokio::task::spawn_blocking(move || {
+        let kptr = kptr as *const std::ffi::c_void;
+        let rc = unsafe { (fn_ptr)(kptr, c_path.as_ptr()) };
+        if rc != 0 {
+            return Err(rc);
+        }
+        Ok(())
+    })
+    .await
+    .unwrap_or(Err(ERRNO_IO_RAW))
+}
+
+/// Async wrapper around [`sys_rename`].
+pub async fn sys_rename_async(
+    kernel: &KernelHandle,
+    old_path: &str,
+    new_path: &str,
+) -> Result<(), i32> {
+    let c_old = CString::new(old_path).map_err(|_| ERRNO_IO_RAW)?;
+    let c_new = CString::new(new_path).map_err(|_| ERRNO_IO_RAW)?;
+    let fn_ptr = kernel.sys_rename;
+    let kptr = kernel.kernel_ptr as usize;
+    tokio::task::spawn_blocking(move || {
+        let kptr = kptr as *const std::ffi::c_void;
+        let rc = unsafe { (fn_ptr)(kptr, c_old.as_ptr(), c_new.as_ptr()) };
+        if rc != 0 {
+            return Err(rc);
+        }
+        Ok(())
+    })
+    .await
+    .unwrap_or(Err(ERRNO_IO_RAW))
+}
+
 // ── kernel-side JSON shape parsers ──────────────────────────────────
 //
 // The kernel hand-rolls JSON in the C callbacks (no serde_json on the

--- a/rust/services/fuse-plugin/tests/nfs_integration.rs
+++ b/rust/services/fuse-plugin/tests/nfs_integration.rs
@@ -559,6 +559,373 @@ async fn readdir_root_empty_when_vfs_path_missing() {
     assert!(result.end);
 }
 
+// ── Slow-callback mock for starvation tests ──────────────────────
+//
+// Same in-memory storage as MockKernel, but `sys_stat` sleeps for a
+// configurable duration to simulate real kernel I/O (Raft consensus,
+// redb reads).  This proves `spawn_blocking` prevents tokio worker
+// starvation: with only 2 tokio workers, N concurrent slow stats
+// would serialize (N/2 × delay) if run directly on the workers, but
+// complete in ~1×delay when offloaded to the blocking thread pool.
+
+use std::sync::atomic::AtomicU64 as AU64;
+use std::time::{Duration, Instant};
+
+struct SlowMockKernel {
+    entries: Mutex<HashMap<String, MockEntry>>,
+    /// Per-stat sleep duration (simulates real kernel I/O latency).
+    stat_delay: Duration,
+    /// Counter: how many stat calls have completed.
+    stat_count: AU64,
+}
+
+impl SlowMockKernel {
+    fn new(stat_delay: Duration) -> Self {
+        let mut entries = HashMap::new();
+        entries.insert(
+            "/".to_string(),
+            MockEntry {
+                is_dir: true,
+                data: vec![],
+            },
+        );
+        Self {
+            entries: Mutex::new(entries),
+            stat_delay,
+            stat_count: AU64::new(0),
+        }
+    }
+}
+
+/// Slow `sys_stat` — sleeps `stat_delay` before responding.
+unsafe extern "C" fn slow_mock_sys_stat(
+    kernel: *const c_void,
+    path: *const c_char,
+    out_buf: *mut *mut u8,
+    out_len: *mut usize,
+) -> i32 {
+    let mock = &*(kernel as *const SlowMockKernel);
+    // Simulate blocking kernel I/O.
+    std::thread::sleep(mock.stat_delay);
+    mock.stat_count
+        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let path_str = CStr::from_ptr(path).to_str().unwrap();
+    let entries = mock.entries.lock().unwrap();
+    match entries.get(path_str) {
+        Some(entry) => {
+            let entry_type = if entry.is_dir { 1u64 } else { 0u64 };
+            let json = format!(
+                r#"{{"path":"{}","entry_type":{},"size":{},"zone_id":"root"}}"#,
+                path_str,
+                entry_type,
+                entry.data.len()
+            );
+            write_out(out_buf, out_len, json.as_bytes());
+            0
+        }
+        None => -1,
+    }
+}
+
+/// Slow `sys_write` — sleeps `stat_delay` before responding.
+unsafe extern "C" fn slow_mock_sys_write(
+    kernel: *const c_void,
+    path: *const c_char,
+    data: *const u8,
+    data_len: usize,
+) -> i32 {
+    let mock = &*(kernel as *const SlowMockKernel);
+    std::thread::sleep(mock.stat_delay);
+    let path_str = CStr::from_ptr(path).to_str().unwrap();
+    let content = std::slice::from_raw_parts(data, data_len).to_vec();
+    let mut entries = mock.entries.lock().unwrap();
+    entries.insert(
+        path_str.to_string(),
+        MockEntry {
+            is_dir: false,
+            data: content,
+        },
+    );
+    0
+}
+
+/// Slow `sys_read` — sleeps `stat_delay` before responding.
+unsafe extern "C" fn slow_mock_sys_read(
+    kernel: *const c_void,
+    path: *const c_char,
+    out_buf: *mut *mut u8,
+    out_len: *mut usize,
+) -> i32 {
+    let mock = &*(kernel as *const SlowMockKernel);
+    std::thread::sleep(mock.stat_delay);
+    let path_str = CStr::from_ptr(path).to_str().unwrap();
+    let entries = mock.entries.lock().unwrap();
+    match entries.get(path_str) {
+        Some(entry) if !entry.is_dir => {
+            write_out(out_buf, out_len, &entry.data);
+            0
+        }
+        _ => -1,
+    }
+}
+
+fn slow_mock_kernel_handle(mock: &SlowMockKernel) -> KernelHandle {
+    KernelHandle {
+        sys_read: slow_mock_sys_read,
+        sys_write: slow_mock_sys_write,
+        sys_stat: slow_mock_sys_stat,
+        // readdir/unlink/mkdir/rmdir/rename use the fast mock —
+        // only stat/read/write need to be slow to prove the point.
+        sys_readdir: mock_sys_readdir_for_slow,
+        sys_unlink: mock_sys_unlink_for_slow,
+        sys_mkdir: mock_sys_mkdir_for_slow,
+        sys_rmdir: mock_sys_rmdir_for_slow,
+        sys_rename: mock_sys_rename_for_slow,
+        sys_stat_batch: mock_sys_stat_batch_for_slow,
+        kernel_ptr: mock as *const SlowMockKernel as *const c_void,
+    }
+}
+
+// Thin forwarding stubs — SlowMockKernel has the same entry layout as
+// MockKernel, so we can reuse the logic with the right cast.
+unsafe extern "C" fn mock_sys_readdir_for_slow(
+    kernel: *const c_void,
+    parent_path: *const c_char,
+    out_buf: *mut *mut u8,
+    out_len: *mut usize,
+) -> i32 {
+    let mock = &*(kernel as *const SlowMockKernel);
+    let parent = CStr::from_ptr(parent_path).to_str().unwrap();
+    let entries = mock.entries.lock().unwrap();
+    if !entries.contains_key(parent) {
+        return -1;
+    }
+    let prefix = if parent == "/" {
+        "/".to_string()
+    } else {
+        format!("{}/", parent)
+    };
+    let mut children = Vec::new();
+    for (path, entry) in entries.iter() {
+        if path == parent {
+            continue;
+        }
+        if let Some(name) = path.strip_prefix(&prefix) {
+            if !name.contains('/') {
+                let entry_type = if entry.is_dir { 1 } else { 0 };
+                children.push(format!(
+                    r#"{{"name":"{}","entry_type":{}}}"#,
+                    name, entry_type
+                ));
+            }
+        }
+    }
+    let json = format!("[{}]", children.join(","));
+    write_out(out_buf, out_len, json.as_bytes());
+    0
+}
+
+unsafe extern "C" fn mock_sys_unlink_for_slow(
+    kernel: *const c_void,
+    path: *const c_char,
+) -> i32 {
+    let mock = &*(kernel as *const SlowMockKernel);
+    let path_str = CStr::from_ptr(path).to_str().unwrap();
+    let mut entries = mock.entries.lock().unwrap();
+    match entries.remove(path_str) {
+        Some(_) => 0,
+        None => -1,
+    }
+}
+
+unsafe extern "C" fn mock_sys_mkdir_for_slow(
+    kernel: *const c_void,
+    path: *const c_char,
+) -> i32 {
+    let mock = &*(kernel as *const SlowMockKernel);
+    let path_str = CStr::from_ptr(path).to_str().unwrap();
+    let mut entries = mock.entries.lock().unwrap();
+    if entries.contains_key(path_str) {
+        return -3;
+    }
+    entries.insert(
+        path_str.to_string(),
+        MockEntry {
+            is_dir: true,
+            data: vec![],
+        },
+    );
+    0
+}
+
+unsafe extern "C" fn mock_sys_rmdir_for_slow(
+    kernel: *const c_void,
+    path: *const c_char,
+) -> i32 {
+    let mock = &*(kernel as *const SlowMockKernel);
+    let path_str = CStr::from_ptr(path).to_str().unwrap();
+    let mut entries = mock.entries.lock().unwrap();
+    match entries.remove(path_str) {
+        Some(e) if e.is_dir => 0,
+        Some(e) => {
+            entries.insert(path_str.to_string(), e);
+            -2
+        }
+        None => -1,
+    }
+}
+
+unsafe extern "C" fn mock_sys_rename_for_slow(
+    kernel: *const c_void,
+    old_path: *const c_char,
+    new_path: *const c_char,
+) -> i32 {
+    let mock = &*(kernel as *const SlowMockKernel);
+    let old = CStr::from_ptr(old_path).to_str().unwrap();
+    let new = CStr::from_ptr(new_path).to_str().unwrap();
+    let mut entries = mock.entries.lock().unwrap();
+    match entries.remove(old) {
+        Some(entry) => {
+            entries.insert(new.to_string(), entry);
+            0
+        }
+        None => -1,
+    }
+}
+
+unsafe extern "C" fn mock_sys_stat_batch_for_slow(
+    _kernel: *const c_void,
+    _paths_json: *const c_char,
+    out_buf: *mut *mut u8,
+    out_len: *mut usize,
+) -> i32 {
+    write_out(out_buf, out_len, b"[]");
+    0
+}
+
+/// **Core starvation regression test.**
+///
+/// Proves that `spawn_blocking` wrappers prevent tokio worker
+/// starvation with slow kernel callbacks.
+///
+/// Setup:
+/// - 2 tokio worker threads (matches production NFS runtime)
+/// - Mock callbacks that sleep 50ms per call (simulates Raft/redb)
+/// - 10 concurrent getattr calls
+///
+/// Expected behavior:
+/// - **With spawn_blocking (current code):** All 10 stats run in
+///   parallel on the blocking thread pool.  Wall time ≈ 50–150ms.
+/// - **Without spawn_blocking (bug):** Only 2 stats can run at a
+///   time (both tokio workers blocked).  Wall time ≈ 250ms+.
+///
+/// We assert wall time < 200ms — tight enough to catch the 5×
+/// serialization but loose enough for CI jitter.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn spawn_blocking_prevents_starvation() {
+    let delay = Duration::from_millis(50);
+    let mock = Box::new(SlowMockKernel::new(delay));
+    let handle = slow_mock_kernel_handle(&mock);
+    let nfs = std::sync::Arc::new(NexusNfs::new(handle, "/".to_string()));
+
+    let n = 10usize;
+    let start = Instant::now();
+
+    let mut tasks = Vec::new();
+    for _ in 0..n {
+        let nfs = nfs.clone();
+        tasks.push(tokio::spawn(async move {
+            // getattr(root) calls sys_stat_async internally.
+            nfs.getattr(nfs.root_dir()).await.unwrap();
+        }));
+    }
+    for t in tasks {
+        t.await.unwrap();
+    }
+
+    let elapsed = start.elapsed();
+
+    // If spawn_blocking works: ~50ms (parallel).
+    // If broken (sync on tokio): ~250ms (10/2 × 50ms serialized).
+    // Use 200ms threshold — generous for CI but still catches 5× regression.
+    assert!(
+        elapsed < Duration::from_millis(200),
+        "10 concurrent stats with 50ms delay took {:?} — \
+         spawn_blocking may not be working (expected < 200ms)",
+        elapsed
+    );
+
+    // Verify all 10 stat calls actually executed (not short-circuited).
+    let count = mock
+        .stat_count
+        .load(std::sync::atomic::Ordering::Relaxed);
+    assert_eq!(
+        count, n as u64,
+        "expected {n} stat calls, got {count}"
+    );
+}
+
+/// Full concurrent lifecycle with slow callbacks — create + write +
+/// read across 10 files in parallel on a 2-worker runtime.
+///
+/// Each file touches 3 slow syscalls (write for create, stat for
+/// fattr, read) = 30 slow calls total.  Without spawn_blocking on
+/// 2 workers this would take 30/2 × 50ms = 750ms.  With
+/// spawn_blocking: ~150ms (3 sequential slow calls per file, all
+/// files in parallel).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn concurrent_slow_lifecycle() {
+    let delay = Duration::from_millis(50);
+    let mock = Box::new(SlowMockKernel::new(delay));
+    let handle = slow_mock_kernel_handle(&mock);
+    let nfs = std::sync::Arc::new(NexusNfs::new(handle, "/".to_string()));
+
+    let n = 10usize;
+    let start = Instant::now();
+
+    let mut tasks = Vec::new();
+    for i in 0..n {
+        let nfs = nfs.clone();
+        tasks.push(tokio::spawn(async move {
+            let root = nfs.root_dir();
+            let fname: nfsserve::nfs::filename3 =
+                format!("slow-{i}.txt").as_bytes().into();
+
+            // Create (write + stat).
+            let (fid, _) = nfs
+                .create(root, &fname, Default::default())
+                .await
+                .unwrap();
+
+            // Write content (write + stat).
+            let payload = format!("payload-{i}");
+            nfs.write(fid, 0, payload.as_bytes()).await.unwrap();
+
+            // Read back.
+            let (data, eof) = nfs.read(fid, 0, 4096).await.unwrap();
+            assert_eq!(data, payload.as_bytes());
+            assert!(eof);
+        }));
+    }
+    for t in tasks {
+        t.await.unwrap();
+    }
+
+    let elapsed = start.elapsed();
+
+    // 5 slow calls per file (create=write+stat, write=write+stat, read),
+    // sequential per file but all files in parallel.
+    // With spawn_blocking: ~250ms (5 × 50ms sequential per file).
+    // Without (2 workers): ~1250ms (50 calls / 2 × 50ms).
+    // Use 500ms threshold.
+    assert!(
+        elapsed < Duration::from_millis(500),
+        "10 concurrent file lifecycles with 50ms delay took {:?} — \
+         spawn_blocking may not be working (expected < 500ms)",
+        elapsed
+    );
+}
+
 /// Non-root inode getattr must still return NOENT for missing paths
 /// (only root gets the synthetic fallback).
 #[tokio::test]

--- a/rust/services/fuse-plugin/tests/nfs_integration.rs
+++ b/rust/services/fuse-plugin/tests/nfs_integration.rs
@@ -725,10 +725,7 @@ unsafe extern "C" fn mock_sys_readdir_for_slow(
     0
 }
 
-unsafe extern "C" fn mock_sys_unlink_for_slow(
-    kernel: *const c_void,
-    path: *const c_char,
-) -> i32 {
+unsafe extern "C" fn mock_sys_unlink_for_slow(kernel: *const c_void, path: *const c_char) -> i32 {
     let mock = &*(kernel as *const SlowMockKernel);
     let path_str = CStr::from_ptr(path).to_str().unwrap();
     let mut entries = mock.entries.lock().unwrap();
@@ -738,10 +735,7 @@ unsafe extern "C" fn mock_sys_unlink_for_slow(
     }
 }
 
-unsafe extern "C" fn mock_sys_mkdir_for_slow(
-    kernel: *const c_void,
-    path: *const c_char,
-) -> i32 {
+unsafe extern "C" fn mock_sys_mkdir_for_slow(kernel: *const c_void, path: *const c_char) -> i32 {
     let mock = &*(kernel as *const SlowMockKernel);
     let path_str = CStr::from_ptr(path).to_str().unwrap();
     let mut entries = mock.entries.lock().unwrap();
@@ -758,10 +752,7 @@ unsafe extern "C" fn mock_sys_mkdir_for_slow(
     0
 }
 
-unsafe extern "C" fn mock_sys_rmdir_for_slow(
-    kernel: *const c_void,
-    path: *const c_char,
-) -> i32 {
+unsafe extern "C" fn mock_sys_rmdir_for_slow(kernel: *const c_void, path: *const c_char) -> i32 {
     let mock = &*(kernel as *const SlowMockKernel);
     let path_str = CStr::from_ptr(path).to_str().unwrap();
     let mut entries = mock.entries.lock().unwrap();
@@ -856,13 +847,8 @@ async fn spawn_blocking_prevents_starvation() {
     );
 
     // Verify all 10 stat calls actually executed (not short-circuited).
-    let count = mock
-        .stat_count
-        .load(std::sync::atomic::Ordering::Relaxed);
-    assert_eq!(
-        count, n as u64,
-        "expected {n} stat calls, got {count}"
-    );
+    let count = mock.stat_count.load(std::sync::atomic::Ordering::Relaxed);
+    assert_eq!(count, n as u64, "expected {n} stat calls, got {count}");
 }
 
 /// Full concurrent lifecycle with slow callbacks — create + write +
@@ -888,14 +874,10 @@ async fn concurrent_slow_lifecycle() {
         let nfs = nfs.clone();
         tasks.push(tokio::spawn(async move {
             let root = nfs.root_dir();
-            let fname: nfsserve::nfs::filename3 =
-                format!("slow-{i}.txt").as_bytes().into();
+            let fname: nfsserve::nfs::filename3 = format!("slow-{i}.txt").as_bytes().into();
 
             // Create (write + stat).
-            let (fid, _) = nfs
-                .create(root, &fname, Default::default())
-                .await
-                .unwrap();
+            let (fid, _) = nfs.create(root, &fname, Default::default()).await.unwrap();
 
             // Write content (write + stat).
             let payload = format!("payload-{i}");


### PR DESCRIPTION
## Summary
- Wrap all NFS `kernel_callbacks::sys_*` calls with `tokio::task::spawn_blocking` so C FFI runs on the blocking thread pool instead of the 2-thread tokio runtime
- Prevents macOS NFS "not responding / is alive again" spam under concurrent load
- Zero change to fuser (Linux/macOS FUSE) and WinFsp (Windows) sync callers

## Files Changed
- `kernel_callbacks.rs` — 8 new `sys_*_async` functions (spawn_blocking wrappers)
- `fs_nfs.rs` — All 11 NFS trait methods now use async wrappers
- `nfs_integration.rs` — 2 new starvation regression tests with slow mock callbacks

## Test plan
- [x] All 42 existing + new tests pass locally
- [x] `spawn_blocking_prevents_starvation`: 10 concurrent 50ms stats on 2-worker runtime complete in ~50ms (would be ~250ms serialized without fix)
- [x] `concurrent_slow_lifecycle`: 10 concurrent create+write+read with 50ms delays complete in ~270ms (would be ~1250ms serialized)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)