### PR TITLE
chore(agents): drop dead ExternalProcessInfo.host_pid field (pid IS the OS pid)

### DIFF
--- a/docs/surface-coverage/api-rpc-surface-coverage.yaml
+++ b/docs/surface-coverage/api-rpc-surface-coverage.yaml
@@ -2131,7 +2131,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.count_by_state
-      source: src/nexus/remote/kernel_client.py:1609
+      source: src/nexus/remote/kernel_client.py:1608
   profiles:
     lite: supported
     sandbox: supported
@@ -3884,7 +3884,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.get
-      source: src/nexus/remote/kernel_client.py:1556
+      source: src/nexus/remote/kernel_client.py:1555
   profiles:
     lite: supported
     sandbox: supported
@@ -3901,7 +3901,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.heartbeat
-      source: src/nexus/remote/kernel_client.py:1582
+      source: src/nexus/remote/kernel_client.py:1581
   profiles:
     lite: supported
     sandbox: supported
@@ -3986,7 +3986,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.register
-      source: src/nexus/remote/kernel_client.py:1517
+      source: src/nexus/remote/kernel_client.py:1516
   profiles:
     lite: supported
     sandbox: supported
@@ -4054,7 +4054,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.signal
-      source: src/nexus/remote/kernel_client.py:1559
+      source: src/nexus/remote/kernel_client.py:1558
   profiles:
     lite: supported
     sandbox: supported
@@ -4139,7 +4139,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.unregister
-      source: src/nexus/remote/kernel_client.py:1550
+      source: src/nexus/remote/kernel_client.py:1549
   profiles:
     lite: supported
     sandbox: supported
@@ -5066,7 +5066,7 @@ operations:
       source: src/nexus/services/agents/agent_rpc_service.py:584
     sdk:
       name: _AgentRegistryProxy.list_agents
-      source: src/nexus/remote/kernel_client.py:1585
+      source: src/nexus/remote/kernel_client.py:1584
   profiles:
     lite: supported
     sandbox: supported
@@ -5084,7 +5084,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.list_by_priority
-      source: src/nexus/remote/kernel_client.py:1613
+      source: src/nexus/remote/kernel_client.py:1612
   profiles:
     lite: supported
     sandbox: supported
@@ -5229,7 +5229,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.list_processes
-      source: src/nexus/remote/kernel_client.py:1588
+      source: src/nexus/remote/kernel_client.py:1587
   profiles:
     lite: supported
     sandbox: supported
@@ -7164,7 +7164,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.register_external
-      source: src/nexus/remote/kernel_client.py:1520
+      source: src/nexus/remote/kernel_client.py:1519
   profiles:
     lite: supported
     sandbox: supported
@@ -9449,7 +9449,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.unregister_external
-      source: src/nexus/remote/kernel_client.py:1553
+      source: src/nexus/remote/kernel_client.py:1552
   profiles:
     lite: supported
     sandbox: supported
@@ -9538,7 +9538,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.update_state
-      source: src/nexus/remote/kernel_client.py:1571
+      source: src/nexus/remote/kernel_client.py:1570
   profiles:
     lite: supported
     sandbox: supported

--- a/src/nexus/contracts/process_types.py
+++ b/src/nexus/contracts/process_types.py
@@ -107,10 +107,12 @@ class ExternalProcessInfo:
     """Connection metadata for external (gRPC/MCP) processes."""
 
     connection_id: str
-    host_pid: int | None = None
     remote_addr: str | None = None
     protocol: str = "grpc"  # "grpc" | "mcp" | "stdio"
     last_heartbeat: datetime | None = None
+    # The OS process id is NOT a field here — the agent's ``pid`` IS the OS
+    # host_pid (nexus-vfs contracts/agent_pid: pid = "{host_pid}[.{local_id}]").
+    # Decode the pid to recover it; a separate field would duplicate it (SSOT).
 
 
 @dataclass(frozen=True, slots=True)
@@ -176,7 +178,6 @@ class AgentDescriptor:
         if self.external_info is not None:
             d["external_info"] = {
                 "connection_id": self.external_info.connection_id,
-                "host_pid": self.external_info.host_pid,
                 "remote_addr": self.external_info.remote_addr,
                 "protocol": self.external_info.protocol,
                 "last_heartbeat": (
@@ -202,7 +203,6 @@ class AgentDescriptor:
             hb = ext_raw.get("last_heartbeat")
             ext_info = ExternalProcessInfo(
                 connection_id=ext_raw["connection_id"],
-                host_pid=ext_raw.get("host_pid"),
                 remote_addr=ext_raw.get("remote_addr"),
                 protocol=ext_raw.get("protocol", "grpc"),
                 last_heartbeat=datetime.fromisoformat(hb) if hb else None,

--- a/src/nexus/remote/kernel_client.py
+++ b/src/nexus/remote/kernel_client.py
@@ -1434,7 +1434,6 @@ class _ProxyAgentDescriptor(SimpleNamespace):
         if ext is not None:
             d["external_info"] = {
                 "connection_id": ext.get("connection_id", ""),
-                "host_pid": ext.get("host_pid"),
                 "remote_addr": ext.get("remote_addr"),
                 "protocol": ext.get("protocol", "grpc"),
                 "last_heartbeat": _iso(ext.get("last_heartbeat")),

--- a/tests/unit/remote/test_kernel_client_hooks.py
+++ b/tests/unit/remote/test_kernel_client_hooks.py
@@ -999,7 +999,6 @@ def test_agent_registry_proxy_descriptor_to_dict_matches_agentdescriptor_shape()
                     "labels": {"capabilities": "search,cache", "eviction_class": "spot"},
                     "external_info": {
                         "connection_id": "c1",
-                        "host_pid": 42,
                         "remote_addr": "10.0.0.1",
                         "protocol": "grpc",
                         "last_heartbeat_ms": 1_700_000_009_000,
@@ -1044,7 +1043,6 @@ def test_agent_registry_proxy_descriptor_to_dict_matches_agentdescriptor_shape()
     assert isinstance(d["created_at"], str) and "T" in d["created_at"]
     assert isinstance(d["updated_at"], str) and "T" in d["updated_at"]
     assert d["external_info"]["connection_id"] == "c1"
-    assert d["external_info"]["host_pid"] == 42
     assert isinstance(d["external_info"]["last_heartbeat"], str)
     # Must be JSON-serializable (the resolver does json.dumps(desc.to_dict())).
     import json as _json


### PR DESCRIPTION
Pairs with nexus-vfs #195 (agent pid = OS host_pid, `"{host_pid}[.{local_id}]"`). The descriptor's stored `host_pid` field is now always None — the OS pid lives in the pid itself — so delete it from the Python mirror (`process_types`) + the `kernel_client` descriptor serialize, and fix the stale test that asserted it. The register **send** keeps `host_pid` (the input the kernel encodes the pid from); only the dead descriptor field/read is removed. Rust-first: shrink Python, don't extend it. Backward+forward compatible. (Merge alongside the nexus-vfs pin bump once #195 lands.)