### PR TITLE
fix(search): close residual #4557 read-gate gaps — batch endpoint, parser hardening, explicit root grants

### DIFF
--- a/.pre-commit-hooks/check_file_size.py
+++ b/.pre-commit-hooks/check_file_size.py
@@ -39,7 +39,6 @@ EXCEPTIONS = [
     "src/nexus/bricks/mcp/server.py",  # 2,157 lines - was 2,136 pre-#3731; auth helpers extracted to auth_bridge.py
     "src/nexus/bricks/auth/postgres_profile_store.py",  # 2,009 lines - #3818 read-path additions; split tracked as follow-up
     "src/nexus/server/api/v2/routers/async_files.py",  # 2,006 lines - asyncio.to_thread wrappers for #4069; split tracked as follow-up
-    "src/nexus/server/api/v2/routers/search.py",  # 2,011 lines - #4557 read-gate additions (write-only-token search gaps); split tracked as follow-up
 ]
 
 

--- a/.pre-commit-hooks/check_file_size.py
+++ b/.pre-commit-hooks/check_file_size.py
@@ -39,6 +39,7 @@ EXCEPTIONS = [
     "src/nexus/bricks/mcp/server.py",  # 2,157 lines - was 2,136 pre-#3731; auth helpers extracted to auth_bridge.py
     "src/nexus/bricks/auth/postgres_profile_store.py",  # 2,009 lines - #3818 read-path additions; split tracked as follow-up
     "src/nexus/server/api/v2/routers/async_files.py",  # 2,006 lines - asyncio.to_thread wrappers for #4069; split tracked as follow-up
+    "src/nexus/server/api/v2/routers/search.py",  # 2,011 lines - #4557 read-gate additions (write-only-token search gaps); split tracked as follow-up
 ]
 
 

--- a/docs/surface-coverage/api-rpc-surface-coverage.yaml
+++ b/docs/surface-coverage/api-rpc-surface-coverage.yaml
@@ -7727,7 +7727,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/expand
-      source: src/nexus/server/api/v2/routers/search.py:1582
+      source: src/nexus/server/api/v2/routers/search.py:1595
   profiles:
     lite: supported
     sandbox: supported
@@ -7751,7 +7751,7 @@ operations:
       source: src/nexus/bricks/search/search_service.py:1791
     http:
       name: POST /api/v2/search/glob
-      source: src/nexus/server/api/v2/routers/search.py:1463
+      source: src/nexus/server/api/v2/routers/search.py:1476
     mcp:
       name: nexus_glob
       source: src/nexus/config/tool_profiles.yaml:1
@@ -7778,7 +7778,7 @@ operations:
       source: src/nexus/bricks/search/search_service.py:2101
     http:
       name: POST /api/v2/search/grep
-      source: src/nexus/server/api/v2/routers/search.py:1340
+      source: src/nexus/server/api/v2/routers/search.py:1353
     mcp:
       name: nexus_grep
       source: src/nexus/config/tool_profiles.yaml:1
@@ -7831,7 +7831,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/index
-      source: src/nexus/server/api/v2/routers/search.py:1525
+      source: src/nexus/server/api/v2/routers/search.py:1538
   profiles:
     lite: supported
     sandbox: supported
@@ -7936,7 +7936,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/refresh
-      source: src/nexus/server/api/v2/routers/search.py:1561
+      source: src/nexus/server/api/v2/routers/search.py:1574
   profiles:
     lite: supported
     sandbox: supported

