### PR TITLE
fix(search): harden #4542 final-list pooling — 10-round adversarial review follow-up

### DIFF
--- a/docs/surface-coverage/api-rpc-surface-coverage.yaml
+++ b/docs/surface-coverage/api-rpc-surface-coverage.yaml
@@ -7642,7 +7642,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/expand
-      source: src/nexus/server/api/v2/routers/search.py:1653
+      source: src/nexus/server/api/v2/routers/search.py:1625
   profiles:
     lite: supported
     sandbox: supported
@@ -7666,7 +7666,7 @@ operations:
       source: src/nexus/bricks/search/search_service.py:1791
     http:
       name: POST /api/v2/search/glob
-      source: src/nexus/server/api/v2/routers/search.py:1534
+      source: src/nexus/server/api/v2/routers/search.py:1506
     mcp:
       name: nexus_glob
       source: src/nexus/config/tool_profiles.yaml:1
@@ -7693,7 +7693,7 @@ operations:
       source: src/nexus/bricks/search/search_service.py:2101
     http:
       name: POST /api/v2/search/grep
-      source: src/nexus/server/api/v2/routers/search.py:1411
+      source: src/nexus/server/api/v2/routers/search.py:1383
     mcp:
       name: nexus_grep
       source: src/nexus/config/tool_profiles.yaml:1
@@ -7746,7 +7746,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/index
-      source: src/nexus/server/api/v2/routers/search.py:1596
+      source: src/nexus/server/api/v2/routers/search.py:1568
   profiles:
     lite: supported
     sandbox: supported
@@ -7764,7 +7764,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/index-directory
-      source: src/nexus/server/api/v2/routers/search.py:1795
+      source: src/nexus/server/api/v2/routers/search.py:1767
   profiles:
     lite: supported
     sandbox: supported
@@ -7781,7 +7781,7 @@ operations:
   transports:
     http:
       name: GET /api/v2/search/indexed-dirs
-      source: src/nexus/server/api/v2/routers/search.py:2013
+      source: src/nexus/server/api/v2/routers/search.py:1985
   profiles:
     lite: supported
     sandbox: supported
@@ -7798,7 +7798,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/indexing-mode
-      source: src/nexus/server/api/v2/routers/search.py:2050
+      source: src/nexus/server/api/v2/routers/search.py:2022
   profiles:
     lite: supported
     sandbox: supported
@@ -7815,7 +7815,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/locate
-      source: src/nexus/server/api/v2/routers/search.py:2231
+      source: src/nexus/server/api/v2/routers/search.py:2203
   profiles:
     lite: supported
     sandbox: supported
@@ -7884,7 +7884,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/purge-unscoped
-      source: src/nexus/server/api/v2/routers/search.py:2177
+      source: src/nexus/server/api/v2/routers/search.py:2149
   profiles:
     lite: supported
     sandbox: supported
@@ -7920,7 +7920,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/query/batch
-      source: src/nexus/server/api/v2/routers/search.py:835
+      source: src/nexus/server/api/v2/routers/search.py:807
   profiles:
     lite: supported
     sandbox: supported
@@ -7937,7 +7937,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/refresh
-      source: src/nexus/server/api/v2/routers/search.py:1632
+      source: src/nexus/server/api/v2/routers/search.py:1604
   profiles:
     lite: supported
     sandbox: supported

--- a/docs/surface-coverage/api-rpc-surface-coverage.yaml
+++ b/docs/surface-coverage/api-rpc-surface-coverage.yaml
@@ -4909,7 +4909,7 @@ operations:
   transports:
     grpc_expose:
       name: initialize_semantic_search
-      source: src/nexus/bricks/search/search_service.py:4741
+      source: src/nexus/bricks/search/search_service.py:4784
   profiles:
     lite: supported
     sandbox: supported
@@ -7642,7 +7642,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/expand
-      source: src/nexus/server/api/v2/routers/search.py:1605
+      source: src/nexus/server/api/v2/routers/search.py:1653
   profiles:
     lite: supported
     sandbox: supported
@@ -7666,7 +7666,7 @@ operations:
       source: src/nexus/bricks/search/search_service.py:1791
     http:
       name: POST /api/v2/search/glob
-      source: src/nexus/server/api/v2/routers/search.py:1486
+      source: src/nexus/server/api/v2/routers/search.py:1534
     mcp:
       name: nexus_glob
       source: src/nexus/config/tool_profiles.yaml:1
@@ -7693,7 +7693,7 @@ operations:
       source: src/nexus/bricks/search/search_service.py:2101
     http:
       name: POST /api/v2/search/grep
-      source: src/nexus/server/api/v2/routers/search.py:1363
+      source: src/nexus/server/api/v2/routers/search.py:1411
     mcp:
       name: nexus_grep
       source: src/nexus/config/tool_profiles.yaml:1
@@ -7746,7 +7746,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/index
-      source: src/nexus/server/api/v2/routers/search.py:1548
+      source: src/nexus/server/api/v2/routers/search.py:1596
   profiles:
     lite: supported
     sandbox: supported
@@ -7764,7 +7764,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/index-directory
-      source: src/nexus/server/api/v2/routers/search.py:1747
+      source: src/nexus/server/api/v2/routers/search.py:1795
   profiles:
     lite: supported
     sandbox: supported
@@ -7781,7 +7781,7 @@ operations:
   transports:
     http:
       name: GET /api/v2/search/indexed-dirs
-      source: src/nexus/server/api/v2/routers/search.py:1965
+      source: src/nexus/server/api/v2/routers/search.py:2013
   profiles:
     lite: supported
     sandbox: supported
@@ -7798,7 +7798,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/indexing-mode
-      source: src/nexus/server/api/v2/routers/search.py:2002
+      source: src/nexus/server/api/v2/routers/search.py:2050
   profiles:
     lite: supported
     sandbox: supported
@@ -7815,7 +7815,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/locate
-      source: src/nexus/server/api/v2/routers/search.py:2183
+      source: src/nexus/server/api/v2/routers/search.py:2231
   profiles:
     lite: supported
     sandbox: supported
@@ -7884,7 +7884,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/purge-unscoped
-      source: src/nexus/server/api/v2/routers/search.py:2129
+      source: src/nexus/server/api/v2/routers/search.py:2177
   profiles:
     lite: supported
     sandbox: supported
@@ -7920,7 +7920,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/query/batch
-      source: src/nexus/server/api/v2/routers/search.py:787
+      source: src/nexus/server/api/v2/routers/search.py:835
   profiles:
     lite: supported
     sandbox: supported
@@ -7937,7 +7937,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/refresh
-      source: src/nexus/server/api/v2/routers/search.py:1584
+      source: src/nexus/server/api/v2/routers/search.py:1632
   profiles:
     lite: supported
     sandbox: supported
@@ -8024,7 +8024,7 @@ operations:
   transports:
     grpc_expose:
       name: semantic_search
-      source: src/nexus/bricks/search/search_service.py:4334
+      source: src/nexus/bricks/search/search_service.py:4377
     mcp:
       name: nexus_semantic_search
       source: src/nexus/config/tool_profiles.yaml:1
@@ -8045,7 +8045,7 @@ operations:
   transports:
     grpc_expose:
       name: semantic_search_index
-      source: src/nexus/bricks/search/search_service.py:4656
+      source: src/nexus/bricks/search/search_service.py:4699
   profiles:
     lite: supported
     sandbox: supported
@@ -8062,7 +8062,7 @@ operations:
   transports:
     grpc_expose:
       name: semantic_search_stats
-      source: src/nexus/bricks/search/search_service.py:4693
+      source: src/nexus/bricks/search/search_service.py:4736
   profiles:
     lite: supported
     sandbox: supported

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -2271,7 +2271,8 @@ class SearchDaemon:
                 # backfill, cap order-preservingly, and leave the final trim
                 # to the shared post-attach boundary so tier weights can
                 # still re-rank the over-fetched window.
-                pooled_legacy = bool(getattr(self.config, "page_aggregation", False))
+                _legacy_cfg = getattr(self, "config", None)
+                pooled_legacy = bool(getattr(_legacy_cfg, "page_aggregation", False))
                 legacy_limit = max(internal_limit, limit * 2) if pooled_legacy else internal_limit
                 results = await self._hybrid_search(
                     query,
@@ -2286,7 +2287,7 @@ class SearchDaemon:
                     from nexus.bricks.search.result_builders import cap_chunks_per_page
 
                     results = cap_chunks_per_page(
-                        results, chunks_per_page=self.config.chunks_per_page
+                        results, chunks_per_page=getattr(_legacy_cfg, "chunks_per_page", 2)
                     )
             fallback_ms = (time.perf_counter() - fallback_start) * 1000
 
@@ -2442,9 +2443,9 @@ class SearchDaemon:
                     id_key=None,
                 )
                 if pooled:
-                    fused = cap_chunks_per_page(
-                        fused, chunks_per_page=self.config.chunks_per_page
-                    )[:limit]
+                    fused = cap_chunks_per_page(fused, chunks_per_page=self.config.chunks_per_page)[
+                        :limit
+                    ]
                 timing["fusion_ms"] = (time.perf_counter() - fusion_start) * 1000
                 record_total()
                 coerced = SearchResultList(

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -2375,9 +2375,15 @@ class SearchDaemon:
         if qvec is None:
             # Without an embedding we still want a useful result — fall back
             # to keyword-only and let the caller decide if that's enough.
+            # Issue #4542 (round-4 review): the per-doc cap must survive the
+            # degraded path too — over-fetch so capping can backfill, then
+            # cap and trim exactly like the fused path.
+            pooled = self.config.page_aggregation
             results = await timed_leg(
                 "keyword_ms",
-                self._fts_backend.keyword_search(query, path, limit, zone_id, timing=timing),
+                self._fts_backend.keyword_search(
+                    query, path, limit * 2 if pooled else limit, zone_id, timing=timing
+                ),
             )
             # Non-default fusion requests still flow through the configured
             # fusion (keyword leg only, empty dense leg) so the advertised
@@ -2393,9 +2399,15 @@ class SearchDaemon:
                     config=FusionConfig(
                         method=FusionMethod(fusion_method), alpha=alpha, rrf_k=rrf_k
                     ),
-                    limit=limit,
+                    # Issue #4542: with the cap active, fuse the full keyword
+                    # list so the per-doc cap can backfill before the trim.
+                    limit=len(results) if pooled else limit,
                     id_key=None,
                 )
+                if pooled:
+                    fused = cap_chunks_per_page(
+                        fused, chunks_per_page=self.config.chunks_per_page
+                    )[:limit]
                 timing["fusion_ms"] = (time.perf_counter() - fusion_start) * 1000
                 record_total()
                 coerced = SearchResultList(
@@ -2411,6 +2423,10 @@ class SearchDaemon:
                 for coerced_result in coerced:
                     coerced_result.semantic_degraded = True
                 return coerced
+            if pooled:
+                results = cap_chunks_per_page(
+                    results, chunks_per_page=self.config.chunks_per_page
+                )[:limit]
             record_total()
             return [self._coerce_to_search_result(r, search_type=search_type) for r in results]
 

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -2259,15 +2259,32 @@ class SearchDaemon:
                     query, internal_limit, path_filter, zone_id=zone_id
                 )
             else:  # hybrid
+                # Issue #4542 (round-5 review): the legacy hybrid stack must
+                # honor the per-doc cap too — backend degradation must not
+                # change flag semantics. Fetch wide enough for BOTH the
+                # tier-boost over-fetch (#4544 internal_limit) and the cap's
+                # backfill, cap order-preservingly, and leave the final trim
+                # to the shared post-attach boundary so tier weights can
+                # still re-rank the over-fetched window.
+                pooled_legacy = bool(getattr(self.config, "page_aggregation", False))
+                legacy_limit = (
+                    max(internal_limit, limit * 2) if pooled_legacy else internal_limit
+                )
                 results = await self._hybrid_search(
                     query,
-                    internal_limit,
+                    legacy_limit,
                     path_filter,
                     alpha,
                     fusion_method,
                     rrf_k,
                     zone_id=zone_id,
                 )
+                if pooled_legacy:
+                    from nexus.bricks.search.result_builders import cap_chunks_per_page
+
+                    results = cap_chunks_per_page(
+                        results, chunks_per_page=self.config.chunks_per_page
+                    )
             fallback_ms = (time.perf_counter() - fallback_start) * 1000
 
             # Track latency
@@ -2297,7 +2314,10 @@ class SearchDaemon:
                 pinned_snapshots=tier_pin,
                 apply_weights=tier_weights_ok,
             )
-            if internal_limit != limit:
+            # Trim covers both the #4544 tier-boost over-fetch and the #4542
+            # pooled legacy fetch (which can exceed limit even when
+            # internal_limit == limit).
+            if internal_limit != limit or len(results) > limit:
                 results = results[:limit]
             return self._with_search_timing(results)
 
@@ -2371,6 +2391,15 @@ class SearchDaemon:
             return [self._coerce_to_search_result(r, search_type=search_type) for r in results]
 
         # Hybrid: 3-way RRF on PG, 2-way on SQLite.
+        # Issue #4542 (round-5 review): with the per-doc cap active, widen the
+        # retrieval legs so candidates just beyond a one-doc-saturated window
+        # can backfill after capping. Any finite window remains theoretically
+        # saturable — page-diversified retrieval is a backend-level change
+        # deliberately out of scope — so this is a documented bound, matching
+        # the federated dispatcher's cap-aware window.
+        pooled = self.config.page_aggregation
+        leg_limit = limit * 2 * (self.config.chunks_per_page + 1) if pooled else limit * 2
+
         qvec = await timed_leg("embed_ms", self._embed_query(query))
         if qvec is None:
             # Without an embedding we still want a useful result — fall back
@@ -2378,11 +2407,10 @@ class SearchDaemon:
             # Issue #4542 (round-4 review): the per-doc cap must survive the
             # degraded path too — over-fetch so capping can backfill, then
             # cap and trim exactly like the fused path.
-            pooled = self.config.page_aggregation
             results = await timed_leg(
                 "keyword_ms",
                 self._fts_backend.keyword_search(
-                    query, path, limit * 2 if pooled else limit, zone_id, timing=timing
+                    query, path, leg_limit if pooled else limit, zone_id, timing=timing
                 ),
             )
             # Non-default fusion requests still flow through the configured
