### PR TITLE
fix(search): honor alpha/fusion/rrf_k on the backend hybrid path

### DIFF
--- a/docs/surface-coverage/api-rpc-surface-coverage.yaml
+++ b/docs/surface-coverage/api-rpc-surface-coverage.yaml
@@ -7642,7 +7642,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/expand
-      source: src/nexus/server/api/v2/routers/search.py:1550
+      source: src/nexus/server/api/v2/routers/search.py:1558
   profiles:
     lite: supported
     sandbox: supported
@@ -7666,7 +7666,7 @@ operations:
       source: src/nexus/bricks/search/search_service.py:1791
     http:
       name: POST /api/v2/search/glob
-      source: src/nexus/server/api/v2/routers/search.py:1431
+      source: src/nexus/server/api/v2/routers/search.py:1439
     mcp:
       name: nexus_glob
       source: src/nexus/config/tool_profiles.yaml:1
@@ -7693,7 +7693,7 @@ operations:
       source: src/nexus/bricks/search/search_service.py:2101
     http:
       name: POST /api/v2/search/grep
-      source: src/nexus/server/api/v2/routers/search.py:1308
+      source: src/nexus/server/api/v2/routers/search.py:1316
     mcp:
       name: nexus_grep
       source: src/nexus/config/tool_profiles.yaml:1
@@ -7746,7 +7746,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/index
-      source: src/nexus/server/api/v2/routers/search.py:1493
+      source: src/nexus/server/api/v2/routers/search.py:1501
   profiles:
     lite: supported
     sandbox: supported
@@ -7764,7 +7764,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/index-directory
-      source: src/nexus/server/api/v2/routers/search.py:1692
+      source: src/nexus/server/api/v2/routers/search.py:1700
   profiles:
     lite: supported
     sandbox: supported
@@ -7781,7 +7781,7 @@ operations:
   transports:
     http:
       name: GET /api/v2/search/indexed-dirs
-      source: src/nexus/server/api/v2/routers/search.py:1910
+      source: src/nexus/server/api/v2/routers/search.py:1918
   profiles:
     lite: supported
     sandbox: supported
@@ -7798,7 +7798,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/indexing-mode
-      source: src/nexus/server/api/v2/routers/search.py:1947
+      source: src/nexus/server/api/v2/routers/search.py:1955
   profiles:
     lite: supported
     sandbox: supported
@@ -7815,7 +7815,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/locate
-      source: src/nexus/server/api/v2/routers/search.py:2128
+      source: src/nexus/server/api/v2/routers/search.py:2136
   profiles:
     lite: supported
     sandbox: supported
@@ -7884,7 +7884,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/purge-unscoped
-      source: src/nexus/server/api/v2/routers/search.py:2074
+      source: src/nexus/server/api/v2/routers/search.py:2082
   profiles:
     lite: supported
     sandbox: supported
@@ -7920,7 +7920,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/query/batch
-      source: src/nexus/server/api/v2/routers/search.py:738
+      source: src/nexus/server/api/v2/routers/search.py:746
   profiles:
     lite: supported
     sandbox: supported
@@ -7937,7 +7937,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/refresh
-      source: src/nexus/server/api/v2/routers/search.py:1529
+      source: src/nexus/server/api/v2/routers/search.py:1537
   profiles:
     lite: supported
     sandbox: supported

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -1789,6 +1789,7 @@ class SearchDaemon:
         path_filter: str | None = None,
         alpha: float = 0.5,
         fusion_method: str = "rrf",
+        rrf_k: int = 60,
         zone_id: str | None = None,
         expand: str = "none",
     ) -> list[SearchResult]:
@@ -1800,6 +1801,7 @@ class SearchDaemon:
                 path_filter=path_filter,
                 alpha=alpha,
                 fusion_method=fusion_method,
+                rrf_k=rrf_k,
                 zone_id=zone_id,
             )
         else:
@@ -1812,6 +1814,7 @@ class SearchDaemon:
                     path_filter=path_filter,
                     alpha=alpha,
                     fusion_method=fusion_method,
+                    rrf_k=rrf_k,
                     zone_id=zone_id,
                 )
 
