### PR TITLE
fix(ci): clear RUSTFLAGS for nexus-vfs cargo install

### DIFF
--- a/.github/workflows/api-surface.yml
+++ b/.github/workflows/api-surface.yml
@@ -236,7 +236,7 @@ jobs:
             echo "::error::could not extract nexus-vfs rev pin from Cargo.toml"
             exit 1
           fi
-          cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "$REV" --bin nexusd-cluster nexus-cluster
+          RUSTFLAGS="" cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "$REV" --bin nexusd-cluster nexus-cluster
 
       - name: Validate API/RPC surface matrix
         if: steps.surface-filter.outputs.surface == 'true'

--- a/.github/workflows/fuse-plugin-macos-nfs-e2e.yml
+++ b/.github/workflows/fuse-plugin-macos-nfs-e2e.yml
@@ -137,7 +137,7 @@ jobs:
           REV: ${{ steps.vfs_rev.outputs.sha }}
         run: |
           set -euo pipefail
-          cargo install --locked \
+          RUSTFLAGS="" cargo install --locked \
             --git https://github.com/nexi-lab/nexus-vfs \
             --rev "$REV" \
             --bin nexusd-cluster nexus-cluster

--- a/.github/workflows/fuse-plugin-windows-e2e.yml
+++ b/.github/workflows/fuse-plugin-windows-e2e.yml
@@ -142,7 +142,7 @@ jobs:
           REV: ${{ steps.vfs_rev.outputs.sha }}
         run: |
           set -euo pipefail
-          cargo install --locked \
+          RUSTFLAGS="" cargo install --locked \
             --git https://github.com/nexi-lab/nexus-vfs \
             --rev "$REV" \
             --bin nexusd-cluster nexus-cluster

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -201,7 +201,7 @@ jobs:
             echo "::error::could not extract nexus-vfs rev pin from Cargo.toml"
             exit 1
           fi
-          cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "$REV" --bin nexusd-cluster nexus-cluster
+          RUSTFLAGS="" cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "$REV" --bin nexusd-cluster nexus-cluster
           sudo ln -sf $(which nexusd-cluster) /usr/local/bin/nexus-cluster
 
       # Pre-build the nexus-server image once with buildx + GHA layer cache.
@@ -704,13 +704,13 @@ jobs:
             exit 1
           fi
           echo "Installing nexusd-cluster at pinned nexus-vfs rev $REV"
-          cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "$REV" --bin nexusd-cluster nexus-cluster
+          RUSTFLAGS="" cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "$REV" --bin nexusd-cluster nexus-cluster
           # Also install the full profile — the binary the Docker image
           # actually ships (nexusd-full, symlinked to nexus-cluster).
           # Same main.rs, but a full-profile-only build/feature
           # regression must not slip past the gate on the slim binary.
           echo "Installing nexusd-full at pinned nexus-vfs rev $REV"
-          cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "$REV" --bin nexusd-full nexus-full
+          RUSTFLAGS="" cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "$REV" --bin nexusd-full nexus-full
 
       - name: Boot smoke test
         if: needs.detect-changes.outputs.code_changed == 'true'


### PR DESCRIPTION
## Summary
- rustc 1.97 (released 2026-07-07, now on CI runners) + `RUSTFLAGS="-D warnings"` (set by setup-rust-toolchain) turns upstream nexus-vfs dead code warnings into errors
- `FileEvent.old_path`, `FileEvent.to_json()` are dead in certain platform configs
- Fix: `RUSTFLAGS=""` override on all `cargo install --git nexus-vfs` steps — we don't own upstream code quality
- Affects 4 workflow files, 6 `cargo install` invocations

## Root cause
The `actions-rust-lang/setup-rust-toolchain@v1` action sets `RUSTFLAGS="-D warnings"` globally. When CI compiles nexus-vfs from pinned rev, rustc 1.97's stricter dead_code lint catches `FileEvent` fields/methods that are unused in certain compilation targets. Previous CI runs either skipped the compile step (no code changes detected) or ran on rustc 1.96.

## Test plan
- [ ] CI all green on this PR (the fix is self-validating)

🤖 Generated with [Claude Code](https://claude.com/claude-code)