### PR TITLE
chore(pins): bump nexus-vfs -> 8fd02896 (agent cert-auth #194/#196/#197)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "a2a"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=27f485acedf4c05cdcade137323176f5ba14f7db#27f485acedf4c05cdcade137323176f5ba14f7db"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=8fd0289624968def6002b53163f5cb9ae8844b1f#8fd0289624968def6002b53163f5cb9ae8844b1f"
 dependencies = [
  "contracts",
  "kernel",
@@ -162,6 +162,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
+name = "asn1-rs"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -169,7 +208,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -237,7 +276,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=27f485acedf4c05cdcade137323176f5ba14f7db#27f485acedf4c05cdcade137323176f5ba14f7db"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=8fd0289624968def6002b53163f5cb9ae8844b1f#8fd0289624968def6002b53163f5cb9ae8844b1f"
 dependencies = [
  "ahash",
  "base64",
@@ -316,7 +355,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex 1.3.0",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -507,7 +546,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -569,7 +608,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=27f485acedf4c05cdcade137323176f5ba14f7db#27f485acedf4c05cdcade137323176f5ba14f7db"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=8fd0289624968def6002b53163f5cb9ae8844b1f#8fd0289624968def6002b53163f5cb9ae8844b1f"
 dependencies = [
  "parking_lot",
  "serde",
@@ -702,7 +741,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -720,6 +759,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -727,6 +772,20 @@ checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid 0.9.6",
  "zeroize",
+]
+
+[[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
 ]
 
 [[package]]
@@ -755,6 +814,17 @@ dependencies = [
  "block-buffer 0.12.1",
  "const-oid 0.10.2",
  "crypto-common 0.2.2",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -805,7 +875,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -991,7 +1061,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1353,7 +1423,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=27f485acedf4c05cdcade137323176f5ba14f7db#27f485acedf4c05cdcade137323176f5ba14f7db"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=8fd0289624968def6002b53163f5cb9ae8844b1f#8fd0289624968def6002b53163f5cb9ae8844b1f"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -1405,7 +1475,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=27f485acedf4c05cdcade137323176f5ba14f7db#27f485acedf4c05cdcade137323176f5ba14f7db"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=8fd0289624968def6002b53163f5cb9ae8844b1f#8fd0289624968def6002b53163f5cb9ae8844b1f"
 dependencies = [
  "ahash",
  "base64",
@@ -1420,6 +1490,7 @@ dependencies = [
  "pem",
  "regex",
  "regex-syntax",
+ "ring",
  "roaring",
  "rustls",
  "serde",
@@ -1431,6 +1502,7 @@ dependencies = [
  "tokio",
  "tonic",
  "tracing",
+ "x509-parser",
 ]
 
 [[package]]
@@ -1601,7 +1673,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=27f485acedf4c05cdcade137323176f5ba14f7db#27f485acedf4c05cdcade137323176f5ba14f7db"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=8fd0289624968def6002b53163f5cb9ae8844b1f#8fd0289624968def6002b53163f5cb9ae8844b1f"
 
 [[package]]
 name = "nexus-search-plugin"
@@ -1693,6 +1765,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1706,7 +1788,16 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -1737,7 +1828,16 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs",
 ]
 
 [[package]]
@@ -1841,7 +1941,7 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1891,7 +1991,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1939,7 +2039,7 @@ dependencies = [
  "pulldown-cmark",
  "pulldown-cmark-to-cmark",
  "regex",
- "syn",
+ "syn 2.0.119",
  "tempfile",
 ]
 
@@ -1953,7 +2053,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2138,7 +2238,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2207,6 +2307,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -2314,7 +2423,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2566,10 +2675,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "tempfile"
@@ -2601,7 +2732,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2676,7 +2807,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2782,7 +2913,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2807,7 +2938,7 @@ dependencies = [
  "prost-build",
  "prost-types",
  "quote",
- "syn",
+ "syn 2.0.119",
  "tempfile",
  "tonic-build",
 ]
@@ -2862,7 +2993,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3028,7 +3159,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
@@ -3123,7 +3254,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3134,7 +3265,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3303,6 +3434,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "x509-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "ring",
+ "rusticata-macros",
+ "thiserror",
+ "time",
+]
+
+[[package]]
 name = "xxhash-rust"
 version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3325,7 +3474,7 @@ checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -217,19 +217,19 @@ exclude = ["nexus-fuse"]
 #
 # Bump alongside the rest of nexus-vfs updates when a downstream
 # change needs newer kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "27f485acedf4c05cdcade137323176f5ba14f7db" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "27f485acedf4c05cdcade137323176f5ba14f7db" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "27f485acedf4c05cdcade137323176f5ba14f7db" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "27f485acedf4c05cdcade137323176f5ba14f7db", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "27f485acedf4c05cdcade137323176f5ba14f7db", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "27f485acedf4c05cdcade137323176f5ba14f7db", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "27f485acedf4c05cdcade137323176f5ba14f7db" }
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "8fd0289624968def6002b53163f5cb9ae8844b1f" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "8fd0289624968def6002b53163f5cb9ae8844b1f" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "8fd0289624968def6002b53163f5cb9ae8844b1f" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "8fd0289624968def6002b53163f5cb9ae8844b1f", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "8fd0289624968def6002b53163f5cb9ae8844b1f", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "8fd0289624968def6002b53163f5cb9ae8844b1f", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "8fd0289624968def6002b53163f5cb9ae8844b1f" }
 # a2a messaging substrate. `default-features = false` leaves the
 # `install` feature (which pulls raft to arm the stream-wakeup observer)
 # OFF, so nexus-side consumers link only the stamp hook and stay
 # raft-free — they reach raft through kernel.sys_* (§6.1). The substrate
 # is armed in production at cluster boot in nexus-vfs, not here.
-a2a = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "27f485acedf4c05cdcade137323176f5ba14f7db", default-features = false }
+a2a = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "8fd0289624968def6002b53163f5cb9ae8844b1f", default-features = false }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ENV CARGO_NET_RETRY=10 \
     CARGO_HTTP_TIMEOUT=120
 # Override for edge/CI or a different pin: --build-arg NEXUS_VFS_REV=<sha|tag>
-ARG NEXUS_VFS_REV=27f485acedf4c05cdcade137323176f5ba14f7db
+ARG NEXUS_VFS_REV=8fd0289624968def6002b53163f5cb9ae8844b1f
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,id=cargo-install-${TARGETARCH},target=/root/.cargo/target \

--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir --no-deps --prefix=/install .
 # enforces agreement) — an unpinned install tracks nexus-vfs HEAD and
 # ships an untested kernel (#4343). --locked honors the source tree's
 # Cargo.lock.
-ARG NEXUS_VFS_REV=27f485acedf4c05cdcade137323176f5ba14f7db
+ARG NEXUS_VFS_REV=8fd0289624968def6002b53163f5cb9ae8844b1f
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-cluster nexus-cluster
 
 # -- Runtime stage --

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -25,7 +25,7 @@ WORKDIR /build
 # (CI preflight enforces agreement) — an unpinned install tracks HEAD
 # and can skew the raft contract against the cluster/witness images.
 # --locked honors the source tree's Cargo.lock.
-ARG NEXUS_VFS_REV=27f485acedf4c05cdcade137323176f5ba14f7db
+ARG NEXUS_VFS_REV=8fd0289624968def6002b53163f5cb9ae8844b1f
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexus-raft-server raft
 
 # ---------- Production image ----------

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=27f485acedf4c05cdcade137323176f5ba14f7db
+ARG NEXUS_VFS_REV=8fd0289624968def6002b53163f5cb9ae8844b1f
 RUN cargo install \
     --locked \
     --git https://github.com/nexi-lab/nexus-vfs \


### PR DESCRIPTION
Bumps the pinned nexus-vfs kernel from `27f485ace` (#195) to `8fd0289624968def6002b53163f5cb9ae8844b1f` (main after #197).

## What it brings
- **#194** — agent cert = pure identity (DID); A2A stamp hook owns mailbox authZ; cross-trust-domain unforgeable authorship (seal/open verified against the CA); cross-node revocation via CA-signed CRL (GetCrl on the enroll plane, file-based `auth revoke --agent`, per-node ~10s refresh). Retires the `--agent-bind-addr` sk- loopback agent plane — agents are now cert-only over mTLS on the main bind.
- **#196** — agent-cert rotation + cross-org authorship (live + unit tests).
- **#197** — declares the `x509-parser` `verify` feature explicitly on `lib` + `raft` (was relying on workspace feature-unification, which does not hold in nexus's dependency graph → `verify_signature` method vanished).
- **#195** (agent pid = OS host_pid) is contained in this SHA and carried along.

## Consistency + verification
- Cargo.toml (8 pins) + Cargo.lock + all 4 Dockerfile `NEXUS_VFS_REV` args bumped together.
- `cargo check --workspace` clean locally (rebuilds `lib` + `raft` grpc, exercising both verify-feature fixes).

## Downstream
Unblocks embedder (hydra) cert-agent authN adoption along the release chain. The `--agent-bind-addr` retirement means local-agent connections migrate to mTLS + a minted cert bundle (`auth mint --subject-type agent`); transport-only smokes can use `serve-local` (NoAuth).