@@ -1828,6 +1831,7 @@ class SearchDaemon:
         path_filter: str | None = None,
         alpha: float = 0.5,
         fusion_method: str = "rrf",
+        rrf_k: int = 60,
         zone_id: str | None = None,
     ) -> list[SearchResult]:
         """Execute a search query with pre-warmed indexes.
@@ -1839,6 +1843,7 @@ class SearchDaemon:
             path_filter: Optional path prefix filter
             alpha: Weight for semantic vs keyword (0.0 = all keyword, 1.0 = all semantic)
             fusion_method: Fusion algorithm for hybrid search ("rrf", "weighted", "rrf_weighted")
+            rrf_k: RRF rank constant for the hybrid fusion stages (default 60)
 
         Returns:
             List of search results sorted by relevance
@@ -1941,6 +1946,9 @@ class SearchDaemon:
                     search_type=search_type,
                     limit=limit,
                     path_filter=path_filter,
+                    alpha=alpha,
+                    fusion_method=fusion_method,
+                    rrf_k=rrf_k,
                     zone_id=effective_zone_id,
                 )
                 backend_ms = (time.perf_counter() - backend_start) * 1000
@@ -2017,14 +2025,26 @@ class SearchDaemon:
         limit: int,
         path_filter: str | None,
         zone_id: str,
+        alpha: float = 0.5,
+        fusion_method: str = "rrf",
+        rrf_k: int = 60,
     ) -> list[SearchResult]:
         """Run keyword / semantic / hybrid via the new search backends.
 
