### PR TITLE
docs: welcome Zhuotao Liu; credit BlockA2A for signed authorship

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,24 @@ Install from PyPI: `pip install nexus-ai-fs`. The package name on PyPI is `nexus
 
 </details>
 
+## Acknowledgments
+
+We welcome **Zhuotao Liu** (Tsinghua University) as a contributor. The
+cross-trust-domain signed-authorship design — agent identity certificates and
+an unforgeable message `from` that any consumer can verify without trusting the
+ingress node — draws on **BlockA2A** (Zhenhua Zou, Zhuotao Liu et al.,
+*BlockA2A: Towards Secure and Verifiable Agent-to-Agent Interoperability*,
+[arXiv:2508.01332](https://arxiv.org/abs/2508.01332)).
+
+- **Adopted:** the sign-and-verify identity model — a sender signs each message
+  with its private key and any receiver verifies it against a resolvable public
+  key (BlockA2A Protocol 2).
+- **Realized on nexus primitives:** the raft log is the ordered, replicated,
+  tamper-evident, strongly-consistent ledger; CA-signed X.509 certificates are
+  the resolvable identity; and the kernel permission gate is the access control.
+  This keeps intra-cluster operation strongly consistent with no external
+  consensus, while leaving the path open to cross-organization (cross-CA) trust.
+
 ## License
 
 Apache License 2.0 — see [LICENSE](LICENSE) for details.


### PR DESCRIPTION
Welcomes **Zhuotao Liu** (Tsinghua University) as a contributor.

The cross-trust-domain **signed-authorship** design — agent identity certificates and an unforgeable message `from` that any consumer can verify without trusting the ingress node — draws on **BlockA2A** (Zhenhua Zou, Zhuotao Liu et al., *Towards Secure and Verifiable Agent-to-Agent Interoperability*, [arXiv:2508.01332](https://arxiv.org/abs/2508.01332)).

**Adopted:** the sign-and-verify identity model — a sender signs each message with its private key, any receiver verifies against a resolvable public key (BlockA2A Protocol 2).

**Realized on nexus primitives:** the raft log is the ordered, replicated, tamper-evident, strongly-consistent ledger; CA-signed X.509 certs are the resolvable identity; the kernel permission gate is the access control — no external consensus, and the model extends to cross-organization (cross-CA) trust.

Design detail: [Nexus Auth Architecture §5](https://s.shareone.vip/s/nexus-auth-architecture).