### PR TITLE
ci: quiesce disabled docker-integration workflow (stop phantom skip)

### DIFF
--- a/.github/workflows/docker-integration.yml
+++ b/.github/workflows/docker-integration.yml
@@ -11,27 +11,16 @@ name: Docker Integration Test
 # 2. Click "New repository secret"
 # 3. Add each secret with the exact name and value shown above
 
+# Auto-triggers are removed while the job is disabled (`if: false` below) so this
+# workflow no longer registers a phantom "skipping" check on every PR (a skipped
+# check reads like coverage but isn't). It runs only on manual dispatch until
+# re-enabled — see #1720 for the checklist: remove `if: false`, confirm the
+# ANTHROPIC_API_KEY + NEXUS_GCS_CREDENTIALS secrets are configured, then restore
+# the `push: [main, develop]` trigger. (Kept, not deleted: this is the only job
+# exercising the nexus-langgraph + nexus-frontend + GCS full-stack path, which
+# external open-source users may rely on.)
 on:
-  push:
-    branches: [main, develop]
-  pull_request:
-    branches: [main, develop]
-    paths:
-      # Docker-related files
-      - 'Dockerfile'
-      - 'docker-compose*.yml'
-      - 'dockerfiles/compose.yaml'
-      - 'nexus-stack.yml'
-      - 'scripts/nexus-docker.sh'
-      - 'docker-entrypoint.sh'
-      - '.github/workflows/docker-integration.yml'
-      # Core source files that affect Docker integration
-      - 'src/nexus/core/**'
-      - 'src/nexus/server/**'
-      - 'src/nexus/storage/**'
-      - 'src/nexus/backends/**'
-      - 'configs/*.yaml'
-      - 'configs/*.yml'
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
The `docker-build-and-init` job is hard-disabled (`if: false`, pending #1720) yet its push/pull_request triggers still fired — so it registered a permanent **"skipping"** check on every PR, a skip that reads like coverage but isn't.

This drops the auto-triggers to manual `workflow_dispatch` only. The job stays `if: false` and the file is **kept, not deleted**: it's the only job exercising the `nexus-langgraph` + `nexus-frontend` + GCS full-stack E2E, which external open-source users may rely on (so per the "production ⇒ fix, not delete" rule it must be re-enabled, not dropped).

The real re-enable — confirm `ANTHROPIC_API_KEY` + `NEXUS_GCS_CREDENTIALS` secrets, remove `if: false`, restore `push: [main, develop]` — is tracked in the reopened #1720.

Verified safe: the only required status check on develop is `every cdylib has a signed-release workflow`; this workflow is not required, so removing its auto-triggers blocks nothing.