-        Hybrid mode performs 3-way RRF on Postgres (chunk-BM25 + page-BM25 +
-        dense) and 2-way RRF on SQLite (chunk-BM25 + dense — there is no
-        page-level BM25 leg yet on the FTS5 vtable).
+        Hybrid mode fuses two stages: the keyword legs first (3-way on
+        Postgres: chunk-BM25 + page-BM25; 2-way on SQLite — no page-level
+        BM25 leg yet on the FTS5 vtable), then keyword × dense. The
+        keyword sub-fusion is always plain RRF; the final stage honours
+        the request's ``fusion_method`` / ``alpha`` / ``rrf_k`` (Issue
+        #4541). Defaults reproduce the historical hardcoded behaviour
+        (plain RRF, k=60) exactly.
         """
-        from nexus.bricks.search.fusion import rrf_fusion
+        from nexus.bricks.search.fusion import (
+            FusionConfig,
+            FusionMethod,
+            fuse_results,
+            rrf_fusion,
+        )
         from nexus.bricks.search.pg_fts_backend import PgFtsBackend
         from nexus.bricks.search.result_builders import _aggregate_chunks_to_pages
 
@@ -2124,10 +2144,16 @@ class SearchDaemon:
             )
             page_kw = []
 
-        # Fuse keyword legs first (chunk + page), then RRF that with dense.
+        # Fuse keyword legs first (chunk + page) with plain RRF, then fuse
+        # that with dense using the request's method / alpha / k.
         fusion_start = time.perf_counter()
-        kw_fused = rrf_fusion(chunk_kw, page_kw, k=60, limit=limit * 2, id_key=None)
-        fused = rrf_fusion(kw_fused, dense, k=60, limit=limit, id_key=None)
+        kw_fused = rrf_fusion(chunk_kw, page_kw, k=rrf_k, limit=limit * 2, id_key=None)
+        fusion_config = FusionConfig(
+            method=FusionMethod(fusion_method),
+            alpha=alpha,
+            rrf_k=rrf_k,
+        )
+        fused = fuse_results(kw_fused, dense, config=fusion_config, limit=limit, id_key=None)
         # Issue #4542: pool the fused list per document so one long doc cannot
         # occupy every hybrid slot. The route over-fetches (fetch_limit =
         # limit × 3 for the ReBAC filter), so pooling at daemon-output size

--- a/src/nexus/bricks/search/federated_search.py
+++ b/src/nexus/bricks/search/federated_search.py
@@ -296,6 +296,7 @@ class FederatedSearchDispatcher:
         path_filter: str | None,
         alpha: float,
         fusion_method: str,
+        rrf_k: int = 60,
         subject: tuple[str, str] | None = None,
     ) -> list[Any]:
         """Search a single zone with capability-aware routing."""
@@ -304,6 +305,10 @@ class FederatedSearchDispatcher:
 
         # Phase 2: Check if this zone has a remote transport in the registry.
         # If so, search via gRPC with a SearchDelegation credential.
+        # NOTE: rrf_k is intentionally NOT forwarded over the remote RPC —
+        # older remote nodes reject unknown search params, so remote zones
+        # fuse with their local default (60) until the RPC surface is
+        # versioned (#4541).
         if self._registry is not None and self._registry.is_remote(zone_id):
             return await self._search_remote_zone(
                 zone_id=zone_id,
@@ -325,6 +330,7 @@ class FederatedSearchDispatcher:
             path_filter=path_filter,
             alpha=effective_alpha,
             fusion_method=fusion_method,
+            rrf_k=rrf_k,
             zone_id=zone_id,
         )
 
@@ -428,9 +434,20 @@ class FederatedSearchDispatcher:
         search_type: str,
         limit: int,
         path_filter: str | None,
+        alpha: float = 0.5,
+        fusion_method: str = "rrf",
+        rrf_k: int = 60,
     ) -> str:
-        """Phase 3: Create a cache key for result caching."""
-        raw = f"{subject[0]}:{subject[1]}|{query}|{search_type}|{limit}|{path_filter}"
+        """Phase 3: Create a cache key for result caching.
+
+        Fusion knobs are part of the key: they change result ordering now
+        that the daemon honours them (#4541), so requests differing only in
+        alpha / fusion_method / rrf_k must not share a cache entry.
+        """
+        raw = (
+            f"{subject[0]}:{subject[1]}|{query}|{search_type}|{limit}|{path_filter}"
+            f"|{alpha}|{fusion_method}|{rrf_k}"
+        )
         return hashlib.sha256(raw.encode()).hexdigest()[:32]
 
     def _get_cached_result(
@@ -489,6 +506,7 @@ class FederatedSearchDispatcher:
         path_filter: str | None = None,
         alpha: float = 0.5,
         fusion_method: str = "rrf",
+        rrf_k: int = 60,
         zone_filter: frozenset[str] | None = None,  # NEW (#3785)
     ) -> FederatedSearchResponse:
         """Public federated search entry point with activity-event instrumentation (#3791).
@@ -509,6 +527,7 @@ class FederatedSearchDispatcher:
                 path_filter=path_filter,
                 alpha=alpha,
                 fusion_method=fusion_method,
+                rrf_k=rrf_k,
                 zone_filter=zone_filter,
             )
         except Exception:
@@ -542,6 +561,7 @@ class FederatedSearchDispatcher:
         path_filter: str | None = None,
         alpha: float = 0.5,
         fusion_method: str = "rrf",
+        rrf_k: int = 60,
         zone_filter: frozenset[str] | None = None,  # NEW (#3785)
     ) -> FederatedSearchResponse:
         """Execute a federated search across all accessible zones.
@@ -554,6 +574,8 @@ class FederatedSearchDispatcher:
             path_filter: Optional path prefix filter.
             alpha: Semantic vs keyword weight.
             fusion_method: Fusion method for intra-zone hybrid search.
+            rrf_k: RRF rank constant for intra-zone hybrid fusion (#4541).
+                Applied to local zones only; remote zones use their default.
             zone_filter: Optional upper-bound zone allow-list. When set,
                 intersects with accessible_zones to enforce per-token zone
                 scoping (#3785).
@@ -564,7 +586,9 @@ class FederatedSearchDispatcher:
         start = time.perf_counter()
 
         # Phase 3: Check result cache
-        cache_key = self._make_cache_key(query, subject, search_type, limit, path_filter)
+        cache_key = self._make_cache_key(
+            query, subject, search_type, limit, path_filter, alpha, fusion_method, rrf_k
+        )
         cached = self._get_cached_result(cache_key, start=start)
         if cached is not None:
             return cached
@@ -615,6 +639,7 @@ class FederatedSearchDispatcher:
                         path_filter,
                         alpha,
                         fusion_method,
+                        rrf_k=rrf_k,
                         subject=subject,
                     ),
                     timeout=self._config.zone_timeout_seconds,
@@ -670,6 +695,7 @@ class FederatedSearchDispatcher:
                             path_filter,
                             alpha,
                             fusion_method,
+                            rrf_k=rrf_k,
                             subject=subject,
                         ),
                         timeout=self._config.zone_timeout_seconds,

--- a/src/nexus/contracts/protocols/search.py
+++ b/src/nexus/contracts/protocols/search.py
@@ -53,6 +53,7 @@ class SearchBrickProtocol(Protocol):
         path_filter: str | None = None,
         alpha: float = 0.5,
         fusion_method: str = "rrf",
+        rrf_k: int = 60,
         adaptive_k: bool = False,
         zone_id: str | None = None,
     ) -> builtins.list[Any]: ...

--- a/src/nexus/server/api/v2/routers/search.py
+++ b/src/nexus/server/api/v2/routers/search.py
@@ -301,9 +301,11 @@ async def search_query(
     path: str | None = Query(None, description="Optional path prefix filter"),
     alpha: float = Query(0.5, description="Semantic vs keyword weight (0.0-1.0)", ge=0.0, le=1.0),
     fusion: str = Query("rrf", description="Fusion method: rrf, weighted, or rrf_weighted"),
+    rrf_k: int = Query(60, description="RRF rank constant for hybrid fusion", ge=1, le=1000),
     expand: str = Query("none", description="Context expansion: none or macro"),
     rerank: bool | None = Query(  # noqa: ARG001
-        None, description="Override reranker (true/false, default: use config)"
+        None,
+        description="Inert: accepted for compatibility; no reranker stage exists (#4541)",
     ),
     graph_mode: str = Query(
         "none", description="Graph enhancement mode: none, low, high, dual, auto"
@@ -368,6 +370,7 @@ async def search_query(
                 path_filter=path,
                 alpha=alpha,
                 fusion_method=fusion,
+                rrf_k=rrf_k,
                 auth_result=auth_result,
                 search_daemon=search_daemon,
                 request=request,
@@ -382,6 +385,7 @@ async def search_query(
             path_filter=path,
             alpha=alpha,
             fusion_method=fusion,
+            rrf_k=rrf_k,
             graph_mode=graph_mode,
             expand=expand,
             auth_result=auth_result,
@@ -404,6 +408,7 @@ async def _handle_single_zone_search(
     path_filter: str | None,
     alpha: float,
     fusion_method: str,
+    rrf_k: int,
     graph_mode: str,
     expand: str,
     auth_result: dict[str, Any],
@@ -524,6 +529,7 @@ async def _handle_single_zone_search(
             path_filter=path_filter,
             alpha=alpha,
             fusion_method=fusion_method,
+            rrf_k=rrf_k,
             zone_id=zone_id,
             expand=expand,
         )
@@ -586,6 +592,7 @@ async def _handle_federated_search(
     path_filter: str | None,
     alpha: float,
     fusion_method: str,
+    rrf_k: int,
     auth_result: dict[str, Any],
     search_daemon: Any,
     request: Request,
@@ -644,6 +651,7 @@ async def _handle_federated_search(
         path_filter=path_filter,
         alpha=alpha,
         fusion_method=fusion_method,
+        rrf_k=rrf_k,
         zone_filter=zone_filter,
     )
 

--- a/tests/integration/services/test_search_router.py
+++ b/tests/integration/services/test_search_router.py
@@ -114,6 +114,37 @@ class TestSearchQueryEndpoint:
         resp = client.get("/api/v2/search/query?q=hello&limit=101")
         assert resp.status_code == 422
 
+    def test_rrf_k_bounds(self, client: "TestClient") -> None:
+        resp = client.get("/api/v2/search/query?q=hello&rrf_k=0")
+        assert resp.status_code == 422
+        resp = client.get("/api/v2/search/query?q=hello&rrf_k=1001")
+        assert resp.status_code == 422
+
+    def test_fusion_params_forwarded_to_daemon(self, client: "TestClient") -> None:
+        """Issue #4541: alpha / fusion / rrf_k must reach daemon.search, not
+        be validated-then-dropped at the route."""
+        app: Any = client.app
+        seen: dict[str, Any] = {}
+
+        async def mock_search(**kwargs: Any) -> list[_MockResult]:
+            seen.clear()
+            seen.update(kwargs)
+            return [_MockResult()]
+
+        app.state.search_daemon.search = mock_search
+
+        resp = client.get("/api/v2/search/query?q=hello&fusion=weighted&alpha=0.9&rrf_k=30")
+        assert resp.status_code == 200
+        assert seen["fusion_method"] == "weighted"
+        assert seen["alpha"] == 0.9
+        assert seen["rrf_k"] == 30
+
+        resp = client.get("/api/v2/search/query?q=hello")
+        assert resp.status_code == 200
+        assert seen["fusion_method"] == "rrf"
+        assert seen["alpha"] == 0.5
+        assert seen["rrf_k"] == 60
+
     def test_health_endpoint(self, client: "TestClient") -> None:
         resp = client.get("/api/v2/search/health")
         assert resp.status_code == 200

--- a/tests/unit/bricks/search/test_daemon_fusion_params.py
+++ b/tests/unit/bricks/search/test_daemon_fusion_params.py
@@ -1,0 +1,184 @@
+"""Fusion request params must reach the backend hybrid path (Issue #4541).
+
+`GET /api/v2/search/query` validates `alpha` / `fusion` (and now `rrf_k`),
+but the primary indexed path `_search_via_backends` historically fused with
+a hardcoded two-stage RRF (k=60), silently ignoring the knobs. These tests
+pin the full chain: `search()` threads the params, `_search_via_backends`
+dispatches on them, and the default request stays byte-identical to the
+legacy hardcoded fusion.
+"""
+
+from __future__ import annotations
+
+from types import MethodType
+from typing import Any
+
+import pytest
+
+
+def _make_daemon() -> Any:
+    """Bare SearchDaemon with fake (non-PG) fts + vector backends.
+
+    Fixture corpus is built so keyword and dense orderings disagree:
+      keyword (BM25):  /a.md (10.0) > /b.md (9.0) > /c.md (8.0)
+      dense  (cosine): /d.md (0.99) > /c.md (0.9) > /a.md (0.5)
+    so any change of fusion method / alpha / k is visible in the ordering.
+    """
+    from nexus.bricks.search.daemon import DaemonConfig, SearchDaemon, SearchResult
+
+    def _kw(path: str, score: float) -> SearchResult:
+        return SearchResult(
+            path=path, chunk_text=path, score=score, chunk_index=0, search_type="keyword"
+        )
+
+    def _dense(path: str, score: float) -> SearchResult:
+        return SearchResult(
+            path=path, chunk_text=path, score=score, chunk_index=0, search_type="semantic"
+        )
+
+    class FakeFtsBackend:
+        async def keyword_search(
+            self,
+            query: str,
+            path: str,
+            limit: int,
+            zone_id: str,
+            *,
+            timing: dict[str, float] | None = None,
+        ) -> list[Any]:
+            return [_kw("/a.md", 10.0), _kw("/b.md", 9.0), _kw("/c.md", 8.0)]
+
+    class FakeVectorBackend:
+        async def semantic_search(
+            self, qvec: list[float], path: str, limit: int, zone_id: str
+        ) -> list[Any]:
+            return [_dense("/d.md", 0.99), _dense("/c.md", 0.9), _dense("/a.md", 0.5)]
+
+    async def _embed_query(self: Any, query: str) -> list[float]:
+        return [0.1, 0.2]
+
+    daemon: Any = SearchDaemon.__new__(SearchDaemon)
+    daemon.last_search_timing = {}
+    daemon._fts_backend = FakeFtsBackend()
+    daemon._vector_backend = FakeVectorBackend()
+    daemon._embed_query = MethodType(_embed_query, daemon)
+    # Disable #4542 final-list page pooling: these tests assert chunk-grain
+    # fusion ordering, which pooling would re-group.
+    daemon.config = DaemonConfig(page_aggregation=False)
+    return daemon
+
+
+async def _hybrid(daemon: Any, **kwargs: Any) -> list[Any]:
+    return await daemon._search_via_backends(
+        "nexus core",
+        search_type="hybrid",
+        limit=4,
+        path_filter=None,
+        zone_id="root",
+        **kwargs,
+    )
+
+
+@pytest.mark.asyncio
+async def test_default_fusion_matches_legacy_two_stage_rrf() -> None:
+    """Regression pin: default params stay byte-identical to the historical
+    hardcoded fusion — plain RRF, k=60, sub-fusion then dense stage."""
+    from nexus.bricks.search.fusion import rrf_fusion
+
+    daemon = _make_daemon()
+    results = await _hybrid(daemon)
+
+    chunk_kw = await daemon._fts_backend.keyword_search("nexus core", "/", 8, "root")
+    dense = await daemon._vector_backend.semantic_search([0.1, 0.2], "/", 8, "root")
+    kw_fused = rrf_fusion(chunk_kw, [], k=60, limit=8, id_key=None)
+    expected = rrf_fusion(kw_fused, dense, k=60, limit=4, id_key=None)
+
+    assert [r.path for r in results] == [e["path"] for e in expected]
+    assert [r.path for r in results] == ["/a.md", "/d.md", "/c.md", "/b.md"]
+    for got, exp in zip(results, expected, strict=True):
+        assert got.score == pytest.approx(exp["score"])
+
+
+@pytest.mark.asyncio
+async def test_weighted_fusion_alpha_changes_ordering() -> None:
+    """fusion=weighted&alpha=0.9 must produce a different ordering than the
+    default RRF (dense-favoured under high alpha)."""
+    daemon = _make_daemon()
+    results = await _hybrid(daemon, alpha=0.9, fusion_method="weighted")
+
+    assert [r.path for r in results] == ["/d.md", "/c.md", "/a.md", "/b.md"]
+
+
+@pytest.mark.asyncio
+async def test_rrf_weighted_alpha_zero_ranks_keyword_only() -> None:
+    """fusion=rrf_weighted&alpha=0.0 ranks by the keyword legs only; the
+    dense-only hit contributes zero score."""
+    daemon = _make_daemon()
+    results = await _hybrid(daemon, alpha=0.0, fusion_method="rrf_weighted")
+
+    assert [r.path for r in results[:3]] == ["/a.md", "/b.md", "/c.md"]
+    dense_only = [r for r in results if r.path == "/d.md"]
+    assert all(r.score == 0.0 for r in dense_only)
+
+
+@pytest.mark.asyncio
+async def test_rrf_k_reaches_fusion() -> None:
+    """A non-default rrf_k must change the fused ordering (with this fixture,
+    k=5 amplifies rank differences enough to swap /c.md above /d.md)."""
+    daemon = _make_daemon()
+    default = await _hybrid(daemon)
+    small_k = await _hybrid(daemon, rrf_k=5)
+
+    assert [r.path for r in default] == ["/a.md", "/d.md", "/c.md", "/b.md"]
+    assert [r.path for r in small_k] == ["/a.md", "/c.md", "/d.md", "/b.md"]
+
+
+@pytest.mark.asyncio
+async def test_search_threads_fusion_params_to_backends() -> None:
+    """`SearchDaemon.search()` must forward alpha / fusion_method / rrf_k to
+    `_search_via_backends` (previously dropped on the floor)."""
+    from nexus.bricks.search.daemon import SearchDaemon, SearchResult
+
+    seen: dict[str, Any] = {}
+
+    daemon: Any = SearchDaemon.__new__(SearchDaemon)
+    daemon._initialized = True
+    daemon._fts_backend = object()
+    daemon._vector_backend = object()
+    daemon._permission_enforcer = None
+    daemon.last_search_timing = {}
+
+    def _track_latency(self: Any, latency_ms: float) -> None:
+        self._last_latency_ms = latency_ms
+
+    async def _attach_path_contexts(self: Any, results: Any, *, zone_id: str) -> None:
+        self._last_context_zone = zone_id
+
+    async def _search_via_backends(self: Any, *args: Any, **kwargs: Any) -> list[SearchResult]:
+        seen.update(kwargs)
+        return [
+            SearchResult(
+                path="/backend.md",
+                chunk_text="backend result",
+                score=1.0,
+                chunk_index=0,
+                search_type="hybrid",
+            )
+        ]
+
+    daemon._track_latency = MethodType(_track_latency, daemon)
+    daemon._attach_path_contexts = MethodType(_attach_path_contexts, daemon)
+    daemon._search_via_backends = MethodType(_search_via_backends, daemon)
+
+    await daemon.search(
+        "nexus core",
+        search_type="hybrid",
+        limit=1,
+        alpha=0.9,
+        fusion_method="weighted",
+        rrf_k=30,
+    )
+
+    assert seen["alpha"] == 0.9
+    assert seen["fusion_method"] == "weighted"
+    assert seen["rrf_k"] == 30

--- a/tests/unit/bricks/search/test_daemon_zone_runner.py
+++ b/tests/unit/bricks/search/test_daemon_zone_runner.py
@@ -68,6 +68,7 @@ async def test_search_with_zone_stays_on_daemon_owner_loop() -> None:
         path_filter: str | None,
         alpha: float,
         fusion_method: str,
+        rrf_k: int,
         zone_id: str | None,
     ) -> list[str]:
         seen.append((asyncio.get_running_loop(), threading.get_ident(), zone_id))


### PR DESCRIPTION
## Summary

Fixes #4541.

`GET /api/v2/search/query` validated `alpha` (0.0–1.0) and `fusion` (`rrf|weighted|rrf_weighted`) but the primary indexed path `_search_via_backends` took neither — hybrid always ran the hardcoded two-stage RRF (`k=60`). Callers could send fusion knobs, get a 200, and nothing changed.

### Changes

- **Thread `alpha` + `fusion_method` + new `rrf_k`** (default 60, `ge=1 le=1000`) from the route through `SearchDaemon.search()` / `_search_on_current_loop()` into `_search_via_backends`.
- **Final `kw_fused × dense` stage** now dispatches via `fuse_results(FusionConfig(method, alpha, rrf_k))`; the page-BM25 sub-fusion stays plain RRF (per issue proposal), with `k=rrf_k`.
- **Defaults byte-identical**: `rrf`, `k=60`, alpha ignored under plain RRF — pinned by a regression test that recomputes the historical hardcoded two-stage fusion.
- **Federated path**: `rrf_k` threads to local zones (remote RPC params intentionally unchanged — older remote nodes reject unknown search params; noted inline). The federated **result cache key now includes `alpha`/`fusion_method`/`rrf_k`** — previously omitted, harmless while the knobs were dead, but cache-conflating once they go live.
- **`rerank` param documented as inert** in its Query description (no reranker stage since the txtai drop) — the issue's related-but-out-of-scope note, description-only.
- `SearchBrickProtocol.search` gains `rrf_k` for contract alignment; surface-coverage yaml regenerated (pure line-number sync).

### Acceptance (from issue)

- `fusion=weighted&alpha=0.9` produces a different ordering than default on a fixture corpus ✅ (`test_weighted_fusion_alpha_changes_ordering`)
- `fusion=rrf_weighted&alpha=0.0` ranks by keyword legs only ✅ (`test_rrf_weighted_alpha_zero_ranks_keyword_only`, dense-only hit scores 0.0)
- Default-param request byte-identical ✅ (`test_default_fusion_matches_legacy_two_stage_rrf`)
- Route params reach the fusion call ✅ (route→`daemon.search` forwarding test + `search()`→`_search_via_backends` threading test + `rrf_k` ordering-change test)

## Testing

- TDD: all new tests written first and watched fail for feature-missing reasons (unexpected kwarg / param dropped / no 422).
- `tests/unit/bricks/search/`: 0 failures.
- `tests/integration/bricks/search/ + test_search_router.py + test_search_zone_set.py`: 409 passed, 8 skipped (PG-gated). (`test_brick_compliance.py` collection is broken on develop — imports `lifecycle_adapter` deleted in 9b0a5031b — pre-existing, excluded.)
- ruff check/format clean; mypy clean on changed files; `validate_api_surface_coverage.py` exit 0.