### PR TITLE
feat(search): apply page_aggregation to the final fused hybrid list (#4542)

### DIFF
--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -2026,6 +2026,7 @@ class SearchDaemon:
         """
         from nexus.bricks.search.fusion import rrf_fusion
         from nexus.bricks.search.pg_fts_backend import PgFtsBackend
+        from nexus.bricks.search.result_builders import _aggregate_chunks_to_pages
 
         path = path_filter or "/"
         timing = _empty_backend_timing()
@@ -2127,6 +2128,12 @@ class SearchDaemon:
         fusion_start = time.perf_counter()
         kw_fused = rrf_fusion(chunk_kw, page_kw, k=60, limit=limit * 2, id_key=None)
         fused = rrf_fusion(kw_fused, dense, k=60, limit=limit, id_key=None)
+        # Issue #4542: pool the fused list per document so one long doc cannot
+        # occupy every hybrid slot. The route over-fetches (fetch_limit =
+        # limit × 3 for the ReBAC filter), so pooling at daemon-output size
+        # still leaves headroom before the caller's final trim.
+        if self.config.page_aggregation:
+            fused = _aggregate_chunks_to_pages(fused, chunks_per_page=self.config.chunks_per_page)
         timing["fusion_ms"] = (time.perf_counter() - fusion_start) * 1000
         record_total()
         return [self._coerce_to_search_result(item, search_type="hybrid") for item in fused]

--- a/src/nexus/bricks/search/federated_search.py
+++ b/src/nexus/bricks/search/federated_search.py
@@ -28,6 +28,7 @@ from typing import Any
 
 from nexus.bricks.search.daemon import _BACKEND_LEG_TIMING_KEYS as _TIMING_LEG_KEYS
 from nexus.bricks.search.fusion import rrf_multi_fusion
+from nexus.bricks.search.result_builders import _aggregate_chunks_to_pages
 from nexus.contracts.protocols.activity import EventKind, Result, emit
 
 logger = logging.getLogger(__name__)
@@ -740,7 +741,11 @@ class FederatedSearchDispatcher:
             fused_results = [_strip_none_context(d) for d in fused_results]
         else:
             # Raw score merge-sort: for homogeneous zones (default)
-            fused_results = _merge_by_raw_score(zone_result_lists, limit)
+            fused_results = _merge_by_raw_score(
+                zone_result_lists,
+                limit,
+                chunks_per_page=self._pooling_chunks_per_page(),
+            )
 
         resp = FederatedSearchResponse(
             results=fused_results,
@@ -752,6 +757,21 @@ class FederatedSearchDispatcher:
         )
         self._cache_result(cache_key, resp)
         return resp
+
+    def _pooling_chunks_per_page(self) -> int | None:
+        """Per-document pooling cap for the flat merge (Issue #4542).
+
+        Reads the default daemon's ``DaemonConfig`` — the single place where
+        NEXUS_SEARCH_PAGE_AGGREGATION / NEXUS_SEARCH_CHUNKS_PER_PAGE land —
+        so one env toggle governs both single-zone and federated pooling.
+        The strict ``is True`` / ``isinstance`` checks keep Mock daemons
+        (tests) from enabling pooling via auto-created attributes.
+        """
+        cfg = getattr(self._daemon, "config", None)
+        if getattr(cfg, "page_aggregation", None) is not True:
+            return None
+        cap = getattr(cfg, "chunks_per_page", None)
+        return cap if isinstance(cap, int) and cap > 0 else None
 
     def invalidate_zone_cache(self, subject: tuple[str, str] | None = None) -> None:
         """Invalidate zone discovery cache."""
@@ -769,6 +789,8 @@ class FederatedSearchDispatcher:
 def _merge_by_raw_score(
     zone_result_lists: list[tuple[str, list[Any]]],
     limit: int,
+    *,
+    chunks_per_page: int | None = None,
 ) -> list[dict[str, Any]]:
     """Merge results from multiple zones by the daemon's score (global sort).
 
@@ -786,8 +808,15 @@ def _merge_by_raw_score(
     """
     all_results: list[dict[str, Any]] = []
     for _zone_id, results in zone_result_lists:
-        for r in results:
-            all_results.append(_result_to_dict(r))
+        zone_dicts = [_result_to_dict(r) for r in results]
+        # Issue #4542: pool per zone (not on the concatenated list) so the
+        # same path in two zones stays two distinct documents. Local-zone
+        # results already collapse to one chunk per doc via the page-grain
+        # zone_qualified_path dedup below; this cap matters for remote-zone
+        # dicts whose dedup key falls back to chunk grain.
+        if chunks_per_page is not None:
+            zone_dicts = _aggregate_chunks_to_pages(zone_dicts, chunks_per_page=chunks_per_page)
+        all_results.extend(zone_dicts)
 
     # Dedup by zone_qualified_path, keeping highest score
     seen: dict[str, dict[str, Any]] = {}

--- a/tests/unit/bricks/search/test_daemon_backend_routing.py
+++ b/tests/unit/bricks/search/test_daemon_backend_routing.py
@@ -239,7 +239,7 @@ async def test_keyword_backend_timing_records_keyword_and_total() -> None:
 
 @pytest.mark.asyncio
 async def test_pg_hybrid_backend_timing_records_each_leg() -> None:
-    from nexus.bricks.search.daemon import SearchDaemon, SearchResult
+    from nexus.bricks.search.daemon import DaemonConfig, SearchDaemon, SearchResult
     from nexus.bricks.search.pg_fts_backend import PgFtsBackend
     from nexus.bricks.search.results import BaseSearchResult
 
@@ -298,6 +298,7 @@ async def test_pg_hybrid_backend_timing_records_each_leg() -> None:
 
     daemon: Any = SearchDaemon.__new__(SearchDaemon)
     daemon.last_search_timing = {}
+    daemon.config = DaemonConfig()
     daemon._fts_backend = FakePgFtsBackend()
     daemon._vector_backend = FakeVectorBackend()
     daemon._embed_query = MethodType(_embed_query, daemon)

--- a/tests/unit/bricks/search/test_final_list_page_pooling.py
+++ b/tests/unit/bricks/search/test_final_list_page_pooling.py
@@ -1,0 +1,223 @@
+"""Final-list per-document pooling for hybrid search (Issue #4542).
+
+``DaemonConfig.page_aggregation`` / ``chunks_per_page`` existed (Issue #3980)
+but were never applied to the final fused hybrid list — one long document
+could occupy every result slot. These tests pin:
+
+- daemon: the fused hybrid list emits at most ``chunks_per_page`` chunks per
+  document, letting other documents enter the top-N;
+- ``page_aggregation=False`` restores chunk-grain behavior exactly;
+- federated: the raw-score flat merge applies the same per-zone pooling so
+  remote-zone (chunk-grain) results are not chunk-diluted, while results for
+  the same path in different zones stay separate.
+"""
+
+from __future__ import annotations
+
+from types import MethodType, SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from nexus.bricks.search.daemon import DaemonConfig, SearchDaemon, SearchResult
+from nexus.bricks.search.federated_search import (
+    FederatedSearchDispatcher,
+    _merge_by_raw_score,
+)
+
+# ---------------------------------------------------------------------------
+# Daemon: hybrid final-list pooling
+# ---------------------------------------------------------------------------
+
+_LONG_DOC_ROWS = [
+    SearchResult(path="/long.md", chunk_text="c0", score=10.0, chunk_index=0, search_type="k"),
+    SearchResult(path="/long.md", chunk_text="c1", score=9.0, chunk_index=1, search_type="k"),
+    SearchResult(path="/long.md", chunk_text="c2", score=8.0, chunk_index=2, search_type="k"),
+    SearchResult(path="/long.md", chunk_text="c3", score=7.0, chunk_index=3, search_type="k"),
+    SearchResult(path="/other-a.md", chunk_text="a", score=6.0, chunk_index=0, search_type="k"),
+    SearchResult(path="/other-b.md", chunk_text="b", score=5.0, chunk_index=0, search_type="k"),
+]
+
+
+class _FakeFtsBackend:
+    """Plain (non-PG) FTS backend → exercises the 2-way hybrid branch."""
+
+    async def keyword_search(
+        self,
+        query: str,
+        path: str,
+        limit: int,
+        zone_id: str,
+        *,
+        timing: dict[str, float] | None = None,
+    ) -> list[SearchResult]:
+        return list(_LONG_DOC_ROWS)
+
+
+class _FakeVectorBackend:
+    async def semantic_search(
+        self, qvec: list[float], path: str, limit: int, zone_id: str
+    ) -> list[SearchResult]:
+        return list(_LONG_DOC_ROWS)
+
+
+def _hybrid_daemon(config: DaemonConfig) -> Any:
+    daemon: Any = SearchDaemon.__new__(SearchDaemon)
+    daemon.last_search_timing = {}
+    daemon.config = config
+    daemon._fts_backend = _FakeFtsBackend()
+    daemon._vector_backend = _FakeVectorBackend()
+
+    async def _embed_query(self: Any, query: str) -> list[float]:
+        return [0.1, 0.2]
+
+    daemon._embed_query = MethodType(_embed_query, daemon)
+    return daemon
+
+
+@pytest.mark.asyncio
+async def test_hybrid_final_list_pools_dominant_doc() -> None:
+    """One long doc matching many chunks is capped at ``chunks_per_page``
+    in the fused hybrid list, so other docs enter the top-N."""
+    daemon = _hybrid_daemon(DaemonConfig(page_aggregation=True, chunks_per_page=2))
+
+    results = await daemon._search_via_backends(
+        "query",
+        search_type="hybrid",
+        limit=6,
+        path_filter=None,
+        zone_id="root",
+    )
+
+    paths = [r.path for r in results]
+    assert paths == ["/long.md", "/long.md", "/other-a.md", "/other-b.md"]
+    # Best two chunks of the dominant doc survive, in fused-rank order.
+    assert [r.chunk_index for r in results[:2]] == [0, 1]
+
+
+@pytest.mark.asyncio
+async def test_page_aggregation_false_restores_chunk_grain_behavior() -> None:
+    """NEXUS_SEARCH_PAGE_AGGREGATION=false parity: no pooling at all."""
+    daemon = _hybrid_daemon(DaemonConfig(page_aggregation=False, chunks_per_page=2))
+
+    results = await daemon._search_via_backends(
+        "query",
+        search_type="hybrid",
+        limit=6,
+        path_filter=None,
+        zone_id="root",
+    )
+
+    paths = [r.path for r in results]
+    assert paths == ["/long.md"] * 4 + ["/other-a.md", "/other-b.md"]
+
+
+@pytest.mark.asyncio
+async def test_chunks_per_page_cap_honored() -> None:
+    daemon = _hybrid_daemon(DaemonConfig(page_aggregation=True, chunks_per_page=1))
+
+    results = await daemon._search_via_backends(
+        "query",
+        search_type="hybrid",
+        limit=6,
+        path_filter=None,
+        zone_id="root",
+    )
+
+    paths = [r.path for r in results]
+    assert paths == ["/long.md", "/other-a.md", "/other-b.md"]
+
+
+# ---------------------------------------------------------------------------
+# Federated: raw-score flat merge pooling
+# ---------------------------------------------------------------------------
+
+
+def _remote_chunk(zone: str, path: str, idx: int, score: float) -> dict[str, Any]:
+    """Remote-zone style result: plain dict, chunk-grain, no
+    ``zone_qualified_path`` (so the merge dedup key stays chunk-grain)."""
+    return {
+        "path": path,
+        "chunk_index": idx,
+        "chunk_text": f"{path}#{idx}",
+        "score": score,
+        "zone_id": zone,
+    }
+
+
+def test_merge_by_raw_score_pools_remote_style_chunks() -> None:
+    zone_lists = [
+        (
+            "zone-a",
+            [
+                _remote_chunk("zone-a", "/doc.md", 0, 0.9),
+                _remote_chunk("zone-a", "/doc.md", 1, 0.8),
+                _remote_chunk("zone-a", "/doc.md", 2, 0.7),
+                _remote_chunk("zone-a", "/doc.md", 3, 0.6),
+                _remote_chunk("zone-a", "/b.md", 0, 0.5),
+            ],
+        ),
+    ]
+
+    merged = _merge_by_raw_score(zone_lists, limit=10, chunks_per_page=2)
+
+    paths = [r["path"] for r in merged]
+    assert paths == ["/doc.md", "/doc.md", "/b.md"]
+
+
+def test_merge_by_raw_score_default_keeps_chunk_grain() -> None:
+    """Without a pooling cap the merge behaves exactly as before."""
+    zone_lists = [
+        (
+            "zone-a",
+            [
+                _remote_chunk("zone-a", "/doc.md", 0, 0.9),
+                _remote_chunk("zone-a", "/doc.md", 1, 0.8),
+                _remote_chunk("zone-a", "/doc.md", 2, 0.7),
+                _remote_chunk("zone-a", "/b.md", 0, 0.5),
+            ],
+        ),
+    ]
+
+    merged = _merge_by_raw_score(zone_lists, limit=10)
+
+    assert len(merged) == 4
+
+
+def test_merge_pooling_is_zone_scoped() -> None:
+    """Same path in two zones = two distinct documents; pooling must not
+    collapse them across zones."""
+    zone_lists = [
+        ("zone-a", [_remote_chunk("zone-a", "/doc.md", 0, 0.9)]),
+        ("zone-b", [_remote_chunk("zone-b", "/doc.md", 0, 0.8)]),
+    ]
+
+    merged = _merge_by_raw_score(zone_lists, limit=10, chunks_per_page=1)
+
+    assert [(r["zone_id"], r["path"]) for r in merged] == [
+        ("zone-a", "/doc.md"),
+        ("zone-b", "/doc.md"),
+    ]
+
+
+def test_dispatcher_reads_pooling_cap_from_daemon_config() -> None:
+    daemon = SimpleNamespace(config=DaemonConfig(page_aggregation=True, chunks_per_page=3))
+    dispatcher = FederatedSearchDispatcher(daemon=daemon, rebac=AsyncMock())
+
+    assert dispatcher._pooling_chunks_per_page() == 3
+
+
+def test_dispatcher_pooling_disabled_by_config() -> None:
+    daemon = SimpleNamespace(config=DaemonConfig(page_aggregation=False, chunks_per_page=2))
+    dispatcher = FederatedSearchDispatcher(daemon=daemon, rebac=AsyncMock())
+
+    assert dispatcher._pooling_chunks_per_page() is None
+
+
+def test_dispatcher_pooling_off_for_configless_daemon() -> None:
+    """Mock daemons (tests) and daemons without a real DaemonConfig must not
+    accidentally enable pooling via Mock auto-attributes."""
+    dispatcher = FederatedSearchDispatcher(daemon=AsyncMock(), rebac=AsyncMock())
+
+    assert dispatcher._pooling_chunks_per_page() is None


### PR DESCRIPTION
## Summary

Closes #4542.

`DaemonConfig.page_aggregation` / `chunks_per_page` (Issue #3980) default ON but were never applied to the final RRF-fused hybrid list — one long document could occupy every hybrid result slot.

- **Daemon** (`daemon.py`): after the final `rrf_fusion(...)` in `_search_via_backends`, pool the fused list with `_aggregate_chunks_to_pages(fused, chunks_per_page=config.chunks_per_page)` when `config.page_aggregation` is true. The route's ReBAC over-fetch (`fetch_limit = limit × 3`) leaves headroom before the caller's final trim. Covers both the PG 3-way and SQLite 2-way hybrid branches.
- **Federated** (`federated_search.py`): the raw-score flat merge now applies the same cap **per zone** (so the same path in two zones stays two documents). Local-zone results already collapse to one chunk per doc via the page-grain `zone_qualified_path` dedup; the cap matters for remote-zone dicts whose dedup key falls back to chunk grain.
- The dispatcher reads the cap from the default daemon's `DaemonConfig` — the single place where `NEXUS_SEARCH_PAGE_AGGREGATION` / `NEXUS_SEARCH_CHUNKS_PER_PAGE` land — so one env toggle governs both single-zone and federated pooling. Strict `is True` / `isinstance` checks keep AsyncMock daemons in tests from enabling pooling via auto-created attributes.

## Acceptance (from #4542)

- ✅ Fixture where one long doc matches many chunks: hybrid returns at most `chunks_per_page` chunks for that doc and other docs enter the top-N (`test_hybrid_final_list_pools_dominant_doc`).
- ✅ `NEXUS_SEARCH_PAGE_AGGREGATION=false` restores current behavior exactly (`test_page_aggregation_false_restores_chunk_grain_behavior`, `test_merge_by_raw_score_default_keeps_chunk_grain`).
- ✅ Federated parity (`test_merge_by_raw_score_pools_remote_style_chunks`, `test_merge_pooling_is_zone_scoped`, dispatcher config-read tests).

## Testing

- New: `tests/unit/bricks/search/test_final_list_page_pooling.py` (9 tests, written first, watched fail, then implemented).
- `tests/unit/bricks/search/` + `tests/integration/bricks/search/test_federated_search.py` + router search tests: green.
- `test_daemon_backend_routing.py` harness updated: the `__new__`-constructed daemon now sets `daemon.config = DaemonConfig()` (real `__init__` always sets it).
- pre-commit (ruff, mypy, boundary checks): all pass.