### PR TITLE
fix(search): adversarial-review hardening for #4541 fusion-param plumbing

### DIFF
--- a/docs/surface-coverage/api-rpc-surface-coverage.yaml
+++ b/docs/surface-coverage/api-rpc-surface-coverage.yaml
@@ -7625,7 +7625,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/consumers/{consumer_name}/skip-to
-      source: src/nexus/server/api/v2/routers/search.py:282
+      source: src/nexus/server/api/v2/routers/search.py:287
   profiles:
     lite: supported
     sandbox: supported
@@ -7642,7 +7642,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/expand
-      source: src/nexus/server/api/v2/routers/search.py:1569
+      source: src/nexus/server/api/v2/routers/search.py:1605
   profiles:
     lite: supported
     sandbox: supported
@@ -7666,7 +7666,7 @@ operations:
       source: src/nexus/bricks/search/search_service.py:1791
     http:
       name: POST /api/v2/search/glob
-      source: src/nexus/server/api/v2/routers/search.py:1450
+      source: src/nexus/server/api/v2/routers/search.py:1486
     mcp:
       name: nexus_glob
       source: src/nexus/config/tool_profiles.yaml:1
@@ -7693,7 +7693,7 @@ operations:
       source: src/nexus/bricks/search/search_service.py:2101
     http:
       name: POST /api/v2/search/grep
-      source: src/nexus/server/api/v2/routers/search.py:1327
+      source: src/nexus/server/api/v2/routers/search.py:1363
     mcp:
       name: nexus_grep
       source: src/nexus/config/tool_profiles.yaml:1
@@ -7729,7 +7729,7 @@ operations:
   transports:
     http:
       name: GET /api/v2/search/health
-      source: src/nexus/server/api/v2/routers/search.py:201
+      source: src/nexus/server/api/v2/routers/search.py:206
   profiles:
     lite: supported
     sandbox: supported
@@ -7746,7 +7746,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/index
-      source: src/nexus/server/api/v2/routers/search.py:1512
+      source: src/nexus/server/api/v2/routers/search.py:1548
   profiles:
     lite: supported
     sandbox: supported
@@ -7764,7 +7764,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/index-directory
-      source: src/nexus/server/api/v2/routers/search.py:1711
+      source: src/nexus/server/api/v2/routers/search.py:1747
   profiles:
     lite: supported
     sandbox: supported
@@ -7781,7 +7781,7 @@ operations:
   transports:
     http:
       name: GET /api/v2/search/indexed-dirs
-      source: src/nexus/server/api/v2/routers/search.py:1929
+      source: src/nexus/server/api/v2/routers/search.py:1965
   profiles:
     lite: supported
     sandbox: supported
@@ -7798,7 +7798,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/indexing-mode
-      source: src/nexus/server/api/v2/routers/search.py:1966
+      source: src/nexus/server/api/v2/routers/search.py:2002
   profiles:
     lite: supported
     sandbox: supported
@@ -7815,7 +7815,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/locate
-      source: src/nexus/server/api/v2/routers/search.py:2147
+      source: src/nexus/server/api/v2/routers/search.py:2183
   profiles:
     lite: supported
     sandbox: supported
@@ -7832,7 +7832,7 @@ operations:
   transports:
     http:
       name: GET /api/v2/search/parked
-      source: src/nexus/server/api/v2/routers/search.py:239
+      source: src/nexus/server/api/v2/routers/search.py:244
   profiles:
     lite: supported
     sandbox: supported
@@ -7849,7 +7849,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/parked/discard
-      source: src/nexus/server/api/v2/routers/search.py:265
+      source: src/nexus/server/api/v2/routers/search.py:270
   profiles:
     lite: supported
     sandbox: supported
@@ -7867,7 +7867,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/parked/retry
-      source: src/nexus/server/api/v2/routers/search.py:248
+      source: src/nexus/server/api/v2/routers/search.py:253
   profiles:
     lite: supported
     sandbox: supported
@@ -7884,7 +7884,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/purge-unscoped
-      source: src/nexus/server/api/v2/routers/search.py:2093
+      source: src/nexus/server/api/v2/routers/search.py:2129
   profiles:
     lite: supported
     sandbox: supported
@@ -7902,7 +7902,7 @@ operations:
   transports:
     http:
       name: GET /api/v2/search/query
-      source: src/nexus/server/api/v2/routers/search.py:300
+      source: src/nexus/server/api/v2/routers/search.py:305
   profiles:
     lite: supported
     sandbox: supported
@@ -7920,7 +7920,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/query/batch
-      source: src/nexus/server/api/v2/routers/search.py:751
+      source: src/nexus/server/api/v2/routers/search.py:787
   profiles:
     lite: supported
     sandbox: supported
@@ -7937,7 +7937,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/refresh
-      source: src/nexus/server/api/v2/routers/search.py:1548
+      source: src/nexus/server/api/v2/routers/search.py:1584
   profiles:
     lite: supported
     sandbox: supported
@@ -7972,7 +7972,7 @@ operations:
   transports:
     http:
       name: GET /api/v2/search/stats
-      source: src/nexus/server/api/v2/routers/search.py:216
+      source: src/nexus/server/api/v2/routers/search.py:221
   profiles:
     lite: supported
     sandbox: supported

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -3012,7 +3012,40 @@ class SearchDaemon:
         fused = fuse_results(
             kw_results, sem_results, config=fusion_config, limit=limit, id_key=None
         )
