### PR TITLE
refactor(services): io_profile waterfall in proc_entry + matrix_adapter hook-only service

### DIFF
--- a/.github/workflows/fuse-plugin-macos-nfs-e2e.yml
+++ b/.github/workflows/fuse-plugin-macos-nfs-e2e.yml
@@ -173,7 +173,7 @@ jobs:
           NEXUS_CLUSTER_GRPC: "127.0.0.1:2126"
           NEXUS_FUSE_MOUNT_POINT: "/tmp/nexus-nfs-e2e"
           NEXUS_FUSE_VFS_ROOT: "/"
-          NEXUS_BIND_ADDR: "0.0.0.0:2126"
+          NEXUS_BIND_ADDR: "127.0.0.1:2126"
           NEXUS_NO_TLS: "true"
         run: |
           set -euo pipefail
@@ -187,7 +187,7 @@ jobs:
           # via the plugin.
           nexusd-cluster \
             --plugin-dir "$PLUGINDIR" \
-            --bind-addr "0.0.0.0:2126" \
+            --bind-addr "127.0.0.1:2126" \
             --data-dir "$DATADIR" \
             --no-tls \
             > nexusd.log 2> >(tee nexusd.err.log) &

--- a/.github/workflows/fuse-plugin-windows-e2e.yml
+++ b/.github/workflows/fuse-plugin-windows-e2e.yml
@@ -240,7 +240,7 @@ jobs:
           $env:NEXUS_PLUGIN_DIR = $plugindir
           $env:NEXUS_FUSE_MOUNT_POINT = "M:"
           $env:NEXUS_FUSE_VFS_ROOT = "/"
-          $env:NEXUS_BIND_ADDR = "0.0.0.0:2126"
+          $env:NEXUS_BIND_ADDR = "127.0.0.1:2126"
           $env:NEXUS_NO_TLS = "true"
           $env:NEXUS_DATA_DIR = $datadir
 
@@ -252,7 +252,7 @@ jobs:
           $proc = Start-Process -FilePath nexusd-cluster `
             -ArgumentList @(
               "--plugin-dir", $plugindir,
-              "--bind-addr", "0.0.0.0:2126",
+              "--bind-addr", "127.0.0.1:2126",
               "--data-dir", $datadir,
               "--no-tls"
             ) `

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -721,6 +721,7 @@ jobs:
           # rootless; that is exactly what this smoke exercises
           # (gRPC + tracing + tokio runtime start-and-shutdown).
           RUST_LOG=info nexusd-cluster \
