### PR TITLE
chore(pins): bump nexus-vfs to ad8c3290b (Resume re-asserts founder topology #183 + 3-voter E2E #184)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "a2a"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=307a5bef8a92643f8099f78353597821a4bd8dbd#307a5bef8a92643f8099f78353597821a4bd8dbd"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=ad8c3290b828e54143e17d7a4bbf26d1746a6b81#ad8c3290b828e54143e17d7a4bbf26d1746a6b81"
 dependencies = [
  "contracts",
  "kernel",
@@ -237,7 +237,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=307a5bef8a92643f8099f78353597821a4bd8dbd#307a5bef8a92643f8099f78353597821a4bd8dbd"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=ad8c3290b828e54143e17d7a4bbf26d1746a6b81#ad8c3290b828e54143e17d7a4bbf26d1746a6b81"
 dependencies = [
  "ahash",
  "base64",
@@ -569,7 +569,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=307a5bef8a92643f8099f78353597821a4bd8dbd#307a5bef8a92643f8099f78353597821a4bd8dbd"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=ad8c3290b828e54143e17d7a4bbf26d1746a6b81#ad8c3290b828e54143e17d7a4bbf26d1746a6b81"
 dependencies = [
  "parking_lot",
  "serde",
@@ -1353,7 +1353,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=307a5bef8a92643f8099f78353597821a4bd8dbd#307a5bef8a92643f8099f78353597821a4bd8dbd"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=ad8c3290b828e54143e17d7a4bbf26d1746a6b81#ad8c3290b828e54143e17d7a4bbf26d1746a6b81"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -1405,7 +1405,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=307a5bef8a92643f8099f78353597821a4bd8dbd#307a5bef8a92643f8099f78353597821a4bd8dbd"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=ad8c3290b828e54143e17d7a4bbf26d1746a6b81#ad8c3290b828e54143e17d7a4bbf26d1746a6b81"
 dependencies = [
  "ahash",
  "base64",
@@ -1601,7 +1601,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=307a5bef8a92643f8099f78353597821a4bd8dbd#307a5bef8a92643f8099f78353597821a4bd8dbd"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=ad8c3290b828e54143e17d7a4bbf26d1746a6b81#ad8c3290b828e54143e17d7a4bbf26d1746a6b81"
 
 [[package]]
 name = "nexus-search-plugin"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -217,19 +217,19 @@ exclude = ["nexus-fuse"]
 #
 # Bump alongside the rest of nexus-vfs updates when a downstream
 # change needs newer kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "307a5bef8a92643f8099f78353597821a4bd8dbd" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "307a5bef8a92643f8099f78353597821a4bd8dbd" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "307a5bef8a92643f8099f78353597821a4bd8dbd" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "307a5bef8a92643f8099f78353597821a4bd8dbd", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "307a5bef8a92643f8099f78353597821a4bd8dbd", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "307a5bef8a92643f8099f78353597821a4bd8dbd", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "307a5bef8a92643f8099f78353597821a4bd8dbd" }
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ad8c3290b828e54143e17d7a4bbf26d1746a6b81" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ad8c3290b828e54143e17d7a4bbf26d1746a6b81" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ad8c3290b828e54143e17d7a4bbf26d1746a6b81" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ad8c3290b828e54143e17d7a4bbf26d1746a6b81", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ad8c3290b828e54143e17d7a4bbf26d1746a6b81", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ad8c3290b828e54143e17d7a4bbf26d1746a6b81", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ad8c3290b828e54143e17d7a4bbf26d1746a6b81" }
 # a2a messaging substrate. `default-features = false` leaves the
 # `install` feature (which pulls raft to arm the stream-wakeup observer)
 # OFF, so nexus-side consumers link only the stamp hook and stay
 # raft-free — they reach raft through kernel.sys_* (§6.1). The substrate
 # is armed in production at cluster boot in nexus-vfs, not here.
-a2a = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "307a5bef8a92643f8099f78353597821a4bd8dbd", default-features = false }
+a2a = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ad8c3290b828e54143e17d7a4bbf26d1746a6b81", default-features = false }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ENV CARGO_NET_RETRY=10 \
     CARGO_HTTP_TIMEOUT=120
 # Override for edge/CI or a different pin: --build-arg NEXUS_VFS_REV=<sha|tag>
-ARG NEXUS_VFS_REV=307a5bef8a92643f8099f78353597821a4bd8dbd
+ARG NEXUS_VFS_REV=ad8c3290b828e54143e17d7a4bbf26d1746a6b81
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,id=cargo-install-${TARGETARCH},target=/root/.cargo/target \

--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir --no-deps --prefix=/install .
 # enforces agreement) — an unpinned install tracks nexus-vfs HEAD and
 # ships an untested kernel (#4343). --locked honors the source tree's
 # Cargo.lock.
-ARG NEXUS_VFS_REV=307a5bef8a92643f8099f78353597821a4bd8dbd
+ARG NEXUS_VFS_REV=ad8c3290b828e54143e17d7a4bbf26d1746a6b81
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-cluster nexus-cluster
 
 # -- Runtime stage --

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -25,7 +25,7 @@ WORKDIR /build
 # (CI preflight enforces agreement) — an unpinned install tracks HEAD
 # and can skew the raft contract against the cluster/witness images.
 # --locked honors the source tree's Cargo.lock.
-ARG NEXUS_VFS_REV=307a5bef8a92643f8099f78353597821a4bd8dbd
+ARG NEXUS_VFS_REV=ad8c3290b828e54143e17d7a4bbf26d1746a6b81
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexus-raft-server raft
 
 # ---------- Production image ----------

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=307a5bef8a92643f8099f78353597821a4bd8dbd
+ARG NEXUS_VFS_REV=ad8c3290b828e54143e17d7a4bbf26d1746a6b81
 RUN cargo install \
     --locked \
     --git https://github.com/nexi-lab/nexus-vfs \


### PR DESCRIPTION
Bumps the nexus-vfs pin `307a5bef8` → `ad8c3290b` across Cargo.toml,
Cargo.lock (cargo-regenerated), and all 4 Dockerfile `NEXUS_VFS_REV` ARGs
(the docker smoke preflight requires the trio to match).

Brings in:
- **nexus-vfs #183** — on `Resume`, a founder re-asserts its own declared
  `--cluster-init` zones + mounts. `plan_boot_action` returns `Resume` whenever
  `root` is already on disk (e.g. an offline `auth mint` before the first daemon
  boot), which skipped the `StaticFounder` arm — so the declared zone was never
  founded and `/agents/*` fell back to node-local root, where an A2A mailbox
  binds root and never replicates cross-machine. Peerless-gated so a founder
  that has voter joiners rejoins instead of re-founding (no split-brain).
- **nexus-vfs #184** — a 3-voter founder-loss election E2E (kill founder →
  surviving 2/3 majority elects a new leader → writes continue).

`ad8c3290b` is a clean forward descendant of the current pin (no regression;
already contains the EC substrate via #182).