### PR TITLE
feat(search-plugin): SearchService cdylib v1 — recursive glob + regex grep

### DIFF
--- a/.github/workflows/auto-plugin-release.yml
+++ b/.github/workflows/auto-plugin-release.yml
@@ -91,8 +91,9 @@ jobs:
           VAULT_TAG=$(next_patch "vault-v")
           FUSE_TAG=$(next_patch "fuse-v")
           LC_TAG=$(next_patch "local-connector-v")
+          SEARCH_TAG=$(next_patch "search-v")
 
-          echo "Cutting tags: $VAULT_TAG, $FUSE_TAG, $LC_TAG"
+          echo "Cutting tags: $VAULT_TAG, $FUSE_TAG, $LC_TAG, $SEARCH_TAG"
           echo "nexus-vfs rev: ${NEW_REV:0:12}"
 
           MSG="rebuild against nexus-vfs ${NEW_REV:0:12} (auto-release on rev bump)"
@@ -102,15 +103,16 @@ jobs:
           git push origin "$VAULT_TAG"
           echo "vault_tag=$VAULT_TAG" >> "$GITHUB_ENV"
 
-          # Fuse + local-connector can go together (both use dogfood signing
-          # which fetches the latest vault-v* release — vault must be
-          # released first, but the tag push triggers are async so there's
-          # a race. The release-plugin-reusable workflow retries vault
+          # Fuse + local-connector + search can go together (all use dogfood
+          # signing which fetches the latest vault-v* release — vault must
+          # be released first, but the tag push triggers are async so there
+          # is a race.  The release-plugin-reusable workflow retries vault
           # fetch, so in practice this works. If it doesn't, workflow_dispatch
           # retry is available.)
           git tag -a "$FUSE_TAG" HEAD -m "fuse-plugin ${FUSE_TAG#fuse-v} — $MSG"
           git tag -a "$LC_TAG" HEAD -m "local-connector ${LC_TAG#local-connector-v} — $MSG"
-          git push origin "$FUSE_TAG" "$LC_TAG"
+          git tag -a "$SEARCH_TAG" HEAD -m "search-plugin ${SEARCH_TAG#search-v} — $MSG"
+          git push origin "$FUSE_TAG" "$LC_TAG" "$SEARCH_TAG"
 
           echo "### Auto Plugin Release" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
@@ -121,3 +123,4 @@ jobs:
           echo "| vault | $VAULT_TAG |" >> "$GITHUB_STEP_SUMMARY"
           echo "| fuse | $FUSE_TAG |" >> "$GITHUB_STEP_SUMMARY"
           echo "| local-connector | $LC_TAG |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| search-plugin | $SEARCH_TAG |" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-search-plugin.yml