@@ -2436,7 +2464,7 @@ class SearchDaemon:
             assert isinstance(pg_fts_backend, PgFtsBackend)
 
             async def timed_pg_keyword_legs() -> tuple[list[Any], list[Any]]:
-                keyword_limit = limit * 2
+                keyword_limit = leg_limit
                 keyword_start = time.perf_counter()
                 keyword_candidates = await pg_fts_backend.keyword_search(
                     query,
@@ -2460,7 +2488,7 @@ class SearchDaemon:
                 timed_pg_keyword_legs(),
                 timed_leg(
                     "vector_ms",
-                    self._vector_backend.semantic_search(qvec, path, limit * 2, zone_id),
+                    self._vector_backend.semantic_search(qvec, path, leg_limit, zone_id),
                 ),
             )
         else:
@@ -2468,12 +2496,12 @@ class SearchDaemon:
                 timed_leg(
                     "keyword_ms",
                     self._fts_backend.keyword_search(
-                        query, path, limit * 2, zone_id, timing=timing
+                        query, path, leg_limit, zone_id, timing=timing
                     ),
                 ),
                 timed_leg(
                     "vector_ms",
-                    self._vector_backend.semantic_search(qvec, path, limit * 2, zone_id),
+                    self._vector_backend.semantic_search(qvec, path, leg_limit, zone_id),
                 ),
             )
             page_kw = []
@@ -2481,7 +2509,11 @@ class SearchDaemon:
         # Fuse keyword legs first (chunk + page) with plain RRF, then fuse
         # that with dense using the request's method / alpha / k.
         fusion_start = time.perf_counter()
-        kw_fused = rrf_fusion(chunk_kw, page_kw, k=rrf_k, limit=limit * 2, id_key=None)
+        # With the cap active, keep the FULL keyword union — truncating the
+        # keyword sub-fusion would re-introduce a fixed window upstream of
+        # the cap's backfill.
+        kw_fused_limit = len(chunk_kw) + len(page_kw) if pooled else limit * 2
+        kw_fused = rrf_fusion(chunk_kw, page_kw, k=rrf_k, limit=kw_fused_limit, id_key=None)
         fusion_config = FusionConfig(
             method=FusionMethod(fusion_method),
             alpha=alpha,

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -2334,7 +2334,7 @@ class SearchDaemon:
             rrf_fusion,
         )
         from nexus.bricks.search.pg_fts_backend import PgFtsBackend
-        from nexus.bricks.search.result_builders import _aggregate_chunks_to_pages
+        from nexus.bricks.search.result_builders import cap_chunks_per_page
 
         path = path_filter or "/"
         timing = _empty_backend_timing()
@@ -2471,13 +2471,22 @@ class SearchDaemon:
             alpha=alpha,
             rrf_k=rrf_k,
         )
-        fused = fuse_results(kw_fused, dense, config=fusion_config, limit=limit, id_key=None)
-        # Issue #4542: pool the fused list per document so one long doc cannot
-        # occupy every hybrid slot. The route over-fetches (fetch_limit =
-        # limit × 3 for the ReBAC filter), so pooling at daemon-output size
-        # still leaves headroom before the caller's final trim.
+        # Issue #4542: cap the fused list per document so one long doc cannot
+        # occupy every hybrid slot. Fuse a wider candidate window first so the
+        # cap can BACKFILL from candidates below the requested-limit cutoff —
+        # trimming inside fusion before capping would let a long doc saturate
+        # the window and return an underfilled page instead of promoting other
+        # docs. The cap is order-preserving (unlike the page-grouped
+        # ``_aggregate_chunks_to_pages`` used by the raw BM25 leg), so the
+        # fused-score ordering survives for downstream over-fetch trims.
         if self.config.page_aggregation:
-            fused = _aggregate_chunks_to_pages(fused, chunks_per_page=self.config.chunks_per_page)
+            fused = fuse_results(
+                kw_fused, dense, config=fusion_config, limit=limit * 2, id_key=None
+            )
+            fused = cap_chunks_per_page(fused, chunks_per_page=self.config.chunks_per_page)
+            fused = fused[:limit]
+        else:
+            fused = fuse_results(kw_fused, dense, config=fusion_config, limit=limit, id_key=None)
         timing["fusion_ms"] = (time.perf_counter() - fusion_start) * 1000
         record_total()
         hybrid_results = SearchResultList(

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -2472,16 +2472,22 @@ class SearchDaemon:
             rrf_k=rrf_k,
         )
         # Issue #4542: cap the fused list per document so one long doc cannot
-        # occupy every hybrid slot. Fuse a wider candidate window first so the
-        # cap can BACKFILL from candidates below the requested-limit cutoff —
-        # trimming inside fusion before capping would let a long doc saturate
-        # the window and return an underfilled page instead of promoting other
-        # docs. The cap is order-preserving (unlike the page-grouped
+        # occupy every hybrid slot. Fuse the COMPLETE candidate union first so
+        # the cap can BACKFILL from candidates below the requested-limit
+        # cutoff — any fixed pre-cap window (limit×N) can still be saturated
+        # by a single long doc and return an underfilled page (round-2
+        # review). The union is already bounded by the legs' own limit×2
+        # fetches, so this adds no meaningful fusion cost. The cap is
+        # order-preserving (unlike the page-grouped
         # ``_aggregate_chunks_to_pages`` used by the raw BM25 leg), so the
         # fused-score ordering survives for downstream over-fetch trims.
         if self.config.page_aggregation:
             fused = fuse_results(
-                kw_fused, dense, config=fusion_config, limit=limit * 2, id_key=None
+                kw_fused,
+                dense,
+                config=fusion_config,
+                limit=len(kw_fused) + len(dense),
+                id_key=None,
             )
             fused = cap_chunks_per_page(fused, chunks_per_page=self.config.chunks_per_page)
             fused = fused[:limit]

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -79,6 +79,11 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Issue #4542 round-10 review: upper bound on the cap-aware retrieval-window
+# widening factor. chunks_per_page itself stays unbounded (emission cap), but
+# retrieval amplification saturates here.
+_MAX_CAP_WIDEN = 4
+
 # Durable mutation consumer names (#4337): single source for the refresh
 # loop, startup reconciliation, parked-event re-drive, and admin skip-to.
 MUTATION_CONSUMER_NAMES: tuple[str, ...] = ("fts", "embedding")
@@ -2267,9 +2272,7 @@ class SearchDaemon:
                 # to the shared post-attach boundary so tier weights can
                 # still re-rank the over-fetched window.
                 pooled_legacy = bool(getattr(self.config, "page_aggregation", False))
