### PR TITLE
docs(search-plugin): internal comment matches absolute-path contract

### DIFF
--- a/rust/services/search-plugin/src/service.rs
+++ b/rust/services/search-plugin/src/service.rs
@@ -69,8 +69,10 @@ fn do_glob(
         }
         // Match against the path RELATIVE to `root_path` — this is
         // what globset patterns naturally target (`docs/*.md` reads
-        // relative to the walk root; the caller composes back to
-        // absolute if they want).
+        // relative to the walk root).  The RESPONSE, however, carries
+        // the absolute vfs_path (line below + search.proto's
+        // GlobResponse.paths contract, matching GrepMatch.path so
+        // callers decode both rpcs' path outputs with one rule).
         let relative = strip_root(root_path, vfs_path);
         let matched = matcher
             .as_ref()


### PR DESCRIPTION
Tail nit from the systematic reconciliation in #4522.

The internal comment inside \`do_glob\` (rust/services/search-plugin/
src/service.rs:70) still read 'the caller composes back to absolute
if they want' — a leftover from the pre-#4522 mental model where the
wire was assumed to return relative paths.  Post-#4522 the wire
contract is locked as absolute (aligned with \`GrepMatch.path\`); this
patch brings the internal comment in line with that.

Pure comment change — the impl at line 87 (\`out.push(vfs_path.to_string())\`)
already pushed absolute paths.  Zero behavior change, zero risk.

## Test plan
- [ ] Rust build + lint green (comment change only)