--- a/scripts/test_read_gate_e2e.py
+++ b/scripts/test_read_gate_e2e.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""E2E for #4557: search scope gated on read-capable zone_perms.
+
+Mints real database API keys (write-only / mixed / read / root-scoped)
+directly in postgres — hash computed locally with the same default HMAC
+salt the server uses when NEXUS_API_KEY_SECRET is unset — then exercises
+/api/v2/search/query and /query/batch through the live server.
+
+Adapted from an earlier draft (branch fix/4557-read-gated-search-scope)
+to upstream #4558's semantics, which landed independently on develop:
+``readable_zone_filter`` / ``token_zone_filter_from_auth`` in
+nexus.bricks.search.federated_search, with the router (search.py) failing
+CLOSED on both the single-zone and federated paths when a token has no
+read-capable zone -- so a write-only token now gets 403 on EITHER path
+(the earlier draft's federated route degraded to a 200-empty response
+instead; upstream is stricter).
+
+Prerequisites: nexus stack running with this branch's fixes.
+
+Usage:
+  PYTHONPATH=src python scripts/test_read_gate_e2e.py
+"""
+
+import json
+import os
+import secrets
+import subprocess
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+from nexus.storage.api_key_ops import hash_api_key  # noqa: E402
+
+API = os.getenv("NEXUS_URL", "http://localhost:2050")
+PG_PORT = os.getenv("PG_PORT", "5450")
+
+passed = 0
+failed = 0
+
+
+def check(name, condition, detail=""):
+    global passed, failed
+    if condition:
+        print(f"  PASS: {name}")
+        passed += 1
+    else:
+        print(f"  FAIL: {name} {detail}")
+        failed += 1
+
+
+def curl(method, path, key, params="", data=None):
+    url = f"{API}{path}"
+    if params:
+        url += f"?{params}"
+    args = [
+        "curl",
+        "-s",
+        "-w",
+        "\n%{http_code}",
+        "-X",
+        method,
+        url,
+        "-H",
+        f"Authorization: Bearer {key}",
+    ]
+    if data is not None:
+        args += ["-H", "Content-Type: application/json", "-d", json.dumps(data)]
+    r = subprocess.run(args, capture_output=True, text=True, timeout=30)
+    body, _, status = r.stdout.rpartition("\n")
+    parsed = json.loads(body) if body.strip() else {}
+    return int(status), parsed
+
+
+def psql(sql):
+    r = subprocess.run(
+        [
+            "psql",
+            "-h",
+            "localhost",
+            "-p",
+            PG_PORT,
+            "-U",
+            "postgres",
+            "-d",
+            "nexus",
+            "-t",
+            "-A",
+            "-c",
+            sql,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=10,
+        env={**os.environ, "PGPASSWORD": "nexus"},
+    )
+    if r.returncode != 0:
+        print(f"  psql error: {r.stderr.strip()}")
+    return r.stdout.strip()
+
+
+def mint_key(name, zones):
+    """Insert an api_keys row + api_key_zones junction rows; return raw key.
+
+    zones: list of (zone_id, perms) tuples.
+    """
+    # secrets.token_hex(16) (32 hex chars) keeps the raw key comfortably
+    # above DatabaseAPIKeyAuth's API_KEY_MIN_LENGTH=32 regardless of how
+    # short `name` is (a short suffix, e.g. token_hex(8) with "wo"/"ro"
+    # names, can land under the minimum and get rejected pre-auth as a
+    # malformed key — a 401 unrelated to the #4557 read gate under test).
+    raw_key = f"sk-e2e-4557-{name}-{secrets.token_hex(16)}"
+    key_hash = hash_api_key(raw_key)
+    key_id = secrets.token_hex(16)
+    psql(
+        "INSERT INTO api_keys (key_id, key_hash, user_id, subject_type, "
+        "subject_id, name, is_admin, inherit_permissions, revoked, created_at) "
+        f"VALUES ('{key_id}', '{key_hash}', 'e2e_4557_{name}', 'user', "
+        f"'e2e_4557_{name}', 'e2e-4557-{name}', 0, 0, 0, NOW()) "
+        "ON CONFLICT (key_id) DO NOTHING"
+    )
+    for zid, perms in zones:
+        psql(
+            "INSERT INTO api_key_zones (key_id, zone_id, permissions, granted_at) "
+            f"VALUES ('{key_id}', '{zid}', '{perms}', NOW()) "
+            "ON CONFLICT (key_id, zone_id) DO NOTHING"
+        )
+    return raw_key
+
+
+def cleanup_previous_run():
+    """Delete rows left behind by a prior run of this script.
+
+    Repeated runs mint fresh api_keys/api_key_zones/rebac_tuples rows every
+    time (random key_id/tuple_id suffixes don't collide), so without this
+    they accumulate indefinitely in shared dev/CI postgres instances.
+    """
+    psql(
+        "DELETE FROM api_key_zones WHERE key_id IN "
+        "(SELECT key_id FROM api_keys WHERE user_id LIKE 'e2e_4557_%')"
+    )
+    psql("DELETE FROM api_keys WHERE user_id LIKE 'e2e_4557_%'")
+    psql("DELETE FROM rebac_tuples WHERE tuple_id LIKE 'zt4557_%'")
+
+
+def main():
+    print("=" * 60)
+    print("READ-GATED SEARCH SCOPE E2E (#4557)")
+    print("=" * 60)
+
+    # -1. Clean up debris from any prior run before minting fresh rows.
+    cleanup_previous_run()
+
+    # 0. Zones (Active phase required by auth-time zone validation)
+    for z in ("e2e4557a", "e2e4557b"):
+        psql(
+            "INSERT INTO zones (zone_id, name, phase, finalizers, created_at, "
+            f"updated_at, indexing_mode) VALUES ('{z}', '{z}', 'Active', '[]', "
+            "NOW(), NOW(), 'all') ON CONFLICT (zone_id) DO NOTHING"
+        )
+
+    # ReBAC: make both zones subject-accessible so federation scope is
+    # decided by the TOKEN filter, not by ReBAC discovery.
+    for name in ("wo", "mixed", "ro"):
+        for z in ("e2e4557a", "e2e4557b"):
+            psql(
+                "INSERT INTO rebac_tuples (tuple_id, zone_id, subject_zone_id, "
+                "object_zone_id, subject_type, subject_id, relation, "
+                "object_type, object_id, created_at) VALUES "
+                f"('zt4557_{name}_{z}', 'root', 'root', 'root', 'user', "
+                f"'e2e_4557_{name}', 'member', 'zone', '{z}', NOW()) "
+                "ON CONFLICT (tuple_id) DO NOTHING"
+            )
+
+    wo_key = mint_key("wo", [("e2e4557a", "w")])
+    mixed_key = mint_key("mixed", [("e2e4557a", "w"), ("e2e4557b", "r")])
+    ro_key = mint_key("ro", [("e2e4557a", "r")])
+    # #4557 gap 3: an EXPLICIT non-read root grant must not be unbounded.
+    # No zone/rebac setup needed for this one -- the gate 403s before any
+    # zone access or ReBAC discovery is consulted.
+    root_wo_key = mint_key("root_wo", [("root", "w")])
+
+    # 1. Write-only token, single-zone search -> 403. Upstream (#4558)
+    # derives token_zone_filter from readable_zone_filter(); a token whose
+    # only zone grant is write-only yields the EMPTY frozenset, which the
+    # router's fail-closed check 403s unconditionally (before the
+    # federated/single-zone branch split even matters).
+    status, body = curl("GET", "/api/v2/search/query", wo_key, "q=alpha")
+    print(f"  wo single-zone: {status} {body.get('detail', '')}")
+    check("write-only single-zone search rejected 403", status == 403)
+    check(
+        "403 detail names the read-permission gate, not the full allow-list",
+        "read permission" in str(body.get("detail", ""))
+        and "e2e4557b" not in str(body.get("detail", "")),
+    )
+
+    # 2. Write-only token, federated=true -> 403 (CHANGED from the earlier
+    # draft's 200-empty: upstream's empty-filter check runs regardless of
+    # the federated flag, so a write-only token fails closed on BOTH paths).
+    status, body = curl("GET", "/api/v2/search/query", wo_key, "q=alpha&federated=true")
+    print(f"  wo federated: {status} {body.get('detail', '')}")
+    check("write-only federated search also rejected 403 (fails closed)", status == 403)
+    check(
+        "403 detail names the read-permission gate",
+        "read permission" in str(body.get("detail", "")),
+    )
+
+    # 3. Mixed token (a:w, b:r) auto-federates; scope excludes the w-only zone
+    status, body = curl("GET", "/api/v2/search/query", mixed_key, "q=alpha")
+    print(
+        f"  mixed: {status} zones_searched={body.get('zones_searched')} total={body.get('total')}"
+    )
+    check("mixed token search returns 200", status == 200)
+    check(
+        "mixed token never searches the write-only zone",
+        "e2e4557a" not in (body.get("zones_searched") or []),
+    )
+
+    # 4. Read token, single-zone search -> 200 (+ hot-path latency smoke:
+    # the gate is O(len(zone_perms)) pure python — anything visible in
+    # latency_ms would indicate an accidental extra round-trip)
+    status, body = curl("GET", "/api/v2/search/query", ro_key, "q=alpha")
+    print(
+        f"  ro single-zone: {status} total={body.get('total')} latency_ms={body.get('latency_ms')}"
+    )
+    check("read token single-zone search allowed", status == 200)
+    check(
+        "read-gated query latency sane (<2000ms)",
+        isinstance(body.get("latency_ms"), (int, float)) and body["latency_ms"] < 2000,
+    )
+
+    # 5. Batch endpoint mirrors the gate (#4557 gap 1: /query/batch had no
+    # read gate at all prior to this branch).
+    status, body = curl(
+        "POST",
+        "/api/v2/search/query/batch",
+        wo_key,
+        data={"queries": [{"q": "alpha"}]},
+    )
+    print(f"  wo batch: {status} {body.get('detail', '')}")
+    check("write-only batch rejected 403", status == 403)
+    check(
+        "batch 403 detail names the read-permission gate",
+        "read permission" in str(body.get("detail", "")),
+    )
+    status, body = curl(
+        "POST",
+        "/api/v2/search/query/batch",
+        ro_key,
+        data={"queries": [{"q": "alpha"}]},
+    )
+    check("read token batch allowed", status == 200)
+
+    # 6. #4557 gap 3: explicit root:"w" grant must not be unbounded. Before
+    # the fix, ANY token whose zone_set was exactly {root} returned
+    # zone_filter=None (unbounded) without ever consulting the granted
+    # letters -- a root:"w" credential could search everything.
+    status, body = curl("GET", "/api/v2/search/query", root_wo_key, "q=alpha")
+    print(f"  root write-only: {status} {body.get('detail', '')}")
+    check("explicit root:w grant rejected 403 (not unbounded)", status == 403)
+    check(
+        "root 403 detail names the read-permission gate",
+        "read permission" in str(body.get("detail", "")),
+    )
+
+    print("=" * 60)
+    print(f"PASSED: {passed}  FAILED: {failed}")
+    print("=" * 60)
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/nexus/bricks/search/federated_search.py
+++ b/src/nexus/bricks/search/federated_search.py
@@ -126,18 +126,29 @@ def readable_zone_filter(
 
     Search is a READ — write-only zone grants must not be searchable
     (Issue #4542 round-8 review). When per-zone perms are known, only
-    zones granting ``r`` or ``x`` pass; an explicit grant list with no
-    readable zones fails CLOSED (empty frozenset → zero searchable
-    zones). Credentials with a zone list but no perms info keep the
-    whole list (legacy tokens predate per-zone perms). Returns ``None``
-    (unbounded) only when the credential carries no explicit zone grant
-    at all.
+    WELL-FORMED entries are consulted — ``isinstance(zp, (list, tuple))
+    and len(zp) == 2 and isinstance(zp[0], str) and isinstance(zp[1],
+    str)`` (Issue #4557: a malformed entry, e.g. ``None`` or a truthy
+    non-str member, must neither crash ``len()`` nor stringify into a
+    false positive, e.g. ``str(True)`` containing "r") — and only zones
+    granting ``r`` or ``x`` pass. An explicit grant list where every
+    entry is malformed, or none is readable, fails CLOSED (empty
+    frozenset → zero searchable zones) — this includes the case where
+    ``zone_perms`` is present but entirely malformed, which must NOT
+    fall back to the raw ``zone_set``. Credentials with a zone list but
+    no perms info at all keep the whole list (legacy tokens predate
+    per-zone perms). Returns ``None`` (unbounded) only when the
+    credential carries no explicit zone grant at all.
     """
     if zone_perms:
         return frozenset(
-            str(zp[0])
+            zp[0]
             for zp in zone_perms
-            if len(zp) == 2 and ("r" in str(zp[1]) or "x" in str(zp[1]))
+            if isinstance(zp, (list, tuple))
+            and len(zp) == 2
+            and isinstance(zp[0], str)
+            and isinstance(zp[1], str)
+            and ("r" in zp[1] or "x" in zp[1])
         )
     if zone_set:
         return frozenset(str(z) for z in zone_set)
@@ -151,19 +162,44 @@ def token_zone_filter_from_auth(
 ) -> frozenset[str] | None:
     """Derive the search-readable token allow-list from an auth result.
 
-    Issue #4542 rounds 8-10: search is a READ. Admin, root-scoped, and
-    unconstrained credentials return ``None`` (unbounded — #4541
+    Issue #4542 rounds 8-10: search is a READ. Admin and unconstrained
+    (empty-scope) credentials return ``None`` (unbounded — #4541
     exemption); otherwise only zones granting ``r``/``x`` pass, and an
     explicit grant list with no readable zone yields the empty set
     (callers fail closed on it).
+
+    Issue #4557 (gap 3): a root-only ``zone_set`` is normally treated as
+    unbounded too (root grants cross-zone access and its id never
+    intersects concrete zone names), but an EXPLICIT non-read root grant
+    must not be unbounded — a ``root:"w"`` credential must not be able to
+    search everything. When ``zone_set == {root_zone_id}``, every
+    WELL-FORMED root entry in ``zone_perms`` (same parsing discipline as
+    ``readable_zone_filter``) is aggregated by UNION — not first-match —
+    so the outcome is order-independent across duplicate entries: if no
+    well-formed root entry exists at all (legacy tokens / absent perms),
+    the exemption stands unchanged (``None``); if any entry grants ``r``
+    or ``x``, it stands (``None``); otherwise every root entry is
+    write-only and the credential fails CLOSED (empty frozenset — the
+    router's existing empty-filter 403 fires from there).
     """
-    raw_zone_set = tuple(auth_result.get("zone_set") or ())
-    if (
-        not raw_zone_set
-        or set(raw_zone_set) == {root_zone_id}
-        or auth_result.get("is_admin", False)
-    ):
+    if auth_result.get("is_admin", False):
         return None
+    raw_zone_set = tuple(auth_result.get("zone_set") or ())
+    if not raw_zone_set:
+        return None
+    if set(raw_zone_set) == {root_zone_id}:
+        root_letters = "".join(
+            zp[1]
+            for zp in (auth_result.get("zone_perms") or ())
+            if isinstance(zp, (list, tuple))
+            and len(zp) == 2
+            and isinstance(zp[0], str)
+            and isinstance(zp[1], str)
+            and zp[0] == root_zone_id
+        )
+        if not root_letters:
+            return None  # No explicit root entry: legacy exemption stands.
+        return None if ("r" in root_letters or "x" in root_letters) else frozenset()
     return readable_zone_filter(raw_zone_set, auth_result.get("zone_perms"))
 
 

--- a/src/nexus/server/api/v2/routers/search.py
+++ b/src/nexus/server/api/v2/routers/search.py
@@ -793,6 +793,19 @@ async def search_query_batch(
     if not raw_queries:
         raise HTTPException(status_code=400, detail="No queries provided")
 
+    # #4557 (gap 1): batch had no read gate at all -- a write-only token
+    # could read via /query/batch even though /query fails it closed.
+    # Batch takes no ``federated`` param (single-zone-only), so both of
+    # /query's single-zone checks apply unconditionally here.
+    from nexus.bricks.search.federated_search import token_zone_filter_from_auth
+
+    token_zone_filter = token_zone_filter_from_auth(auth_result, root_zone_id=ROOT_ZONE_ID)
+    if token_zone_filter is not None:
+        if not token_zone_filter:
+            raise HTTPException(403, "Token has no zone with read permission for search")
+        if zone_id not in token_zone_filter:
+            raise HTTPException(403, f"Token has no read permission for zone {zone_id}")
+
     if not search_daemon.is_initialized:
         raise HTTPException(status_code=503, detail="Search daemon is still initializing")
 

--- a/tests/integration/services/test_search_zone_set.py
+++ b/tests/integration/services/test_search_zone_set.py
@@ -342,6 +342,62 @@ class TestBatchReadGate:
 
 
 @pytest.mark.skipif(not _HAS_FASTAPI_TESTCLIENT, reason="fastapi test client not available")
+class TestExplicitRootGrantLetters:
+    """Issue #4557 (gap 3): an explicit non-read root grant (root:"w") must
+    not be unbounded -- token_zone_filter_from_auth must fail closed and the
+    router's existing empty-filter 403 must fire on /query."""
+
+    def test_root_write_only_key_query_rejected(self):
+        app = _build_app_with_auth(
+            {
+                "user_id": "u",
+                "zone_id": "root",
+                "zone_set": ["root"],
+                "zone_perms": [["root", "w"]],
+            }
+        )
+        resp = TestClient(app).get("/api/v2/search/query?q=alpha")
+        assert resp.status_code == 403, resp.text
+        assert "Token has no zone with read permission for search" in resp.json()["detail"]
+
+    def test_root_read_key_query_ok(self):
+        app = _build_app_with_auth(
+            {
+                "user_id": "u",
+                "zone_id": "root",
+                "zone_set": ["root"],
+                "zone_perms": [["root", "r"]],
+            }
+        )
+        resp = TestClient(app).get("/api/v2/search/query?q=alpha")
+        assert resp.status_code == 200, resp.text
+
+    def test_duplicate_root_entries_aggregate_order_independently(self):
+        for zone_perms in ([["root", "w"], ["root", "rx"]], [["root", "rx"], ["root", "w"]]):
+            app = _build_app_with_auth(
+                {
+                    "user_id": "u",
+                    "zone_id": "root",
+                    "zone_set": ["root"],
+                    "zone_perms": zone_perms,
+                }
+            )
+            resp = TestClient(app).get("/api/v2/search/query?q=alpha")
+            assert resp.status_code == 200, resp.text
+
+    def test_root_zone_set_no_zone_perms_query_ok_legacy(self):
+        app = _build_app_with_auth(
+            {
+                "user_id": "u",
+                "zone_id": "root",
+                "zone_set": ["root"],
+            }
+        )
+        resp = TestClient(app).get("/api/v2/search/query?q=alpha")
+        assert resp.status_code == 200, resp.text
+
+
+@pytest.mark.skipif(not _HAS_FASTAPI_TESTCLIENT, reason="fastapi test client not available")
 class TestSingleZoneTokenFederatedEscape:
     """Issue #4542 round-6 review: a single-zone token requesting
     federated=true must still be confined to its zone — the router used to

--- a/tests/integration/services/test_search_zone_set.py
+++ b/tests/integration/services/test_search_zone_set.py
@@ -242,6 +242,105 @@ class TestFederatedDispatcherZoneFilter:
         assert resp.zones_searched == ["eng"], f"expected only eng, got {resp.zones_searched}"
 
 
+def _build_app_with_auth(auth: dict):
+    """App builder for #4557 tests -- takes the full auth dict, unlike
+    ``TestSearchZoneSet._build_app`` which only parameterizes zone_set."""
+    from nexus.server.api.v2.routers.search import router
+
+    app = FastAPI()
+    app.include_router(router)
+
+    mock_daemon = MagicMock()
+    mock_daemon.is_initialized = True
+    mock_daemon.get_health.return_value = {"status": "ok"}
+
+    async def mock_search(**kwargs):
+        return [_MockResult(path="result.txt", chunk_text="found", score=0.9)]
+
+    mock_daemon.search = mock_search
+    mock_daemon.batch_search = AsyncMock(return_value=[[]])
+    app.state.search_daemon = mock_daemon
+    app.state.search_daemon_enabled = True
+    app.state.record_store = MagicMock()
+    app.state.async_session_factory = MagicMock()
+    app.state.async_read_session_factory = MagicMock()
+
+    from nexus.server.dependencies import require_auth
+
+    app.dependency_overrides[require_auth] = lambda: {"authenticated": True, **auth}
+    return app
+
+
+@pytest.mark.skipif(not _HAS_FASTAPI_TESTCLIENT, reason="fastapi test client not available")
+class TestBatchReadGate:
+    """Issue #4557 (gap 1): /query/batch had no read gate at all -- a
+    write-only token could read via batch even though /query fails it
+    closed. Batch takes no ``federated`` param, so both of /query's
+    single-zone checks (empty-filter and not-a-member) apply unconditionally."""
+
+    def test_write_only_token_batch_rejected(self):
+        app = _build_app_with_auth(
+            {
+                "user_id": "u",
+                "zone_id": "eng",
+                "zone_set": ["eng"],
+                "zone_perms": [["eng", "w"]],
+            }
+        )
+        resp = TestClient(app).post(
+            "/api/v2/search/query/batch", json={"queries": [{"q": "alpha"}]}
+        )
+        assert resp.status_code == 403, resp.text
+        assert "read permission" in resp.json()["detail"]
+
+    def test_readable_token_batch_ok(self):
+        app = _build_app_with_auth(
+            {
+                "user_id": "u",
+                "zone_id": "eng",
+                "zone_set": ["eng"],
+                "zone_perms": [["eng", "r"]],
+            }
+        )
+        resp = TestClient(app).post(
+            "/api/v2/search/query/batch", json={"queries": [{"q": "alpha"}]}
+        )
+        assert resp.status_code == 200, resp.text
+
+    def test_no_readable_zone_at_all_batch_rejected(self):
+        """Multi-zone, all-write-only grant -> readable_zone_filter yields
+        the empty frozenset -> the empty-filter branch fires (distinct from
+        the not-a-member branch above)."""
+        app = _build_app_with_auth(
+            {
+                "user_id": "u",
+                "zone_id": "eng",
+                "zone_set": ["eng", "legal"],
+                "zone_perms": [["eng", "w"], ["legal", "w"]],
+            }
+        )
+        resp = TestClient(app).post(
+            "/api/v2/search/query/batch", json={"queries": [{"q": "alpha"}]}
+        )
+        assert resp.status_code == 403, resp.text
+        assert "Token has no zone with read permission for search" in resp.json()["detail"]
+
+    def test_legacy_token_without_zone_perms_batch_ok(self):
+        """Credential with a zone list but no perms info at all keeps the
+        legacy behaviour (whole list readable)."""
+        app = _build_app_with_auth(
+            {
+                "user_id": "u",
+                "zone_id": "eng",
+                "zone_set": ["eng"],
+            }
+        )
+        resp = TestClient(app).post(
+            "/api/v2/search/query/batch", json={"queries": [{"q": "alpha"}]}
+        )
+        assert resp.status_code == 200, resp.text
+
+
 @pytest.mark.skipif(not _HAS_FASTAPI_TESTCLIENT, reason="fastapi test client not available")
 class TestSingleZoneTokenFederatedEscape:
     """Issue #4542 round-6 review: a single-zone token requesting

--- a/tests/unit/bricks/search/test_readable_zone_filter.py
+++ b/tests/unit/bricks/search/test_readable_zone_filter.py
@@ -1,0 +1,117 @@
+"""Unit tests for readable_zone_filter / token_zone_filter_from_auth (#4557).
+
+Covers the three verified gaps in the #4542/#4558 read-attenuation logic:
+
+  Gap B: a malformed zone_perms entry (``None``, a non-list/tuple, wrong
+      length, or a non-str member) must neither crash ``readable_zone_filter``
+      nor stringify into a false-positive READABLE zone (e.g. ``str(True)``
+      contains "r").
+  Gap C: an explicit non-read root grant (``root_zone_id`` with zone_perms
+      that only ever grant write) must not be treated as unbounded access —
+      ``token_zone_filter_from_auth`` must fail closed (empty frozenset), not
+      return ``None``.
+"""
+
+from __future__ import annotations
+
+from nexus.bricks.search.federated_search import (
+    readable_zone_filter,
+    token_zone_filter_from_auth,
+)
+
+ROOT = "root"
+
+
+class TestReadableZoneFilterMalformedEntries:
+    def test_mixed_malformed_and_valid_entries_no_exception(self) -> None:
+        """A None entry must not raise TypeError from len(None); a non-str
+        perms member (True) must not stringify into a false-positive read
+        grant; only the one well-formed, readable entry survives."""
+        zone_perms = [
+            None,
+            "junk",
+            ["eng", "r"],
+            ["ops", True],
+            [1, "r"],
+            ["a", "b", "c"],
+        ]
+        result = readable_zone_filter(["eng", "ops"], zone_perms)
+        assert result == frozenset({"eng"})
+
+    def test_all_malformed_entries_fail_closed_not_zone_set_fallback(self) -> None:
+        """zone_perms present but every entry malformed -> empty frozenset
+        (fail closed), NOT a fall-through to the raw zone_set."""
+        result = readable_zone_filter(["eng", "ops"], [None, ["x"]])
+        assert result == frozenset()
+        assert result is not None
+
+    def test_empty_zone_perms_falls_back_to_zone_set(self) -> None:
+        """Falsy zone_perms (legacy tokens) keep the whole zone_set."""
+        result = readable_zone_filter(["eng", "ops"], [])
+        assert result == frozenset({"eng", "ops"})
+
+    def test_no_zone_set_no_zone_perms_returns_none(self) -> None:
+        assert readable_zone_filter([], None) is None
+
+    def test_well_formed_write_only_entry_excluded(self) -> None:
+        result = readable_zone_filter(["eng", "legal"], [["eng", "r"], ["legal", "w"]])
+        assert result == frozenset({"eng"})
+
+
+class TestTokenZoneFilterFromAuthRootGrant:
+    def test_root_write_only_grant_fails_closed(self) -> None:
+        auth = {"zone_set": ["root"], "zone_perms": [["root", "w"]]}
+        assert token_zone_filter_from_auth(auth, root_zone_id=ROOT) == frozenset()
+
+    def test_root_read_grant_stays_unbounded(self) -> None:
+        auth = {"zone_set": ["root"], "zone_perms": [["root", "r"]]}
+        assert token_zone_filter_from_auth(auth, root_zone_id=ROOT) is None
+
+    def test_root_execute_grant_stays_unbounded(self) -> None:
+        auth = {"zone_set": ["root"], "zone_perms": [["root", "x"]]}
+        assert token_zone_filter_from_auth(auth, root_zone_id=ROOT) is None
+
+    def test_duplicate_root_entries_aggregate_order_independently_forward(self) -> None:
+        auth = {
+            "zone_set": ["root"],
+            "zone_perms": [["root", "w"], ["root", "rx"]],
+        }
+        assert token_zone_filter_from_auth(auth, root_zone_id=ROOT) is None
+
+    def test_duplicate_root_entries_aggregate_order_independently_reversed(self) -> None:
+        auth = {
+            "zone_set": ["root"],
+            "zone_perms": [["root", "rx"], ["root", "w"]],
+        }
+        assert token_zone_filter_from_auth(auth, root_zone_id=ROOT) is None
+
+    def test_root_zone_set_no_zone_perms_legacy_unchanged(self) -> None:
+        """A root-only zone_set with NO zone_perms at all (legacy tokens
+        predate per-zone perms) keeps the pre-#4557 exemption."""
+        auth = {"zone_set": ["root"]}
+        assert token_zone_filter_from_auth(auth, root_zone_id=ROOT) is None
+
+    def test_root_zone_set_empty_zone_perms_legacy_unchanged(self) -> None:
+        auth = {"zone_set": ["root"], "zone_perms": []}
+        assert token_zone_filter_from_auth(auth, root_zone_id=ROOT) is None
+
+    def test_admin_with_root_write_only_stays_unbounded(self) -> None:
+        auth = {
+            "zone_set": ["root"],
+            "zone_perms": [["root", "w"]],
+            "is_admin": True,
+        }
+        assert token_zone_filter_from_auth(auth, root_zone_id=ROOT) is None
+
+    def test_malformed_root_entries_treated_as_absent_legacy_unchanged(self) -> None:
+        """Malformed root entries don't count as an "explicit" grant --
+        same well-formed test as readable_zone_filter."""
+        auth = {"zone_set": ["root"], "zone_perms": [None, ["root"], [1, "w"]]}
+        assert token_zone_filter_from_auth(auth, root_zone_id=ROOT) is None
+
+    def test_unconstrained_credential_stays_unbounded(self) -> None:
+        assert token_zone_filter_from_auth({"zone_set": []}, root_zone_id=ROOT) is None
+
+    def test_non_root_zone_set_uses_readable_zone_filter(self) -> None:
+        auth = {"zone_set": ["eng"], "zone_perms": [["eng", "w"]]}
+        assert token_zone_filter_from_auth(auth, root_zone_id=ROOT) == frozenset()


### PR DESCRIPTION
## Summary
- Closes the residual #4557 gaps left after #4558 landed the core read-gating (`readable_zone_filter` / `token_zone_filter_from_auth` + fail-closed `search_query` gate) in `develop`:
  1. **`/query/batch` had no read gate** — a write-only token could still read search results through the batch endpoint. It now applies the same #4542-style fail-closed gate as `/query`.
  2. **`readable_zone_filter` parsing hardened** — a malformed `None` entry in `zone_perms` raised `TypeError` (→ 500), and a non-string perms member (`True` → `"True"` ⊃ `"r"`) counted the zone as *readable* (fail-open). Entries now require str/str pairs; malformed entries are skipped; all-malformed grants fail closed.
  3. **Explicit non-read root grant closed** — `token_zone_filter_from_auth` returned `None` (unbounded) for any root-scoped token without consulting letters, so a `root:"w"` key searched everything. Root-scoped tokens with well-formed root entries now require `r`/`x` (order-independent across duplicate entries); legacy root tokens without perms info are unchanged.
- Adds `scripts/test_read_gate_e2e.py`: live-stack harness minting real write-only / mixed / read-only / `root:w` DB keys and verifying gate behavior end-to-end.

Rewrites this PR's original stacked branch: the pre-#4558 implementation was superseded when #4558 merged; this is the slim delta on `develop`.

## Test plan
- New tests: batch-gate (403/200), `readable_zone_filter` malformed-entry matrix (no-crash, fail-closed, no bool coercion), root-letter cases incl. duplicate-entry order independence — `tests/unit/bricks/search/test_readable_zone_filter.py` + extensions to `tests/integration/services/test_search_zone_set.py` (all 14 pre-existing upstream tests untouched and passing).
- Suites: 498 passed, 8 pre-existing Postgres-gated skips; ruff clean; `api-rpc-surface-coverage.yaml` regenerated + validated.
- Live validation from this branch via `nexus up --build` (isolated instance, branch code verified in-container): `scripts/test_read_gate_e2e.py` **13/0**; `scripts/test_build_perf_e2e.py` (demo preset, HERB QA) **26/0**.
