### PR TITLE
fix(search): fail-open graph branch when backend is unavailable

### DIFF
--- a/src/nexus/bricks/search/graph_search_service.py
+++ b/src/nexus/bricks/search/graph_search_service.py
@@ -58,6 +58,15 @@ class DaemonSemanticSearchWrapper:
         ]
 
 
+class GraphBackendUnavailable(Exception):
+    """Raised when no graph-capable backend is available on the daemon.
+
+    Callers (e.g. the search router) should catch this and fall back to
+    normal search — the graph feature was removed in #3699 and the
+    ``NEXUS_TXTAI_GRAPH`` knob is vestigial.
+    """
+
+
 async def graph_enhanced_search(
     query: str,
     search_type: str,  # noqa: ARG001
@@ -90,17 +99,31 @@ async def graph_enhanced_search(
 
     Returns:
         List of BaseSearchResult
+
+    Raises:
+        GraphBackendUnavailable: When the daemon has no graph-capable backend.
+            Callers should catch this and fall back to normal search.
     """
     effective_zone_id = zone_id or ROOT_ZONE_ID
-    backend = getattr(search_daemon, "_backend", None)
+
+    # After #3699, SearchDaemon owns ``_fts_backend`` / ``_vector_backend``
+    # — the old ``_backend`` attribute no longer exists.  Check the new
+    # attributes and look for a ``graph_search`` method on either.
+    backend = getattr(search_daemon, "_fts_backend", None) or getattr(
+        search_daemon, "_vector_backend", None
+    )
     if backend is None:
-        logger.warning("graph_enhanced_search: no backend available on daemon")
-        return []
+        raise GraphBackendUnavailable(
+            "graph_enhanced_search: daemon has no fts/vector backend; "
+            "txtai graph was removed in #3699 — falling back to normal search"
+        )
 
     graph_search_fn = getattr(backend, "graph_search", None)
     if graph_search_fn is None:
-        logger.warning("graph_enhanced_search: backend does not support graph_search")
-        return []
+        raise GraphBackendUnavailable(
+            f"graph_enhanced_search: backend {type(backend).__name__} "
+            f"does not expose graph_search — falling back to normal search"
+        )
 
     results: list[BaseSearchResult] = await graph_search_fn(
         query, zone_id=effective_zone_id, limit=limit, path_filter=path_filter

--- a/src/nexus/server/api/v2/routers/search.py
+++ b/src/nexus/server/api/v2/routers/search.py
@@ -38,6 +38,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel
 
 from nexus.bricks.search.daemon import _BACKEND_LEG_TIMING_KEYS
+from nexus.bricks.search.graph_search_service import GraphBackendUnavailable
 from nexus.lib.pagination import build_paginated_list_response
 from nexus.lib.rebac_filter import apply_rebac_filter as _apply_rebac_filter
 from nexus.lib.rebac_filter import compute_rebac_fetch_limit as _compute_rebac_fetch_limit
@@ -470,52 +471,68 @@ async def _handle_single_zone_search(
         if effective_graph_mode != "none":
             from nexus.bricks.search.graph_search_service import graph_enhanced_search
 
-            results = await graph_enhanced_search(
-                query=q,
-                search_type=search_type,
-                limit=fetch_limit,
-                path_filter=path_filter,
-                alpha=alpha,
-                graph_mode=effective_graph_mode,
-                record_store=record_store,
-                async_session_factory=async_session_factory,
-                search_daemon=search_daemon,
-                zone_id=zone_id,
-            )
+            graph_fell_back = False
+            results: list[Any] = []
+            try:
+                results = await graph_enhanced_search(
+                    query=q,
+                    search_type=search_type,
+                    limit=fetch_limit,
+                    path_filter=path_filter,
+                    alpha=alpha,
+                    graph_mode=effective_graph_mode,
+                    record_store=record_store,
+                    async_session_factory=async_session_factory,
+                    search_daemon=search_daemon,
+                    zone_id=zone_id,
+                )
+            except GraphBackendUnavailable:
+                # Fail-open: graph backend was removed in #3699 and the
+                # NEXUS_TXTAI_GRAPH knob is vestigial.  Fall through to
+                # normal search instead of returning zero results.
+                logger.warning(
+                    "graph_mode=%s requested but graph backend unavailable; "
+                    "falling back to normal search (txtai graph removed in #3699)",
+                    effective_graph_mode,
+                )
+                effective_graph_mode = "none"
+                graph_fell_back = True
 
-            # ReBAC file-level filtering (Decision #17)
-            pre_filter_count = len(results)
-            results, filter_ms = _apply_rebac_filter(
-                results,
-                permission_enforcer,
-                auth_result,
-                zone_id,
-                operation_context=op_context,
-            )
-            post_filter_count = len(results)
-            results = results[:effective_limit]
+            if not graph_fell_back:
+                # ReBAC file-level filtering (Decision #17)
+                pre_filter_count = len(results)
+                results, filter_ms = _apply_rebac_filter(
+                    results,
+                    permission_enforcer,
+                    auth_result,
+                    zone_id,
+                    operation_context=op_context,
+                )
+                post_filter_count = len(results)
+                results = results[:effective_limit]
 
-            latency_ms = (time.perf_counter() - start_time) * 1000
+                latency_ms = (time.perf_counter() - start_time) * 1000
 
-            graph_latency_breakdown = {
-                "total_ms": round(latency_ms, 2),
-                "permission_filter_ms": round(filter_ms, 2),
-            }
-            _bind_search_phase_timings(graph_latency_breakdown)
+                graph_latency_breakdown = {
+                    "total_ms": round(latency_ms, 2),
+                    "permission_filter_ms": round(filter_ms, 2),
+                }
+                _bind_search_phase_timings(graph_latency_breakdown)
 
-            response: dict[str, Any] = {
-                "query": q,
-                "search_type": search_type,
-                "graph_mode": effective_graph_mode,
-                "results": [_serialize_search_result(r) for r in results],
-                "total": len(results),
-                "latency_ms": round(latency_ms, 2),
-                "latency_breakdown": graph_latency_breakdown,
-                **_rebac_denial_stats(pre_filter_count, post_filter_count, effective_limit),
-            }
-            if routing_info:
-                response["routing"] = routing_info
-            return response
+                response: dict[str, Any] = {
+                    "query": q,
+                    "search_type": search_type,
+                    "graph_mode": effective_graph_mode,
+                    "results": [_serialize_search_result(r) for r in results],
+                    "total": len(results),
+                    "latency_ms": round(latency_ms, 2),
+                    "latency_breakdown": graph_latency_breakdown,
+                    **_rebac_denial_stats(pre_filter_count, post_filter_count, effective_limit),
+                }
+                if routing_info:
+                    response["routing"] = routing_info
+                return response
+            # else: graph fell back to normal search — fall through below
 
         results = await search_daemon.search(
             query=q,


### PR DESCRIPTION
## Summary

Fixes #4546 — When `NEXUS_TXTAI_GRAPH=true` is set, every `graph_mode != none` query silently returns zero results because `graph_enhanced_search()` reads a nonexistent `search_daemon._backend` attribute.

## Root Cause

After #3699, `SearchDaemon` owns `_fts_backend` / `_vector_backend` — the old `_backend` attribute was removed. `graph_enhanced_search()` still looked for `_backend`, got `None`, and returned `[]` instead of falling back to normal search.

## Fix

**`graph_search_service.py`:**
- Check `_fts_backend` / `_vector_backend` instead of `_backend`
- Raise `GraphBackendUnavailable` when no graph-capable backend is found (instead of silently returning `[]`)

**`search.py` (router):**
- Catch `GraphBackendUnavailable` and fall through to normal hybrid search with a warning log
- Add `graph_fell_back` flag to cleanly skip the graph response path on fallback

## Behavior Change

| Before | After |
|--------|-------|
| `NEXUS_TXTAI_GRAPH=true` + `graph_mode=low` → `[]` (zero results, no error) | Falls back to normal hybrid search with warning log |

## Verification

- `graph_enhanced_search` now correctly looks for `_fts_backend`/`_vector_backend`
- Router catches `GraphBackendUnavailable` and falls through to `search_daemon.search()`
- Warning log emitted so operators know graph mode fell back
