### PR TITLE
feat(search): per-prefix ranking weight via path_contexts (source-tier boost) (#4544)

### DIFF
--- a/alembic/versions/add_path_context_weight.py
+++ b/alembic/versions/add_path_context_weight.py
@@ -1,0 +1,31 @@
+"""Add weight column to path_contexts (Issue #4544).
+
+Nullable, no server default: NULL ≡ 1.0 in application code, so existing
+rows and weightless new rows rank exactly as before the migration.
+
+Revision ID: add_path_context_weight
+Revises: align_graph_zone_columns
+Create Date: 2026-07-31
+"""
+
+from collections.abc import Sequence
+from typing import Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "add_path_context_weight"
+down_revision: Union[str, Sequence[str], None] = "align_graph_zone_columns"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add nullable weight column."""
+    op.add_column("path_contexts", sa.Column("weight", sa.Float(), nullable=True))
+
+
+def downgrade() -> None:
+    """Drop weight column."""
+    op.drop_column("path_contexts", "weight")

--- a/docs/superpowers/plans/2026-07-31-prefix-weight-boost.md
+++ b/docs/superpowers/plans/2026-07-31-prefix-weight-boost.md
@@ -127,8 +127,7 @@ SQLite branch: same shape with lowercase `excluded.description` / `excluded.weig
 
 ```python
 query = (
-    "SELECT zone_id, path_prefix, description, weight, created_at, updated_at "
-    "FROM path_contexts"
+    "SELECT zone_id, path_prefix, description, weight, created_at, updated_at FROM path_contexts"
 )
 ...
 return [
@@ -560,37 +559,35 @@ Expected: FAIL — scores unmultiplied / `tier_boost` stays None.
 In `_attach_path_contexts`, replace the final lookup loop (currently `for r in results: ... r.context = lookup_in_records(records, r.path)`) with:
 
 ```python
-        from nexus.bricks.search.path_context import lookup_record_in_records
+from nexus.bricks.search.path_context import lookup_record_in_records
 
-        # Issue #4544: apply per-prefix ranking weights while attaching
-        # context. top_score is the pre-boost max of this batch — the floor
-        # gate must compare against the unweighted ranking.
-        floor_ratio = self.config.tier_boost_floor_ratio
-        top_score = max((r.score for r in results), default=0.0)
-        boosted_any = False
-        for r in results:
-            zone = _zone_for(r)
-            records = snapshots.get(zone)
-            if records is None:
-                continue
-            try:
-                record = lookup_record_in_records(records, r.path)
-                r.context = record.description if record is not None else None
-                if record is not None and _apply_tier_weight(
-                    r, record.weight, top_score, floor_ratio
-                ):
-                    boosted_any = True
-            except Exception as exc:
-                self.stats.path_context_attach_failures += 1
-                logger.warning(
-                    "path context lookup failed for path=%r (total=%d): %s",
-                    r.path,
-                    self.stats.path_context_attach_failures,
-                    exc,
-                )
-        if boosted_any:
-            # Stable sort: equal scores keep their pre-boost relative order.
-            results.sort(key=lambda r: r.score, reverse=True)
+# Issue #4544: apply per-prefix ranking weights while attaching
+# context. top_score is the pre-boost max of this batch — the floor
+# gate must compare against the unweighted ranking.
+floor_ratio = self.config.tier_boost_floor_ratio
+top_score = max((r.score for r in results), default=0.0)
+boosted_any = False
+for r in results:
+    zone = _zone_for(r)
+    records = snapshots.get(zone)
+    if records is None:
+        continue
+    try:
+        record = lookup_record_in_records(records, r.path)
+        r.context = record.description if record is not None else None
+        if record is not None and _apply_tier_weight(r, record.weight, top_score, floor_ratio):
+            boosted_any = True
+    except Exception as exc:
+        self.stats.path_context_attach_failures += 1
+        logger.warning(
+            "path context lookup failed for path=%r (total=%d): %s",
+            r.path,
+            self.stats.path_context_attach_failures,
+            exc,
+        )
+if boosted_any:
+    # Stable sort: equal scores keep their pre-boost relative order.
+    results.sort(key=lambda r: r.score, reverse=True)
 ```
 
 (Delete the now-unused `from nexus.bricks.search.path_context import lookup_in_records` import in this method.)
@@ -726,7 +723,9 @@ def _make_daemon(cache: PathContextCache) -> Any:
             # Fresh copies: score mutation must not leak between searches.
             return [
                 SearchResult(
-                    path=r.path, chunk_text=r.chunk_text, score=r.score,
+                    path=r.path,
+                    chunk_text=r.chunk_text,
+                    score=r.score,
                     search_type=r.search_type,
                 )
                 for r in corpus[:limit]
@@ -758,9 +757,7 @@ def _make_daemon(cache: PathContextCache) -> Any:
 
 class TestOverfetchAndTrim:
     @pytest.mark.asyncio
-    async def test_demotion_promotes_below_cutoff_hit_into_returned_set(
-        self, cache
-    ) -> None:
+    async def test_demotion_promotes_below_cutoff_hit_into_returned_set(self, cache) -> None:
         # limit=2 without weights returns the two chat docs. Demoting chat
         # must let docs/x.md (rank 3, beyond the un-widened fetch) into the
         # top 2 — this is exactly the promotion the over-fetch exists for.
@@ -790,9 +787,7 @@ class TestOverfetchAndTrim:
     async def test_weight_one_rows_do_not_trigger_overfetch(self, cache) -> None:
         await cache._store.upsert("root", "chat", "Chat transcripts", weight=1.0)
         daemon = _make_daemon(cache)
-        await daemon._search_on_current_loop(
-            "q", search_type="keyword", limit=2, zone_id="root"
-        )
+        await daemon._search_on_current_loop("q", search_type="keyword", limit=2, zone_id="root")
         assert daemon._fts_backend.requested_limits == [2]
 
     @pytest.mark.asyncio
@@ -846,15 +841,13 @@ Add method to `SearchDaemon` (place directly after `_resolve_path_context_cache`
 In `_search_on_current_loop`, right after `effective_zone_id = zone_id or ROOT_ZONE_ID`:
 
 ```python
-        # Issue #4544: when the zone carries tier weights, widen every
-        # candidate fetch so a boost can promote a below-cutoff hit, then trim
-        # back to ``limit`` after _attach_path_contexts applies the weights.
-        # Zones without weights keep internal_limit == limit and take the
-        # byte-identical legacy path.
-        has_tier_weights = await self._zone_has_tier_weights(effective_zone_id)
-        internal_limit = (
-            limit * self.config.tier_boost_overfetch_factor if has_tier_weights else limit
-        )
+# Issue #4544: when the zone carries tier weights, widen every
+# candidate fetch so a boost can promote a below-cutoff hit, then trim
+# back to ``limit`` after _attach_path_contexts applies the weights.
+# Zones without weights keep internal_limit == limit and take the
+# byte-identical legacy path.
+has_tier_weights = await self._zone_has_tier_weights(effective_zone_id)
+internal_limit = limit * self.config.tier_boost_overfetch_factor if has_tier_weights else limit
 ```
 
 Then replace fetch sizes (leave `alpha`/`fusion_method`/`rrf_k` untouched):
@@ -1114,20 +1107,22 @@ class TestTierBoostFederated:
         from nexus.bricks.search.federated_search import _strip_none_context
 
         assert "tier_boost" not in _strip_none_context(
-            {"path": "a", "score": 1.0, "tier_boost": None}
+            {
+                "path": "a",
+                "score": 1.0,
+                "tier_boost": None,
+            }
         )
-        assert _strip_none_context({"path": "a", "score": 1.0, "tier_boost": 0.5})[
-            "tier_boost"
-        ] == 0.5
+        assert (
+            _strip_none_context({"path": "a", "score": 1.0, "tier_boost": 0.5})["tier_boost"] == 0.5
+        )
 
     def test_result_to_dict_omits_unset_tier_boost(self) -> None:
         from nexus.bricks.search.federated_search import _result_to_dict
         from nexus.bricks.search.results import BaseSearchResult
 
         plain = BaseSearchResult(path="a", chunk_text="", score=1.0, zone_id="z1")
-        boosted = BaseSearchResult(
-            path="b", chunk_text="", score=0.5, zone_id="z1", tier_boost=0.5
-        )
+        boosted = BaseSearchResult(path="b", chunk_text="", score=0.5, zone_id="z1", tier_boost=0.5)
         assert "tier_boost" not in _result_to_dict(plain)
         assert _result_to_dict(boosted)["tier_boost"] == 0.5
 

--- a/docs/superpowers/plans/2026-07-31-prefix-weight-boost.md
+++ b/docs/superpowers/plans/2026-07-31-prefix-weight-boost.md
@@ -1,0 +1,1230 @@
+# Per-Prefix Ranking Weight (Source-Tier Boost) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let admins seed a per-prefix `weight` on `path_contexts` rows that multiplies search-result scores (with `tier_boost` attribution), so noisy prefixes rank below curated ones. Issue #4544.
+
+**Architecture:** Additive `weight` column on `path_contexts` → carried through `PathContextRecord`/cache → applied in `SearchDaemon._attach_path_contexts` (multiply + stamp + stable re-sort), with a conditional daemon-side over-fetch in `_search_on_current_loop` so boosts can promote below-cutoff hits. Zone with no weights ≠ 1.0 → code path byte-identical to today. Spec: `docs/superpowers/specs/2026-07-31-prefix-weight-boost-design.md`.
+
+**Tech Stack:** Python 3.12+ (repo), SQLAlchemy async + raw SQL, Alembic, FastAPI, Click, pytest + pytest-asyncio.
+
+## Global Constraints
+
+- Weight validation range at API/CLI: **0.1 ≤ weight ≤ 10.0**; DB `NULL` ≡ 1.0.
+- Floor-ratio gate: applies to **uplifts only** (`w > 1.0`); default ratio **0.25**; `0` disables. Demotions always apply.
+- Over-fetch factor default **3**; env `NEXUS_SEARCH_TIER_BOOST_OVERFETCH`. Floor env: `NEXUS_SEARCH_TIER_BOOST_FLOOR_RATIO`.
+- Byte-identity: with no weight ≠ 1.0 configured, search behavior (results, order, scores, timing keys) must be unchanged.
+- Run tests from the worktree root as: `PYTHONPATH=$PWD/src /Users/tafeng/nexus/.venv/bin/python -m pytest <path> -x -q`
+  (do NOT `uv run` — native deps break in worktrees; do NOT create a bare `.venv` here).
+- Commit style: conventional commits (`feat(search): ...`), reference `#4544`. Do not push or open a PR in this plan.
+- All new code must pass `pre-commit` (ruff). If pre-commit fails on unrelated files, use `git commit --no-verify` only for docs-only commits.
+
+---
+
+### Task 1: `weight` column — migration, model, record, store
+
+**Files:**
+- Create: `alembic/versions/add_path_context_weight.py`
+- Modify: `src/nexus/storage/models/path_context.py`
+- Modify: `src/nexus/bricks/search/path_context.py` (PathContextRecord, upsert, list)
+- Modify (fixtures — schema drift): `tests/integration/bricks/search/test_daemon_context_attach.py`, `tests/integration/bricks/search/test_path_context.py`, `tests/integration/server/api/v2/routers/test_path_contexts_router.py`
+- Test: `tests/integration/bricks/search/test_path_context.py`
+
+**Interfaces:**
+- Consumes: existing `PathContextStore` / `PathContextRecord` in `src/nexus/bricks/search/path_context.py`.
+- Produces: `PathContextRecord.weight: float | None` (default `None`); `PathContextStore.upsert(zone_id: str, path_prefix: str, description: str, weight: float | None = None) -> None`; `list()` rows carry `weight`. Later tasks rely on these exact names.
+
+- [ ] **Step 1: Write the failing store test**
+
+Each raw `CREATE TABLE path_contexts` fixture in the three test files above must gain a `weight FLOAT` line (nullable, no default) after `description`:
+
+```sql
+CREATE TABLE path_contexts (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    zone_id TEXT NOT NULL DEFAULT 'root',
+    path_prefix TEXT NOT NULL,
+    description TEXT NOT NULL,
+    weight FLOAT,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(zone_id, path_prefix)
+)
+```
+
+Add to `tests/integration/bricks/search/test_path_context.py` (mirror its existing fixture/test style):
+
+```python
+class TestWeightColumn:
+    """Issue #4544: nullable per-prefix ranking weight."""
+
+    @pytest.mark.asyncio
+    async def test_upsert_and_list_weight_roundtrip(self, store) -> None:
+        await store.upsert("root", "chat/logs", "Chat transcripts", weight=0.5)
+        records = await store.list("root")
+        rec = next(r for r in records if r.path_prefix == "chat/logs")
+        assert rec.weight == 0.5
+
+    @pytest.mark.asyncio
+    async def test_weight_defaults_to_none(self, store) -> None:
+        await store.upsert("root", "docs/curated", "Curated docs")
+        records = await store.list("root")
+        rec = next(r for r in records if r.path_prefix == "docs/curated")
+        assert rec.weight is None
+
+    @pytest.mark.asyncio
+    async def test_upsert_without_weight_resets_existing_weight(self, store) -> None:
+        # PUT-replace semantics: an upsert that omits weight clears it.
+        await store.upsert("root", "chat/logs", "Chat transcripts", weight=0.5)
+        await store.upsert("root", "chat/logs", "Chat transcripts v2")
+        records = await store.list("root")
+        rec = next(r for r in records if r.path_prefix == "chat/logs")
+        assert rec.weight is None
+```
+
+(Reuse the file's existing `store` fixture name — if it differs, adapt to the actual fixture, but do not create a new engine pattern.)
+
+- [ ] **Step 2: Run the new tests to verify they fail**
+
+Run: `PYTHONPATH=$PWD/src /Users/tafeng/nexus/.venv/bin/python -m pytest tests/integration/bricks/search/test_path_context.py -q -k Weight`
+Expected: FAIL — `upsert() got an unexpected keyword argument 'weight'` (or `AttributeError: weight`).
+
+- [ ] **Step 3: Implement record + store changes**
+
+In `src/nexus/bricks/search/path_context.py`:
+
+`PathContextRecord` gains a field (after `description`):
+
+```python
+@dataclass(frozen=True)
+class PathContextRecord:
+    """One row in the path_contexts table."""
+
+    zone_id: str
+    path_prefix: str
+    description: str
+    created_at: datetime
+    updated_at: datetime
+    # Issue #4544: per-prefix ranking weight; None ≡ 1.0 (no boost).
+    weight: float | None = None
+```
+
+`upsert` — new signature `async def upsert(self, zone_id: str, path_prefix: str, description: str, weight: float | None = None) -> None:` and both SQL branches gain the column. Postgres branch:
+
+```sql
+INSERT INTO path_contexts
+    (zone_id, path_prefix, description, weight, created_at, updated_at)
+VALUES
+    (:zone_id, :path_prefix, :description, :weight, :now, :now)
+ON CONFLICT (zone_id, path_prefix) DO UPDATE
+SET description = EXCLUDED.description,
+    weight      = EXCLUDED.weight,
+    updated_at  = EXCLUDED.updated_at
+```
+
+SQLite branch: same shape with lowercase `excluded.description` / `excluded.weight` / `excluded.updated_at` (match the existing SQLite branch). Both param dicts gain `"weight": weight`. Note: an upsert without `weight` deliberately resets it to NULL — PUT-replace semantics (documented in the docstring).
+
+`list()` — SELECT gains the column and positional indices shift:
+
+```python
+query = (
+    "SELECT zone_id, path_prefix, description, weight, created_at, updated_at "
+    "FROM path_contexts"
+)
+...
+return [
+    PathContextRecord(
+        zone_id=row[0],
+        path_prefix=row[1],
+        description=row[2],
+        weight=row[3],
+        created_at=_coerce_datetime(row[4]),
+        updated_at=_coerce_datetime(row[5]),
+    )
+    for row in rows
+]
+```
+
+In `src/nexus/storage/models/path_context.py` add after `description` (import `Float` from sqlalchemy):
+
+```python
+    # Issue #4544: per-prefix ranking weight; NULL ≡ 1.0 (no boost).
+    weight: Mapped[float | None] = mapped_column(Float, nullable=True)
+```
+
+- [ ] **Step 4: Write the alembic migration**
+
+First confirm the head: run `alembic -c alembic/alembic.ini heads` — expected single head `align_graph_zone_columns (knowledge_platform)`. If it changed since plan-writing, use the actual head.
+
+Create `alembic/versions/add_path_context_weight.py`:
+
+```python
+"""Add weight column to path_contexts (Issue #4544).
+
+Nullable, no server default: NULL ≡ 1.0 in application code, so existing
+rows and weightless new rows rank exactly as before the migration.
+
+Revision ID: add_path_context_weight
+Revises: align_graph_zone_columns
+Create Date: 2026-07-31
+"""
+
+from collections.abc import Sequence
+from typing import Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "add_path_context_weight"
+down_revision: Union[str, Sequence[str], None] = "align_graph_zone_columns"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add nullable weight column."""
+    op.add_column("path_contexts", sa.Column("weight", sa.Float(), nullable=True))
+
+
+def downgrade() -> None:
+    """Drop weight column."""
+    op.drop_column("path_contexts", "weight")
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `PYTHONPATH=$PWD/src /Users/tafeng/nexus/.venv/bin/python -m pytest tests/integration/bricks/search/test_path_context.py tests/integration/bricks/search/test_daemon_context_attach.py -q`
+Expected: PASS (including all pre-existing tests — the fixture schema change must not break them).
+
+- [ ] **Step 6: Verify migration is a single head**
+
+Run: `alembic -c alembic/alembic.ini heads`
+Expected: exactly one head: `add_path_context_weight`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add alembic/versions/add_path_context_weight.py src/nexus/storage/models/path_context.py src/nexus/bricks/search/path_context.py tests/integration/bricks/search/test_path_context.py tests/integration/bricks/search/test_daemon_context_attach.py tests/integration/server/api/v2/routers/test_path_contexts_router.py
+git commit -m "feat(search): add nullable weight column to path_contexts (#4544)"
+```
+
+---
+
+### Task 2: record lookup helper, `tier_boost` field, weight-apply helper, config knobs
+
+**Files:**
+- Modify: `src/nexus/bricks/search/path_context.py` (`lookup_record_in_records`, rewire `lookup_in_records`)
+- Modify: `src/nexus/bricks/search/results.py` (`tier_boost` field)
+- Modify: `src/nexus/bricks/search/daemon.py` (DaemonConfig knobs ~line 278 area; module-level `_apply_tier_weight`; import `get_env_float`)
+- Test: `tests/unit/bricks/search/test_tier_boost.py` (new)
+
+**Interfaces:**
+- Consumes: `PathContextRecord.weight` from Task 1.
+- Produces (later tasks call these exactly):
+  - `lookup_record_in_records(records: list[PathContextRecord], path: str) -> PathContextRecord | None` in `nexus.bricks.search.path_context`
+  - `BaseSearchResult.tier_boost: float | None = None` in `nexus.bricks.search.results`
+  - `_apply_tier_weight(result: Any, weight: float | None, top_score: float, floor_ratio: float) -> bool` module-level in `nexus.bricks.search.daemon`
+  - `DaemonConfig.tier_boost_overfetch_factor: int` (default 3), `DaemonConfig.tier_boost_floor_ratio: float` (default 0.25)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/unit/bricks/search/test_tier_boost.py`:
+
+```python
+"""Per-prefix ranking weight primitives (Issue #4544).
+
+Covers the record-grain prefix lookup, the score-multiply helper with the
+uplift-only floor-ratio gate, and idempotency (a result already stamped
+with tier_boost is never boosted twice — batch_search re-attaches).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from nexus.bricks.search.daemon import _apply_tier_weight
+from nexus.bricks.search.path_context import (
+    PathContextRecord,
+    lookup_in_records,
+    lookup_record_in_records,
+)
+from nexus.bricks.search.results import BaseSearchResult
+
+
+def _rec(prefix: str, weight: float | None = None) -> PathContextRecord:
+    now = datetime(2026, 7, 31)
+    return PathContextRecord(
+        zone_id="root",
+        path_prefix=prefix,
+        description=f"desc:{prefix or 'root'}",
+        created_at=now,
+        updated_at=now,
+        weight=weight,
+    )
+
+
+def _result(path: str = "chat/logs/a.md", score: float = 1.0) -> BaseSearchResult:
+    return BaseSearchResult(path=path, chunk_text="", score=score)
+
+
+class TestLookupRecord:
+    def test_returns_longest_prefix_record(self) -> None:
+        records = sorted(
+            [_rec("chat", weight=0.9), _rec("chat/logs", weight=0.5)],
+            key=lambda r: len(r.path_prefix),
+            reverse=True,
+        )
+        rec = lookup_record_in_records(records, "chat/logs/a.md")
+        assert rec is not None and rec.weight == 0.5
+
+    def test_no_match_returns_none(self) -> None:
+        assert lookup_record_in_records([_rec("docs")], "src/a.py") is None
+
+    def test_description_wrapper_unchanged(self) -> None:
+        # lookup_in_records keeps its historical contract.
+        assert lookup_in_records([_rec("docs")], "docs/a.md") == "desc:docs"
+        assert lookup_in_records([_rec("docs")], "src/a.py") is None
+
+
+class TestApplyTierWeight:
+    def test_none_and_one_are_noops(self) -> None:
+        r = _result(score=1.0)
+        assert _apply_tier_weight(r, None, top_score=1.0, floor_ratio=0.25) is False
+        assert _apply_tier_weight(r, 1.0, top_score=1.0, floor_ratio=0.25) is False
+        assert r.score == 1.0 and r.tier_boost is None
+
+    def test_demotion_applies_and_stamps(self) -> None:
+        r = _result(score=1.0)
+        assert _apply_tier_weight(r, 0.5, top_score=1.0, floor_ratio=0.25) is True
+        assert r.score == 0.5 and r.tier_boost == 0.5
+
+    def test_demotion_ignores_floor_gate(self) -> None:
+        # Far-below-top result still gets demoted.
+        r = _result(score=0.01)
+        assert _apply_tier_weight(r, 0.5, top_score=1.0, floor_ratio=0.25) is True
+        assert r.score == 0.005
+
+    def test_uplift_blocked_below_floor(self) -> None:
+        r = _result(score=0.1)  # 0.1 < 0.25 * 1.0
+        assert _apply_tier_weight(r, 2.0, top_score=1.0, floor_ratio=0.25) is False
+        assert r.score == 0.1 and r.tier_boost is None
+
+    def test_uplift_applies_above_floor(self) -> None:
+        r = _result(score=0.5)
+        assert _apply_tier_weight(r, 2.0, top_score=1.0, floor_ratio=0.25) is True
+        assert r.score == 1.0 and r.tier_boost == 2.0
+
+    def test_zero_ratio_disables_gate(self) -> None:
+        r = _result(score=0.001)
+        assert _apply_tier_weight(r, 2.0, top_score=1.0, floor_ratio=0.0) is True
+
+    def test_idempotent_on_stamped_result(self) -> None:
+        # batch_search re-runs attach on already-boosted results: no w².
+        r = _result(score=1.0)
+        assert _apply_tier_weight(r, 0.5, top_score=1.0, floor_ratio=0.25) is True
+        assert _apply_tier_weight(r, 0.5, top_score=1.0, floor_ratio=0.25) is False
+        assert r.score == 0.5
+
+
+class TestConfigKnobs:
+    def test_defaults(self) -> None:
+        from nexus.bricks.search.daemon import DaemonConfig
+
+        cfg = DaemonConfig()
+        assert cfg.tier_boost_overfetch_factor == 3
+        assert cfg.tier_boost_floor_ratio == 0.25
+
+    def test_env_overrides(self, monkeypatch) -> None:
+        from nexus.bricks.search.daemon import DaemonConfig
+
+        monkeypatch.setenv("NEXUS_SEARCH_TIER_BOOST_OVERFETCH", "5")
+        monkeypatch.setenv("NEXUS_SEARCH_TIER_BOOST_FLOOR_RATIO", "0.5")
+        cfg = DaemonConfig()
+        assert cfg.tier_boost_overfetch_factor == 5
+        assert cfg.tier_boost_floor_ratio == 0.5
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `PYTHONPATH=$PWD/src /Users/tafeng/nexus/.venv/bin/python -m pytest tests/unit/bricks/search/test_tier_boost.py -q`
+Expected: FAIL — `ImportError: cannot import name '_apply_tier_weight'` / `lookup_record_in_records`.
+
+- [ ] **Step 3: Implement**
+
+`src/nexus/bricks/search/results.py` — add after `macro_line_end`:
+
+```python
+    # Issue #4544: per-prefix source-tier weight applied to score (None = unboosted)
+    tier_boost: float | None = None
+```
+
+`src/nexus/bricks/search/path_context.py` — replace `lookup_in_records` body with record-grain core + wrapper:
+
+```python
+def lookup_record_in_records(
+    records: builtins.list[PathContextRecord], path: str
+) -> PathContextRecord | None:
+    """Longest-prefix lookup returning the full record (Issue #4544).
+
+    Records must be sorted by ``len(path_prefix)`` DESC so the first
+    slash-boundary match is the longest prefix.
+    """
+    for record in records:
+        prefix = record.path_prefix
+        if prefix == "":
+            return record
+        if path == prefix or path.startswith(prefix + "/"):
+            return record
+    return None
+
+
+def lookup_in_records(records: builtins.list[PathContextRecord], path: str) -> str | None:
+    """Longest-prefix lookup returning only the description (Issue #3773 contract)."""
+    record = lookup_record_in_records(records, path)
+    return record.description if record is not None else None
+```
+
+(Keep the original docstring notes about sort order on the record-grain function.)
+
+`src/nexus/bricks/search/daemon.py`:
+
+1. Extend the config import (line ~50):
+
+```python
+from nexus.bricks.search.config import get_env_bool as _get_env_bool
+from nexus.bricks.search.config import get_env_float as _get_env_float
+from nexus.bricks.search.config import get_env_int as _get_env_int
+```
+
+2. DaemonConfig — add after the `macro_chunk_*` block, same `field(default_factory=...)` env pattern:
+
+```python
+    # Per-prefix ranking weight (Issue #4544). When the effective zone has any
+    # path_contexts row with weight != 1.0, the daemon widens its candidate
+    # fetch by ``tier_boost_overfetch_factor`` so a boost can promote a
+    # below-cutoff hit, then trims back to the requested limit after the
+    # weights are applied. ``tier_boost_floor_ratio`` gates uplifts only:
+    # a result scoring below ratio*top cannot be boosted past strong matches
+    # (0 disables the gate). Demotions always apply.
+    tier_boost_overfetch_factor: int = field(
+        default_factory=lambda: _get_env_int("NEXUS_SEARCH_TIER_BOOST_OVERFETCH", 3)
+    )
+    tier_boost_floor_ratio: float = field(
+        default_factory=lambda: _get_env_float("NEXUS_SEARCH_TIER_BOOST_FLOOR_RATIO", 0.25)
+    )
+```
+
+3. Module-level helper (place near `_merge_backend_timing`, before the SearchDaemon class):
+
+```python
+def _apply_tier_weight(
+    result: Any,
+    weight: float | None,
+    top_score: float,
+    floor_ratio: float,
+) -> bool:
+    """Multiply ``result.score`` by a path-prefix weight (Issue #4544).
+
+    Returns True when the weight was applied. Skips: no/neutral weight,
+    already-stamped results (``batch_search`` re-runs attach on results whose
+    inner search already applied weights — without this guard the score would
+    compound to weight²), and uplifts on results scoring below
+    ``floor_ratio * top_score`` (metadata may reorder near-peers but must not
+    lift weak matches past strong ones). Demotions always apply.
+    """
+    if weight is None or weight == 1.0:
+        return False
+    if getattr(result, "tier_boost", None) is not None:
+        return False
+    if weight > 1.0 and floor_ratio > 0.0 and result.score < floor_ratio * top_score:
+        return False
+    result.score *= weight
+    result.tier_boost = weight
+    return True
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `PYTHONPATH=$PWD/src /Users/tafeng/nexus/.venv/bin/python -m pytest tests/unit/bricks/search/test_tier_boost.py -q`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/nexus/bricks/search/results.py src/nexus/bricks/search/path_context.py src/nexus/bricks/search/daemon.py tests/unit/bricks/search/test_tier_boost.py
+git commit -m "feat(search): tier-weight primitives — record lookup, tier_boost field, apply helper, config knobs (#4544)"
+```
+
+---
+
+### Task 3: boost inside `_attach_path_contexts` (+ batch block context rewire)
+
+**Files:**
+- Modify: `src/nexus/bricks/search/daemon.py` — `_attach_path_contexts` (~1647–1755) and the `batch_search` attach block (~2375–2390)
+- Modify: `docs/superpowers/specs/2026-07-31-prefix-weight-boost-design.md` (documented deviation, see Step 3)
+- Test: `tests/integration/bricks/search/test_daemon_context_attach.py`
+
+**Interfaces:**
+- Consumes: `lookup_record_in_records`, `_apply_tier_weight`, `DaemonConfig.tier_boost_floor_ratio` (Task 2).
+- Produces: `_attach_path_contexts` now multiplies scores, stamps `tier_boost`, and stable-re-sorts the list in place when ≥1 weight applied. Signature unchanged: `async def _attach_path_contexts(self, results: list[SearchResult], *, zone_id: str | None = None) -> None`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/integration/bricks/search/test_daemon_context_attach.py` (uses the file's existing `cache` fixture and the `SearchDaemon.__new__` harness pattern from `TestAttachUsesCallerZone.test_real_daemon_attach_falls_back_to_caller_zone`):
+
+```python
+def _bare_daemon(cache) -> "SearchDaemon":
+    """Attach-only daemon harness (no startup())."""
+    from nexus.bricks.search.daemon import DaemonConfig, SearchDaemon
+
+    daemon = SearchDaemon.__new__(SearchDaemon)
+    daemon.config = DaemonConfig()
+    daemon._path_context_cache = cache
+    daemon._path_context_cache_by_loop = {}
+    daemon._path_context_engines_by_loop = {}
+
+    class _Stats:
+        path_context_attach_failures = 0
+        path_context_resolve_failures = 0
+
+    daemon.stats = _Stats()
+    return daemon
+
+
+class TestTierWeightAttach:
+    """Issue #4544: _attach_path_contexts applies per-prefix weights."""
+
+    @pytest.mark.asyncio
+    async def test_demotion_reorders_below_equal_relevance_peer(self, cache) -> None:
+        from nexus.bricks.search.daemon import SearchResult
+
+        await cache._store.upsert("root", "chat", "Chat transcripts", weight=0.5)
+        daemon = _bare_daemon(cache)
+        noisy = SearchResult(path="chat/a.md", chunk_text="", score=1.0)
+        curated = SearchResult(path="docs/a.md", chunk_text="", score=0.9)
+        results = [noisy, curated]
+        await daemon._attach_path_contexts(results, zone_id="root")
+        assert noisy.score == 0.5 and noisy.tier_boost == 0.5
+        assert curated.score == 0.9 and curated.tier_boost is None
+        assert results == [curated, noisy]  # re-sorted in place
+
+    @pytest.mark.asyncio
+    async def test_no_weights_leaves_list_untouched(self, cache) -> None:
+        from nexus.bricks.search.daemon import SearchResult
+
+        # Fixture rows have no weight → byte-identity: same objects, order, scores.
+        daemon = _bare_daemon(cache)
+        r1 = SearchResult(path="docs/a.md", chunk_text="", score=0.4)
+        r2 = SearchResult(path="docs/b.md", chunk_text="", score=0.9)
+        results = [r1, r2]  # deliberately unsorted
+        await daemon._attach_path_contexts(results, zone_id="root")
+        assert results == [r1, r2]
+        assert r1.score == 0.4 and r2.score == 0.9
+        assert r1.tier_boost is None and r2.tier_boost is None
+        assert r1.context == "Project documentation"  # context still attached
+
+    @pytest.mark.asyncio
+    async def test_uplift_gated_by_floor_ratio(self, cache) -> None:
+        from nexus.bricks.search.daemon import SearchResult
+
+        await cache._store.upsert("root", "docs", "Project documentation", weight=2.0)
+        daemon = _bare_daemon(cache)
+        strong = SearchResult(path="src/x.py", chunk_text="", score=1.0)
+        weak_boosted = SearchResult(path="docs/a.md", chunk_text="", score=0.1)
+        near_peer_boosted = SearchResult(path="docs/b.md", chunk_text="", score=0.6)
+        results = [strong, near_peer_boosted, weak_boosted]
+        await daemon._attach_path_contexts(results, zone_id="root")
+        assert weak_boosted.score == 0.1 and weak_boosted.tier_boost is None
+        assert near_peer_boosted.score == 1.2 and near_peer_boosted.tier_boost == 2.0
+        assert results[0] is near_peer_boosted  # promoted past strong
+
+    @pytest.mark.asyncio
+    async def test_double_attach_is_idempotent(self, cache) -> None:
+        from nexus.bricks.search.daemon import SearchResult
+
+        await cache._store.upsert("root", "chat", "Chat transcripts", weight=0.5)
+        daemon = _bare_daemon(cache)
+        r = SearchResult(path="chat/a.md", chunk_text="", score=1.0)
+        await daemon._attach_path_contexts([r], zone_id="root")
+        await daemon._attach_path_contexts([r], zone_id="root")
+        assert r.score == 0.5  # not 0.25
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `PYTHONPATH=$PWD/src /Users/tafeng/nexus/.venv/bin/python -m pytest tests/integration/bricks/search/test_daemon_context_attach.py -q -k TierWeight`
+Expected: FAIL — scores unmultiplied / `tier_boost` stays None.
+
+- [ ] **Step 3: Implement**
+
+In `_attach_path_contexts`, replace the final lookup loop (currently `for r in results: ... r.context = lookup_in_records(records, r.path)`) with:
+
+```python
+        from nexus.bricks.search.path_context import lookup_record_in_records
+
+        # Issue #4544: apply per-prefix ranking weights while attaching
+        # context. top_score is the pre-boost max of this batch — the floor
+        # gate must compare against the unweighted ranking.
+        floor_ratio = self.config.tier_boost_floor_ratio
+        top_score = max((r.score for r in results), default=0.0)
+        boosted_any = False
+        for r in results:
+            zone = _zone_for(r)
+            records = snapshots.get(zone)
+            if records is None:
+                continue
+            try:
+                record = lookup_record_in_records(records, r.path)
+                r.context = record.description if record is not None else None
+                if record is not None and _apply_tier_weight(
+                    r, record.weight, top_score, floor_ratio
+                ):
+                    boosted_any = True
+            except Exception as exc:
+                self.stats.path_context_attach_failures += 1
+                logger.warning(
+                    "path context lookup failed for path=%r (total=%d): %s",
+                    r.path,
+                    self.stats.path_context_attach_failures,
+                    exc,
+                )
+        if boosted_any:
+            # Stable sort: equal scores keep their pre-boost relative order.
+            results.sort(key=lambda r: r.score, reverse=True)
+```
+
+(Delete the now-unused `from nexus.bricks.search.path_context import lookup_in_records` import in this method.)
+
+In the `batch_search` attach block (~2375): swap `lookup_in_records` for the record-grain call but attach **context only** — do NOT apply weights there:
+
+```python
+            if records is not None:
+                from nexus.bricks.search.path_context import lookup_record_in_records
+
+                # Issue #4544 note: weights are NOT applied here. Each inner
+                # self.search() already ran _attach_path_contexts (multiply +
+                # tier_boost stamp); re-applying against post-boost scores
+                # would re-evaluate the floor gate against a shifted top and
+                # boost previously-gated results. This block only backfills
+                # ``context`` for legacy/mocked daemons.
+                for inner in results:
+                    for r in inner:
+                        try:
+                            record = lookup_record_in_records(records, r.path)
+                            r.context = record.description if record is not None else None
+                        except Exception as exc:
+                            self.stats.path_context_attach_failures += 1
+                            logger.warning(
+                                "path context lookup failed for path=%r (total=%d): %s",
+                                r.path,
+                                self.stats.path_context_attach_failures,
+                                exc,
+                            )
+```
+
+**Spec deviation (record it):** spec §2 says the batch block gets "the same boost logic"; implementation keeps it context-only for the reason in the comment above. Update the spec's §2 bullet to match (one sentence: "The `batch_search` inline attach block stays context-only — inner `search()` calls already applied weights; re-applying against post-boost scores would re-evaluate the floor gate against a shifted top.").
+
+- [ ] **Step 4: Run to verify pass (plus no regressions in the file)**
+
+Run: `PYTHONPATH=$PWD/src /Users/tafeng/nexus/.venv/bin/python -m pytest tests/integration/bricks/search/test_daemon_context_attach.py tests/unit/bricks/search/test_tier_boost.py -q`
+Expected: PASS — all pre-existing attach tests still green (they exercise context-only rows, which take the `w is None` no-op path).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/nexus/bricks/search/daemon.py tests/integration/bricks/search/test_daemon_context_attach.py docs/superpowers/specs/2026-07-31-prefix-weight-boost-design.md
+git commit -m "feat(search): apply per-prefix tier weights in _attach_path_contexts (#4544)"
+```
+
+---
+
+### Task 4: conditional over-fetch + trim in `_search_on_current_loop`
+
+**Files:**
+- Modify: `src/nexus/bricks/search/daemon.py` — `_search_on_current_loop` (~1826–2018), new method `_zone_has_tier_weights`
+- Test: `tests/unit/bricks/search/test_daemon_tier_boost_overfetch.py` (new)
+
+**Interfaces:**
+- Consumes: `_resolve_path_context_cache` / `PathContextCache.refresh_if_stale` / `snapshot_zone` (existing), `PathContextRecord.weight` (Task 1), boosted `_attach_path_contexts` (Task 3), `DaemonConfig.tier_boost_overfetch_factor` (Task 2).
+- Produces: `async def _zone_has_tier_weights(self, zone_id: str) -> bool` on `SearchDaemon`. Public `search()` / `_search_on_current_loop` signatures unchanged.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/bricks/search/test_daemon_tier_boost_overfetch.py`. Harness mirrors `tests/unit/bricks/search/test_daemon_fusion_params.py::_make_daemon` (bare `SearchDaemon.__new__`, fake fts/vector backends) plus the sqlite path-context cache from `tests/integration/bricks/search/test_daemon_context_attach.py`:
+
+```python
+"""Conditional over-fetch for tier weights (Issue #4544).
+
+When the effective zone has a path_contexts weight != 1.0 the daemon must
+widen its backend fetch (limit × tier_boost_overfetch_factor), apply the
+weights, re-sort, and trim back to the requested limit — so a boost can
+promote a hit that the un-widened fusion would have cut. Zones with no
+weights must hit the byte-identical legacy path (no widened fetch).
+"""
+
+from __future__ import annotations
+
+from types import MethodType
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from nexus.bricks.search.path_context import PathContextCache, PathContextStore
+
+CREATE_TABLE_SQL = """
+CREATE TABLE path_contexts (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    zone_id TEXT NOT NULL DEFAULT 'root',
+    path_prefix TEXT NOT NULL,
+    description TEXT NOT NULL,
+    weight FLOAT,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(zone_id, path_prefix)
+)
+"""
+
+
+@pytest_asyncio.fixture
+async def cache():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:", future=True)
+    async with engine.begin() as conn:
+        await conn.exec_driver_sql(CREATE_TABLE_SQL)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    store = PathContextStore(async_session_factory=factory, db_type="sqlite")
+    yield PathContextCache(store=store)
+    await engine.dispose()
+
+
+def _make_daemon(cache: PathContextCache) -> Any:
+    """Keyword-only daemon: N corpus docs, keyword_search honours ``limit``
+    and records the limits it was asked for."""
+    from nexus.bricks.search.daemon import DaemonConfig, SearchDaemon, SearchResult
+
+    corpus = [
+        SearchResult(path="chat/a.md", chunk_text="", score=10.0, search_type="keyword"),
+        SearchResult(path="chat/b.md", chunk_text="", score=9.0, search_type="keyword"),
+        SearchResult(path="docs/x.md", chunk_text="", score=8.0, search_type="keyword"),
+    ]
+
+    class FakeFtsBackend:
+        def __init__(self) -> None:
+            self.requested_limits: list[int] = []
+
+        async def keyword_search(
+            self,
+            query: str,
+            path: str,
+            limit: int,
+            zone_id: str,
+            *,
+            timing: dict[str, float] | None = None,
+        ) -> list[Any]:
+            self.requested_limits.append(limit)
+            # Fresh copies: score mutation must not leak between searches.
+            return [
+                SearchResult(
+                    path=r.path, chunk_text=r.chunk_text, score=r.score,
+                    search_type=r.search_type,
+                )
+                for r in corpus[:limit]
+            ]
+
+    class FakeVectorBackend:
+        async def semantic_search(
+            self, qvec: list[float], path: str, limit: int, zone_id: str
+        ) -> list[Any]:
+            return []
+
+    class _Stats:
+        path_context_attach_failures = 0
+        path_context_resolve_failures = 0
+
+    daemon: Any = SearchDaemon.__new__(SearchDaemon)
+    daemon.last_search_timing = {}
+    daemon._initialized = True
+    daemon._fts_backend = FakeFtsBackend()
+    daemon._vector_backend = FakeVectorBackend()
+    daemon._path_context_cache = cache
+    daemon._path_context_cache_by_loop = {}
+    daemon._path_context_engines_by_loop = {}
+    daemon.stats = _Stats()
+    daemon._track_latency = MethodType(lambda self, ms: None, daemon)
+    daemon.config = DaemonConfig(page_aggregation=False)
+    return daemon
+
+
+class TestOverfetchAndTrim:
+    @pytest.mark.asyncio
+    async def test_demotion_promotes_below_cutoff_hit_into_returned_set(
+        self, cache
+    ) -> None:
+        # limit=2 without weights returns the two chat docs. Demoting chat
+        # must let docs/x.md (rank 3, beyond the un-widened fetch) into the
+        # top 2 — this is exactly the promotion the over-fetch exists for.
+        await cache._store.upsert("root", "chat", "Chat transcripts", weight=0.5)
+        daemon = _make_daemon(cache)
+        results = await daemon._search_on_current_loop(
+            "q", search_type="keyword", limit=2, zone_id="root"
+        )
+        assert len(results) == 2  # trimmed back to the requested limit
+        assert daemon._fts_backend.requested_limits == [2 * 3]  # widened fetch
+        paths = [r.path for r in results]
+        assert "docs/x.md" in paths
+        assert results[0].path == "docs/x.md"  # 8.0 beats 10.0*0.5
+
+    @pytest.mark.asyncio
+    async def test_no_weights_keeps_legacy_fetch_size(self, cache) -> None:
+        await cache._store.upsert("root", "chat", "Chat transcripts")  # no weight
+        daemon = _make_daemon(cache)
+        results = await daemon._search_on_current_loop(
+            "q", search_type="keyword", limit=2, zone_id="root"
+        )
+        assert daemon._fts_backend.requested_limits == [2]  # byte-identical path
+        assert [r.path for r in results] == ["chat/a.md", "chat/b.md"]
+        assert all(r.tier_boost is None for r in results)
+
+    @pytest.mark.asyncio
+    async def test_weight_one_rows_do_not_trigger_overfetch(self, cache) -> None:
+        await cache._store.upsert("root", "chat", "Chat transcripts", weight=1.0)
+        daemon = _make_daemon(cache)
+        await daemon._search_on_current_loop(
+            "q", search_type="keyword", limit=2, zone_id="root"
+        )
+        assert daemon._fts_backend.requested_limits == [2]
+
+    @pytest.mark.asyncio
+    async def test_probe_failure_fails_soft(self, cache) -> None:
+        daemon = _make_daemon(cache)
+
+        async def _boom(self: Any) -> Any:
+            raise RuntimeError("cache resolution exploded")
+
+        daemon._resolve_path_context_cache = MethodType(_boom, daemon)
+        results = await daemon._search_on_current_loop(
+            "q", search_type="keyword", limit=2, zone_id="root"
+        )
+        assert [r.path for r in results] == ["chat/a.md", "chat/b.md"]
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `PYTHONPATH=$PWD/src /Users/tafeng/nexus/.venv/bin/python -m pytest tests/unit/bricks/search/test_daemon_tier_boost_overfetch.py -q`
+Expected: FAIL — `requested_limits == [2]` where `[6]` expected; `docs/x.md` absent.
+
+- [ ] **Step 3: Implement**
+
+Add method to `SearchDaemon` (place directly after `_resolve_path_context_cache`):
+
+```python
+    async def _zone_has_tier_weights(self, zone_id: str) -> bool:
+        """True when the zone has any path-context weight != 1.0 (Issue #4544).
+
+        Decides whether _search_on_current_loop widens its candidate fetch.
+        Fail-soft: any error means "no over-fetch" — the search itself must
+        never break on a weight probe, and _attach_path_contexts still runs
+        its own fail-soft pass later in the same request. The refresh here is
+        the same fingerprint check attach pays, so the steady-state cost is
+        one cache hit.
+        """
+        try:
+            cache = await self._resolve_path_context_cache()
+            if cache is None:
+                return False
+            await cache.refresh_if_stale(zone_id)
+            snapshot = cache.snapshot_zone(zone_id)
+        except Exception as exc:
+            logger.debug("tier-weight probe failed for zone=%r: %s", zone_id, exc)
+            return False
+        if not snapshot:
+            return False
+        return any(rec.weight is not None and rec.weight != 1.0 for rec in snapshot)
+```
+
+In `_search_on_current_loop`, right after `effective_zone_id = zone_id or ROOT_ZONE_ID`:
+
+```python
+        # Issue #4544: when the zone carries tier weights, widen every
+        # candidate fetch so a boost can promote a below-cutoff hit, then trim
+        # back to ``limit`` after _attach_path_contexts applies the weights.
+        # Zones without weights keep internal_limit == limit and take the
+        # byte-identical legacy path.
+        has_tier_weights = await self._zone_has_tier_weights(effective_zone_id)
+        internal_limit = (
+            limit * self.config.tier_boost_overfetch_factor if has_tier_weights else limit
+        )
+```
+
+Then replace fetch sizes (leave `alpha`/`fusion_method`/`rrf_k` untouched):
+
+| Site (current line refs) | Change |
+|---|---|
+| keyword branch `_search_via_backends(..., limit=limit, ...)` (~1871) | `limit=internal_limit` |
+| keyword fallback `_keyword_search(query, limit, path_filter, ...)` (~1895) | `_keyword_search(query, internal_limit, path_filter, ...)` |
+| legacy hybrid prefetch `_keyword_search(query, limit * 3, ...)` (~1933) | `internal_limit * 3` |
+| hybrid `_search_via_backends(..., limit=limit, ...)` (~1947) | `limit=internal_limit` |
+| `_fuse_ranked_results(hybrid_keyword_results, results, limit)` (~1962) | pass `internal_limit` |
+| `_semantic_search(query, limit, path_filter, ...)` (~1980) | `internal_limit` |
+| `_hybrid_search(query, limit, path_filter, alpha, fusion_method, ...)` (~1982) | `internal_limit` |
+
+And at each of the four attach+return sites (keyword backend ~1883, keyword fallback ~1923, hybrid backend ~1970, legacy fallback ~2013), trim after attach:
+
+```python
+                        await self._attach_path_contexts(backend_results, zone_id=effective_zone_id)
+                        if internal_limit != limit:
+                            backend_results = backend_results[:limit]
+                        return self._with_search_timing(backend_results)
+```
+
+(Same three-line pattern with the local variable name at each site: `keyword_results`, `results`, `results`.)
+
+- [ ] **Step 4: Run to verify pass + guard the neighbors**
+
+Run: `PYTHONPATH=$PWD/src /Users/tafeng/nexus/.venv/bin/python -m pytest tests/unit/bricks/search/test_daemon_tier_boost_overfetch.py tests/unit/bricks/search/test_daemon_fusion_params.py tests/unit/bricks/search/test_daemon_backend_routing.py tests/unit/bricks/search/test_final_list_page_pooling.py -q`
+Expected: PASS — fusion-params byte-identity pins and backend routing untouched.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/nexus/bricks/search/daemon.py tests/unit/bricks/search/test_daemon_tier_boost_overfetch.py
+git commit -m "feat(search): conditional over-fetch + trim so tier boosts can promote hits (#4544)"
+```
+
+---
+
+### Task 5: API weight field, `tier_boost` serialization, CLI `--weight`, surface regen
+
+**Files:**
+- Modify: `src/nexus/server/api/v2/routers/path_contexts.py` (PathContextIn/Out, upsert, list)
+- Modify: `src/nexus/server/api/v2/routers/search.py` (`_serialize_search_result`, ~156–188)
+- Modify: `src/nexus/cli/commands/path_context.py` (set `--weight`, list rendering)
+- Modify (regenerated): `docs/surface-coverage/api-rpc-surface-coverage.yaml`
+- Test: `tests/integration/server/api/v2/routers/test_path_contexts_router.py`, `tests/unit/cli/test_path_context_cli.py`
+
+**Interfaces:**
+- Consumes: `PathContextStore.upsert(..., weight=...)` (Task 1); `SearchResult.tier_boost` (Task 2).
+- Produces: HTTP surface — PUT/GET `/api/v2/path-contexts/` carry `weight`; search responses carry `tier_boost` when set. CLI: `nexus path-context set PREFIX DESC --weight 0.5`.
+
+- [ ] **Step 1: Write the failing router tests**
+
+Append to `tests/integration/server/api/v2/routers/test_path_contexts_router.py`, mirroring its existing client/auth fixtures:
+
+```python
+class TestWeightField:
+    """Issue #4544: weight on the path-contexts CRUD surface."""
+
+    def test_put_persists_and_echoes_weight(self, admin_client) -> None:
+        resp = admin_client.put(
+            "/api/v2/path-contexts/",
+            json={"path_prefix": "chat/logs", "description": "Chat", "weight": 0.5},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["weight"] == 0.5
+        listed = admin_client.get("/api/v2/path-contexts/").json()["contexts"]
+        entry = next(c for c in listed if c["path_prefix"] == "chat/logs")
+        assert entry["weight"] == 0.5
+
+    def test_list_emits_null_weight_for_unset(self, admin_client) -> None:
+        admin_client.put(
+            "/api/v2/path-contexts/",
+            json={"path_prefix": "docs", "description": "Docs"},
+        )
+        listed = admin_client.get("/api/v2/path-contexts/").json()["contexts"]
+        entry = next(c for c in listed if c["path_prefix"] == "docs")
+        assert entry["weight"] is None
+
+    def test_weight_bounds_rejected(self, admin_client) -> None:
+        for bad in (0.05, 10.5, 0.0, -1.0):
+            resp = admin_client.put(
+                "/api/v2/path-contexts/",
+                json={"path_prefix": "x", "description": "d", "weight": bad},
+            )
+            assert resp.status_code == 422, f"weight={bad} must be rejected"
+```
+
+(Adapt the fixture name to the file's actual admin-auth client fixture.)
+
+And the serializer test — append to the serializer test class in `tests/integration/bricks/search/test_daemon_context_attach.py` (near `test_context_field_emitted_when_set`, which pins `_serialize_search_result`):
+
+```python
+    def test_tier_boost_emitted_when_set_and_omitted_when_none(self) -> None:
+        from nexus.bricks.search.daemon import SearchResult
+        from nexus.server.api.v2.routers.search import _serialize_search_result
+
+        boosted = SearchResult(path="a", chunk_text="", score=0.5, tier_boost=0.5)
+        plain = SearchResult(path="b", chunk_text="", score=0.5)
+        assert _serialize_search_result(boosted)["tier_boost"] == 0.5
+        assert "tier_boost" not in _serialize_search_result(plain)
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `PYTHONPATH=$PWD/src /Users/tafeng/nexus/.venv/bin/python -m pytest tests/integration/server/api/v2/routers/test_path_contexts_router.py -q -k Weight`
+Expected: FAIL — `weight` key absent / 200 where 422 expected.
+
+- [ ] **Step 3: Implement router + serializer**
+
+`src/nexus/server/api/v2/routers/path_contexts.py`:
+
+```python
+class PathContextIn(BaseModel):
+    zone_id: str = Field(default=ROOT_ZONE_ID, max_length=255)
+    path_prefix: str = Field(max_length=1024)
+    description: str = Field(max_length=4096, min_length=1)
+    # Issue #4544: per-prefix ranking weight; None ≡ 1.0. PUT-replace
+    # semantics — omitting weight on an update clears any stored value.
+    weight: float | None = Field(default=None, ge=0.1, le=10.0)
+```
+
+`PathContextOut` gains `weight: float | None = None`. Upsert endpoint:
+
+```python
+    await store.upsert(body.zone_id, body.path_prefix, body.description, weight=body.weight)
+    return {
+        "zone_id": body.zone_id,
+        "path_prefix": body.path_prefix,
+        "description": body.description,
+        "weight": body.weight,
+    }
+```
+
+List endpoint dict gains `"weight": r.weight,` after `"description"`.
+
+`src/nexus/server/api/v2/routers/search.py` `_serialize_search_result` — after the `context` block:
+
+```python
+    tier_boost = getattr(result, "tier_boost", None)
+    if tier_boost is not None:
+        out["tier_boost"] = round(tier_boost, 4)
+```
+
+- [ ] **Step 4: Implement CLI**
+
+`src/nexus/cli/commands/path_context.py` — `set` command gains:
+
+```python
+@click.option(
+    "--weight",
+    type=float,
+    default=None,
+    help="Ranking weight 0.1-10.0 (<1 demotes, >1 boosts; omit to clear).",
+)
+```
+
+Thread `weight: float | None` through `path_context_set`'s signature and body:
+
+```python
+    result = client.put(
+        "/api/v2/path-contexts/",
+        {
+            "zone_id": zone_id,
+            "path_prefix": path_prefix,
+            "description": description,
+            "weight": weight,
+        },
+    )
+```
+
+Success line appends the weight when set:
+
+```python
+    weight_note = f" [weight={result.get('weight')}]" if result.get("weight") is not None else ""
+    console.print(
+        f"[nexus.success]set[/nexus.success] "
+        f"{result.get('zone_id')}:{result.get('path_prefix')} = "
+        f"{result.get('description')!r}{weight_note}"
+    )
+```
+
+`list` rendering appends the same `[weight=...]` suffix per entry when `entry.get("weight") is not None`.
+
+**Fix the existing CLI payload pin:** `tests/unit/cli/test_path_context_cli.py::TestPathContextSet::test_put_sends_expected_payload` asserts the exact PUT dict — it must gain `"weight": None`:
+
+```python
+        fake.put.assert_called_once_with(
+            "/api/v2/path-contexts/",
+            {"zone_id": "root", "path_prefix": "src", "description": "x", "weight": None},
+        )
+```
+
+Then add to the same class (same `CliRunner`/`_patched_client` harness):
+
+```python
+    def test_weight_option_sent_in_payload(self) -> None:
+        runner = CliRunner(env=_ENV)
+        fake = _patched_client(
+            put={
+                "zone_id": "root",
+                "path_prefix": "chat",
+                "description": "x",
+                "weight": 0.5,
+            }
+        )
+        with patch("nexus.cli.api_client.get_api_client_from_options", return_value=fake):
+            result = runner.invoke(
+                path_context,
+                ["set", "chat", "x", "--weight", "0.5", "--remote-url", MOCK_URL],
+            )
+        assert result.exit_code == 0, result.output
+        assert fake.put.call_args.args[1]["weight"] == 0.5
+        assert "[weight=0.5]" in result.output
+```
+
+- [ ] **Step 5: Run router + CLI + serializer tests**
+
+Run: `PYTHONPATH=$PWD/src /Users/tafeng/nexus/.venv/bin/python -m pytest tests/integration/server/api/v2/routers/test_path_contexts_router.py tests/unit/cli/test_path_context_cli.py tests/integration/bricks/search/test_daemon_context_attach.py -q`
+Expected: PASS.
+
+- [ ] **Step 6: Regenerate the surface-coverage YAML**
+
+Run: `PYTHONPATH=$PWD/src /Users/tafeng/nexus/.venv/bin/python scripts/gen_api_surface_coverage.py`
+Then: `PYTHONPATH=$PWD/src /Users/tafeng/nexus/.venv/bin/python -m pytest tests/surface_coverage -q`
+Expected: YAML diff limited to path-contexts/search entries; surface tests PASS. (#4541 lesson: router edits without regen fail CI.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/nexus/server/api/v2/routers/path_contexts.py src/nexus/server/api/v2/routers/search.py src/nexus/cli/commands/path_context.py docs/surface-coverage/api-rpc-surface-coverage.yaml tests/integration/server/api/v2/routers/test_path_contexts_router.py tests/unit/cli/test_path_context_cli.py tests/integration/bricks/search/test_daemon_context_attach.py
+git commit -m "feat(search): expose path-context weight via API/CLI, emit tier_boost attribution (#4544)"
+```
+
+---
+
+### Task 6: federated wire hygiene + owning-zone weight test
+
+**Files:**
+- Modify: `src/nexus/bricks/search/federated_search.py` (`_strip_none_context`, ~865)
+- Test: `tests/integration/bricks/search/test_federated_search.py`
+
+**Interfaces:**
+- Consumes: `tier_boost` field (Task 2); daemon-side boosting (Tasks 3–4).
+- Produces: federated result dicts never carry `tier_boost: null`; carry the value when set. No signature changes.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/integration/bricks/search/test_federated_search.py`, following its existing dispatcher/mock-daemon patterns:
+
+```python
+class TestTierBoostFederated:
+    """Issue #4544: owning-zone weights flow through the federated merge."""
+
+    def test_strip_removes_null_tier_boost_and_keeps_value(self) -> None:
+        from nexus.bricks.search.federated_search import _strip_none_context
+
+        assert "tier_boost" not in _strip_none_context(
+            {"path": "a", "score": 1.0, "tier_boost": None}
+        )
+        assert _strip_none_context({"path": "a", "score": 1.0, "tier_boost": 0.5})[
+            "tier_boost"
+        ] == 0.5
+
+    def test_result_to_dict_omits_unset_tier_boost(self) -> None:
+        from nexus.bricks.search.federated_search import _result_to_dict
+        from nexus.bricks.search.results import BaseSearchResult
+
+        plain = BaseSearchResult(path="a", chunk_text="", score=1.0, zone_id="z1")
+        boosted = BaseSearchResult(
+            path="b", chunk_text="", score=0.5, zone_id="z1", tier_boost=0.5
+        )
+        assert "tier_boost" not in _result_to_dict(plain)
+        assert _result_to_dict(boosted)["tier_boost"] == 0.5
+
+    def test_merge_by_raw_score_orders_on_boosted_scores(self) -> None:
+        from nexus.bricks.search.federated_search import _merge_by_raw_score
+        from nexus.bricks.search.results import BaseSearchResult
+
+        # zone-a demoted its chat hit (1.0 -> 0.4) before returning; zone-b's
+        # unweighted 0.6 must now outrank it in the merged list.
+        za = BaseSearchResult(
+            path="chat/a.md", chunk_text="", score=0.4, zone_id="za", tier_boost=0.4
+        )
+        zb = BaseSearchResult(path="docs/b.md", chunk_text="", score=0.6, zone_id="zb")
+        merged = _merge_by_raw_score([("za", [za]), ("zb", [zb])], limit=2)
+        assert [m["path"] for m in merged] == ["docs/b.md", "chat/a.md"]
+        assert merged[1]["tier_boost"] == 0.4
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `PYTHONPATH=$PWD/src /Users/tafeng/nexus/.venv/bin/python -m pytest tests/integration/bricks/search/test_federated_search.py -q -k TierBoost`
+Expected: FAIL — `tier_boost: None` present in stripped dict.
+
+- [ ] **Step 3: Implement**
+
+`src/nexus/bricks/search/federated_search.py` — extend `_strip_none_context` (name kept; 4 call sites unchanged):
+
+```python
+def _strip_none_context(d: dict[str, Any]) -> dict[str, Any]:
+    """Match the non-federated router's omit-when-None contract for
+    ``context`` (Issue #3773, review Rounds 5-6) and ``tier_boost``
+    (Issue #4544): every federated emission path must route through this so
+    ``null`` never leaks onto the wire and the fusion strategies stay
+    shape-consistent."""
+    for key in ("context", "tier_boost"):
+        if d.get(key) is None:
+            d.pop(key, None)
+    return d
+```
+
+Also verify (read, no code change expected) that the remote-zone RPC search response path serializes result dicts from the daemon's dataclasses — `tier_boost` then flows automatically; if the remote handler whitelists fields, add `tier_boost` there and note it in the commit message. Start from `FederatedSearchDispatcher._search_remote_zone` (`transport.call_rpc("search", ...)`) and grep the servicer: `grep -rn "\"search\"" src/nexus/server --include="*.py"`.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `PYTHONPATH=$PWD/src /Users/tafeng/nexus/.venv/bin/python -m pytest tests/integration/bricks/search/test_federated_search.py -q`
+Expected: PASS (whole file — no regressions in existing federated tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/nexus/bricks/search/federated_search.py tests/integration/bricks/search/test_federated_search.py
+git commit -m "feat(search): keep tier_boost off the federated wire when unset (#4544)"
+```
+
+---
+
+### Task 7: full regression sweep
+
+**Files:**
+- No new files — verification only (fix anything it surfaces).
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces: green suite; branch ready for review/PR flow.
+
+- [ ] **Step 1: Run the focused search + storage + router suites**
+
+Run:
+```bash
+PYTHONPATH=$PWD/src /Users/tafeng/nexus/.venv/bin/python -m pytest \
+  tests/unit/bricks/search tests/integration/bricks/search \
+  tests/integration/server/api/v2/routers/test_path_contexts_router.py \
+  tests/unit/cli/test_path_context_cli.py \
+  tests/surface_coverage -q
+```
+Expected: PASS. These suites contain the byte-identity pins (`test_daemon_fusion_params.py` legacy-fusion regression, page-pooling tests, all #3773 attach tests) — any failure here is a real regression, not noise.
+
+- [ ] **Step 2: Run the migration-adjacent tests**
+
+Run: `PYTHONPATH=$PWD/src /Users/tafeng/nexus/.venv/bin/python -m pytest tests/migrations tests/unit/storage -q`
+Expected: PASS.
+
+- [ ] **Step 3: Lint**
+
+Run: `pre-commit run --files $(git diff --name-only develop...HEAD | tr '\n' ' ')`
+Expected: PASS (ruff/format clean). Fix and amend if not.
+
+- [ ] **Step 4: Final commit (only if fixes were needed)**
+
+```bash
+git add -A && git commit -m "test(search): regression fixes for tier-weight sweep (#4544)"
+```
+
+---
+
+## Self-review notes (already applied)
+
+- Spec §2 batch-block deviation is intentional and documented in Task 3 (double-gate wobble on post-boost scores); the spec file is amended in the same commit.
+- Spec coverage check: schema/store (§1→Task 1), attach boost + floor gate + idempotency (§2→Tasks 2–3), over-fetch/trim (§3→Task 4), API/CLI/serializer/surface (§4→Task 5), federated (§5→Task 6), config knobs (§6→Task 2), testing incl. byte-identity (§7→all + Task 7).
+- Type consistency: `weight: float | None` everywhere; `tier_boost: float | None`; `_apply_tier_weight(result, weight, top_score, floor_ratio) -> bool`; `_zone_has_tier_weights(zone_id: str) -> bool`.

--- a/docs/superpowers/specs/2026-07-31-prefix-weight-boost-design.md
+++ b/docs/superpowers/specs/2026-07-31-prefix-weight-boost-design.md
@@ -70,9 +70,7 @@ as today, then apply the weight `w = record.weight or 1.0`:
 - **Re-sort:** stable descending sort by `score`, executed only when at
   least one multiply happened. No weights applied → the list object and its
   order are untouched.
-- The `batch_search` inline attach block gets the same boost logic (it
-  shares the snapshot walk; idempotency makes the second pass a no-op for
-  already-boosted results).
+- The `batch_search` inline attach block stays context-only — inner `search()` calls already applied weights; re-applying against post-boost scores would re-evaluate the floor gate against a shifted top.
 - Fail-soft contract unchanged: any per-result failure increments
   `path_context_attach_failures` and leaves that result unboosted.
 

--- a/docs/superpowers/specs/2026-07-31-prefix-weight-boost-design.md
+++ b/docs/superpowers/specs/2026-07-31-prefix-weight-boost-design.md
@@ -101,6 +101,17 @@ Cost: the snapshot work is the same work attach pays later in the same
 request; the incremental cost is one cache-fingerprint check per search,
 and the wider fetch only occurs for zones that actually configured weights.
 
+Bounded approximation (adversarial-review amendment): weights re-rank
+within the widened window of `limit × factor` raw candidates only — if
+more than `limit × factor` raw hits from a demoted prefix outscore an
+unweighted hit, that hit stays outside the window and cannot be promoted.
+Exact weighted top-K would require pushing weights into every backend
+query; this design explicitly trades that away for the attach-point
+approach. Weights only mutate ranking when the pool was actually widened
+(factor ≥ 2 and probe succeeded); otherwise they are suppressed and
+counted in `tier_boost_suppressed_searches` / `tier_boost_probe_failures`
+(exposed via search stats).
+
 Macro expansion (`expand=macro`, #4398) runs in `search()` after the
 trimmed list is returned — unaffected.
 

--- a/docs/superpowers/specs/2026-07-31-prefix-weight-boost-design.md
+++ b/docs/superpowers/specs/2026-07-31-prefix-weight-boost-design.md
@@ -101,6 +101,15 @@ Cost: the snapshot work is the same work attach pays later in the same
 request; the incremental cost is one cache-fingerprint check per search,
 and the wider fetch only occurs for zones that actually configured weights.
 
+Pre-filter stage (adversarial-review amendment): weights — including the
+floor gate's `top_score` — are computed over the daemon's candidate pool,
+BEFORE route-level ReBAC filtering, in the same pipeline stage as RRF
+fusion ranks, attribute boost (#1092), and page pooling (#4542), all of
+which already depend on later-filtered candidates. Relocating weight
+finalization post-ReBAC would contradict the attach-point placement and
+break federated composition (remote zones weight server-side, before the
+local caller's filter). Accepted trade-off.
+
 Bounded approximation (adversarial-review amendment): weights re-rank
 within the widened window of `limit × factor` raw candidates only — if
 more than `limit × factor` raw hits from a demoted prefix outscore an

--- a/docs/superpowers/specs/2026-07-31-prefix-weight-boost-design.md
+++ b/docs/superpowers/specs/2026-07-31-prefix-weight-boost-design.md
@@ -1,0 +1,188 @@
+# Per-Prefix Ranking Weight via path_contexts (Source-Tier Boost) — Design
+
+**Issue:** [#4544](https://github.com/nexi-lab/nexus/issues/4544)
+**Date:** 2026-07-31
+**Status:** Approved (design review with user)
+
+## Problem
+
+All path prefixes rank equally in hybrid search, but real corpora have
+authority tiers — curated docs vs chat transcripts vs archived material.
+There is no way to tell the ranker "this prefix is noisier than that one."
+
+The per-prefix metadata infrastructure already exists: `path_contexts`
+(longest-prefix-matched, per-zone LRU-cached, admin-CRUD-managed) and
+`_attach_path_contexts` in the search daemon, which already walks every
+result set to attach a `context` string.
+
+## Decisions (from design review)
+
+| Decision | Choice |
+|---|---|
+| Boost placement | `_attach_path_contexts` + conditional daemon over-fetch (covers backend, legacy, graph, batch paths uniformly) |
+| Floor-ratio gate | Uplifts only (`w > 1.0`), default ratio 0.25, configurable, 0 disables. Demotions always apply |
+| Weight validation range | 0.1 – 10.0 at API/CLI layer; NULL/absent ≡ 1.0 |
+
+## 1. Schema + store
+
+- **Migration:** additive alembic migration adding `weight FLOAT NULL` to
+  `path_contexts`. No server default — `NULL ≡ 1.0` in code, so existing
+  rows and new rows without a weight behave exactly as today. Downgrade
+  drops the column.
+- **Model:** `PathContextModel` gains the matching nullable `Float` column
+  so `Base.metadata.create_all` (SQLite dev/test) stays in parity with the
+  Alembic-managed production schema.
+- **Record:** `PathContextRecord` gains `weight: float | None = None`.
+- **Store:** `PathContextStore.upsert(zone_id, path_prefix, description,
+  weight=None)` writes the column in both the PostgreSQL and SQLite
+  `ON CONFLICT DO UPDATE` branches; `list()` selects it.
+- **Cache:** no changes. Weight edits go through `upsert`, which bumps
+  `updated_at`, so the existing `(row_count, max_updated_at)` zone
+  fingerprint invalidates the `PathContextCache` correctly.
+- **Lookup:** new `lookup_record_in_records(records, path) ->
+  PathContextRecord | None` returning the full matched record; the existing
+  `lookup_in_records` becomes a thin `.description` wrapper so current
+  callers are untouched.
+
+## 2. Boost application in `_attach_path_contexts`
+
+For each result, after the longest-prefix match: attach `context` exactly
+as today, then apply the weight `w = record.weight or 1.0`:
+
+- `w == 1.0` → nothing. No stamp, no multiply — byte-identical behavior.
+- **Floor-ratio gate (uplifts only):** if `w > 1.0` and
+  `result.score < floor_ratio × top_score`, skip the boost. `top_score` is
+  the max *pre-boost* score of the incoming batch, computed once per call.
+  Rationale: metadata may reorder near-peers but must not lift weak matches
+  past strong ones. Demotions (`w < 1.0`) always apply — demoting an
+  already-weak hit is harmless and keeps the noisy-prefix acceptance test
+  meaningful.
+- **Apply:** `result.score *= w`; stamp `result.tier_boost = w`.
+- **Attribution field:** new `tier_boost: float | None = None` on
+  `BaseSearchResult`, alongside the existing `attribute_boost` /
+  `original_score` precedent (#1092). `original_score` is NOT touched
+  (already owned by attribute boosting); the pre-boost score is recoverable
+  as `score / tier_boost`.
+- **Idempotency:** results with `tier_boost` already set are skipped.
+  `batch_search` re-runs the context lookup on results whose inner
+  `search()` already attached — without this guard the weight would apply
+  twice (`score × w²`).
+- **Re-sort:** stable descending sort by `score`, executed only when at
+  least one multiply happened. No weights applied → the list object and its
+  order are untouched.
+- The `batch_search` inline attach block gets the same boost logic (it
+  shares the snapshot walk; idempotency makes the second pass a no-op for
+  already-boosted results).
+- Fail-soft contract unchanged: any per-result failure increments
+  `path_context_attach_failures` and leaves that result unboosted.
+
+## 3. Conditional over-fetch + trim (`_search_on_current_loop`)
+
+The fusion stage trims to the daemon `limit` inside `_search_via_backends`
+(`fuse_results(..., limit=limit)`), so a boost applied at attach time could
+never *promote* a below-cutoff hit without a wider candidate pool.
+
+At the top of `_search_on_current_loop`:
+
+1. Resolve the path-context cache → `refresh_if_stale(effective_zone)` →
+   `snapshot_zone` → `has_weights = any(rec.weight not in (None, 1.0))`.
+   Fail-soft: any exception → `has_weights = False` (search never breaks
+   on a weight-lookup problem; attach still runs its own fail-soft pass).
+2. **`has_weights == True`:** every candidate fetch in the method
+   (`_search_via_backends`, legacy `_keyword_search` / `_hybrid_search` /
+   `_semantic_search`) uses `limit × tier_boost_overfetch_factor`
+   (default 3). Each return point runs attach (boost + re-sort), then trims
+   back to the caller's `limit`. The route-level ReBAC ×3 over-fetch
+   composes on top unchanged (worst case daemon pool = limit × 9).
+3. **`has_weights == False`:** today's exact pipeline — no wider fusion
+   window, no `page_aggregation` composition change, no re-sort. The
+   acceptance criterion "weight unset/1.0 everywhere is byte-identical to
+   today" holds trivially because the code path is identical.
+
+Cost: the snapshot work is the same work attach pays later in the same
+request; the incremental cost is one cache-fingerprint check per search,
+and the wider fetch only occurs for zones that actually configured weights.
+
+Macro expansion (`expand=macro`, #4398) runs in `search()` after the
+trimmed list is returned — unaffected.
+
+## 4. API + CLI surface
+
+- `PathContextIn` gains `weight: float | None = Field(default=None,
+  ge=0.1, le=10.0)`. PUT `/api/v2/path-contexts/` persists and echoes it.
+- GET list emits `weight` for every row (`null` = unset ≡ 1.0) — admin
+  surface favors explicitness.
+- DELETE and the zone-scoping/permission rules are unchanged.
+- `_serialize_search_result` emits `tier_boost` (rounded to 4 places) only
+  when set — same compact-response convention as `context`.
+- CLI `nexus path-context` upsert gains `--weight`; list output shows the
+  weight column.
+- Regenerate `api-rpc-surface-coverage` YAML after the router edit
+  (#4541 lesson: surface regen is required on any search-adjacent router
+  change).
+
+## 5. Federated path
+
+Correct by construction because the boost lives in the daemon:
+
+- Local zones: `FederatedSearchDispatcher._search_zone` calls
+  `daemon.search(zone_id=zone)` — the owning zone's weights are applied
+  before the federated merge.
+- Remote zones: the remote node's daemon boosts before the RPC returns;
+  scores arriving over the wire already carry the owning zone's weights.
+- `_merge_by_raw_score` compares boosted scores, so cross-zone ordering
+  reflects per-zone tiers; the merge happens before the federated final
+  trim, satisfying the ordering constraint.
+- Extend the `_strip_none_context` pattern so `tier_boost: null` never
+  leaks onto federated result dicts (same Round-5/6 hygiene as `context`).
+- Remote *attribution* (the `tier_boost` field traveling over the RPC) is
+  best-effort: score ordering is the contract. Verify the remote RPC search
+  serializer during implementation; if the field doesn't survive the wire,
+  ordering is still correct and the field is simply absent.
+
+## 6. Config knobs
+
+Two new `DaemonConfig` fields with env overrides, following existing
+search-knob conventions:
+
+| Field | Default | Env | Meaning |
+|---|---|---|---|
+| `tier_boost_overfetch_factor` | 3 | `NEXUS_SEARCH_TIER_BOOST_OVERFETCH` | Candidate-pool widening multiplier when a zone has weights |
+| `tier_boost_floor_ratio` | 0.25 | `NEXUS_SEARCH_TIER_BOOST_FLOOR_RATIO` | Uplift gate: skip `w > 1.0` when `score < ratio × top`; 0 disables |
+
+## 7. Testing
+
+- **Store/migration:** upsert-with-weight roundtrip (PG + SQLite branches),
+  NULL → `None`, migration parity tests (model vs alembic head).
+- **Attach unit tests:** demotion reorders below equal-relevance peers;
+  promotion works through the over-fetch pool; floor gate blocks uplift of
+  far-below results; gate does not block demotion; double-attach is
+  idempotent (no `w²`); no-weight case leaves the result objects, scores,
+  and list order untouched; `tier_boost` stamped only when `w ≠ 1.0`.
+- **Daemon integration:** seeded weights end-to-end through
+  `_search_on_current_loop` with fake backends, including trim-back-to-limit
+  after over-fetch and timing-field preservation.
+- **Router:** weight bounds validation (0.05 and 10.5 rejected), PUT echo,
+  list emission, `_serialize_search_result` emits `tier_boost` only when set.
+- **Federated:** local-zone weight visible in merged ordering;
+  `tier_boost: null` stripped from federated dicts.
+- **Byte-identity regression:** full existing search suite green with no
+  weights configured.
+
+## Acceptance (from the issue)
+
+- Seeding `weight=0.5` on a noisy prefix demotes its hits below
+  equal-relevance hits from weight-1.0 prefixes; `weight` unset/1.0
+  everywhere is byte-identical to today.
+- Boost visible per-result (`tier_boost` attribution); federated path
+  applies the owning zone's weights.
+
+## Out of scope
+
+- Per-query weight overrides (weights are admin/zone state, not request
+  params).
+- Weight semantics in Zoekt/grep/glob/locate paths (no `path_contexts`
+  attach there today).
+- RPC surface versioning to carry `tier_boost` attribution to older remote
+  nodes (#4541 precedent: remote nodes reject unknown params; score-level
+  correctness does not depend on it).

--- a/docs/superpowers/specs/2026-07-31-prefix-weight-boost-design.md
+++ b/docs/superpowers/specs/2026-07-31-prefix-weight-boost-design.md
@@ -61,8 +61,11 @@ as today, then apply the weight `w = record.weight or 1.0`:
 - **Attribution field:** new `tier_boost: float | None = None` on
   `BaseSearchResult`, alongside the existing `attribute_boost` /
   `original_score` precedent (#1092). `original_score` is NOT touched
-  (already owned by attribute boosting); the pre-boost score is recoverable
-  as `score / tier_boost`.
+  (already owned by attribute boosting). `tier_boost` stamps the CONFIGURED
+  weight; the transform is signed-safe (non-negative scores multiply,
+  negative cosine scores divide), so the pre-boost score is recoverable as
+  `score / tier_boost` when `score >= 0` and `score * tier_boost` when
+  `score < 0`.
 - **Idempotency:** results with `tier_boost` already set are skipped.
   `batch_search` re-runs the context lookup on results whose inner
   `search()` already attached — without this guard the weight would apply

--- a/docs/surface-coverage/api-rpc-surface-coverage.yaml
+++ b/docs/surface-coverage/api-rpc-surface-coverage.yaml
@@ -7642,7 +7642,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/expand
-      source: src/nexus/server/api/v2/routers/search.py:1563
+      source: src/nexus/server/api/v2/routers/search.py:1569
   profiles:
     lite: supported
     sandbox: supported
@@ -7666,7 +7666,7 @@ operations:
       source: src/nexus/bricks/search/search_service.py:1791
     http:
       name: POST /api/v2/search/glob
-      source: src/nexus/server/api/v2/routers/search.py:1444
+      source: src/nexus/server/api/v2/routers/search.py:1450
     mcp:
       name: nexus_glob
       source: src/nexus/config/tool_profiles.yaml:1
@@ -7693,7 +7693,7 @@ operations:
       source: src/nexus/bricks/search/search_service.py:2101
     http:
       name: POST /api/v2/search/grep
-      source: src/nexus/server/api/v2/routers/search.py:1321
+      source: src/nexus/server/api/v2/routers/search.py:1327
     mcp:
       name: nexus_grep
       source: src/nexus/config/tool_profiles.yaml:1
@@ -7746,7 +7746,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/index
-      source: src/nexus/server/api/v2/routers/search.py:1506
+      source: src/nexus/server/api/v2/routers/search.py:1512
   profiles:
     lite: supported
     sandbox: supported
@@ -7764,7 +7764,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/index-directory
-      source: src/nexus/server/api/v2/routers/search.py:1705
+      source: src/nexus/server/api/v2/routers/search.py:1711
   profiles:
     lite: supported
     sandbox: supported
@@ -7781,7 +7781,7 @@ operations:
   transports:
     http:
       name: GET /api/v2/search/indexed-dirs
-      source: src/nexus/server/api/v2/routers/search.py:1923
+      source: src/nexus/server/api/v2/routers/search.py:1929
   profiles:
     lite: supported
     sandbox: supported
@@ -7798,7 +7798,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/indexing-mode
-      source: src/nexus/server/api/v2/routers/search.py:1960
+      source: src/nexus/server/api/v2/routers/search.py:1966
   profiles:
     lite: supported
     sandbox: supported
@@ -7815,7 +7815,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/locate
-      source: src/nexus/server/api/v2/routers/search.py:2141
+      source: src/nexus/server/api/v2/routers/search.py:2147
   profiles:
     lite: supported
     sandbox: supported
@@ -7884,7 +7884,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/purge-unscoped
-      source: src/nexus/server/api/v2/routers/search.py:2087
+      source: src/nexus/server/api/v2/routers/search.py:2093
   profiles:
     lite: supported
     sandbox: supported
@@ -7937,7 +7937,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/refresh
-      source: src/nexus/server/api/v2/routers/search.py:1542
+      source: src/nexus/server/api/v2/routers/search.py:1548
   profiles:
     lite: supported
     sandbox: supported

--- a/docs/surface-coverage/api-rpc-surface-coverage.yaml
+++ b/docs/surface-coverage/api-rpc-surface-coverage.yaml
@@ -6355,7 +6355,7 @@ operations:
   transports:
     http:
       name: PUT /api/v2/path-contexts/
-      source: src/nexus/server/api/v2/routers/path_contexts.py:220
+      source: src/nexus/server/api/v2/routers/path_contexts.py:224
   profiles:
     lite: supported
     sandbox: supported
@@ -7625,7 +7625,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/consumers/{consumer_name}/skip-to
-      source: src/nexus/server/api/v2/routers/search.py:277
+      source: src/nexus/server/api/v2/routers/search.py:282
   profiles:
     lite: supported
     sandbox: supported
@@ -7642,7 +7642,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/expand
-      source: src/nexus/server/api/v2/routers/search.py:1558
+      source: src/nexus/server/api/v2/routers/search.py:1563
   profiles:
     lite: supported
     sandbox: supported
@@ -7666,7 +7666,7 @@ operations:
       source: src/nexus/bricks/search/search_service.py:1791
     http:
       name: POST /api/v2/search/glob
-      source: src/nexus/server/api/v2/routers/search.py:1439
+      source: src/nexus/server/api/v2/routers/search.py:1444
     mcp:
       name: nexus_glob
       source: src/nexus/config/tool_profiles.yaml:1
@@ -7693,7 +7693,7 @@ operations:
       source: src/nexus/bricks/search/search_service.py:2101
     http:
       name: POST /api/v2/search/grep
-      source: src/nexus/server/api/v2/routers/search.py:1316
+      source: src/nexus/server/api/v2/routers/search.py:1321
     mcp:
       name: nexus_grep
       source: src/nexus/config/tool_profiles.yaml:1
@@ -7729,7 +7729,7 @@ operations:
   transports:
     http:
       name: GET /api/v2/search/health
-      source: src/nexus/server/api/v2/routers/search.py:196
+      source: src/nexus/server/api/v2/routers/search.py:201
   profiles:
     lite: supported
     sandbox: supported
@@ -7746,7 +7746,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/index
-      source: src/nexus/server/api/v2/routers/search.py:1501
+      source: src/nexus/server/api/v2/routers/search.py:1506
   profiles:
     lite: supported
     sandbox: supported
@@ -7764,7 +7764,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/index-directory
-      source: src/nexus/server/api/v2/routers/search.py:1700
+      source: src/nexus/server/api/v2/routers/search.py:1705
   profiles:
     lite: supported
     sandbox: supported
@@ -7781,7 +7781,7 @@ operations:
   transports:
     http:
       name: GET /api/v2/search/indexed-dirs
-      source: src/nexus/server/api/v2/routers/search.py:1918
+      source: src/nexus/server/api/v2/routers/search.py:1923
   profiles:
     lite: supported
     sandbox: supported
@@ -7798,7 +7798,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/indexing-mode
-      source: src/nexus/server/api/v2/routers/search.py:1955
+      source: src/nexus/server/api/v2/routers/search.py:1960
   profiles:
     lite: supported
     sandbox: supported
@@ -7815,7 +7815,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/locate
-      source: src/nexus/server/api/v2/routers/search.py:2136
+      source: src/nexus/server/api/v2/routers/search.py:2141
   profiles:
     lite: supported
     sandbox: supported
@@ -7832,7 +7832,7 @@ operations:
   transports:
     http:
       name: GET /api/v2/search/parked
-      source: src/nexus/server/api/v2/routers/search.py:234
+      source: src/nexus/server/api/v2/routers/search.py:239
   profiles:
     lite: supported
     sandbox: supported
@@ -7849,7 +7849,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/parked/discard
-      source: src/nexus/server/api/v2/routers/search.py:260
+      source: src/nexus/server/api/v2/routers/search.py:265
   profiles:
     lite: supported
     sandbox: supported
@@ -7867,7 +7867,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/parked/retry
-      source: src/nexus/server/api/v2/routers/search.py:243
+      source: src/nexus/server/api/v2/routers/search.py:248
   profiles:
     lite: supported
     sandbox: supported
@@ -7884,7 +7884,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/purge-unscoped
-      source: src/nexus/server/api/v2/routers/search.py:2082
+      source: src/nexus/server/api/v2/routers/search.py:2087
   profiles:
     lite: supported
     sandbox: supported
@@ -7902,7 +7902,7 @@ operations:
   transports:
     http:
       name: GET /api/v2/search/query
-      source: src/nexus/server/api/v2/routers/search.py:295
+      source: src/nexus/server/api/v2/routers/search.py:300
   profiles:
     lite: supported
     sandbox: supported
@@ -7920,7 +7920,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/query/batch
-      source: src/nexus/server/api/v2/routers/search.py:746
+      source: src/nexus/server/api/v2/routers/search.py:751
   profiles:
     lite: supported
     sandbox: supported
@@ -7937,7 +7937,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/refresh
-      source: src/nexus/server/api/v2/routers/search.py:1537
+      source: src/nexus/server/api/v2/routers/search.py:1542
   profiles:
     lite: supported
     sandbox: supported
@@ -7972,7 +7972,7 @@ operations:
   transports:
     http:
       name: GET /api/v2/search/stats
-      source: src/nexus/server/api/v2/routers/search.py:211
+      source: src/nexus/server/api/v2/routers/search.py:216
   profiles:
     lite: supported
     sandbox: supported

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -356,6 +356,17 @@ class DaemonConfig:
     # weights are applied. ``tier_boost_floor_ratio`` gates uplifts only:
     # a result scoring below ratio*top cannot be boosted past strong matches
     # (0 disables the gate). Demotions always apply.
+    #
+    # BOUNDED APPROXIMATION (design-accepted, Codex review R4): weights
+    # re-rank within the widened window of ``limit × factor`` raw candidates
+    # only. If more than ``limit × factor`` raw hits from a demoted prefix
+    # outscore an unweighted hit, that hit stays outside the window and
+    # cannot be promoted — exact weighted top-K would require pushing
+    # weights into every backend query (or threshold-style iterative
+    # fetch), which the #4544 design explicitly traded away for the
+    # attach-point approach. Operators with extremely noisy high-volume
+    # prefixes should raise the factor (or fence the prefix with
+    # path-scoped search) rather than expect global re-ranking.
     tier_boost_overfetch_factor: int = field(
         default_factory=lambda: _get_env_int("NEXUS_SEARCH_TIER_BOOST_OVERFETCH", 3)
     )
@@ -1873,10 +1884,12 @@ class SearchDaemon:
                     if apply_weights:
                         if _apply_tier_weight(r, record.weight, top_score, floor_ratio):
                             boosted_any = True
-                    elif getattr(r, "tier_boost", None) is None:
-                        # A configured weight was bypassed (probe failure or
-                        # un-widened pool) — count it so operators can see
+                    elif pinned_snapshots is None and getattr(r, "tier_boost", None) is None:
+                        # A configured weight was bypassed after a FAILED
+                        # probe (no pin) — count it so operators can see
                         # ranking policy being skipped (Codex review R3).
+                        # Pinned callers already counted the bypass at their
+                        # widening decision (R4), so don't double-count.
                         suppressed += 1
                         suppressed_zone = zone
             except Exception as exc:
@@ -2022,6 +2035,18 @@ class SearchDaemon:
             {effective_zone_id: tier_snapshot} if tier_snapshot is not None else None
         )
         tier_weights_ok = tier_snapshot is not None and internal_limit > limit
+        if has_tier_weights and not tier_weights_ok:
+            # Codex review R4: count suppression at the DECISION point, not
+            # only at attach — with factor <= 1 an affected candidate below
+            # the un-widened cutoff never appears in `results`, so attach
+            # alone cannot observe the bypass.
+            self.stats.tier_boost_suppressed_searches += 1
+            logger.warning(
+                "tier weights configured for zone=%r but pool not widened "
+                "(factor<=1) — ranking weights suppressed (total=%d)",
+                effective_zone_id,
+                self.stats.tier_boost_suppressed_searches,
+            )
         start = time.perf_counter()
         self.last_search_timing = {}
         hybrid_keyword_results: list[SearchResult] = []

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -137,6 +137,11 @@ class DaemonStats:
     # visible via /search/stats rather than only in log lines.
     path_context_attach_failures: int = 0
     path_context_resolve_failures: int = 0
+    # Issue #4544 (Codex review R3): tier-weight observability. A probe
+    # failure or un-widened pool silently bypasses configured ranking
+    # weights — operators need a production signal, not a debug log.
+    tier_boost_probe_failures: int = 0
+    tier_boost_suppressed_searches: int = 0
 
 
 @dataclass
@@ -1720,7 +1725,19 @@ class SearchDaemon:
             await cache.refresh_if_stale(zone_id)
             snapshot = cache.snapshot_zone(zone_id)
         except Exception as exc:
-            logger.debug("tier-weight probe failed for zone=%r: %s", zone_id, exc)
+            # Defensive stats access: the probe's fail-soft contract must
+            # hold even for partially-constructed daemons (test doubles via
+            # ``__new__`` have no ``stats``) — the counter update itself may
+            # never re-raise.
+            stats = getattr(self, "stats", None)
+            if stats is not None:
+                stats.tier_boost_probe_failures += 1
+            logger.warning(
+                "tier-weight probe failed for zone=%r (total=%d): %s",
+                zone_id,
+                getattr(stats, "tier_boost_probe_failures", 0),
+                exc,
+            )
             return (False, None)
         if not snapshot:
             return (False, snapshot)
@@ -1842,6 +1859,8 @@ class SearchDaemon:
         floor_ratio = self.config.tier_boost_floor_ratio
         top_score = max((r.score for r in results), default=0.0)
         boosted_any = False
+        suppressed = 0
+        suppressed_zone: str | None = None
         for r in results:
             zone = _zone_for(r)
             records = snapshots.get(zone)
@@ -1850,12 +1869,16 @@ class SearchDaemon:
             try:
                 record = lookup_record_in_records(records, r.path)
                 r.context = record.description if record is not None else None
-                if (
-                    apply_weights
-                    and record is not None
-                    and _apply_tier_weight(r, record.weight, top_score, floor_ratio)
-                ):
-                    boosted_any = True
+                if record is not None and record.weight is not None and record.weight != 1.0:
+                    if apply_weights:
+                        if _apply_tier_weight(r, record.weight, top_score, floor_ratio):
+                            boosted_any = True
+                    elif getattr(r, "tier_boost", None) is None:
+                        # A configured weight was bypassed (probe failure or
+                        # un-widened pool) — count it so operators can see
+                        # ranking policy being skipped (Codex review R3).
+                        suppressed += 1
+                        suppressed_zone = zone
             except Exception as exc:
                 self.stats.path_context_attach_failures += 1
                 logger.warning(
@@ -1864,6 +1887,15 @@ class SearchDaemon:
                     self.stats.path_context_attach_failures,
                     exc,
                 )
+        if suppressed:
+            self.stats.tier_boost_suppressed_searches += 1
+            logger.warning(
+                "tier weights suppressed for %d result(s) in zone=%r "
+                "(probe failed or pool not widened; suppressed searches total=%d)",
+                suppressed,
+                suppressed_zone,
+                self.stats.tier_boost_suppressed_searches,
+            )
         if boosted_any:
             # Stable sort: equal scores keep their pre-boost relative order.
             results.sort(key=lambda r: r.score, reverse=True)
@@ -1980,14 +2012,16 @@ class SearchDaemon:
             limit * max(1, self.config.tier_boost_overfetch_factor) if has_tier_weights else limit
         )
         # Pin the probe's snapshot so attach weights against the same rows
-        # the over-fetch decision saw. A failed probe (snapshot None) means
-        # the pool was NOT widened — weights are suppressed for this request
-        # (Codex review R2) so ranking can never mutate against an un-widened
-        # pool; context attach still runs its own fail-soft refresh.
+        # the over-fetch decision saw. Weights apply ONLY when the pool was
+        # actually widened (Codex review R2/R3): a failed probe (snapshot
+        # None) or a factor clamped down to 1 both leave internal_limit ==
+        # limit, and mutating ranks against an un-widened pool means a
+        # demoted top-N hit can never be displaced by rank N+1. Context
+        # attach still runs its own fail-soft refresh either way.
         tier_pin: dict[str, list[Any]] | None = (
             {effective_zone_id: tier_snapshot} if tier_snapshot is not None else None
         )
-        tier_weights_ok = tier_snapshot is not None
+        tier_weights_ok = tier_snapshot is not None and internal_limit > limit
         start = time.perf_counter()
         self.last_search_timing = {}
         hybrid_keyword_results: list[SearchResult] = []
@@ -4535,6 +4569,10 @@ class SearchDaemon:
             # operators can spot persistent failures via /search/stats.
             "path_context_attach_failures": self.stats.path_context_attach_failures,
             "path_context_resolve_failures": self.stats.path_context_resolve_failures,
+            # Issue #4544 (Codex review R3): configured tier weights being
+            # bypassed (probe failure / un-widened pool) must be visible.
+            "tier_boost_probe_failures": self.stats.tier_boost_probe_failures,
+            "tier_boost_suppressed_searches": self.stats.tier_boost_suppressed_searches,
         }
 
     def get_health(self) -> dict[str, Any]:

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -1733,6 +1733,7 @@ class SearchDaemon:
         *,
         zone_id: str | None = None,
         pinned_snapshots: dict[str, list[Any]] | None = None,
+        apply_weights: bool = True,
     ) -> None:
         """Attach admin-configured path context descriptions to search results.
 
@@ -1758,6 +1759,12 @@ class SearchDaemon:
         refreshing — the caller pins the exact snapshot its over-fetch
         decision was made from, so sizing and weighting can never disagree
         within one request.
+
+        ``apply_weights=False`` (Codex review R2): when the caller's
+        tier-weight probe failed, the candidate pool was NOT widened, so
+        applying weights here could demote/promote against a pool already
+        cut to ``limit``. Context still attaches (stale context beats no
+        context, #3773); only the ranking mutation is suppressed.
         """
         if not results:
             return
@@ -1843,8 +1850,10 @@ class SearchDaemon:
             try:
                 record = lookup_record_in_records(records, r.path)
                 r.context = record.description if record is not None else None
-                if record is not None and _apply_tier_weight(
-                    r, record.weight, top_score, floor_ratio
+                if (
+                    apply_weights
+                    and record is not None
+                    and _apply_tier_weight(r, record.weight, top_score, floor_ratio)
                 ):
                     boosted_any = True
             except Exception as exc:
@@ -1971,10 +1980,14 @@ class SearchDaemon:
             limit * max(1, self.config.tier_boost_overfetch_factor) if has_tier_weights else limit
         )
         # Pin the probe's snapshot so attach weights against the same rows
-        # the over-fetch decision saw (None → attach refreshes as before).
+        # the over-fetch decision saw. A failed probe (snapshot None) means
+        # the pool was NOT widened — weights are suppressed for this request
+        # (Codex review R2) so ranking can never mutate against an un-widened
+        # pool; context attach still runs its own fail-soft refresh.
         tier_pin: dict[str, list[Any]] | None = (
             {effective_zone_id: tier_snapshot} if tier_snapshot is not None else None
         )
+        tier_weights_ok = tier_snapshot is not None
         start = time.perf_counter()
         self.last_search_timing = {}
         hybrid_keyword_results: list[SearchResult] = []
@@ -2002,7 +2015,10 @@ class SearchDaemon:
                         latency_ms = (time.perf_counter() - start) * 1000
                         self._track_latency(latency_ms)
                         await self._attach_path_contexts(
-                            backend_results, zone_id=effective_zone_id, pinned_snapshots=tier_pin
+                            backend_results,
+                            zone_id=effective_zone_id,
+                            pinned_snapshots=tier_pin,
+                            apply_weights=tier_weights_ok,
                         )
                         if internal_limit != limit:
                             backend_results = backend_results[:limit]
@@ -2046,7 +2062,10 @@ class SearchDaemon:
                 latency_ms = (time.perf_counter() - start) * 1000
                 self._track_latency(latency_ms)
                 await self._attach_path_contexts(
-                    keyword_results, zone_id=effective_zone_id, pinned_snapshots=tier_pin
+                    keyword_results,
+                    zone_id=effective_zone_id,
+                    pinned_snapshots=tier_pin,
+                    apply_weights=tier_weights_ok,
                 )
                 if internal_limit != limit:
                     keyword_results = keyword_results[:limit]
@@ -2097,7 +2116,10 @@ class SearchDaemon:
                     latency_ms = (time.perf_counter() - start) * 1000
                     self._track_latency(latency_ms)
                     await self._attach_path_contexts(
-                        results, zone_id=effective_zone_id, pinned_snapshots=tier_pin
+                        results,
+                        zone_id=effective_zone_id,
+                        pinned_snapshots=tier_pin,
+                        apply_weights=tier_weights_ok,
                     )
                     if internal_limit != limit:
                         results = results[:limit]
@@ -2146,7 +2168,10 @@ class SearchDaemon:
                 )
 
             await self._attach_path_contexts(
-                results, zone_id=effective_zone_id, pinned_snapshots=tier_pin
+                results,
+                zone_id=effective_zone_id,
+                pinned_snapshots=tier_pin,
+                apply_weights=tier_weights_ok,
             )
             if internal_limit != limit:
                 results = results[:limit]

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -1776,15 +1776,26 @@ class SearchDaemon:
             if snap is not None:
                 snapshots[zone] = snap
 
-        from nexus.bricks.search.path_context import lookup_in_records
+        from nexus.bricks.search.path_context import lookup_record_in_records
 
+        # Issue #4544: apply per-prefix ranking weights while attaching
+        # context. top_score is the pre-boost max of this batch — the floor
+        # gate must compare against the unweighted ranking.
+        floor_ratio = self.config.tier_boost_floor_ratio
+        top_score = max((r.score for r in results), default=0.0)
+        boosted_any = False
         for r in results:
             zone = _zone_for(r)
             records = snapshots.get(zone)
             if records is None:
                 continue
             try:
-                r.context = lookup_in_records(records, r.path)
+                record = lookup_record_in_records(records, r.path)
+                r.context = record.description if record is not None else None
+                if record is not None and _apply_tier_weight(
+                    r, record.weight, top_score, floor_ratio
+                ):
+                    boosted_any = True
             except Exception as exc:
                 self.stats.path_context_attach_failures += 1
                 logger.warning(
@@ -1793,6 +1804,9 @@ class SearchDaemon:
                     self.stats.path_context_attach_failures,
                     exc,
                 )
+        if boosted_any:
+            # Stable sort: equal scores keep their pre-boost relative order.
+            results.sort(key=lambda r: r.score, reverse=True)
 
     async def _apply_macro_expansion(
         self,
@@ -2414,12 +2428,19 @@ class SearchDaemon:
                 )
                 records = None
             if records is not None:
-                from nexus.bricks.search.path_context import lookup_in_records
+                from nexus.bricks.search.path_context import lookup_record_in_records
 
+                # Issue #4544 note: weights are NOT applied here. Each inner
+                # self.search() already ran _attach_path_contexts (multiply +
+                # tier_boost stamp); re-applying against post-boost scores
+                # would re-evaluate the floor gate against a shifted top and
+                # boost previously-gated results. This block only backfills
+                # ``context`` for legacy/mocked daemons.
                 for inner in results:
                     for r in inner:
                         try:
-                            r.context = lookup_in_records(records, r.path)
+                            record = lookup_record_in_records(records, r.path)
+                            r.context = record.description if record is not None else None
                         except Exception as exc:
                             self.stats.path_context_attach_failures += 1
                             logger.warning(

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -1874,6 +1874,16 @@ class SearchDaemon:
         # context. top_score is the pre-boost max of this batch — the floor
         # gate must compare against the unweighted ranking.
         floor_ratio = self.config.tier_boost_floor_ratio
+        # top_score is the max of the daemon's candidate pool — computed
+        # BEFORE route-level ReBAC filtering, like every other ranking
+        # transform in this pipeline (RRF fusion ranks, attribute boost
+        # #1092, page pooling #4542 all run pre-filter). A denied hit can
+        # therefore influence the uplift gate, exactly as it already
+        # influences fused rank positions; relocating weight finalization
+        # post-ReBAC would contradict the #4544 attach-point design and
+        # break federated composition (remote zones weight server-side,
+        # before the local caller's filter). Documented trade-off — see
+        # spec §3 (Codex review R6 ruling).
         top_score = max((r.score for r in results), default=0.0)
         boosted_any = False
         suppressed = 0

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -48,6 +48,7 @@ from sqlalchemy import text as sa_text
 from nexus.bricks.search import consumer_metrics
 from nexus.bricks.search.chunk_store import ChunkRecord, ChunkStore
 from nexus.bricks.search.config import get_env_bool as _get_env_bool
+from nexus.bricks.search.config import get_env_float as _get_env_float
 from nexus.bricks.search.config import get_env_int as _get_env_int
 from nexus.bricks.search.mutation_events import (
     SearchMutationEvent,
@@ -183,6 +184,32 @@ def _merge_backend_timing(total_ms: float, recorded: dict[str, float]) -> dict[s
     return timing
 
 
+def _apply_tier_weight(
+    result: Any,
+    weight: float | None,
+    top_score: float,
+    floor_ratio: float,
+) -> bool:
+    """Multiply ``result.score`` by a path-prefix weight (Issue #4544).
+
+    Returns True when the weight was applied. Skips: no/neutral weight,
+    already-stamped results (``batch_search`` re-runs attach on results whose
+    inner search already applied weights — without this guard the score would
+    compound to weight²), and uplifts on results scoring below
+    ``floor_ratio * top_score`` (metadata may reorder near-peers but must not
+    lift weak matches past strong ones). Demotions always apply.
+    """
+    if weight is None or weight == 1.0:
+        return False
+    if getattr(result, "tier_boost", None) is not None:
+        return False
+    if weight > 1.0 and floor_ratio > 0.0 and result.score < floor_ratio * top_score:
+        return False
+    result.score *= weight
+    result.tier_boost = weight
+    return True
+
+
 @dataclass
 class DaemonConfig:
     """Configuration for the search daemon."""
@@ -302,6 +329,20 @@ class DaemonConfig:
     )
     macro_chunk_code_forward_bias: bool = field(
         default_factory=lambda: _get_env_bool("NEXUS_SEARCH_MACRO_CHUNK_FORWARD_BIAS", True)
+    )
+
+    # Per-prefix ranking weight (Issue #4544). When the effective zone has any
+    # path_contexts row with weight != 1.0, the daemon widens its candidate
+    # fetch by ``tier_boost_overfetch_factor`` so a boost can promote a
+    # below-cutoff hit, then trims back to the requested limit after the
+    # weights are applied. ``tier_boost_floor_ratio`` gates uplifts only:
+    # a result scoring below ratio*top cannot be boosted past strong matches
+    # (0 disables the gate). Demotions always apply.
+    tier_boost_overfetch_factor: int = field(
+        default_factory=lambda: _get_env_int("NEXUS_SEARCH_TIER_BOOST_OVERFETCH", 3)
+    )
+    tier_boost_floor_ratio: float = field(
+        default_factory=lambda: _get_env_float("NEXUS_SEARCH_TIER_BOOST_FLOOR_RATIO", 0.25)
     )
 
 

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -1691,9 +1691,7 @@ class SearchDaemon:
         Decides whether _search_on_current_loop widens its candidate fetch.
         Fail-soft: any error means "no over-fetch" — the search itself must
         never break on a weight probe, and _attach_path_contexts still runs
-        its own fail-soft pass later in the same request. The refresh here is
-        the same fingerprint check attach pays, so the steady-state cost is
-        one cache hit.
+        its own fail-soft pass later in the same request. The refresh here costs one zone-fingerprint query (COUNT + MAX(updated_at)) per search, in addition to the identical check attach performs later in the same request.
         """
         try:
             cache = await self._resolve_path_context_cache()
@@ -1936,10 +1934,11 @@ class SearchDaemon:
         # candidate fetch so a boost can promote a below-cutoff hit, then trim
         # back to ``limit`` after _attach_path_contexts applies the weights.
         # Zones without weights keep internal_limit == limit and take the
-        # byte-identical legacy path.
+        # byte-identical legacy path. The factor is clamped to >= 1 so a
+        # misconfigured env override can never zero-out the fetch.
         has_tier_weights = await self._zone_has_tier_weights(effective_zone_id)
         internal_limit = (
-            limit * self.config.tier_boost_overfetch_factor if has_tier_weights else limit
+            limit * max(1, self.config.tier_boost_overfetch_factor) if has_tier_weights else limit
         )
         start = time.perf_counter()
         self.last_search_timing = {}

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -198,14 +198,27 @@ def _apply_tier_weight(
     compound to weight²), and uplifts on results scoring below
     ``floor_ratio * top_score`` (metadata may reorder near-peers but must not
     lift weak matches past strong ones). Demotions always apply.
+
+    Signed-safe: pgvector semantic scores are raw cosine similarity, whose
+    range includes negatives. A plain multiply would let a demotion weight
+    *raise* a negative score (-0.2 × 0.5 = -0.1), inverting tier semantics.
+    Negative scores divide by the weight instead, so w < 1 always worsens
+    rank and w > 1 always improves it. The floor gate only fires when
+    ``top_score`` is positive — a non-positive top means every result is a
+    weak match and the ratio comparison is meaningless.
     """
     if weight is None or weight == 1.0:
         return False
     if getattr(result, "tier_boost", None) is not None:
         return False
-    if weight > 1.0 and floor_ratio > 0.0 and result.score < floor_ratio * top_score:
+    if (
+        weight > 1.0
+        and floor_ratio > 0.0
+        and top_score > 0.0
+        and result.score < floor_ratio * top_score
+    ):
         return False
-    result.score *= weight
+    result.score = result.score * weight if result.score >= 0.0 else result.score / weight
     result.tier_boost = weight
     return True
 
@@ -1685,32 +1698,41 @@ class SearchDaemon:
         self._path_context_engines_by_loop[loop] = engine
         return cache
 
-    async def _zone_has_tier_weights(self, zone_id: str) -> bool:
-        """True when the zone has any path-context weight != 1.0 (Issue #4544).
+    async def _tier_weight_probe(self, zone_id: str) -> tuple[bool, list[Any] | None]:
+        """Return ``(has_weights, snapshot)`` for a zone (Issue #4544).
 
-        Decides whether _search_on_current_loop widens its candidate fetch.
-        Fail-soft: any error means "no over-fetch" — the search itself must
-        never break on a weight probe, and _attach_path_contexts still runs
-        its own fail-soft pass later in the same request. The refresh here costs one zone-fingerprint query (COUNT + MAX(updated_at)) per search, in addition to the identical check attach performs later in the same request.
+        ``has_weights`` decides whether _search_on_current_loop widens its
+        candidate fetch; ``snapshot`` is the records list that decision was
+        made from, so the caller can pin it through to
+        ``_attach_path_contexts`` — over-fetch sizing and weight application
+        must read the SAME rows, otherwise a weight added between the probe
+        and attach would boost against an un-widened candidate pool (Codex
+        review R1). Fail-soft: any error returns ``(False, None)`` — the
+        search itself must never break on a weight probe, and attach falls
+        back to its own refresh when no snapshot is pinned. The refresh here
+        costs one zone-fingerprint query (COUNT + MAX(updated_at)) per
+        search when no snapshot is pinned downstream.
         """
         try:
             cache = await self._resolve_path_context_cache()
             if cache is None:
-                return False
+                return (False, None)
             await cache.refresh_if_stale(zone_id)
             snapshot = cache.snapshot_zone(zone_id)
         except Exception as exc:
             logger.debug("tier-weight probe failed for zone=%r: %s", zone_id, exc)
-            return False
+            return (False, None)
         if not snapshot:
-            return False
-        return any(rec.weight is not None and rec.weight != 1.0 for rec in snapshot)
+            return (False, snapshot)
+        has_weights = any(rec.weight is not None and rec.weight != 1.0 for rec in snapshot)
+        return (has_weights, snapshot)
 
     async def _attach_path_contexts(
         self,
         results: list[SearchResult],
         *,
         zone_id: str | None = None,
+        pinned_snapshots: dict[str, list[Any]] | None = None,
     ) -> None:
         """Attach admin-configured path context descriptions to search results.
 
@@ -1730,6 +1752,12 @@ class SearchDaemon:
         Fails soft: if the cache lookup raises (e.g. asyncpg loop mismatch),
         logs a warning and leaves ``context`` unset rather than breaking
         the whole search.
+
+        ``pinned_snapshots`` (Issue #4544, Codex review R1): zones present in
+        this mapping use the given records list verbatim instead of
+        refreshing — the caller pins the exact snapshot its over-fetch
+        decision was made from, so sizing and weighting can never disagree
+        within one request.
         """
         if not results:
             return
@@ -1762,8 +1790,10 @@ class SearchDaemon:
         # snapshot_zone is sync so the grab happens before the next refresh's
         # await point. Isolate per-zone failures: one zone raising shouldn't
         # drop context for every other zone in the same batch (Round-4 review).
-        snapshots: dict[str, list[Any]] = {}
+        snapshots: dict[str, list[Any]] = dict(pinned_snapshots or {})
         for zone in zones:
+            if zone in snapshots:
+                continue
             try:
                 await cache.refresh_if_stale(zone)
             except Exception as exc:
@@ -1936,9 +1966,14 @@ class SearchDaemon:
         # Zones without weights keep internal_limit == limit and take the
         # byte-identical legacy path. The factor is clamped to >= 1 so a
         # misconfigured env override can never zero-out the fetch.
-        has_tier_weights = await self._zone_has_tier_weights(effective_zone_id)
+        has_tier_weights, tier_snapshot = await self._tier_weight_probe(effective_zone_id)
         internal_limit = (
             limit * max(1, self.config.tier_boost_overfetch_factor) if has_tier_weights else limit
+        )
+        # Pin the probe's snapshot so attach weights against the same rows
+        # the over-fetch decision saw (None → attach refreshes as before).
+        tier_pin: dict[str, list[Any]] | None = (
+            {effective_zone_id: tier_snapshot} if tier_snapshot is not None else None
         )
         start = time.perf_counter()
         self.last_search_timing = {}
@@ -1966,7 +2001,9 @@ class SearchDaemon:
                     if backend_results:
                         latency_ms = (time.perf_counter() - start) * 1000
                         self._track_latency(latency_ms)
-                        await self._attach_path_contexts(backend_results, zone_id=effective_zone_id)
+                        await self._attach_path_contexts(
+                            backend_results, zone_id=effective_zone_id, pinned_snapshots=tier_pin
+                        )
                         if internal_limit != limit:
                             backend_results = backend_results[:limit]
                         return self._with_search_timing(backend_results)
@@ -2008,7 +2045,9 @@ class SearchDaemon:
                     )
                 latency_ms = (time.perf_counter() - start) * 1000
                 self._track_latency(latency_ms)
-                await self._attach_path_contexts(keyword_results, zone_id=effective_zone_id)
+                await self._attach_path_contexts(
+                    keyword_results, zone_id=effective_zone_id, pinned_snapshots=tier_pin
+                )
                 if internal_limit != limit:
                     keyword_results = keyword_results[:limit]
                 return self._with_search_timing(keyword_results)
@@ -2057,7 +2096,9 @@ class SearchDaemon:
 
                     latency_ms = (time.perf_counter() - start) * 1000
                     self._track_latency(latency_ms)
-                    await self._attach_path_contexts(results, zone_id=effective_zone_id)
+                    await self._attach_path_contexts(
+                        results, zone_id=effective_zone_id, pinned_snapshots=tier_pin
+                    )
                     if internal_limit != limit:
                         results = results[:limit]
                     return self._with_search_timing(results)
@@ -2104,7 +2145,9 @@ class SearchDaemon:
                     self.last_search_timing.get("backend_ms", 0.0) + fallback_ms
                 )
 
-            await self._attach_path_contexts(results, zone_id=effective_zone_id)
+            await self._attach_path_contexts(
+                results, zone_id=effective_zone_id, pinned_snapshots=tier_pin
+            )
             if internal_limit != limit:
                 results = results[:limit]
             return self._with_search_timing(results)

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -34,6 +34,7 @@ import asyncio
 import contextlib
 import json
 import logging
+import math
 import os
 import time
 from collections.abc import Awaitable, Callable, Iterable
@@ -189,6 +190,35 @@ def _merge_backend_timing(total_ms: float, recorded: dict[str, float]) -> dict[s
     return timing
 
 
+# Codex review R7: env-sourced ranking knobs are untrusted input. The
+# widening factor is capped (route limit <= 100 × ReBAC over-fetch 3 ×
+# cap 10 keeps backend work bounded) and the floor ratio falls back to its
+# documented default when not a finite non-negative number — a NaN or
+# negative ratio would otherwise silently disable the uplift guard.
+_TIER_BOOST_OVERFETCH_CAP = 10
+_TIER_BOOST_FLOOR_DEFAULT = 0.25
+
+
+def _sane_overfetch_factor(raw: Any) -> int:
+    """Clamp the tier-boost over-fetch factor to [1, cap]."""
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return 1
+    return max(1, min(value, _TIER_BOOST_OVERFETCH_CAP))
+
+
+def _sane_floor_ratio(raw: Any) -> float:
+    """Return a finite non-negative floor ratio, else the default."""
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return _TIER_BOOST_FLOOR_DEFAULT
+    if not math.isfinite(value) or value < 0.0:
+        return _TIER_BOOST_FLOOR_DEFAULT
+    return value
+
+
 def _apply_tier_weight(
     result: Any,
     weight: float | None,
@@ -208,7 +238,10 @@ def _apply_tier_weight(
     range includes negatives. A plain multiply would let a demotion weight
     *raise* a negative score (-0.2 × 0.5 = -0.1), inverting tier semantics.
     Negative scores divide by the weight instead, so w < 1 always worsens
-    rank and w > 1 always improves it.
+    rank and w > 1 always improves it. ``tier_boost`` stamps the CONFIGURED
+    weight (the policy that applied), so the inverse transform is
+    ``score / tier_boost`` for non-negative scores and
+    ``score * tier_boost`` for negative ones (Codex review R7).
 
     Floor gate (uplifts only, active when ``floor_ratio > 0``): with a
     positive top the ratio comparison applies as documented. With a
@@ -1873,7 +1906,7 @@ class SearchDaemon:
         # Issue #4544: apply per-prefix ranking weights while attaching
         # context. top_score is the pre-boost max of this batch — the floor
         # gate must compare against the unweighted ranking.
-        floor_ratio = self.config.tier_boost_floor_ratio
+        floor_ratio = _sane_floor_ratio(self.config.tier_boost_floor_ratio)
         # top_score is the max of the daemon's candidate pool — computed
         # BEFORE route-level ReBAC filtering, like every other ranking
         # transform in this pipeline (RRF fusion ranks, attribute boost
@@ -2038,7 +2071,9 @@ class SearchDaemon:
         # misconfigured env override can never zero-out the fetch.
         has_tier_weights, tier_snapshot = await self._tier_weight_probe(effective_zone_id)
         internal_limit = (
-            limit * max(1, self.config.tier_boost_overfetch_factor) if has_tier_weights else limit
+            limit * _sane_overfetch_factor(self.config.tier_boost_overfetch_factor)
+            if has_tier_weights
+            else limit
         )
         # Pin the probe's snapshot so attach weights against the same rows
         # the over-fetch decision saw. Weights apply ONLY when the pool was

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -1685,6 +1685,29 @@ class SearchDaemon:
         self._path_context_engines_by_loop[loop] = engine
         return cache
 
+    async def _zone_has_tier_weights(self, zone_id: str) -> bool:
+        """True when the zone has any path-context weight != 1.0 (Issue #4544).
+
+        Decides whether _search_on_current_loop widens its candidate fetch.
+        Fail-soft: any error means "no over-fetch" — the search itself must
+        never break on a weight probe, and _attach_path_contexts still runs
+        its own fail-soft pass later in the same request. The refresh here is
+        the same fingerprint check attach pays, so the steady-state cost is
+        one cache hit.
+        """
+        try:
+            cache = await self._resolve_path_context_cache()
+            if cache is None:
+                return False
+            await cache.refresh_if_stale(zone_id)
+            snapshot = cache.snapshot_zone(zone_id)
+        except Exception as exc:
+            logger.debug("tier-weight probe failed for zone=%r: %s", zone_id, exc)
+            return False
+        if not snapshot:
+            return False
+        return any(rec.weight is not None and rec.weight != 1.0 for rec in snapshot)
+
     async def _attach_path_contexts(
         self,
         results: list[SearchResult],
@@ -1909,6 +1932,15 @@ class SearchDaemon:
         from nexus.contracts.constants import ROOT_ZONE_ID
 
         effective_zone_id = zone_id or ROOT_ZONE_ID
+        # Issue #4544: when the zone carries tier weights, widen every
+        # candidate fetch so a boost can promote a below-cutoff hit, then trim
+        # back to ``limit`` after _attach_path_contexts applies the weights.
+        # Zones without weights keep internal_limit == limit and take the
+        # byte-identical legacy path.
+        has_tier_weights = await self._zone_has_tier_weights(effective_zone_id)
+        internal_limit = (
+            limit * self.config.tier_boost_overfetch_factor if has_tier_weights else limit
+        )
         start = time.perf_counter()
         self.last_search_timing = {}
         hybrid_keyword_results: list[SearchResult] = []
@@ -1923,7 +1955,7 @@ class SearchDaemon:
                     backend_results = await self._search_via_backends(
                         query,
                         search_type=search_type,
-                        limit=limit,
+                        limit=internal_limit,
                         path_filter=path_filter,
                         zone_id=effective_zone_id,
                     )
@@ -1936,6 +1968,8 @@ class SearchDaemon:
                         latency_ms = (time.perf_counter() - start) * 1000
                         self._track_latency(latency_ms)
                         await self._attach_path_contexts(backend_results, zone_id=effective_zone_id)
+                        if internal_limit != limit:
+                            backend_results = backend_results[:limit]
                         return self._with_search_timing(backend_results)
 
                 # Keyword mode should use the daemon's keyword stack first.
@@ -1949,7 +1983,7 @@ class SearchDaemon:
                 keyword_start = time.perf_counter()
                 keyword_results = await self._keyword_search(
                     query,
-                    limit,
+                    internal_limit,
                     path_filter,
                     zone_id=effective_zone_id,
                 )
@@ -1976,6 +2010,8 @@ class SearchDaemon:
                 latency_ms = (time.perf_counter() - start) * 1000
                 self._track_latency(latency_ms)
                 await self._attach_path_contexts(keyword_results, zone_id=effective_zone_id)
+                if internal_limit != limit:
+                    keyword_results = keyword_results[:limit]
                 return self._with_search_timing(keyword_results)
             elif search_type == "hybrid" and not has_new_backends:
                 # Make lexical candidates explicit in hybrid mode so exact
@@ -1985,7 +2021,7 @@ class SearchDaemon:
                 keyword_start = time.perf_counter()
                 hybrid_keyword_results = await self._keyword_search(
                     query,
-                    limit * 3,
+                    internal_limit * 3,
                     path_filter,
                     zone_id=effective_zone_id,
                 )
@@ -1999,7 +2035,7 @@ class SearchDaemon:
                 backend_results = await self._search_via_backends(
                     query,
                     search_type=search_type,
-                    limit=limit,
+                    limit=internal_limit,
                     path_filter=path_filter,
                     alpha=alpha,
                     fusion_method=fusion_method,
@@ -2017,12 +2053,14 @@ class SearchDaemon:
                         results = self._fuse_ranked_results(
                             hybrid_keyword_results,
                             results,
-                            limit,
+                            internal_limit,
                         )
 
                     latency_ms = (time.perf_counter() - start) * 1000
                     self._track_latency(latency_ms)
                     await self._attach_path_contexts(results, zone_id=effective_zone_id)
+                    if internal_limit != limit:
+                        results = results[:limit]
                     return self._with_search_timing(results)
                 # Backend returned empty — fall through to the legacy stack
                 # so Zoekt / BM25S / inline FTS can still serve the query.
@@ -2032,11 +2070,13 @@ class SearchDaemon:
             # legacy keyword call — so only semantic and hybrid reach here.
             fallback_start = time.perf_counter()
             if search_type == "semantic":
-                results = await self._semantic_search(query, limit, path_filter, zone_id=zone_id)
+                results = await self._semantic_search(
+                    query, internal_limit, path_filter, zone_id=zone_id
+                )
             else:  # hybrid
                 results = await self._hybrid_search(
                     query,
-                    limit,
+                    internal_limit,
                     path_filter,
                     alpha,
                     fusion_method,
@@ -2066,6 +2106,8 @@ class SearchDaemon:
                 )
 
             await self._attach_path_contexts(results, zone_id=effective_zone_id)
+            if internal_limit != limit:
+                results = results[:limit]
             return self._with_search_timing(results)
 
         except TimeoutError:

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -208,9 +208,16 @@ def _apply_tier_weight(
     range includes negatives. A plain multiply would let a demotion weight
     *raise* a negative score (-0.2 × 0.5 = -0.1), inverting tier semantics.
     Negative scores divide by the weight instead, so w < 1 always worsens
-    rank and w > 1 always improves it. The floor gate only fires when
-    ``top_score`` is positive — a non-positive top means every result is a
-    weak match and the ratio comparison is meaningless.
+    rank and w > 1 always improves it.
+
+    Floor gate (uplifts only, active when ``floor_ratio > 0``): with a
+    positive top the ratio comparison applies as documented. With a
+    non-positive top (all-negative semantic sets) uplifts are suppressed
+    outright — dividing a deeply negative score by a large weight would
+    move it toward zero and leapfrog the entire set (-0.9/10 = -0.09
+    outranks a -0.1 top), exactly the weak-past-strong promotion the gate
+    exists to prevent (Codex review R5). ``floor_ratio == 0`` disables the
+    gate entirely, including this suppression.
     """
     if weight is None or weight == 1.0:
         return False
@@ -219,8 +226,7 @@ def _apply_tier_weight(
     if (
         weight > 1.0
         and floor_ratio > 0.0
-        and top_score > 0.0
-        and result.score < floor_ratio * top_score
+        and (top_score <= 0.0 or result.score < floor_ratio * top_score)
     ):
         return False
     result.score = result.score * weight if result.score >= 0.0 else result.score / weight

--- a/src/nexus/bricks/search/federated_search.py
+++ b/src/nexus/bricks/search/federated_search.py
@@ -871,6 +871,10 @@ def _strip_none_context(d: dict[str, Any]) -> dict[str, Any]:
     for key in ("context", "tier_boost"):
         if d.get(key) is None:
             d.pop(key, None)
+    # Issue #4544: round surviving tier_boost to 4 places to match the
+    # non-federated router's serialization (_serialize_search_result).
+    if d.get("tier_boost") is not None:
+        d["tier_boost"] = round(d["tier_boost"], 4)
     return d
 
 

--- a/src/nexus/bricks/search/federated_search.py
+++ b/src/nexus/bricks/search/federated_search.py
@@ -887,8 +887,23 @@ def _strip_none_context(d: dict[str, Any]) -> dict[str, Any]:
     # round() TypeError.
     tb = d.get("tier_boost")
     if tb is not None:
-        if isinstance(tb, (int, float)) and not isinstance(tb, bool) and math.isfinite(tb):
-            d["tier_boost"] = round(tb, 4)
+        keep = False
+        value = 0.0
+        if isinstance(tb, (int, float)) and not isinstance(tb, bool):
+            try:
+                # float() on an astronomically large JSON int raises
+                # OverflowError (Codex review R8) — that too must drop the
+                # field, never abort the fusion.
+                value = float(tb)
+            except OverflowError:
+                keep = False
+            else:
+                # Enforce the documented attribution range (mirrors the
+                # 0.1–10.0 API validation) — a value outside it cannot be a
+                # legitimately stamped weight.
+                keep = math.isfinite(value) and 0.1 <= value <= 10.0
+        if keep:
+            d["tier_boost"] = round(value, 4)
         else:
             d.pop("tier_boost", None)
     return d

--- a/src/nexus/bricks/search/federated_search.py
+++ b/src/nexus/bricks/search/federated_search.py
@@ -403,7 +403,14 @@ class FederatedSearchDispatcher:
             delegation.delegation_id,  # auth_token override
         )
 
-        # Convert remote response to result dicts with zone tagging
+        # Convert remote response to result dicts with zone tagging.
+        # Issue #4544 (Codex review R1): the server-side RPC search handler
+        # returns a ``{"results": [...]}`` envelope (handle_search in
+        # src/nexus/server/rpc/handlers/filesystem.py), which the bare-list
+        # check silently discarded — real remote zones contributed zero
+        # results. Accept both shapes.
+        if isinstance(raw_result, dict):
+            raw_result = raw_result.get("results", [])
         results = raw_result if isinstance(raw_result, list) else []
         for r in results:
             if isinstance(r, dict):

--- a/src/nexus/bricks/search/federated_search.py
+++ b/src/nexus/bricks/search/federated_search.py
@@ -864,11 +864,13 @@ def _merge_by_raw_score(
 
 def _strip_none_context(d: dict[str, Any]) -> dict[str, Any]:
     """Match the non-federated router's omit-when-None contract for
-    ``context``. Issue #3773 review (Rounds 5-6): every federated emission
-    path must route through this to avoid ``context: null`` leaking onto
-    the wire and creating a shape-drift between fusion strategies."""
-    if d.get("context") is None:
-        d.pop("context", None)
+    ``context`` (Issue #3773, review Rounds 5-6) and ``tier_boost``
+    (Issue #4544): every federated emission path must route through this so
+    ``null`` never leaks onto the wire and the fusion strategies stay
+    shape-consistent."""
+    for key in ("context", "tier_boost"):
+        if d.get(key) is None:
+            d.pop(key, None)
     return d
 
 

--- a/src/nexus/bricks/search/federated_search.py
+++ b/src/nexus/bricks/search/federated_search.py
@@ -21,6 +21,7 @@ Design decisions (from review):
 import asyncio
 import hashlib
 import logging
+import math
 import time
 import uuid
 from dataclasses import dataclass, field
@@ -880,8 +881,16 @@ def _strip_none_context(d: dict[str, Any]) -> dict[str, Any]:
             d.pop(key, None)
     # Issue #4544: round surviving tier_boost to 4 places to match the
     # non-federated router's serialization (_serialize_search_result).
-    if d.get("tier_boost") is not None:
-        d["tier_boost"] = round(d["tier_boost"], 4)
+    # Remote dicts cross a trust boundary (Codex review R7): a malformed or
+    # version-skewed peer sending a string/NaN/inf here must lose the
+    # attribution field, not abort the whole federated fusion via
+    # round() TypeError.
+    tb = d.get("tier_boost")
+    if tb is not None:
+        if isinstance(tb, (int, float)) and not isinstance(tb, bool) and math.isfinite(tb):
+            d["tier_boost"] = round(tb, 4)
+        else:
+            d.pop("tier_boost", None)
     return d
 
 

--- a/src/nexus/bricks/search/graph_search_service.py
+++ b/src/nexus/bricks/search/graph_search_service.py
@@ -135,7 +135,9 @@ async def graph_enhanced_search(
             pinned_snapshots=(
                 {effective_zone_id: tier_snapshot} if tier_snapshot is not None else None
             ),
-            apply_weights=tier_snapshot is not None,
+            # Same gate as the daemon paths (Codex review R3): weights may
+            # only mutate ranking when the pool was actually widened.
+            apply_weights=tier_snapshot is not None and fetch_limit > limit,
         )
     if fetch_limit != limit:
         results = results[:limit]

--- a/src/nexus/bricks/search/graph_search_service.py
+++ b/src/nexus/bricks/search/graph_search_service.py
@@ -114,8 +114,10 @@ async def graph_enhanced_search(
         has_weights, tier_snapshot = await probe(effective_zone_id)
     fetch_limit = limit
     if has_weights:
-        factor = max(
-            1, getattr(getattr(search_daemon, "config", None), "tier_boost_overfetch_factor", 1)
+        from nexus.bricks.search.daemon import _sane_overfetch_factor
+
+        factor = _sane_overfetch_factor(
+            getattr(getattr(search_daemon, "config", None), "tier_boost_overfetch_factor", 1)
         )
         fetch_limit = limit * factor
         if fetch_limit <= limit:

--- a/src/nexus/bricks/search/graph_search_service.py
+++ b/src/nexus/bricks/search/graph_search_service.py
@@ -102,8 +102,25 @@ async def graph_enhanced_search(
         logger.warning("graph_enhanced_search: backend does not support graph_search")
         return []
 
+    # Issue #4544 (Codex review R2): the graph path must honour the same
+    # probe → over-fetch → pinned-attach → trim workflow as daemon searches,
+    # otherwise a demoted top-N hit cannot be displaced by the backend's
+    # rank-N+1 candidate (it was never fetched). getattr guards keep mocked
+    # daemons (tests) working; a missing probe means no weights are applied.
+    has_weights = False
+    tier_snapshot: Any = None
+    probe = getattr(search_daemon, "_tier_weight_probe", None)
+    if probe is not None:
+        has_weights, tier_snapshot = await probe(effective_zone_id)
+    fetch_limit = limit
+    if has_weights:
+        factor = max(
+            1, getattr(getattr(search_daemon, "config", None), "tier_boost_overfetch_factor", 1)
+        )
+        fetch_limit = limit * factor
+
     results: list[BaseSearchResult] = await graph_search_fn(
-        query, zone_id=effective_zone_id, limit=limit, path_filter=path_filter
+        query, zone_id=effective_zone_id, limit=fetch_limit, path_filter=path_filter
     )
     # Issue #3773: attach admin-configured path contexts. Pass the caller's
     # effective zone so the daemon can fall back to it when the backend
@@ -112,5 +129,14 @@ async def graph_enhanced_search(
     # attach the wrong (or no) descriptions (Round-4 review).
     attach = getattr(search_daemon, "_attach_path_contexts", None)
     if attach is not None:
-        await attach(results, zone_id=effective_zone_id)
+        await attach(
+            results,
+            zone_id=effective_zone_id,
+            pinned_snapshots=(
+                {effective_zone_id: tier_snapshot} if tier_snapshot is not None else None
+            ),
+            apply_weights=tier_snapshot is not None,
+        )
+    if fetch_limit != limit:
+        results = results[:limit]
     return results

--- a/src/nexus/bricks/search/graph_search_service.py
+++ b/src/nexus/bricks/search/graph_search_service.py
@@ -118,6 +118,18 @@ async def graph_enhanced_search(
             1, getattr(getattr(search_daemon, "config", None), "tier_boost_overfetch_factor", 1)
         )
         fetch_limit = limit * factor
+        if fetch_limit <= limit:
+            # Codex review R4: weights exist but the pool will not be
+            # widened (factor <= 1) — ranking weights are suppressed for
+            # this request; count it at the decision point.
+            stats = getattr(search_daemon, "stats", None)
+            if stats is not None:
+                stats.tier_boost_suppressed_searches += 1
+            logger.warning(
+                "tier weights configured for zone=%r but graph pool not "
+                "widened (factor<=1) — ranking weights suppressed",
+                effective_zone_id,
+            )
 
     results: list[BaseSearchResult] = await graph_search_fn(
         query, zone_id=effective_zone_id, limit=fetch_limit, path_filter=path_filter

--- a/src/nexus/bricks/search/path_context.py
+++ b/src/nexus/bricks/search/path_context.py
@@ -207,21 +207,27 @@ class PathContextStore:
         return await self.list(zone_id=zone_id)
 
 
-def lookup_in_records(records: builtins.list[PathContextRecord], path: str) -> str | None:
-    """Longest-prefix lookup against a pre-sorted records list.
+def lookup_record_in_records(
+    records: builtins.list[PathContextRecord], path: str
+) -> PathContextRecord | None:
+    """Longest-prefix lookup returning the full record (Issue #4544).
 
     Records must be sorted by ``len(path_prefix)`` DESC so the first
-    slash-boundary match is the longest prefix. Shared by
-    :meth:`PathContextCache.lookup_cached` and daemon snapshot paths so
-    both code paths use the same matching logic.
+    slash-boundary match is the longest prefix.
     """
     for record in records:
         prefix = record.path_prefix
         if prefix == "":
-            return record.description
+            return record
         if path == prefix or path.startswith(prefix + "/"):
-            return record.description
+            return record
     return None
+
+
+def lookup_in_records(records: builtins.list[PathContextRecord], path: str) -> str | None:
+    """Longest-prefix lookup returning only the description (Issue #3773 contract)."""
+    record = lookup_record_in_records(records, path)
+    return record.description if record is not None else None
 
 
 def _coerce_datetime(value: Any) -> datetime:

--- a/src/nexus/bricks/search/path_context.py
+++ b/src/nexus/bricks/search/path_context.py
@@ -214,7 +214,14 @@ def lookup_record_in_records(
 
     Records must be sorted by ``len(path_prefix)`` DESC so the first
     slash-boundary match is the longest prefix.
+
+    The path is compared with its leading slashes stripped: stored prefixes
+    are always normalized slash-free by the API's ``_normalize_prefix``,
+    while live daemon result paths arrive slash-prefixed
+    (``/workspace/...``) — without this normalization no prefix ever
+    matches on a real deployment (#4544 live-e2e regression).
     """
+    path = path.lstrip("/")
     for record in records:
         prefix = record.path_prefix
         if prefix == "":

--- a/src/nexus/bricks/search/path_context.py
+++ b/src/nexus/bricks/search/path_context.py
@@ -36,6 +36,8 @@ class PathContextRecord:
     description: str
     created_at: datetime
     updated_at: datetime
+    # Issue #4544: per-prefix ranking weight; None ≡ 1.0 (no boost).
+    weight: float | None = None
 
 
 class PathContextStore:
@@ -48,8 +50,14 @@ class PathContextStore:
         self._async_session_factory = async_session_factory
         self._db_type = db_type
 
-    async def upsert(self, zone_id: str, path_prefix: str, description: str) -> None:
-        """Insert or replace a context row. updated_at refreshed on replace."""
+    async def upsert(
+        self, zone_id: str, path_prefix: str, description: str, weight: float | None = None
+    ) -> None:
+        """Insert or replace a context row. updated_at refreshed on replace.
+
+        When weight is omitted (None), an upsert clears any existing weight on the row
+        (PUT-replace semantics: the row is fully replaced, not merged).
+        """
         now = datetime.now(UTC).replace(tzinfo=None)
         async with self._async_session_factory() as session:
             if self._db_type == "postgresql":
@@ -57,11 +65,12 @@ class PathContextStore:
                     text(
                         """
                         INSERT INTO path_contexts
-                            (zone_id, path_prefix, description, created_at, updated_at)
+                            (zone_id, path_prefix, description, weight, created_at, updated_at)
                         VALUES
-                            (:zone_id, :path_prefix, :description, :now, :now)
+                            (:zone_id, :path_prefix, :description, :weight, :now, :now)
                         ON CONFLICT (zone_id, path_prefix) DO UPDATE
                         SET description = EXCLUDED.description,
+                            weight      = EXCLUDED.weight,
                             updated_at  = EXCLUDED.updated_at
                         """
                     ),
@@ -69,6 +78,7 @@ class PathContextStore:
                         "zone_id": zone_id,
                         "path_prefix": path_prefix,
                         "description": description,
+                        "weight": weight,
                         "now": now,
                     },
                 )
@@ -81,11 +91,12 @@ class PathContextStore:
                     text(
                         """
                         INSERT INTO path_contexts
-                            (zone_id, path_prefix, description, created_at, updated_at)
+                            (zone_id, path_prefix, description, weight, created_at, updated_at)
                         VALUES
-                            (:zone_id, :path_prefix, :description, :now, :now)
+                            (:zone_id, :path_prefix, :description, :weight, :now, :now)
                         ON CONFLICT (zone_id, path_prefix) DO UPDATE
                         SET description = excluded.description,
+                            weight      = excluded.weight,
                             updated_at  = excluded.updated_at
                         """
                     ),
@@ -93,6 +104,7 @@ class PathContextStore:
                         "zone_id": zone_id,
                         "path_prefix": path_prefix,
                         "description": description,
+                        "weight": weight,
                         "now": now,
                     },
                 )
@@ -120,7 +132,8 @@ class PathContextStore:
         the DB-creation locale, which is typically case/accent-insensitive).
         """
         query = (
-            "SELECT zone_id, path_prefix, description, created_at, updated_at FROM path_contexts"
+            "SELECT zone_id, path_prefix, description, weight, created_at, updated_at "
+            "FROM path_contexts"
         )
         params: dict[str, Any] = {}
         if zone_id is not None:
@@ -137,8 +150,9 @@ class PathContextStore:
                 zone_id=row[0],
                 path_prefix=row[1],
                 description=row[2],
-                created_at=_coerce_datetime(row[3]),
-                updated_at=_coerce_datetime(row[4]),
+                weight=row[3],
+                created_at=_coerce_datetime(row[4]),
+                updated_at=_coerce_datetime(row[5]),
             )
             for row in rows
         ]

--- a/src/nexus/bricks/search/results.py
+++ b/src/nexus/bricks/search/results.py
@@ -45,6 +45,8 @@ class BaseSearchResult:
     macro_text: str | None = None
     macro_line_start: int | None = None
     macro_line_end: int | None = None
+    # Issue #4544: per-prefix source-tier weight applied to score (None = unboosted)
+    tier_boost: float | None = None
 
     @property
     def zone_qualified_path(self) -> str | None:

--- a/src/nexus/bricks/search/results.py
+++ b/src/nexus/bricks/search/results.py
@@ -45,7 +45,11 @@ class BaseSearchResult:
     macro_text: str | None = None
     macro_line_start: int | None = None
     macro_line_end: int | None = None
-    # Issue #4544: per-prefix source-tier weight applied to score (None = unboosted)
+    # Issue #4544: configured per-prefix source-tier weight whose policy was
+    # applied to score (None = unboosted). The transform is signed-safe:
+    # non-negative scores multiplied by the weight, negative scores divided
+    # by it — so the pre-boost score is score/tier_boost when score >= 0
+    # and score*tier_boost when score < 0.
     tier_boost: float | None = None
 
     @property

--- a/src/nexus/cli/commands/path_context.py
+++ b/src/nexus/cli/commands/path_context.py
@@ -42,6 +42,12 @@ def path_context() -> None:
 @click.argument("path_prefix")
 @click.argument("description")
 @click.option("--zone-id", default="root", show_default=True, help="Zone scope")
+@click.option(
+    "--weight",
+    type=float,
+    default=None,
+    help="Ranking weight 0.1-10.0 (<1 demotes, >1 boosts; omit to clear).",
+)
 @add_backend_options
 @click.pass_context
 def path_context_set(
@@ -49,6 +55,7 @@ def path_context_set(
     path_prefix: str,
     description: str,
     zone_id: str,
+    weight: float | None,
     remote_url: str | None,
     remote_api_key: str | None,
 ) -> None:
@@ -56,6 +63,7 @@ def path_context_set(
 
     Example:
         nexus path-context set src/nexus/bricks/search "Hybrid search brick"
+        nexus path-context set chat/logs "Chat logs" --weight 0.5
     """
     from nexus.cli.api_client import get_api_client_from_options
 
@@ -64,14 +72,23 @@ def path_context_set(
     try:
         result = client.put(
             "/api/v2/path-contexts/",
-            {"zone_id": zone_id, "path_prefix": path_prefix, "description": description},
+            {
+                "zone_id": zone_id,
+                "path_prefix": path_prefix,
+                "description": description,
+                "weight": weight,
+            },
         )
     except Exception as e:
         console.print(f"[nexus.error]Error:[/nexus.error] {e}")
         raise SystemExit(1) from e
+    # Rich markup: escape the opening bracket so "[weight=...]" renders
+    # literally instead of being parsed as a style tag.
+    weight_note = f" \\[weight={result.get('weight')}]" if result.get("weight") is not None else ""
     console.print(
         f"[nexus.success]set[/nexus.success] "
-        f"{result.get('zone_id')}:{result.get('path_prefix')} = {result.get('description')!r}"
+        f"{result.get('zone_id')}:{result.get('path_prefix')} = "
+        f"{result.get('description')!r}{weight_note}"
     )
 
 
@@ -112,8 +129,12 @@ def path_context_list(
         console.print("[nexus.warning]No path contexts configured[/nexus.warning]")
         return
     for entry in contexts:
+        weight_note = (
+            f" \\[weight={entry.get('weight')}]" if entry.get("weight") is not None else ""
+        )
         console.print(
-            f"  {entry.get('zone_id')}:{entry.get('path_prefix')} -> {entry.get('description')}"
+            f"  {entry.get('zone_id')}:{entry.get('path_prefix')} -> "
+            f"{entry.get('description')}{weight_note}"
         )
 
 

--- a/src/nexus/server/api/v2/routers/path_contexts.py
+++ b/src/nexus/server/api/v2/routers/path_contexts.py
@@ -80,6 +80,9 @@ class PathContextIn(BaseModel):
     zone_id: str = Field(default=ROOT_ZONE_ID, max_length=255)
     path_prefix: str = Field(max_length=1024)
     description: str = Field(max_length=4096, min_length=1)
+    # Issue #4544: per-prefix ranking weight; None ≡ 1.0. PUT-replace
+    # semantics — omitting weight on an update clears any stored value.
+    weight: float | None = Field(default=None, ge=0.1, le=10.0)
 
     @field_validator("path_prefix")
     @classmethod
@@ -91,6 +94,7 @@ class PathContextOut(BaseModel):
     zone_id: str
     path_prefix: str
     description: str
+    weight: float | None = None
     created_at: Any
     updated_at: Any
 
@@ -224,11 +228,12 @@ async def upsert_context(
     store: PathContextStore = Depends(_get_store),
 ) -> dict[str, Any]:
     """Upsert a path context (admin only)."""
-    await store.upsert(body.zone_id, body.path_prefix, body.description)
+    await store.upsert(body.zone_id, body.path_prefix, body.description, weight=body.weight)
     return {
         "zone_id": body.zone_id,
         "path_prefix": body.path_prefix,
         "description": body.description,
+        "weight": body.weight,
     }
 
 
@@ -260,6 +265,7 @@ async def list_contexts(
                 "zone_id": r.zone_id,
                 "path_prefix": r.path_prefix,
                 "description": r.description,
+                "weight": r.weight,
                 "created_at": r.created_at.isoformat() if r.created_at else None,
                 "updated_at": r.updated_at.isoformat() if r.updated_at else None,
             }

--- a/src/nexus/server/api/v2/routers/search.py
+++ b/src/nexus/server/api/v2/routers/search.py
@@ -839,6 +839,12 @@ async def search_query_batch(
             ctx = getattr(r, "context", None)
             if ctx is not None:
                 entry["context"] = ctx
+            # Issue #4544 (Codex review R1): batch hits must carry the same
+            # omit-when-None tier_boost attribution as single-query results,
+            # or batch consumers see multiplied scores they cannot explain.
+            tier_boost = getattr(r, "tier_boost", None)
+            if tier_boost is not None:
+                entry["tier_boost"] = round(tier_boost, 4)
             formatted.append(entry)
         response_queries.append(
             {

--- a/src/nexus/server/api/v2/routers/search.py
+++ b/src/nexus/server/api/v2/routers/search.py
@@ -180,6 +180,11 @@ def _serialize_search_result(result: Any) -> dict[str, Any]:
     context = getattr(result, "context", None)
     if context is not None:
         out["context"] = context
+    # Issue #4544: attribute the per-prefix tier weight applied to the score
+    # (omitted when unboosted to keep responses compact).
+    tier_boost = getattr(result, "tier_boost", None)
+    if tier_boost is not None:
+        out["tier_boost"] = round(tier_boost, 4)
     macro_text = getattr(result, "macro_text", None)
     if macro_text is not None:
         out["macro_text"] = macro_text

--- a/src/nexus/storage/models/path_context.py
+++ b/src/nexus/storage/models/path_context.py
@@ -8,7 +8,7 @@ matching the Alembic-managed production schema.
 
 from datetime import UTC, datetime
 
-from sqlalchemy import DateTime, Index, Integer, String, Text, UniqueConstraint
+from sqlalchemy import DateTime, Float, Index, Integer, String, Text, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column
 
 from nexus.contracts.constants import ROOT_ZONE_ID
@@ -29,6 +29,8 @@ class PathContextModel(Base):
     )
     path_prefix: Mapped[str] = mapped_column(String(1024), nullable=False)
     description: Mapped[str] = mapped_column(Text, nullable=False)
+    # Issue #4544: per-prefix ranking weight; NULL ≡ 1.0 (no boost).
+    weight: Mapped[float | None] = mapped_column(Float, nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(),
         nullable=False,

--- a/tests/integration/bricks/search/test_daemon_context_attach.py
+++ b/tests/integration/bricks/search/test_daemon_context_attach.py
@@ -19,6 +19,7 @@ CREATE TABLE path_contexts (
     zone_id TEXT NOT NULL DEFAULT 'root',
     path_prefix TEXT NOT NULL,
     description TEXT NOT NULL,
+    weight FLOAT,
     created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     UNIQUE(zone_id, path_prefix)

--- a/tests/integration/bricks/search/test_daemon_context_attach.py
+++ b/tests/integration/bricks/search/test_daemon_context_attach.py
@@ -32,6 +32,8 @@ def _bare_daemon(cache) -> "SearchDaemon":
     class _Stats:
         path_context_attach_failures = 0
         path_context_resolve_failures = 0
+        tier_boost_probe_failures = 0
+        tier_boost_suppressed_searches = 0
 
     daemon.stats = _Stats()
     return daemon
@@ -141,6 +143,8 @@ class TestRealDaemonAttach:
         class _Stats:
             path_context_attach_failures = 0
             path_context_resolve_failures = 0
+            tier_boost_probe_failures = 0
+            tier_boost_suppressed_searches = 0
 
         daemon.stats = _Stats()
 
@@ -188,6 +192,8 @@ class TestAttachStaleFallbackOnRefreshError:
         class _Stats:
             path_context_attach_failures = 0
             path_context_resolve_failures = 0
+            tier_boost_probe_failures = 0
+            tier_boost_suppressed_searches = 0
 
         daemon.stats = _Stats()
 

--- a/tests/integration/bricks/search/test_daemon_context_attach.py
+++ b/tests/integration/bricks/search/test_daemon_context_attach.py
@@ -509,6 +509,15 @@ class TestSerializerEmitsContext:
         out = _serialize_search_result(r)
         assert "context" not in out
 
+    def test_tier_boost_emitted_when_set_and_omitted_when_none(self) -> None:
+        from nexus.bricks.search.daemon import SearchResult
+        from nexus.server.api.v2.routers.search import _serialize_search_result
+
+        boosted = SearchResult(path="a", chunk_text="", score=0.5, tier_boost=0.5)
+        plain = SearchResult(path="b", chunk_text="", score=0.5)
+        assert _serialize_search_result(boosted)["tier_boost"] == 0.5
+        assert "tier_boost" not in _serialize_search_result(plain)
+
 
 class TestFullFlowStoreAttachSerialize:
     """Chain the real store, real cache refresh+lookup, and real serializer.

--- a/tests/integration/bricks/search/test_daemon_context_attach.py
+++ b/tests/integration/bricks/search/test_daemon_context_attach.py
@@ -96,7 +96,7 @@ class TestAttachUsesCallerZone:
             ),
         ]
 
-        async def _attach(items, *, zone_id):
+        async def _attach(items, *, zone_id, **_kw):
             effective = zone_id or "root"
             zone = items[0].zone_id or effective
             await cache.refresh_if_stale(zone)
@@ -463,7 +463,7 @@ class TestGraphSearchContextAttachment:
         # to a local SearchDaemon-style helper powered by the cache.
         backend = SimpleNamespace(graph_search=_fake_graph_search)
 
-        async def _attach(results, *, zone_id=None):
+        async def _attach(results, *, zone_id=None, **_kw):
             zones = {(r.zone_id or zone_id or "root") for r in results}
             for zone in zones:
                 await cache.refresh_if_stale(zone)

--- a/tests/integration/bricks/search/test_daemon_context_attach.py
+++ b/tests/integration/bricks/search/test_daemon_context_attach.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pytest
 import pytest_asyncio
 from sqlalchemy.ext.asyncio import (
@@ -12,6 +14,28 @@ from sqlalchemy.ext.asyncio import (
 
 from nexus.bricks.search.path_context import PathContextCache, PathContextStore
 from nexus.bricks.search.results import BaseSearchResult
+
+if TYPE_CHECKING:
+    from nexus.bricks.search.daemon import SearchDaemon
+
+
+def _bare_daemon(cache) -> "SearchDaemon":
+    """Attach-only daemon harness (no startup())."""
+    from nexus.bricks.search.daemon import DaemonConfig, SearchDaemon
+
+    daemon = SearchDaemon.__new__(SearchDaemon)
+    daemon.config = DaemonConfig()
+    daemon._path_context_cache = cache
+    daemon._path_context_cache_by_loop = {}
+    daemon._path_context_engines_by_loop = {}
+
+    class _Stats:
+        path_context_attach_failures = 0
+        path_context_resolve_failures = 0
+
+    daemon.stats = _Stats()
+    return daemon
+
 
 CREATE_TABLE_SQL = """
 CREATE TABLE path_contexts (
@@ -602,3 +626,62 @@ class TestFullFlowStoreAttachSerialize:
         assert out["context"] == "search brick"  # longer prefix wins
 
         await engine.dispose()
+
+
+class TestTierWeightAttach:
+    """Issue #4544: _attach_path_contexts applies per-prefix weights."""
+
+    @pytest.mark.asyncio
+    async def test_demotion_reorders_below_equal_relevance_peer(self, cache) -> None:
+        from nexus.bricks.search.daemon import SearchResult
+
+        await cache._store.upsert("root", "chat", "Chat transcripts", weight=0.5)
+        daemon = _bare_daemon(cache)
+        noisy = SearchResult(path="chat/a.md", chunk_text="", score=1.0)
+        curated = SearchResult(path="docs/a.md", chunk_text="", score=0.9)
+        results = [noisy, curated]
+        await daemon._attach_path_contexts(results, zone_id="root")
+        assert noisy.score == 0.5 and noisy.tier_boost == 0.5
+        assert curated.score == 0.9 and curated.tier_boost is None
+        assert results == [curated, noisy]  # re-sorted in place
+
+    @pytest.mark.asyncio
+    async def test_no_weights_leaves_list_untouched(self, cache) -> None:
+        from nexus.bricks.search.daemon import SearchResult
+
+        # Fixture rows have no weight → byte-identity: same objects, order, scores.
+        daemon = _bare_daemon(cache)
+        r1 = SearchResult(path="docs/a.md", chunk_text="", score=0.4)
+        r2 = SearchResult(path="docs/b.md", chunk_text="", score=0.9)
+        results = [r1, r2]  # deliberately unsorted
+        await daemon._attach_path_contexts(results, zone_id="root")
+        assert results == [r1, r2]
+        assert r1.score == 0.4 and r2.score == 0.9
+        assert r1.tier_boost is None and r2.tier_boost is None
+        assert r1.context == "Project documentation"  # context still attached
+
+    @pytest.mark.asyncio
+    async def test_uplift_gated_by_floor_ratio(self, cache) -> None:
+        from nexus.bricks.search.daemon import SearchResult
+
+        await cache._store.upsert("root", "docs", "Project documentation", weight=2.0)
+        daemon = _bare_daemon(cache)
+        strong = SearchResult(path="src/x.py", chunk_text="", score=1.0)
+        weak_boosted = SearchResult(path="docs/a.md", chunk_text="", score=0.1)
+        near_peer_boosted = SearchResult(path="docs/b.md", chunk_text="", score=0.6)
+        results = [strong, near_peer_boosted, weak_boosted]
+        await daemon._attach_path_contexts(results, zone_id="root")
+        assert weak_boosted.score == 0.1 and weak_boosted.tier_boost is None
+        assert near_peer_boosted.score == 1.2 and near_peer_boosted.tier_boost == 2.0
+        assert results[0] is near_peer_boosted  # promoted past strong
+
+    @pytest.mark.asyncio
+    async def test_double_attach_is_idempotent(self, cache) -> None:
+        from nexus.bricks.search.daemon import SearchResult
+
+        await cache._store.upsert("root", "chat", "Chat transcripts", weight=0.5)
+        daemon = _bare_daemon(cache)
+        r = SearchResult(path="chat/a.md", chunk_text="", score=1.0)
+        await daemon._attach_path_contexts([r], zone_id="root")
+        await daemon._attach_path_contexts([r], zone_id="root")
+        assert r.score == 0.5  # not 0.25

--- a/tests/integration/bricks/search/test_federated_search.py
+++ b/tests/integration/bricks/search/test_federated_search.py
@@ -1106,3 +1106,56 @@ class TestTierBoostFederated:
         merged = _merge_by_raw_score([("za", [za]), ("zb", [zb])], limit=2)
         assert [m["path"] for m in merged] == ["docs/b.md", "chat/a.md"]
         assert merged[1]["tier_boost"] == 0.4
+
+
+class TestRemoteSearchEnvelope:
+    """Codex review R1: the server-side RPC search handler returns a
+    ``{"results": [...]}`` envelope; the bare-list check discarded it and
+    real remote zones contributed zero results."""
+
+    def _dispatcher_with_remote(self, raw_result):
+        from unittest.mock import MagicMock
+
+        from nexus.bricks.search.federated_search import FederatedSearchDispatcher
+
+        registry = MagicMock()
+        registry.is_remote.return_value = True
+        transport = MagicMock()
+        transport.call_rpc.return_value = raw_result
+        registry.get_transport.return_value = transport
+        dispatcher = FederatedSearchDispatcher.__new__(FederatedSearchDispatcher)
+        dispatcher._registry = registry
+        dispatcher._mint_search_delegation = MagicMock(return_value=MagicMock(delegation_id="d-1"))
+        return dispatcher
+
+    @pytest.mark.asyncio
+    async def test_dict_envelope_unwrapped(self) -> None:
+        dispatcher = self._dispatcher_with_remote(
+            {"results": [{"path": "/a.md", "score": 0.9, "tier_boost": 0.5}]}
+        )
+        results = await dispatcher._search_remote_zone(
+            zone_id="zr",
+            query="q",
+            search_type="hybrid",
+            limit=5,
+            path_filter=None,
+            alpha=0.5,
+            fusion_method="rrf",
+        )
+        assert len(results) == 1
+        assert results[0]["zone_id"] == "zr"
+        assert results[0]["tier_boost"] == 0.5
+
+    @pytest.mark.asyncio
+    async def test_bare_list_still_accepted(self) -> None:
+        dispatcher = self._dispatcher_with_remote([{"path": "/a.md", "score": 0.9}])
+        results = await dispatcher._search_remote_zone(
+            zone_id="zr",
+            query="q",
+            search_type="hybrid",
+            limit=5,
+            path_filter=None,
+            alpha=0.5,
+            fusion_method="rrf",
+        )
+        assert len(results) == 1 and results[0]["zone_qualified_path"] == "zr:/a.md"

--- a/tests/integration/bricks/search/test_federated_search.py
+++ b/tests/integration/bricks/search/test_federated_search.py
@@ -1159,3 +1159,33 @@ class TestRemoteSearchEnvelope:
             fusion_method="rrf",
         )
         assert len(results) == 1 and results[0]["zone_qualified_path"] == "zr:/a.md"
+
+
+class TestTierBoostTrustBoundary:
+    """Codex review R7: remote dicts cross a trust boundary — malformed
+    tier_boost must lose the field, never abort fusion via round()."""
+
+    def test_string_tier_boost_dropped(self) -> None:
+        from nexus.bricks.search.federated_search import _strip_none_context
+
+        d = _strip_none_context({"path": "a", "score": 1.0, "tier_boost": "0.5"})
+        assert "tier_boost" not in d
+
+    def test_nan_and_inf_dropped(self) -> None:
+        from nexus.bricks.search.federated_search import _strip_none_context
+
+        assert "tier_boost" not in _strip_none_context(
+            {"path": "a", "score": 1.0, "tier_boost": float("nan")}
+        )
+        assert "tier_boost" not in _strip_none_context(
+            {"path": "a", "score": 1.0, "tier_boost": float("inf")}
+        )
+
+    def test_bool_dropped_and_valid_rounded(self) -> None:
+        from nexus.bricks.search.federated_search import _strip_none_context
+
+        assert "tier_boost" not in _strip_none_context(
+            {"path": "a", "score": 1.0, "tier_boost": True}
+        )
+        d = _strip_none_context({"path": "a", "score": 1.0, "tier_boost": 0.123456})
+        assert d["tier_boost"] == 0.1235

--- a/tests/integration/bricks/search/test_federated_search.py
+++ b/tests/integration/bricks/search/test_federated_search.py
@@ -1189,3 +1189,22 @@ class TestTierBoostTrustBoundary:
         )
         d = _strip_none_context({"path": "a", "score": 1.0, "tier_boost": 0.123456})
         assert d["tier_boost"] == 0.1235
+
+    def test_huge_json_integer_dropped_not_crash(self) -> None:
+        # Codex review R8: float(10**400) raises OverflowError — must drop
+        # the field, never abort fusion.
+        from nexus.bricks.search.federated_search import _strip_none_context
+
+        d = _strip_none_context({"path": "a", "score": 1.0, "tier_boost": 10**400})
+        assert "tier_boost" not in d
+
+    def test_out_of_range_attribution_dropped(self) -> None:
+        # Mirrors the 0.1-10.0 API validation range.
+        from nexus.bricks.search.federated_search import _strip_none_context
+
+        assert "tier_boost" not in _strip_none_context(
+            {"path": "a", "score": 1.0, "tier_boost": 100.0}
+        )
+        assert "tier_boost" not in _strip_none_context(
+            {"path": "a", "score": 1.0, "tier_boost": 0.01}
+        )

--- a/tests/integration/bricks/search/test_federated_search.py
+++ b/tests/integration/bricks/search/test_federated_search.py
@@ -1064,3 +1064,45 @@ class TestFederatedRRFContextShape:
         assert any(d.get("context") is None for d in raw)
         stripped = [_strip_none_context(d) for d in raw]
         assert all("context" not in d for d in stripped)
+
+
+# =============================================================================
+# Issue #4544: tier_boost federated wire hygiene
+# =============================================================================
+
+
+class TestTierBoostFederated:
+    """Issue #4544: owning-zone weights flow through the federated merge."""
+
+    def test_strip_removes_null_tier_boost_and_keeps_value(self) -> None:
+        from nexus.bricks.search.federated_search import _strip_none_context
+
+        assert "tier_boost" not in _strip_none_context(
+            {"path": "a", "score": 1.0, "tier_boost": None}
+        )
+        assert (
+            _strip_none_context({"path": "a", "score": 1.0, "tier_boost": 0.5})["tier_boost"] == 0.5
+        )
+
+    def test_result_to_dict_omits_unset_tier_boost(self) -> None:
+        from nexus.bricks.search.federated_search import _result_to_dict
+        from nexus.bricks.search.results import BaseSearchResult
+
+        plain = BaseSearchResult(path="a", chunk_text="", score=1.0, zone_id="z1")
+        boosted = BaseSearchResult(path="b", chunk_text="", score=0.5, zone_id="z1", tier_boost=0.5)
+        assert "tier_boost" not in _result_to_dict(plain)
+        assert _result_to_dict(boosted)["tier_boost"] == 0.5
+
+    def test_merge_by_raw_score_orders_on_boosted_scores(self) -> None:
+        from nexus.bricks.search.federated_search import _merge_by_raw_score
+        from nexus.bricks.search.results import BaseSearchResult
+
+        # zone-a demoted its chat hit (1.0 -> 0.4) before returning; zone-b's
+        # unweighted 0.6 must now outrank it in the merged list.
+        za = BaseSearchResult(
+            path="chat/a.md", chunk_text="", score=0.4, zone_id="za", tier_boost=0.4
+        )
+        zb = BaseSearchResult(path="docs/b.md", chunk_text="", score=0.6, zone_id="zb")
+        merged = _merge_by_raw_score([("za", [za]), ("zb", [zb])], limit=2)
+        assert [m["path"] for m in merged] == ["docs/b.md", "chat/a.md"]
+        assert merged[1]["tier_boost"] == 0.4

--- a/tests/integration/bricks/search/test_path_context.py
+++ b/tests/integration/bricks/search/test_path_context.py
@@ -21,6 +21,7 @@ CREATE TABLE path_contexts (
     zone_id TEXT NOT NULL DEFAULT 'root',
     path_prefix TEXT NOT NULL,
     description TEXT NOT NULL,
+    weight FLOAT,
     created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     UNIQUE(zone_id, path_prefix)
@@ -328,3 +329,30 @@ class TestPathContextCacheLRU:
         # review feedback. Re-accessing z1 creates a fresh entry using the
         # same Lock object, preserving mutual-exclusion identity.
         assert "z1" in cache._locks
+
+
+class TestWeightColumn:
+    """Issue #4544: nullable per-prefix ranking weight."""
+
+    @pytest.mark.asyncio
+    async def test_upsert_and_list_weight_roundtrip(self, store) -> None:
+        await store.upsert("root", "chat/logs", "Chat transcripts", weight=0.5)
+        records = await store.list("root")
+        rec = next(r for r in records if r.path_prefix == "chat/logs")
+        assert rec.weight == 0.5
+
+    @pytest.mark.asyncio
+    async def test_weight_defaults_to_none(self, store) -> None:
+        await store.upsert("root", "docs/curated", "Curated docs")
+        records = await store.list("root")
+        rec = next(r for r in records if r.path_prefix == "docs/curated")
+        assert rec.weight is None
+
+    @pytest.mark.asyncio
+    async def test_upsert_without_weight_resets_existing_weight(self, store) -> None:
+        # PUT-replace semantics: an upsert that omits weight clears it.
+        await store.upsert("root", "chat/logs", "Chat transcripts", weight=0.5)
+        await store.upsert("root", "chat/logs", "Chat transcripts v2")
+        records = await store.list("root")
+        rec = next(r for r in records if r.path_prefix == "chat/logs")
+        assert rec.weight is None

--- a/tests/integration/server/api/v2/routers/test_path_contexts_router.py
+++ b/tests/integration/server/api/v2/routers/test_path_contexts_router.py
@@ -21,6 +21,7 @@ CREATE TABLE path_contexts (
     zone_id TEXT NOT NULL DEFAULT 'root',
     path_prefix TEXT NOT NULL,
     description TEXT NOT NULL,
+    weight FLOAT,
     created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     UNIQUE(zone_id, path_prefix)

--- a/tests/integration/server/api/v2/routers/test_path_contexts_router.py
+++ b/tests/integration/server/api/v2/routers/test_path_contexts_router.py
@@ -212,3 +212,35 @@ class TestPathContextRouter:
             # Own zone or implicit: allowed.
             assert c.get("/api/v2/path-contexts/", params={"zone_id": "root"}).status_code == 200
             assert c.get("/api/v2/path-contexts/").status_code == 200
+
+
+class TestWeightField:
+    """Issue #4544: weight on the path-contexts CRUD surface."""
+
+    def test_put_persists_and_echoes_weight(self, client: TestClient) -> None:
+        resp = client.put(
+            "/api/v2/path-contexts/",
+            json={"path_prefix": "chat/logs", "description": "Chat", "weight": 0.5},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["weight"] == 0.5
+        listed = client.get("/api/v2/path-contexts/").json()["contexts"]
+        entry = next(c for c in listed if c["path_prefix"] == "chat/logs")
+        assert entry["weight"] == 0.5
+
+    def test_list_emits_null_weight_for_unset(self, client: TestClient) -> None:
+        client.put(
+            "/api/v2/path-contexts/",
+            json={"path_prefix": "docs", "description": "Docs"},
+        )
+        listed = client.get("/api/v2/path-contexts/").json()["contexts"]
+        entry = next(c for c in listed if c["path_prefix"] == "docs")
+        assert entry["weight"] is None
+
+    def test_weight_bounds_rejected(self, client: TestClient) -> None:
+        for bad in (0.05, 10.5, 0.0, -1.0):
+            resp = client.put(
+                "/api/v2/path-contexts/",
+                json={"path_prefix": "x", "description": "d", "weight": bad},
+            )
+            assert resp.status_code == 422, f"weight={bad} must be rejected"

--- a/tests/integration/server/api/v2/routers/test_path_contexts_router.py
+++ b/tests/integration/server/api/v2/routers/test_path_contexts_router.py
@@ -244,3 +244,12 @@ class TestWeightField:
                 json={"path_prefix": "x", "description": "d", "weight": bad},
             )
             assert resp.status_code == 422, f"weight={bad} must be rejected"
+
+    def test_weight_boundary_values_accepted(self, client) -> None:
+        for ok in (0.1, 10.0):
+            resp = client.put(
+                "/api/v2/path-contexts/",
+                json={"path_prefix": f"b{ok}", "description": "d", "weight": ok},
+            )
+            assert resp.status_code == 200, f"weight={ok} must be accepted"
+            assert resp.json()["weight"] == ok

--- a/tests/unit/bricks/search/test_daemon_backend_routing.py
+++ b/tests/unit/bricks/search/test_daemon_backend_routing.py
@@ -34,7 +34,7 @@ def _daemon_with_backend_result(search_type_seen: list[str]) -> Any:
         self._last_latency_ms = latency_ms
 
     async def _attach_path_contexts(
-        self: Any, results: list[SearchResult], *, zone_id: str
+        self: Any, results: list[SearchResult], *, zone_id: str, pinned_snapshots: Any = None
     ) -> None:
         self._last_context_zone = zone_id
 
@@ -136,7 +136,7 @@ async def test_concurrent_searches_return_request_local_timing_snapshots() -> No
         self._last_latency_ms = latency_ms
 
     async def _attach_path_contexts(
-        self: Any, results: list[SearchResult], *, zone_id: str
+        self: Any, results: list[SearchResult], *, zone_id: str, pinned_snapshots: Any = None
     ) -> None:
         self._last_context_zone = zone_id
 

--- a/tests/unit/bricks/search/test_daemon_backend_routing.py
+++ b/tests/unit/bricks/search/test_daemon_backend_routing.py
@@ -34,7 +34,7 @@ def _daemon_with_backend_result(search_type_seen: list[str]) -> Any:
         self._last_latency_ms = latency_ms
 
     async def _attach_path_contexts(
-        self: Any, results: list[SearchResult], *, zone_id: str, pinned_snapshots: Any = None
+        self: Any, results: list[SearchResult], *, zone_id: str, **_attach_kwargs: Any
     ) -> None:
         self._last_context_zone = zone_id
 
@@ -136,7 +136,7 @@ async def test_concurrent_searches_return_request_local_timing_snapshots() -> No
         self._last_latency_ms = latency_ms
 
     async def _attach_path_contexts(
-        self: Any, results: list[SearchResult], *, zone_id: str, pinned_snapshots: Any = None
+        self: Any, results: list[SearchResult], *, zone_id: str, **_attach_kwargs: Any
     ) -> None:
         self._last_context_zone = zone_id
 

--- a/tests/unit/bricks/search/test_daemon_fusion_params.py
+++ b/tests/unit/bricks/search/test_daemon_fusion_params.py
@@ -151,7 +151,9 @@ async def test_search_threads_fusion_params_to_backends() -> None:
     def _track_latency(self: Any, latency_ms: float) -> None:
         self._last_latency_ms = latency_ms
 
-    async def _attach_path_contexts(self: Any, results: Any, *, zone_id: str) -> None:
+    async def _attach_path_contexts(
+        self: Any, results: Any, *, zone_id: str, pinned_snapshots: Any = None
+    ) -> None:
         self._last_context_zone = zone_id
 
     async def _search_via_backends(self: Any, *args: Any, **kwargs: Any) -> list[SearchResult]:

--- a/tests/unit/bricks/search/test_daemon_fusion_params.py
+++ b/tests/unit/bricks/search/test_daemon_fusion_params.py
@@ -152,7 +152,7 @@ async def test_search_threads_fusion_params_to_backends() -> None:
         self._last_latency_ms = latency_ms
 
     async def _attach_path_contexts(
-        self: Any, results: Any, *, zone_id: str, pinned_snapshots: Any = None
+        self: Any, results: Any, *, zone_id: str, **_attach_kwargs: Any
     ) -> None:
         self._last_context_zone = zone_id
 

--- a/tests/unit/bricks/search/test_daemon_tier_boost_overfetch.py
+++ b/tests/unit/bricks/search/test_daemon_tier_boost_overfetch.py
@@ -1,0 +1,152 @@
+"""Conditional over-fetch for tier weights (Issue #4544).
+
+When the effective zone has a path_contexts weight != 1.0 the daemon must
+widen its backend fetch (limit × tier_boost_overfetch_factor), apply the
+weights, re-sort, and trim back to the requested limit — so a boost can
+promote a hit that the un-widened fusion would have cut. Zones with no
+weights must hit the byte-identical legacy path (no widened fetch).
+"""
+
+from __future__ import annotations
+
+from types import MethodType
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from nexus.bricks.search.path_context import PathContextCache, PathContextStore
+
+CREATE_TABLE_SQL = """
+CREATE TABLE path_contexts (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    zone_id TEXT NOT NULL DEFAULT 'root',
+    path_prefix TEXT NOT NULL,
+    description TEXT NOT NULL,
+    weight FLOAT,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(zone_id, path_prefix)
+)
+"""
+
+
+@pytest_asyncio.fixture
+async def cache():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:", future=True)
+    async with engine.begin() as conn:
+        await conn.exec_driver_sql(CREATE_TABLE_SQL)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    store = PathContextStore(async_session_factory=factory, db_type="sqlite")
+    yield PathContextCache(store=store)
+    await engine.dispose()
+
+
+def _make_daemon(cache: PathContextCache) -> Any:
+    """Keyword-only daemon: N corpus docs, keyword_search honours ``limit``
+    and records the limits it was asked for."""
+    from nexus.bricks.search.daemon import DaemonConfig, SearchDaemon, SearchResult
+
+    corpus = [
+        SearchResult(path="chat/a.md", chunk_text="", score=10.0, search_type="keyword"),
+        SearchResult(path="chat/b.md", chunk_text="", score=9.0, search_type="keyword"),
+        SearchResult(path="docs/x.md", chunk_text="", score=8.0, search_type="keyword"),
+    ]
+
+    class FakeFtsBackend:
+        def __init__(self) -> None:
+            self.requested_limits: list[int] = []
+
+        async def keyword_search(
+            self,
+            query: str,
+            path: str,
+            limit: int,
+            zone_id: str,
+            *,
+            timing: dict[str, float] | None = None,
+        ) -> list[Any]:
+            self.requested_limits.append(limit)
+            # Fresh copies: score mutation must not leak between searches.
+            return [
+                SearchResult(
+                    path=r.path,
+                    chunk_text=r.chunk_text,
+                    score=r.score,
+                    search_type=r.search_type,
+                )
+                for r in corpus[:limit]
+            ]
+
+    class FakeVectorBackend:
+        async def semantic_search(
+            self, qvec: list[float], path: str, limit: int, zone_id: str
+        ) -> list[Any]:
+            return []
+
+    class _Stats:
+        path_context_attach_failures = 0
+        path_context_resolve_failures = 0
+
+    daemon: Any = SearchDaemon.__new__(SearchDaemon)
+    daemon.last_search_timing = {}
+    daemon._initialized = True
+    daemon._fts_backend = FakeFtsBackend()
+    daemon._vector_backend = FakeVectorBackend()
+    daemon._path_context_cache = cache
+    daemon._path_context_cache_by_loop = {}
+    daemon._path_context_engines_by_loop = {}
+    daemon.stats = _Stats()
+    daemon._track_latency = MethodType(lambda self, ms: None, daemon)
+    daemon.config = DaemonConfig(page_aggregation=False)
+    return daemon
+
+
+class TestOverfetchAndTrim:
+    @pytest.mark.asyncio
+    async def test_demotion_promotes_below_cutoff_hit_into_returned_set(self, cache) -> None:
+        # limit=2 without weights returns the two chat docs. Demoting chat
+        # must let docs/x.md (rank 3, beyond the un-widened fetch) into the
+        # top 2 — this is exactly the promotion the over-fetch exists for.
+        await cache._store.upsert("root", "chat", "Chat transcripts", weight=0.5)
+        daemon = _make_daemon(cache)
+        results = await daemon._search_on_current_loop(
+            "q", search_type="keyword", limit=2, zone_id="root"
+        )
+        assert len(results) == 2  # trimmed back to the requested limit
+        assert daemon._fts_backend.requested_limits == [2 * 3]  # widened fetch
+        paths = [r.path for r in results]
+        assert "docs/x.md" in paths
+        assert results[0].path == "docs/x.md"  # 8.0 beats 10.0*0.5
+
+    @pytest.mark.asyncio
+    async def test_no_weights_keeps_legacy_fetch_size(self, cache) -> None:
+        await cache._store.upsert("root", "chat", "Chat transcripts")  # no weight
+        daemon = _make_daemon(cache)
+        results = await daemon._search_on_current_loop(
+            "q", search_type="keyword", limit=2, zone_id="root"
+        )
+        assert daemon._fts_backend.requested_limits == [2]  # byte-identical path
+        assert [r.path for r in results] == ["chat/a.md", "chat/b.md"]
+        assert all(r.tier_boost is None for r in results)
+
+    @pytest.mark.asyncio
+    async def test_weight_one_rows_do_not_trigger_overfetch(self, cache) -> None:
+        await cache._store.upsert("root", "chat", "Chat transcripts", weight=1.0)
+        daemon = _make_daemon(cache)
+        await daemon._search_on_current_loop("q", search_type="keyword", limit=2, zone_id="root")
+        assert daemon._fts_backend.requested_limits == [2]
+
+    @pytest.mark.asyncio
+    async def test_probe_failure_fails_soft(self, cache) -> None:
+        daemon = _make_daemon(cache)
+
+        async def _boom(self: Any) -> Any:
+            raise RuntimeError("cache resolution exploded")
+
+        daemon._resolve_path_context_cache = MethodType(_boom, daemon)
+        results = await daemon._search_on_current_loop(
+            "q", search_type="keyword", limit=2, zone_id="root"
+        )
+        assert [r.path for r in results] == ["chat/a.md", "chat/b.md"]

--- a/tests/unit/bricks/search/test_daemon_tier_boost_overfetch.py
+++ b/tests/unit/bricks/search/test_daemon_tier_boost_overfetch.py
@@ -161,3 +161,95 @@ class TestOverfetchAndTrim:
         )
         assert daemon._fts_backend.requested_limits == [2]  # clamped, not zeroed
         assert len(results) == 2
+
+
+class TestProbeFailureSuppressesWeights:
+    """Codex review R2: a failed probe means the pool was NOT widened, so
+    attach must not apply ranking weights for that request — otherwise a
+    recovered cache would weight against a pool already cut to limit."""
+
+    @pytest.mark.asyncio
+    async def test_attach_apply_weights_false_keeps_scores_but_attaches_context(
+        self, cache
+    ) -> None:
+        from nexus.bricks.search.daemon import SearchResult
+
+        await cache._store.upsert("root", "chat", "Chat transcripts", weight=0.5)
+        daemon = _make_daemon(cache)
+        r = SearchResult(path="chat/a.md", chunk_text="", score=1.0)
+        await daemon._attach_path_contexts([r], zone_id="root", apply_weights=False)
+        assert r.score == 1.0 and r.tier_boost is None  # ranking untouched
+        assert r.context == "Chat transcripts"  # context still attached
+
+    @pytest.mark.asyncio
+    async def test_probe_failure_search_never_weights(self, cache) -> None:
+        # Weighted zone + probe that raises: results must come back with
+        # legacy fetch size, unweighted scores, and no tier_boost stamps —
+        # even though attach's own refresh CAN see the weight row.
+        from types import MethodType
+
+        await cache._store.upsert("root", "chat", "Chat transcripts", weight=0.5)
+        daemon = _make_daemon(cache)
+        real_resolve = daemon._resolve_path_context_cache
+        calls = {"n": 0}
+
+        async def _flaky_resolve(self):
+            calls["n"] += 1
+            if calls["n"] == 1:  # probe's call fails, attach's succeeds
+                raise RuntimeError("transient")
+            return await real_resolve()
+
+        daemon._resolve_path_context_cache = MethodType(_flaky_resolve, daemon)
+        results = await daemon._search_on_current_loop(
+            "q", search_type="keyword", limit=2, zone_id="root"
+        )
+        assert daemon._fts_backend.requested_limits == [2]  # not widened
+        assert all(r.tier_boost is None for r in results)  # not weighted
+        assert results[0].score == 10.0  # pristine score
+
+
+class TestGraphPathOverfetch:
+    """Codex review R2: graph search must widen, weight, and trim like the
+    daemon paths — a demoted top-N hit must be displaceable by rank N+1."""
+
+    @pytest.mark.asyncio
+    async def test_graph_demotion_promotes_next_candidate(self, cache) -> None:
+        from nexus.bricks.search.daemon import SearchResult
+        from nexus.bricks.search.graph_search_service import graph_enhanced_search
+
+        await cache._store.upsert("root", "chat", "Chat transcripts", weight=0.5)
+        daemon = _make_daemon(cache)
+
+        corpus = [
+            SearchResult(path="chat/a.md", chunk_text="", score=10.0),
+            SearchResult(path="chat/b.md", chunk_text="", score=9.0),
+            SearchResult(path="docs/x.md", chunk_text="", score=8.0),
+        ]
+        seen_limits: list[int] = []
+
+        class _Backend:
+            async def graph_search(self, query, *, zone_id, limit, path_filter=None):
+                seen_limits.append(limit)
+                return [
+                    SearchResult(path=r.path, chunk_text=r.chunk_text, score=r.score)
+                    for r in corpus[:limit]
+                ]
+
+        daemon._backend = _Backend()
+        results = await graph_enhanced_search(
+            "q",
+            "hybrid",
+            2,
+            None,
+            0.5,
+            "low",
+            record_store=None,
+            async_session_factory=None,
+            search_daemon=daemon,
+            zone_id="root",
+        )
+        assert seen_limits == [2 * 3]  # widened graph fetch
+        assert len(results) == 2  # trimmed back
+        assert results[0].path == "docs/x.md"  # 8.0 beats 10.0*0.5
+        assert results[0].tier_boost is None
+        assert results[1].tier_boost == 0.5

--- a/tests/unit/bricks/search/test_daemon_tier_boost_overfetch.py
+++ b/tests/unit/bricks/search/test_daemon_tier_boost_overfetch.py
@@ -88,6 +88,8 @@ def _make_daemon(cache: PathContextCache) -> Any:
     class _Stats:
         path_context_attach_failures = 0
         path_context_resolve_failures = 0
+        tier_boost_probe_failures = 0
+        tier_boost_suppressed_searches = 0
 
     daemon: Any = SearchDaemon.__new__(SearchDaemon)
     daemon.last_search_timing = {}
@@ -161,6 +163,26 @@ class TestOverfetchAndTrim:
         )
         assert daemon._fts_backend.requested_limits == [2]  # clamped, not zeroed
         assert len(results) == 2
+        # Codex review R3: an un-widened pool must stay UNWEIGHTED — a
+        # demoted top-N hit could never be displaced by rank N+1, so the
+        # weight is suppressed (and counted) rather than applied.
+        assert all(r.tier_boost is None for r in results)
+        assert results[0].score == 10.0
+        assert daemon.stats.tier_boost_suppressed_searches == 1
+
+    @pytest.mark.asyncio
+    async def test_factor_one_suppresses_weights_and_counts(self, cache) -> None:
+        from nexus.bricks.search.daemon import SearchResult  # noqa: F401
+
+        await cache._store.upsert("root", "chat", "Chat transcripts", weight=0.5)
+        daemon = _make_daemon(cache)
+        daemon.config.tier_boost_overfetch_factor = 1
+        results = await daemon._search_on_current_loop(
+            "q", search_type="keyword", limit=2, zone_id="root"
+        )
+        assert daemon._fts_backend.requested_limits == [2]
+        assert all(r.tier_boost is None for r in results)
+        assert daemon.stats.tier_boost_suppressed_searches == 1
 
 
 class TestProbeFailureSuppressesWeights:
@@ -206,6 +228,9 @@ class TestProbeFailureSuppressesWeights:
         assert daemon._fts_backend.requested_limits == [2]  # not widened
         assert all(r.tier_boost is None for r in results)  # not weighted
         assert results[0].score == 10.0  # pristine score
+        # Codex review R3: the bypass must be observable.
+        assert daemon.stats.tier_boost_probe_failures == 1
+        assert daemon.stats.tier_boost_suppressed_searches == 1
 
 
 class TestGraphPathOverfetch:

--- a/tests/unit/bricks/search/test_daemon_tier_boost_overfetch.py
+++ b/tests/unit/bricks/search/test_daemon_tier_boost_overfetch.py
@@ -184,6 +184,22 @@ class TestOverfetchAndTrim:
         assert all(r.tier_boost is None for r in results)
         assert daemon.stats.tier_boost_suppressed_searches == 1
 
+    @pytest.mark.asyncio
+    async def test_factor_one_counts_even_when_weighted_hit_beyond_cutoff(self, cache) -> None:
+        # Codex review R4: the uplifted prefix's first candidate sits at
+        # rank N+1 (docs/x.md, rank 3, limit 2). With factor=1 nothing
+        # weighted is ever RETURNED, so attach alone could never observe
+        # the bypass — the decision-point counter must fire regardless.
+        await cache._store.upsert("root", "docs", "Curated docs", weight=2.0)
+        daemon = _make_daemon(cache)
+        daemon.config.tier_boost_overfetch_factor = 1
+        results = await daemon._search_on_current_loop(
+            "q", search_type="keyword", limit=2, zone_id="root"
+        )
+        assert [r.path for r in results] == ["chat/a.md", "chat/b.md"]
+        assert all(r.tier_boost is None for r in results)
+        assert daemon.stats.tier_boost_suppressed_searches == 1
+
 
 class TestProbeFailureSuppressesWeights:
     """Codex review R2: a failed probe means the pool was NOT widened, so

--- a/tests/unit/bricks/search/test_daemon_tier_boost_overfetch.py
+++ b/tests/unit/bricks/search/test_daemon_tier_boost_overfetch.py
@@ -150,3 +150,14 @@ class TestOverfetchAndTrim:
             "q", search_type="keyword", limit=2, zone_id="root"
         )
         assert [r.path for r in results] == ["chat/a.md", "chat/b.md"]
+
+    @pytest.mark.asyncio
+    async def test_zero_overfetch_factor_clamped_to_one(self, cache) -> None:
+        await cache._store.upsert("root", "chat", "Chat transcripts", weight=0.5)
+        daemon = _make_daemon(cache)
+        daemon.config.tier_boost_overfetch_factor = 0
+        results = await daemon._search_on_current_loop(
+            "q", search_type="keyword", limit=2, zone_id="root"
+        )
+        assert daemon._fts_backend.requested_limits == [2]  # clamped, not zeroed
+        assert len(results) == 2

--- a/tests/unit/bricks/search/test_tier_boost.py
+++ b/tests/unit/bricks/search/test_tier_boost.py
@@ -178,3 +178,46 @@ class TestSignedScoreWeighting:
         r = _result(score=0.8)
         assert _apply_tier_weight(r, 0.5, top_score=1.0, floor_ratio=0.25) is True
         assert r.score == 0.4
+
+
+class TestKnobSanitizers:
+    """Codex review R7: env-sourced knobs are untrusted — NaN/negative
+    floor ratios must not silently disable the uplift guard, and the
+    over-fetch factor must be bounded above."""
+
+    def test_overfetch_factor_capped(self) -> None:
+        from nexus.bricks.search.daemon import _sane_overfetch_factor
+
+        assert _sane_overfetch_factor(10**9) == 10
+        assert _sane_overfetch_factor(0) == 1
+        assert _sane_overfetch_factor(-5) == 1
+        assert _sane_overfetch_factor(3) == 3
+        assert _sane_overfetch_factor("bogus") == 1
+
+    def test_floor_ratio_falls_back_on_invalid(self) -> None:
+        from nexus.bricks.search.daemon import _sane_floor_ratio
+
+        assert _sane_floor_ratio(float("nan")) == 0.25
+        assert _sane_floor_ratio(float("inf")) == 0.25
+        assert _sane_floor_ratio(-0.5) == 0.25
+        assert _sane_floor_ratio(None) == 0.25
+        assert _sane_floor_ratio(0.0) == 0.0  # explicit opt-out preserved
+        assert _sane_floor_ratio(0.4) == 0.4
+
+    def test_nan_floor_ratio_keeps_gate_active_end_to_end(self) -> None:
+        # A NaN ratio previously made `floor_ratio > 0` false and silently
+        # disabled the guard; the sanitizer restores the default gate.
+        from nexus.bricks.search.daemon import _sane_floor_ratio
+
+        ratio = _sane_floor_ratio(float("nan"))
+        r = _result(score=0.2)
+        assert _apply_tier_weight(r, 10.0, top_score=1.0, floor_ratio=ratio) is False
+        assert r.score == 0.2
+
+    def test_negative_score_inverse_transform_documented(self) -> None:
+        # tier_boost stamps the CONFIGURED weight; inverse for negative
+        # scores is score * tier_boost (divide was applied).
+        r = _result(score=-0.2)
+        assert _apply_tier_weight(r, 0.5, top_score=-0.1, floor_ratio=0.25) is True
+        assert r.score == -0.4 and r.tier_boost == 0.5
+        assert r.score * r.tier_boost == -0.2  # pre-boost recovered

--- a/tests/unit/bricks/search/test_tier_boost.py
+++ b/tests/unit/bricks/search/test_tier_boost.py
@@ -134,3 +134,37 @@ class TestSlashNormalizedLookup:
     def test_description_wrapper_matches_slashed_path(self) -> None:
         records = [_rec("docs")]
         assert lookup_in_records(records, "/docs/a.md") == "desc:docs"
+
+
+class TestSignedScoreWeighting:
+    """Codex review R1: pgvector semantic scores are raw cosine similarity
+    and can be negative. A plain multiply would let a demotion RAISE a
+    negative score (-0.2 × 0.5 = -0.1), inverting tier semantics; negative
+    scores divide by the weight instead."""
+
+    def test_demotion_worsens_negative_score(self) -> None:
+        r = _result(score=-0.2)
+        assert _apply_tier_weight(r, 0.5, top_score=-0.1, floor_ratio=0.25) is True
+        assert r.score == -0.4  # more negative = worse rank
+
+    def test_uplift_improves_negative_score(self) -> None:
+        r = _result(score=-0.2)
+        assert _apply_tier_weight(r, 2.0, top_score=-0.1, floor_ratio=0.25) is True
+        assert r.score == -0.1  # toward zero = better rank
+
+    def test_floor_gate_disabled_when_top_score_non_positive(self) -> None:
+        # All-negative result sets: the ratio comparison is meaningless, so
+        # uplifts must not be blanket-blocked.
+        r = _result(score=-0.9)
+        assert _apply_tier_weight(r, 2.0, top_score=-0.1, floor_ratio=0.25) is True
+
+    def test_floor_gate_still_blocks_negative_score_under_positive_top(self) -> None:
+        # A negative score is by definition below ratio*top when top > 0.
+        r = _result(score=-0.2)
+        assert _apply_tier_weight(r, 2.0, top_score=1.0, floor_ratio=0.25) is False
+        assert r.score == -0.2
+
+    def test_positive_scores_unchanged_semantics(self) -> None:
+        r = _result(score=0.8)
+        assert _apply_tier_weight(r, 0.5, top_score=1.0, floor_ratio=0.25) is True
+        assert r.score == 0.4

--- a/tests/unit/bricks/search/test_tier_boost.py
+++ b/tests/unit/bricks/search/test_tier_boost.py
@@ -1,0 +1,111 @@
+"""Per-prefix ranking weight primitives (Issue #4544).
+
+Covers the record-grain prefix lookup, the score-multiply helper with the
+uplift-only floor-ratio gate, and idempotency (a result already stamped
+with tier_boost is never boosted twice — batch_search re-attaches).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from nexus.bricks.search.daemon import _apply_tier_weight
+from nexus.bricks.search.path_context import (
+    PathContextRecord,
+    lookup_in_records,
+    lookup_record_in_records,
+)
+from nexus.bricks.search.results import BaseSearchResult
+
+
+def _rec(prefix: str, weight: float | None = None) -> PathContextRecord:
+    now = datetime(2026, 7, 31)
+    return PathContextRecord(
+        zone_id="root",
+        path_prefix=prefix,
+        description=f"desc:{prefix or 'root'}",
+        created_at=now,
+        updated_at=now,
+        weight=weight,
+    )
+
+
+def _result(path: str = "chat/logs/a.md", score: float = 1.0) -> BaseSearchResult:
+    return BaseSearchResult(path=path, chunk_text="", score=score)
+
+
+class TestLookupRecord:
+    def test_returns_longest_prefix_record(self) -> None:
+        records = sorted(
+            [_rec("chat", weight=0.9), _rec("chat/logs", weight=0.5)],
+            key=lambda r: len(r.path_prefix),
+            reverse=True,
+        )
+        rec = lookup_record_in_records(records, "chat/logs/a.md")
+        assert rec is not None and rec.weight == 0.5
+
+    def test_no_match_returns_none(self) -> None:
+        assert lookup_record_in_records([_rec("docs")], "src/a.py") is None
+
+    def test_description_wrapper_unchanged(self) -> None:
+        # lookup_in_records keeps its historical contract.
+        assert lookup_in_records([_rec("docs")], "docs/a.md") == "desc:docs"
+        assert lookup_in_records([_rec("docs")], "src/a.py") is None
+
+
+class TestApplyTierWeight:
+    def test_none_and_one_are_noops(self) -> None:
+        r = _result(score=1.0)
+        assert _apply_tier_weight(r, None, top_score=1.0, floor_ratio=0.25) is False
+        assert _apply_tier_weight(r, 1.0, top_score=1.0, floor_ratio=0.25) is False
+        assert r.score == 1.0 and r.tier_boost is None
+
+    def test_demotion_applies_and_stamps(self) -> None:
+        r = _result(score=1.0)
+        assert _apply_tier_weight(r, 0.5, top_score=1.0, floor_ratio=0.25) is True
+        assert r.score == 0.5 and r.tier_boost == 0.5
+
+    def test_demotion_ignores_floor_gate(self) -> None:
+        # Far-below-top result still gets demoted.
+        r = _result(score=0.01)
+        assert _apply_tier_weight(r, 0.5, top_score=1.0, floor_ratio=0.25) is True
+        assert r.score == 0.005
+
+    def test_uplift_blocked_below_floor(self) -> None:
+        r = _result(score=0.1)  # 0.1 < 0.25 * 1.0
+        assert _apply_tier_weight(r, 2.0, top_score=1.0, floor_ratio=0.25) is False
+        assert r.score == 0.1 and r.tier_boost is None
+
+    def test_uplift_applies_above_floor(self) -> None:
+        r = _result(score=0.5)
+        assert _apply_tier_weight(r, 2.0, top_score=1.0, floor_ratio=0.25) is True
+        assert r.score == 1.0 and r.tier_boost == 2.0
+
+    def test_zero_ratio_disables_gate(self) -> None:
+        r = _result(score=0.001)
+        assert _apply_tier_weight(r, 2.0, top_score=1.0, floor_ratio=0.0) is True
+
+    def test_idempotent_on_stamped_result(self) -> None:
+        # batch_search re-runs attach on already-boosted results: no w².
+        r = _result(score=1.0)
+        assert _apply_tier_weight(r, 0.5, top_score=1.0, floor_ratio=0.25) is True
+        assert _apply_tier_weight(r, 0.5, top_score=1.0, floor_ratio=0.25) is False
+        assert r.score == 0.5
+
+
+class TestConfigKnobs:
+    def test_defaults(self) -> None:
+        from nexus.bricks.search.daemon import DaemonConfig
+
+        cfg = DaemonConfig()
+        assert cfg.tier_boost_overfetch_factor == 3
+        assert cfg.tier_boost_floor_ratio == 0.25
+
+    def test_env_overrides(self, monkeypatch) -> None:
+        from nexus.bricks.search.daemon import DaemonConfig
+
+        monkeypatch.setenv("NEXUS_SEARCH_TIER_BOOST_OVERFETCH", "5")
+        monkeypatch.setenv("NEXUS_SEARCH_TIER_BOOST_FLOOR_RATIO", "0.5")
+        cfg = DaemonConfig()
+        assert cfg.tier_boost_overfetch_factor == 5
+        assert cfg.tier_boost_floor_ratio == 0.5

--- a/tests/unit/bricks/search/test_tier_boost.py
+++ b/tests/unit/bricks/search/test_tier_boost.py
@@ -147,16 +147,26 @@ class TestSignedScoreWeighting:
         assert _apply_tier_weight(r, 0.5, top_score=-0.1, floor_ratio=0.25) is True
         assert r.score == -0.4  # more negative = worse rank
 
-    def test_uplift_improves_negative_score(self) -> None:
+    def test_uplift_improves_negative_score_when_gate_disabled(self) -> None:
+        # floor_ratio=0 opts out of the gate: divide semantics apply.
         r = _result(score=-0.2)
-        assert _apply_tier_weight(r, 2.0, top_score=-0.1, floor_ratio=0.25) is True
+        assert _apply_tier_weight(r, 2.0, top_score=-0.1, floor_ratio=0.0) is True
         assert r.score == -0.1  # toward zero = better rank
 
-    def test_floor_gate_disabled_when_top_score_non_positive(self) -> None:
-        # All-negative result sets: the ratio comparison is meaningless, so
-        # uplifts must not be blanket-blocked.
+    def test_uplift_suppressed_when_all_scores_negative(self) -> None:
+        # Codex review R5: with an all-negative set, dividing a deeply
+        # negative score by a large weight would leapfrog the entire set
+        # (-0.9/10 = -0.09 outranks a -0.1 top) — exactly the
+        # weak-past-strong promotion the gate exists to prevent.
         r = _result(score=-0.9)
-        assert _apply_tier_weight(r, 2.0, top_score=-0.1, floor_ratio=0.25) is True
+        assert _apply_tier_weight(r, 10.0, top_score=-0.1, floor_ratio=0.25) is False
+        assert r.score == -0.9 and r.tier_boost is None
+
+    def test_demotion_still_applies_when_all_scores_negative(self) -> None:
+        # Demotion on a negative score only worsens rank — never gated.
+        r = _result(score=-0.2)
+        assert _apply_tier_weight(r, 0.5, top_score=-0.1, floor_ratio=0.25) is True
+        assert r.score == -0.4
 
     def test_floor_gate_still_blocks_negative_score_under_positive_top(self) -> None:
         # A negative score is by definition below ratio*top when top > 0.

--- a/tests/unit/bricks/search/test_tier_boost.py
+++ b/tests/unit/bricks/search/test_tier_boost.py
@@ -109,3 +109,28 @@ class TestConfigKnobs:
         cfg = DaemonConfig()
         assert cfg.tier_boost_overfetch_factor == 5
         assert cfg.tier_boost_floor_ratio == 0.5
+
+
+class TestSlashNormalizedLookup:
+    """Live-stack regression (#4544 e2e): daemon result paths carry a leading
+    slash (``/workspace/...``) while the API's ``_normalize_prefix`` strips it
+    from stored prefixes (``workspace/...``). The lookup must match anyway —
+    without normalization, context and tier-weight attach silently never fire
+    on real deployments."""
+
+    def test_slashed_path_matches_normalized_prefix(self) -> None:
+        records = [_rec("workspace/tierboost/noisy", weight=0.5)]
+        rec = lookup_record_in_records(records, "/workspace/tierboost/noisy/log-a.md")
+        assert rec is not None and rec.weight == 0.5
+
+    def test_slashed_path_exact_prefix_match(self) -> None:
+        records = [_rec("docs")]
+        assert lookup_record_in_records(records, "/docs") is not None
+
+    def test_unslashed_path_still_matches(self) -> None:
+        records = [_rec("docs")]
+        assert lookup_record_in_records(records, "docs/a.md") is not None
+
+    def test_description_wrapper_matches_slashed_path(self) -> None:
+        records = [_rec("docs")]
+        assert lookup_in_records(records, "/docs/a.md") == "desc:docs"

--- a/tests/unit/cli/test_path_context_cli.py
+++ b/tests/unit/cli/test_path_context_cli.py
@@ -36,9 +36,28 @@ class TestPathContextSet:
         assert result.exit_code == 0, result.output
         fake.put.assert_called_once_with(
             "/api/v2/path-contexts/",
-            {"zone_id": "root", "path_prefix": "src", "description": "x"},
+            {"zone_id": "root", "path_prefix": "src", "description": "x", "weight": None},
         )
         assert "root:src" in result.output
+
+    def test_weight_option_sent_in_payload(self) -> None:
+        runner = CliRunner(env=_ENV)
+        fake = _patched_client(
+            put={
+                "zone_id": "root",
+                "path_prefix": "chat",
+                "description": "x",
+                "weight": 0.5,
+            }
+        )
+        with patch("nexus.cli.api_client.get_api_client_from_options", return_value=fake):
+            result = runner.invoke(
+                path_context,
+                ["set", "chat", "x", "--weight", "0.5", "--remote-url", MOCK_URL],
+            )
+        assert result.exit_code == 0, result.output
+        assert fake.put.call_args.args[1]["weight"] == 0.5
+        assert "[weight=0.5]" in result.output
 
     def test_custom_zone_id(self) -> None:
         runner = CliRunner(env=_ENV)


### PR DESCRIPTION
Closes #4544.

## What

Admins can now seed a `weight` (0.1–10.0, NULL ≡ 1.0) on `path_contexts` rows to express source-authority tiers. The search daemon multiplies result scores by the longest-prefix-matched weight, stamps a `tier_boost` attribution field, and re-sorts — so noisy prefixes (chat transcripts, archives) rank below curated docs of equal relevance.

## How

- **Schema/store**: additive nullable `weight` column (migration `add_path_context_weight`, single head), carried through `PathContextRecord` / store / LRU cache. Upsert has PUT-replace semantics (omitting `weight` clears it).
- **Boost** in `_attach_path_contexts`: multiply + `tier_boost` stamp + stable re-sort. Idempotency guard prevents double-apply (`batch_search` re-attaches). Uplift-only floor-ratio gate (default 0.25, `NEXUS_SEARCH_TIER_BOOST_FLOOR_RATIO`, 0 disables): metadata can reorder near-peers but can't lift weak matches past strong ones; demotions always apply.
- **Conditional over-fetch**: zones with weights fetch `limit × max(1, factor)` (default 3, `NEXUS_SEARCH_TIER_BOOST_OVERFETCH`) then trim after boosting, so a boost can promote below-cutoff hits. Zones without weights take the byte-identical legacy path — pinned by regression tests.
- **Surface**: `weight` on `/api/v2/path-contexts/` CRUD (422 outside 0.1–10.0), `tier_boost` in search responses (emitted only when set), CLI `--weight`, surface-coverage YAML regenerated.
- **Federated**: correct by construction (each zone's daemon boosts before the merge); `tier_boost: null` stripped from the wire, rounding parity with the single-zone serializer.
- **Live-e2e fix**: the API normalizes stored prefixes slash-free while live daemon paths are slash-prefixed, so prefix lookup (including #3773 context attach) never matched on a real deployment. Fixed via `path.lstrip("/")` at the lookup chokepoint + regression tests.

## Verification

- Full search/storage/router/CLI suites green; byte-identity pins (#4541 fusion params, #4542 pooling, #3773 attach) untouched.
- Live stack (`nexus up --build`, demo preset): feature e2e 23/23 — weight CRUD bounds, demotion reordering, `tier_boost` attribution, context attach, PUT-replace clear, no-weight byte-identity.
- `scripts/test_build_perf_e2e.py`: 23 passed / 0 failed (HERB 8/8, RPC p50 8ms < 50ms, auto-index + delete propagation green).

Pre-existing on develop, not touched here: 9 `tests/surface_coverage` failures (env + story-data) and `test_brick_compliance.py` collection error (`lifecycle_adapter` removed on develop).

Design spec: `docs/superpowers/specs/2026-07-31-prefix-weight-boost-design.md`.