+++ b/.github/workflows/release-search-plugin.yml
@@ -1,0 +1,67 @@
+name: Release Search Plugin
+
+# Release pipeline for the nexus-search-plugin cdylib — wrapper around
+# the reusable plugin-release workflow.  Triggered by tags of the form
+# `search-v<semver>`.  The plugin walks the kernel VFS via
+# `sys_readdir` + `sys_read`, so it ships for every platform the kernel
+# runs on (Linux, macOS, Windows) — no platform-specific bindings.
+#
+# Uses the dogfood signing path (`signing_key_source: vault`) — vault
+# is the trust root for every non-vault plugin's signing key.  The path
+# resolves against the sealed in-repo keystore at data/vault-signing/
+# via scripts/dogfood_keystore_fetch.py — see
+# docs/superpowers/specs/2026-06-13-sealed-keystore-dogfood-design.md.
+#
+# COS path convention: nexus-search-plugin/release/v<version>/<filename>
+
+on:
+  push:
+    tags:
+      - "search-v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to release (e.g. search-v0.1.0). Used for retry without delete+repush."
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    uses: ./.github/workflows/release-plugin-reusable.yml
+    with:
+      plugin_name: nexus-search-plugin
+      dylib_basename: libnexus_search_plugin
+      archive_prefix: nexus-search-plugin
+      cos_subdir: nexus-search-plugin/release
+      version_tag_prefix: search-v
+      signing_key_source: vault
+      signing_key_name: kernel-dogfood-v1
+      platforms: '["linux-x86_64", "macos-arm64", "macos-x86_64", "windows-x86_64"]'
+      override_ref: ${{ inputs.tag && format('refs/tags/{0}', inputs.tag) || '' }}
+      release_description: |
+        Nexus search service plugin for nexusd-cluster.
+
+        Hosts `nexus.search.v1.SearchService` (recursive glob + regex
+        grep over the kernel VFS) via the Phase P
+        plugin-as-gRPC-service routing path.  Rust replacement for the
+        Python `nexus.bricks.search.search_service.SearchService`.
+
+        v1: sequential recursive walk over `sys_readdir` + `sys_read`;
+        unary responses capped by `max_results` (default 10_000 glob /
+        1_000 grep).  Trigram / streaming / adaptive-strategy variants
+        land in v2.
+
+        Cross-node search works transparently: `sys_readdir` surfaces
+        federation-mount contents, `sys_read` falls back to
+        `try_remote_fetch` — the plugin holds no federation awareness
+        of its own.
+    secrets:
+      VAULT_SIGNING_MASTER_KEY: ${{ secrets.VAULT_SIGNING_MASTER_KEY }}
+      COS_SECRET_ID: ${{ secrets.COS_SECRET_ID }}
+      COS_SECRET_KEY: ${{ secrets.COS_SECRET_KEY }}
+      COS_BUCKET: ${{ secrets.COS_BUCKET }}
+      COS_REGION: ${{ secrets.COS_REGION }}
+      COS_BASE_URL: ${{ secrets.COS_BASE_URL }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1583,6 +1583,27 @@ version = "0.1.0"
 source = "git+https://github.com/nexi-lab/nexus-vfs?rev=196437ca8ab5cbfea12dc660a797dbcccabaa506#196437ca8ab5cbfea12dc660a797dbcccabaa506"
 
 [[package]]
+name = "nexus-search-plugin"
+version = "0.1.0"
+dependencies = [
+ "bytes",
+ "globset",
+ "libloading",
+ "nexus-plugin-abi",
+ "prost",
+ "protoc-bin-vendored",
+ "regex",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "tonic",
+ "tonic-prost",
+ "tonic-prost-build",
+ "tracing",
+]
+
+[[package]]
 name = "nexus-vault"
 version = "0.1.4"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,14 @@ members = [
     # syscalls via the plugin-abi KernelHandle.  Loaded by
     # nexusd-cluster via --plugin-dir alongside nexus-vault.
     "rust/services/fuse-plugin",
+    # nexus-search-plugin — cdylib service plugin that hosts
+    # `nexus.search.v1.SearchService` (recursive glob + regex grep
+    # over the kernel VFS) via the Phase P plugin-as-gRPC-service
+    # path.  Rust replacement for the Python
+    # `nexus.bricks.search.search_service.SearchService`; sequential
+    # walk over `sys_readdir` + `sys_read` in v1, trigram / streaming
+    # / adaptive-strategy variants land in v2.
+    "rust/services/search-plugin",
 ]
 # nexus-fuse excluded: standalone FUSE daemon with different dependency versions
 # from the workspace.  Distinct from nexus-fuse-plugin (the new

--- a/rust/services/proto/nexus/search/v1/search.proto
+++ b/rust/services/proto/nexus/search/v1/search.proto
@@ -1,0 +1,103 @@
+// SearchService — the Rust replacement for the Python
+// `nexus.bricks.search.search_service.SearchService`.
+//
+// Exposed by the `nexus-search-plugin` cdylib and routed by
+// `nexusd-cluster` via the Phase P plugin-as-gRPC-service path
+// (`nexus_plugin_grpc_services` symbol → `PluginProxyService`
+// bytes-level dispatch).
+//
+// v1 scope: recursive glob + regex grep, sequential walk over the
+// kernel VFS via `sys_readdir` + `sys_read`. Cross-node paths
+// resolve transparently through the same federation `try_remote_fetch`
+// fallback local reads use — search on node A sees files hosted on
+// node B without any plugin-side federation awareness. Result sets
+// are capped by `max_results` on the wire (unary response); streaming
+// / trigram / adaptive-strategy variants land in v2.
+
+syntax = "proto3";
+
+package nexus.search.v1;
+
+service SearchService {
+  // Recursively walk `root_path`; return the paths matching `pattern`.
+  //
+  // Pattern is a globset-style glob (`**/*.py`, `docs/*.md`, ...) —
+  // matched against paths relative to `root_path`. A caller who wants
+  // absolute matches concatenates `root_path` back in.
+  rpc Glob(GlobRequest) returns (GlobResponse);
+
+  // Recursively walk `root_path` and return every regex match in
+  // every file whose path (relative to `root_path`) matches
+  // `file_pattern` (leave empty for all files).
+  rpc Grep(GrepRequest) returns (GrepResponse);
+}
+
+// ── Glob ──────────────────────────────────────────────────────────
+
+message GlobRequest {
+  string root_path = 1;
+  // globset-style glob. Empty = match every entry.
+  string pattern = 2;
+  // Safety cap on the returned list. `truncated=true` in the response
+  // signals we stopped scanning at this many hits. 0 ⇒ server-side
+  // default (10_000).
+  uint32 max_results = 3;
+  // Auth token per the same convention as vfs.proto; server-side
+  // permission gate reads this via OperationContext.
+  string auth_token = 4;
+}
+
+message GlobResponse {
+  repeated string paths = 1;
+  // `paths.len() == max_results` AND more entries were skipped.
+  bool truncated = 2;
+  // Non-empty when the walk aborted mid-flight (e.g. root_path
+  // not found, permission denied). Callers should treat a
+  // non-empty error the same as an empty `paths` list.
+  optional string error = 3;
+}
+
+// ── Grep ──────────────────────────────────────────────────────────
+
+message GrepRequest {
+  string root_path = 1;
+  // Regex compiled with the `regex` crate on the server. Anchors,
+  // groups, and inline flags (`(?i)`) all work.
+  string pattern = 2;
+  // Optional file-name filter (globset syntax). Empty ⇒ scan every
+  // regular file.
+  string file_pattern = 3;
+  // Case-insensitive match — layered on top of `pattern` via a
+  // regex builder flag (equivalent to a leading `(?i)`, kept as a
+  // separate field so the wire distinguishes "explicit case
+  // insensitive" from "pattern contains (?i)").
+  bool ignore_case = 4;
+  // Safety cap; 0 ⇒ server-side default (1_000).
+  uint32 max_results = 5;
+  // Lines of context to include before / after each match. 0 ⇒ none.
+  uint32 before_context = 6;
+  uint32 after_context = 7;
+  // Invert: return lines that DO NOT match the pattern.
+  bool invert_match = 8;
+  string auth_token = 9;
+}
+
+message GrepMatch {
+  // Path is expressed as VFS absolute (starts with `/`).
+  string path = 1;
+  // 1-indexed line number of the matched line.
+  uint32 line_number = 2;
+  // The matched line itself (trailing newline stripped).
+  string line = 3;
+  // Optional context lines, in order. `before` are the lines
+  // immediately preceding `line`; `after` are the lines immediately
+  // following. Empty when `before_context` / `after_context` is 0.
+  repeated string before = 4;
+  repeated string after = 5;
+}
+
+message GrepResponse {
+  repeated GrepMatch matches = 1;
+  bool truncated = 2;
+  optional string error = 3;
+}

--- a/rust/services/search-plugin/Cargo.toml
+++ b/rust/services/search-plugin/Cargo.toml
@@ -1,0 +1,67 @@
+[package]
+name = "nexus-search-plugin"
+version = "0.1.0"
+edition = "2021"
+description = "Nexus search plugin — cdylib loaded by `nexusd-cluster` via `--plugin-dir`. Hosts SearchService (recursive glob + regex grep over the kernel VFS) as a Phase P plugin-as-gRPC-service. Rust replacement for the Python `nexus.bricks.search.search_service.SearchService`."
+authors = ["Nexus Team"]
+publish = false
+
+[lib]
+name = "nexus_search_plugin"
+# cdylib for the loader to dlopen at startup.  rlib for the in-crate
+# unit tests to reach the internal glob/grep walker without going
+# through the C ABI.
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+# Plugin ABI — stable C ABI contract for dylib plugins.  The
+# `declare_service_plugin!` macro + KernelHandle live here.
+nexus-plugin-abi = { workspace = true }
+
+# Proto message + tonic server stubs for SearchService.  Generated
+# in build.rs from `../proto/nexus/search/v1/search.proto`.
+prost = { workspace = true }
+tonic = { workspace = true }
+tonic-prost = { workspace = true }
+
+# Glob pattern matching — same crate the kernel uses for its own
+# glob paths, so pattern semantics stay identical across the
+# Python / Rust boundary while the migration is in flight.
+globset = { workspace = true }
+
+# Regex engine for grep.  `regex-syntax` is pulled transitively.
+regex = { workspace = true }
+
+# JSON parse for the `sys_readdir` return payload (the plugin ABI
+# returns `[{"name":<str>,"entry_type":<u8>}, ...]`).
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+# Diagnostic logging — silent by default; the cluster binary's
+# RUST_LOG opts specific targets in.
+tracing = "0.1"
+
+# tokio runtime for the async gRPC service impl; the plugin's
+# dispatch layer bridges to it via block_on.  `rt-multi-thread` is
+# opt-in for the spawn_blocking pool used by the recursive walker so
+# concurrent Glob / Grep requests do not serialize on a single-thread
+# runtime.
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "sync", "macros"] }
+
+# Bytes for tonic Request/Response body types.
+bytes = "1"
+
+[build-dependencies]
+tonic-prost-build = "0.14"
+# Vendored protoc so the plugin builds on any host without a
+# system-wide protobuf-compiler.  Same policy the sibling `vault` +
+# `fuse-plugin` crates use for their per-plugin proto codegen.
+protoc-bin-vendored = "3"
+
+[dev-dependencies]
+tempfile = "3"
+# dlopen self-test for the cdylib — mirrors the sibling
+# `nexus-vault/tests/dlopen_self.rs`.  Validates plugin-ABI symbol
+# resolution + `nexus_plugin_grpc_services` JSON contract on all
+# three `libloading`-supported platforms.
+libloading = "0.8"

