### PR TITLE
test(federation): mTLS federation e2e in CI (§B mTLS drive-out regression guard)

### DIFF
--- a/.github/workflows/mtls-federation-e2e.yml
+++ b/.github/workflows/mtls-federation-e2e.yml
@@ -100,8 +100,16 @@ jobs:
           # The joiner must DiscoverZones + JoinZone the founder over mTLS and
           # the founder must commit the AddNode for it. Poll the founder log
           # for the converged voter set [1, 2].
-          deadline=$((SECONDS + 120))
+          # The daemon colours its logs (tracing ANSI), which puts escape
+          # sequences between a field name and its `=value`; strip them so
+          # `field=value` greps match. `docker logs` on some hosts strips ANSI
+          # for us, GitHub's runner does not.
+          strip_ansi() { sed -E 's/\x1B\[[0-9;]*[a-zA-Z]//g'; }
+          deadline=$((SECONDS + 150))
+          flog=""; jlog=""
           while [ $SECONDS -lt $deadline ]; do
+            flog=$(docker logs nexus-mtls-founder 2>&1 | strip_ansi)
+            jlog=$(docker logs nexus-mtls-joiner 2>&1 | strip_ansi)
             # STABLE convergence, both directions over mTLS:
             #   1. founder commits AddNode → voters=[1, 2] (joiner→founder RPCs);
             #   2. joiner installs the ConfState and catches up to the leader
@@ -109,27 +117,25 @@ jobs:
             #      broken when the leader dialed the joiner in plaintext).
             # Asserting only (1) would pass even while the joiner churns
             # "leader unreachable" forever, so (2) is the real judge.
-            if docker logs nexus-mtls-founder 2>&1 \
-                 | grep -q 'conf_change.applied.*change_type=AddNode.*voters=\[1, 2\]' \
-               && docker logs nexus-mtls-joiner 2>&1 \
-                 | grep -q 'caught up to leader'; then
+            if echo "$flog" | grep -q 'conf_change.applied.*change_type=AddNode.*voters=\[1, 2\]' \
+               && echo "$jlog" | grep -q 'caught up to leader'; then
               echo "OK: federation converged over mTLS — voters=[1, 2], joiner caught up"
               # The founder actually served mTLS, the joiner actually reached it
               # over https, and the founder dialed the joiner back over https
               # (not a plaintext fallback in either direction).
-              docker logs nexus-mtls-founder 2>&1 | grep -q 'TLS mode: mTLS' \
+              echo "$flog" | grep -q 'TLS mode: mTLS' \
                 || { echo '::error::founder did not enable mTLS'; exit 1; }
-              docker logs nexus-mtls-joiner 2>&1 | grep -q 'DiscoverZones: peer reported federation zones' \
+              echo "$jlog" | grep -q 'DiscoverZones: peer reported federation zones' \
                 || { echo '::error::joiner did not discover over mTLS'; exit 1; }
-              docker logs nexus-mtls-founder 2>&1 | grep -q 'raft client connected.*endpoint="https://joiner' \
+              echo "$flog" | grep -q 'raft client connected.*endpoint="https://joiner' \
                 || { echo '::error::founder did not dial the joiner over https'; exit 1; }
               exit 0
             fi
             sleep 3
           done
-          echo "::error::federation did not converge over mTLS within 120s"
-          echo "===== founder ====="; docker logs nexus-mtls-founder 2>&1 | tail -80
-          echo "===== joiner ====="; docker logs nexus-mtls-joiner 2>&1 | tail -80
+          echo "::error::federation did not converge over mTLS within 150s"
+          echo "===== founder ====="; echo "$flog" | tail -80
+          echo "===== joiner ====="; echo "$jlog" | tail -80
           exit 1
 
       - name: Tear down

