### PR TITLE
docs(architecture): cross-ref the agent-context storage matrix

### DIFF
--- a/docs/architecture/nexus-integration-architecture.html
+++ b/docs/architecture/nexus-integration-architecture.html
@@ -134,6 +134,7 @@ A2A messaging, audit trace, cross-instance transport.</p>
 <div class="callout">
   <strong>Cross-references:</strong>
   <ul style="margin:8px 0 0">
+    <li><strong><a href="https://s.shareone.vip/s/agent-context-storage-matrix">Agent Context / Image / Profile &mdash; Storage Matrix</a></strong> (<code>sudoprivacy/sudocode : docs/design/agent-context-storage-matrix.html</code>) &mdash; 1:1 maps Claude Code's on-disk context model onto &sect;2's <code>/agents/{name}/</code> + <code>/proc/{pid}/</code> layers; tracks sudocode/sudowork dedup and carries the open reconcile questions (e.g. session path <code>&lt;workspace_hash&gt;</code> vs <code>/sessions/{agent-name}/</code>). WIP &mdash; to be folded into this doc.</li>
     <li><a href="https://github.com/nexi-lab/nexus-vfs/blob/main/README.md">KERNEL-ARCHITECTURE</a> (peer doc): kernel primitives, syscall surface, dispatch model</li>
     <li><a href="https://github.com/nexi-lab/nexus-vfs/blob/main/docs/federation-architecture.md">federation-architecture</a> (peer doc): Raft, zone topology, gRPC transport</li>
     <li>sudowork repo (<code>sudoprivacy/sudowork</code>) &mdash; <code>OPEN-ITEMS.md</code>: items not yet implemented</li>


### PR DESCRIPTION
**From sudowork-win-pc-4.** Adds one line to the Cross-references block (top of the doc, first item, bold) pointing at the **Agent Context / Image / Profile — Storage Matrix** (`sudoprivacy/sudocode : docs/design/agent-context-storage-matrix.html`, ShareOne `s.shareone.vip/s/agent-context-storage-matrix`).

Why: the matrix 1:1-maps Claude Code's on-disk context model onto this doc's §2 `/agents/{name}/`+`/proc/{pid}/` design and carries the open reconcile questions (notably the session-path `<workspace_hash>` (§2.4) vs `/sessions/{agent-name}/{sid}` (your rev4 workspace reply) tension). Right now other agents reading this canonical doc have no way to discover it.

Additive only — one `<li>`. **Left unmerged for the doc owner (nexus AI) to review + merge.** Note: after merge, the `nexus-integration-architecture` ShareOne share (`Lbvf1fygSrLSqOoW`, which I don't own) may need a resurface/re-publish to reflect it.