-                legacy_limit = (
-                    max(internal_limit, limit * 2) if pooled_legacy else internal_limit
-                )
+                legacy_limit = max(internal_limit, limit * 2) if pooled_legacy else internal_limit
                 results = await self._hybrid_search(
                     query,
                     legacy_limit,
@@ -2398,7 +2401,13 @@ class SearchDaemon:
         # deliberately out of scope — so this is a documented bound, matching
         # the federated dispatcher's cap-aware window.
         pooled = self.config.page_aggregation
-        leg_limit = limit * 2 * (self.config.chunks_per_page + 1) if pooled else limit * 2
+        # The widening factor is BOUNDED (round-10 review): chunks_per_page is
+        # an emission cap with no configured maximum, and multiplying raw
+        # retrieval windows by an operator-supplied value lets a large cap
+        # amplify every leg into massive scans. Backfill benefit plateaus
+        # quickly, so widening saturates at ×(_MAX_CAP_WIDEN + 1).
+        widen = min(self.config.chunks_per_page, _MAX_CAP_WIDEN) + 1
+        leg_limit = limit * 2 * widen if pooled else limit * 2
 
         qvec = await timed_leg("embed_ms", self._embed_query(query))
         if qvec is None:
@@ -2452,9 +2461,9 @@ class SearchDaemon:
                     coerced_result.semantic_degraded = True
                 return coerced
             if pooled:
-                results = cap_chunks_per_page(
-                    results, chunks_per_page=self.config.chunks_per_page
-                )[:limit]
+                results = cap_chunks_per_page(results, chunks_per_page=self.config.chunks_per_page)[
+                    :limit
+                ]
             record_total()
             return [self._coerce_to_search_result(r, search_type=search_type) for r in results]
 

--- a/src/nexus/bricks/search/federated_search.py
+++ b/src/nexus/bricks/search/federated_search.py
@@ -29,7 +29,7 @@ from typing import Any
 
 from nexus.bricks.search.daemon import _BACKEND_LEG_TIMING_KEYS as _TIMING_LEG_KEYS
 from nexus.bricks.search.fusion import rrf_multi_fusion
-from nexus.bricks.search.result_builders import _aggregate_chunks_to_pages
+from nexus.bricks.search.result_builders import cap_chunks_per_page
 from nexus.contracts.protocols.activity import EventKind, Result, emit
 
 logger = logging.getLogger(__name__)
@@ -923,22 +923,32 @@ def _merge_by_raw_score(
     all_results: list[dict[str, Any]] = []
     for _zone_id, results in zone_result_lists:
         zone_dicts = [_result_to_dict(r) for r in results]
-        # Issue #4542: pool per zone (not on the concatenated list) so the
-        # same path in two zones stays two distinct documents. Local-zone
-        # results already collapse to one chunk per doc via the page-grain
-        # zone_qualified_path dedup below; this cap matters for remote-zone
-        # dicts whose dedup key falls back to chunk grain.
+        # Issue #4542: cap per zone (not on the concatenated list) so the
+        # same path in two zones stays two distinct documents. The cap is
+        # order-preserving over the zone's daemon-sorted list.
         if chunks_per_page is not None:
-            zone_dicts = _aggregate_chunks_to_pages(zone_dicts, chunks_per_page=chunks_per_page)
+            zone_dicts = cap_chunks_per_page(zone_dicts, chunks_per_page=chunks_per_page)
         all_results.extend(zone_dicts)
 
-    # Dedup by zone_qualified_path, keeping highest score
+    # Dedup, keeping highest score. With pooling OFF this is the historical
+    # page-grain zone_qualified_path key (one chunk per doc per zone). With
+    # pooling ON the page-grain key would collapse every doc straight back
+    # to one chunk — ``zone_qualified_path`` carries no chunk index on
+    # either the local dataclass or the remote-dict shape — so dedup
+    # switches to chunk grain and lets ``chunks_per_page`` govern
+    # per-document emission (Issue #4542 review hardening).
     seen: dict[str, dict[str, Any]] = {}
     for r in all_results:
-        key = r.get(
-            "zone_qualified_path",
-            f"{r.get('zone_id', '')}:{r.get('path', '')}:{r.get('chunk_index', 0)}",
-        )
+        if chunks_per_page is None:
+            key = r.get(
+                "zone_qualified_path",
+                f"{r.get('zone_id', '')}:{r.get('path', '')}:{r.get('chunk_index', 0)}",
+            )
+        else:
+            page_key = r.get("zone_qualified_path") or (
+                f"{r.get('zone_id', '')}:{r.get('path', '')}"
+            )
+            key = f"{page_key}:{r.get('chunk_index', 0)}"
         existing = seen.get(key)
         if existing is None or r.get("score", 0.0) > existing.get("score", 0.0):
             seen[key] = r

--- a/src/nexus/bricks/search/federated_search.py
+++ b/src/nexus/bricks/search/federated_search.py
@@ -717,15 +717,32 @@ class FederatedSearchDispatcher:
         # zones happen to be accessible. Resolved once here.
         pooling_cap = self._pooling_chunks_per_page()
 
+        def _zone_fetch_limit(zone_id: str, base: int) -> int:
+            """Cap-aware per-zone fetch window (rounds 3+6 review).
+
+            A zone window saturated by one long doc leaves nothing to
+            backfill after the per-doc cap. Local HYBRID zones already cap
+            internally at the daemon (full-union backfill) — widening them
+            again would compound multipliers into pathological retrieval
+            windows (round-6 review), so they keep the base window. The
+            wider window applies only where dispatcher-side capping is the
+            only protection: semantic/keyword effective types and remote
+            zones. A fixed window remains theoretically saturable —
+            adaptive pagination is deliberately out of scope; flag-off
+            keeps the historical window everywhere.
+            """
+            if pooling_cap is None:
+                return base
+            effective_type, _ = self._get_effective_search_type(zone_id, search_type)
+            is_remote = self._registry is not None and self._registry.is_remote(zone_id)
+            if effective_type == "hybrid" and not is_remote:
+                return base
+            return base * (pooling_cap + 1)
+
         # Single zone: skip fusion overhead
         if len(searchable_zones) == 1:
             zone_id = searchable_zones[0]
-            # With the cap active, over-fetch so capping can backfill other
-            # docs instead of shrinking the page; flag-off keeps the
-            # historical exact-limit fetch.
-            single_zone_fetch = (
-                limit if pooling_cap is None else limit * self._config.over_fetch_factor
-            )
+            single_zone_fetch = _zone_fetch_limit(zone_id, limit)
             try:
                 results = await asyncio.wait_for(
                     self._search_zone(
@@ -781,18 +798,8 @@ class FederatedSearchDispatcher:
                     latency_ms=(time.perf_counter() - start) * 1000,
                 )
 
-        # 2. Multi-zone fan-out with concurrency bound (decision 16A)
-        per_zone_limit = limit * self._config.over_fetch_factor
-        if pooling_cap is not None:
-            # Cap-aware over-fetch (round-3 review): a zone window saturated
-            # by one long doc leaves nothing to backfill after the per-doc
-            # cap. Local hybrid zones already cap at the daemon (full-union
-            # backfill), so the widened window guards the semantic/keyword
-            # and version-skewed remote paths. A fixed window remains
-            # theoretically saturable — adaptive per-zone pagination is
-            # deliberately out of scope (remote re-dispatch + delegation
-            # cost); flag-off keeps the historical window exactly.
-            per_zone_limit = limit * self._config.over_fetch_factor * (pooling_cap + 1)
+        # 2. Multi-zone fan-out with concurrency bound (decision 16A).
+        # Per-zone fetch windows are cap-aware via _zone_fetch_limit.
         semaphore = asyncio.Semaphore(self._config.max_concurrent_zones)
 
         async def _bounded_search(
@@ -805,7 +812,9 @@ class FederatedSearchDispatcher:
                             zone_id,
                             query,
                             search_type,
-                            per_zone_limit,
+                            _zone_fetch_limit(
+                                zone_id, limit * self._config.over_fetch_factor
+                            ),
                             path_filter,
                             alpha,
                             fusion_method,

--- a/src/nexus/bricks/search/federated_search.py
+++ b/src/nexus/bricks/search/federated_search.py
@@ -20,6 +20,7 @@ Design decisions (from review):
 
 import asyncio
 import hashlib
+import json
 import logging
 import math
 import time
@@ -497,15 +498,29 @@ class FederatedSearchDispatcher:
         filter, so without it a broadly-scoped request could seed a cache
         entry that a later narrowly-scoped token would read back — leaking
         results from zones outside that token's scope (#4541 review).
+
+        Canonical-JSON serialization (round-5 review): delimiter
+        concatenation allowed cross-field collisions — subject_id
+        ``alice|foo`` + query ``bar`` hashed identically to ``alice`` +
+        ``foo|bar`` — and cache lookup precedes ReBAC, so a collision would
+        leak another subject's results. JSON escaping makes field
+        boundaries unambiguous, and the empty allow-list (``[]``, zero
+        zones) stays distinct from the wildcard (``null``).
         """
-        # None means "no allow-list" (wildcard); an EMPTY set means "access
-        # to zero zones" and must not collide with the wildcard entry, or an
-        # unrestricted request could seed a cache entry that an empty-scoped
-        # token reads back (#4541 review).
-        zone_scope = "*" if zone_filter is None else "zf:" + ",".join(sorted(zone_filter))
-        raw = (
-            f"{subject[0]}:{subject[1]}|{query}|{search_type}|{limit}|{path_filter}"
-            f"|{alpha}|{fusion_method}|{rrf_k}|{zone_scope}"
+        raw = json.dumps(
+            [
+                subject[0],
+                subject[1],
+                query,
+                search_type,
+                limit,
+                path_filter,
+                alpha,
+                fusion_method,
+                rrf_k,
+                sorted(zone_filter) if zone_filter is not None else None,
+            ],
+            separators=(",", ":"),
         )
         return hashlib.sha256(raw.encode()).hexdigest()[:32]
 

--- a/src/nexus/bricks/search/federated_search.py
+++ b/src/nexus/bricks/search/federated_search.py
@@ -697,16 +697,27 @@ class FederatedSearchDispatcher:
                 latency_ms=(time.perf_counter() - start) * 1000,
             )
 
+        # Issue #4542 (round-3 review): the per-document cap applies on EVERY
+        # federated control path, so behavior does not depend on how many
+        # zones happen to be accessible. Resolved once here.
+        pooling_cap = self._pooling_chunks_per_page()
+
         # Single zone: skip fusion overhead
         if len(searchable_zones) == 1:
             zone_id = searchable_zones[0]
+            # With the cap active, over-fetch so capping can backfill other
+            # docs instead of shrinking the page; flag-off keeps the
+            # historical exact-limit fetch.
+            single_zone_fetch = (
+                limit if pooling_cap is None else limit * self._config.over_fetch_factor
+            )
             try:
                 results = await asyncio.wait_for(
                     self._search_zone(
                         zone_id,
                         query,
                         search_type,
-                        limit,
+                        single_zone_fetch,
                         path_filter,
                         alpha,
                         fusion_method,
@@ -728,7 +739,12 @@ class FederatedSearchDispatcher:
                         subject=subject,
                         rebac=self._rebac,
                     )
-                result_dicts = [_result_to_dict(r) for r in results[:limit]]
+                result_dicts = [_result_to_dict(r) for r in results]
+                if pooling_cap is not None:
+                    result_dicts = cap_chunks_per_page(
+                        result_dicts, chunks_per_page=pooling_cap
+                    )
+                result_dicts = result_dicts[:limit]
                 resp = FederatedSearchResponse(
                     results=result_dicts,
                     zones_searched=[zone_id],
@@ -752,6 +768,16 @@ class FederatedSearchDispatcher:
 
         # 2. Multi-zone fan-out with concurrency bound (decision 16A)
         per_zone_limit = limit * self._config.over_fetch_factor
+        if pooling_cap is not None:
+            # Cap-aware over-fetch (round-3 review): a zone window saturated
+            # by one long doc leaves nothing to backfill after the per-doc
+            # cap. Local hybrid zones already cap at the daemon (full-union
+            # backfill), so the widened window guards the semantic/keyword
+            # and version-skewed remote paths. A fixed window remains
+            # theoretically saturable — adaptive per-zone pagination is
+            # deliberately out of scope (remote re-dispatch + delegation
+            # cost); flag-off keeps the historical window exactly.
+            per_zone_limit = limit * self._config.over_fetch_factor * (pooling_cap + 1)
         semaphore = asyncio.Semaphore(self._config.max_concurrent_zones)
 
         async def _bounded_search(
@@ -857,7 +883,7 @@ class FederatedSearchDispatcher:
             fused_results = _merge_by_raw_score(
                 zone_result_lists,
                 limit,
-                chunks_per_page=self._pooling_chunks_per_page(),
+                chunks_per_page=pooling_cap,
             )
 
         resp = FederatedSearchResponse(

--- a/src/nexus/bricks/search/federated_search.py
+++ b/src/nexus/bricks/search/federated_search.py
@@ -118,6 +118,32 @@ class FederationUnreachableError(Exception):
     """
 
 
+def readable_zone_filter(
+    zone_set: Any,
+    zone_perms: Any,
+) -> frozenset[str] | None:
+    """Derive a federated zone allow-list from a credential's grants.
+
+    Search is a READ — write-only zone grants must not be searchable
+    (Issue #4542 round-8 review). When per-zone perms are known, only
+    zones granting ``r`` or ``x`` pass; an explicit grant list with no
+    readable zones fails CLOSED (empty frozenset → zero searchable
+    zones). Credentials with a zone list but no perms info keep the
+    whole list (legacy tokens predate per-zone perms). Returns ``None``
+    (unbounded) only when the credential carries no explicit zone grant
+    at all.
+    """
+    if zone_perms:
+        return frozenset(
+            str(zp[0])
+            for zp in zone_perms
+            if len(zp) == 2 and ("r" in str(zp[1]) or "x" in str(zp[1]))
+        )
+    if zone_set:
+        return frozenset(str(z) for z in zone_set)
+    return None
+
+
 def is_all_peers_failed(response: FederatedSearchResponse) -> bool:
     """Return True when the response reflects zero reachable peers.
 

--- a/src/nexus/bricks/search/federated_search.py
+++ b/src/nexus/bricks/search/federated_search.py
@@ -852,8 +852,14 @@ class FederatedSearchDispatcher:
         if not zone_result_lists:
             fused_results: list[dict[str, Any]] = []
         elif len(zone_result_lists) == 1:
+            # Issue #4542 (round-4 review): the one-surviving-zone branch must
+            # honor the cap too — zone failures or empty zones must not
+            # silently change the flag semantics.
             _zone_id, results = zone_result_lists[0]
-            fused_results = [_result_to_dict(r) for r in results[:limit]]
+            fused_results = [_result_to_dict(r) for r in results]
+            if pooling_cap is not None:
+                fused_results = cap_chunks_per_page(fused_results, chunks_per_page=pooling_cap)
+            fused_results = fused_results[:limit]
         elif self._config.fusion_strategy == FederatedFusionStrategy.RRF or (
             fusion_method == "weighted" and search_type == "hybrid"
         ):
@@ -867,12 +873,35 @@ class FederatedSearchDispatcher:
             # raw scores stay comparable and keep the default merge;
             # rrf/rrf_weighted scores share one reciprocal-rank formula and
             # stay comparable too.
+            # Issue #4542 (round-4 review): with the cap active, cap each zone
+            # list first (zone-scoped budgets) and fuse at CHUNK grain — the
+            # page-grain zone_qualified_path key would collapse every doc back
+            # to one chunk, silently overriding chunks_per_page > 1 and
+            # underfilling the page. Flag-off keeps the historical page-grain
+            # fusion identity exactly.
+            rrf_lists: list[tuple[str, list[Any]]] = zone_result_lists
+            rrf_id_key = "zone_qualified_path"
+            if pooling_cap is not None:
+                capped_lists: list[tuple[str, list[Any]]] = []
+                for zid, zresults in zone_result_lists:
+                    zdicts = [_result_to_dict(r) for r in zresults]
+                    zdicts = cap_chunks_per_page(zdicts, chunks_per_page=pooling_cap)
+                    for d in zdicts:
+                        page_key = d.get("zone_qualified_path") or (
+                            f"{d.get('zone_id', '')}:{d.get('path', '')}"
+                        )
+                        d["_zq_chunk"] = f"{page_key}:{d.get('chunk_index', 0)}"
+                    capped_lists.append((zid, zdicts))
+                rrf_lists = capped_lists
+                rrf_id_key = "_zq_chunk"
             fused_results = rrf_multi_fusion(
-                result_lists=zone_result_lists,
+                result_lists=rrf_lists,
                 k=60,
                 limit=limit,
-                id_key="zone_qualified_path",
+                id_key=rrf_id_key,
             )
+            for d in fused_results:
+                d.pop("_zq_chunk", None)
             # Issue #3773 (Round-6 review): rrf_multi_fusion emits dicts built
             # from __dataclass_fields__ verbatim, so ``context: None`` leaks
             # into the wire. Normalize here so every federated code path

--- a/src/nexus/bricks/search/federated_search.py
+++ b/src/nexus/bricks/search/federated_search.py
@@ -144,6 +144,42 @@ def readable_zone_filter(
     return None
 
 
+def token_zone_filter_from_auth(
+    auth_result: dict[str, Any],
+    *,
+    root_zone_id: str,
+) -> frozenset[str] | None:
+    """Derive the search-readable token allow-list from an auth result.
+
+    Issue #4542 rounds 8-10: search is a READ. Admin, root-scoped, and
+    unconstrained credentials return ``None`` (unbounded — #4541
+    exemption); otherwise only zones granting ``r``/``x`` pass, and an
+    explicit grant list with no readable zone yields the empty set
+    (callers fail closed on it).
+    """
+    raw_zone_set = tuple(auth_result.get("zone_set") or ())
+    if (
+        not raw_zone_set
+        or set(raw_zone_set) == {root_zone_id}
+        or auth_result.get("is_admin", False)
+    ):
+        return None
+    return readable_zone_filter(raw_zone_set, auth_result.get("zone_perms"))
+
+
+def daemon_pooling_cap(daemon: Any) -> int | None:
+    """Resolve the per-document pooling cap from a daemon's DaemonConfig.
+
+    Strict ``is True`` / ``isinstance`` guards keep Mock daemons (tests)
+    from enabling pooling via auto-created attributes (Issue #4542).
+    """
+    cfg = getattr(daemon, "config", None)
+    if getattr(cfg, "page_aggregation", None) is not True:
+        return None
+    cap = getattr(cfg, "chunks_per_page", None)
+    return cap if isinstance(cap, int) and cap > 0 else None
+
+
 def is_all_peers_failed(response: FederatedSearchResponse) -> bool:
     """Return True when the response reflects zero reachable peers.
 
@@ -984,11 +1020,7 @@ class FederatedSearchDispatcher:
         The strict ``is True`` / ``isinstance`` checks keep Mock daemons
         (tests) from enabling pooling via auto-created attributes.
         """
-        cfg = getattr(self._daemon, "config", None)
-        if getattr(cfg, "page_aggregation", None) is not True:
-            return None
-        cap = getattr(cfg, "chunks_per_page", None)
-        return cap if isinstance(cap, int) and cap > 0 else None
+        return daemon_pooling_cap(self._daemon)
 
     def invalidate_zone_cache(self, subject: tuple[str, str] | None = None) -> None:
         """Invalidate zone discovery cache."""

--- a/src/nexus/bricks/search/federated_search.py
+++ b/src/nexus/bricks/search/federated_search.py
@@ -763,7 +763,9 @@ class FederatedSearchDispatcher:
             is_remote = self._registry is not None and self._registry.is_remote(zone_id)
             if effective_type == "hybrid" and not is_remote:
                 return base
-            return base * (pooling_cap + 1)
+            # Bounded widening (round-10 review): the emission cap has no
+            # configured maximum, so amplification saturates at ×5.
+            return base * (min(pooling_cap, 4) + 1)
 
         # Single zone: skip fusion overhead
         if len(searchable_zones) == 1:
@@ -799,9 +801,7 @@ class FederatedSearchDispatcher:
                     )
                 result_dicts = [_result_to_dict(r) for r in results]
                 if pooling_cap is not None:
-                    result_dicts = cap_chunks_per_page(
-                        result_dicts, chunks_per_page=pooling_cap
-                    )
+                    result_dicts = cap_chunks_per_page(result_dicts, chunks_per_page=pooling_cap)
                 result_dicts = result_dicts[:limit]
                 resp = FederatedSearchResponse(
                     results=result_dicts,
@@ -838,9 +838,7 @@ class FederatedSearchDispatcher:
                             zone_id,
                             query,
                             search_type,
-                            _zone_fetch_limit(
-                                zone_id, limit * self._config.over_fetch_factor
-                            ),
+                            _zone_fetch_limit(zone_id, limit * self._config.over_fetch_factor),
                             path_filter,
                             alpha,
                             fusion_method,

--- a/src/nexus/bricks/search/result_builders.py
+++ b/src/nexus/bricks/search/result_builders.py
@@ -150,3 +150,30 @@ def _aggregate_chunks_to_pages(
     for _page_score, page_chunks in ranked_pages:
         out.extend(page_chunks[:chunks_per_page])
     return out
+
+
+def cap_chunks_per_page(
+    chunks: list[dict[str, Any]],
+    *,
+    chunks_per_page: int,
+) -> list[dict[str, Any]]:
+    """Order-preserving per-page emission cap (Issue #4542 review hardening).
+
+    Unlike ``_aggregate_chunks_to_pages`` — which max-pools page scores,
+    re-ranks pages, and emits page-GROUPED output for the raw BM25 leg —
+    this keeps the caller's ordering intact and simply drops each page's
+    chunks beyond ``chunks_per_page``. For an input already sorted by fused
+    score this retains exactly the top-K chunks of every page in global
+    score order, so downstream trims never drop a higher-scored document
+    in favor of a lower-scored chunk of an earlier page.
+    """
+    counts: dict[str, int] = {}
+    out: list[dict[str, Any]] = []
+    for r in chunks:
+        path = r.get("path") or ""
+        key = path or str(r.get("id") or id(r))
+        emitted = counts.get(key, 0)
+        if emitted < chunks_per_page:
+            counts[key] = emitted + 1
+            out.append(r)
+    return out

--- a/src/nexus/bricks/search/result_builders.py
+++ b/src/nexus/bricks/search/result_builders.py
@@ -153,10 +153,10 @@ def _aggregate_chunks_to_pages(
 
 
 def cap_chunks_per_page(
-    chunks: list[dict[str, Any]],
+    chunks: list[Any],
     *,
     chunks_per_page: int,
-) -> list[dict[str, Any]]:
+) -> list[Any]:
     """Order-preserving per-page emission cap (Issue #4542 review hardening).
 
     Unlike ``_aggregate_chunks_to_pages`` — which max-pools page scores,
@@ -166,12 +166,18 @@ def cap_chunks_per_page(
     score this retains exactly the top-K chunks of every page in global
     score order, so downstream trims never drop a higher-scored document
     in favor of a lower-scored chunk of an earlier page.
+
+    Accepts result dicts or dataclass rows (the degraded hybrid keyword
+    fallback caps raw ``BaseSearchResult`` objects); rows without a path
+    each count as their own page.
     """
     counts: dict[str, int] = {}
-    out: list[dict[str, Any]] = []
+    out: list[Any] = []
     for r in chunks:
-        path = r.get("path") or ""
-        key = path or str(r.get("id") or id(r))
+        if isinstance(r, dict):
+            key = (r.get("path") or "") or str(r.get("id") or id(r))
+        else:
+            key = getattr(r, "path", "") or str(id(r))
         emitted = counts.get(key, 0)
         if emitted < chunks_per_page:
             counts[key] = emitted + 1

--- a/src/nexus/bricks/search/search_service.py
+++ b/src/nexus/bricks/search/search_service.py
@@ -4183,6 +4183,24 @@ class SearchService:
         # fallback actually fires.
         LAST_SEMANTIC_DEGRADED.set(False)
 
+        # Issue #4542 round-9 review: an explicitly scoped credential with no
+        # READABLE zone fails closed BEFORE any retrieval work. An empty
+        # readable scope is an authorization outcome, not a peer outage — it
+        # must not reach the local hybrid/vector paths, and it must not be
+        # laundered through is_all_peers_failed into the un-scoped BM25S/SQL
+        # fallback.
+        if context is not None and not (
+            getattr(context, "is_admin", False) or getattr(context, "is_system", False)
+        ):
+            from nexus.bricks.search.federated_search import readable_zone_filter
+
+            _readable_scope = readable_zone_filter(
+                getattr(context, "zone_set", None) or (),
+                getattr(context, "zone_perms", None) or (),
+            )
+            if _readable_scope is not None and not _readable_scope:
+                return []
+
         # Step 1 — real RRF hybrid when requested. We always invoke the
         # helper (even with no vec backend) so the one-shot "no-vec"
         # warning fires for users who asked for hybrid explicitly via

--- a/src/nexus/bricks/search/search_service.py
+++ b/src/nexus/bricks/search/search_service.py
@@ -4225,11 +4225,25 @@ class SearchService:
                         (getattr(context, "subject_type", None) or "user"),
                         (getattr(context, "user_id", None) or ""),
                     )
+                    # Issue #4542 round-7 review: propagate the context's
+                    # zone allow-list into the inner dispatch. Without it, a
+                    # scoped token whose allowed zone is unavailable could
+                    # receive results from any zone its SUBJECT can reach
+                    # (credential-scope breach). ``OperationContext.zone_set``
+                    # is the contract-level allow-list (#3785); admin/system
+                    # contexts keep the legacy unbounded federation.
+                    _ctx_zone_set = getattr(context, "zone_set", None) or ()
+                    _unbounded = bool(
+                        getattr(context, "is_admin", False)
+                        or getattr(context, "is_system", False)
+                        or not _ctx_zone_set
+                    )
                     return await dispatcher.search(
                         query=query,
                         subject=subject,
                         search_type="semantic",
                         limit=limit,
+                        zone_filter=None if _unbounded else frozenset(_ctx_zone_set),
                     )
                 except Exception as exc:
                     # Real dispatch failed — treat as all-peers-failed so the

--- a/src/nexus/bricks/search/search_service.py
+++ b/src/nexus/bricks/search/search_service.py
@@ -4238,12 +4238,23 @@ class SearchService:
                         or getattr(context, "is_system", False)
                         or not _ctx_zone_set
                     )
+                    # Round-8 review: search is a READ — write-only zone
+                    # grants must not be searchable, so derive the filter
+                    # from zone_perms (r/x only) when present.
+                    from nexus.bricks.search.federated_search import (
+                        readable_zone_filter,
+                    )
+
                     return await dispatcher.search(
                         query=query,
                         subject=subject,
                         search_type="semantic",
                         limit=limit,
-                        zone_filter=None if _unbounded else frozenset(_ctx_zone_set),
+                        zone_filter=None
+                        if _unbounded
+                        else readable_zone_filter(
+                            _ctx_zone_set, getattr(context, "zone_perms", None)
+                        ),
                     )
                 except Exception as exc:
                     # Real dispatch failed — treat as all-peers-failed so the

--- a/src/nexus/server/api/v2/routers/search.py
+++ b/src/nexus/server/api/v2/routers/search.py
@@ -716,14 +716,33 @@ async def _handle_federated_search(
             from nexus.server.dependencies import get_operation_context
 
             op_context = get_operation_context(auth_result)
+            # Issue #4542 round-6 review: this all-peers-failed fallback
+            # replaces the dispatcher's capped results wholesale, so it must
+            # honor the per-document cap itself — fetch wider so the cap can
+            # backfill, cap, then trim. Config read uses the same strict
+            # guards as the dispatcher (Mock-safe).
+            _fb_cfg = getattr(search_daemon, "config", None)
+            _fb_cap = (
+                getattr(_fb_cfg, "chunks_per_page", None)
+                if getattr(_fb_cfg, "page_aggregation", None) is True
+                else None
+            )
+            if not isinstance(_fb_cap, int) or _fb_cap <= 0:
+                _fb_cap = None
             fallback_start = time.perf_counter()
             bm25s_results = await search_service.semantic_search(
                 query=q,
                 path=path_filter or "/",
-                limit=limit,
+                limit=limit if _fb_cap is None else limit * 2,
                 search_mode="semantic",  # triggers SANDBOX fallback inside SearchService
                 context=op_context,
             )
+            if _fb_cap is not None:
+                from nexus.bricks.search.result_builders import cap_chunks_per_page
+
+                bm25s_results = cap_chunks_per_page(
+                    list(bm25s_results), chunks_per_page=_fb_cap
+                )[:limit]
             # Record the degraded-path BM25S fallback work so the bound
             # total_ms / fallback_ms reflect it (Codex R3).
             fed_fallback_ms = (time.perf_counter() - fallback_start) * 1000

--- a/src/nexus/server/api/v2/routers/search.py
+++ b/src/nexus/server/api/v2/routers/search.py
@@ -343,13 +343,18 @@ async def search_query(
     # grants fail closed). Legacy tokens without perms info keep the full
     # explicit zone_set; root-scoped and unconstrained credentials stay
     # unbounded (mirrors the #4541 fed_zone_filter exemption).
+    # Round-10 review: admin credentials bypass zone permission checks
+    # repo-wide — do not attenuate or 403 them here. Root-scoped and
+    # unconstrained credentials likewise stay unbounded (#4541 exemption).
     token_zone_filter = None
-    if raw_zone_set and set(raw_zone_set) != {ROOT_ZONE_ID}:
+    if (
+        raw_zone_set
+        and set(raw_zone_set) != {ROOT_ZONE_ID}
+        and not auth_result.get("is_admin", False)
+    ):
         from nexus.bricks.search.federated_search import readable_zone_filter
 
-        token_zone_filter = readable_zone_filter(
-            raw_zone_set, auth_result.get("zone_perms")
-        )
+        token_zone_filter = readable_zone_filter(raw_zone_set, auth_result.get("zone_perms"))
     # #3785: auto-promote to federated when token grants multiple zones,
     # even if caller didn't pass federated=true. Single-zone tokens
     # (zone_set == (zone_id,)) hit the unchanged single-zone path.
@@ -764,9 +769,9 @@ async def _handle_federated_search(
             if _fb_cap is not None:
                 from nexus.bricks.search.result_builders import cap_chunks_per_page
 
-                bm25s_results = cap_chunks_per_page(
-                    list(bm25s_results), chunks_per_page=_fb_cap
-                )[:limit]
+                bm25s_results = cap_chunks_per_page(list(bm25s_results), chunks_per_page=_fb_cap)[
+                    :limit
+                ]
             # Record the degraded-path BM25S fallback work so the bound
             # total_ms / fallback_ms reflect it (Codex R3).
             fed_fallback_ms = (time.perf_counter() - fallback_start) * 1000

--- a/src/nexus/server/api/v2/routers/search.py
+++ b/src/nexus/server/api/v2/routers/search.py
@@ -356,6 +356,22 @@ async def search_query(
     if len(zone_set) > 1:
         federated = True
 
+    # Issue #4542 round-9 review: enforce the token's read attenuation on
+    # BOTH routes. The federated route gets it via zone_filter; the
+    # single-zone route must check it here, and an explicitly scoped token
+    # with no readable zone fails closed regardless of route.
+    if token_zone_filter is not None:
+        if not token_zone_filter:
+            raise HTTPException(
+                status_code=403,
+                detail="Token has no zone with read permission; search requires read access",
+            )
+        if not federated and zone_id not in token_zone_filter:
+            raise HTTPException(
+                status_code=403,
+                detail=f"Token has no read permission for zone {zone_id}",
+            )
+
     if not search_daemon.is_initialized:
         raise HTTPException(status_code=503, detail="Search daemon is still initializing")
 

--- a/src/nexus/server/api/v2/routers/search.py
+++ b/src/nexus/server/api/v2/routers/search.py
@@ -338,6 +338,18 @@ async def search_query(
     # must never be treated as a token allow-list (#4541 review round 5).
     raw_zone_set = tuple(auth_result.get("zone_set") or ())
     zone_set = raw_zone_set or (zone_id,)
+    # Issue #4542 round-8 review: search is a READ — when the token carries
+    # per-zone perms, only zones granting r/x are searchable (write-only
+    # grants fail closed). Legacy tokens without perms info keep the full
+    # explicit zone_set; root-scoped and unconstrained credentials stay
+    # unbounded (mirrors the #4541 fed_zone_filter exemption).
+    token_zone_filter = None
+    if raw_zone_set and set(raw_zone_set) != {ROOT_ZONE_ID}:
+        from nexus.bricks.search.federated_search import readable_zone_filter
+
+        token_zone_filter = readable_zone_filter(
+            raw_zone_set, auth_result.get("zone_perms")
+        )
     # #3785: auto-promote to federated when token grants multiple zones,
     # even if caller didn't pass federated=true. Single-zone tokens
     # (zone_set == (zone_id,)) hit the unchanged single-zone path.
@@ -383,10 +395,6 @@ async def search_query(
     # exactly {root} (root grants cross-zone access and its id never
     # intersects concrete zone names). A multi-zone scope that happens to
     # include root keeps its pre-existing filtered behaviour.
-    fed_zone_filter = (
-        frozenset(raw_zone_set) if raw_zone_set and set(raw_zone_set) != {ROOT_ZONE_ID} else None
-    )
-
     async def _work() -> dict[str, Any]:
         # --- Federated search path (Issue #3147) ---
         # NOTE: expand= is single-zone only; federated path does not support it.
@@ -402,7 +410,7 @@ async def search_query(
                 auth_result=auth_result,
                 search_daemon=search_daemon,
                 request=request,
-                zone_filter=fed_zone_filter,
+                zone_filter=token_zone_filter,
             )
 
         return await _handle_single_zone_search(

--- a/src/nexus/server/api/v2/routers/search.py
+++ b/src/nexus/server/api/v2/routers/search.py
@@ -338,44 +338,23 @@ async def search_query(
     # must never be treated as a token allow-list (#4541 review round 5).
     raw_zone_set = tuple(auth_result.get("zone_set") or ())
     zone_set = raw_zone_set or (zone_id,)
-    # Issue #4542 round-8 review: search is a READ — when the token carries
-    # per-zone perms, only zones granting r/x are searchable (write-only
-    # grants fail closed). Legacy tokens without perms info keep the full
-    # explicit zone_set; root-scoped and unconstrained credentials stay
-    # unbounded (mirrors the #4541 fed_zone_filter exemption).
-    # Round-10 review: admin credentials bypass zone permission checks
-    # repo-wide — do not attenuate or 403 them here. Root-scoped and
-    # unconstrained credentials likewise stay unbounded (#4541 exemption).
-    token_zone_filter = None
-    if (
-        raw_zone_set
-        and set(raw_zone_set) != {ROOT_ZONE_ID}
-        and not auth_result.get("is_admin", False)
-    ):
-        from nexus.bricks.search.federated_search import readable_zone_filter
+    # #4542 rounds 8-10: readable allow-list (None = admin/root/unbounded).
+    from nexus.bricks.search.federated_search import token_zone_filter_from_auth
 
-        token_zone_filter = readable_zone_filter(raw_zone_set, auth_result.get("zone_perms"))
+    token_zone_filter = token_zone_filter_from_auth(auth_result, root_zone_id=ROOT_ZONE_ID)
     # #3785: auto-promote to federated when token grants multiple zones,
     # even if caller didn't pass federated=true. Single-zone tokens
     # (zone_set == (zone_id,)) hit the unchanged single-zone path.
     if len(zone_set) > 1:
         federated = True
 
-    # Issue #4542 round-9 review: enforce the token's read attenuation on
-    # BOTH routes. The federated route gets it via zone_filter; the
-    # single-zone route must check it here, and an explicitly scoped token
-    # with no readable zone fails closed regardless of route.
+    # Issue #4542 round-9: read attenuation on BOTH routes — federated via
+    # zone_filter, single-zone checked here; no-readable-zone fails closed.
     if token_zone_filter is not None:
         if not token_zone_filter:
-            raise HTTPException(
-                status_code=403,
-                detail="Token has no zone with read permission; search requires read access",
-            )
+            raise HTTPException(403, "Token has no zone with read permission for search")
         if not federated and zone_id not in token_zone_filter:
-            raise HTTPException(
-                status_code=403,
-                detail=f"Token has no read permission for zone {zone_id}",
-            )
+            raise HTTPException(403, f"Token has no read permission for zone {zone_id}")
 
     if not search_daemon.is_initialized:
         raise HTTPException(status_code=503, detail="Search daemon is still initializing")
@@ -745,19 +724,12 @@ async def _handle_federated_search(
             from nexus.server.dependencies import get_operation_context
 
             op_context = get_operation_context(auth_result)
-            # Issue #4542 round-6 review: this all-peers-failed fallback
-            # replaces the dispatcher's capped results wholesale, so it must
-            # honor the per-document cap itself — fetch wider so the cap can
-            # backfill, cap, then trim. Config read uses the same strict
-            # guards as the dispatcher (Mock-safe).
-            _fb_cfg = getattr(search_daemon, "config", None)
-            _fb_cap = (
-                getattr(_fb_cfg, "chunks_per_page", None)
-                if getattr(_fb_cfg, "page_aggregation", None) is True
-                else None
-            )
-            if not isinstance(_fb_cap, int) or _fb_cap <= 0:
-                _fb_cap = None
+            # Issue #4542 round-6: this all-peers-failed fallback replaces the
+            # dispatcher's capped results wholesale, so it must honor the
+            # per-document cap itself — fetch wider, cap, trim.
+            from nexus.bricks.search.federated_search import daemon_pooling_cap
+
+            _fb_cap = daemon_pooling_cap(search_daemon)
             fallback_start = time.perf_counter()
             bm25s_results = await search_service.semantic_search(
                 query=q,

--- a/tests/integration/services/test_search_zone_set.py
+++ b/tests/integration/services/test_search_zone_set.py
@@ -240,3 +240,139 @@ class TestFederatedDispatcherZoneFilter:
         # The dispatcher should have only searched eng (intersection of
         # accessible {eng,legal,ops} and zone_filter {eng}).
         assert resp.zones_searched == ["eng"], f"expected only eng, got {resp.zones_searched}"
+
+
+@pytest.mark.skipif(not _HAS_FASTAPI_TESTCLIENT, reason="fastapi test client not available")
+class TestSingleZoneTokenFederatedEscape:
+    """Issue #4542 round-6 review: a single-zone token requesting
+    federated=true must still be confined to its zone — the router used to
+    forward zone_filter=None for one-element zone_sets, letting the query
+    fan out to every zone the SUBJECT can reach (credential-scope escape)."""
+
+    def test_single_zone_token_federated_true_forwards_zone_filter(self, monkeypatch):
+        builder = TestSearchZoneSet()
+        app = builder._build_app(["eng"])
+        client = TestClient(app)
+
+        from nexus.server.api.v2.routers import search as search_mod
+
+        captured = {}
+
+        async def fake_federated(*, zone_filter=None, **kwargs):
+            captured["zone_filter"] = zone_filter
+            return {"results": [], "federated": True}
+
+        monkeypatch.setattr(search_mod, "_handle_federated_search", fake_federated)
+        resp = client.get("/api/v2/search/query?q=alpha&federated=true")
+        assert resp.status_code == 200, resp.text
+        assert captured["zone_filter"] == frozenset({"eng"})
+
+    def test_no_explicit_zone_set_keeps_unbounded_federation(self, monkeypatch):
+        """Credentials WITHOUT an explicit zone allow-list keep the legacy
+        subject-wide federation (zone_filter=None)."""
+        from nexus.server.api.v2.routers.search import router
+
+        app = FastAPI()
+        app.include_router(router)
+        mock_daemon = MagicMock()
+        mock_daemon.is_initialized = True
+
+        async def mock_search(**kwargs):
+            return []
+
+        mock_daemon.search = mock_search
+        app.state.search_daemon = mock_daemon
+        app.state.search_daemon_enabled = True
+        app.state.record_store = MagicMock()
+        app.state.async_read_session_factory = MagicMock()
+
+        from nexus.server.dependencies import require_auth
+
+        app.dependency_overrides[require_auth] = lambda: {
+            "authenticated": True,
+            "user_id": "test_user",
+            "zone_id": "eng",
+            # no zone_set key: synthesized fallback, not a token grant
+        }
+        client = TestClient(app)
+
+        from nexus.server.api.v2.routers import search as search_mod
+
+        captured = {}
+
+        async def fake_federated(*, zone_filter=None, **kwargs):
+            captured["zone_filter"] = zone_filter
+            return {"results": [], "federated": True}
+
+        monkeypatch.setattr(search_mod, "_handle_federated_search", fake_federated)
+        resp = client.get("/api/v2/search/query?q=alpha&federated=true")
+        assert resp.status_code == 200, resp.text
+        assert captured["zone_filter"] is None
+
+
+@pytest.mark.skipif(not _HAS_FASTAPI_TESTCLIENT, reason="fastapi test client not available")
+class TestSandboxFallbackPooling:
+    """Issue #4542 round-6 review: the SANDBOX all-peers-failed fallback
+    replaces the dispatcher's capped results wholesale, so it must apply the
+    per-document cap itself (fetch wider, cap, trim)."""
+
+    def test_all_peers_failed_fallback_caps(self, monkeypatch):
+        from nexus.bricks.search.daemon import DaemonConfig
+        from nexus.server.api.v2.routers.search import router
+
+        app = FastAPI()
+        app.include_router(router)
+
+        mock_daemon = MagicMock()
+        mock_daemon.is_initialized = True
+        mock_daemon.config = DaemonConfig(page_aggregation=True, chunks_per_page=1)
+        app.state.search_daemon = mock_daemon
+        app.state.search_daemon_enabled = True
+        app.state.record_store = MagicMock()
+        app.state.async_read_session_factory = MagicMock()
+        app.state.deployment_profile = "sandbox"
+
+        rebac = MagicMock()
+        rebac.list_accessible_zones = AsyncMock(return_value=[])
+        app.state.rebac_service = rebac
+
+        captured = {}
+
+        async def fake_semantic_search(**kwargs):
+            captured["limit"] = kwargs.get("limit")
+            rows = [
+                {"path": "/long.md", "chunk_index": i, "score": 0.9 - i * 0.1,
+                 "chunk_text": f"c{i}", "semantic_degraded": True}
+                for i in range(3)
+            ]
+            rows.append(
+                {"path": "/other.md", "chunk_index": 0, "score": 0.5,
+                 "chunk_text": "o", "semantic_degraded": True}
+            )
+            return rows[: kwargs.get("limit", 10)]
+
+        search_service = MagicMock()
+        search_service.semantic_search = fake_semantic_search
+        nexus_fs = MagicMock()
+        nexus_fs.service.return_value = search_service
+        app.state.nexus_fs = nexus_fs
+
+        from nexus.server.dependencies import require_auth
+
+        app.dependency_overrides[require_auth] = lambda: {
+            "authenticated": True,
+            "user_id": "test_user",
+            "subject_type": "user",
+            "subject_id": "test_user",
+            "zone_id": "eng",
+            "zone_set": ["eng"],
+        }
+        client = TestClient(app)
+
+        resp = client.get("/api/v2/search/query?q=alpha&federated=true&limit=3")
+        assert resp.status_code == 200, resp.text
+
+        paths = [r["path"] for r in resp.json()["results"]]
+        assert paths == ["/long.md", "/other.md"]
+        # Fetched wider than the requested limit so the cap could backfill.
+        assert captured["limit"] > 3

--- a/tests/integration/services/test_search_zone_set.py
+++ b/tests/integration/services/test_search_zone_set.py
@@ -341,13 +341,23 @@ class TestSandboxFallbackPooling:
         async def fake_semantic_search(**kwargs):
             captured["limit"] = kwargs.get("limit")
             rows = [
-                {"path": "/long.md", "chunk_index": i, "score": 0.9 - i * 0.1,
-                 "chunk_text": f"c{i}", "semantic_degraded": True}
+                {
+                    "path": "/long.md",
+                    "chunk_index": i,
+                    "score": 0.9 - i * 0.1,
+                    "chunk_text": f"c{i}",
+                    "semantic_degraded": True,
+                }
                 for i in range(3)
             ]
             rows.append(
-                {"path": "/other.md", "chunk_index": 0, "score": 0.5,
-                 "chunk_text": "o", "semantic_degraded": True}
+                {
+                    "path": "/other.md",
+                    "chunk_index": 0,
+                    "score": 0.5,
+                    "chunk_text": "o",
+                    "semantic_degraded": True,
+                }
             )
             return rows[: kwargs.get("limit", 10)]
 
@@ -439,3 +449,55 @@ class TestWriteOnlyTokenSingleZoneRoute:
         client = self._client([["eng", "r"]])
         resp = client.get("/api/v2/search/query?q=alpha")
         assert resp.status_code == 200, resp.text
+
+
+@pytest.mark.skipif(not _HAS_FASTAPI_TESTCLIENT, reason="fastapi test client not available")
+class TestAdminBypassesReadAttenuation:
+    """Issue #4542 round-10 review: admin credentials bypass zone permission
+    checks repo-wide — scoped/write-only admin keys must not be 403'd or
+    attenuated."""
+
+    def test_write_only_scoped_admin_key_still_searches(self, monkeypatch):
+        builder = TestSearchZoneSet()
+        app = builder._build_app(["eng"])
+        from nexus.server.dependencies import require_auth
+
+        app.dependency_overrides[require_auth] = lambda: {
+            "authenticated": True,
+            "user_id": "root",
+            "zone_id": "eng",
+            "zone_set": ["eng"],
+            "zone_perms": [["eng", "w"]],
+            "is_admin": True,
+        }
+        client = TestClient(app)
+        resp = client.get("/api/v2/search/query?q=alpha")
+        assert resp.status_code == 200, resp.text
+
+    def test_admin_federated_stays_unbounded(self, monkeypatch):
+        builder = TestSearchZoneSet()
+        app = builder._build_app(["eng"])
+        from nexus.server.dependencies import require_auth
+
+        app.dependency_overrides[require_auth] = lambda: {
+            "authenticated": True,
+            "user_id": "root",
+            "zone_id": "eng",
+            "zone_set": ["eng"],
+            "zone_perms": [["eng", "rw"]],
+            "is_admin": True,
+        }
+        client = TestClient(app)
+
+        from nexus.server.api.v2.routers import search as search_mod
+
+        captured = {}
+
+        async def fake_federated(*, zone_filter=None, **kwargs):
+            captured["zone_filter"] = zone_filter
+            return {"results": [], "federated": True}
+
+        monkeypatch.setattr(search_mod, "_handle_federated_search", fake_federated)
+        resp = client.get("/api/v2/search/query?q=alpha&federated=true")
+        assert resp.status_code == 200, resp.text
+        assert captured["zone_filter"] is None

--- a/tests/integration/services/test_search_zone_set.py
+++ b/tests/integration/services/test_search_zone_set.py
@@ -409,3 +409,33 @@ class TestRouterReadableZoneFilter:
         resp = client.get("/api/v2/search/query?q=alpha")
         assert resp.status_code == 200, resp.text
         assert captured["zone_filter"] == frozenset({"eng"})
+
+
+@pytest.mark.skipif(not _HAS_FASTAPI_TESTCLIENT, reason="fastapi test client not available")
+class TestWriteOnlyTokenSingleZoneRoute:
+    """Issue #4542 round-9 review: the non-federated single-zone route must
+    enforce the token's read attenuation too."""
+
+    def _client(self, zone_perms):
+        builder = TestSearchZoneSet()
+        app = builder._build_app(["eng"])
+        from nexus.server.dependencies import require_auth
+
+        app.dependency_overrides[require_auth] = lambda: {
+            "authenticated": True,
+            "user_id": "test_user",
+            "zone_id": "eng",
+            "zone_set": ["eng"],
+            "zone_perms": zone_perms,
+        }
+        return TestClient(app)
+
+    def test_write_only_token_rejected_on_single_zone_route(self):
+        client = self._client([["eng", "w"]])
+        resp = client.get("/api/v2/search/query?q=alpha")
+        assert resp.status_code == 403
+
+    def test_readable_token_passes_single_zone_route(self):
+        client = self._client([["eng", "r"]])
+        resp = client.get("/api/v2/search/query?q=alpha")
+        assert resp.status_code == 200, resp.text

--- a/tests/integration/services/test_search_zone_set.py
+++ b/tests/integration/services/test_search_zone_set.py
@@ -376,3 +376,36 @@ class TestSandboxFallbackPooling:
         assert paths == ["/long.md", "/other.md"]
         # Fetched wider than the requested limit so the cap could backfill.
         assert captured["limit"] > 3
+
+
+@pytest.mark.skipif(not _HAS_FASTAPI_TESTCLIENT, reason="fastapi test client not available")
+class TestRouterReadableZoneFilter:
+    """Issue #4542 round-8 review: the router's federated zone_filter keeps
+    only zones the token can READ."""
+
+    def test_write_only_zone_excluded_from_filter(self, monkeypatch):
+        builder = TestSearchZoneSet()
+        app = builder._build_app(["eng", "legal"])
+        from nexus.server.dependencies import require_auth
+
+        app.dependency_overrides[require_auth] = lambda: {
+            "authenticated": True,
+            "user_id": "test_user",
+            "zone_id": "eng",
+            "zone_set": ["eng", "legal"],
+            "zone_perms": [["eng", "r"], ["legal", "w"]],
+        }
+        client = TestClient(app)
+
+        from nexus.server.api.v2.routers import search as search_mod
+
+        captured = {}
+
+        async def fake_federated(*, zone_filter=None, **kwargs):
+            captured["zone_filter"] = zone_filter
+            return {"results": [], "federated": True}
+
+        monkeypatch.setattr(search_mod, "_handle_federated_search", fake_federated)
+        resp = client.get("/api/v2/search/query?q=alpha")
+        assert resp.status_code == 200, resp.text
+        assert captured["zone_filter"] == frozenset({"eng"})

--- a/tests/unit/bricks/search/test_daemon_backend_routing.py
+++ b/tests/unit/bricks/search/test_daemon_backend_routing.py
@@ -312,7 +312,10 @@ async def test_pg_hybrid_backend_timing_records_each_leg() -> None:
     )
 
     assert {result.path for result in results} == {"/chunk.md", "/page.md", "/dense.md"}
-    assert daemon._fts_backend.keyword_limits == [64]
+    # Issue #4542 (round-5 review): with page_aggregation on (default config)
+    # the retrieval legs widen to limit*2*(chunks_per_page+1) = 18 so the
+    # per-doc cap can backfill; page_candidate_limit(18) = 144.
+    assert daemon._fts_backend.keyword_limits == [144]
     assert daemon.last_search_timing.keys() >= _BACKEND_TIMING_KEYS
     assert daemon.last_search_timing["backend_ms"] >= 0.0
     assert daemon.last_search_timing["embed_ms"] >= 0.0

--- a/tests/unit/bricks/search/test_federated_degraded.py
+++ b/tests/unit/bricks/search/test_federated_degraded.py
@@ -195,3 +195,62 @@ class TestSearchServiceSandboxFallback:
         b = _make_sandbox_service()
         a._sandbox_fallback_warned = True
         assert b._sandbox_fallback_warned is False
+
+
+class TestSandboxInnerFederationZoneScope:
+    """Issue #4542 round-7 review: the SANDBOX semantic fallback re-enters the
+    federation dispatcher — it must carry the context's zone allow-list, or a
+    scoped token whose allowed zone is down could receive results from any
+    zone its subject can reach."""
+
+    def _svc_with_dispatcher(self, captured: dict) -> SearchService:
+        svc = _make_sandbox_service()
+
+        async def disp_search(**kwargs):
+            captured.update(kwargs)
+            return FederatedSearchResponse(
+                results=[
+                    {
+                        "path": "/doc.md",
+                        "zone_id": "eng",
+                        "score": 0.9,
+                        "chunk_text": "x",
+                        "chunk_index": 0,
+                    }
+                ],
+                zones_searched=["eng"],
+                zones_failed=[],
+            )
+
+        dispatcher = MagicMock()
+        dispatcher.search = disp_search
+        svc._federation_dispatcher = dispatcher
+        return svc
+
+    @pytest.mark.asyncio
+    async def test_scoped_context_forwards_zone_filter(self) -> None:
+        from nexus.contracts.types import OperationContext
+
+        captured: dict = {}
+        svc = self._svc_with_dispatcher(captured)
+        ctx = OperationContext(user_id="alice", groups=[], zone_id="eng")
+
+        await svc._semantic_search_sandbox(
+            query="q", path="/", limit=5, context=ctx, search_mode="semantic"
+        )
+
+        assert captured["zone_filter"] == frozenset({"eng"})
+
+    @pytest.mark.asyncio
+    async def test_admin_context_keeps_unbounded_federation(self) -> None:
+        from nexus.contracts.types import OperationContext
+
+        captured: dict = {}
+        svc = self._svc_with_dispatcher(captured)
+        ctx = OperationContext(user_id="root", groups=[], zone_id="eng", is_admin=True)
+
+        await svc._semantic_search_sandbox(
+            query="q", path="/", limit=5, context=ctx, search_mode="semantic"
+        )
+
+        assert captured["zone_filter"] is None

--- a/tests/unit/bricks/search/test_federated_degraded.py
+++ b/tests/unit/bricks/search/test_federated_degraded.py
@@ -254,3 +254,47 @@ class TestSandboxInnerFederationZoneScope:
         )
 
         assert captured["zone_filter"] is None
+
+
+class TestReadableZoneFilter:
+    """Issue #4542 round-8 review: write-only zone grants are not searchable."""
+
+    def test_write_only_grant_fails_closed(self) -> None:
+        from nexus.bricks.search.federated_search import readable_zone_filter
+
+        assert readable_zone_filter(("eng",), (("eng", "w"),)) == frozenset()
+
+    def test_mixed_grants_keep_readable_only(self) -> None:
+        from nexus.bricks.search.federated_search import readable_zone_filter
+
+        out = readable_zone_filter(
+            ("eng", "legal", "ops"),
+            (("eng", "r"), ("legal", "w"), ("ops", "rwx")),
+        )
+        assert out == frozenset({"eng", "ops"})
+
+    def test_zone_set_without_perms_kept_whole(self) -> None:
+        from nexus.bricks.search.federated_search import readable_zone_filter
+
+        assert readable_zone_filter(["eng", "legal"], None) == frozenset({"eng", "legal"})
+
+    def test_no_grants_means_unbounded(self) -> None:
+        from nexus.bricks.search.federated_search import readable_zone_filter
+
+        assert readable_zone_filter((), ()) is None
+
+    @pytest.mark.asyncio
+    async def test_write_only_context_fails_closed_in_sandbox_dispatch(self) -> None:
+        from nexus.contracts.types import OperationContext
+
+        captured: dict = {}
+        svc = TestSandboxInnerFederationZoneScope()._svc_with_dispatcher(captured)
+        ctx = OperationContext(
+            user_id="alice", groups=[], zone_id="eng", zone_perms=(("eng", "w"),)
+        )
+
+        await svc._semantic_search_sandbox(
+            query="q", path="/", limit=5, context=ctx, search_mode="semantic"
+        )
+
+        assert captured["zone_filter"] == frozenset()

--- a/tests/unit/bricks/search/test_federated_degraded.py
+++ b/tests/unit/bricks/search/test_federated_degraded.py
@@ -285,6 +285,8 @@ class TestReadableZoneFilter:
 
     @pytest.mark.asyncio
     async def test_write_only_context_fails_closed_in_sandbox_dispatch(self) -> None:
+        """Round-9 strengthened round-8: a write-only context now fails
+        closed at SANDBOX entry — the dispatcher is never reached."""
         from nexus.contracts.types import OperationContext
 
         captured: dict = {}
@@ -293,8 +295,48 @@ class TestReadableZoneFilter:
             user_id="alice", groups=[], zone_id="eng", zone_perms=(("eng", "w"),)
         )
 
-        await svc._semantic_search_sandbox(
+        out = await svc._semantic_search_sandbox(
             query="q", path="/", limit=5, context=ctx, search_mode="semantic"
         )
 
-        assert captured["zone_filter"] == frozenset()
+        assert out == []
+        assert "zone_filter" not in captured  # dispatch never happened
+
+
+class TestWriteOnlyContextFailsClosedEverywhere:
+    """Issue #4542 round-9 review: an empty readable scope is an
+    authorization outcome — SANDBOX local/vector/BM25S paths must not run."""
+
+    @pytest.mark.asyncio
+    async def test_write_only_context_gets_no_results_and_no_fallback(self) -> None:
+        from nexus.contracts.types import OperationContext
+
+        svc = _make_sandbox_service()
+        # Any retrieval work reaching these would be a leak.
+        svc._hybrid_search_sandbox = None  # type: ignore[assignment]
+        svc._try_sqlite_vec_sandbox = None  # type: ignore[assignment]
+
+        dispatched = {"called": False}
+
+        async def disp_search(**kwargs):
+            dispatched["called"] = True
+            return FederatedSearchResponse(
+                results=[{"path": "/secret.md", "score": 0.9}],
+                zones_searched=["eng"],
+                zones_failed=[],
+            )
+
+        dispatcher = MagicMock()
+        dispatcher.search = disp_search
+        svc._federation_dispatcher = dispatcher
+
+        ctx = OperationContext(
+            user_id="alice", groups=[], zone_id="eng", zone_perms=(("eng", "w"),)
+        )
+
+        out = await svc._semantic_search_sandbox(
+            query="q", path="/", limit=5, context=ctx, search_mode="semantic"
+        )
+
+        assert out == []
+        assert dispatched["called"] is False

--- a/tests/unit/bricks/search/test_final_list_page_pooling.py
+++ b/tests/unit/bricks/search/test_final_list_page_pooling.py
@@ -733,6 +733,7 @@ async def test_legacy_hybrid_fallback_caps_at_shared_boundary() -> None:
         path_filter: str | None,
         alpha: float,
         fusion_method: str,
+        rrf_k: int = 60,
         *,
         zone_id: str | None = None,
     ) -> list[SearchResult]:

--- a/tests/unit/bricks/search/test_final_list_page_pooling.py
+++ b/tests/unit/bricks/search/test_final_list_page_pooling.py
@@ -394,3 +394,35 @@ def test_merge_flag_off_keeps_historical_page_grain_dedup() -> None:
     merged = _merge_by_raw_score(zone_lists, limit=10)
 
     assert [(r["path"], r["chunk_index"]) for r in merged] == [("/doc.md", 0), ("/b.md", 0)]
+
+
+@pytest.mark.asyncio
+async def test_backfill_survives_asymmetric_legs_saturated_by_one_doc() -> None:
+    """Round-2 review scenario: keyword leg is ENTIRELY one doc (12 chunks)
+    and the dense leg is half that doc — a fixed limit×2 fusion window kept
+    mostly long-doc chunks and returned an underfilled page. Fusing the full
+    candidate union must fill all requested slots."""
+    long_kw = [_chunk("/long.md", i, 12.0 - i) for i in range(12)]
+    dense = [_chunk("/long.md", i, 0.99 - i * 0.01) for i in range(6)] + [
+        _chunk(f"/other-{j}.md", 0, 0.5 - j * 0.01) for j in range(6)
+    ]
+
+    daemon: Any = SearchDaemon.__new__(SearchDaemon)
+    daemon.last_search_timing = {}
+    daemon.config = DaemonConfig(page_aggregation=True, chunks_per_page=2)
+    daemon._fts_backend = _RowsFtsBackend(long_kw)
+    daemon._vector_backend = _RowsVectorBackend(dense)
+
+    async def _embed_query(self: Any, query: str) -> list[float]:
+        return [0.1, 0.2]
+
+    daemon._embed_query = MethodType(_embed_query, daemon)
+
+    results = await daemon._search_via_backends(
+        "query", search_type="hybrid", limit=6, path_filter=None, zone_id="root"
+    )
+
+    paths = [r.path for r in results]
+    assert len(paths) == 6
+    assert paths.count("/long.md") == 2
+    assert len({p for p in paths if p != "/long.md"}) == 4

--- a/tests/unit/bricks/search/test_final_list_page_pooling.py
+++ b/tests/unit/bricks/search/test_final_list_page_pooling.py
@@ -221,3 +221,176 @@ def test_dispatcher_pooling_off_for_configless_daemon() -> None:
     dispatcher = FederatedSearchDispatcher(daemon=AsyncMock(), rebac=AsyncMock())
 
     assert dispatcher._pooling_chunks_per_page() is None
+
+
+# ---------------------------------------------------------------------------
+# Review hardening (#4550 follow-up): backfill, ordering, real federated shapes
+# ---------------------------------------------------------------------------
+
+
+class _RowsFtsBackend:
+    def __init__(self, rows: list[SearchResult]) -> None:
+        self._rows = rows
+
+    async def keyword_search(
+        self,
+        query: str,
+        path: str,
+        limit: int,
+        zone_id: str,
+        *,
+        timing: dict[str, float] | None = None,
+    ) -> list[SearchResult]:
+        return list(self._rows)
+
+
+class _RowsVectorBackend:
+    def __init__(self, rows: list[SearchResult]) -> None:
+        self._rows = rows
+
+    async def semantic_search(
+        self, qvec: list[float], path: str, limit: int, zone_id: str
+    ) -> list[SearchResult]:
+        return list(self._rows)
+
+
+def _daemon_with_rows(config: DaemonConfig, rows: list[SearchResult]) -> Any:
+    daemon: Any = SearchDaemon.__new__(SearchDaemon)
+    daemon.last_search_timing = {}
+    daemon.config = config
+    daemon._fts_backend = _RowsFtsBackend(rows)
+    daemon._vector_backend = _RowsVectorBackend(rows)
+
+    async def _embed_query(self: Any, query: str) -> list[float]:
+        return [0.1, 0.2]
+
+    daemon._embed_query = MethodType(_embed_query, daemon)
+    return daemon
+
+
+def _chunk(path: str, idx: int, score: float) -> SearchResult:
+    return SearchResult(
+        path=path, chunk_text=f"{path}#{idx}", score=score, chunk_index=idx, search_type="k"
+    )
+
+
+@pytest.mark.asyncio
+async def test_pooling_backfills_below_the_requested_limit_cutoff() -> None:
+    """When one doc's chunks fill the entire requested-limit window, the cap
+    must backfill other docs from below the cutoff instead of returning an
+    underfilled page (review finding: fuse-then-trim-then-cap starved the
+    response)."""
+    rows = [_chunk("/long.md", i, 10.0 - i) for i in range(8)] + [
+        _chunk("/other-a.md", 0, 1.5),
+        _chunk("/other-b.md", 0, 1.0),
+    ]
+    daemon = _daemon_with_rows(DaemonConfig(page_aggregation=True, chunks_per_page=2), rows)
+
+    results = await daemon._search_via_backends(
+        "query", search_type="hybrid", limit=6, path_filter=None, zone_id="root"
+    )
+
+    paths = [r.path for r in results]
+    assert paths == ["/long.md", "/long.md", "/other-a.md", "/other-b.md"]
+
+
+@pytest.mark.asyncio
+async def test_pooling_preserves_fused_score_ordering() -> None:
+    """The cap must be a stable filter over the fused ranking, not a
+    page-grouped re-emission: a doc's second chunk may not leapfrog a
+    higher-scored doc (review finding: A=0.9, A=0.1, B=0.8 ordering)."""
+    rows = [
+        _chunk("/a.md", 0, 10.0),
+        _chunk("/b.md", 0, 9.0),
+        _chunk("/a.md", 1, 8.0),
+        _chunk("/c.md", 0, 7.0),
+    ]
+    daemon = _daemon_with_rows(DaemonConfig(page_aggregation=True, chunks_per_page=2), rows)
+
+    results = await daemon._search_via_backends(
+        "query", search_type="hybrid", limit=4, path_filter=None, zone_id="root"
+    )
+
+    assert [r.path for r in results] == ["/a.md", "/b.md", "/a.md", "/c.md"]
+    scores = [r.score for r in results]
+    assert scores == sorted(scores, reverse=True)
+
+
+def _local_result(zone: str, path: str, idx: int, score: float) -> SearchResult:
+    """Production local-zone shape: dataclass tagged with zone_id, whose
+    ``zone_qualified_path`` property is PAGE-grain (``zone:path``)."""
+    r = _chunk(path, idx, score)
+    r.zone_id = zone
+    return r
+
+
+def _remote_result(zone: str, path: str, idx: int, score: float) -> dict[str, Any]:
+    """Production remote-zone shape: dict with an explicit page-grain
+    ``zone_qualified_path`` (see _search_remote_zone)."""
+    return {
+        "path": path,
+        "chunk_index": idx,
+        "chunk_text": f"{path}#{idx}",
+        "score": score,
+        "zone_id": zone,
+        "zone_qualified_path": f"{zone}:{path}",
+    }
+
+
+def test_merge_cap_honored_on_local_dataclass_shape() -> None:
+    """Review finding: the page-grain zone_qualified_path dedup collapsed
+    every doc back to ONE chunk, silently overriding chunks_per_page > 1 on
+    the shapes production actually emits."""
+    zone_lists = [
+        (
+            "zone-a",
+            [
+                _local_result("zone-a", "/doc.md", 0, 0.9),
+                _local_result("zone-a", "/doc.md", 1, 0.8),
+                _local_result("zone-a", "/doc.md", 2, 0.7),
+                _local_result("zone-a", "/b.md", 0, 0.5),
+            ],
+        ),
+    ]
+
+    merged = _merge_by_raw_score(zone_lists, limit=10, chunks_per_page=2)
+
+    assert [r["path"] for r in merged] == ["/doc.md", "/doc.md", "/b.md"]
+
+
+def test_merge_cap_honored_on_remote_dict_shape() -> None:
+    zone_lists = [
+        (
+            "zone-a",
+            [
+                _remote_result("zone-a", "/doc.md", 0, 0.9),
+                _remote_result("zone-a", "/doc.md", 1, 0.8),
+                _remote_result("zone-a", "/doc.md", 2, 0.7),
+                _remote_result("zone-a", "/b.md", 0, 0.5),
+            ],
+        ),
+    ]
+
+    merged = _merge_by_raw_score(zone_lists, limit=10, chunks_per_page=2)
+
+    assert [r["path"] for r in merged] == ["/doc.md", "/doc.md", "/b.md"]
+
+
+def test_merge_flag_off_keeps_historical_page_grain_dedup() -> None:
+    """With pooling disabled the merge must keep the pre-#4542 behavior on
+    production shapes: page-grain dedup, one (highest-scoring) chunk per doc
+    per zone."""
+    zone_lists = [
+        (
+            "zone-a",
+            [
+                _local_result("zone-a", "/doc.md", 0, 0.9),
+                _local_result("zone-a", "/doc.md", 1, 0.8),
+                _local_result("zone-a", "/b.md", 0, 0.5),
+            ],
+        ),
+    ]
+
+    merged = _merge_by_raw_score(zone_lists, limit=10)
+
+    assert [(r["path"], r["chunk_index"]) for r in merged] == [("/doc.md", 0), ("/b.md", 0)]

--- a/tests/unit/bricks/search/test_final_list_page_pooling.py
+++ b/tests/unit/bricks/search/test_final_list_page_pooling.py
@@ -539,3 +539,145 @@ async def test_multi_zone_saturated_window_backfills() -> None:
     # One chunk per doc (cap=1) and the below-window docs backfilled.
     assert len(set(paths)) == 3
     assert any("next" in p for p in paths)
+
+
+# ---------------------------------------------------------------------------
+# Round-4 review: degraded/alternate paths and cache zone scoping
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_hybrid_embed_failure_fallback_still_caps() -> None:
+    """Round-4 review: an embedding-provider outage sent hybrid down the
+    keyword-only fallback which bypassed the cap and fetched exact-limit
+    (no backfill headroom)."""
+
+    class _SlicingFtsBackend:
+        def __init__(self, rows: list[SearchResult]) -> None:
+            self._rows = rows
+            self.seen_limits: list[int] = []
+
+        async def keyword_search(
+            self,
+            query: str,
+            path: str,
+            limit: int,
+            zone_id: str,
+            *,
+            timing: dict[str, float] | None = None,
+        ) -> list[SearchResult]:
+            self.seen_limits.append(limit)
+            return list(self._rows)[:limit]
+
+    rows = [_chunk("/long.md", i, 10.0 - i) for i in range(4)] + [
+        _chunk("/other-a.md", 0, 5.0),
+        _chunk("/other-b.md", 0, 4.0),
+    ]
+    daemon: Any = SearchDaemon.__new__(SearchDaemon)
+    daemon.last_search_timing = {}
+    daemon.config = DaemonConfig(page_aggregation=True, chunks_per_page=1)
+    daemon._fts_backend = _SlicingFtsBackend(rows)
+    daemon._vector_backend = _RowsVectorBackend([])
+
+    async def _embed_query(self: Any, query: str) -> None:
+        return None
+
+    daemon._embed_query = MethodType(_embed_query, daemon)
+
+    results = await daemon._search_via_backends(
+        "query", search_type="hybrid", limit=4, path_filter=None, zone_id="root"
+    )
+
+    paths = [r.path for r in results]
+    assert paths == ["/long.md", "/other-a.md", "/other-b.md"]
+    # Over-fetched beyond the requested limit so the cap could backfill.
+    assert daemon._fts_backend.seen_limits[0] > 4
+
+
+@pytest.mark.asyncio
+async def test_survivor_branch_applies_cap_when_other_zone_empty() -> None:
+    """Round-4 review: with one zone empty, the one-surviving-list branch
+    sliced without capping — zone failures must not change flag semantics."""
+    seen: dict[str, int] = {}
+    daemon = _capture_daemon(
+        {
+            "za": [
+                _local_result("za", "/doc.md", 0, 0.9),
+                _local_result("za", "/doc.md", 1, 0.8),
+                _local_result("za", "/b.md", 0, 0.5),
+            ],
+            "zb": [],
+        },
+        DaemonConfig(page_aggregation=True, chunks_per_page=1),
+        seen,
+    )
+    dispatcher = FederatedSearchDispatcher(daemon=daemon, rebac=_rebac_for(["za", "zb"]))
+
+    resp = await dispatcher.search(query="q", subject=("user", "u1"), limit=2)
+
+    assert [r["path"] for r in resp.results] == ["/doc.md", "/b.md"]
+
+
+@pytest.mark.asyncio
+async def test_rrf_strategy_honors_cap_at_chunk_grain() -> None:
+    """Round-4 review: RRF fusion deduped at page grain, returning one chunk
+    per doc regardless of chunks_per_page and underfilling the request."""
+    from nexus.bricks.search.federated_search import FederatedSearchConfig
+
+    seen: dict[str, int] = {}
+    daemon = _capture_daemon(
+        {
+            "za": [
+                _local_result("za", "/doc.md", 0, 0.9),
+                _local_result("za", "/doc.md", 1, 0.8),
+                _local_result("za", "/doc.md", 2, 0.7),
+                _local_result("za", "/b.md", 0, 0.5),
+            ],
+            "zb": [_local_result("zb", "/c.md", 0, 0.6)],
+        },
+        DaemonConfig(page_aggregation=True, chunks_per_page=2),
+        seen,
+    )
+    dispatcher = FederatedSearchDispatcher(
+        daemon=daemon,
+        rebac=_rebac_for(["za", "zb"]),
+        config=FederatedSearchConfig(fusion_strategy="rrf"),
+    )
+
+    resp = await dispatcher.search(query="q", subject=("user", "u1"), limit=4)
+
+    paths = [r["path"] for r in resp.results]
+    assert paths.count("/doc.md") == 2
+    assert set(paths) == {"/doc.md", "/b.md", "/c.md"}
+    assert all("_zq_chunk" not in r for r in resp.results)
+
+
+@pytest.mark.asyncio
+async def test_result_cache_scoped_by_zone_filter() -> None:
+    """Round-4 review (tenant isolation): a broad-scope and a narrow-scope
+    token for the same subject must not share a cache entry."""
+    from nexus.bricks.search.federated_search import FederatedSearchConfig
+
+    seen: dict[str, int] = {}
+    daemon = _capture_daemon(
+        {
+            "za": [_local_result("za", "/a.md", 0, 0.9)],
+            "zb": [_local_result("zb", "/b.md", 0, 0.8)],
+        },
+        DaemonConfig(page_aggregation=True, chunks_per_page=2),
+        seen,
+    )
+    dispatcher = FederatedSearchDispatcher(
+        daemon=daemon,
+        rebac=_rebac_for(["za", "zb"]),
+        config=FederatedSearchConfig(result_cache_enabled=True),
+    )
+
+    broad = await dispatcher.search(query="q", subject=("user", "u1"), limit=10)
+    narrow = await dispatcher.search(
+        query="q", subject=("user", "u1"), limit=10, zone_filter=frozenset({"za"})
+    )
+
+    assert {r["zone_id"] for r in broad.results} == {"za", "zb"}
+    assert not narrow.cached
+    assert {r["zone_id"] for r in narrow.results} == {"za"}

--- a/tests/unit/bricks/search/test_final_list_page_pooling.py
+++ b/tests/unit/bricks/search/test_final_list_page_pooling.py
@@ -484,7 +484,9 @@ async def test_single_zone_federated_applies_cap_with_overfetch() -> None:
     )
     dispatcher = FederatedSearchDispatcher(daemon=daemon, rebac=_rebac_for(["z1"]))
 
-    resp = await dispatcher.search(query="q", subject=("user", "u1"), limit=2)
+    resp = await dispatcher.search(
+        query="q", subject=("user", "u1"), search_type="semantic", limit=2
+    )
 
     assert [r["path"] for r in resp.results] == ["/doc.md", "/b.md"]
     # Over-fetched so the cap can backfill instead of shrinking the page.
@@ -532,7 +534,9 @@ async def test_multi_zone_saturated_window_backfills() -> None:
     )
     dispatcher = FederatedSearchDispatcher(daemon=daemon, rebac=_rebac_for(["za", "zb"]))
 
-    resp = await dispatcher.search(query="q", subject=("user", "u1"), limit=3)
+    resp = await dispatcher.search(
+        query="q", subject=("user", "u1"), search_type="semantic", limit=3
+    )
 
     paths = [r["path"] for r in resp.results]
     assert len(paths) == 3
@@ -805,3 +809,36 @@ async def test_leg_windows_widen_so_backfill_survives_saturated_prefix() -> None
 
     paths = [r.path for r in results]
     assert paths == ["/long.md", "/other-a.md", "/other-b.md"]
+
+
+# ---------------------------------------------------------------------------
+# Round-6 review: fetch-window compounding
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_local_hybrid_zones_keep_historical_fetch_window() -> None:
+    """Round-6 review: the dispatcher's cap-aware widening must NOT stack on
+    top of the local hybrid daemon's own cap-aware legs — the multipliers
+    compounded into pathological retrieval windows. Local hybrid zones keep
+    the historical limit x over_fetch_factor window; semantic zones (where
+    dispatcher-side capping is the only protection) get the wider one."""
+    seen: dict[str, int] = {}
+    rows = {
+        "za": [_local_result("za", "/a.md", 0, 0.9)],
+        "zb": [_local_result("zb", "/b.md", 0, 0.8)],
+    }
+    config = DaemonConfig(page_aggregation=True, chunks_per_page=2)
+
+    daemon = _capture_daemon(rows, config, seen)
+    dispatcher = FederatedSearchDispatcher(daemon=daemon, rebac=_rebac_for(["za", "zb"]))
+    await dispatcher.search(query="q", subject=("user", "u1"), search_type="hybrid", limit=5)
+    # over_fetch_factor default = 2 → historical window 10, no (cap+1) stacking.
+    assert seen == {"za": 10, "zb": 10}
+
+    seen.clear()
+    daemon = _capture_daemon(rows, config, seen)
+    dispatcher = FederatedSearchDispatcher(daemon=daemon, rebac=_rebac_for(["za", "zb"]))
+    await dispatcher.search(query="q", subject=("user", "u1"), search_type="semantic", limit=5)
+    # Semantic zones are only capped dispatcher-side → widened by (cap+1).
+    assert seen == {"za": 30, "zb": 30}

--- a/tests/unit/bricks/search/test_final_list_page_pooling.py
+++ b/tests/unit/bricks/search/test_final_list_page_pooling.py
@@ -426,3 +426,116 @@ async def test_backfill_survives_asymmetric_legs_saturated_by_one_doc() -> None:
     assert len(paths) == 6
     assert paths.count("/long.md") == 2
     assert len({p for p in paths if p != "/long.md"}) == 4
+
+
+# ---------------------------------------------------------------------------
+# Round-3 review: dispatcher-level cap behavior on both federated control paths
+# ---------------------------------------------------------------------------
+
+
+def _capture_daemon(
+    zone_results: dict[str, list[Any]],
+    config: DaemonConfig,
+    seen_limits: dict[str, int],
+) -> Any:
+    """Mock daemon that honors the requested limit (slices its fixture) and
+    records the limit each zone was asked for."""
+    daemon = SimpleNamespace(config=config, is_initialized=True)
+
+    async def search(
+        query: str,
+        search_type: str = "hybrid",
+        limit: int = 10,
+        path_filter: str | None = None,
+        alpha: float = 0.5,
+        fusion_method: str = "rrf",
+        zone_id: str | None = None,
+        **kwargs: Any,
+    ) -> list[Any]:
+        seen_limits[zone_id or ""] = limit
+        return list(zone_results.get(zone_id or "", []))[:limit]
+
+    daemon.search = search
+    return daemon
+
+
+def _rebac_for(zones: list[str]) -> AsyncMock:
+    rebac = AsyncMock()
+    rebac.list_accessible_zones = AsyncMock(return_value=zones)
+    return rebac
+
+
+@pytest.mark.asyncio
+async def test_single_zone_federated_applies_cap_with_overfetch() -> None:
+    """Round-3 review: the single-zone fast path bypassed pooling entirely —
+    the cap must not depend on how many zones are accessible."""
+    seen: dict[str, int] = {}
+    daemon = _capture_daemon(
+        {
+            "z1": [
+                _local_result("z1", "/doc.md", 0, 0.9),
+                _local_result("z1", "/doc.md", 1, 0.8),
+                _local_result("z1", "/doc.md", 2, 0.7),
+                _local_result("z1", "/b.md", 0, 0.5),
+            ]
+        },
+        DaemonConfig(page_aggregation=True, chunks_per_page=1),
+        seen,
+    )
+    dispatcher = FederatedSearchDispatcher(daemon=daemon, rebac=_rebac_for(["z1"]))
+
+    resp = await dispatcher.search(query="q", subject=("user", "u1"), limit=2)
+
+    assert [r["path"] for r in resp.results] == ["/doc.md", "/b.md"]
+    # Over-fetched so the cap can backfill instead of shrinking the page.
+    assert seen["z1"] > 2
+
+
+@pytest.mark.asyncio
+async def test_single_zone_federated_flag_off_keeps_fast_path() -> None:
+    seen: dict[str, int] = {}
+    daemon = _capture_daemon(
+        {
+            "z1": [
+                _local_result("z1", "/doc.md", 0, 0.9),
+                _local_result("z1", "/doc.md", 1, 0.8),
+                _local_result("z1", "/b.md", 0, 0.5),
+            ]
+        },
+        DaemonConfig(page_aggregation=False, chunks_per_page=2),
+        seen,
+    )
+    dispatcher = FederatedSearchDispatcher(daemon=daemon, rebac=_rebac_for(["z1"]))
+
+    resp = await dispatcher.search(query="q", subject=("user", "u1"), limit=2)
+
+    # Historical behavior: exact-limit fetch, no cap, no dedup on this path.
+    assert seen["z1"] == 2
+    assert [r["path"] for r in resp.results] == ["/doc.md", "/doc.md"]
+
+
+@pytest.mark.asyncio
+async def test_multi_zone_saturated_window_backfills() -> None:
+    """Round-3 review repro: limit=3, cap=1, each zone's leading window is one
+    long doc with the next doc ranked just below it. The cap-aware wider
+    window must let other docs backfill instead of underfilling the page."""
+    config = DaemonConfig(page_aggregation=True, chunks_per_page=1)
+    seen: dict[str, int] = {}
+
+    def zone_rows(zone: str) -> list[Any]:
+        rows = [_local_result(zone, f"/{zone}-long.md", i, 1.0 - i * 0.01) for i in range(6)]
+        rows.append(_local_result(zone, f"/{zone}-next.md", 0, 0.9))
+        return rows
+
+    daemon = _capture_daemon(
+        {"za": zone_rows("za"), "zb": zone_rows("zb")}, config, seen
+    )
+    dispatcher = FederatedSearchDispatcher(daemon=daemon, rebac=_rebac_for(["za", "zb"]))
+
+    resp = await dispatcher.search(query="q", subject=("user", "u1"), limit=3)
+
+    paths = [r["path"] for r in resp.results]
+    assert len(paths) == 3
+    # One chunk per doc (cap=1) and the below-window docs backfilled.
+    assert len(set(paths)) == 3
+    assert any("next" in p for p in paths)

--- a/tests/unit/bricks/search/test_final_list_page_pooling.py
+++ b/tests/unit/bricks/search/test_final_list_page_pooling.py
@@ -681,3 +681,127 @@ async def test_result_cache_scoped_by_zone_filter() -> None:
     assert {r["zone_id"] for r in broad.results} == {"za", "zb"}
     assert not narrow.cached
     assert {r["zone_id"] for r in narrow.results} == {"za"}
+
+
+# ---------------------------------------------------------------------------
+# Round-5 review: cache-key collisions, legacy hybrid, window saturation
+# ---------------------------------------------------------------------------
+
+
+def test_cache_key_has_no_cross_field_collisions() -> None:
+    """Round-5 review: delimiter concatenation let subject_id 'alice|foo' +
+    query 'bar' collide with subject 'alice' + query 'foo|bar' — and cache
+    lookup precedes ReBAC, so a collision leaks another subject's results."""
+    dispatcher = FederatedSearchDispatcher(daemon=AsyncMock(), rebac=AsyncMock())
+
+    k1 = dispatcher._make_cache_key("bar", ("user", "alice|foo"), "hybrid", 10, None)
+    k2 = dispatcher._make_cache_key("foo|bar", ("user", "alice"), "hybrid", 10, None)
+    k3 = dispatcher._make_cache_key("bar", ("user:x", "alice"), "hybrid", 10, None)
+    k4 = dispatcher._make_cache_key("bar", ("user", "x:alice"), "hybrid", 10, None)
+
+    assert len({k1, k2, k3, k4}) == 4
+
+
+@pytest.mark.asyncio
+async def test_legacy_hybrid_fallback_caps_at_shared_boundary() -> None:
+    """Round-5 review: when the new backends are absent, hybrid routes to the
+    legacy ``_hybrid_search`` stack which bypassed the cap entirely."""
+    daemon: Any = SearchDaemon.__new__(SearchDaemon)
+    daemon._initialized = True
+    daemon._fts_backend = None
+    daemon._vector_backend = None
+    daemon._permission_enforcer = None
+    daemon.last_search_timing = {}
+    daemon.config = DaemonConfig(page_aggregation=True, chunks_per_page=1)
+
+    def _track_latency(self: Any, latency_ms: float) -> None:
+        self._last_latency_ms = latency_ms
+
+    async def _attach_path_contexts(
+        self: Any, results: Any, *, zone_id: str, **_attach_kwargs: Any
+    ) -> None:
+        return None
+
+    legacy_limits: list[int] = []
+
+    async def _hybrid_search(
+        self: Any,
+        query: str,
+        limit: int,
+        path_filter: str | None,
+        alpha: float,
+        fusion_method: str,
+        *,
+        zone_id: str | None = None,
+    ) -> list[SearchResult]:
+        legacy_limits.append(limit)
+        rows = [_chunk("/long.md", i, 10.0 - i) for i in range(4)] + [
+            _chunk("/other-a.md", 0, 5.0),
+            _chunk("/other-b.md", 0, 4.0),
+        ]
+        return rows[:limit]
+
+    async def _keyword_search(self: Any, *args: Any, **kwargs: Any) -> list[SearchResult]:
+        return []
+
+    daemon._track_latency = MethodType(_track_latency, daemon)
+    daemon._attach_path_contexts = MethodType(_attach_path_contexts, daemon)
+    daemon._hybrid_search = MethodType(_hybrid_search, daemon)
+    daemon._keyword_search = MethodType(_keyword_search, daemon)
+
+    results = await daemon.search("q", search_type="hybrid", limit=3, zone_id="root")
+
+    paths = [r.path for r in results]
+    assert paths == ["/long.md", "/other-a.md", "/other-b.md"]
+    # Legacy stack was asked for a wider window so the cap could backfill.
+    assert legacy_limits[0] > 3
+
+
+@pytest.mark.asyncio
+async def test_leg_windows_widen_so_backfill_survives_saturated_prefix() -> None:
+    """Round-5 review: with limit=4 and cap=1, eight leading one-doc chunks
+    saturated the old limit*2 leg windows; alternatives at ranks 9-10 were
+    never fetched and the response underfilled."""
+
+    class _SlicingBackend:
+        def __init__(self, rows: list[SearchResult]) -> None:
+            self._rows = rows
+
+        async def keyword_search(
+            self,
+            query: str,
+            path: str,
+            limit: int,
+            zone_id: str,
+            *,
+            timing: dict[str, float] | None = None,
+        ) -> list[SearchResult]:
+            return list(self._rows)[:limit]
+
+        async def semantic_search(
+            self, qvec: list[float], path: str, limit: int, zone_id: str
+        ) -> list[SearchResult]:
+            return list(self._rows)[:limit]
+
+    rows = [_chunk("/long.md", i, 10.0 - i * 0.1) for i in range(8)] + [
+        _chunk("/other-a.md", 0, 5.0),
+        _chunk("/other-b.md", 0, 4.0),
+    ]
+    backend = _SlicingBackend(rows)
+    daemon: Any = SearchDaemon.__new__(SearchDaemon)
+    daemon.last_search_timing = {}
+    daemon.config = DaemonConfig(page_aggregation=True, chunks_per_page=1)
+    daemon._fts_backend = backend
+    daemon._vector_backend = backend
+
+    async def _embed_query(self: Any, query: str) -> list[float]:
+        return [0.1, 0.2]
+
+    daemon._embed_query = MethodType(_embed_query, daemon)
+
+    results = await daemon._search_via_backends(
+        "query", search_type="hybrid", limit=4, path_filter=None, zone_id="root"
+    )
+
+    paths = [r.path for r in results]
+    assert paths == ["/long.md", "/other-a.md", "/other-b.md"]

--- a/tests/unit/bricks/search/test_final_list_page_pooling.py
+++ b/tests/unit/bricks/search/test_final_list_page_pooling.py
@@ -529,9 +529,7 @@ async def test_multi_zone_saturated_window_backfills() -> None:
         rows.append(_local_result(zone, f"/{zone}-next.md", 0, 0.9))
         return rows
 
-    daemon = _capture_daemon(
-        {"za": zone_rows("za"), "zb": zone_rows("zb")}, config, seen
-    )
+    daemon = _capture_daemon({"za": zone_rows("za"), "zb": zone_rows("zb")}, config, seen)
     dispatcher = FederatedSearchDispatcher(daemon=daemon, rebac=_rebac_for(["za", "zb"]))
 
     resp = await dispatcher.search(
@@ -842,3 +840,52 @@ async def test_local_hybrid_zones_keep_historical_fetch_window() -> None:
     await dispatcher.search(query="q", subject=("user", "u1"), search_type="semantic", limit=5)
     # Semantic zones are only capped dispatcher-side → widened by (cap+1).
     assert seen == {"za": 30, "zb": 30}
+
+
+@pytest.mark.asyncio
+async def test_retrieval_widening_is_bounded_for_huge_caps() -> None:
+    """Round-10 review: chunks_per_page is an unbounded emission cap — the
+    retrieval-window widening it drives must saturate, or cap=1000 turns a
+    limit=100 request into ~600k-row leg scans."""
+
+    class _LimitCaptureBackend:
+        def __init__(self) -> None:
+            self.limits: list[int] = []
+
+        async def keyword_search(
+            self,
+            query: str,
+            path: str,
+            limit: int,
+            zone_id: str,
+            *,
+            timing: dict[str, float] | None = None,
+        ) -> list[SearchResult]:
+            self.limits.append(limit)
+            return []
+
+        async def semantic_search(
+            self, qvec: list[float], path: str, limit: int, zone_id: str
+        ) -> list[SearchResult]:
+            self.limits.append(limit)
+            return []
+
+    backend = _LimitCaptureBackend()
+    daemon: Any = SearchDaemon.__new__(SearchDaemon)
+    daemon.last_search_timing = {}
+    daemon.config = DaemonConfig(page_aggregation=True, chunks_per_page=1000)
+    daemon._fts_backend = backend
+    daemon._vector_backend = backend
+
+    async def _embed_query(self: Any, query: str) -> list[float]:
+        return [0.1, 0.2]
+
+    daemon._embed_query = MethodType(_embed_query, daemon)
+
+    await daemon._search_via_backends(
+        "query", search_type="hybrid", limit=100, path_filter=None, zone_id="root"
+    )
+
+    # Widening saturates: limit * 2 * (min(cap, 4) + 1) = 1000, not 200_200.
+    assert backend.limits
+    assert max(backend.limits) <= 1000


### PR DESCRIPTION
## Summary

Follow-up to merged PR #4550 (#4542 final-list per-document pooling). Ran a 10-round adversarial review-fix loop (Codex) over the pooling change; every finding was verified against the code, fixed with a regression test that fails on the pre-fix commit, and re-reviewed the next round. 10 commits, one per round.

## Correctness fixes (pooling semantics)

- **Backfill**: fusing/trimming at `limit` before capping let one long doc saturate the window and return an underfilled page. The daemon now fuses the full kw+dense candidate union, caps, then trims; the keyword sub-fusion keeps its full union too.
- **Ordering**: new order-preserving `cap_chunks_per_page` replaces the page-grouped `_aggregate_chunks_to_pages` on final lists — fused-score order survives downstream trims.
- **Every control path caps** (flag semantics no longer depend on which path served the query): federated single-zone fast path, one-surviving-zone branch, RRF strategy (chunk-grain fusion identity when cap on), embed-failure keyword fallback, legacy hybrid stack, and the SANDBOX all-peers-failed fallback.
- **Federated dedup**: `zone_qualified_path` is page-grain on both production shapes and silently collapsed every doc to one chunk; dedup switches to chunk grain when the cap is on, keeps the historical key byte-for-byte when off.
- **Bounded amplification**: cap-aware window widening saturates at ×(min(cap,4)+1); local-hybrid zones keep historical windows (no dispatcher×daemon multiplier compounding).

## Security fixes (pre-existing, surfaced by the review)

- Result-cache key: canonical-JSON serialization (delimiter injection allowed cross-subject collisions) + includes the token's `zone_filter` (broad/narrow tokens no longer share entries).
- Single-zone token + `federated=true` could fan out to every subject-accessible zone; explicit zone_sets now always forwarded.
- SANDBOX inner federation dispatch now carries the context's zone allow-list.
- Write-only zone grants are no longer searchable (`readable_zone_filter`, fail-closed at the router 403 gate and at SANDBOX entry); admin credentials keep their repo-wide bypass.

## Documented accepted bounds

Finite retrieval windows remain theoretically saturable by a single document — page-diversified retrieval is a backend-level change deliberately out of scope; widening is bounded instead. Adaptive per-zone pagination likewise out of scope (remote re-dispatch + delegation cost).

## Testing

~30 new regression tests across `test_final_list_page_pooling.py`, `test_federated_degraded.py`, `test_search_zone_set.py`; each round's tests verified RED on the pre-fix commit. Full search unit + federated integration + router sweeps green; pre-commit (ruff, mypy, boundary checks) pass.