### PR TITLE
refactor: KernelAbi → KernelSyscall rename (nexus-vfs #147 + downstream)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=d0a11fa2d2fa3ae5ecbbc19f3a0537afce4f5c8c#d0a11fa2d2fa3ae5ecbbc19f3a0537afce4f5c8c"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=3350b1386d11214a7a132e23d3eb179d756b1dc9#3350b1386d11214a7a132e23d3eb179d756b1dc9"
 dependencies = [
  "ahash",
  "base64",
@@ -550,7 +550,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=d0a11fa2d2fa3ae5ecbbc19f3a0537afce4f5c8c#d0a11fa2d2fa3ae5ecbbc19f3a0537afce4f5c8c"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=3350b1386d11214a7a132e23d3eb179d756b1dc9#3350b1386d11214a7a132e23d3eb179d756b1dc9"
 dependencies = [
  "parking_lot",
  "serde",
@@ -1343,7 +1343,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=d0a11fa2d2fa3ae5ecbbc19f3a0537afce4f5c8c#d0a11fa2d2fa3ae5ecbbc19f3a0537afce4f5c8c"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=3350b1386d11214a7a132e23d3eb179d756b1dc9#3350b1386d11214a7a132e23d3eb179d756b1dc9"
 dependencies = [
  "ahash",
  "base64",
@@ -1394,7 +1394,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=d0a11fa2d2fa3ae5ecbbc19f3a0537afce4f5c8c#d0a11fa2d2fa3ae5ecbbc19f3a0537afce4f5c8c"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=3350b1386d11214a7a132e23d3eb179d756b1dc9#3350b1386d11214a7a132e23d3eb179d756b1dc9"
 dependencies = [
  "ahash",
  "base64",
@@ -1589,7 +1589,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=d0a11fa2d2fa3ae5ecbbc19f3a0537afce4f5c8c#d0a11fa2d2fa3ae5ecbbc19f3a0537afce4f5c8c"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=3350b1386d11214a7a132e23d3eb179d756b1dc9#3350b1386d11214a7a132e23d3eb179d756b1dc9"
 
 [[package]]
 name = "nexus-vault"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -209,13 +209,13 @@ exclude = ["nexus-fuse"]
 #
 # Bump alongside the rest of nexus-vfs updates when a downstream
 # change needs newer kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "d0a11fa2d2fa3ae5ecbbc19f3a0537afce4f5c8c" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "d0a11fa2d2fa3ae5ecbbc19f3a0537afce4f5c8c" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "d0a11fa2d2fa3ae5ecbbc19f3a0537afce4f5c8c" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "d0a11fa2d2fa3ae5ecbbc19f3a0537afce4f5c8c", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "d0a11fa2d2fa3ae5ecbbc19f3a0537afce4f5c8c", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "d0a11fa2d2fa3ae5ecbbc19f3a0537afce4f5c8c", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "d0a11fa2d2fa3ae5ecbbc19f3a0537afce4f5c8c" }
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "3350b1386d11214a7a132e23d3eb179d756b1dc9" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "3350b1386d11214a7a132e23d3eb179d756b1dc9" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "3350b1386d11214a7a132e23d3eb179d756b1dc9" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "3350b1386d11214a7a132e23d3eb179d756b1dc9", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "3350b1386d11214a7a132e23d3eb179d756b1dc9", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "3350b1386d11214a7a132e23d3eb179d756b1dc9", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "3350b1386d11214a7a132e23d3eb179d756b1dc9" }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ENV CARGO_NET_RETRY=10 \
     CARGO_HTTP_TIMEOUT=120
 # Override for edge/CI or a different pin: --build-arg NEXUS_VFS_REV=<sha|tag>
-ARG NEXUS_VFS_REV=d0a11fa2d2fa3ae5ecbbc19f3a0537afce4f5c8c
+ARG NEXUS_VFS_REV=3350b1386d11214a7a132e23d3eb179d756b1dc9
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,id=cargo-install-${TARGETARCH},target=/root/.cargo/target \

--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir --no-deps --prefix=/install .
 # enforces agreement) — an unpinned install tracks nexus-vfs HEAD and
 # ships an untested kernel (#4343). --locked honors the source tree's
 # Cargo.lock.
-ARG NEXUS_VFS_REV=d0a11fa2d2fa3ae5ecbbc19f3a0537afce4f5c8c
+ARG NEXUS_VFS_REV=3350b1386d11214a7a132e23d3eb179d756b1dc9
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-cluster nexus-cluster
 
 # -- Runtime stage --

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -25,7 +25,7 @@ WORKDIR /build
 # (CI preflight enforces agreement) — an unpinned install tracks HEAD
 # and can skew the raft contract against the cluster/witness images.
 # --locked honors the source tree's Cargo.lock.
-ARG NEXUS_VFS_REV=d0a11fa2d2fa3ae5ecbbc19f3a0537afce4f5c8c
+ARG NEXUS_VFS_REV=3350b1386d11214a7a132e23d3eb179d756b1dc9
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexus-raft-server raft
 
 # ---------- Production image ----------

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=d0a11fa2d2fa3ae5ecbbc19f3a0537afce4f5c8c
+ARG NEXUS_VFS_REV=3350b1386d11214a7a132e23d3eb179d756b1dc9
 RUN cargo install \
     --locked \
     --git https://github.com/nexi-lab/nexus-vfs \

--- a/rust/services/src/acp/service.rs
+++ b/rust/services/src/acp/service.rs
@@ -35,7 +35,7 @@ use serde_json::{json, Value};
 
 use super::agent_config::AgentConfig;
 use super::paths;
-use kernel::abi::KernelAbi;
+use kernel::abi::KernelSyscall;
 use kernel::kernel::{Kernel, OperationContext};
 use kernel::service_registry::{RustCallError, RustService};
 
@@ -162,7 +162,7 @@ pub(crate) type OnTerminateCallback = Arc<dyn Fn(&str) + Send + Sync>;
 
 // ── Service ─────────────────────────────────────────────────────────────
 
-pub(crate) struct AcpService<K: KernelAbi> {
+pub(crate) struct AcpService<K: KernelSyscall> {
     kernel: Arc<K>,
     default_zone: String,
     agent_registry: RwLock<Option<Arc<dyn AgentRegistry>>>,
@@ -179,7 +179,7 @@ struct ActiveSession {
     fd_paths: [String; 3],
 }
 
-impl<K: KernelAbi> AcpService<K> {
+impl<K: KernelSyscall> AcpService<K> {
     pub(crate) const NAME: &'static str = "acp";
 
     pub(crate) fn new(kernel: Arc<K>, default_zone: String) -> Self {
@@ -414,9 +414,9 @@ impl AcpService<Kernel> {
 }
 
 // `persist_result` lives in the generic impl because its body only
-// touches the `KernelAbi` trait surface (`sys_write`); the
+// touches the `KernelSyscall` trait surface (`sys_write`); the
 // `call_agent` path (which is generic over K) needs to call it.
-impl<K: KernelAbi> AcpService<K> {
+impl<K: KernelSyscall> AcpService<K> {
     pub(crate) fn persist_result(
         &self,
         result: &AcpResult,
@@ -449,7 +449,7 @@ impl<K: KernelAbi> AcpService<K> {
 // ── call_agent (unix only — depends on AcpSubprocess) ──────────────────
 
 #[cfg(unix)]
-impl<K: KernelAbi> AcpService<K> {
+impl<K: KernelSyscall> AcpService<K> {
     /// Run a one-shot ACP call against `req.agent_id`. See module
     /// docs for the lifecycle. Errors map onto AcpResult fields:
     ///   - timeout            -> timed_out=true, exit_code=-1
@@ -844,7 +844,7 @@ fn build_metadata(
 
 // ── RustService dispatch ────────────────────────────────────────────────
 
-impl<K: KernelAbi> RustService for AcpService<K> {
+impl<K: KernelSyscall> RustService for AcpService<K> {
     fn name(&self) -> &str {
         Self::NAME
     }
@@ -921,7 +921,7 @@ struct AcpCallReq {
     context: AcpContext,
 }
 
-fn dispatch_acp_call<K: KernelAbi>(
+fn dispatch_acp_call<K: KernelSyscall>(
     svc: &AcpService<K>,
     payload: &[u8],
 ) -> Result<Vec<u8>, RustCallError> {
@@ -957,7 +957,7 @@ fn dispatch_acp_call<K: KernelAbi>(
     }
 }
 
-fn dispatch_list_configs<K: KernelAbi>(
+fn dispatch_list_configs<K: KernelSyscall>(
     svc: &AcpService<K>,
     payload: &[u8],
 ) -> Result<Vec<u8>, RustCallError> {
@@ -978,7 +978,7 @@ fn dispatch_list_configs<K: KernelAbi>(
     encode(&out)
 }
 
-fn dispatch_list_processes<K: KernelAbi>(
+fn dispatch_list_processes<K: KernelSyscall>(
     svc: &AcpService<K>,
     payload: &[u8],
 ) -> Result<Vec<u8>, RustCallError> {
@@ -1008,7 +1008,7 @@ struct AcpKillReq {
     context: AcpContext,
 }
 
-fn dispatch_kill<K: KernelAbi>(
+fn dispatch_kill<K: KernelSyscall>(
     svc: &AcpService<K>,
     payload: &[u8],
 ) -> Result<Vec<u8>, RustCallError> {
@@ -1029,7 +1029,7 @@ struct AcpSetSystemPromptReq {
     context: AcpContext,
 }
 
-fn dispatch_set_system_prompt<K: KernelAbi>(
+fn dispatch_set_system_prompt<K: KernelSyscall>(
     svc: &AcpService<K>,
     payload: &[u8],
 ) -> Result<Vec<u8>, RustCallError> {
@@ -1050,7 +1050,7 @@ struct AcpAgentReq {
     context: AcpContext,
 }
 
-fn dispatch_get_system_prompt<K: KernelAbi>(
+fn dispatch_get_system_prompt<K: KernelSyscall>(
     svc: &AcpService<K>,
     payload: &[u8],
 ) -> Result<Vec<u8>, RustCallError> {
@@ -1071,7 +1071,7 @@ struct AcpSetEnabledSkillsReq {
     context: AcpContext,
 }
 
-fn dispatch_set_enabled_skills<K: KernelAbi>(
+fn dispatch_set_enabled_skills<K: KernelSyscall>(
     svc: &AcpService<K>,
     payload: &[u8],
 ) -> Result<Vec<u8>, RustCallError> {
@@ -1085,7 +1085,7 @@ fn dispatch_set_enabled_skills<K: KernelAbi>(
     }))
 }
 
-fn dispatch_get_enabled_skills<K: KernelAbi>(
+fn dispatch_get_enabled_skills<K: KernelSyscall>(
     svc: &AcpService<K>,
     payload: &[u8],
 ) -> Result<Vec<u8>, RustCallError> {
@@ -1110,7 +1110,7 @@ fn default_history_limit() -> usize {
     50
 }
 
-fn dispatch_history<K: KernelAbi>(
+fn dispatch_history<K: KernelSyscall>(
     svc: &AcpService<K>,
     payload: &[u8],
 ) -> Result<Vec<u8>, RustCallError> {

--- a/rust/services/src/acp/subprocess.rs
+++ b/rust/services/src/acp/subprocess.rs
@@ -38,7 +38,7 @@ use tokio::process::{Child, ChildStderr, ChildStdin, ChildStdout, Command};
 
 use super::agent_config::AgentConfig;
 use super::paths;
-use kernel::abi::KernelAbi;
+use kernel::abi::KernelSyscall;
 use kernel::kernel::{KernelError, OperationContext};
 
 const PIPE_CAPACITY: usize = 1 << 20;
@@ -144,7 +144,7 @@ impl AcpSubprocess {
     ///   * register fails partway through — already-registered pipes
     ///     are unlinked before returning so we don't leak DT_PIPE
     ///     entries on the failure path.
-    pub(crate) async fn spawn<K: KernelAbi>(
+    pub(crate) async fn spawn<K: KernelSyscall>(
         cfg: &AgentConfig,
         cwd: &Path,
         kernel: &K,
@@ -263,7 +263,7 @@ impl AcpSubprocess {
     /// ownership via `take_stdio_for_connection` has also dropped.
     ///
     /// Idempotent: subsequent calls are no-ops.
-    pub(crate) fn unregister_pipes<K: KernelAbi>(&mut self, kernel: &K) {
+    pub(crate) fn unregister_pipes<K: KernelSyscall>(&mut self, kernel: &K) {
         let _ = unlink_quiet(kernel, &self.stdin_path);
         let _ = unlink_quiet(kernel, &self.stdout_path);
         let _ = unlink_quiet(kernel, &self.stderr_path);
@@ -309,7 +309,7 @@ fn dup_raw(raw: i32) -> Result<i32, SubprocessError> {
     Ok(dup)
 }
 
-fn register_stdio_pipe<K: KernelAbi>(
+fn register_stdio_pipe<K: KernelSyscall>(
     kernel: &K,
     path: &str,
     read_fd: i32,
@@ -347,7 +347,7 @@ fn register_stdio_pipe<K: KernelAbi>(
         .map_err(|e: KernelError| format!("{e:?}"))
 }
 
-fn unlink_quiet<K: KernelAbi>(kernel: &K, path: &str) -> Result<(), KernelError> {
+fn unlink_quiet<K: KernelSyscall>(kernel: &K, path: &str) -> Result<(), KernelError> {
     let ctx = OperationContext::new(
         /* user_id */ "system", /* zone_id */ "root", /* is_admin */ true,
         /* agent_id */ None, /* is_system */ true,

--- a/rust/services/src/audit/mod.rs
+++ b/rust/services/src/audit/mod.rs
@@ -33,7 +33,7 @@ use contracts::{is_system_path, OperationContext};
 use parking_lot::Mutex;
 use serde::Serialize;
 
-use kernel::abi::KernelAbi;
+use kernel::abi::KernelSyscall;
 use kernel::core::dispatch::{
     FileEvent, FileEventType, HookContext, MutationObserver, NativeInterceptHook,
 };
@@ -76,12 +76,12 @@ pub struct AuditRecord {
 /// appended via `kernel.sys_write(audit_path, …)`. DT_STREAM
 /// short-circuits inside `sys_write` (kernel `io.rs`), so audit writes
 /// don't recursively re-enter the audit hook.
-pub struct AuditHook<K: KernelAbi> {
+pub struct AuditHook<K: KernelSyscall> {
     sender: mpsc::SyncSender<AuditRecord>,
     _kernel: Arc<K>,
 }
 
-impl<K: KernelAbi> AuditHook<K> {
+impl<K: KernelSyscall> AuditHook<K> {
     /// Background flush channel capacity. At ~300 B per JSON record this is
     /// ~2.5 MB worst-case before try_send drops records (best-effort audit).
     const CHANNEL_CAP: usize = 8192;
@@ -175,7 +175,7 @@ fn audit_writer_ctx(zone_id: &str) -> OperationContext {
     ctx
 }
 
-impl<K: KernelAbi> NativeInterceptHook for AuditHook<K> {
+impl<K: KernelSyscall> NativeInterceptHook for AuditHook<K> {
     fn name(&self) -> &str {
         "audit"
     }
@@ -241,7 +241,7 @@ pub const AUDIT_SERVICE_NAME: &str = "audit";
 /// registers the hook.  Callers (typically `install_root` +
 /// `ZoneAuditAutoWire`) guarantee once-per-zone through their own
 /// bookkeeping.
-pub fn install<K: KernelAbi>(
+pub fn install<K: KernelSyscall>(
     kernel: Arc<K>,
     handle: &ServiceHandle,
     zone_id: &str,
@@ -266,7 +266,7 @@ pub fn install<K: KernelAbi>(
 /// must not register the `AuditHook` writer.
 ///
 /// Idempotent on repeated calls per zone (same shape as `install`).
-pub fn prepare_stream_only<K: KernelAbi>(
+pub fn prepare_stream_only<K: KernelSyscall>(
     kernel: &K,
     zone_id: &str,
     stream_path: &str,
@@ -289,7 +289,7 @@ pub fn prepare_stream_only<K: KernelAbi>(
 ///      internal `HashSet<String>` so a re-mount is a harmless
 ///      no-op.
 ///
-/// `K = Kernel`-specific (not generic over `K: KernelAbi`) because
+/// `K = Kernel`-specific (not generic over `K: KernelSyscall`) because
 /// `kernel.register_observer` is a kernel-internal accessor — same
 /// reason `ManagedAgentService::install_returning` is gated to
 /// `K = Kernel`. Slim builds that ship a non-Kernel `K` use
@@ -388,7 +388,7 @@ impl MutationObserver for ZoneAuditAutoWire {
     }
 }
 
-fn setup_audit_stream<K: KernelAbi>(
+fn setup_audit_stream<K: KernelSyscall>(
     kernel: &K,
     zone_id: &str,
     stream_path: &str,
@@ -728,7 +728,7 @@ mod tests {
             /* agent_id */ Some("agent-test"),
             /* is_system */ false,
         );
-        KernelAbi::sys_write(kernel.as_ref(), target, &writer_ctx, b"payload", 0)
+        KernelSyscall::sys_write(kernel.as_ref(), target, &writer_ctx, b"payload", 0)
             .expect("sys_write target payload");
 
         // Poll the audit stream until the flush thread has drained
@@ -743,9 +743,13 @@ mod tests {
         let mut captured: Option<Vec<u8>> = None;
         for _ in 0..20 {
             std::thread::sleep(std::time::Duration::from_millis(10));
-            if let Ok(read) =
-                KernelAbi::sys_read(kernel.as_ref(), "/__sys__/audit/traces/", &reader_ctx, 0, 0)
-            {
+            if let Ok(read) = KernelSyscall::sys_read(
+                kernel.as_ref(),
+                "/__sys__/audit/traces/",
+                &reader_ctx,
+                0,
+                0,
+            ) {
                 if let Some(data) = read.data {
                     if !data.is_empty() {
                         captured = Some(data);

--- a/rust/services/src/audit_node/bootstrap.rs
+++ b/rust/services/src/audit_node/bootstrap.rs
@@ -2,10 +2,10 @@
 //!
 //! Zone creation + learner join reach the federation through
 //! `kernel.distributed_coordinator()`, which is a kernel-internal
-//! accessor not exposed on the `KernelAbi` trait. Like
+//! accessor not exposed on the `KernelSyscall` trait. Like
 //! `audit::install_root`, this path is therefore gated to `K = Kernel`
 //! (production wiring); the generic collect loop in the parent module
-//! stays `K: KernelAbi`.
+//! stays `K: KernelSyscall`.
 
 use kernel::kernel::Kernel;
 

--- a/rust/services/src/audit_node/mod.rs
+++ b/rust/services/src/audit_node/mod.rs
@@ -13,7 +13,7 @@
 //!    learner, and register the `/audit/traces/` DT_STREAM locally on each
 //!    joined zone (no `AuditHook` — consumer, not producer).
 //!
-//! 2. **Collect/gather loop** (this module, generic over `K: KernelAbi`):
+//! 2. **Collect/gather loop** (this module, generic over `K: KernelSyscall`):
 //!    poll every joined zone's `/audit/traces/` stream from the persisted
 //!    offset, append new entries to the audit-node's local zone, and
 //!    persist the new offset. Local layout:
@@ -23,7 +23,7 @@
 //!    /{audit_zone}/collect/{source_zone}/offset    ← last-read position
 //!    ```
 //!
-//! The collect loop is synchronous (the `KernelAbi` syscalls are blocking)
+//! The collect loop is synchronous (the `KernelSyscall` syscalls are blocking)
 //! and runs on a dedicated OS thread; [`AuditNode::stop`] wakes it
 //! promptly via a condvar. Integration correctness (cross-zone routing,
 //! DT_STREAM offset chaining) is exercised by the docker federation E2E
@@ -36,7 +36,7 @@ use std::time::Duration;
 use contracts::OperationContext;
 use parking_lot::{Condvar, Mutex};
 
-use kernel::abi::KernelAbi;
+use kernel::abi::KernelSyscall;
 
 mod bootstrap;
 
@@ -60,7 +60,7 @@ pub struct AuditCheckpoint {
 }
 
 /// Audit-node service: collect/gather loop over joined production zones.
-pub struct AuditNode<K: KernelAbi> {
+pub struct AuditNode<K: KernelSyscall> {
     kernel: Arc<K>,
     audit_zone_id: String,
     stream_path: String,
@@ -74,7 +74,7 @@ pub struct AuditNode<K: KernelAbi> {
     wakeup: Condvar,
 }
 
-impl<K: KernelAbi> AuditNode<K> {
+impl<K: KernelSyscall> AuditNode<K> {
     /// Construct with default stream path / batch size / poll interval.
     pub fn new(kernel: Arc<K>, audit_zone_id: impl Into<String>) -> Self {
         Self::with_config(

--- a/rust/services/src/managed_agent/mod.rs
+++ b/rust/services/src/managed_agent/mod.rs
@@ -46,7 +46,7 @@ use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
 
-use kernel::abi::KernelAbi;
+use kernel::abi::KernelSyscall;
 use kernel::core::agents::registry::{
     AgentDescriptor, AgentKind, AgentRegistry, AgentState, RepoMount,
 };
@@ -180,13 +180,13 @@ impl std::error::Error for ManagedAgentError {}
 // Services rlib does NOT depend on the sudocode crate (cross-repo
 // git-deps would couple services' build to a specific sudocode rev,
 // which is the wrong layer for cross-repo coupling — same reason
-// `KernelAbi` lives at the trait boundary). Instead, services
+// `KernelSyscall` lives at the trait boundary). Instead, services
 // declares a small DI trait that nexus's binary edge
 // (`profiles/cluster` for all builds — the sole binary edge
 // Python wheel) implements by wrapping `sudocode_runtime::spawn_task`.
 // The trait method is `dyn`-dispatched but only fires once per
 // `start_session` call (out of the hot path); the spawn body itself
-// is fully monomorphised over `K: KernelAbi` inside the concrete
+// is fully monomorphised over `K: KernelSyscall` inside the concrete
 // impl, so there's no per-`sys_read` vtable cost.
 
 /// Per-pid spawn handle returned by [`SpawnTask::spawn`]. Concrete
@@ -232,7 +232,7 @@ pub enum AgentLoopState {
 /// runtime crate the deployment chose (today: sudocode); generic K
 /// keeps the spawn body monomorphised against the same kernel
 /// concrete that the service holds.
-pub trait SpawnTask<K: KernelAbi>: Send + Sync + 'static {
+pub trait SpawnTask<K: KernelSyscall>: Send + Sync + 'static {
     /// Spawn the per-pid runtime body. Returns an opaque handle the
     /// service stores in its `spawn_handles` sidecar; the
     /// on_terminate observer aborts via the handle on session
@@ -257,7 +257,7 @@ pub trait SpawnTask<K: KernelAbi>: Send + Sync + 'static {
 
 // ── Service ─────────────────────────────────────────────────────────────
 
-pub(crate) struct ManagedAgentService<K: KernelAbi> {
+pub(crate) struct ManagedAgentService<K: KernelSyscall> {
     /// Shared kernel handle for `start_session` to stamp the per-pid
     /// procfs subtree (`/proc/{pid}/`, `/proc/{pid}/workspace/`,
     /// workspace shortcut DT_LINK, per-repo alias DT_LINKs) and for
@@ -279,7 +279,7 @@ pub(crate) struct ManagedAgentService<K: KernelAbi> {
     spawn_handles: Arc<dashmap::DashMap<String, Box<dyn SpawnHandle>>>,
 }
 
-impl<K: KernelAbi> ManagedAgentService<K> {
+impl<K: KernelSyscall> ManagedAgentService<K> {
     pub(crate) const NAME: &'static str = "managed_agent";
 
     /// Service constructor.  Production callers reach this through
@@ -532,10 +532,10 @@ impl<K: KernelAbi> ManagedAgentService<K> {
 // Production install path stays specific to the concrete `Kernel`
 // because `register_on_terminate` is an inherent accessor on
 // `AgentRegistry` reached through `kernel.agent_registry()` — that
-// accessor is deliberately *not* on the `KernelAbi` trait (the v2
+// accessor is deliberately *not* on the `KernelSyscall` trait (the v2
 // audit pulled kernel-internal struct accessors out of the
 // service-facing surface). Lifecycle methods stay generic above so
-// non-Kernel `K: KernelAbi` test fixtures and future runtime targets
+// non-Kernel `K: KernelSyscall` test fixtures and future runtime targets
 // (sudo-code in-process spawn) compile without `Kernel`.
 impl ManagedAgentService<kernel::kernel::Kernel> {
     /// Install the service into a freshly-constructed kernel:
@@ -674,7 +674,7 @@ impl From<ManagedAgentError> for RustCallError {
     }
 }
 
-impl<K: KernelAbi> RustService for ManagedAgentService<K> {
+impl<K: KernelSyscall> RustService for ManagedAgentService<K> {
     fn name(&self) -> &str {
         Self::NAME
     }
@@ -1261,14 +1261,14 @@ mod tests {
                 propagates_cross_node: false,
             };
 
-            // Use UFCS through KernelAbi so we get the single-path
+            // Use UFCS through KernelSyscall so we get the single-path
             // trait wrappers (sys_read_single / sys_write_with_link_depth)
             // — the inherent Kernel::sys_read/sys_write are now batch-shaped
             // (&[ReadRequest] / &[WriteRequest]).
-            KernelAbi::sys_write(kernel.as_ref(), &shortcut, &ctx, payload, 0)
+            KernelSyscall::sys_write(kernel.as_ref(), &shortcut, &ctx, payload, 0)
                 .expect("sys_write through workspace shortcut DT_LINK");
 
-            let read = KernelAbi::sys_read(
+            let read = KernelSyscall::sys_read(
                 kernel.as_ref(),
                 &canonical,
                 &ctx,
@@ -1320,10 +1320,10 @@ mod tests {
                 propagates_cross_node: false,
             };
 
-            KernelAbi::sys_write(kernel.as_ref(), &shortcut, &ctx, &llm_authored, 0)
+            KernelSyscall::sys_write(kernel.as_ref(), &shortcut, &ctx, &llm_authored, 0)
                 .expect("sys_write through workspace shortcut DT_LINK");
 
-            let read = KernelAbi::sys_read(kernel.as_ref(), &canonical, &ctx, 0, 0)
+            let read = KernelSyscall::sys_read(kernel.as_ref(), &canonical, &ctx, 0, 0)
                 .expect("sys_read on canonical chat-with-me");
             let bytes = read.data.expect("stream data present");
             let json: serde_json::Value =

--- a/rust/services/src/managed_agent/proc_entry.rs
+++ b/rust/services/src/managed_agent/proc_entry.rs
@@ -28,7 +28,7 @@
 
 use contracts::OperationContext;
 
-use kernel::abi::KernelAbi;
+use kernel::abi::KernelSyscall;
 use kernel::core::agents::registry::AgentDescriptor;
 
 const DT_DIR: i32 = 1;
@@ -61,7 +61,7 @@ fn sys_ctx() -> OperationContext {
 /// Stamp the per-pid metastore subtree at start_session time. Idempotent
 /// against re-spawn / restart paths — every `sys_setattr` call accepts
 /// a matching existing entry as a successful no-op.
-pub(crate) fn register_proc_entry<K: KernelAbi>(
+pub(crate) fn register_proc_entry<K: KernelSyscall>(
     kernel: &K,
     desc: &AgentDescriptor,
 ) -> Result<(), String> {
@@ -118,7 +118,7 @@ pub(crate) fn register_proc_entry<K: KernelAbi>(
 /// canonical chat-with-me DT_STREAM also goes here — its lifetime is
 /// the pid's; any persistent inbox lives at `/agents/{name}/chat-with-me`
 /// instead.
-pub(crate) fn unregister_proc_entry<K: KernelAbi>(kernel: &K, desc: &AgentDescriptor) {
+pub(crate) fn unregister_proc_entry<K: KernelSyscall>(kernel: &K, desc: &AgentDescriptor) {
     let pid = desc.pid.as_str();
     let pid_root = format!("/proc/{pid}");
     let workspace_root = format!("/proc/{pid}/workspace");
@@ -145,7 +145,7 @@ pub(crate) fn unregister_proc_entry<K: KernelAbi>(kernel: &K, desc: &AgentDescri
     let _ = kernel.sys_unlink(&pid_root, &ctx, false);
 }
 
-fn create_dt_dir<K: KernelAbi>(kernel: &K, path: &str) -> Result<(), String> {
+fn create_dt_dir<K: KernelSyscall>(kernel: &K, path: &str) -> Result<(), String> {
     kernel
         .sys_setattr(
             path, DT_DIR, /* backend_name */ "", /* backend */ None,
@@ -161,7 +161,7 @@ fn create_dt_dir<K: KernelAbi>(kernel: &K, path: &str) -> Result<(), String> {
         .map_err(|e| format!("sys_setattr(DT_DIR at {path:?}): {e:?}"))
 }
 
-fn create_dt_link<K: KernelAbi>(kernel: &K, path: &str, target: &str) -> Result<(), String> {
+fn create_dt_link<K: KernelSyscall>(kernel: &K, path: &str, target: &str) -> Result<(), String> {
     kernel
         .sys_setattr(
             path,
@@ -190,7 +190,7 @@ fn create_dt_link<K: KernelAbi>(kernel: &K, path: &str, target: &str) -> Result<
         .map_err(|e| format!("sys_setattr(DT_LINK at {path:?} → {target:?}): {e:?}"))
 }
 
-fn create_dt_stream<K: KernelAbi>(
+fn create_dt_stream<K: KernelSyscall>(
     kernel: &K,
     path: &str,
     capacity: usize,

--- a/rust/services/src/matrix_adapter/media.rs
+++ b/rust/services/src/matrix_adapter/media.rs
@@ -35,7 +35,7 @@ use crate::matrix_adapter::router::AdapterState;
 /// chat surface without forcing a streaming upload path on D3.
 const MAX_UPLOAD_BYTES: usize = 50 * 1024 * 1024;
 
-fn require_kernel<K: kernel::abi::KernelAbi>(
+fn require_kernel<K: kernel::abi::KernelSyscall>(
     state: &AdapterState<K>,
 ) -> Result<&Arc<K>, AdapterError> {
     state
@@ -48,7 +48,7 @@ fn require_kernel<K: kernel::abi::KernelAbi>(
 /// `/media/{media_id}` and return the resulting `mxc://` URI. The
 /// caller's `Content-Type` (best-effort) is stamped onto the
 /// metastore entry so `/download` can echo it back.
-pub async fn upload<K: kernel::abi::KernelAbi>(
+pub async fn upload<K: kernel::abi::KernelSyscall>(
     State(state): State<AdapterState<K>>,
     Extension(_session): Extension<AuthSession>,
     headers: HeaderMap,
@@ -180,7 +180,7 @@ pub async fn upload<K: kernel::abi::KernelAbi>(
 /// `server_name`; D3 only serves the local one and returns
 /// `M_BAD_JSON` for cross-server requests (federation media is a
 /// future concern).
-pub async fn download<K: kernel::abi::KernelAbi>(
+pub async fn download<K: kernel::abi::KernelSyscall>(
     State(state): State<AdapterState<K>>,
     Extension(_session): Extension<AuthSession>,
     Path((server, media_id)): Path<(String, String)>,
@@ -254,7 +254,7 @@ pub async fn download<K: kernel::abi::KernelAbi>(
 /// `GET /_matrix/media/v3/thumbnail/{server}/{media_id}` — D3 returns
 /// the original asset. Matrix spec permits this when the homeserver
 /// does not generate thumbnails.
-pub async fn thumbnail<K: kernel::abi::KernelAbi>(
+pub async fn thumbnail<K: kernel::abi::KernelSyscall>(
     state: State<AdapterState<K>>,
     session: Extension<AuthSession>,
     path: Path<(String, String)>,

--- a/rust/services/src/matrix_adapter/middleware.rs
+++ b/rust/services/src/matrix_adapter/middleware.rs
@@ -34,7 +34,7 @@ pub fn parse_bearer(headers: &axum::http::HeaderMap) -> Option<&str> {
 /// Axum `from_fn_with_state` middleware. Reads the bearer token,
 /// resolves it through the [`AuthBackend`], stamps the resolved
 /// [`AuthSession`] into request extensions, and delegates to `next`.
-pub async fn require_access_token<K: kernel::abi::KernelAbi>(
+pub async fn require_access_token<K: kernel::abi::KernelSyscall>(
     State(state): State<AdapterState<K>>,
     mut req: Request,
     next: Next,

--- a/rust/services/src/matrix_adapter/rooms.rs
+++ b/rust/services/src/matrix_adapter/rooms.rs
@@ -63,7 +63,7 @@ fn now_ms() -> i64 {
         .unwrap_or(0)
 }
 
-fn require_kernel<K: kernel::abi::KernelAbi>(
+fn require_kernel<K: kernel::abi::KernelSyscall>(
     state: &AdapterState<K>,
 ) -> Result<&Arc<K>, AdapterError> {
     state
@@ -79,7 +79,7 @@ fn require_kernel<K: kernel::abi::KernelAbi>(
 /// we synthesise a minimal `m.room.create` + `m.room.member` set so
 /// stock clients see a sensible room. ReBAC-derived membership is a
 /// D3 follow-up; today the requesting user is reported as joined.
-pub async fn room_state<K: kernel::abi::KernelAbi>(
+pub async fn room_state<K: kernel::abi::KernelSyscall>(
     State(state): State<AdapterState<K>>,
     Extension(session): Extension<AuthSession>,
     Path(room_id): Path<String>,
@@ -92,7 +92,7 @@ pub async fn room_state<K: kernel::abi::KernelAbi>(
 /// `GET /_matrix/client/v3/rooms/{rid}/state/{event_type}/{state_key}`
 /// — single state event. Same synthesis as `room_state`, filtered by
 /// `event_type` + `state_key`.
-pub async fn room_state_event<K: kernel::abi::KernelAbi>(
+pub async fn room_state_event<K: kernel::abi::KernelSyscall>(
     State(state): State<AdapterState<K>>,
     Extension(session): Extension<AuthSession>,
     Path((room_id, event_type, state_key)): Path<(String, String, String)>,
@@ -138,7 +138,7 @@ fn default_dir() -> String {
 /// chunk so the client sees newest-first. Real backwards seek lands
 /// in D3 alongside `/sync` once the stream offsets surface a "tail"
 /// query.
-pub async fn room_messages<K: kernel::abi::KernelAbi>(
+pub async fn room_messages<K: kernel::abi::KernelSyscall>(
     State(state): State<AdapterState<K>>,
     Extension(session): Extension<AuthSession>,
     Path(room_id): Path<String>,
@@ -207,7 +207,7 @@ pub async fn room_messages<K: kernel::abi::KernelAbi>(
 
 /// `GET /_matrix/client/v3/rooms/{rid}/joined_members` — D2 returns
 /// the requesting user only. D3 derives this from ReBAC.
-pub async fn joined_members<K: kernel::abi::KernelAbi>(
+pub async fn joined_members<K: kernel::abi::KernelSyscall>(
     State(state): State<AdapterState<K>>,
     Extension(session): Extension<AuthSession>,
     Path(room_id): Path<String>,
@@ -230,7 +230,7 @@ pub async fn joined_members<K: kernel::abi::KernelAbi>(
 /// MailboxStampingHook rewrites `from` from OperationContext, so the
 /// adapter cannot forge sender even if the client's PDU body claims
 /// otherwise.
-pub async fn room_send<K: kernel::abi::KernelAbi>(
+pub async fn room_send<K: kernel::abi::KernelSyscall>(
     State(state): State<AdapterState<K>>,
     Extension(session): Extension<AuthSession>,
     Path((room_id, _event_type, _txn_id)): Path<(String, String, String)>,
@@ -288,7 +288,7 @@ pub struct CreateRoomRequest {
 /// `/agents/{name}/chat-with-me` DT_STREAM. The Matrix client sees a
 /// fresh room_id; subsequent `/send` writes round-trip through the
 /// path-based codec.
-pub async fn create_room<K: kernel::abi::KernelAbi>(
+pub async fn create_room<K: kernel::abi::KernelSyscall>(
     State(state): State<AdapterState<K>>,
     Extension(_session): Extension<AuthSession>,
     Json(req): Json<CreateRoomRequest>,
@@ -324,7 +324,7 @@ pub async fn create_room<K: kernel::abi::KernelAbi>(
 /// stream path to the user's joined-rooms set so `/sync` pumps it.
 /// ReBAC-backed authorisation is a follow-up; today the join is
 /// admitted unconditionally for any caller with a valid token.
-pub async fn room_join<K: kernel::abi::KernelAbi>(
+pub async fn room_join<K: kernel::abi::KernelSyscall>(
     State(state): State<AdapterState<K>>,
     Extension(session): Extension<AuthSession>,
     Path(room_id): Path<String>,
@@ -341,7 +341,7 @@ pub async fn room_join<K: kernel::abi::KernelAbi>(
 
 /// `POST /_matrix/client/v3/rooms/{rid}/leave` — removes the room
 /// from the user's joined-rooms set.
-pub async fn room_leave<K: kernel::abi::KernelAbi>(
+pub async fn room_leave<K: kernel::abi::KernelSyscall>(
     State(state): State<AdapterState<K>>,
     Extension(session): Extension<AuthSession>,
     Path(room_id): Path<String>,
@@ -393,7 +393,7 @@ fn synth_state_events(stream_path: &str, server_name: &str, user_id: &str) -> Ve
 /// `services::managed_agent::proc_entry::create_dt_stream` — the two
 /// callers (managed-agent spawn vs Matrix createRoom) share the same
 /// DT_STREAM contract, just at different paths.
-fn create_chat_stream<K: kernel::abi::KernelAbi>(
+fn create_chat_stream<K: kernel::abi::KernelSyscall>(
     kernel: &std::sync::Arc<K>,
     path: &str,
 ) -> Result<(), AdapterError> {

--- a/rust/services/src/matrix_adapter/router.rs
+++ b/rust/services/src/matrix_adapter/router.rs
@@ -33,7 +33,7 @@ pub type JoinedRooms = Arc<parking_lot::RwLock<HashMap<String, HashSet<String>>>
 
 /// Shared adapter state — composed once at boot and cloned into each
 /// handler. Cheap to clone (`Arc` and `String`).
-pub struct AdapterState<K: kernel::abi::KernelAbi> {
+pub struct AdapterState<K: kernel::abi::KernelSyscall> {
     pub auth: AuthBackendRef,
     /// Matrix server-name suffix for the homeserver. Used in
     /// `LoginResponse.home_server` and the room-id ↔ stream-path
@@ -47,7 +47,7 @@ pub struct AdapterState<K: kernel::abi::KernelAbi> {
     pub joined_rooms: JoinedRooms,
 }
 
-impl<K: kernel::abi::KernelAbi> AdapterState<K> {
+impl<K: kernel::abi::KernelSyscall> AdapterState<K> {
     /// Convenience constructor with an empty joined-rooms set.
     /// Production builds compose state by hand because they wire
     /// extra config; tests use this constructor.
@@ -64,7 +64,7 @@ impl<K: kernel::abi::KernelAbi> AdapterState<K> {
 // Hand-written `Clone` because `#[derive(Clone)]` would require
 // `K: Clone`, but we hold an `Arc<K>` which is `Clone` regardless of
 // `K`'s own clone-ability.
-impl<K: kernel::abi::KernelAbi> Clone for AdapterState<K> {
+impl<K: kernel::abi::KernelSyscall> Clone for AdapterState<K> {
     fn clone(&self) -> Self {
         Self {
             auth: self.auth.clone(),
@@ -79,7 +79,7 @@ impl<K: kernel::abi::KernelAbi> Clone for AdapterState<K> {
 /// endpoints with the token-protected ones; downstream PRs (D2/D3)
 /// add room read/write + sync routes underneath the same shared
 /// state without restructuring the boot wire-up.
-pub fn build_router<K: kernel::abi::KernelAbi>(state: AdapterState<K>) -> Router {
+pub fn build_router<K: kernel::abi::KernelSyscall>(state: AdapterState<K>) -> Router {
     // Public — no token middleware. `login` is the only way to get one.
     let public = Router::new().route("/_matrix/client/v3/login", post(login::<K>));
 
@@ -136,7 +136,7 @@ pub fn build_router<K: kernel::abi::KernelAbi>(state: AdapterState<K>) -> Router
     public.merge(protected).with_state(state)
 }
 
-async fn login<K: kernel::abi::KernelAbi>(
+async fn login<K: kernel::abi::KernelSyscall>(
     State(state): State<AdapterState<K>>,
     Json(req): Json<LoginRequest>,
 ) -> Result<Json<LoginResponse>, AdapterError> {
@@ -174,7 +174,7 @@ async fn login<K: kernel::abi::KernelAbi>(
     }))
 }
 
-async fn logout<K: kernel::abi::KernelAbi>(
+async fn logout<K: kernel::abi::KernelSyscall>(
     State(state): State<AdapterState<K>>,
     Extension(session): Extension<AuthSession>,
 ) -> Result<Json<EmptyResponse>, AdapterError> {

--- a/rust/services/src/matrix_adapter/sync.rs
+++ b/rust/services/src/matrix_adapter/sync.rs
@@ -44,7 +44,7 @@ pub struct SyncQuery {
 /// pin a thread forever.
 const MAX_LONG_POLL_MS: u64 = 30_000;
 
-pub async fn sync<K: kernel::abi::KernelAbi>(
+pub async fn sync<K: kernel::abi::KernelSyscall>(
     State(state): State<AdapterState<K>>,
     Extension(session): Extension<AuthSession>,
     Query(query): Query<SyncQuery>,
@@ -150,7 +150,7 @@ fn encode_since(offsets: &HashMap<String, u64>) -> String {
 
 // ── room pump ─────────────────────────────────────────────────────
 
-async fn pump_rooms<K: kernel::abi::KernelAbi>(
+async fn pump_rooms<K: kernel::abi::KernelSyscall>(
     kernel: &Arc<K>,
     joined: &[String],
     offsets: &mut HashMap<String, u64>,
@@ -186,7 +186,7 @@ async fn pump_rooms<K: kernel::abi::KernelAbi>(
     Ok(rooms_with_events)
 }
 
-fn pump_one_room<K: kernel::abi::KernelAbi>(
+fn pump_one_room<K: kernel::abi::KernelSyscall>(
     kernel: &Arc<K>,
     stream_path: &str,
     server_name: &str,
@@ -216,7 +216,7 @@ fn pump_one_room<K: kernel::abi::KernelAbi>(
     Ok((events, next_offset))
 }
 
-fn require_kernel<K: kernel::abi::KernelAbi>(
+fn require_kernel<K: kernel::abi::KernelSyscall>(
     state: &AdapterState<K>,
 ) -> Result<&Arc<K>, AdapterError> {
     state


### PR DESCRIPTION
## Summary
- **Commit 1**: Bump nexus-vfs pin to `3350b13` — includes `abi.rs` → `kernel/syscall.rs` file move and `KernelAbi` → `KernelSyscall` trait rename (nexus-vfs #147). Backward compat alias preserves compilation.
- **Commit 2**: Mechanical `KernelAbi` → `KernelSyscall` rename across all 12 nexus service files (acp, audit, audit_node, managed_agent, matrix_adapter)

## Motivation
`KernelAbi` was misleading — it's the syscall trait surface, not an ABI. `KernelSyscall` matches the kernel architecture doc naming. The file move (`abi.rs` → `kernel/syscall.rs`) colocates the trait with its implementation (`kernel/syscall_impl.rs`, née `io.rs`).

## Test plan
- [x] `cargo build --workspace` passes locally
- [x] `cargo test -p nexus-fuse-plugin` passes
- [ ] CI all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)