### PR TITLE
chore(pins): bump nexus-vfs b7e6a8450 -> 27f485ace (#195 agent pid = OS host_pid)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "a2a"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=b7e6a845042df1534554943b936869d3156cd432#b7e6a845042df1534554943b936869d3156cd432"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=27f485acedf4c05cdcade137323176f5ba14f7db#27f485acedf4c05cdcade137323176f5ba14f7db"
 dependencies = [
  "contracts",
  "kernel",
@@ -237,7 +237,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=b7e6a845042df1534554943b936869d3156cd432#b7e6a845042df1534554943b936869d3156cd432"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=27f485acedf4c05cdcade137323176f5ba14f7db#27f485acedf4c05cdcade137323176f5ba14f7db"
 dependencies = [
  "ahash",
  "base64",
@@ -569,7 +569,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=b7e6a845042df1534554943b936869d3156cd432#b7e6a845042df1534554943b936869d3156cd432"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=27f485acedf4c05cdcade137323176f5ba14f7db#27f485acedf4c05cdcade137323176f5ba14f7db"
 dependencies = [
  "parking_lot",
  "serde",
@@ -1353,7 +1353,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=b7e6a845042df1534554943b936869d3156cd432#b7e6a845042df1534554943b936869d3156cd432"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=27f485acedf4c05cdcade137323176f5ba14f7db#27f485acedf4c05cdcade137323176f5ba14f7db"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -1405,7 +1405,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=b7e6a845042df1534554943b936869d3156cd432#b7e6a845042df1534554943b936869d3156cd432"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=27f485acedf4c05cdcade137323176f5ba14f7db#27f485acedf4c05cdcade137323176f5ba14f7db"
 dependencies = [
  "ahash",
  "base64",
@@ -1601,7 +1601,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=b7e6a845042df1534554943b936869d3156cd432#b7e6a845042df1534554943b936869d3156cd432"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=27f485acedf4c05cdcade137323176f5ba14f7db#27f485acedf4c05cdcade137323176f5ba14f7db"
 
 [[package]]
 name = "nexus-search-plugin"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -217,19 +217,19 @@ exclude = ["nexus-fuse"]
 #
 # Bump alongside the rest of nexus-vfs updates when a downstream
 # change needs newer kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "b7e6a845042df1534554943b936869d3156cd432" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "b7e6a845042df1534554943b936869d3156cd432" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "b7e6a845042df1534554943b936869d3156cd432" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "b7e6a845042df1534554943b936869d3156cd432", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "b7e6a845042df1534554943b936869d3156cd432", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "b7e6a845042df1534554943b936869d3156cd432", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "b7e6a845042df1534554943b936869d3156cd432" }
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "27f485acedf4c05cdcade137323176f5ba14f7db" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "27f485acedf4c05cdcade137323176f5ba14f7db" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "27f485acedf4c05cdcade137323176f5ba14f7db" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "27f485acedf4c05cdcade137323176f5ba14f7db", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "27f485acedf4c05cdcade137323176f5ba14f7db", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "27f485acedf4c05cdcade137323176f5ba14f7db", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "27f485acedf4c05cdcade137323176f5ba14f7db" }
 # a2a messaging substrate. `default-features = false` leaves the
 # `install` feature (which pulls raft to arm the stream-wakeup observer)
 # OFF, so nexus-side consumers link only the stamp hook and stay
 # raft-free — they reach raft through kernel.sys_* (§6.1). The substrate
 # is armed in production at cluster boot in nexus-vfs, not here.
-a2a = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "b7e6a845042df1534554943b936869d3156cd432", default-features = false }
+a2a = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "27f485acedf4c05cdcade137323176f5ba14f7db", default-features = false }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ENV CARGO_NET_RETRY=10 \
     CARGO_HTTP_TIMEOUT=120
 # Override for edge/CI or a different pin: --build-arg NEXUS_VFS_REV=<sha|tag>
-ARG NEXUS_VFS_REV=b7e6a845042df1534554943b936869d3156cd432
+ARG NEXUS_VFS_REV=27f485acedf4c05cdcade137323176f5ba14f7db
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,id=cargo-install-${TARGETARCH},target=/root/.cargo/target \

--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir --no-deps --prefix=/install .
 # enforces agreement) — an unpinned install tracks nexus-vfs HEAD and
 # ships an untested kernel (#4343). --locked honors the source tree's
 # Cargo.lock.
-ARG NEXUS_VFS_REV=b7e6a845042df1534554943b936869d3156cd432
+ARG NEXUS_VFS_REV=27f485acedf4c05cdcade137323176f5ba14f7db
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-cluster nexus-cluster
 
 # -- Runtime stage --

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -25,7 +25,7 @@ WORKDIR /build
 # (CI preflight enforces agreement) — an unpinned install tracks HEAD
 # and can skew the raft contract against the cluster/witness images.
 # --locked honors the source tree's Cargo.lock.
-ARG NEXUS_VFS_REV=b7e6a845042df1534554943b936869d3156cd432
+ARG NEXUS_VFS_REV=27f485acedf4c05cdcade137323176f5ba14f7db
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexus-raft-server raft
 
 # ---------- Production image ----------

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=b7e6a845042df1534554943b936869d3156cd432
+ARG NEXUS_VFS_REV=27f485acedf4c05cdcade137323176f5ba14f7db
 RUN cargo install \
     --locked \
     --git https://github.com/nexi-lab/nexus-vfs \


### PR DESCRIPTION
Deploys nexus-vfs #195 — the per-run agent pid is the OS `host_pid` (`"{host_pid}[.local_id]"`, `contracts::agent_pid`) instead of a synthetic uuid, and the redundant `ExternalProcessInfo.host_pid` field is gone (SSOT). So `/proc/{pid}`/`ps`/`kill`/`gdb` align with the real OS process. Pairs with the Python dead-field cleanup (#4539, already on develop). Trio bumped together; `cargo fetch --locked` passes.