--- a/.github/workflows/mtls-federation-e2e.yml
+++ b/.github/workflows/mtls-federation-e2e.yml
@@ -1,0 +1,138 @@
+name: mTLS Federation E2E
+
+# Turns real mutual TLS ON over a 2-node federation and proves it still
+# discovers, joins, and converges membership — the regression guard for the
+# nexus-vfs §B mTLS drive-out (the one-shot join/discover RPCs becoming
+# TLS-aware, and the rustls crypto-provider pin). Every other federation
+# harness runs `--no-tls`; this is the only one that exercises the mTLS path
+# end to end in a real multi-container deployment.
+#
+# Runs `dockerfiles/docker-compose.mtls-federation-test.yml`:
+#   founder creates `sharedzone` (env-driven), joiner DiscoverZones + JoinZone
+#   over mTLS by container service name, and the founder commits
+#   `AddNode ... voters=[1, 2]`.
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main, develop]
+    paths:
+      - 'dockerfiles/docker-compose.mtls-federation-test.yml'
+      - 'dockerfiles/Dockerfile.nexusd-cluster'
+      - '.github/workflows/mtls-federation-e2e.yml'
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - 'dockerfiles/docker-compose.mtls-federation-test.yml'
+      - 'dockerfiles/Dockerfile.nexusd-cluster'
+      - '.github/workflows/mtls-federation-e2e.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  # nexus-vfs SHA under test. Pinned to merged main carrying the §B mTLS
+  # drive-out (PR #150) + the learned-peer-scheme fix (PR #152) rather than
+  # read from Cargo.toml, because the repo pin has not yet been bumped to
+  # include them — this test exists to guard exactly those commits. Switch to
+  # the Cargo.toml pin once it advances past them.
+  NEXUS_VFS_REV: 13960f1ca52b94521c14fa89b7a029a88dc8ae61
+
+jobs:
+  mtls-federation-e2e:
+    name: mTLS Federation E2E (Docker)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout nexus
+        uses: actions/checkout@v4
+
+      - name: Checkout nexus-vfs source (§B mTLS fixes)
+        uses: actions/checkout@v4
+        with:
+          repository: nexi-lab/nexus-vfs
+          ref: ${{ env.NEXUS_VFS_REV }}
+          path: nexus-vfs-src
+          fetch-depth: 1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build nexusd-cluster image (with §B mTLS fixes)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: dockerfiles/Dockerfile.nexusd-cluster
+          build-contexts: |
+            nexus-vfs-src=nexus-vfs-src
+          load: true
+          tags: nexusd-cluster:latest
+          cache-from: type=gha,scope=mtls-federation-e2e
+          cache-to: type=gha,scope=mtls-federation-e2e,mode=max
+
+      - name: Rust toolchain (for the cert-gen helper)
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          rustflags: ''
+
+      - name: Mint the shared cluster CA + per-node certs
+        # One CA signs both node certs, each carrying every container name in
+        # its SANs (apply_tls sets no domain_name) and a pinned .node_id so
+        # the daemon adopts the id the cert's URI SAN was minted for. Written
+        # under dockerfiles/mtls-certs/<node>/, which the compose bind-mounts.
+        run: |
+          cargo run --manifest-path nexus-vfs-src/rust/raft/Cargo.toml \
+            --example gen_federation_certs -- \
+            "${GITHUB_WORKSPACE}/dockerfiles/mtls-certs" founder:1 joiner:2
+          echo "--- founder cert SANs ---"
+          openssl x509 -in "${GITHUB_WORKSPACE}/dockerfiles/mtls-certs/founder/tls/node.pem" \
+            -noout -ext subjectAltName
+
+      - name: Start the mTLS federation
+        run: |
+          docker compose -f dockerfiles/docker-compose.mtls-federation-test.yml up -d
+          docker compose -f dockerfiles/docker-compose.mtls-federation-test.yml ps
+
+      - name: Assert membership converged over mTLS
+        run: |
+          # The joiner must DiscoverZones + JoinZone the founder over mTLS and
+          # the founder must commit the AddNode for it. Poll the founder log
+          # for the converged voter set [1, 2].
+          deadline=$((SECONDS + 120))
+          while [ $SECONDS -lt $deadline ]; do
+            # STABLE convergence, both directions over mTLS:
+            #   1. founder commits AddNode → voters=[1, 2] (joiner→founder RPCs);
+            #   2. joiner installs the ConfState and catches up to the leader
+            #      (founder→joiner replication — the direction that was silently
+            #      broken when the leader dialed the joiner in plaintext).
+            # Asserting only (1) would pass even while the joiner churns
+            # "leader unreachable" forever, so (2) is the real judge.
+            if docker logs nexus-mtls-founder 2>&1 \
+                 | grep -q 'conf_change.applied.*change_type=AddNode.*voters=\[1, 2\]' \
+               && docker logs nexus-mtls-joiner 2>&1 \
+                 | grep -q 'caught up to leader'; then
+              echo "OK: federation converged over mTLS — voters=[1, 2], joiner caught up"
+              # The founder actually served mTLS, the joiner actually reached it
+              # over https, and the founder dialed the joiner back over https
+              # (not a plaintext fallback in either direction).
+              docker logs nexus-mtls-founder 2>&1 | grep -q 'TLS mode: mTLS' \
+                || { echo '::error::founder did not enable mTLS'; exit 1; }
+              docker logs nexus-mtls-joiner 2>&1 | grep -q 'DiscoverZones: peer reported federation zones' \
+                || { echo '::error::joiner did not discover over mTLS'; exit 1; }
+              docker logs nexus-mtls-founder 2>&1 | grep -q 'raft client connected.*endpoint="https://joiner' \
+                || { echo '::error::founder did not dial the joiner over https'; exit 1; }
+              exit 0
+            fi
+            sleep 3
+          done
+          echo "::error::federation did not converge over mTLS within 120s"
+          echo "===== founder ====="; docker logs nexus-mtls-founder 2>&1 | tail -80
+          echo "===== joiner ====="; docker logs nexus-mtls-joiner 2>&1 | tail -80
+          exit 1
+
+      - name: Tear down
+        if: always()
+        run: |
+          docker compose -f dockerfiles/docker-compose.mtls-federation-test.yml down -v --remove-orphans || true