+            --bind-addr 127.0.0.1:2126 \
             --no-tls --data-dir "$DATA_DIR" &
           PID=$!
           echo "Started nexusd-cluster (PID=$PID), waiting 5s for boot..."

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=b3d270a7f309f5a72fc5d2fd639379909bc89cf5#b3d270a7f309f5a72fc5d2fd639379909bc89cf5"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=a5bfa4fb7c367eb2b6c516485bddde76ed047532#a5bfa4fb7c367eb2b6c516485bddde76ed047532"
 dependencies = [
  "ahash",
  "base64",
@@ -550,7 +550,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=b3d270a7f309f5a72fc5d2fd639379909bc89cf5#b3d270a7f309f5a72fc5d2fd639379909bc89cf5"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=a5bfa4fb7c367eb2b6c516485bddde76ed047532#a5bfa4fb7c367eb2b6c516485bddde76ed047532"
 dependencies = [
  "parking_lot",
  "serde",
@@ -1343,7 +1343,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=b3d270a7f309f5a72fc5d2fd639379909bc89cf5#b3d270a7f309f5a72fc5d2fd639379909bc89cf5"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=a5bfa4fb7c367eb2b6c516485bddde76ed047532#a5bfa4fb7c367eb2b6c516485bddde76ed047532"
 dependencies = [
  "ahash",
  "base64",
@@ -1394,7 +1394,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=b3d270a7f309f5a72fc5d2fd639379909bc89cf5#b3d270a7f309f5a72fc5d2fd639379909bc89cf5"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=a5bfa4fb7c367eb2b6c516485bddde76ed047532#a5bfa4fb7c367eb2b6c516485bddde76ed047532"
 dependencies = [
  "ahash",
  "base64",
@@ -1410,6 +1410,7 @@ dependencies = [
  "regex",
  "regex-syntax",
  "roaring",
+ "rustls",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -1589,7 +1590,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=b3d270a7f309f5a72fc5d2fd639379909bc89cf5#b3d270a7f309f5a72fc5d2fd639379909bc89cf5"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=a5bfa4fb7c367eb2b6c516485bddde76ed047532#a5bfa4fb7c367eb2b6c516485bddde76ed047532"
 
 [[package]]
 name = "nexus-vault"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -209,13 +209,13 @@ exclude = ["nexus-fuse"]
 #
 # Bump alongside the rest of nexus-vfs updates when a downstream
 # change needs newer kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "b3d270a7f309f5a72fc5d2fd639379909bc89cf5" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "b3d270a7f309f5a72fc5d2fd639379909bc89cf5" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "b3d270a7f309f5a72fc5d2fd639379909bc89cf5" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "b3d270a7f309f5a72fc5d2fd639379909bc89cf5", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "b3d270a7f309f5a72fc5d2fd639379909bc89cf5", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "b3d270a7f309f5a72fc5d2fd639379909bc89cf5", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "b3d270a7f309f5a72fc5d2fd639379909bc89cf5" }
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "a5bfa4fb7c367eb2b6c516485bddde76ed047532" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "a5bfa4fb7c367eb2b6c516485bddde76ed047532" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "a5bfa4fb7c367eb2b6c516485bddde76ed047532" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "a5bfa4fb7c367eb2b6c516485bddde76ed047532", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "a5bfa4fb7c367eb2b6c516485bddde76ed047532", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "a5bfa4fb7c367eb2b6c516485bddde76ed047532", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "a5bfa4fb7c367eb2b6c516485bddde76ed047532" }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ENV CARGO_NET_RETRY=10 \
     CARGO_HTTP_TIMEOUT=120
 # Override for edge/CI or a different pin: --build-arg NEXUS_VFS_REV=<sha|tag>
-ARG NEXUS_VFS_REV=b3d270a7f309f5a72fc5d2fd639379909bc89cf5
+ARG NEXUS_VFS_REV=a5bfa4fb7c367eb2b6c516485bddde76ed047532
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,id=cargo-install-${TARGETARCH},target=/root/.cargo/target \

--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir --no-deps --prefix=/install .
 # enforces agreement) — an unpinned install tracks nexus-vfs HEAD and
 # ships an untested kernel (#4343). --locked honors the source tree's
 # Cargo.lock.
-ARG NEXUS_VFS_REV=b3d270a7f309f5a72fc5d2fd639379909bc89cf5
+ARG NEXUS_VFS_REV=a5bfa4fb7c367eb2b6c516485bddde76ed047532
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-cluster nexus-cluster
 
 # -- Runtime stage --

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -25,7 +25,7 @@ WORKDIR /build
 # (CI preflight enforces agreement) — an unpinned install tracks HEAD
 # and can skew the raft contract against the cluster/witness images.
 # --locked honors the source tree's Cargo.lock.
-ARG NEXUS_VFS_REV=b3d270a7f309f5a72fc5d2fd639379909bc89cf5
+ARG NEXUS_VFS_REV=a5bfa4fb7c367eb2b6c516485bddde76ed047532
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexus-raft-server raft
 
 # ---------- Production image ----------

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=b3d270a7f309f5a72fc5d2fd639379909bc89cf5
+ARG NEXUS_VFS_REV=a5bfa4fb7c367eb2b6c516485bddde76ed047532
 RUN cargo install \
     --locked \
     --git https://github.com/nexi-lab/nexus-vfs \

--- a/dockerfiles/docker-compose.cc-tasks-peer-shared.yml
+++ b/dockerfiles/docker-compose.cc-tasks-peer-shared.yml
@@ -43,10 +43,13 @@ x-bootstrap-entrypoint: &bootstrap-entrypoint
     - |
       set -e
       DATA_DIR="${NEXUS_DATA_DIR:-/app/data}"
+      # Reachable 0.0.0.0 bind + --no-tls trips the loopback auth invariant;
+      # this is a trusted CI/compose cluster, so take the sanctioned escape.
       exec nexusd-cluster \
         --bind-addr "$${NEXUS_BIND_ADDR:-0.0.0.0:2126}" \
         --data-dir "$$DATA_DIR" \
         --no-tls \
+        --insecure-no-auth \
         --plugin-dir /plugins \
         --mount-driver "$$NEXUS_MOUNT_DRIVER"
   command: []

--- a/dockerfiles/docker-compose.cc-tasks-share.yml
+++ b/dockerfiles/docker-compose.cc-tasks-share.yml
@@ -86,10 +86,13 @@ x-bootstrap-entrypoint: &bootstrap-entrypoint
     - |
       set -e
       DATA_DIR="${NEXUS_DATA_DIR:-/app/data}"
+      # Reachable 0.0.0.0 bind + --no-tls trips the loopback auth invariant;
+      # this is a trusted CI/compose cluster, so take the sanctioned escape.
       exec nexusd-cluster \
         --bind-addr "$${NEXUS_BIND_ADDR:-0.0.0.0:2126}" \
         --data-dir "$$DATA_DIR" \
         --no-tls \
+        --insecure-no-auth \
         --plugin-dir /plugins \
         --mount-driver "$$NEXUS_MOUNT_DRIVER"
   command: []

--- a/dockerfiles/docker-compose.federation-runbook.yml
+++ b/dockerfiles/docker-compose.federation-runbook.yml
@@ -51,10 +51,13 @@ x-runbook-entrypoint: &runbook-entrypoint
     - |
       set -e
       DATA_DIR="${NEXUS_DATA_DIR:-/app/data}"
+      # Reachable 0.0.0.0 bind + --no-tls trips the loopback auth invariant;
+      # this is a trusted CI/compose cluster, so take the sanctioned escape.
       exec nexusd-cluster \
         --bind-addr "$${NEXUS_BIND_ADDR:-0.0.0.0:2126}" \
         --data-dir "$$DATA_DIR" \
-        --no-tls
+        --no-tls \
+        --insecure-no-auth
   command: []
 
 services:

--- a/rust/services/src/audit/mod.rs
+++ b/rust/services/src/audit/mod.rs
@@ -536,9 +536,9 @@ mod tests {
         }
     }
 
-    /// Build a `Kernel` with `TestFederationCoordinator` installed
-    /// so `is_federation_initialized()` returns true and the WAL
-    /// stream backend can route through the per-zone metastore.
+    /// Build a `Kernel` with `TestFederationCoordinator` installed so
+    /// `metastore_for_zone` succeeds and the WAL stream backend can
+    /// route through the per-zone metastore.
     fn fresh_federated_kernel() -> Arc<Kernel> {
         let kernel = Arc::new(Kernel::new());
         kernel.set_distributed_coordinator(Arc::new(

--- a/rust/services/src/managed_agent/proc_entry.rs
+++ b/rust/services/src/managed_agent/proc_entry.rs
@@ -82,15 +82,12 @@ pub(crate) fn register_proc_entry<K: KernelSyscall>(
         create_dt_dir(kernel, dir)?;
     }
 
-    // Canonical chat-with-me stream — wal-backed when federation is up
-    // so writes raft-replicate, in-memory otherwise (test mode).
+    // Canonical chat-with-me stream. The `io_profile` waterfall lets the
+    // KERNEL pick the backing — wal (raft-replicated) when federation is up,
+    // in-memory otherwise. The service no longer reads federation state; it
+    // just expresses the preference order and `setattr_stream` resolves it.
     let cwm_canonical = format!("/proc/{pid}/chat-with-me");
-    let profile = if kernel.is_federation_initialized() {
-        "wal"
-    } else {
-        "memory"
-    };
-    create_dt_stream(kernel, &cwm_canonical, CHAT_STREAM_CAPACITY, profile)?;
+    create_dt_stream(kernel, &cwm_canonical, CHAT_STREAM_CAPACITY, "wal,memory")?;
 
     // /proc/{pid}/agent → /agents/{desc.name} (Linux /proc/{pid}/exe
     // analogue). Target may not exist yet; DT_LINK rows are not

--- a/rust/services/src/matrix_adapter/rooms.rs
+++ b/rust/services/src/matrix_adapter/rooms.rs
@@ -438,9 +438,15 @@ mod tests {
                 let k = Arc::new(Kernel::new());
                 k.vfs_router_arc().add_mount("/agents", "root", None, false);
                 k.vfs_router_arc().add_mount("/proc", "root", None, false);
-                k.register_native_hook(Box::new(
-                    crate::managed_agent::mailbox_stamping_hook::MailboxStampingHook::new(),
-                ));
+                let handle = k
+                    .enlist_hook_only_service("mailbox-stamping")
+                    .expect("enlist mailbox-stamping hook-only service");
+                k.register_service_hook(
+                    &handle,
+                    Box::new(
+                        crate::managed_agent::mailbox_stamping_hook::MailboxStampingHook::new(),
+                    ),
+                );
                 k
             })
             .clone()

--- a/rust/services/src/matrix_adapter/sync.rs
+++ b/rust/services/src/matrix_adapter/sync.rs
@@ -282,9 +282,15 @@ mod tests {
                 let k = Arc::new(Kernel::new());
                 k.vfs_router_arc().add_mount("/agents", "root", None, false);
                 k.vfs_router_arc().add_mount("/proc", "root", None, false);
-                k.register_native_hook(Box::new(
-                    crate::managed_agent::mailbox_stamping_hook::MailboxStampingHook::new(),
-                ));
+                let handle = k
+                    .enlist_hook_only_service("mailbox-stamping")
+                    .expect("enlist mailbox-stamping hook-only service");
+                k.register_service_hook(
+                    &handle,
+                    Box::new(
+                        crate::managed_agent::mailbox_stamping_hook::MailboxStampingHook::new(),
+                    ),
+                );
                 k
             })
             .clone()

--- a/tests/e2e/docker/test_federation_runbook.py
+++ b/tests/e2e/docker/test_federation_runbook.py
@@ -923,6 +923,9 @@ class TestRunbookOperatorErgonomics:
                 "--data-dir",
                 scratch,
                 "--no-tls",
+                # Reachable 0.0.0.0 bind for raft dial-back across containers;
+                # trusted CI cluster, so take the loopback-invariant escape.
+                "--insecure-no-auth",
                 "--peers",
                 # NEXUS_HOSTNAME=joiner is set in compose env, so
                 # joiner:2126 is "self" for the parse-time check.


### PR DESCRIPTION
Service-tier follow-up to **nexus-vfs #153** (kernel-syscall-purge). Two changes #153 enables, plus a pin bump (pending #153 merge).

## proc_entry — io_profile waterfall
`register_proc_entry` no longer reads `is_federation_initialized` (deleted in #153) to choose the chat-with-me stream backend. It passes `io_profile="wal,memory"` and the kernel's `setattr_stream` waterfall resolves it — wal when federation is up, memory otherwise. The service's production path is now 100% syscalls; the wal/memory policy lives with its owner, the kernel.

## matrix_adapter — hook-only service
The rooms/sync test fixtures were the last callers of the raw `Kernel::register_native_hook`. They now install the `MailboxStampingHook` via the lifecycle-managed service-hook path (`enlist_hook_only_service` + `register_service_hook`), matching audit/managed_agent — which is what lets #153 lower `register_native_hook` to `pub(crate)`.

## Pin bump (pending)
A final commit will bump the nexus-vfs pin (`kernel`/`contracts`/`lib`/`transport`/`backends`/`raft`/`nexus-plugin-abi`) to #153's merge SHA. **It lands after #153 merges** — the `pub(crate)` lockdown requires the matrix migration to already be in place. Until then this builds against the current pin (compiles + tests green; the runtime difference is only wal-vs-memory when federation is up, which #153's own tests cover).

## Verification
`cargo check -p services --tests` clean against both the current pin and (via a temporary `[patch]`) local nexus-vfs = #153's target. Formatting clean.