-        return [self._coerce_to_search_result(item, search_type="hybrid") for item in fused]
+
+        # Rebuild results in the legacy fallback shape: every field comes from
+        # the first-seen leg result (keyword leg wins ties) and only ``score``
+        # carries the fused value. The historical inline loop never rewrote
+        # per-leg modality fields (keyword_score / vector_score), so default
+        # responses must not start doing so now (#4541 review — byte-identical
+        # defaults includes serialized field values, not just ordering).
+        best: dict[str, SearchResult] = {}
+        for r in [*kw_results, *sem_results]:
+            best.setdefault(f"{r.path}:{r.chunk_index}", r)
+
+        out: list[SearchResult] = []
+        for item in fused:
+            key = f"{item.get('path', '')}:{item.get('chunk_index', 0)}"
+            src = best.get(key)
+            if src is None:
+                out.append(self._coerce_to_search_result(item, search_type="hybrid"))
+                continue
+            out.append(
+                SearchResult(
+                    path=src.path,
+                    chunk_text=src.chunk_text,
+                    score=float(item.get("score", 0.0)),
+                    chunk_index=src.chunk_index,
+                    start_offset=src.start_offset,
+                    end_offset=src.end_offset,
+                    line_start=src.line_start,
+                    line_end=src.line_end,
+                    keyword_score=src.keyword_score,
+                    vector_score=src.vector_score,
+                    search_type="hybrid",
+                )
+            )
+        return out
 
     async def _search_zoekt(
         self,

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -156,7 +156,14 @@ class SearchResult(BaseSearchResult):
 
 
 class SearchResultList(list[SearchResult]):
-    """Search results plus a request-local timing snapshot."""
+    """Search results plus a request-local timing snapshot.
+
+    ``semantic_degraded`` carries request-level degradation (#3778 marker for
+    #4541 review R8): per-result stamping alone loses the signal when the
+    degraded response is EMPTY, so the daemon also flags the list itself.
+    """
+
+    semantic_degraded: bool = False
 
     def __init__(
         self,
@@ -459,7 +466,13 @@ class SearchDaemon:
         self._search_timing_var().set(dict(value))
 
     def _with_search_timing(self, results: Iterable[SearchResult]) -> SearchResultList:
-        return SearchResultList(results, search_timing=self.last_search_timing)
+        wrapped = SearchResultList(results, search_timing=self.last_search_timing)
+        # Preserve request-level degradation set by the degraded hybrid
+        # branches — it must survive re-wrapping even when the list is empty
+        # (#4541 review R8).
+        if getattr(results, "semantic_degraded", False):
+            wrapped.semantic_degraded = True
+        return wrapped
 
     def __init__(
         self,
@@ -2385,14 +2398,16 @@ class SearchDaemon:
                 )
                 timing["fusion_ms"] = (time.perf_counter() - fusion_start) * 1000
                 record_total()
-                coerced = [
+                coerced = SearchResultList(
                     self._coerce_to_search_result(item, search_type=search_type) for item in fused
-                ]
+                )
                 # The dense leg is missing entirely, so a semantic-weighted
                 # request may legitimately score everything 0.0 — stamp the
                 # #3778 degradation marker so callers can distinguish
                 # "semantic retrieval failed" from a genuine ranking
-                # (#4541 review round 6).
+                # (#4541 review round 6). The list-level flag survives even
+                # when the response is empty (round 8).
+                coerced.semantic_degraded = True
                 for coerced_result in coerced:
                     coerced_result.semantic_degraded = True
                 return coerced
@@ -2425,16 +2440,30 @@ class SearchDaemon:
                 timing["page_keyword_ms"] = (time.perf_counter() - page_start) * 1000
                 return keyword_candidates[:keyword_limit], page_results
 
-            (chunk_kw, page_kw), dense = await asyncio.gather(
+            kw_outcome, dense_outcome = await asyncio.gather(
                 timed_pg_keyword_legs(),
                 timed_leg(
                     "vector_ms",
                     self._vector_backend.semantic_search(qvec, path, limit * 2, zone_id),
                 ),
-                return_exceptions=False,
+                return_exceptions=True,
             )
+            # Keyword-leg failures propagate as before; only the dense leg is
+            # fail-soft — a pgvector/connection error degrades to keyword-only
+            # (empty dense leg, stamped below for non-default requests)
+            # instead of aborting the whole hybrid query (#4541 review R8).
+            if isinstance(kw_outcome, BaseException):
+                raise kw_outcome
+            chunk_kw, page_kw = kw_outcome
+            if isinstance(dense_outcome, BaseException):
+                logger.warning(
+                    "hybrid dense leg failed; continuing keyword-only: %s", dense_outcome
+                )
+                dense = []
+            else:
+                dense = dense_outcome
         else:
-            chunk_kw, dense = await asyncio.gather(
+            kw_outcome, dense_outcome = await asyncio.gather(
                 timed_leg(
                     "keyword_ms",
                     self._fts_backend.keyword_search(
@@ -2445,8 +2474,18 @@ class SearchDaemon:
                     "vector_ms",
                     self._vector_backend.semantic_search(qvec, path, limit * 2, zone_id),
                 ),
-                return_exceptions=False,
+                return_exceptions=True,
             )
+            if isinstance(kw_outcome, BaseException):
+                raise kw_outcome
+            chunk_kw = kw_outcome
+            if isinstance(dense_outcome, BaseException):
+                logger.warning(
+                    "hybrid dense leg failed; continuing keyword-only: %s", dense_outcome
+                )
+                dense = []
+            else:
+                dense = dense_outcome
             page_kw = []
 
         # Fuse keyword legs first (chunk + page) with plain RRF, then fuse
@@ -2467,15 +2506,17 @@ class SearchDaemon:
             fused = _aggregate_chunks_to_pages(fused, chunks_per_page=self.config.chunks_per_page)
         timing["fusion_ms"] = (time.perf_counter() - fusion_start) * 1000
         record_total()
-        hybrid_results = [
+        hybrid_results = SearchResultList(
             self._coerce_to_search_result(item, search_type="hybrid") for item in fused
-        ]
-        # Embedding succeeded but the dense leg came back empty (empty or
-        # mismatched vector index): a non-default fusion request is ranking
-        # on keyword legs alone — stamp the #3778 marker like the qvec-None
-        # branch does. Default requests stay unstamped (byte-identical)
-        # (#4541 review round 7).
+        )
+        # Embedding succeeded but the dense leg came back empty or failed
+        # (fail-soft above): a non-default fusion request is ranking on
+        # keyword legs alone — stamp the #3778 marker like the qvec-None
+        # branch does, on the list too so empty responses keep the signal.
+        # Default requests stay unstamped (byte-identical) (#4541 review
+        # rounds 7-8).
         if not dense and (fusion_method != FusionMethod.RRF.value or rrf_k != 60):
+            hybrid_results.semantic_degraded = True
             for hybrid_result in hybrid_results:
                 hybrid_result.semantic_degraded = True
         return hybrid_results
@@ -3060,11 +3101,15 @@ class SearchDaemon:
         # default contract reconstructs the legacy shape below
         # (#4541 review round 6).
         if fusion_method != FusionMethod.RRF.value or rrf_k != 60:
-            coerced = [self._coerce_to_search_result(item, search_type="hybrid") for item in fused]
+            coerced = SearchResultList(
+                self._coerce_to_search_result(item, search_type="hybrid") for item in fused
+            )
             # Semantic leg failed or returned nothing: the non-default fusion
-            # ranked on keyword results alone — stamp the #3778 marker so
-            # callers can tell (#4541 review round 7).
+            # ranked on keyword results alone — stamp the #3778 marker (list-
+            # level too, so empty responses keep the signal) (#4541 review
+            # rounds 7-8).
             if not sem_results:
+                coerced.semantic_degraded = True
                 for coerced_result in coerced:
                     coerced_result.semantic_degraded = True
             return coerced

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -3068,26 +3068,15 @@ class SearchDaemon:
         from nexus.bricks.search.fusion import FusionConfig, FusionMethod, fuse_results
 
         # Run keyword and semantic in parallel
-        kw_task = asyncio.ensure_future(
-            self._keyword_search(query, limit * 3, path_filter, zone_id=zone_id)
+        # Same asymmetric contract as the primary indexed path (#4541 review
+        # round 10): keyword failures cancel the semantic task and propagate
+        # promptly (no dense-only "hybrid" responses, no waiting behind a
+        # hung semantic leg); semantic failures degrade to an empty leg and
+        # are stamped below for non-default fusion requests.
+        kw_results, sem_results = await self._gather_legs_fail_soft_dense(
+            self._keyword_search(query, limit * 3, path_filter, zone_id=zone_id),
+            self._semantic_search(query, limit * 3, path_filter, zone_id=zone_id),
         )
-        sem_task = asyncio.ensure_future(
-            self._semantic_search(query, limit * 3, path_filter, zone_id=zone_id)
-        )
-
-        raw_results = await asyncio.gather(kw_task, sem_task, return_exceptions=True)
-
-        kw_results: list[SearchResult] = []
-        sem_results: list[SearchResult] = []
-
-        if isinstance(raw_results[0], BaseException):
-            logger.warning("Keyword search failed: %s", raw_results[0])
-        else:
-            kw_results = raw_results[0]
-        if isinstance(raw_results[1], BaseException):
-            logger.warning("Semantic search failed: %s", raw_results[1])
-        else:
-            sem_results = raw_results[1]
 
         fusion_config = FusionConfig(
             method=FusionMethod(fusion_method),

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -1998,9 +1998,9 @@ class SearchDaemon:
         path_filter: str | None = None,
         alpha: float = 0.5,
         fusion_method: str = "rrf",
-        rrf_k: int = 60,
         zone_id: str | None = None,
         expand: str = "none",
+        rrf_k: int = 60,
     ) -> list[SearchResult]:
         if zone_id is None:
             results = await self._search_on_current_loop(
@@ -2040,8 +2040,8 @@ class SearchDaemon:
         path_filter: str | None = None,
         alpha: float = 0.5,
         fusion_method: str = "rrf",
-        rrf_k: int = 60,
         zone_id: str | None = None,
+        rrf_k: int = 60,
     ) -> list[SearchResult]:
         """Execute a search query with pre-warmed indexes.
 

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -2467,7 +2467,18 @@ class SearchDaemon:
             fused = _aggregate_chunks_to_pages(fused, chunks_per_page=self.config.chunks_per_page)
         timing["fusion_ms"] = (time.perf_counter() - fusion_start) * 1000
         record_total()
-        return [self._coerce_to_search_result(item, search_type="hybrid") for item in fused]
+        hybrid_results = [
+            self._coerce_to_search_result(item, search_type="hybrid") for item in fused
+        ]
+        # Embedding succeeded but the dense leg came back empty (empty or
+        # mismatched vector index): a non-default fusion request is ranking
+        # on keyword legs alone — stamp the #3778 marker like the qvec-None
+        # branch does. Default requests stay unstamped (byte-identical)
+        # (#4541 review round 7).
+        if not dense and (fusion_method != FusionMethod.RRF.value or rrf_k != 60):
+            for hybrid_result in hybrid_results:
+                hybrid_result.semantic_degraded = True
+        return hybrid_results
 
     async def _embed_query(self, query: str) -> list[float] | None:
         """Embed a query string for the new vector backends.
@@ -3049,7 +3060,14 @@ class SearchDaemon:
         # default contract reconstructs the legacy shape below
         # (#4541 review round 6).
         if fusion_method != FusionMethod.RRF.value or rrf_k != 60:
-            return [self._coerce_to_search_result(item, search_type="hybrid") for item in fused]
+            coerced = [self._coerce_to_search_result(item, search_type="hybrid") for item in fused]
+            # Semantic leg failed or returned nothing: the non-default fusion
+            # ranked on keyword results alone — stamp the #3778 marker so
+            # callers can tell (#4541 review round 7).
+            if not sem_results:
+                for coerced_result in coerced:
+                    coerced_result.semantic_degraded = True
+            return coerced
 
         # Rebuild results in the legacy fallback shape: every field comes from
         # the first-seen leg result (keyword leg wins ties) and only ``score``

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -2366,6 +2366,28 @@ class SearchDaemon:
                 "keyword_ms",
                 self._fts_backend.keyword_search(query, path, limit, zone_id, timing=timing),
             )
+            # Non-default fusion requests still flow through the configured
+            # fusion (keyword leg only, empty dense leg) so the advertised
+            # knobs are honoured even when the embedding dependency is down
+            # (#4541 review round 4). Alpha alone doesn't count: it has no
+            # effect under plain RRF, and the exact default request keeps the
+            # historical raw-keyword shortcut byte-identical.
+            if fusion_method != FusionMethod.RRF.value or rrf_k != 60:
+                fusion_start = time.perf_counter()
+                fused = fuse_results(
+                    results,
+                    [],
+                    config=FusionConfig(
+                        method=FusionMethod(fusion_method), alpha=alpha, rrf_k=rrf_k
+                    ),
+                    limit=limit,
+                    id_key=None,
+                )
+                timing["fusion_ms"] = (time.perf_counter() - fusion_start) * 1000
+                record_total()
+                return [
+                    self._coerce_to_search_result(item, search_type=search_type) for item in fused
+                ]
             record_total()
             return [self._coerce_to_search_result(r, search_type=search_type) for r in results]
 

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -2440,30 +2440,15 @@ class SearchDaemon:
                 timing["page_keyword_ms"] = (time.perf_counter() - page_start) * 1000
                 return keyword_candidates[:keyword_limit], page_results
 
-            kw_outcome, dense_outcome = await asyncio.gather(
+            (chunk_kw, page_kw), dense = await self._gather_legs_fail_soft_dense(
                 timed_pg_keyword_legs(),
                 timed_leg(
                     "vector_ms",
                     self._vector_backend.semantic_search(qvec, path, limit * 2, zone_id),
                 ),
-                return_exceptions=True,
             )
-            # Keyword-leg failures propagate as before; only the dense leg is
-            # fail-soft — a pgvector/connection error degrades to keyword-only
-            # (empty dense leg, stamped below for non-default requests)
-            # instead of aborting the whole hybrid query (#4541 review R8).
-            if isinstance(kw_outcome, BaseException):
-                raise kw_outcome
-            chunk_kw, page_kw = kw_outcome
-            if isinstance(dense_outcome, BaseException):
-                logger.warning(
-                    "hybrid dense leg failed; continuing keyword-only: %s", dense_outcome
-                )
-                dense = []
-            else:
-                dense = dense_outcome
         else:
-            kw_outcome, dense_outcome = await asyncio.gather(
+            chunk_kw, dense = await self._gather_legs_fail_soft_dense(
                 timed_leg(
                     "keyword_ms",
                     self._fts_backend.keyword_search(
@@ -2474,18 +2459,7 @@ class SearchDaemon:
                     "vector_ms",
                     self._vector_backend.semantic_search(qvec, path, limit * 2, zone_id),
                 ),
-                return_exceptions=True,
             )
-            if isinstance(kw_outcome, BaseException):
-                raise kw_outcome
-            chunk_kw = kw_outcome
-            if isinstance(dense_outcome, BaseException):
-                logger.warning(
-                    "hybrid dense leg failed; continuing keyword-only: %s", dense_outcome
-                )
-                dense = []
-            else:
-                dense = dense_outcome
             page_kw = []
 
         # Fuse keyword legs first (chunk + page) with plain RRF, then fuse
@@ -2520,6 +2494,36 @@ class SearchDaemon:
             for hybrid_result in hybrid_results:
                 hybrid_result.semantic_degraded = True
         return hybrid_results
+
+    @staticmethod
+    async def _gather_legs_fail_soft_dense(
+        kw_awaitable: Awaitable[T],
+        dense_awaitable: Awaitable[list[Any]],
+    ) -> tuple[T, list[Any]]:
+        """Run the keyword and dense legs concurrently with asymmetric failure
+        handling (#4541 review R8/R9).
+
+        Keyword failures propagate PROMPTLY — the dense task is cancelled and
+        drained first, so a hung vector backend cannot pin the request while
+        the keyword error waits. Dense failures degrade to an empty leg (the
+        caller stamps ``semantic_degraded`` for non-default fusion requests)
+        instead of aborting the whole hybrid query.
+        """
+        kw_task = asyncio.ensure_future(kw_awaitable)
+        dense_task = asyncio.ensure_future(dense_awaitable)
+        try:
+            kw_result = await kw_task
+        except BaseException:
+            dense_task.cancel()
+            with contextlib.suppress(BaseException):
+                await dense_task
+            raise
+        try:
+            dense_result: list[Any] = await dense_task
+        except Exception as exc:
+            logger.warning("hybrid dense leg failed; continuing keyword-only: %s", exc)
+            dense_result = []
+        return kw_result, dense_result
 
     async def _embed_query(self, query: str) -> list[float] | None:
         """Embed a query string for the new vector backends.

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -2252,6 +2252,7 @@ class SearchDaemon:
                     path_filter,
                     alpha,
                     fusion_method,
+                    rrf_k,
                     zone_id=zone_id,
                 )
             fallback_ms = (time.perf_counter() - fallback_start) * 1000
@@ -2962,15 +2963,24 @@ class SearchDaemon:
         query: str,
         limit: int,
         path_filter: str | None,
-        alpha: float,  # noqa: ARG002
-        fusion_method: str,  # noqa: ARG002
+        alpha: float,
+        fusion_method: str = "rrf",
+        rrf_k: int = 60,
         *,
         zone_id: str | None = None,
     ) -> list[SearchResult]:
-        """Hybrid search combining keyword and semantic results via RRF.
+        """Hybrid search combining keyword and semantic results (legacy fallback).
 
-        Pipeline: BM25/Zoekt + Dense -> RRF fusion -> results
+        Pipeline: BM25/Zoekt + Dense -> fusion -> results
+
+        Honours the request's fusion knobs via the shared fusion module so
+        the degraded/no-backend path keeps the same semantics as the primary
+        indexed path (#4541 review). ``top_rank_bonus`` stays off to preserve
+        this path's historical default scoring (plain reciprocal-rank sums,
+        k=60, no bonus).
         """
+        from nexus.bricks.search.fusion import FusionConfig, FusionMethod, fuse_results
+
         # Run keyword and semantic in parallel
         kw_task = asyncio.ensure_future(
             self._keyword_search(query, limit * 3, path_filter, zone_id=zone_id)
@@ -2993,42 +3003,16 @@ class SearchDaemon:
         else:
             sem_results = raw_results[1]
 
-        # RRF fusion (k=60)
-        rrf_k = 60
-        scores: dict[str, float] = {}
-        best: dict[str, SearchResult] = {}
-
-        for rank, r in enumerate(kw_results):
-            key = f"{r.path}:{r.chunk_index}"
-            scores[key] = scores.get(key, 0.0) + 1.0 / (rrf_k + rank + 1)
-            if key not in best:
-                best[key] = r
-
-        for rank, r in enumerate(sem_results):
-            key = f"{r.path}:{r.chunk_index}"
-            scores[key] = scores.get(key, 0.0) + 1.0 / (rrf_k + rank + 1)
-            if key not in best:
-                best[key] = r
-
-        # Sort by fused score, take top limit
-        sorted_keys = sorted(scores, key=lambda k: scores[k], reverse=True)[:limit]
-
-        return [
-            SearchResult(
-                path=best[k].path,
-                chunk_text=best[k].chunk_text,
-                score=scores[k],
-                chunk_index=best[k].chunk_index,
-                start_offset=best[k].start_offset,
-                end_offset=best[k].end_offset,
-                line_start=best[k].line_start,
-                line_end=best[k].line_end,
-                keyword_score=best[k].keyword_score,
-                vector_score=best[k].vector_score,
-                search_type="hybrid",
-            )
-            for k in sorted_keys
-        ]
+        fusion_config = FusionConfig(
+            method=FusionMethod(fusion_method),
+            alpha=alpha,
+            rrf_k=rrf_k,
+            top_rank_bonus=False,
+        )
+        fused = fuse_results(
+            kw_results, sem_results, config=fusion_config, limit=limit, id_key=None
+        )
+        return [self._coerce_to_search_result(item, search_type="hybrid") for item in fused]
 
     async def _search_zoekt(
         self,

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -2385,9 +2385,17 @@ class SearchDaemon:
                 )
                 timing["fusion_ms"] = (time.perf_counter() - fusion_start) * 1000
                 record_total()
-                return [
+                coerced = [
                     self._coerce_to_search_result(item, search_type=search_type) for item in fused
                 ]
+                # The dense leg is missing entirely, so a semantic-weighted
+                # request may legitimately score everything 0.0 — stamp the
+                # #3778 degradation marker so callers can distinguish
+                # "semantic retrieval failed" from a genuine ranking
+                # (#4541 review round 6).
+                for coerced_result in coerced:
+                    coerced_result.semantic_degraded = True
+                return coerced
             record_total()
             return [self._coerce_to_search_result(r, search_type=search_type) for r in results]
 
@@ -3034,6 +3042,14 @@ class SearchDaemon:
         fused = fuse_results(
             kw_results, sem_results, config=fusion_config, limit=limit, id_key=None
         )
+
+        # Non-default fusion keeps the fusion module's provenance fields:
+        # keyword_score / vector_score reflect the legs that actually produced
+        # the fused score (matching the primary indexed path). Only the exact
+        # default contract reconstructs the legacy shape below
+        # (#4541 review round 6).
+        if fusion_method != FusionMethod.RRF.value or rrf_k != 60:
+            return [self._coerce_to_search_result(item, search_type="hybrid") for item in fused]
 
         # Rebuild results in the legacy fallback shape: every field comes from
         # the first-seen leg result (keyword leg wins ties) and only ``score``

--- a/src/nexus/bricks/search/federated_search.py
+++ b/src/nexus/bricks/search/federated_search.py
@@ -306,10 +306,12 @@ class FederatedSearchDispatcher:
 
         # Phase 2: Check if this zone has a remote transport in the registry.
         # If so, search via gRPC with a SearchDelegation credential.
-        # NOTE: rrf_k is intentionally NOT forwarded over the remote RPC —
-        # older remote nodes reject unknown search params, so remote zones
-        # fuse with their local default (60) until the RPC surface is
-        # versioned (#4541).
+        # rrf_k travels on the wire like alpha/fusion_method. The remote
+        # ``handle_search`` RPC handler reads params selectively (hasattr) and
+        # currently honours none of the fusion knobs — a pre-existing gap that
+        # applies equally to alpha/fusion_method — so unknown params are
+        # ignored by old peers and the field is ready when the remote handler
+        # grows fusion support (#4541 review).
         if self._registry is not None and self._registry.is_remote(zone_id):
             return await self._search_remote_zone(
                 zone_id=zone_id,
@@ -319,6 +321,7 @@ class FederatedSearchDispatcher:
                 path_filter=path_filter,
                 alpha=effective_alpha,
                 fusion_method=fusion_method,
+                rrf_k=rrf_k,
                 subject=subject,
             )
 
@@ -356,6 +359,7 @@ class FederatedSearchDispatcher:
         path_filter: str | None,
         alpha: float,
         fusion_method: str,
+        rrf_k: int = 60,
         subject: tuple[str, str] | None = None,
     ) -> list[Any]:
         """Search a remote zone via gRPC with SearchDelegation auth.
@@ -390,6 +394,7 @@ class FederatedSearchDispatcher:
             "zone_id": zone_id,
             "alpha": alpha,
             "fusion_method": fusion_method,
+            "rrf_k": rrf_k,
         }
         if path_filter:
             params["path_filter"] = path_filter
@@ -445,16 +450,24 @@ class FederatedSearchDispatcher:
         alpha: float = 0.5,
         fusion_method: str = "rrf",
         rrf_k: int = 60,
+        zone_filter: frozenset[str] | None = None,
     ) -> str:
         """Phase 3: Create a cache key for result caching.
 
         Fusion knobs are part of the key: they change result ordering now
         that the daemon honours them (#4541), so requests differing only in
         alpha / fusion_method / rrf_k must not share a cache entry.
+
+        The token's zone allow-list (#3785) is also part of the key: cache
+        lookup happens before accessible zones are intersected with the
+        filter, so without it a broadly-scoped request could seed a cache
+        entry that a later narrowly-scoped token would read back — leaking
+        results from zones outside that token's scope (#4541 review).
         """
+        zone_scope = ",".join(sorted(zone_filter)) if zone_filter else "*"
         raw = (
             f"{subject[0]}:{subject[1]}|{query}|{search_type}|{limit}|{path_filter}"
-            f"|{alpha}|{fusion_method}|{rrf_k}"
+            f"|{alpha}|{fusion_method}|{rrf_k}|{zone_scope}"
         )
         return hashlib.sha256(raw.encode()).hexdigest()[:32]
 
@@ -595,7 +608,15 @@ class FederatedSearchDispatcher:
 
         # Phase 3: Check result cache
         cache_key = self._make_cache_key(
-            query, subject, search_type, limit, path_filter, alpha, fusion_method, rrf_k
+            query,
+            subject,
+            search_type,
+            limit,
+            path_filter,
+            alpha,
+            fusion_method,
+            rrf_k,
+            zone_filter=zone_filter,
         )
         cached = self._get_cached_result(cache_key, start=start)
         if cached is not None:

--- a/src/nexus/bricks/search/federated_search.py
+++ b/src/nexus/bricks/search/federated_search.py
@@ -788,8 +788,18 @@ class FederatedSearchDispatcher:
         elif len(zone_result_lists) == 1:
             _zone_id, results = zone_result_lists[0]
             fused_results = [_result_to_dict(r) for r in results[:limit]]
-        elif self._config.fusion_strategy == FederatedFusionStrategy.RRF:
-            # RRF: for heterogeneous zones with different scoring functions
+        elif (
+            self._config.fusion_strategy == FederatedFusionStrategy.RRF
+            or fusion_method == "weighted"
+        ):
+            # RRF: for heterogeneous zones with different scoring functions.
+            # ALSO forced for fusion_method=weighted (#4541 review round 8):
+            # weighted fusion min-max normalizes scores INSIDE each zone, so
+            # raw values are shard-local — the top hit of a weak zone scores
+            # 1.0 and would outrank materially stronger hits from another
+            # zone under a raw-score merge. Rank-based fusion is the only
+            # cross-zone-safe merge for that method; rrf/rrf_weighted scores
+            # share one reciprocal-rank formula and stay comparable.
             fused_results = rrf_multi_fusion(
                 result_lists=zone_result_lists,
                 k=60,

--- a/src/nexus/bricks/search/federated_search.py
+++ b/src/nexus/bricks/search/federated_search.py
@@ -325,6 +325,15 @@ class FederatedSearchDispatcher:
         """Search a single zone with capability-aware routing."""
         effective_type, alpha_override = self._get_effective_search_type(zone_id, search_type)
         effective_alpha = alpha_override if alpha_override is not None else alpha
+        # 13B safety promotion (keyword -> hybrid alpha=1.0 under leaky BM25S/
+        # Zoekt) must not run WEIGHTED fusion: the cross-zone merge guard only
+        # sees the original request type, and weighted scores are shard-local
+        # min-max normalized. rrf_weighted honours the alpha=1.0 override
+        # (semantic-only, preserving 13B) while producing reciprocal-rank
+        # scores that stay comparable across zones (#4541 review round 10).
+        effective_fusion = fusion_method
+        if effective_type != search_type and fusion_method == "weighted":
+            effective_fusion = "rrf_weighted"
 
         # Phase 2: Check if this zone has a remote transport in the registry.
         # If so, search via gRPC with a SearchDelegation credential.
@@ -344,7 +353,7 @@ class FederatedSearchDispatcher:
                 limit=limit,
                 path_filter=path_filter,
                 alpha=effective_alpha,
-                fusion_method=fusion_method,
+                fusion_method=effective_fusion,
                 rrf_k=rrf_k,
                 subject=subject,
             )
@@ -357,7 +366,7 @@ class FederatedSearchDispatcher:
             limit=limit,
             path_filter=path_filter,
             alpha=effective_alpha,
-            fusion_method=fusion_method,
+            fusion_method=effective_fusion,
             rrf_k=rrf_k,
             zone_id=zone_id,
         )
@@ -532,6 +541,10 @@ class FederatedSearchDispatcher:
             # report backend work that did not happen (Codex R8). Leave empty;
             # the ``cached=True`` flag marks the response.
             search_timing={},
+            # Degradation IS a property of the cached payload — a hit serves
+            # the same (possibly empty) degraded results, so the marker must
+            # survive the clone (#4541 review round 10).
+            semantic_degraded=response.semantic_degraded,
         )
 
     def _cache_result(self, cache_key: str, response: FederatedSearchResponse) -> None:

--- a/src/nexus/bricks/search/federated_search.py
+++ b/src/nexus/bricks/search/federated_search.py
@@ -297,8 +297,8 @@ class FederatedSearchDispatcher:
         path_filter: str | None,
         alpha: float,
         fusion_method: str,
-        rrf_k: int = 60,
         subject: tuple[str, str] | None = None,
+        rrf_k: int = 60,
     ) -> list[Any]:
         """Search a single zone with capability-aware routing."""
         effective_type, alpha_override = self._get_effective_search_type(zone_id, search_type)
@@ -361,8 +361,8 @@ class FederatedSearchDispatcher:
         path_filter: str | None,
         alpha: float,
         fusion_method: str,
-        rrf_k: int = 60,
         subject: tuple[str, str] | None = None,
+        rrf_k: int = 60,
     ) -> list[Any]:
         """Search a remote zone via gRPC with SearchDelegation auth.
 
@@ -534,8 +534,8 @@ class FederatedSearchDispatcher:
         path_filter: str | None = None,
         alpha: float = 0.5,
         fusion_method: str = "rrf",
-        rrf_k: int = 60,
         zone_filter: frozenset[str] | None = None,  # NEW (#3785)
+        rrf_k: int = 60,
     ) -> FederatedSearchResponse:
         """Public federated search entry point with activity-event instrumentation (#3791).
 
@@ -589,8 +589,8 @@ class FederatedSearchDispatcher:
         path_filter: str | None = None,
         alpha: float = 0.5,
         fusion_method: str = "rrf",
-        rrf_k: int = 60,
         zone_filter: frozenset[str] | None = None,  # NEW (#3785)
+        rrf_k: int = 60,
     ) -> FederatedSearchResponse:
         """Execute a federated search across all accessible zones.
 

--- a/src/nexus/bricks/search/federated_search.py
+++ b/src/nexus/bricks/search/federated_search.py
@@ -102,6 +102,11 @@ class FederatedSearchResponse:
     # phase split as a single-zone one. Remote zones (gRPC peers) do not return
     # per-leg timing through the delegation path, so they don't contribute here.
     search_timing: dict[str, float] = field(default_factory=dict)
+    # #3778 marker (#4541 review round 9): True when any zone served this
+    # query with a degraded dense leg — captured BEFORE ReBAC filtering so
+    # the signal survives empty and fully-filtered responses (and cache hits,
+    # since the cached object carries it).
+    semantic_degraded: bool = False
 
 
 class FederationUnreachableError(Exception):
@@ -123,6 +128,23 @@ def is_all_peers_failed(response: FederatedSearchResponse) -> bool:
     if not response.zones_searched and not response.zones_failed:
         return True
     return bool(not response.results and len(response.zones_failed) >= len(response.zones_searched))
+
+
+def _zone_results_degraded(results: Any) -> bool:
+    """True when a zone's results carry the #3778 degradation marker — either
+    list-level (``SearchResultList.semantic_degraded``, which survives empty
+    responses) or per-result (local result objects / remote result dicts).
+    Checked BEFORE ReBAC filtering so a fully-filtered response keeps the
+    signal (#4541 review round 9)."""
+    if getattr(results, "semantic_degraded", False):
+        return True
+    for r in results:
+        if isinstance(r, dict):
+            if r.get("semantic_degraded"):
+                return True
+        elif getattr(r, "semantic_degraded", None):
+            return True
+    return False
 
 
 def _aggregate_zone_timing(timings: list[dict[str, float]]) -> dict[str, float]:
@@ -685,6 +707,7 @@ class FederatedSearchDispatcher:
                 zone_timing = _aggregate_zone_timing(
                     [dict(getattr(results, "search_timing", {}) or {})]
                 )
+                zone_degraded = _zone_results_degraded(results)
                 # Per-file ReBAC post-filter (Phase 2+)
                 if self._enable_per_file_rebac:
                     results = await filter_federated_results(
@@ -700,6 +723,7 @@ class FederatedSearchDispatcher:
                     zones_skipped=zones_skipped,
                     latency_ms=(time.perf_counter() - start) * 1000,
                     search_timing=zone_timing,
+                    semantic_degraded=zone_degraded,
                 )
                 self._cache_result(cache_key, resp)
                 return resp
@@ -753,6 +777,7 @@ class FederatedSearchDispatcher:
         # split survives fan-out, even for zones that returned no results.
         zone_timings: list[dict[str, float]] = []
 
+        any_zone_degraded = False
         for zone_id, outcome in zone_outcomes:
             if isinstance(outcome, BaseException):
                 logger.warning("[FEDERATED] Zone %s failed: %s", zone_id, outcome)
@@ -762,6 +787,8 @@ class FederatedSearchDispatcher:
                 timing = getattr(outcome, "search_timing", None)
                 if isinstance(timing, dict):
                     zone_timings.append(timing)
+                if not any_zone_degraded and _zone_results_degraded(outcome):
+                    any_zone_degraded = True
                 if outcome:  # non-empty results
                     zone_result_lists.append((zone_id, outcome))
 
@@ -788,18 +815,19 @@ class FederatedSearchDispatcher:
         elif len(zone_result_lists) == 1:
             _zone_id, results = zone_result_lists[0]
             fused_results = [_result_to_dict(r) for r in results[:limit]]
-        elif (
-            self._config.fusion_strategy == FederatedFusionStrategy.RRF
-            or fusion_method == "weighted"
+        elif self._config.fusion_strategy == FederatedFusionStrategy.RRF or (
+            fusion_method == "weighted" and search_type == "hybrid"
         ):
             # RRF: for heterogeneous zones with different scoring functions.
-            # ALSO forced for fusion_method=weighted (#4541 review round 8):
-            # weighted fusion min-max normalizes scores INSIDE each zone, so
-            # raw values are shard-local — the top hit of a weak zone scores
-            # 1.0 and would outrank materially stronger hits from another
-            # zone under a raw-score merge. Rank-based fusion is the only
-            # cross-zone-safe merge for that method; rrf/rrf_weighted scores
-            # share one reciprocal-rank formula and stay comparable.
+            # ALSO forced for weighted HYBRID fusion (#4541 review rounds
+            # 8-9): weighted fusion min-max normalizes scores INSIDE each
+            # zone, so raw values are shard-local — the top hit of a weak
+            # zone scores 1.0 and would outrank materially stronger hits from
+            # another zone under a raw-score merge. Keyword/semantic requests
+            # never run weighted fusion (the knob is hybrid-only), so their
+            # raw scores stay comparable and keep the default merge;
+            # rrf/rrf_weighted scores share one reciprocal-rank formula and
+            # stay comparable too.
             fused_results = rrf_multi_fusion(
                 result_lists=zone_result_lists,
                 k=60,
@@ -826,6 +854,7 @@ class FederatedSearchDispatcher:
             zones_skipped=zones_skipped,
             latency_ms=(time.perf_counter() - start) * 1000,
             search_timing=_aggregate_zone_timing(zone_timings),
+            semantic_degraded=any_zone_degraded,
         )
         self._cache_result(cache_key, resp)
         return resp

--- a/src/nexus/bricks/search/federated_search.py
+++ b/src/nexus/bricks/search/federated_search.py
@@ -306,12 +306,14 @@ class FederatedSearchDispatcher:
 
         # Phase 2: Check if this zone has a remote transport in the registry.
         # If so, search via gRPC with a SearchDelegation credential.
-        # rrf_k travels on the wire like alpha/fusion_method. The remote
-        # ``handle_search`` RPC handler reads params selectively (hasattr) and
-        # currently honours none of the fusion knobs — a pre-existing gap that
-        # applies equally to alpha/fusion_method — so unknown params are
-        # ignored by old peers and the field is ready when the remote handler
-        # grows fusion support (#4541 review).
+        # rrf_k travels on the wire like alpha/fusion_method so the payload is
+        # complete whenever the remote side can serve it. KNOWN GAP (pre-#4541,
+        # applies to every field including query): the remote ``search`` RPC is
+        # rejected by ``parse_method_params`` as an unknown method — it has no
+        # METHOD_PARAMS schema and is not @rpc_expose'd — so registry-remote
+        # zones currently land in ``zones_failed`` and no fusion knob (or any
+        # param) reaches them. Tracked as #4556; fixing the RPC
+        # surface is out of scope for the fusion-param plumbing.
         if self._registry is not None and self._registry.is_remote(zone_id):
             return await self._search_remote_zone(
                 zone_id=zone_id,
@@ -410,11 +412,12 @@ class FederatedSearchDispatcher:
         )
 
         # Convert remote response to result dicts with zone tagging.
-        # Issue #4544 (Codex review R1): the server-side RPC search handler
-        # returns a ``{"results": [...]}`` envelope (handle_search in
-        # src/nexus/server/rpc/handlers/filesystem.py), which the bare-list
-        # check silently discarded — real remote zones contributed zero
-        # results. Accept both shapes.
+        # Issue #4544 (Codex review R1) / #4541 review: the server-side RPC
+        # search handler returns a ``{"results": [...]}`` envelope
+        # (handle_search in src/nexus/server/rpc/handlers/filesystem.py),
+        # which the bare-list check silently discarded — real remote zones
+        # contributed zero results. Older transports may hand back a bare
+        # list — accept both shapes.
         if isinstance(raw_result, dict):
             raw_result = raw_result.get("results", [])
         results = raw_result if isinstance(raw_result, list) else []
@@ -464,7 +467,11 @@ class FederatedSearchDispatcher:
         entry that a later narrowly-scoped token would read back — leaking
         results from zones outside that token's scope (#4541 review).
         """
-        zone_scope = ",".join(sorted(zone_filter)) if zone_filter else "*"
+        # None means "no allow-list" (wildcard); an EMPTY set means "access
+        # to zero zones" and must not collide with the wildcard entry, or an
+        # unrestricted request could seed a cache entry that an empty-scoped
+        # token reads back (#4541 review).
+        zone_scope = "*" if zone_filter is None else "zf:" + ",".join(sorted(zone_filter))
         raw = (
             f"{subject[0]}:{subject[1]}|{query}|{search_type}|{limit}|{path_filter}"
             f"|{alpha}|{fusion_method}|{rrf_k}|{zone_scope}"

--- a/src/nexus/contracts/protocols/search.py
+++ b/src/nexus/contracts/protocols/search.py
@@ -53,9 +53,9 @@ class SearchBrickProtocol(Protocol):
         path_filter: str | None = None,
         alpha: float = 0.5,
         fusion_method: str = "rrf",
-        rrf_k: int = 60,
         adaptive_k: bool = False,
         zone_id: str | None = None,
+        rrf_k: int = 60,
     ) -> builtins.list[Any]: ...
 
     def get_stats(self) -> dict[str, Any]: ...

--- a/src/nexus/server/api/v2/routers/search.py
+++ b/src/nexus/server/api/v2/routers/search.py
@@ -777,7 +777,9 @@ async def _handle_federated_search(
         response_dict["zones_skipped"] = fed_response.zones_skipped
     if fed_response.cached:
         response_dict["cached"] = True
-    if semantic_degraded:
+    # Either the #3778 sandbox BM25S fallback (local flag) or a zone-level
+    # degraded dense leg reported by the dispatcher (#4541 review round 9).
+    if semantic_degraded or getattr(fed_response, "semantic_degraded", False):
         response_dict["semantic_degraded"] = True
     return response_dict
 

--- a/src/nexus/server/api/v2/routers/search.py
+++ b/src/nexus/server/api/v2/routers/search.py
@@ -570,6 +570,14 @@ async def _handle_single_zone_search(
         backend_ms = daemon_timing.get("backend_ms", 0.0)
         rerank_ms = daemon_timing.get("rerank_ms", 0.0)
 
+        # Capture request-level degradation BEFORE the ReBAC filter — it
+        # returns a plain list, dropping the SearchResultList flag. The
+        # list-level flag matters for EMPTY degraded responses, where no
+        # per-result marker exists (#4541 review round 8).
+        semantic_degraded_flag = bool(getattr(results, "semantic_degraded", False)) or any(
+            getattr(r, "semantic_degraded", None) for r in results
+        )
+
         # ReBAC file-level filtering (Decision #17)
         pre_filter_count = len(results)
         results, filter_ms = _apply_rebac_filter(
@@ -603,6 +611,9 @@ async def _handle_single_zone_search(
             "latency_breakdown": latency_breakdown,
             **_rebac_denial_stats(pre_filter_count, post_filter_count, effective_limit),
         }
+        # Truthy-only so default responses stay byte-identical (#3778 shape).
+        if semantic_degraded_flag:
+            response["semantic_degraded"] = True
         if routing_info:
             response["routing"] = routing_info
         return response

--- a/src/nexus/server/api/v2/routers/search.py
+++ b/src/nexus/server/api/v2/routers/search.py
@@ -185,6 +185,11 @@ def _serialize_search_result(result: Any) -> dict[str, Any]:
     tier_boost = getattr(result, "tier_boost", None)
     if tier_boost is not None:
         out["tier_boost"] = round(tier_boost, 4)
+    # #3778 marker, stamped by the daemon when the dense leg was unavailable
+    # for a semantic-weighted fusion request (#4541 review round 6). Emitted
+    # only when set so default responses stay byte-identical.
+    if getattr(result, "semantic_degraded", None):
+        out["semantic_degraded"] = True
     macro_text = getattr(result, "macro_text", None)
     if macro_text is not None:
         out["macro_text"] = macro_text

--- a/src/nexus/server/api/v2/routers/search.py
+++ b/src/nexus/server/api/v2/routers/search.py
@@ -327,8 +327,12 @@ async def search_query(
     start_time = time.perf_counter()
     zone_id = auth_result.get("zone_id") or ROOT_ZONE_ID
 
-    zone_set_raw = auth_result.get("zone_set") or [zone_id]
-    zone_set = tuple(zone_set_raw)
+    # Raw credential scope vs synthesized routing scope: an EMPTY zone_set is
+    # the auth contract for unconstrained credentials (admin/internal keys) —
+    # only the synthesized fallback below uses the active zone_id, and that
+    # must never be treated as a token allow-list (#4541 review round 5).
+    raw_zone_set = tuple(auth_result.get("zone_set") or ())
+    zone_set = raw_zone_set or (zone_id,)
     # #3785: auto-promote to federated when token grants multiple zones,
     # even if caller didn't pass federated=true. Single-zone tokens
     # (zone_set == (zone_id,)) hit the unchanged single-zone path.
@@ -364,14 +368,19 @@ async def search_query(
 
     target_zone = zone_id if zone_id != ROOT_ZONE_ID else None
 
-    # Token zone allow-list for the federated path (#3785). A singleton
-    # non-root zone_set must scope federation too: without it, a single-zone
-    # token requesting federated=true reached the dispatcher with no filter
-    # and searched every subject-accessible zone, bypassing the token's
-    # allow-list (#4541 review round 3). Root-scoped tokens stay unrestricted
-    # — the root zone grants cross-zone access by definition, and its zone id
-    # would never intersect with concrete zone names.
-    fed_zone_filter = frozenset(zone_set) if set(zone_set) != {ROOT_ZONE_ID} else None
+    # Token zone allow-list for the federated path (#3785). An EXPLICIT
+    # singleton non-root zone_set must scope federation too: without it, a
+    # single-zone token requesting federated=true reached the dispatcher with
+    # no filter and searched every subject-accessible zone, bypassing the
+    # token's allow-list (#4541 review round 3). Unrestricted stays None for:
+    # an empty raw scope (unconstrained/admin credentials — the synthesized
+    # zone_id fallback is routing metadata, not an allow-list) and a scope of
+    # exactly {root} (root grants cross-zone access and its id never
+    # intersects concrete zone names). A multi-zone scope that happens to
+    # include root keeps its pre-existing filtered behaviour.
+    fed_zone_filter = (
+        frozenset(raw_zone_set) if raw_zone_set and set(raw_zone_set) != {ROOT_ZONE_ID} else None
+    )
 
     async def _work() -> dict[str, Any]:
         # --- Federated search path (Issue #3147) ---

--- a/src/nexus/server/api/v2/routers/search.py
+++ b/src/nexus/server/api/v2/routers/search.py
@@ -364,6 +364,15 @@ async def search_query(
 
     target_zone = zone_id if zone_id != ROOT_ZONE_ID else None
 
+    # Token zone allow-list for the federated path (#3785). A singleton
+    # non-root zone_set must scope federation too: without it, a single-zone
+    # token requesting federated=true reached the dispatcher with no filter
+    # and searched every subject-accessible zone, bypassing the token's
+    # allow-list (#4541 review round 3). Root-scoped tokens stay unrestricted
+    # — the root zone grants cross-zone access by definition, and its zone id
+    # would never intersect with concrete zone names.
+    fed_zone_filter = frozenset(zone_set) if set(zone_set) != {ROOT_ZONE_ID} else None
+
     async def _work() -> dict[str, Any]:
         # --- Federated search path (Issue #3147) ---
         # NOTE: expand= is single-zone only; federated path does not support it.
@@ -379,7 +388,7 @@ async def search_query(
                 auth_result=auth_result,
                 search_daemon=search_daemon,
                 request=request,
-                zone_filter=frozenset(zone_set) if len(zone_set) > 1 else None,
+                zone_filter=fed_zone_filter,
             )
 
         return await _handle_single_zone_search(

--- a/tests/integration/bricks/search/test_federated_search.py
+++ b/tests/integration/bricks/search/test_federated_search.py
@@ -592,6 +592,59 @@ class TestResultCaching:
 
         assert not resp.cached
 
+    @pytest.mark.asyncio
+    async def test_cache_scoped_by_zone_filter(self) -> None:
+        """A narrowly-scoped token must not read back a broadly-scoped cache
+        entry (#4541 review): cache lookup happens before zone_filter
+        intersection, so the filter must be part of the cache key."""
+        daemon = _make_daemon(
+            {
+                "zone_a": [_make_result("a.txt", 5.0)],
+                "zone_b": [_make_result("b.txt", 3.0)],
+            }
+        )
+        rebac = _make_rebac(["zone_a", "zone_b"])
+
+        config = FederatedSearchConfig(result_cache_enabled=True)
+        dispatcher = FederatedSearchDispatcher(daemon=daemon, rebac=rebac, config=config)
+
+        broad = await dispatcher.search(
+            "test", subject=("user", "alice"), zone_filter=frozenset({"zone_a", "zone_b"})
+        )
+        assert {r["zone_id"] for r in broad.results} == {"zone_a", "zone_b"}
+
+        narrow = await dispatcher.search(
+            "test", subject=("user", "alice"), zone_filter=frozenset({"zone_a"})
+        )
+        assert not narrow.cached
+        assert {r["zone_id"] for r in narrow.results} == {"zone_a"}
+
+        # Same scope again -> cache hit, still zone_a only.
+        narrow2 = await dispatcher.search(
+            "test", subject=("user", "alice"), zone_filter=frozenset({"zone_a"})
+        )
+        assert narrow2.cached
+        assert {r["zone_id"] for r in narrow2.results} == {"zone_a"}
+
+    @pytest.mark.asyncio
+    async def test_cache_scoped_by_fusion_knobs(self) -> None:
+        """Requests differing only in alpha/fusion_method/rrf_k must not
+        share a cache entry now that the daemon honours them (#4541)."""
+        daemon = _make_daemon({"zone_a": [_make_result("a.txt", 5.0)]})
+        rebac = _make_rebac(["zone_a"])
+
+        config = FederatedSearchConfig(result_cache_enabled=True)
+        dispatcher = FederatedSearchDispatcher(daemon=daemon, rebac=rebac, config=config)
+
+        await dispatcher.search("test", subject=("user", "alice"))
+        weighted = await dispatcher.search(
+            "test", subject=("user", "alice"), fusion_method="weighted", alpha=0.9
+        )
+        small_k = await dispatcher.search("test", subject=("user", "alice"), rrf_k=5)
+
+        assert not weighted.cached
+        assert not small_k.cached
+
 
 # =============================================================================
 # filter_federated_results (Issue #3147, gap item 5)

--- a/tests/integration/bricks/search/test_federated_search.py
+++ b/tests/integration/bricks/search/test_federated_search.py
@@ -651,6 +651,57 @@ class TestResultCaching:
         assert paths == ["a1.txt", "b1.txt", "a2.txt", "b2.txt"]
 
     @pytest.mark.asyncio
+    async def test_weighted_merge_not_forced_for_keyword_search(self) -> None:
+        """#4541 review round 9: keyword/semantic requests never run weighted
+        fusion, so their comparable raw scores keep the default merge."""
+        daemon = _make_daemon(
+            {
+                "zone_a": [_make_result("a1.txt", 1.0), _make_result("a2.txt", 0.2)],
+                "zone_b": [_make_result("b1.txt", 0.99), _make_result("b2.txt", 0.98)],
+            }
+        )
+        rebac = _make_rebac(["zone_a", "zone_b"])
+        dispatcher = FederatedSearchDispatcher(daemon=daemon, rebac=rebac)
+
+        resp = await dispatcher.search(
+            "test",
+            subject=("user", "alice"),
+            search_type="keyword",
+            fusion_method="weighted",
+        )
+
+        paths = [r["path"] for r in resp.results]
+        assert paths == ["a1.txt", "b1.txt", "b2.txt", "a2.txt"]  # raw-score merge
+
+    @pytest.mark.asyncio
+    async def test_federated_response_carries_degradation_flag(self) -> None:
+        """#4541 review round 9: zone-level degradation (even with an empty
+        result list) surfaces on the FederatedSearchResponse."""
+        from nexus.bricks.search.daemon import SearchResultList
+
+        degraded_empty = SearchResultList([])
+        degraded_empty.semantic_degraded = True
+
+        daemon = AsyncMock()
+        daemon.is_initialized = True
+
+        async def mock_search(**kwargs):
+            return degraded_empty
+
+        daemon.search = mock_search
+        rebac = _make_rebac(["zone_a"])
+        dispatcher = FederatedSearchDispatcher(daemon=daemon, rebac=rebac)
+
+        resp = await dispatcher.search("test", subject=("user", "alice"))
+        assert resp.results == []
+        assert resp.semantic_degraded is True
+
+        healthy = _make_daemon({"zone_a": [_make_result("a.txt", 5.0)]})
+        dispatcher2 = FederatedSearchDispatcher(daemon=healthy, rebac=_make_rebac(["zone_a"]))
+        resp2 = await dispatcher2.search("test", subject=("user", "alice"))
+        assert resp2.semantic_degraded is False
+
+    @pytest.mark.asyncio
     async def test_positional_zone_filter_signature_unchanged(self) -> None:
         """#4541 review round 3: rrf_k sits AFTER zone_filter so a legacy
         positional call ending in the allow-list set still binds it to

--- a/tests/integration/bricks/search/test_federated_search.py
+++ b/tests/integration/bricks/search/test_federated_search.py
@@ -12,6 +12,7 @@ Tests each responsibility in isolation with mocks:
 
 import asyncio
 from dataclasses import dataclass
+from typing import Any
 from unittest.mock import AsyncMock
 
 import pytest
@@ -1378,3 +1379,65 @@ class TestTierBoostTrustBoundary:
         assert "tier_boost" not in _strip_none_context(
             {"path": "a", "score": 1.0, "tier_boost": 0.01}
         )
+
+
+class TestRound10Hardening:
+    @pytest.mark.asyncio
+    async def test_cache_hit_preserves_degradation_marker(self) -> None:
+        """#4541 review round 10: a cache hit serves the same degraded
+        payload, so semantic_degraded must survive the cache-hit clone."""
+        from nexus.bricks.search.daemon import SearchResultList
+        from nexus.bricks.search.federated_search import FederatedSearchConfig
+
+        degraded_empty = SearchResultList([])
+        degraded_empty.semantic_degraded = True
+
+        daemon = AsyncMock()
+        daemon.is_initialized = True
+
+        async def mock_search(**kwargs):
+            return degraded_empty
+
+        daemon.search = mock_search
+        config = FederatedSearchConfig(result_cache_enabled=True)
+        dispatcher = FederatedSearchDispatcher(
+            daemon=daemon, rebac=_make_rebac(["zone_a"]), config=config
+        )
+
+        miss = await dispatcher.search("test", subject=("user", "alice"))
+        assert miss.semantic_degraded is True and not miss.cached
+
+        hit = await dispatcher.search("test", subject=("user", "alice"))
+        assert hit.cached is True
+        assert hit.semantic_degraded is True
+
+    @pytest.mark.asyncio
+    async def test_leaky_keyword_promotion_avoids_weighted_fusion(self) -> None:
+        """#4541 review round 10: the 13B keyword->hybrid safety promotion
+        must not run weighted fusion (shard-local normalized scores would be
+        raw-merged); it substitutes rrf_weighted, which honours the alpha=1.0
+        override with cross-zone-comparable scores."""
+        seen: dict[str, Any] = {}
+
+        daemon = AsyncMock()
+        daemon.is_initialized = True
+        daemon.get_stats = lambda: {"bm25_documents": 5, "zoekt_available": False}
+
+        async def mock_search(**kwargs):
+            seen.update(kwargs)
+            return [_make_result("a.txt", 5.0)]
+
+        daemon.search = mock_search
+        dispatcher = FederatedSearchDispatcher(daemon=daemon, rebac=_make_rebac(["zone_a"]))
+
+        await dispatcher.search(
+            "test",
+            subject=("user", "alice"),
+            search_type="keyword",
+            fusion_method="weighted",
+            alpha=0.3,
+        )
+
+        assert seen["search_type"] == "hybrid"  # 13B promotion happened
+        assert seen["alpha"] == 1.0
+        assert seen["fusion_method"] == "rrf_weighted"  # not weighted

--- a/tests/integration/bricks/search/test_federated_search.py
+++ b/tests/integration/bricks/search/test_federated_search.py
@@ -627,6 +627,28 @@ class TestResultCaching:
         assert {r["zone_id"] for r in narrow2.results} == {"zone_a"}
 
     @pytest.mark.asyncio
+    async def test_positional_zone_filter_signature_unchanged(self) -> None:
+        """#4541 review round 3: rrf_k sits AFTER zone_filter so a legacy
+        positional call ending in the allow-list set still binds it to
+        zone_filter (not rrf_k, which would silently drop zone scoping)."""
+        daemon = _make_daemon(
+            {
+                "zone_a": [_make_result("a.txt", 5.0)],
+                "zone_b": [_make_result("b.txt", 3.0)],
+            }
+        )
+        rebac = _make_rebac(["zone_a", "zone_b"])
+        dispatcher = FederatedSearchDispatcher(daemon=daemon, rebac=rebac)
+
+        # Legacy positional shape: ..., alpha, fusion_method, zone_filter.
+        resp = await dispatcher.search(
+            "test", ("user", "alice"), "hybrid", 10, None, 0.5, "rrf", frozenset({"zone_a"})
+        )
+
+        assert resp.zones_searched == ["zone_a"]
+        assert {r["zone_id"] for r in resp.results} == {"zone_a"}
+
+    @pytest.mark.asyncio
     async def test_empty_zone_filter_does_not_read_wildcard_cache(self) -> None:
         """An EMPTY allow-list (access to zero zones) must not collide with
         the unrestricted (None) cache entry (#4541 review round 2)."""

--- a/tests/integration/bricks/search/test_federated_search.py
+++ b/tests/integration/bricks/search/test_federated_search.py
@@ -627,6 +627,30 @@ class TestResultCaching:
         assert {r["zone_id"] for r in narrow2.results} == {"zone_a"}
 
     @pytest.mark.asyncio
+    async def test_weighted_fusion_merges_by_rank_not_raw_score(self) -> None:
+        """#4541 review round 8: weighted fusion min-max normalizes scores
+        per zone, so cross-zone merge must be rank-based — a weak zone's 1.0
+        top hit must not displace a strong zone's runner-up wholesale."""
+        daemon = _make_daemon(
+            {
+                "zone_a": [_make_result("a1.txt", 1.0), _make_result("a2.txt", 0.2)],
+                "zone_b": [_make_result("b1.txt", 0.99), _make_result("b2.txt", 0.98)],
+            }
+        )
+        rebac = _make_rebac(["zone_a", "zone_b"])
+        dispatcher = FederatedSearchDispatcher(daemon=daemon, rebac=rebac)
+
+        resp = await dispatcher.search(
+            "test", subject=("user", "alice"), fusion_method="weighted", alpha=0.5
+        )
+
+        paths = [r["path"] for r in resp.results]
+        # Raw-score merge would order [a1, b1, b2, a2] (shard-local scores
+        # compared globally); rank-based fusion pairs equal ranks across
+        # zones: [a1, b1] (rank 1) then [a2, b2] (rank 2).
+        assert paths == ["a1.txt", "b1.txt", "a2.txt", "b2.txt"]
+
+    @pytest.mark.asyncio
     async def test_positional_zone_filter_signature_unchanged(self) -> None:
         """#4541 review round 3: rrf_k sits AFTER zone_filter so a legacy
         positional call ending in the allow-list set still binds it to

--- a/tests/integration/bricks/search/test_federated_search.py
+++ b/tests/integration/bricks/search/test_federated_search.py
@@ -627,6 +627,26 @@ class TestResultCaching:
         assert {r["zone_id"] for r in narrow2.results} == {"zone_a"}
 
     @pytest.mark.asyncio
+    async def test_empty_zone_filter_does_not_read_wildcard_cache(self) -> None:
+        """An EMPTY allow-list (access to zero zones) must not collide with
+        the unrestricted (None) cache entry (#4541 review round 2)."""
+        daemon = _make_daemon({"zone_a": [_make_result("a.txt", 5.0)]})
+        rebac = _make_rebac(["zone_a"])
+
+        config = FederatedSearchConfig(result_cache_enabled=True)
+        dispatcher = FederatedSearchDispatcher(daemon=daemon, rebac=rebac, config=config)
+
+        unrestricted = await dispatcher.search("test", subject=("user", "alice"))
+        assert len(unrestricted.results) == 1
+
+        empty_scope = await dispatcher.search(
+            "test", subject=("user", "alice"), zone_filter=frozenset()
+        )
+        assert not empty_scope.cached
+        assert empty_scope.results == []
+        assert empty_scope.zones_searched == []
+
+    @pytest.mark.asyncio
     async def test_cache_scoped_by_fusion_knobs(self) -> None:
         """Requests differing only in alpha/fusion_method/rrf_k must not
         share a cache entry now that the daemon honours them (#4541)."""

--- a/tests/integration/services/test_search_router.py
+++ b/tests/integration/services/test_search_router.py
@@ -145,6 +145,30 @@ class TestSearchQueryEndpoint:
         assert seen["alpha"] == 0.5
         assert seen["rrf_k"] == 60
 
+    def test_semantic_degraded_flag_survives_empty_results(self, client: "TestClient") -> None:
+        """#4541 review round 8: request-level degradation reaches the
+        response even when the degraded result list is empty."""
+        from nexus.bricks.search.daemon import SearchResultList
+
+        app: Any = client.app
+
+        async def mock_search(**kwargs: Any) -> SearchResultList:
+            degraded = SearchResultList([])
+            degraded.semantic_degraded = True
+            return degraded
+
+        app.state.search_daemon.search = mock_search
+        resp = client.get("/api/v2/search/query?q=hello&fusion=weighted&alpha=1.0")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == 0
+        assert data["semantic_degraded"] is True
+
+    def test_semantic_degraded_absent_by_default(self, client: "TestClient") -> None:
+        resp = client.get("/api/v2/search/query?q=hello")
+        assert resp.status_code == 200
+        assert "semantic_degraded" not in resp.json()
+
     def test_health_endpoint(self, client: "TestClient") -> None:
         resp = client.get("/api/v2/search/health")
         assert resp.status_code == 200

--- a/tests/integration/services/test_search_zone_set.py
+++ b/tests/integration/services/test_search_zone_set.py
@@ -116,6 +116,53 @@ class TestSearchZoneSet:
         assert captured["zone_filter"] is not None
         assert sorted(captured["zone_filter"]) == ["eng", "legal"]
 
+    def test_singleton_token_explicit_federated_stays_scoped(self, monkeypatch):
+        """#4541 review round 3: a single-zone (non-root) token requesting
+        federated=true must still be scoped to its allow-list — previously it
+        reached the dispatcher with zone_filter=None and searched every
+        subject-accessible zone."""
+        app = self._build_app(["eng"])
+        client = TestClient(app)
+
+        from nexus.server.api.v2.routers import search as search_mod
+
+        captured = {}
+
+        async def fake_federated(*, zone_filter=None, **kwargs):
+            captured["zone_filter"] = zone_filter
+            return {"results": [], "federated": True}
+
+        monkeypatch.setattr(search_mod, "_handle_federated_search", fake_federated)
+        resp = client.get("/api/v2/search/query?q=alpha&federated=true")
+        assert resp.status_code == 200, resp.text
+        assert captured["zone_filter"] == frozenset({"eng"})
+
+    def test_root_token_federated_stays_unrestricted(self, monkeypatch):
+        """Root-scoped tokens keep wildcard federation: the root zone grants
+        cross-zone access and its id never matches concrete zone names."""
+        from nexus.server.api.v2.routers import search as search_mod
+        from nexus.server.dependencies import require_auth
+
+        app = self._build_app(["root"])
+        app.dependency_overrides[require_auth] = lambda: {
+            "authenticated": True,
+            "user_id": "test_user",
+            "zone_id": "root",
+            "zone_set": ["root"],
+        }
+        client = TestClient(app)
+
+        captured = {}
+
+        async def fake_federated(*, zone_filter=None, **kwargs):
+            captured["zone_filter"] = zone_filter
+            return {"results": [], "federated": True}
+
+        monkeypatch.setattr(search_mod, "_handle_federated_search", fake_federated)
+        resp = client.get("/api/v2/search/query?q=alpha&federated=true")
+        assert resp.status_code == 200, resp.text
+        assert captured["zone_filter"] is None
+
 
 @pytest.mark.skipif(not _HAS_FASTAPI_TESTCLIENT, reason="fastapi test client not available")
 class TestFederatedDispatcherZoneFilter:

--- a/tests/integration/services/test_search_zone_set.py
+++ b/tests/integration/services/test_search_zone_set.py
@@ -137,6 +137,33 @@ class TestSearchZoneSet:
         assert resp.status_code == 200, resp.text
         assert captured["zone_filter"] == frozenset({"eng"})
 
+    def test_unconstrained_admin_federated_stays_unrestricted(self, monkeypatch):
+        """#4541 review round 5: an EMPTY zone_set is the auth contract for
+        unconstrained credentials — the synthesized active-zone fallback must
+        not become a hard allow-list under federated=true."""
+        from nexus.server.api.v2.routers import search as search_mod
+        from nexus.server.dependencies import require_auth
+
+        app = self._build_app(["eng"])
+        app.dependency_overrides[require_auth] = lambda: {
+            "authenticated": True,
+            "user_id": "admin_user",
+            "zone_id": "eng",  # active routing zone, NOT a token allow-list
+            "zone_set": [],
+        }
+        client = TestClient(app)
+
+        captured = {}
+
+        async def fake_federated(*, zone_filter=None, **kwargs):
+            captured["zone_filter"] = zone_filter
+            return {"results": [], "federated": True}
+
+        monkeypatch.setattr(search_mod, "_handle_federated_search", fake_federated)
+        resp = client.get("/api/v2/search/query?q=alpha&federated=true")
+        assert resp.status_code == 200, resp.text
+        assert captured["zone_filter"] is None
+
     def test_root_token_federated_stays_unrestricted(self, monkeypatch):
         """Root-scoped tokens keep wildcard federation: the root zone grants
         cross-zone access and its id never matches concrete zone names."""

--- a/tests/unit/bricks/search/test_daemon_fusion_params.py
+++ b/tests/unit/bricks/search/test_daemon_fusion_params.py
@@ -201,7 +201,17 @@ def _make_fallback_daemon() -> Any:
     from nexus.bricks.search.daemon import SearchDaemon, SearchResult
 
     def _res(path: str, score: float, st: str) -> SearchResult:
-        return SearchResult(path=path, chunk_text=path, score=score, chunk_index=0, search_type=st)
+        # Legs carry distinguishable per-modality fields so tests can pin
+        # the legacy first-seen field-preservation contract.
+        return SearchResult(
+            path=path,
+            chunk_text=path,
+            score=score,
+            chunk_index=0,
+            search_type=st,
+            keyword_score=score if st == "keyword" else None,
+            vector_score=score if st == "semantic" else None,
+        )
 
     async def _keyword_search(
         self: Any, query: str, limit: int, path_filter: Any, *, zone_id: Any = None
@@ -246,6 +256,18 @@ async def test_fallback_default_matches_legacy_inline_rrf() -> None:
     assert [r.path for r in results] == expected_order == ["/a.md", "/c.md", "/d.md", "/b.md"]
     for r in results:
         assert r.score == pytest.approx(expected[r.path])
+
+    # Byte-identical includes serialized field values, not just ordering:
+    # the legacy loop copied every field from the FIRST-seen leg result
+    # (keyword leg wins) and never rewrote per-leg modality scores.
+    by_path = {r.path: r for r in results}
+    assert by_path["/a.md"].keyword_score == 10.0
+    assert by_path["/a.md"].vector_score is None  # kw-first, despite dense hit
+    assert by_path["/c.md"].keyword_score == 8.0
+    assert by_path["/c.md"].vector_score is None
+    assert by_path["/d.md"].keyword_score is None  # dense-only
+    assert by_path["/d.md"].vector_score == 0.99
+    assert all(r.search_type == "hybrid" for r in results)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/bricks/search/test_daemon_fusion_params.py
+++ b/tests/unit/bricks/search/test_daemon_fusion_params.py
@@ -351,3 +351,46 @@ async def test_search_threads_fusion_params_to_fallback() -> None:
     )
 
     assert seen == {"alpha": 0.9, "fusion_method": "weighted", "rrf_k": 30}
+
+
+@pytest.mark.asyncio
+async def test_search_positional_signature_unchanged() -> None:
+    """#4541 review round 3: rrf_k sits at the signature TAIL so pre-existing
+    positional callers keep binding zone_id in position 7."""
+    from nexus.bricks.search.daemon import SearchDaemon, SearchResult
+
+    seen: dict[str, Any] = {}
+
+    daemon: Any = SearchDaemon.__new__(SearchDaemon)
+    daemon._initialized = True
+    daemon._fts_backend = object()
+    daemon._vector_backend = object()
+    daemon._permission_enforcer = None
+    daemon.last_search_timing = {}
+
+    def _track_latency(self: Any, latency_ms: float) -> None:
+        self._last_latency_ms = latency_ms
+
+    async def _attach_path_contexts(self: Any, results: Any, *, zone_id: str) -> None:
+        self._last_context_zone = zone_id
+
+    async def _search_via_backends(self: Any, *args: Any, **kwargs: Any) -> list[SearchResult]:
+        seen.update(kwargs)
+        return [
+            SearchResult(
+                path="/backend.md",
+                chunk_text="backend result",
+                score=1.0,
+                chunk_index=0,
+                search_type="keyword",
+            )
+        ]
+
+    daemon._track_latency = MethodType(_track_latency, daemon)
+    daemon._attach_path_contexts = MethodType(_attach_path_contexts, daemon)
+    daemon._search_via_backends = MethodType(_search_via_backends, daemon)
+
+    # Legacy positional call shape: 7th positional arg is zone_id.
+    await daemon.search("nexus core", "keyword", 10, None, 0.5, "rrf", "tenant-a")
+
+    assert seen["zone_id"] == "tenant-a"

--- a/tests/unit/bricks/search/test_daemon_fusion_params.py
+++ b/tests/unit/bricks/search/test_daemon_fusion_params.py
@@ -184,3 +184,148 @@ async def test_search_threads_fusion_params_to_backends() -> None:
     assert seen["alpha"] == 0.9
     assert seen["fusion_method"] == "weighted"
     assert seen["rrf_k"] == 30
+
+
+# =============================================================================
+# Legacy fallback path (#4541 review): _hybrid_search must honour the same
+# fusion knobs as the primary indexed path, with byte-identical defaults.
+# =============================================================================
+
+
+def _make_fallback_daemon() -> Any:
+    """Bare daemon exercising the legacy `_hybrid_search` fallback.
+
+    Same divergent corpus as `_make_daemon` but served through the legacy
+    `_keyword_search` / `_semantic_search` stack (no indexed backends).
+    """
+    from nexus.bricks.search.daemon import SearchDaemon, SearchResult
+
+    def _res(path: str, score: float, st: str) -> SearchResult:
+        return SearchResult(path=path, chunk_text=path, score=score, chunk_index=0, search_type=st)
+
+    async def _keyword_search(
+        self: Any, query: str, limit: int, path_filter: Any, *, zone_id: Any = None
+    ) -> list[Any]:
+        return [
+            _res("/a.md", 10.0, "keyword"),
+            _res("/b.md", 9.0, "keyword"),
+            _res("/c.md", 8.0, "keyword"),
+        ]
+
+    async def _semantic_search(
+        self: Any, query: str, limit: int, path_filter: Any, *, zone_id: Any = None
+    ) -> list[Any]:
+        return [
+            _res("/d.md", 0.99, "semantic"),
+            _res("/c.md", 0.9, "semantic"),
+            _res("/a.md", 0.5, "semantic"),
+        ]
+
+    daemon: Any = SearchDaemon.__new__(SearchDaemon)
+    daemon.last_search_timing = {}
+    daemon._keyword_search = MethodType(_keyword_search, daemon)
+    daemon._semantic_search = MethodType(_semantic_search, daemon)
+    return daemon
+
+
+@pytest.mark.asyncio
+async def test_fallback_default_matches_legacy_inline_rrf() -> None:
+    """Regression pin: default fallback fusion stays byte-identical to the
+    historical inline loop — plain reciprocal-rank sums, k=60, no top-rank
+    bonus."""
+    daemon = _make_fallback_daemon()
+    results = await daemon._hybrid_search("nexus core", 4, None, 0.5, "rrf")
+
+    kw = [("/a.md", 1), ("/b.md", 2), ("/c.md", 3)]
+    sem = [("/d.md", 1), ("/c.md", 2), ("/a.md", 3)]
+    expected: dict[str, float] = {}
+    for path, rank in kw + sem:
+        expected[path] = expected.get(path, 0.0) + 1.0 / (60 + rank)
+    expected_order = sorted(expected, key=lambda p: expected[p], reverse=True)
+
+    assert [r.path for r in results] == expected_order == ["/a.md", "/c.md", "/d.md", "/b.md"]
+    for r in results:
+        assert r.score == pytest.approx(expected[r.path])
+
+
+@pytest.mark.asyncio
+async def test_fallback_weighted_alpha_changes_ordering() -> None:
+    daemon = _make_fallback_daemon()
+    low = await daemon._hybrid_search("nexus core", 4, None, 0.05, "weighted")
+    high = await daemon._hybrid_search("nexus core", 4, None, 0.95, "weighted")
+
+    assert [r.path for r in low] != [r.path for r in high]
+    assert [r.path for r in low][0] == "/a.md"
+    assert [r.path for r in high][0] == "/d.md"
+
+
+@pytest.mark.asyncio
+async def test_fallback_rrf_weighted_alpha_zero_ranks_keyword_only() -> None:
+    daemon = _make_fallback_daemon()
+    results = await daemon._hybrid_search("nexus core", 4, None, 0.0, "rrf_weighted")
+
+    assert [r.path for r in results[:3]] == ["/a.md", "/b.md", "/c.md"]
+
+
+@pytest.mark.asyncio
+async def test_fallback_rrf_k_reaches_fusion() -> None:
+    daemon = _make_fallback_daemon()
+    default = await daemon._hybrid_search("nexus core", 4, None, 0.5, "rrf")
+    small_k = await daemon._hybrid_search("nexus core", 4, None, 0.5, "rrf", 1)
+
+    assert [r.score for r in small_k] != [r.score for r in default]
+
+
+@pytest.mark.asyncio
+async def test_search_threads_fusion_params_to_fallback() -> None:
+    """With no indexed backends, `search()` must forward the fusion knobs to
+    the legacy `_hybrid_search` fallback."""
+    from nexus.bricks.search.daemon import SearchDaemon, SearchResult
+
+    seen: dict[str, Any] = {}
+
+    daemon: Any = SearchDaemon.__new__(SearchDaemon)
+    daemon._initialized = True
+    daemon._fts_backend = None
+    daemon._vector_backend = None
+    daemon._permission_enforcer = None
+    daemon.last_search_timing = {}
+
+    def _track_latency(self: Any, latency_ms: float) -> None:
+        self._last_latency_ms = latency_ms
+
+    async def _attach_path_contexts(self: Any, results: Any, *, zone_id: str) -> None:
+        self._last_context_zone = zone_id
+
+    async def _keyword_search(self: Any, *args: Any, **kwargs: Any) -> list[Any]:
+        return []
+
+    async def _hybrid_search(
+        self: Any,
+        query: str,
+        limit: int,
+        path_filter: Any,
+        alpha: float,
+        fusion_method: str = "rrf",
+        rrf_k: int = 60,
+        *,
+        zone_id: Any = None,
+    ) -> list[SearchResult]:
+        seen.update({"alpha": alpha, "fusion_method": fusion_method, "rrf_k": rrf_k})
+        return []
+
+    daemon._track_latency = MethodType(_track_latency, daemon)
+    daemon._attach_path_contexts = MethodType(_attach_path_contexts, daemon)
+    daemon._keyword_search = MethodType(_keyword_search, daemon)
+    daemon._hybrid_search = MethodType(_hybrid_search, daemon)
+
+    await daemon.search(
+        "nexus core",
+        search_type="hybrid",
+        limit=1,
+        alpha=0.9,
+        fusion_method="weighted",
+        rrf_k=30,
+    )
+
+    assert seen == {"alpha": 0.9, "fusion_method": "weighted", "rrf_k": 30}

--- a/tests/unit/bricks/search/test_daemon_fusion_params.py
+++ b/tests/unit/bricks/search/test_daemon_fusion_params.py
@@ -316,7 +316,9 @@ async def test_search_threads_fusion_params_to_fallback() -> None:
     def _track_latency(self: Any, latency_ms: float) -> None:
         self._last_latency_ms = latency_ms
 
-    async def _attach_path_contexts(self: Any, results: Any, *, zone_id: str) -> None:
+    async def _attach_path_contexts(
+        self: Any, results: Any, *, zone_id: str, **kwargs: Any
+    ) -> None:
         self._last_context_zone = zone_id
 
     async def _keyword_search(self: Any, *args: Any, **kwargs: Any) -> list[Any]:
@@ -371,7 +373,9 @@ async def test_search_positional_signature_unchanged() -> None:
     def _track_latency(self: Any, latency_ms: float) -> None:
         self._last_latency_ms = latency_ms
 
-    async def _attach_path_contexts(self: Any, results: Any, *, zone_id: str) -> None:
+    async def _attach_path_contexts(
+        self: Any, results: Any, *, zone_id: str, **kwargs: Any
+    ) -> None:
         self._last_context_zone = zone_id
 
     async def _search_via_backends(self: Any, *args: Any, **kwargs: Any) -> list[SearchResult]:
@@ -601,3 +605,21 @@ async def test_keyword_failure_propagates_promptly_despite_hung_dense_leg() -> N
     with pytest.raises(RuntimeError, match="fts down"):
         await asyncio.wait_for(_hybrid(daemon), timeout=5)
     assert dense_cancelled.is_set()
+
+
+@pytest.mark.asyncio
+async def test_fallback_keyword_failure_propagates() -> None:
+    """#4541 review round 10: the legacy fallback holds the same asymmetric
+    contract as the primary path — keyword failures propagate (no dense-only
+    'hybrid' response), only the semantic leg is fail-soft."""
+    daemon = _make_fallback_daemon()
+
+    async def _keyword_search(
+        self: Any, query: str, limit: int, path_filter: Any, *, zone_id: Any = None
+    ) -> list[Any]:
+        raise RuntimeError("keyword stack down")
+
+    daemon._keyword_search = MethodType(_keyword_search, daemon)
+
+    with pytest.raises(RuntimeError, match="keyword stack down"):
+        await daemon._hybrid_search("nexus core", 4, None, 0.5, "rrf")

--- a/tests/unit/bricks/search/test_daemon_fusion_params.py
+++ b/tests/unit/bricks/search/test_daemon_fusion_params.py
@@ -443,3 +443,34 @@ async def test_no_embedding_honours_weighted_alpha() -> None:
     results = await _hybrid(daemon, alpha=1.0, fusion_method="weighted")
 
     assert all(r.score == 0.0 for r in results)
+
+
+@pytest.mark.asyncio
+async def test_no_embedding_non_default_results_stamped_degraded() -> None:
+    """#4541 review round 6: the dense leg is missing, so non-default fusion
+    results carry the #3778 semantic_degraded marker."""
+    daemon = _make_no_embed_daemon()
+    results = await _hybrid(daemon, alpha=1.0, fusion_method="weighted")
+
+    assert results and all(r.semantic_degraded is True for r in results)
+
+    # The byte-identical default shortcut stays unstamped.
+    default = await _hybrid(daemon)
+    assert all(not r.semantic_degraded for r in default)
+
+
+@pytest.mark.asyncio
+async def test_fallback_non_default_keeps_fusion_provenance() -> None:
+    """#4541 review round 6: non-default fallback fusion reports the leg
+    scores that actually produced the fused score (shared hits carry BOTH
+    keyword_score and vector_score), unlike the legacy default shape."""
+    daemon = _make_fallback_daemon()
+    results = await daemon._hybrid_search("nexus core", 4, None, 0.5, "rrf_weighted")
+
+    by_path = {r.path: r for r in results}
+    # /a.md is in both legs: fusion provenance keeps both modality scores.
+    assert by_path["/a.md"].keyword_score == 10.0
+    assert by_path["/a.md"].vector_score == 0.5
+    # /d.md is dense-only.
+    assert by_path["/d.md"].keyword_score is None
+    assert by_path["/d.md"].vector_score == 0.99

--- a/tests/unit/bricks/search/test_daemon_fusion_params.py
+++ b/tests/unit/bricks/search/test_daemon_fusion_params.py
@@ -560,3 +560,44 @@ async def test_empty_degraded_response_keeps_list_level_flag() -> None:
     results = await _hybrid(daemon, alpha=1.0, fusion_method="weighted")
     assert list(results) == []
     assert getattr(results, "semantic_degraded", False) is True
+
+
+@pytest.mark.asyncio
+async def test_keyword_failure_propagates_promptly_despite_hung_dense_leg() -> None:
+    """#4541 review round 9: a keyword-leg failure must not wait on (or be
+    masked by) a hung vector backend — the dense task is cancelled and the
+    keyword error re-raised promptly."""
+    import asyncio
+
+    daemon = _make_daemon()
+    dense_cancelled = asyncio.Event()
+
+    class FailingFtsBackend:
+        async def keyword_search(
+            self,
+            query: str,
+            path: str,
+            limit: int,
+            zone_id: str,
+            *,
+            timing: dict[str, float] | None = None,
+        ) -> list[Any]:
+            raise RuntimeError("fts down")
+
+    class HangingVectorBackend:
+        async def semantic_search(
+            self, qvec: list[float], path: str, limit: int, zone_id: str
+        ) -> list[Any]:
+            try:
+                await asyncio.sleep(3600)
+            except asyncio.CancelledError:
+                dense_cancelled.set()
+                raise
+            return []
+
+    daemon._fts_backend = FailingFtsBackend()
+    daemon._vector_backend = HangingVectorBackend()
+
+    with pytest.raises(RuntimeError, match="fts down"):
+        await asyncio.wait_for(_hybrid(daemon), timeout=5)
+    assert dense_cancelled.is_set()

--- a/tests/unit/bricks/search/test_daemon_fusion_params.py
+++ b/tests/unit/bricks/search/test_daemon_fusion_params.py
@@ -474,3 +474,42 @@ async def test_fallback_non_default_keeps_fusion_provenance() -> None:
     # /d.md is dense-only.
     assert by_path["/d.md"].keyword_score is None
     assert by_path["/d.md"].vector_score == 0.99
+
+
+@pytest.mark.asyncio
+async def test_empty_dense_leg_stamps_non_default_results_degraded() -> None:
+    """#4541 review round 7: embedding OK but vector index empty — non-default
+    fusion is ranking on keyword legs alone and must carry the marker."""
+    daemon = _make_daemon()
+
+    class EmptyVectorBackend:
+        async def semantic_search(
+            self, qvec: list[float], path: str, limit: int, zone_id: str
+        ) -> list[Any]:
+            return []
+
+    daemon._vector_backend = EmptyVectorBackend()
+
+    stamped = await _hybrid(daemon, alpha=1.0, fusion_method="weighted")
+    assert stamped and all(r.semantic_degraded is True for r in stamped)
+
+    default = await _hybrid(daemon)
+    assert all(not r.semantic_degraded for r in default)
+
+
+@pytest.mark.asyncio
+async def test_fallback_empty_semantic_leg_stamps_non_default_degraded() -> None:
+    daemon = _make_fallback_daemon()
+
+    async def _semantic_search(
+        self: Any, query: str, limit: int, path_filter: Any, *, zone_id: Any = None
+    ) -> list[Any]:
+        return []
+
+    daemon._semantic_search = MethodType(_semantic_search, daemon)
+
+    stamped = await daemon._hybrid_search("nexus core", 4, None, 0.0, "rrf_weighted")
+    assert stamped and all(r.semantic_degraded is True for r in stamped)
+
+    default = await daemon._hybrid_search("nexus core", 4, None, 0.5, "rrf")
+    assert all(not r.semantic_degraded for r in default)

--- a/tests/unit/bricks/search/test_daemon_fusion_params.py
+++ b/tests/unit/bricks/search/test_daemon_fusion_params.py
@@ -394,3 +394,52 @@ async def test_search_positional_signature_unchanged() -> None:
     await daemon.search("nexus core", "keyword", 10, None, 0.5, "rrf", "tenant-a")
 
     assert seen["zone_id"] == "tenant-a"
+
+
+# =============================================================================
+# Embedding-unavailable hybrid branch (#4541 review round 4): the keyword-only
+# degradation must still honour non-default fusion knobs.
+# =============================================================================
+
+
+def _make_no_embed_daemon() -> Any:
+    daemon = _make_daemon()
+
+    async def _embed_query(self: Any, query: str) -> None:
+        return None
+
+    daemon._embed_query = MethodType(_embed_query, daemon)
+    return daemon
+
+
+@pytest.mark.asyncio
+async def test_no_embedding_default_keeps_raw_keyword_shortcut() -> None:
+    """Byte-identical default: embedding loss + default knobs returns the raw
+    keyword results exactly as before (BM25 scores untouched)."""
+    daemon = _make_no_embed_daemon()
+    results = await _hybrid(daemon)
+
+    assert [r.path for r in results] == ["/a.md", "/b.md", "/c.md"]
+    assert [r.score for r in results] == [10.0, 9.0, 8.0]
+
+
+@pytest.mark.asyncio
+async def test_no_embedding_honours_rrf_k() -> None:
+    """Non-default rrf_k re-scores the keyword leg through the fusion module
+    instead of silently returning raw BM25 scores."""
+    daemon = _make_no_embed_daemon()
+    results = await _hybrid(daemon, rrf_k=5)
+
+    assert [r.path for r in results] == ["/a.md", "/b.md", "/c.md"]
+    assert [r.score for r in results] != [10.0, 9.0, 8.0]
+    assert results[0].score == pytest.approx(1.0 / 6 + 0.05)  # rank-1 RRF + top bonus
+
+
+@pytest.mark.asyncio
+async def test_no_embedding_honours_weighted_alpha() -> None:
+    """weighted&alpha=1.0 assigns zero weight to the only (keyword) leg —
+    scores must reflect the requested fusion, not raw BM25."""
+    daemon = _make_no_embed_daemon()
+    results = await _hybrid(daemon, alpha=1.0, fusion_method="weighted")
+
+    assert all(r.score == 0.0 for r in results)

--- a/tests/unit/bricks/search/test_daemon_fusion_params.py
+++ b/tests/unit/bricks/search/test_daemon_fusion_params.py
@@ -513,3 +513,50 @@ async def test_fallback_empty_semantic_leg_stamps_non_default_degraded() -> None
 
     default = await daemon._hybrid_search("nexus core", 4, None, 0.5, "rrf")
     assert all(not r.semantic_degraded for r in default)
+
+
+@pytest.mark.asyncio
+async def test_dense_leg_exception_fails_soft() -> None:
+    """#4541 review round 8: a vector-backend exception degrades hybrid to
+    keyword-only instead of aborting the whole query."""
+    daemon = _make_daemon()
+
+    class RaisingVectorBackend:
+        async def semantic_search(
+            self, qvec: list[float], path: str, limit: int, zone_id: str
+        ) -> list[Any]:
+            raise RuntimeError("pgvector connection lost")
+
+    daemon._vector_backend = RaisingVectorBackend()
+
+    default = await _hybrid(daemon)
+    assert [r.path for r in default] == ["/a.md", "/b.md", "/c.md"]
+    assert all(not r.semantic_degraded for r in default)
+
+    stamped = await _hybrid(daemon, alpha=1.0, fusion_method="weighted")
+    assert stamped and all(r.semantic_degraded is True for r in stamped)
+
+
+@pytest.mark.asyncio
+async def test_empty_degraded_response_keeps_list_level_flag() -> None:
+    """#4541 review round 8: when the keyword leg is ALSO empty, the degraded
+    response is empty — the list-level flag is the only surviving signal."""
+    daemon = _make_no_embed_daemon()
+
+    class EmptyFtsBackend:
+        async def keyword_search(
+            self,
+            query: str,
+            path: str,
+            limit: int,
+            zone_id: str,
+            *,
+            timing: dict[str, float] | None = None,
+        ) -> list[Any]:
+            return []
+
+    daemon._fts_backend = EmptyFtsBackend()
+
+    results = await _hybrid(daemon, alpha=1.0, fusion_method="weighted")
+    assert list(results) == []
+    assert getattr(results, "semantic_degraded", False) is True


### PR DESCRIPTION
## Summary

Ten-round adversarial review-fix loop over the merged #4541 delta (PR #4551). 22 findings fixed across 10 commits; 2 pre-existing issues filed separately (#4556 remote search RPC dead path, #4557 zone_perms read-gating).

### Security / correctness
- **Federated result cache scoping** (opt-in cache): key now includes `alpha`/`fusion_method`/`rrf_k`, the token's `zone_filter` (broad→narrow token no longer reads back out-of-scope zones), and distinguishes `None` (wildcard) from an EMPTY allow-list.
- **Federation scope derivation**: explicit singleton non-root `zone_set` now scopes `federated=true` (was: unrestricted); empty raw scope (unconstrained/admin) and `{root}` stay wildcard; the synthesized `zone_id` fallback is never treated as an allow-list.
- **Positional compatibility**: `rrf_k` moved to signature tails — mid-signature insertion silently re-bound legacy positional `zone_id`/`zone_filter` args (wrong-tenant reads / dropped zone scoping).

### Fusion-knob completeness (all degraded paths honour the request)
- Legacy `_hybrid_search` fallback fuses via the shared fusion module (default byte-identical incl. field shape; non-default keeps fusion provenance).
- No-embedding and empty/failed-dense-leg branches honour non-default knobs and stamp the #3778 `semantic_degraded` marker (per-result + list-level + truthy-only response field — survives empty, fully-filtered, and cached responses).
- Dense leg is fail-soft (keyword failures cancel it and propagate promptly — no hangs behind a stuck vector backend); same asymmetric contract on the legacy fallback.

### Federated ranking
- `fusion_method=weighted` (hybrid) forces rank-based cross-zone merge — weighted scores are min-max normalized per zone and not raw-comparable. Keyword/semantic keep the default merge; the 13B keyword→hybrid safety promotion substitutes `rrf_weighted` so promoted zones can't smuggle shard-local weighted scores into a raw merge.

### Out of scope, filed
- #4556: remote federated `search` RPC rejected as unknown method (pre-existing dead path; dispatcher side is now envelope-tolerant and payload-complete).
- #4557: `zone_set` includes write-only zones — search scope not gated on read-capable `zone_perms` (pre-existing, needs auth-surface plumbing).

## Testing
- 30+ new regression tests (fusion knobs on every degraded path, byte-identical default pins incl. serialized field values, cache scoping broad→narrow/empty/knobs/cache-hit, positional signatures, singleton/admin/root federation scope, prompt keyword-failure propagation with hung dense leg, cross-zone weighted merge, 13B promotion).
- Full search suites on the rebased tree (post-#4544): 790 passed / 16 PG-skipped; ruff + mypy clean.

Refs #4541