--- a/.gitignore
+++ b/.gitignore
@@ -273,3 +273,6 @@ nexus_witness_data/
 # redb database files (runtime artifacts from nexusd-cluster / tests)
 *.redb
 :memory:.redb
+
+# Generated test certs for the mTLS federation e2e (minted per-run by the workflow)
+dockerfiles/mtls-certs/

--- a/dockerfiles/docker-compose.mtls-federation-test.yml
+++ b/dockerfiles/docker-compose.mtls-federation-test.yml
@@ -1,0 +1,85 @@
+# Federation over **mutual TLS** — the regression harness for nexus-vfs §B
+# (the mTLS drive-out). Every other federation compose runs `--no-tls`; this
+# one turns real mTLS on and proves a two-node cluster still discovers, joins,
+# and converges membership over it.
+#
+# Shape (env-driven S3 unified bring-up — no offline `share`/`join` sidecar):
+#   * founder — creates `sharedzone` from NEXUS_FEDERATION_ZONES, serves mTLS.
+#   * joiner  — NEXUS_PEERS=founder:2126, no zones of its own. At boot it
+#     DiscoverZones(founder) over mTLS, finds `sharedzone`, and auto-joins via
+#     JoinZone over mTLS. Both RPCs are exactly the one-shot helpers the §B
+#     fix made TLS-aware.
+#
+# Shared CA: the `mtls-federation-e2e` workflow runs
+# `raft --example gen_federation_certs` to mint ONE cluster CA + per-node
+# certs (with every container name in the SANs, since apply_tls sets no
+# domain_name), writes them under `./mtls-certs/<node>/`, and mounts each
+# node's bundle read-only at `/certs`. The entrypoint copies it into
+# `<data_dir>/tls` before boot so `bootstrap_tls` reuses the shared bundle
+# instead of self-signing a per-node CA (which would never cross-verify).
+#
+# Success signal: founder's raft log commits `AddNode peer_node_id=<joiner>`
+# for `sharedzone`, i.e. `voters=[<founder>, <joiner>]` — membership converged
+# over mTLS. The test asserts on that.
+
+x-mtls-node: &mtls-node
+  image: nexusd-cluster:latest
+  # Copy the mounted shared-CA bundle into the data dir, then run the daemon
+  # with TLS ON (no --no-tls). `set -e` so a missing bundle fails loud rather
+  # than silently self-signing a per-node CA.
+  entrypoint:
+    - /bin/sh
+    - -c
+    - |
+      set -e
+      cp -r /certs/. /app/data/
+      exec nexusd-cluster --bind-addr 0.0.0.0:2126 --data-dir /app/data
+  command: []
+  networks:
+    - mtls-net
+
+services:
+  founder:
+    <<: *mtls-node
+    container_name: nexus-mtls-founder
+    hostname: founder
+    environment:
+      NEXUS_HOSTNAME: founder
+      NEXUS_ADVERTISE_ADDR: founder:2126
+      # Static topology: create `sharedzone` and mount it at /shared. The
+      # joiner discovers this over mTLS and auto-joins.
+      NEXUS_FEDERATION_ZONES: sharedzone
+      NEXUS_FEDERATION_MOUNTS: /shared=sharedzone
+      RUST_LOG: info,nexus_raft=info
+    volumes:
+      - ./mtls-certs/founder:/certs:ro
+    # Ready only once `sharedzone` exists on disk. The daemon's DiscoverZones
+    # is one-shot at boot, so the joiner must not start until the zone it
+    # discovers is actually created — otherwise it races, finds nothing, and
+    # comes up root-only.
+    healthcheck:
+      test: ["CMD-SHELL", "test -f /app/data/sharedzone/raft/raft.redb"]
+      interval: 2s
+      timeout: 2s
+      retries: 30
+      start_period: 3s
+
+  joiner:
+    <<: *mtls-node
+    container_name: nexus-mtls-joiner
+    hostname: joiner
+    depends_on:
+      founder:
+        condition: service_healthy
+    environment:
+      NEXUS_HOSTNAME: joiner
+      NEXUS_ADVERTISE_ADDR: joiner:2126
+      # No zones of its own — discover + auto-join the founder's over mTLS.
+      NEXUS_PEERS: founder:2126
+      RUST_LOG: info,nexus_raft=info
+    volumes:
+      - ./mtls-certs/joiner:/certs:ro
+
+networks:
+  mtls-net:
+    name: nexus-mtls-net