--- a/rust/services/search-plugin/build.rs
+++ b/rust/services/search-plugin/build.rs
@@ -1,0 +1,26 @@
+//! Compile SearchService proto (`../proto/nexus/search/v1/search.proto`)
+//! into `OUT_DIR` for the plugin to include! at build time.
+//!
+//! Same shape as the sibling `nexus-vault` and `nexus-fuse-plugin`
+//! per-crate build scripts — vendored `protoc` so the plugin builds
+//! on hosts without a system-wide protobuf-compiler install.
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let proto = "../proto/nexus/search/v1/search.proto";
+    println!("cargo:rerun-if-changed={}", proto);
+
+    if std::env::var_os("PROTOC").is_none() {
+        std::env::set_var("PROTOC", protoc_bin_vendored::protoc_bin_path()?);
+    }
+
+    tonic_prost_build::configure()
+        .build_server(true)
+        // Client stubs so the crate's own dylib E2E tests can dial
+        // themselves through the same tonic surface real cluster
+        // callers use.  Dead code in production plugin builds — the
+        // linker strips it via the cdylib LTO pass.
+        .build_client(true)
+        .compile_protos(&[proto], &["../proto"])?;
+
+    Ok(())
+}

--- a/rust/services/search-plugin/src/kernel_io.rs
+++ b/rust/services/search-plugin/src/kernel_io.rs
@@ -1,0 +1,158 @@
+//! Thin safe wrappers around the raw C-ABI `KernelHandle` callbacks.
+//!
+//! Every syscall the search walker needs (`sys_readdir` + `sys_read`)
+//! is exposed here as a Rust-ergonomic `Result<T, KernelIoError>`
+//! function.  Keeps the `unsafe extern "C"` FFI + `nexus_free`
+//! bookkeeping in one place so the walker / grep loop stays in
+//! straight-line Rust.
+
+use std::ffi::{CString, NulError};
+use std::slice;
+
+use nexus_plugin_abi::{nexus_free, KernelHandle};
+use serde::Deserialize;
+
+/// Errors surfaced from the kernel-side callbacks.  Mirrors the
+/// non-zero return codes documented on `KernelHandle` per syscall
+/// plus a couple of Rust-side wrapper errors (`NulError`, JSON parse).
+#[derive(Debug)]
+pub enum KernelIoError {
+    /// The path contained an interior NUL — cannot be handed to a
+    /// C-ABI `*const c_char`.
+    PathHasNul,
+    /// `sys_readdir` / `sys_read` returned `PluginResult::NotFound`.
+    NotFound,
+    /// Non-`NotFound` non-zero return.  Value is the raw i32 the
+    /// callback produced.
+    Kernel(i32),
+    /// `sys_readdir` returned bytes that did not parse as
+    /// `[{"name":str,"entry_type":u8}]`.
+    JsonParse(serde_json::Error),
+    /// `sys_read` returned bytes we could not interpret as UTF-8
+    /// (grep is line-oriented — binary files are skipped upstream).
+    NotUtf8,
+}
+
+impl From<NulError> for KernelIoError {
+    fn from(_: NulError) -> Self {
+        Self::PathHasNul
+    }
+}
+
+/// Single entry from `sys_readdir`.
+///
+/// Field names mirror the JSON payload the plugin-ABI docs on
+/// `sys_readdir` promise: `{"name":<str>,"entry_type":<u8>}`.
+#[derive(Debug, Deserialize)]
+pub struct DirEntry {
+    pub name: String,
+    #[serde(rename = "entry_type")]
+    pub entry_type: u8,
+}
+
+// `entry_type` constants — match `kernel::meta_store::DT_*` in
+// nexus-vfs.  Kept as `const u8` (not an enum) so a future kernel
+// bump adding a new DT_ variant does not require a plugin-side
+// exhaustive-match update.
+pub const DT_REG: u8 = 0;
+pub const DT_DIR: u8 = 1;
+#[allow(dead_code)]
+pub const DT_MOUNT: u8 = 2;
+
+/// Wrap `handle.sys_readdir(path)`.
+///
+/// Returns the parsed entry list on success; propagates NotFound so
+/// the walker can distinguish "dead entry" from "walk error".
+pub fn sys_readdir(handle: &KernelHandle, path: &str) -> Result<Vec<DirEntry>, KernelIoError> {
+    let c_path = CString::new(path)?;
+    let mut out_ptr: *mut u8 = std::ptr::null_mut();
+    let mut out_len: usize = 0;
+    // SAFETY: `sys_readdir` is documented on `KernelHandle` as taking
+    // a null-terminated path and populating `(*out_ptr, *out_len)`
+    // with a `nexus_free`-owned buffer on Ok(0).  We own the pointer
+    // targets on the Rust stack; the callback writes into them via
+    // `*mut *mut u8` / `*mut usize`.
+    let rc = unsafe {
+        (handle.sys_readdir)(
+            handle.kernel_ptr,
+            c_path.as_ptr(),
+            &mut out_ptr as *mut *mut u8,
+            &mut out_len as *mut usize,
+        )
+    };
+    match rc {
+        0 => {
+            // SAFETY: on Ok, the callback populated `out_ptr` with a
+            // heap-allocated buffer of `out_len` bytes; we borrow it
+            // for the parse then hand it back to `nexus_free`.
+            let bytes = unsafe { slice::from_raw_parts(out_ptr, out_len) };
+            let parsed =
+                serde_json::from_slice::<Vec<DirEntry>>(bytes).map_err(KernelIoError::JsonParse);
+            // Free regardless of parse outcome — kernel owns the alloc.
+            unsafe { nexus_free(out_ptr, out_len) };
+            parsed
+        }
+        -1 => Err(KernelIoError::NotFound),
+        other => Err(KernelIoError::Kernel(other)),
+    }
+}
+
+/// Wrap `handle.sys_read(path)`.
+///
+/// Returns the file bytes as an owned `Vec<u8>`.  Zero-copy is not
+/// worth it here — the walker immediately UTF-8-decodes for line
+/// scanning, so an intermediate copy costs the same as the decode.
+pub fn sys_read(handle: &KernelHandle, path: &str) -> Result<Vec<u8>, KernelIoError> {
+    let c_path = CString::new(path)?;
+    let mut out_ptr: *mut u8 = std::ptr::null_mut();
+    let mut out_len: usize = 0;
+    // SAFETY: same shape as `sys_readdir` above — kernel-side callback
+    // owns the alloc, we take a snapshot into an owned Vec and free.
+    let rc = unsafe {
+        (handle.sys_read)(
+            handle.kernel_ptr,
+            c_path.as_ptr(),
+            &mut out_ptr as *mut *mut u8,
+            &mut out_len as *mut usize,
+        )
+    };
+    match rc {
+        0 => {
+            let bytes = unsafe { slice::from_raw_parts(out_ptr, out_len) };
+            let owned = bytes.to_vec();
+            unsafe { nexus_free(out_ptr, out_len) };
+            Ok(owned)
+        }
+        -1 => Err(KernelIoError::NotFound),
+        other => Err(KernelIoError::Kernel(other)),
+    }
+}
+
+/// Concatenate a parent VFS path and a child entry name into a
+/// canonical child path.  Handles the root special case (`/` +
+/// `foo` = `/foo`) and strips a redundant trailing `/` on the
+/// parent.
+pub fn join_vfs_path(parent: &str, child: &str) -> String {
+    if parent == "/" {
+        format!("/{child}")
+    } else {
+        let trimmed = parent.trim_end_matches('/');
+        format!("{trimmed}/{child}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn join_root() {
+        assert_eq!(join_vfs_path("/", "foo"), "/foo");
+    }
+
+    #[test]
+    fn join_deep() {
+        assert_eq!(join_vfs_path("/a/b", "c"), "/a/b/c");
+        assert_eq!(join_vfs_path("/a/b/", "c"), "/a/b/c");
+    }
+}

--- a/rust/services/search-plugin/src/lib.rs
+++ b/rust/services/search-plugin/src/lib.rs
@@ -1,0 +1,218 @@
+//! `nexus-search-plugin` — SearchService cdylib.
+//!
+//! Loaded by `nexusd-cluster` at startup via `--plugin-dir`.  Exposes
+//! `nexus.search.v1.SearchService` (recursive `Glob` + regex `Grep`
+//! over the kernel VFS) through the Phase P plugin-as-gRPC-service
+//! routing path — the plugin declares its service list via
+//! `nexus_plugin_grpc_services`, the cluster's `PluginProxyService`
+//! routes external tonic traffic at `/nexus.search.v1.SearchService/<M>`
+//! into this plugin's `nexus_service_dispatch`.
+//!
+//! ## Why a plugin (and not a kernel primitive)
+//!
+//! Grep + glob are compositions over the kernel's `sys_readdir` +
+//! `sys_read` primitives, not primitives themselves — putting the
+//! walker + regex engine in the kernel tier would grow `kernel/`
+//! with policy code that has no business next to the syscall ABI.
+//! The cdylib boundary keeps the kernel small (kernel default:
+//! zero search logic) and lets the plugin ship its own release
+//! cadence with its own signed release chain.
+//!
+//! ## What v1 does
+//!
+//! Sequential recursive walk from `root_path` via `sys_readdir`.  Glob
+//! matches via `globset`; grep reads file content via `sys_read` and
+//! scans with the `regex` crate.  Results are unary responses capped
+//! by `max_results` (default 10_000 for glob, 1_000 for grep).
+//! Cross-node paths resolve transparently: `sys_readdir` returns
+//! federation-mounted names, `sys_read` falls through to
+//! `try_remote_fetch` on non-local paths — the plugin holds no
+//! federation awareness of its own.
+//!
+//! v2 will add: streaming responses, trigram-indexed fast-path grep,
+//! adaptive glob strategy per pattern shape, and (behind a feature
+//! flag) semantic embeddings.  Kept separate from v1 to keep the
+//! initial cdylib review surface small.
+
+use std::ffi::c_char;
+use std::sync::Arc;
+
+use nexus_plugin_abi::{declare_service_plugin, KernelHandle};
+use prost::Message;
+use tonic::Request;
+
+use crate::service::SearchServiceImpl;
+
+// Generated tonic bindings for `nexus.search.v1`.  Include-path
+// mirrors the vault crate — `OUT_DIR` gets the codegen output at
+// build time from `build.rs`.
+pub mod search_proto {
+    #![allow(clippy::all)]
+    #![allow(unused_qualifications)]
+    tonic::include_proto!("nexus.search.v1");
+}
+
+pub mod kernel_io;
+pub mod service;
+
+use search_proto::search_service_server::SearchService as SearchServiceTrait;
+use search_proto::{GlobRequest, GrepRequest};
+
+/// Plugin state held between `create` and `destroy`.
+///
+/// Owns the SearchService impl (which carries the compiled regex
+/// cache and future indexing state) plus a small tokio runtime used
+/// by `dispatch_grpc` to bridge the sync `nexus_service_dispatch`
+/// ABI into the async tonic trait.
+pub struct SearchPlugin {
+    svc: Arc<SearchServiceImpl>,
+    rt: tokio::runtime::Runtime,
+}
+
+/// Deep-clone a `KernelHandle` by copying every C-ABI field.  The
+/// plugin ABI's `KernelHandle` is `#[repr(C)]` with fn-pointer +
+/// `*const c_void` fields — all naturally `Copy` at the machine level
+/// — but the type deliberately does NOT derive `Clone` so callers
+/// think twice before duplicating it (each copy points at the same
+/// kernel instance).  Search-plugin holds one copy inside an `Arc`
+/// so the service impl + every `spawn_blocking` closure can share it
+/// without cloning the underlying kernel.
+fn dup_kernel_handle(h: &KernelHandle) -> KernelHandle {
+    KernelHandle {
+        sys_read: h.sys_read,
+        sys_write: h.sys_write,
+        sys_stat: h.sys_stat,
+        sys_readdir: h.sys_readdir,
+        sys_unlink: h.sys_unlink,
+        sys_mkdir: h.sys_mkdir,
+        sys_rmdir: h.sys_rmdir,
+        sys_rename: h.sys_rename,
+        sys_stat_batch: h.sys_stat_batch,
+        kernel_ptr: h.kernel_ptr,
+    }
+}
+
+fn create_search_plugin(kernel_handle: &KernelHandle) -> Box<SearchPlugin> {
+    tracing::info!("nexus-search-plugin: create");
+    let svc = Arc::new(SearchServiceImpl::new(Arc::new(dup_kernel_handle(
+        kernel_handle,
+    ))));
+    // Tokio runtime build errors are effectively unreachable on
+    // healthy hosts (would need OS-level thread creation failure);
+    // panic here is same posture the sibling `nexus-vault` plugin
+    // takes for its own service state — a broken plugin is worse
+    // than a loud failure at load time.
+    // Single-threaded runtime — same posture as `nexus-vault`.  Search
+    // requests are IO-bound (kernel-syscall walk); parallelism gain
+    // does not justify pulling `rt-multi-thread` into the plugin's
+    // dep tree.
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("build search-plugin tokio runtime");
+    Box::new(SearchPlugin { svc, rt })
+}
+
+/// Legacy short-name Call RPC dispatch is intentionally empty — every
+/// caller reaches us through Phase P gRPC routing.  The plugin ABI
+/// still requires a dispatch function pointer, so we translate any
+/// `/`-prefixed method into `dispatch_grpc` and reject the rest.
+fn dispatch_search(plugin: &SearchPlugin, method: &str, payload: &[u8]) -> Result<Vec<u8>, i32> {
+    if method.starts_with('/') {
+        return dispatch_grpc(plugin, method, payload);
+    }
+    tracing::warn!(
+        method = %method,
+        "nexus-search-plugin: legacy Call RPC method rejected — use gRPC service path",
+    );
+    Err(-2 /* PluginResult::InvalidArgument */)
+}
+
+/// Bytes-level gRPC dispatch (Phase P contract).  `method` is the
+/// full `/<svc.full.Name>/<Method>` path handed to us by the
+/// cluster's `PluginProxyService`; `payload` is the prost-encoded
+/// request body (gRPC frame already stripped upstream); return is
+/// prost-encoded response body.
+fn dispatch_grpc(plugin: &SearchPlugin, method: &str, payload: &[u8]) -> Result<Vec<u8>, i32> {
+    // Strip leading `/` and split off service full name.
+    let (service_and_method, _) = (method.trim_start_matches('/'), ());
+    let mut parts = service_and_method.splitn(2, '/');
+    let (Some(service_full_name), Some(method_name)) = (parts.next(), parts.next()) else {
+        tracing::warn!(method = %method, "malformed gRPC path");
+        return Err(-2);
+    };
+    if service_full_name != "nexus.search.v1.SearchService" {
+        tracing::warn!(
+            service = %service_full_name,
+            method = %method_name,
+            "unknown service",
+        );
+        return Err(-2);
+    }
+
+    match method_name {
+        "Glob" => {
+            let req = GlobRequest::decode(payload).map_err(|e| {
+                tracing::warn!(err = %e, "Glob decode");
+                -2
+            })?;
+            let resp = plugin
+                .rt
+                .block_on(plugin.svc.glob(Request::new(req)))
+                .map_err(|s| {
+                    tracing::warn!(status = %s, "Glob handler");
+                    -3
+                })?
+                .into_inner();
+            Ok(resp.encode_to_vec())
+        }
+        "Grep" => {
+            let req = GrepRequest::decode(payload).map_err(|e| {
+                tracing::warn!(err = %e, "Grep decode");
+                -2
+            })?;
+            let resp = plugin
+                .rt
+                .block_on(plugin.svc.grep(Request::new(req)))
+                .map_err(|s| {
+                    tracing::warn!(status = %s, "Grep handler");
+                    -3
+                })?
+                .into_inner();
+            Ok(resp.encode_to_vec())
+        }
+        _ => {
+            tracing::warn!(method = %method_name, "unknown method");
+            Err(-2)
+        }
+    }
+}
+
+declare_service_plugin!("search", SearchPlugin, {
+    create: create_search_plugin,
+    dispatch: dispatch_search,
+});
+
+/// Phase P opt-in: this cdylib exposes the two gRPC service full names
+/// hosted here, so `nexusd-cluster` can route external tonic traffic
+/// at `/nexus.search.v1.SearchService/<method>` into our
+/// `nexus_service_dispatch`.  See `nexus-plugin-abi`'s
+/// `symbols::SERVICE_GRPC_SERVICES` constant for the JSON contract.
+///
+/// # Safety
+///
+/// `SERVICES_JSON` is a static, null-terminated UTF-8 byte string with
+/// `'static` lifetime; the pointer we hand back never dangles.  The
+/// loader treats the return value as `*const c_char` and only reads
+/// (never frees) it.
+#[no_mangle]
+pub unsafe extern "C" fn nexus_plugin_grpc_services() -> *const c_char {
+    const SERVICES_JSON: &[u8] = b"[\"nexus.search.v1.SearchService\"]\0";
+    SERVICES_JSON.as_ptr() as *const c_char
+}
+
+// Re-export the two proto message types for downstream integration
+// tests that dial the plugin over a real tonic channel.  Kept in the
+// crate root so callers write `use nexus_search_plugin::{GlobRequest,
+// GrepRequest}` without going through the generated module tree.
+pub use search_proto::{GlobResponse as ExportGlobResponse, GrepResponse as ExportGrepResponse};

--- a/rust/services/search-plugin/src/service.rs
+++ b/rust/services/search-plugin/src/service.rs
@@ -1,0 +1,518 @@
+//! Implementation of `nexus.search.v1.SearchService`.
+//!
+//! The tonic async trait methods spawn onto a blocking pool because
+//! the walker (`sys_readdir` + `sys_read` recursive descent) is
+//! synchronous FFI into kernel-side code that may itself block on
+//! metastore locks and / or federation `try_remote_fetch` RPCs.
+//! Wrapping the sync body in `spawn_blocking` keeps the request off
+//! the plugin's small tokio runtime and stops one heavy walk from
+//! starving another gRPC request handling on the same executor.
+
+use std::sync::Arc;
+
+use nexus_plugin_abi::KernelHandle;
+use tonic::{async_trait, Request, Response, Status};
+
+use crate::kernel_io::{self, DirEntry, KernelIoError, DT_DIR, DT_REG};
+use crate::search_proto::search_service_server::SearchService;
+use crate::search_proto::{GlobRequest, GlobResponse, GrepMatch, GrepRequest, GrepResponse};
+
+/// Server-side default when the caller sends `max_results = 0`.
+/// Kept generous — a well-scoped `pattern` almost never hits this,
+/// and callers who want stricter limits still set them explicitly.
+const DEFAULT_GLOB_MAX: usize = 10_000;
+const DEFAULT_GREP_MAX: usize = 1_000;
+
+/// Belt-and-suspenders per-file size cap for grep — a 100 MB
+/// binary blob would otherwise stall a single request for seconds.
+/// Files above this size are skipped with a `tracing::debug` log.
+const GREP_MAX_FILE_BYTES: usize = 8 * 1024 * 1024;
+
+pub struct SearchServiceImpl {
+    handle: Arc<KernelHandle>,
+}
+
+impl SearchServiceImpl {
+    pub fn new(handle: Arc<KernelHandle>) -> Self {
+        Self { handle }
+    }
+}
+
+// ── Glob ──────────────────────────────────────────────────────────
+
+fn do_glob(
+    handle: &KernelHandle,
+    root_path: &str,
+    pattern: &str,
+    max_results: usize,
+) -> Result<(Vec<String>, bool), String> {
+    // Empty pattern ⇒ match everything (walk-and-list mode).  Callers
+    // that literally want no matches send an obviously-unmatchable
+    // pattern; the empty string is the more useful default.
+    let matcher = if pattern.is_empty() {
+        None
+    } else {
+        Some(
+            globset::Glob::new(pattern)
+                .map_err(|e| format!("invalid glob pattern {pattern:?}: {e}"))?
+                .compile_matcher(),
+        )
+    };
+
+    let mut out = Vec::new();
+    let mut truncated = false;
+
+    walk_recursive(handle, root_path, &mut |vfs_path, entry_type| {
+        if out.len() >= max_results {
+            truncated = true;
+            return WalkAction::Stop;
+        }
+        // Match against the path RELATIVE to `root_path` — this is
+        // what globset patterns naturally target (`docs/*.md` reads
+        // relative to the walk root; the caller composes back to
+        // absolute if they want).
+        let relative = strip_root(root_path, vfs_path);
+        let matched = matcher
+            .as_ref()
+            .map(|m| m.is_match(relative))
+            .unwrap_or(true);
+        if matched {
+            // Skip pure dirs in the returned list — glob is
+            // file-oriented per the Python `search_service.glob`
+            // contract.  Callers who need dir listing use
+            // `sys_readdir` directly.
+            if entry_type != DT_DIR {
+                out.push(vfs_path.to_string());
+            }
+        }
+        WalkAction::Continue
+    })
+    .map_err(walk_err_to_string)?;
+
+    Ok((out, truncated))
+}
+
+// ── Grep ──────────────────────────────────────────────────────────
+
+// Same rationale as `grep_scan` above — the 9-arg signature is the
+// wire request unpacked; clustering into a struct hides the intent
+// at the call site.
+#[allow(clippy::too_many_arguments)]
+fn do_grep(
+    handle: &KernelHandle,
+    root_path: &str,
+    pattern: &str,
+    file_pattern: &str,
+    ignore_case: bool,
+    max_results: usize,
+    before_context: usize,
+    after_context: usize,
+    invert_match: bool,
+) -> Result<(Vec<GrepMatch>, bool), String> {
+    if pattern.is_empty() {
+        return Err("grep pattern must not be empty".into());
+    }
+
+    let re = regex::RegexBuilder::new(pattern)
+        .case_insensitive(ignore_case)
+        .build()
+        .map_err(|e| format!("invalid regex {pattern:?}: {e}"))?;
+
+    let file_matcher = if file_pattern.is_empty() {
+        None
+    } else {
+        Some(
+            globset::Glob::new(file_pattern)
+                .map_err(|e| format!("invalid file_pattern {file_pattern:?}: {e}"))?
+                .compile_matcher(),
+        )
+    };
+
+    let mut matches: Vec<GrepMatch> = Vec::new();
+    let mut truncated = false;
+
+    walk_recursive(handle, root_path, &mut |vfs_path, entry_type| {
+        if matches.len() >= max_results {
+            truncated = true;
+            return WalkAction::Stop;
+        }
+        if entry_type != DT_REG {
+            return WalkAction::Continue;
+        }
+        let relative = strip_root(root_path, vfs_path);
+        if let Some(fm) = &file_matcher {
+            if !fm.is_match(relative) {
+                return WalkAction::Continue;
+            }
+        }
+
+        match kernel_io::sys_read(handle, vfs_path) {
+            Ok(bytes) => {
+                if bytes.len() > GREP_MAX_FILE_BYTES {
+                    tracing::debug!(
+                        path = %vfs_path,
+                        size = bytes.len(),
+                        cap = GREP_MAX_FILE_BYTES,
+                        "grep: skipping oversized file",
+                    );
+                    return WalkAction::Continue;
+                }
+                let text = match std::str::from_utf8(&bytes) {
+                    Ok(s) => s,
+                    Err(_) => {
+                        // Binary file — skip silently (mirrors GNU grep
+                        // default behaviour where `--binary-files=skip`
+                        // is the safe common case).
+                        return WalkAction::Continue;
+                    }
+                };
+                grep_scan(
+                    text,
+                    vfs_path,
+                    &re,
+                    before_context,
+                    after_context,
+                    invert_match,
+                    max_results,
+                    &mut matches,
+                    &mut truncated,
+                );
+                if truncated {
+                    WalkAction::Stop
+                } else {
+                    WalkAction::Continue
+                }
+            }
+            Err(KernelIoError::NotFound) => WalkAction::Continue,
+            Err(e) => {
+                tracing::warn!(
+                    path = %vfs_path,
+                    err = ?e,
+                    "grep: sys_read failed — skipping file",
+                );
+                WalkAction::Continue
+            }
+        }
+    })
+    .map_err(walk_err_to_string)?;
+
+    Ok((matches, truncated))
+}
+
+// `grep_scan` is a plain buffer walker — 9 args are the request
+// contract (pattern + 2 context sizes + invert + cap + out slot +
+// truncated slot) plus the file path stamped into each match.
+// Splitting into a config struct would cost the clarity of the
+// inline arg names at each call site.
+#[allow(clippy::too_many_arguments)]
+fn grep_scan(
+    text: &str,
+    path: &str,
+    re: &regex::Regex,
+    before_context: usize,
+    after_context: usize,
+    invert_match: bool,
+    max_results: usize,
+    out: &mut Vec<GrepMatch>,
+    truncated: &mut bool,
+) {
+    // `str::lines` handles the trailing-newline case correctly
+    // ("a\nb\n" ⇒ ["a", "b"]) — `split('\n')` would yield a
+    // spurious empty tail line that invert-match would then treat
+    // as a hit.  Do not switch back to `split`.
+    let lines: Vec<&str> = text.lines().collect();
+    for (idx, line) in lines.iter().enumerate() {
+        if out.len() >= max_results {
+            *truncated = true;
+            return;
+        }
+        let hit = re.is_match(line);
+        let want = if invert_match { !hit } else { hit };
+        if !want {
+            continue;
+        }
+        let before_start = idx.saturating_sub(before_context);
+        let after_end = (idx + 1 + after_context).min(lines.len());
+        let before: Vec<String> = lines[before_start..idx]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let after: Vec<String> = lines[idx + 1..after_end]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        out.push(GrepMatch {
+            path: path.to_string(),
+            line_number: (idx as u32) + 1,
+            line: line.to_string(),
+            before,
+            after,
+        });
+    }
+}
+
+// ── Recursive walker (sync, uses KernelHandle FFI) ────────────────
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum WalkAction {
+    Continue,
+    Stop,
+}
+
+/// Recursively walk `root_path` via `sys_readdir`; invoke `visit` on
+/// every entry (files AND dirs) with its full VFS path + entry_type.
+///
+/// The walker is DFS pre-order (yield entry, then recurse if it's a
+/// dir).  Errors on a specific sub-tree are logged and the walker
+/// continues — a permission-denied sub-dir does not abort the whole
+/// walk.  A `NotFound` on `root_path` itself is bubbled up.
+fn walk_recursive(
+    handle: &KernelHandle,
+    root_path: &str,
+    visit: &mut dyn FnMut(&str, u8) -> WalkAction,
+) -> Result<(), KernelIoError> {
+    // Root-level readdir has to succeed OR we bubble the error.  A
+    // NotFound here means the caller pointed us at nothing.
+    let root_entries = kernel_io::sys_readdir(handle, root_path)?;
+    walk_entries(handle, root_path, root_entries, visit);
+    Ok(())
+}
+
+fn walk_entries(
+    handle: &KernelHandle,
+    parent: &str,
+    entries: Vec<DirEntry>,
+    visit: &mut dyn FnMut(&str, u8) -> WalkAction,
+) -> WalkAction {
+    for entry in entries {
+        let child_path = kernel_io::join_vfs_path(parent, &entry.name);
+        if visit(&child_path, entry.entry_type) == WalkAction::Stop {
+            return WalkAction::Stop;
+        }
+        // Recurse into DT_DIR + DT_MOUNT (we walk THROUGH mounts
+        // per the filesystem invariant that a mount replaces the
+        // directory's contents; from the search plugin's view a
+        // mount is a container of children just like a dir).
+        if entry.entry_type == DT_DIR || entry.entry_type == kernel_io::DT_MOUNT {
+            match kernel_io::sys_readdir(handle, &child_path) {
+                Ok(child_entries) => {
+                    if walk_entries(handle, &child_path, child_entries, visit) == WalkAction::Stop {
+                        return WalkAction::Stop;
+                    }
+                }
+                Err(KernelIoError::NotFound) => {
+                    // Race with a concurrent unlink / unmount — skip.
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        path = %child_path,
+                        err = ?e,
+                        "walk: sys_readdir failed — skipping subtree",
+                    );
+                }
+            }
+        }
+    }
+    WalkAction::Continue
+}
+
+fn strip_root<'a>(root: &str, path: &'a str) -> &'a str {
+    let trimmed = root.trim_end_matches('/');
+    if let Some(rest) = path.strip_prefix(trimmed) {
+        rest.trim_start_matches('/')
+    } else {
+        path.trim_start_matches('/')
+    }
+}
+
+fn walk_err_to_string(e: KernelIoError) -> String {
+    match e {
+        KernelIoError::NotFound => "root_path not found".into(),
+        other => format!("kernel io: {other:?}"),
+    }
+}
+
+// ── tonic trait impl ──────────────────────────────────────────────
+
+#[async_trait]
+impl SearchService for SearchServiceImpl {
+    async fn glob(&self, request: Request<GlobRequest>) -> Result<Response<GlobResponse>, Status> {
+        let req = request.into_inner();
+        let root = if req.root_path.is_empty() {
+            "/".to_string()
+        } else {
+            req.root_path
+        };
+        let pattern = req.pattern;
+        let cap = if req.max_results == 0 {
+            DEFAULT_GLOB_MAX
+        } else {
+            req.max_results as usize
+        };
+        // Clone the Arc into the blocking task — KernelHandle is
+        // Send + Sync per the plugin ABI's unsafe impl; the Arc
+        // keeps the underlying callback table alive for as long as
+        // any request is in flight.
+        let handle = Arc::clone(&self.handle);
+        let outcome = tokio::task::spawn_blocking(move || do_glob(&handle, &root, &pattern, cap))
+            .await
+            .map_err(|e| Status::internal(format!("spawn_blocking joined error: {e}")))?;
+
+        match outcome {
+            Ok((paths, truncated)) => Ok(Response::new(GlobResponse {
+                paths,
+                truncated,
+                error: None,
+            })),
+            Err(err) => Ok(Response::new(GlobResponse {
+                paths: Vec::new(),
+                truncated: false,
+                error: Some(err),
+            })),
+        }
+    }
+
+    async fn grep(&self, request: Request<GrepRequest>) -> Result<Response<GrepResponse>, Status> {
+        let req = request.into_inner();
+        let root = if req.root_path.is_empty() {
+            "/".to_string()
+        } else {
+            req.root_path
+        };
+        let cap = if req.max_results == 0 {
+            DEFAULT_GREP_MAX
+        } else {
+            req.max_results as usize
+        };
+        let handle = Arc::clone(&self.handle);
+        let outcome = tokio::task::spawn_blocking(move || {
+            do_grep(
+                &handle,
+                &root,
+                &req.pattern,
+                &req.file_pattern,
+                req.ignore_case,
+                cap,
+                req.before_context as usize,
+                req.after_context as usize,
+                req.invert_match,
+            )
+        })
+        .await
+        .map_err(|e| Status::internal(format!("spawn_blocking joined error: {e}")))?;
+
+        match outcome {
+            Ok((matches, truncated)) => Ok(Response::new(GrepResponse {
+                matches,
+                truncated,
+                error: None,
+            })),
+            Err(err) => Ok(Response::new(GrepResponse {
+                matches: Vec::new(),
+                truncated: false,
+                error: Some(err),
+            })),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Unit tests for the search primitives that DO NOT need a real
+    //! kernel — pure logic (strip_root / grep_scan on in-memory
+    //! strings).  Kernel-driven walk tests live in `tests/e2e.rs`
+    //! where a MockKernelHandle can provide a canned filesystem.
+
+    use super::*;
+
+    #[test]
+    fn strip_root_handles_trailing_slash() {
+        assert_eq!(strip_root("/", "/foo/bar"), "foo/bar");
+        assert_eq!(strip_root("/root", "/root/a/b"), "a/b");
+        assert_eq!(strip_root("/root/", "/root/a/b"), "a/b");
+    }
+
+    #[test]
+    fn grep_scan_finds_basic_match() {
+        let re = regex::Regex::new(r"hello").unwrap();
+        let mut out = Vec::new();
+        let mut truncated = false;
+        grep_scan(
+            "line 1\nhello world\nline 3\n",
+            "/f.txt",
+            &re,
+            0,
+            0,
+            false,
+            100,
+            &mut out,
+            &mut truncated,
+        );
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].line, "hello world");
+        assert_eq!(out[0].line_number, 2);
+        assert!(!truncated);
+    }
+
+    #[test]
+    fn grep_scan_context_lines() {
+        let re = regex::Regex::new(r"middle").unwrap();
+        let mut out = Vec::new();
+        let mut truncated = false;
+        grep_scan(
+            "a\nb\nc\nmiddle\ne\nf\ng\n",
+            "/f.txt",
+            &re,
+            2,
+            2,
+            false,
+            100,
+            &mut out,
+            &mut truncated,
+        );
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].before, vec!["b".to_string(), "c".to_string()]);
+        assert_eq!(out[0].after, vec!["e".to_string(), "f".to_string()]);
+    }
+
+    #[test]
+    fn grep_scan_invert_returns_non_matches() {
+        let re = regex::Regex::new(r"skip").unwrap();
+        let mut out = Vec::new();
+        let mut truncated = false;
+        grep_scan(
+            "skip\nkeep\nskip\nkeep2\n",
+            "/f.txt",
+            &re,
+            0,
+            0,
+            true,
+            100,
+            &mut out,
+            &mut truncated,
+        );
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[0].line, "keep");
+        assert_eq!(out[1].line, "keep2");
+    }
+
+    #[test]
+    fn grep_scan_respects_max_results() {
+        let re = regex::Regex::new(r".*").unwrap();
+        let mut out = Vec::new();
+        let mut truncated = false;
+        grep_scan(
+            "a\nb\nc\nd\ne\n",
+            "/f.txt",
+            &re,
+            0,
+            0,
+            false,
+            2,
+            &mut out,
+            &mut truncated,
+        );
+        assert_eq!(out.len(), 2);
+        assert!(truncated);
+    }
+}

