### PR TITLE
fix(scripts): dogfood vault boot drops retired --bootstrap-mode

### DIFF
--- a/scripts/_dogfood_vault.py
+++ b/scripts/_dogfood_vault.py
@@ -192,12 +192,16 @@ def boot_cluster(
     env["NEXUS_DATA_DIR"] = str(data_dir)
     env["RUST_LOG"] = env.get("RUST_LOG", "warn")
 
-    # `--bind-addr` (not `--bind`) and an explicit `--bootstrap-mode`
-    # are both required for daemon mode; without them the cluster either
-    # rejects the CLI or silently picks a non-ephemeral path. `static`
-    # = single-node, no federation — the right shape for a tempdir-only
-    # ephemeral vault. `--data-dir` keeps every redb file inside the
-    # tempdir so the cluster has no path to anything persistent.
+    # `--bind-addr` (not `--bind`) is required for daemon mode; without
+    # it the cluster never opens a gRPC port and the port-wait loop
+    # times out.  `--data-dir` keeps every redb file inside the tempdir
+    # so the cluster has no path to anything persistent.
+    #
+    # `--bootstrap-mode` was retired by Phase G (nexus-vfs #118) — the
+    # daemon now auto-detects boot semantics via `plan_boot_action`.
+    # An empty data-dir with no federation env vars resolves to row 2
+    # (RootlessDynamic), which is the correct shape for an ephemeral
+    # vault: single-node, no federation, gRPC serve.
     proc = subprocess.Popen(
         [
             str(nexusd_cluster),
@@ -208,8 +212,6 @@ def boot_cluster(
             "--no-tls",
             "--bind-addr",
             f"127.0.0.1:{port}",
-            "--bootstrap-mode",
-            "static",
         ],
         env=env,
         stdout=subprocess.PIPE,


### PR DESCRIPTION
## Summary

Surfaced by cutting the first \`search-v0.1.0\` tag: every plugin
release run fails at the vault key-fetch step with

> cluster did not start listening on 127.0.0.1:NNNN within deadline

Phase G (nexus-vfs #118, sweep #51b9ce3d9) retired \`--bootstrap-mode\`
and shifted boot-shape detection to \`plan_boot_action\`, but
\`scripts/_dogfood_vault.py\` was missed in that sweep.  The stale flag
makes the daemon reject the CLI at parse time; the caller's
port-wait loop then times out with a message that reads like a
network hang rather than an argparse failure.

Post-Phase-G an empty data-dir with no \`NEXUS_FEDERATION_*\` env
resolves to row 2 (RootlessDynamic) — single-node, no federation,
gRPC serve — exactly the ephemeral-vault shape.

This unblocks the \`Package and upload\` job on every plugin release
workflow (vault, fuse, local-connector, search) that runs against a
post-Phase-G nexus-vfs pin.

## Test plan

- [x] grep confirms \`--bootstrap-mode\` no longer exists in the cluster CLI
- [x] loopback + \`--no-tls\` matches the \`ServeLocal\` shape the daemon uses for trusted-local backends (auth_posture recognises without \`--insecure-no-auth\`)
- [ ] CI green
- [ ] Re-run the failing \`Release Search Plugin\` job (search-v0.1.0) via workflow_dispatch after this merges — should reach signed archives on all 4 platforms