--- a/dockerfiles/docker-compose.mtls-federation-test.yml
+++ b/dockerfiles/docker-compose.mtls-federation-test.yml
@@ -51,6 +51,9 @@ services:
       NEXUS_FEDERATION_ZONES: sharedzone
       NEXUS_FEDERATION_MOUNTS: /shared=sharedzone
       RUST_LOG: info,nexus_raft=info
+      # Plain logs so the CI assertion's `field=value` greps aren't split by
+      # tracing's ANSI colour codes (the assert also strips ANSI defensively).
+      NO_COLOR: "1"
     volumes:
       - ./mtls-certs/founder:/certs:ro
     # Ready only once `sharedzone` exists on disk. The daemon's DiscoverZones
@@ -77,6 +80,9 @@ services:
       # No zones of its own — discover + auto-join the founder's over mTLS.
       NEXUS_PEERS: founder:2126
       RUST_LOG: info,nexus_raft=info
+      # Plain logs so the CI assertion's `field=value` greps aren't split by
+      # tracing's ANSI colour codes (the assert also strips ANSI defensively).
+      NO_COLOR: "1"
     volumes:
       - ./mtls-certs/joiner:/certs:ro
 


### PR DESCRIPTION
First CI harness to turn **real mutual TLS on** over a multi-container federation and prove it converges — every other federation harness runs `--no-tls`. It regression-guards the nexus-vfs §B mTLS work:
- **PR #150** — the one-shot join/discover RPCs became TLS-aware + the rustls crypto-provider pin;
- **PR #152** — learned peer endpoints scheme with the cluster TLS posture (the founder→joiner replication direction).

Both were bugs that only surface with TLS actually on, which nothing exercised until now.

## What it runs

`dockerfiles/docker-compose.mtls-federation-test.yml` — an env-driven S3 bring-up (no offline `share`/`join` sidecar): founder creates `sharedzone` from `NEXUS_FEDERATION_ZONES`; joiner (`NEXUS_PEERS=founder:2126`) `DiscoverZones` + auto-`JoinZone` over mTLS **by container service name**. A shared CA (minted by `raft --example gen_federation_certs`, with every node name in the SANs since `apply_tls` sets no `domain_name`) is copied into each node's data dir at boot so `bootstrap_tls` reuses it rather than self-signing a per-node CA.

The image is built from a pinned nexus-vfs SHA (`13960f1c`, carrying #150 + #152) — the repo `Cargo.toml` pin has not been bumped to include them yet, so the workflow checks out that SHA directly.

## The assertion (stable convergence, both directions)

- founder commits `AddNode → voters=[1, 2]` (joiner→founder RPCs), **and**
- joiner installs the ConfState + **catches up to the leader** (founder→joiner replication over `https://` — the direction the scheme bug silently broke; asserting only the membership change would pass even while the joiner churns "leader unreachable").
- plus sanity: founder served mTLS, joiner discovered over mTLS, founder dialed the joiner over `https://`.

Validated locally on Docker Desktop end to end (converges in ~10s; pre-#152 it churned + errored `leader unreachable`).