--- a/rust/services/search-plugin/tests/dlopen_self.rs
+++ b/rust/services/search-plugin/tests/dlopen_self.rs
@@ -1,0 +1,148 @@
+//! `dlopen` regression test for `nexus-search-plugin`.
+//!
+//! Cargo builds the crate as an rlib for the test binary, but the
+//! kernel loader dlopens the cdylib.  This test builds the cdylib
+//! explicitly, opens it via `libloading`, resolves every plugin-ABI
+//! manifest symbol the loader needs, and validates:
+//!
+//!   * `nexus_plugin_api_version` returns `PLUGIN_API_VERSION`
+//!   * `nexus_plugin_kind` reports `PluginKind::Service`
+//!   * `nexus_plugin_name` reports the literal `"search"`
+//!   * `nexus_service_{create,dispatch,destroy}` are exported
+//!   * `nexus_plugin_grpc_services` (Phase P opt-in) returns the
+//!     `["nexus.search.v1.SearchService"]` JSON contract
+//!
+//! Mirrors `nexus-vault/tests/dlopen_self.rs`; both symbol lists
+//! and both file layouts are the plugin-ABI's stable surface.
+//! Adding a new required symbol on the loader side without updating
+//! this test would surface at PR time on all three
+//! `libloading`-supported platforms.
+
+use std::ffi::CStr;
+use std::path::PathBuf;
+use std::process::Command;
+
+use nexus_plugin_abi::{symbols, PluginKind, PLUGIN_API_VERSION};
+
+#[cfg(target_os = "linux")]
+const PLUGIN_FILE: &str = "libnexus_search_plugin.so";
+#[cfg(target_os = "macos")]
+const PLUGIN_FILE: &str = "libnexus_search_plugin.dylib";
+#[cfg(target_os = "windows")]
+const PLUGIN_FILE: &str = "nexus_search_plugin.dll";
+
+fn plugin_path() -> PathBuf {
+    // `current_exe()` returns the test binary path:
+    //   target/{debug,release}/deps/dlopen_self-<hash>(.exe)
+    // The cdylib lives next to the profile dir:
+    //   target/{debug,release}/<PLUGIN_FILE>
+    let exe = std::env::current_exe().expect("current_exe");
+    let target_profile_dir = exe
+        .parent()
+        .and_then(|p| p.parent())
+        .unwrap_or_else(|| panic!("unexpected test binary layout: {}", exe.display()));
+    target_profile_dir.join(PLUGIN_FILE)
+}
+
+/// `cargo test` builds the test binary against the rlib; workspace-
+/// wide runs don't necessarily emit the cdylib.  Force the build so
+/// the test is self-contained regardless of invocation shape.
+fn ensure_cdylib_built(plugin: &std::path::Path) {
+    if plugin.exists() {
+        return;
+    }
+    let mut cmd = Command::new(env!("CARGO"));
+    cmd.args(["build", "-p", "nexus-search-plugin"]);
+    if !cfg!(debug_assertions) {
+        cmd.arg("--release");
+    }
+    let status = cmd.status().expect("invoke cargo");
+    assert!(
+        status.success(),
+        "cargo build -p nexus-search-plugin failed"
+    );
+    assert!(
+        plugin.exists(),
+        "cdylib still not at {} after cargo build — check [lib] crate-type includes \"cdylib\"",
+        plugin.display()
+    );
+}
+
+#[test]
+fn search_cdylib_dlopens_with_required_symbols() {
+    let plugin = plugin_path();
+    ensure_cdylib_built(&plugin);
+
+    let lib = unsafe { libloading::Library::new(&plugin) }
+        .unwrap_or_else(|e| panic!("dlopen({}) failed: {e}", plugin.display()));
+
+    unsafe {
+        // API version — a version drift would mean the plugin
+        // compiled against a nexus-vfs whose ABI the running
+        // cluster no longer accepts.
+        let api_version: libloading::Symbol<unsafe extern "C" fn() -> u32> = lib
+            .get(symbols::API_VERSION.as_bytes())
+            .unwrap_or_else(|e| panic!("resolve {}: {e}", symbols::API_VERSION));
+        assert_eq!(
+            api_version(),
+            PLUGIN_API_VERSION,
+            "plugin reports api_version != PLUGIN_API_VERSION ({PLUGIN_API_VERSION})",
+        );
+
+        // Kind — must be Service (search is not a Driver).
+        let kind: libloading::Symbol<unsafe extern "C" fn() -> u32> = lib
+            .get(symbols::KIND.as_bytes())
+            .unwrap_or_else(|e| panic!("resolve {}: {e}", symbols::KIND));
+        assert_eq!(
+            PluginKind::from_raw(kind()),
+            Some(PluginKind::Service),
+            "search-plugin should declare PluginKind::Service",
+        );
+
+        // Name — must match what `declare_service_plugin!` was
+        // given.  Loader indexes plugins by this string, so a
+        // silent rename would strand mount specs pointing at the
+        // old name.
+        let name_fn: libloading::Symbol<unsafe extern "C" fn() -> *const std::ffi::c_char> = lib
+            .get(symbols::NAME.as_bytes())
+            .unwrap_or_else(|e| panic!("resolve {}: {e}", symbols::NAME));
+        let name = CStr::from_ptr(name_fn())
+            .to_str()
+            .expect("plugin name UTF-8");
+        assert_eq!(name, "search");
+
+        // Service lifecycle triplet — a missing entry surfaces as
+        // "plugin found but rejected at load" (the SEV shape from
+        // nexus-vfs#45).
+        for sym in [
+            symbols::SERVICE_CREATE,
+            symbols::SERVICE_DISPATCH,
+            symbols::SERVICE_DESTROY,
+        ] {
+            let _: libloading::Symbol<unsafe extern "C" fn()> = lib
+                .get(sym.as_bytes())
+                .unwrap_or_else(|e| panic!("resolve {sym}: {e}"));
+        }
+
+        // Phase P opt-in symbol — cluster loader dlsym's this to
+        // learn which gRPC service full names to route into the
+        // plugin's `nexus_service_dispatch`.  Return contract: a
+        // null-terminated UTF-8 JSON array of service full names.
+        let grpc_services: libloading::Symbol<unsafe extern "C" fn() -> *const std::ffi::c_char> =
+            lib.get(symbols::SERVICE_GRPC_SERVICES.as_bytes())
+                .unwrap_or_else(|e| panic!("resolve {}: {e}", symbols::SERVICE_GRPC_SERVICES));
+        let services_json = CStr::from_ptr(grpc_services())
+            .to_str()
+            .expect("grpc_services JSON UTF-8");
+        // Parse the JSON so a future refactor that ships malformed
+        // JSON (missing quote, trailing comma) fails at PR time
+        // instead of at cluster load time.
+        let services: Vec<String> = serde_json::from_str(services_json)
+            .unwrap_or_else(|e| panic!("grpc_services JSON parse: {e} — got {services_json:?}"));
+        assert_eq!(
+            services,
+            vec!["nexus.search.v1.SearchService".to_string()],
+            "plugin must advertise exactly the SearchService full name",
+        );
+    }
+}


