### PR TITLE
chore(pins): bump nexus-vfs 22991d258 -> e2ea0f2c4 (#186 auth-mint read-only resolver)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "a2a"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=22991d25889a6f89ce5744286f22615222f39263#22991d25889a6f89ce5744286f22615222f39263"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=e2ea0f2c418ea1d0c194cd23b38efab467893195#e2ea0f2c418ea1d0c194cd23b38efab467893195"
 dependencies = [
  "contracts",
  "kernel",
@@ -237,7 +237,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=22991d25889a6f89ce5744286f22615222f39263#22991d25889a6f89ce5744286f22615222f39263"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=e2ea0f2c418ea1d0c194cd23b38efab467893195#e2ea0f2c418ea1d0c194cd23b38efab467893195"
 dependencies = [
  "ahash",
  "base64",
@@ -569,7 +569,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=22991d25889a6f89ce5744286f22615222f39263#22991d25889a6f89ce5744286f22615222f39263"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=e2ea0f2c418ea1d0c194cd23b38efab467893195#e2ea0f2c418ea1d0c194cd23b38efab467893195"
 dependencies = [
  "parking_lot",
  "serde",
@@ -1353,7 +1353,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=22991d25889a6f89ce5744286f22615222f39263#22991d25889a6f89ce5744286f22615222f39263"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=e2ea0f2c418ea1d0c194cd23b38efab467893195#e2ea0f2c418ea1d0c194cd23b38efab467893195"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -1405,7 +1405,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=22991d25889a6f89ce5744286f22615222f39263#22991d25889a6f89ce5744286f22615222f39263"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=e2ea0f2c418ea1d0c194cd23b38efab467893195#e2ea0f2c418ea1d0c194cd23b38efab467893195"
 dependencies = [
  "ahash",
  "base64",
@@ -1601,7 +1601,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=22991d25889a6f89ce5744286f22615222f39263#22991d25889a6f89ce5744286f22615222f39263"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=e2ea0f2c418ea1d0c194cd23b38efab467893195#e2ea0f2c418ea1d0c194cd23b38efab467893195"
 
 [[package]]
 name = "nexus-search-plugin"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -217,19 +217,19 @@ exclude = ["nexus-fuse"]
 #
 # Bump alongside the rest of nexus-vfs updates when a downstream
 # change needs newer kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "22991d25889a6f89ce5744286f22615222f39263" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "22991d25889a6f89ce5744286f22615222f39263" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "22991d25889a6f89ce5744286f22615222f39263" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "22991d25889a6f89ce5744286f22615222f39263", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "22991d25889a6f89ce5744286f22615222f39263", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "22991d25889a6f89ce5744286f22615222f39263", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "22991d25889a6f89ce5744286f22615222f39263" }
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "e2ea0f2c418ea1d0c194cd23b38efab467893195" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "e2ea0f2c418ea1d0c194cd23b38efab467893195" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "e2ea0f2c418ea1d0c194cd23b38efab467893195" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "e2ea0f2c418ea1d0c194cd23b38efab467893195", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "e2ea0f2c418ea1d0c194cd23b38efab467893195", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "e2ea0f2c418ea1d0c194cd23b38efab467893195", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "e2ea0f2c418ea1d0c194cd23b38efab467893195" }
 # a2a messaging substrate. `default-features = false` leaves the
 # `install` feature (which pulls raft to arm the stream-wakeup observer)
 # OFF, so nexus-side consumers link only the stamp hook and stay
 # raft-free — they reach raft through kernel.sys_* (§6.1). The substrate
 # is armed in production at cluster boot in nexus-vfs, not here.
-a2a = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "22991d25889a6f89ce5744286f22615222f39263", default-features = false }
+a2a = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "e2ea0f2c418ea1d0c194cd23b38efab467893195", default-features = false }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ENV CARGO_NET_RETRY=10 \
     CARGO_HTTP_TIMEOUT=120
 # Override for edge/CI or a different pin: --build-arg NEXUS_VFS_REV=<sha|tag>
-ARG NEXUS_VFS_REV=22991d25889a6f89ce5744286f22615222f39263
+ARG NEXUS_VFS_REV=e2ea0f2c418ea1d0c194cd23b38efab467893195
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,id=cargo-install-${TARGETARCH},target=/root/.cargo/target \

--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir --no-deps --prefix=/install .
 # enforces agreement) — an unpinned install tracks nexus-vfs HEAD and
 # ships an untested kernel (#4343). --locked honors the source tree's
 # Cargo.lock.
-ARG NEXUS_VFS_REV=22991d25889a6f89ce5744286f22615222f39263
+ARG NEXUS_VFS_REV=e2ea0f2c418ea1d0c194cd23b38efab467893195
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-cluster nexus-cluster
 
 # -- Runtime stage --

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -25,7 +25,7 @@ WORKDIR /build
 # (CI preflight enforces agreement) — an unpinned install tracks HEAD
 # and can skew the raft contract against the cluster/witness images.
 # --locked honors the source tree's Cargo.lock.
-ARG NEXUS_VFS_REV=22991d25889a6f89ce5744286f22615222f39263
+ARG NEXUS_VFS_REV=e2ea0f2c418ea1d0c194cd23b38efab467893195
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexus-raft-server raft
 
 # ---------- Production image ----------

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=22991d25889a6f89ce5744286f22615222f39263
+ARG NEXUS_VFS_REV=e2ea0f2c418ea1d0c194cd23b38efab467893195
 RUN cargo install \
     --locked \
     --git https://github.com/nexi-lab/nexus-vfs \


### PR DESCRIPTION
Bumps the nexus-vfs pin to `e2ea0f2c4` (nexus-vfs #186, merged to main).

## What #186 fixes
- Offline `auth mint` now resolves the cluster API-key secret from the enrolled `tls/api-key-secret` SSOT (the same resolver the daemon uses) — an enrolled node mints agent keys with **no `NEXUS_API_KEY_SECRET` env**.
- Root-caused + fixed a latent hazard in the #185 resolver: it **persisted** the env secret on first use, so an offline mint's throwaway secret got stamped into the node SSOT and flipped a **later** daemon boot from auth-off to auth-on under the wrong secret. The resolver is now **read-only** (persisted-file wins → env → never writes). Guarded by `federation_survives_joiner_restart`.

## Pin trio
`Cargo.toml` + `Cargo.lock` + all 4 Dockerfile `NEXUS_VFS_REV` ARGs (`Dockerfile` + `dockerfiles/{minimal,raft-server,raft-witness}`) bumped together so the docker smoke preflight sees a single rev. `cargo fetch --locked` passes against the new rev.