### PR TITLE
fix(search-v1): systematic reconciliation of two post-v1 patches

### DIFF
--- a/rust/services/proto/nexus/search/v1/search.proto
+++ b/rust/services/proto/nexus/search/v1/search.proto
@@ -19,11 +19,14 @@ syntax = "proto3";
 package nexus.search.v1;
 
 service SearchService {
-  // Recursively walk `root_path`; return the paths matching `pattern`.
+  // Recursively walk `root_path`; return the absolute VFS paths of
+  // entries matching `pattern`.
   //
   // Pattern is a globset-style glob (`**/*.py`, `docs/*.md`, ...) —
-  // matched against paths relative to `root_path`. A caller who wants
-  // absolute matches concatenates `root_path` back in.
+  // MATCHED against each entry's path relative to `root_path`.  The
+  // RESPONSE paths are the full absolute VFS path (starts with `/`),
+  // matching `GrepMatch.path` convention across the service so callers
+  // decode both rpcs' path fields with one rule.
   rpc Glob(GlobRequest) returns (GlobResponse);
 
   // Recursively walk `root_path` and return every regex match in
@@ -48,6 +51,9 @@ message GlobRequest {
 }
 
 message GlobResponse {
+  // Absolute VFS paths of matching entries (each starts with `/`).
+  // Same convention as `GrepMatch.path` — the callers decode both
+  // rpcs' path outputs with one rule.
   repeated string paths = 1;
   // `paths.len() == max_results` AND more entries were skipped.
   bool truncated = 2;

--- a/scripts/_dogfood_vault.py
+++ b/scripts/_dogfood_vault.py
@@ -192,26 +192,29 @@ def boot_cluster(
     env["NEXUS_DATA_DIR"] = str(data_dir)
     env["RUST_LOG"] = env.get("RUST_LOG", "warn")
 
-    # `--bind-addr` (not `--bind`) is required for daemon mode; without
-    # it the cluster never opens a gRPC port and the port-wait loop
-    # times out.  `--data-dir` keeps every redb file inside the tempdir
-    # so the cluster has no path to anything persistent.
+    # Use the `serve-local` subcommand rather than hand-composing
+    # `--bind-addr 127.0.0.1:<port> --no-tls` on the top-level daemon
+    # path.  `serve-local` is the SSOT for the trusted-local-backend
+    # invariant (its handler in nexus-vfs profiles/cluster/src/lib.rs
+    # forces both), and its docstring explicitly calls out that it
+    # exists so this invariant lives in the binary instead of being
+    # hand-written — and drifting — at each spawn site (the
+    # `--bootstrap-mode` breakage that hit sudowork / moss / sudocode
+    # at once is the failure mode this closes).  This script was one
+    # of those drift sites; the fix routes it back through the SSOT.
     #
-    # `--bootstrap-mode` was retired by Phase G (nexus-vfs #118) — the
-    # daemon now auto-detects boot semantics via `plan_boot_action`.
-    # An empty data-dir with no federation env vars resolves to row 2
-    # (RootlessDynamic), which is the correct shape for an ephemeral
-    # vault: single-node, no federation, gRPC serve.
+    # `--plugin-dir` and `--data-dir` are `global = true` clap args on
+    # the daemon's CommonArgs, so they compose with the subcommand.
     proc = subprocess.Popen(
         [
             str(nexusd_cluster),
+            "serve-local",
+            "--port",
+            str(port),
             "--plugin-dir",
             str(plugin_dir),
             "--data-dir",
             str(data_dir),
-            "--no-tls",
-            "--bind-addr",
-            f"127.0.0.1:{port}",
         ],
         env=env,
         stdout=subprocess.PIPE,

--- a/tests/e2e/docker/test_search_plugin.py
+++ b/tests/e2e/docker/test_search_plugin.py
@@ -117,12 +117,10 @@ class TestSearchGlob:
         r = search_glob(NODE_GRPC, base, "**/*.py", api_key=api_key)
         assert "error" not in r, f"glob returned error: {r}"
         paths = set(r["result"]["paths"])
-        # The plugin currently returns ABSOLUTE VFS paths (service.rs:85
-        # pushes `vfs_path.to_string()`), even though the proto docstring
-        # for GlobResponse.paths says "relative to root_path".  We lock
-        # in the actual wire behavior and file the doc/impl drift as a
-        # separate follow-up (search.proto:24 vs service.rs:85) — the
-        # E2E's job is to snapshot reality, not adjudicate the contract.
+        # GlobResponse.paths are absolute VFS paths — same convention as
+        # GrepMatch.path.  See the service-level comment on
+        # `rpc Glob` in search.proto for the "match relative, return
+        # absolute" split.
         assert f"{base}/foo.py" in paths, f"missing foo.py in {paths}"
         assert f"{base}/sub/bar.py" in paths, f"missing sub/bar.py in {paths}"
         assert f"{base}/sub/deeper/baz.py" in paths, f"missing sub/deeper/baz.py in {paths}"


### PR DESCRIPTION
Follow-up on Category A of the search-plugin v1 close-the-loop plan.
Both patches were "works" but not "long-term systematically correct".
This PR routes them back through the SSOTs.

## Commit 1 — dogfood boot via \`serve-local\`

**Problem PR #4520 left unresolved:** it replaced retired
\`--bootstrap-mode static\` with hand-composed \`--bind-addr
127.0.0.1:{port} --no-tls\` on the top-level daemon path.  That
worked but re-perpetuated the anti-pattern the \`serve-local\`
subcommand was created to prevent — the "trusted-local-backend =
loopback + no-tls" invariant lived in two places, so a future
auth_posture drift would silently break signing again.

\`serve-local\`'s own docstring calls this out:

> This is the ONE mode the embedding products (sudowork / moss /
> sudocode) use to spawn a private per-process nexus backend. It
> exists so the loopback + no-tls invariant lives in the binary
> instead of being hand-written — and drifting — at each spawn
> site (the '--bootstrap-mode' breakage that hit all three at once
> is the failure mode this closes).

**Verified before edit:** \`serve-local\`'s clap def is
\`#[arg(long, default_value_t = 2126)] port: u16\` — \`--port <N>\`
overrides.  \`--plugin-dir\` and \`--data-dir\` are \`global = true\`
so they compose with the subcommand.

## Commit 2 — GlobResponse.paths doc/impl reconciliation

**Problem A.4 (#4521) left unresolved:** \`search.proto:22-26\`
implied GlobResponse.paths were relative to root_path ("a caller who
wants absolute matches concatenates root_path back in") but
\`service.rs:85\` pushes \`vfs_path.to_string()\` (absolute).  My A.4
test adapted to the impl-side truth but the proto SSOT stayed
wrong.

**Why doc-side, not impl-side:** \`GrepMatch.path\` is documented AND
implemented as absolute VFS ("Path is expressed as VFS absolute
(starts with \`/\`)").  Changing Glob to relative would leave
callers decoding SearchService with two different path-form rules
across the two rpcs — SRP + orthogonality broken across the
same-tier API surface.  Aligning the proto doc to match Grep is
the systematically correct move — zero wire behavior change, zero
impl churn.

Also refreshes the A.4 test comment to reference the reconciled
proto contract instead of "snapshot-drift".

## 9-principle audit summary

| Principle | Fix 1 (serve-local) | Fix 2 (proto doc) |
|-----------|--------------------|--------------------|
| 1a simpler/robust | ✓ 5→3 flags | ✓ 1-file doc, no impl churn |
| 1b no kernel abi churn | ✓ script | ✓ pure doc |
| 1c right file | ✓ scripts/_dogfood_vault.py | ✓ search.proto (wire SSOT) |
| 1d SRP/orthogonality | ✓ serve-local is the SRP primitive | ✓ Glob + Grep share one path convention |
| 2 no boundary leak | ✓ | ✓ |
| 3 SSOT | ✓ restores single copy | ✓ doc matches impl matches Grep |
| 4 DRY | ✓ | ✓ one rule for two rpcs |
| 5 Rust-first | N/A (script + proto) | N/A (proto is IDL) |
| 6 Perf | N/A (boot-time) | N/A (already-absolute payload) |
| 7 Raft contract | N/A | N/A |
| 8 systematic vs patch | ✓ routes through the exact seam designed to prevent this class | ✓ reconciles at SSOT layer |
| 9 E2E depth | Empirical: v0.1.1 release run + tests/integration/dogfood_keystore_e2e.py | A.4 test's assertion now matches reconciled contract |

## Test plan

- [ ] Rust build/lint green (proto codegen re-runs on \`.proto\` change)
- [ ] search-plugin E2E green (contract is unchanged; impl unchanged)
- [ ] Next \`search-v*\` cut against post-merge develop successfully signs (empirical dogfood cover)