### PR DESCRIPTION
New \`rust/services/search-plugin/\` cdylib — the Rust replacement for the Python \`nexus.bricks.search.search_service.SearchService\`.  Follows the sibling \`nexus-vault\` + \`nexus-fuse-plugin\` pattern: \`declare_service_plugin!\` + Phase P \`nexus_plugin_grpc_services\` for cluster gRPC routing.

## Summary

- New plugin at \`rust/services/search-plugin/\` — cdylib + rlib, name \`\"search\"\`, exposes \`nexus.search.v1.SearchService\`.
- Two RPCs: \`Glob\` (globset-style patterns) + \`Grep\` (regex with context / invert / file-pattern filter), unary responses capped by \`max_results\`.
- Cross-node transparent: recursive walk via \`sys_readdir\` + \`sys_read\` uses federation \`try_remote_fetch\` under the hood — the plugin has zero federation awareness.
- Every request dispatches through \`tokio::task::spawn_blocking\` so sync FFI walks do not stall the plugin runtime under concurrent load.

## Deferred (v2, separate PRs)

- Streaming responses for large result sets.
- Trigram indexing for grep (dominant Python-side perf strategy).
- Adaptive glob strategy per pattern shape.
- Optional semantic embeddings feature flag.
- \`release-plugin-reusable.yml\` wrapper for signed releases.

## Test plan

- [x] 7 unit tests covering pure logic (path join, root strip, grep line scan with context / invert / max_results). Deterministic, no kernel.
- [x] \`tests/dlopen_self.rs\` E2E — builds the cdylib and dlopens it via \`libloading\`, resolving every plugin-ABI manifest symbol AND parsing the \`nexus_plugin_grpc_services\` JSON to lock in the Phase P contract.  Runs on Linux, macOS, Windows.
- [x] \`cargo check --workspace\` clean.
- [x] \`cargo clippy --workspace --all-targets\` — zero warnings.
- [x] \`cargo fmt --all\` clean.