### PR TITLE
fix(benchmarks): green the nightly Full Suite (3 pre-existing failures exposed by #4531)

### DIFF
--- a/tests/benchmarks/test_search_benchmarks.py
+++ b/tests/benchmarks/test_search_benchmarks.py
@@ -146,7 +146,10 @@ class TestSectionAwareGrepBenchmarks:
                 },
             ],
         }
-        metadata_store.metastore_get_file_metadata.return_value = json.dumps(section_index)
+        # `_filter_results_by_section` reads md_structure via the consolidated
+        # kernel xattr API `get_xattr(path, "md_structure")` (self._kernel IS the
+        # metadata_store), NOT the old `metastore_get_file_metadata`.
+        metadata_store.get_xattr.return_value = json.dumps(section_index)
         service = SearchService(
             metadata_store=metadata_store,
             nexus_fs=None,
@@ -158,11 +161,9 @@ class TestSectionAwareGrepBenchmarks:
         ]
 
         def filter_once():
-            metadata_store.metastore_get_file_metadata.reset_mock()
+            metadata_store.get_xattr.reset_mock()
             filtered = service._filter_results_by_section(grep_results, "## API")
-            metadata_store.metastore_get_file_metadata.assert_called_once_with(
-                "/bench.md", "md_structure"
-            )
+            metadata_store.get_xattr.assert_called_once_with("/bench.md", "md_structure")
             return filtered
 
         result = benchmark(filter_once)

--- a/tests/benchmarks/test_thread_pool_exhaustion.py
+++ b/tests/benchmarks/test_thread_pool_exhaustion.py
@@ -16,6 +16,7 @@ Or run the in-process test:
 import argparse
 import asyncio
 import os
+import shutil
 import statistics
 import sys
 import tempfile
@@ -228,6 +229,12 @@ async def test_in_process_thread_exhaustion(
     timeout: float = 60.0,
 ) -> TestResults:
     """Test thread pool exhaustion with in-process NexusFS."""
+    if shutil.which("nexus-cluster") is None:
+        pytest.skip(
+            "in-process thread-exhaustion needs the nexus-cluster kernel binary "
+            "(create_nexus_fs opens a raft metastore); absent in the Python-only "
+            "benchmark env"
+        )
     from nexus.backends.storage.cas_local import CASLocalBackend
     from nexus.contracts.types import OperationContext
 
@@ -346,6 +353,12 @@ async def test_async_thread_exhaustion(
     timeout: float = 60.0,
 ) -> TestResults:
     """Test that simulates exact FastAPI server behavior with asyncio.to_thread."""
+    if shutil.which("nexus-cluster") is None:
+        pytest.skip(
+            "async thread-exhaustion needs the nexus-cluster kernel binary "
+            "(create_nexus_fs opens a raft metastore); absent in the Python-only "
+            "benchmark env"
+        )
     from nexus.backends.storage.cas_local import CASLocalBackend
     from nexus.contracts.types import OperationContext
 


### PR DESCRIPTION
The nightly Full-Suite split (#4531) made the full `tests/benchmarks/` suite actually run, surfacing **3 pre-existing failures** that main-only gating had hidden:

- **test_search_benchmarks** `test_section_filter_uses_cached_structure_ranges`: mocked the stale `metastore_get_file_metadata`, but `_filter_results_by_section` now reads md_structure via the consolidated kernel `get_xattr` API (`self._kernel` **is** the metadata_store). Rewired the mock → `get_xattr`; the benchmark + result assertions (1000 results, lines 501–1500) are unchanged.
- **test_thread_pool_exhaustion** (in-process + async): both open a raft metastore via `create_nexus_fs`, which needs the `nexus-cluster` kernel binary — absent in the Python-only benchmark env (`kernel=None` → `NoneType.sys_setattr`). Skip when `shutil.which('nexus-cluster') is None`, matching how the HTTP / pg-fts benchmarks skip on a missing dependency.

Verified locally (via the repo .venv): the search path returns 1000 filtered results calling `get_xattr` once; the guard's `shutil.which` is `None` in a kernel-less env so both thread-pool tests skip. Also dispatching the Full-Suite workflow on this branch to confirm end-to-end in CI (the PR's own Critical Subset does not include these).