### PR TITLE
feat(#36): managed-agent raw ACP control plane + ServiceRegistry daemon wiring

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -620,10 +620,12 @@ jobs:
       - name: Kernel pin consistency preflight
         if: needs.detect-changes.outputs.code_changed == 'true'
         # Every nexus-vfs pin in the repo must agree: the Cargo.toml
-        # crate pins, the Cargo.lock resolution, the shipping image ARG
-        # (Dockerfile), and the federation test/witness image ARGs.
-        # A partial bump ships a kernel the gate below never tested —
-        # the exact drift class behind #4343.
+        # crate pins, the Cargo.lock resolution, and the remaining image
+        # ARGs (dockerfiles/Dockerfile.{minimal,raft-server,raft-witness}).
+        # The main image's nexusd-full now pins nexus-vfs THROUGH
+        # Cargo.lock (it builds the nexus-local `nexusd` crate, #36), not
+        # an ARG. A partial bump ships a kernel the gate below never
+        # tested — the exact drift class behind #4343.
         run: |
           set -euo pipefail
           # Every nexus-vfs install — in Dockerfiles AND workflow
@@ -686,31 +688,34 @@ jobs:
             exit 1
           fi
 
-      - name: Install nexusd-cluster from nexus-vfs (pinned rev)
+      - name: Install cluster kernels (nexusd-cluster from nexus-vfs, nexusd-full nexus-local)
         if: needs.detect-changes.outputs.code_changed == 'true'
-        # Pin to the rev shipped by this checkout. The preflight above
-        # guarantees Cargo.toml == Cargo.lock == every Dockerfile ARG,
-        # so extracting from Cargo.toml IS the shipping rev. An
-        # unpinned install tracks nexus-vfs HEAD and can silently
-        # drift from what the Docker image ships — exactly how a
-        # durable-metastore regression (#4343) could pass smoke while
-        # the pinned kernel is broken. --locked honors the source
-        # tree's Cargo.lock (fresh dep resolution drifts on upstream
-        # releases).
+        # Two binaries, two sources — both gated because both ship:
+        #   * nexusd-cluster = the slim federation kernel, still built
+        #     straight from nexus-vfs at the Cargo.toml-pinned rev. The
+        #     preflight above guarantees Cargo.toml == Cargo.lock == every
+        #     remaining Dockerfile ARG, so extracting from Cargo.toml IS
+        #     the shipping rev.
+        #   * nexusd-full = the binary the Docker image actually ships
+        #     (symlinked to nexus-cluster). As of #36 it is the
+        #     nexus-local `nexusd` crate (nexus-vfs cluster boot PLUS the
+        #     managed_agent/acp service set), NOT the nexus-vfs
+        #     `nexus-full` profile, so it must be built from THIS tree
+        #     (`--path rust/nexusd`) or the gate would test a binary the
+        #     image no longer ships.
+        # --locked honors the source tree's Cargo.lock (fresh dep
+        # resolution drifts on upstream releases); an unpinned install
+        # tracks nexus-vfs HEAD.
         run: |
           REV=$(grep 'nexus-vfs' Cargo.toml | grep -m1 -oE 'rev = "[a-f0-9]{40}"' | cut -d'"' -f2)
           if [ -z "$REV" ]; then
             echo "::error::could not extract nexus-vfs rev pin from Cargo.toml"
             exit 1
           fi
-          echo "Installing nexusd-cluster at pinned nexus-vfs rev $REV"
+          echo "Installing nexusd-cluster (slim) at pinned nexus-vfs rev $REV"
           cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "$REV" --bin nexusd-cluster nexus-cluster
-          # Also install the full profile — the binary the Docker image
-          # actually ships (nexusd-full, symlinked to nexus-cluster).
-          # Same main.rs, but a full-profile-only build/feature
-          # regression must not slip past the gate on the slim binary.
-          echo "Installing nexusd-full at pinned nexus-vfs rev $REV"
-          cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "$REV" --bin nexusd-full nexus-full
+          echo "Installing nexusd-full from the nexus-local crate rust/nexusd (the shipped binary)"
+          cargo install --locked --path rust/nexusd --bin nexusd-full
 
       - name: Boot smoke test
         if: needs.detect-changes.outputs.code_changed == 'true'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,7 +173,7 @@ dependencies = [
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
 ]
 
@@ -218,10 +218,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "auth"
+version = "0.1.0"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=520768934ed805a2c5d8a22a0c20f52f75c8dddc#520768934ed805a2c5d8a22a0c20f52f75c8dddc"
+dependencies = [
+ "contracts",
+ "dashmap",
+ "hmac 0.13.0",
+ "kernel",
+ "parking_lot",
+ "rand 0.10.2",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "tonic",
+ "tracing",
+ "transport",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+]
 
 [[package]]
 name = "axum"
@@ -289,6 +331,7 @@ dependencies = [
  "fastcdc",
  "futures",
  "globset",
+ "hmac 0.13.0",
  "kernel",
  "lib",
  "libc",
@@ -300,9 +343,11 @@ dependencies = [
  "rayon",
  "redb",
  "regex",
+ "reqwest",
  "roaring",
  "serde",
  "serde_json",
+ "sha2 0.11.0",
  "simdutf8",
  "tempfile",
  "tokio",
@@ -344,7 +389,7 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "cexpr",
  "clang-sys",
  "itertools",
@@ -357,6 +402,21 @@ dependencies = [
  "shlex 1.3.0",
  "syn 2.0.119",
 ]
+
+[[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -459,6 +519,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex 2.0.1",
 ]
 
@@ -482,6 +544,17 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "chrono"
@@ -556,10 +629,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
 
 [[package]]
 name = "compare"
@@ -615,6 +713,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -645,6 +753,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -695,7 +812,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -715,6 +832,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
  "cipher",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
 ]
 
 [[package]]
@@ -814,6 +940,7 @@ dependencies = [
  "block-buffer 0.12.1",
  "const-oid 0.10.2",
  "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -826,6 +953,12 @@ dependencies = [
  "quote",
  "syn 3.0.3",
 ]
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "ed25519"
@@ -883,6 +1016,15 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "erased-serde"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c138974f9d5e7fe373eb04df7cae98833802ae4b11c24ac7039a21d5af4b26c"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "errno"
@@ -988,10 +1130,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "fuser"
 version = "0.17.0"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "libc",
  "log",
  "memchr",
@@ -1094,6 +1242,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1101,6 +1258,16 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1126,7 +1293,19 @@ dependencies = [
  "js-sys",
  "libc",
  "r-efi",
+ "rand_core 0.10.1",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getset"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cf442baaabe4213ce7d1239afc26c039180b6456da2cededa316ae2c8a77a77"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1228,6 +1407,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "http"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1304,6 +1492,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-timeout"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1322,13 +1525,16 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
+ "base64",
  "bytes",
  "futures-channel",
  "futures-util",
  "http",
  "http-body",
  "hyper",
+ "ipnet",
  "libc",
+ "percent-encoding",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -1361,6 +1567,109 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1389,6 +1698,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1408,6 +1723,65 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
+dependencies = [
+ "getrandom 0.4.3",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -1497,7 +1871,7 @@ dependencies = [
  "serde_json",
  "sha2 0.11.0",
  "string-interner",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
  "tokio",
  "tonic",
@@ -1528,6 +1902,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1550,6 +1930,12 @@ checksum = "0b6180140927ee907000b0aa540091f6ea512ead4447c92b8fc35bc72788a5a6"
 dependencies = [
  "hashbrown 0.17.1",
 ]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lsm-tree"
@@ -1580,6 +1966,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef0d4ed8669f8f8826eb00dc878084aa8f253506c4fd5e8f58f5bce72ddb97e"
 dependencies = [
  "twox-hash",
+]
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
 ]
 
 [[package]]
@@ -1640,6 +2035,29 @@ name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+
+[[package]]
+name = "nexus-cluster"
+version = "0.1.1"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=520768934ed805a2c5d8a22a0c20f52f75c8dddc#520768934ed805a2c5d8a22a0c20f52f75c8dddc"
+dependencies = [
+ "a2a",
+ "anyhow",
+ "auth",
+ "backends",
+ "clap",
+ "contracts",
+ "gethostname",
+ "kernel",
+ "raft 0.1.0",
+ "rand 0.10.2",
+ "tokio",
+ "tonic",
+ "tracing",
+ "tracing-appender",
+ "tracing-subscriber",
+ "transport",
+]
 
 [[package]]
 name = "nexus-fuse-plugin"
@@ -1717,6 +2135,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "nexusd"
+version = "0.1.0"
+dependencies = [
+ "a2a",
+ "anyhow",
+ "backends",
+ "nexus-cluster",
+ "services",
+]
+
+[[package]]
 name = "nfsserve"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1738,7 +2167,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -1857,6 +2286,12 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "page_size"
@@ -1979,10 +2414,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "prettyplease"
@@ -2066,6 +2519,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "protobuf"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
+dependencies = [
+ "bytes",
+]
+
+[[package]]
+name = "protobuf-build"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2df9942df2981178a930a72d442de47e2f0df18ad68e50a30f816f1848215ad0"
+dependencies = [
+ "bitflags 1.3.2",
+ "protobuf",
+ "protobuf-codegen",
+ "regex",
+]
+
+[[package]]
+name = "protobuf-codegen"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "033460afb75cf755fcfc16dfaed20b86468082a2ea24e05ac35ab4a099a017d6"
+dependencies = [
+ "protobuf",
+]
+
+[[package]]
 name = "protoc-bin-vendored"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2135,7 +2618,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "memchr",
  "unicase",
 ]
@@ -2160,6 +2643,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+dependencies = [
+ "aws-lc-rs",
+ "bytes",
+ "getrandom 0.4.3",
+ "lru-slab",
+ "rand 0.10.2",
+ "rand_pcg",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2175,12 +2715,124 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "raft"
+version = "0.1.0"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=520768934ed805a2c5d8a22a0c20f52f75c8dddc#520768934ed805a2c5d8a22a0c20f52f75c8dddc"
+dependencies = [
+ "base64",
+ "bincode",
+ "bytes",
+ "contracts",
+ "dashmap",
+ "gethostname",
+ "kernel",
+ "lib",
+ "parking_lot",
+ "pem",
+ "prost",
+ "protobuf",
+ "protoc-bin-vendored",
+ "raft 0.7.0",
+ "rand 0.10.2",
+ "rcgen",
+ "redb",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "slog",
+ "tempfile",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "tonic",
+ "tonic-prost",
+ "tonic-prost-build",
+ "tracing",
+ "tracing-subscriber",
+ "x509-parser",
+]
+
+[[package]]
+name = "raft"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f12688b23a649902762d4c11d854d73c49c9b93138f2de16403ef9f571ad5bae"
+dependencies = [
+ "bytes",
+ "fxhash",
+ "getset",
+ "protobuf",
+ "raft-proto",
+ "rand 0.8.7",
+ "slog",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "raft-proto"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb6884896294f553e8d5cfbdb55080b9f5f2f43394afff59c9f077e0f4b46d6b"
+dependencies = [
+ "bytes",
+ "protobuf",
+ "protobuf-build",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2204,6 +2856,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rcgen"
+version = "0.14.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57f6d249aad744e274e682777a50283a225a32705394ee6d5fcc01efa25e4055"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "x509-parser",
+ "yasna",
+]
+
+[[package]]
 name = "redb"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2218,7 +2884,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -2269,6 +2935,46 @@ name = "regex-syntax"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+]
 
 [[package]]
 name = "ring"
@@ -2324,7 +3030,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2337,6 +3043,7 @@ version = "0.23.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -2347,13 +3054,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -2361,6 +3108,7 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -2379,10 +3127,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.13.1",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "self_cell"
@@ -2477,7 +3266,7 @@ dependencies = [
  "dashmap",
  "fjall",
  "futures",
- "hmac",
+ "hmac 0.12.1",
  "kernel",
  "libc",
  "parking_lot",
@@ -2488,7 +3277,7 @@ dependencies = [
  "serde_json",
  "sha1",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tonic",
  "tonic-prost",
@@ -2579,7 +3368,17 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
 ]
 
 [[package]]
@@ -2599,6 +3398,18 @@ name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "slog"
+version = "2.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b3b8565691b22d2bdfc066426ed48f837fc0c5f2c8cad8d9718f7f99d6995c1"
+dependencies = [
+ "anyhow",
+ "erased-serde",
+ "rustversion",
+ "serde_core",
+]
 
 [[package]]
 name = "smallvec"
@@ -2636,6 +3447,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2664,6 +3481,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
+
+[[package]]
 name = "syn"
 version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2690,6 +3513,9 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synstructure"
@@ -2717,11 +3543,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2782,6 +3628,31 @@ checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
 dependencies = [
  "crunchy",
 ]
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -2963,6 +3834,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags 2.13.1",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
 name = "tower-layer"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2983,6 +3872,19 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
+dependencies = [
+ "crossbeam-channel",
+ "symlink",
+ "thiserror 2.0.18",
+ "time",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -3023,12 +3925,50 @@ version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "transport"
+version = "0.1.0"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=520768934ed805a2c5d8a22a0c20f52f75c8dddc#520768934ed805a2c5d8a22a0c20f52f75c8dddc"
+dependencies = [
+ "axum",
+ "backends",
+ "base64",
+ "bytes",
+ "chrono",
+ "contracts",
+ "dashmap",
+ "futures",
+ "http",
+ "http-body",
+ "http-body-util",
+ "kernel",
+ "lib",
+ "parking_lot",
+ "pem",
+ "prost",
+ "raft 0.1.0",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "thiserror 2.0.18",
+ "tokio",
+ "tonic",
+ "tower",
+ "tracing",
+ "uuid",
+ "x509-parser",
 ]
 
 [[package]]
@@ -3078,6 +4018,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3113,6 +4071,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3138,6 +4106,16 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3173,6 +4151,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "widestring"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3193,6 +4213,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -3409,7 +4438,7 @@ dependencies = [
  "parking_lot",
  "paste",
  "static_assertions",
- "thiserror",
+ "thiserror 2.0.18",
  "widestring",
  "windows",
  "winfsp-sys",
@@ -3434,6 +4463,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
 name = "x509-parser"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3447,7 +4482,7 @@ dependencies = [
  "oid-registry",
  "ring",
  "rusticata-macros",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
 ]
 
@@ -3456,6 +4491,39 @@ name = "xxhash-rust"
 version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "985eec839aaf2a1270af8f4ebcf63cf9401cfd90f0902f97c28d9f104ffbde72"
+
+[[package]]
+name = "yasna"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282"
+dependencies = [
+ "bit-vec",
+ "time",
+]
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
+]
 
 [[package]]
 name = "zerocopy"
@@ -3478,10 +4546,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "zmij"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "a2a"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=1a7fc31c807877879338306d30954b371b92a9ff#1a7fc31c807877879338306d30954b371b92a9ff"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=520768934ed805a2c5d8a22a0c20f52f75c8dddc#520768934ed805a2c5d8a22a0c20f52f75c8dddc"
 dependencies = [
  "contracts",
  "kernel",
@@ -276,7 +276,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=1a7fc31c807877879338306d30954b371b92a9ff#1a7fc31c807877879338306d30954b371b92a9ff"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=520768934ed805a2c5d8a22a0c20f52f75c8dddc#520768934ed805a2c5d8a22a0c20f52f75c8dddc"
 dependencies = [
  "ahash",
  "base64",
@@ -608,7 +608,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=1a7fc31c807877879338306d30954b371b92a9ff#1a7fc31c807877879338306d30954b371b92a9ff"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=520768934ed805a2c5d8a22a0c20f52f75c8dddc#520768934ed805a2c5d8a22a0c20f52f75c8dddc"
 dependencies = [
  "parking_lot",
  "serde",
@@ -1423,7 +1423,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=1a7fc31c807877879338306d30954b371b92a9ff#1a7fc31c807877879338306d30954b371b92a9ff"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=520768934ed805a2c5d8a22a0c20f52f75c8dddc#520768934ed805a2c5d8a22a0c20f52f75c8dddc"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -1475,7 +1475,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=1a7fc31c807877879338306d30954b371b92a9ff#1a7fc31c807877879338306d30954b371b92a9ff"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=520768934ed805a2c5d8a22a0c20f52f75c8dddc#520768934ed805a2c5d8a22a0c20f52f75c8dddc"
 dependencies = [
  "ahash",
  "base64",
@@ -1673,7 +1673,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=1a7fc31c807877879338306d30954b371b92a9ff#1a7fc31c807877879338306d30954b371b92a9ff"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=520768934ed805a2c5d8a22a0c20f52f75c8dddc#520768934ed805a2c5d8a22a0c20f52f75c8dddc"
 
 [[package]]
 name = "nexus-search-plugin"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "a2a"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=520768934ed805a2c5d8a22a0c20f52f75c8dddc#520768934ed805a2c5d8a22a0c20f52f75c8dddc"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=f9613915b00108e01d2b6e2fb346bdc1ae04481e#f9613915b00108e01d2b6e2fb346bdc1ae04481e"
 dependencies = [
  "contracts",
  "kernel",
@@ -220,7 +220,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 [[package]]
 name = "auth"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=520768934ed805a2c5d8a22a0c20f52f75c8dddc#520768934ed805a2c5d8a22a0c20f52f75c8dddc"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=f9613915b00108e01d2b6e2fb346bdc1ae04481e#f9613915b00108e01d2b6e2fb346bdc1ae04481e"
 dependencies = [
  "contracts",
  "dashmap",
@@ -318,7 +318,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=520768934ed805a2c5d8a22a0c20f52f75c8dddc#520768934ed805a2c5d8a22a0c20f52f75c8dddc"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=f9613915b00108e01d2b6e2fb346bdc1ae04481e#f9613915b00108e01d2b6e2fb346bdc1ae04481e"
 dependencies = [
  "ahash",
  "base64",
@@ -706,7 +706,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=520768934ed805a2c5d8a22a0c20f52f75c8dddc#520768934ed805a2c5d8a22a0c20f52f75c8dddc"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=f9613915b00108e01d2b6e2fb346bdc1ae04481e#f9613915b00108e01d2b6e2fb346bdc1ae04481e"
 dependencies = [
  "parking_lot",
  "serde",
@@ -1797,7 +1797,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=520768934ed805a2c5d8a22a0c20f52f75c8dddc#520768934ed805a2c5d8a22a0c20f52f75c8dddc"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=f9613915b00108e01d2b6e2fb346bdc1ae04481e#f9613915b00108e01d2b6e2fb346bdc1ae04481e"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -1849,7 +1849,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=520768934ed805a2c5d8a22a0c20f52f75c8dddc#520768934ed805a2c5d8a22a0c20f52f75c8dddc"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=f9613915b00108e01d2b6e2fb346bdc1ae04481e#f9613915b00108e01d2b6e2fb346bdc1ae04481e"
 dependencies = [
  "ahash",
  "base64",
@@ -2039,7 +2039,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 [[package]]
 name = "nexus-cluster"
 version = "0.1.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=520768934ed805a2c5d8a22a0c20f52f75c8dddc#520768934ed805a2c5d8a22a0c20f52f75c8dddc"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=f9613915b00108e01d2b6e2fb346bdc1ae04481e#f9613915b00108e01d2b6e2fb346bdc1ae04481e"
 dependencies = [
  "a2a",
  "anyhow",
@@ -2091,7 +2091,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=520768934ed805a2c5d8a22a0c20f52f75c8dddc#520768934ed805a2c5d8a22a0c20f52f75c8dddc"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=f9613915b00108e01d2b6e2fb346bdc1ae04481e#f9613915b00108e01d2b6e2fb346bdc1ae04481e"
 
 [[package]]
 name = "nexus-search-plugin"
@@ -2717,7 +2717,7 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 [[package]]
 name = "raft"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=520768934ed805a2c5d8a22a0c20f52f75c8dddc#520768934ed805a2c5d8a22a0c20f52f75c8dddc"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=f9613915b00108e01d2b6e2fb346bdc1ae04481e#f9613915b00108e01d2b6e2fb346bdc1ae04481e"
 dependencies = [
  "base64",
  "bincode",
@@ -3940,7 +3940,7 @@ dependencies = [
 [[package]]
 name = "transport"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=520768934ed805a2c5d8a22a0c20f52f75c8dddc#520768934ed805a2c5d8a22a0c20f52f75c8dddc"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=f9613915b00108e01d2b6e2fb346bdc1ae04481e#f9613915b00108e01d2b6e2fb346bdc1ae04481e"
 dependencies = [
  "axum",
  "backends",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -223,24 +223,24 @@ exclude = ["nexus-fuse"]
 #
 # Bump alongside the rest of nexus-vfs updates when a downstream
 # change needs newer kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "520768934ed805a2c5d8a22a0c20f52f75c8dddc" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "520768934ed805a2c5d8a22a0c20f52f75c8dddc" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "520768934ed805a2c5d8a22a0c20f52f75c8dddc" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "520768934ed805a2c5d8a22a0c20f52f75c8dddc", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "520768934ed805a2c5d8a22a0c20f52f75c8dddc", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "520768934ed805a2c5d8a22a0c20f52f75c8dddc", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "520768934ed805a2c5d8a22a0c20f52f75c8dddc" }
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "f9613915b00108e01d2b6e2fb346bdc1ae04481e" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "f9613915b00108e01d2b6e2fb346bdc1ae04481e" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "f9613915b00108e01d2b6e2fb346bdc1ae04481e" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "f9613915b00108e01d2b6e2fb346bdc1ae04481e", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "f9613915b00108e01d2b6e2fb346bdc1ae04481e", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "f9613915b00108e01d2b6e2fb346bdc1ae04481e", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "f9613915b00108e01d2b6e2fb346bdc1ae04481e" }
 # The cluster daemon library entry (`nexus_cluster::run_with_services`),
 # consumed by the nexus-side assembly binary (`rust/nexusd`) that composes
 # the kernel/federation boot with the nexus service set via the
 # ServiceRegistry bring-up seam.
-nexus-cluster = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "520768934ed805a2c5d8a22a0c20f52f75c8dddc" }
+nexus-cluster = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "f9613915b00108e01d2b6e2fb346bdc1ae04481e" }
 # a2a messaging substrate. `default-features = false` leaves the
 # `install` feature (which pulls raft to arm the stream-wakeup observer)
 # OFF, so nexus-side consumers link only the stamp hook and stay
 # raft-free — they reach raft through kernel.sys_* (§6.1). The substrate
 # is armed in production at cluster boot in nexus-vfs, not here.
-a2a = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "520768934ed805a2c5d8a22a0c20f52f75c8dddc", default-features = false }
+a2a = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "f9613915b00108e01d2b6e2fb346bdc1ae04481e", default-features = false }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,12 @@ members = [
     # walk over `sys_readdir` + `sys_read` in v1, trigram / streaming
     # / adaptive-strategy variants land in v2.
     "rust/services/search-plugin",
+    # nexusd — the nexus full daemon assembly binary (`nexusd-full`).
+    # Composes the nexus-vfs cluster boot (`nexus_cluster::run_with_services`)
+    # with the nexus service set (managed_agent, acp) via the
+    # ServiceRegistry bring-up seam. Supersedes the pure nexus-vfs
+    # `nexusd-full` (no nexus services) as the production daemon.
+    "rust/nexusd",
 ]
 # nexus-fuse excluded: standalone FUSE daemon with different dependency versions
 # from the workspace.  Distinct from nexus-fuse-plugin (the new
@@ -224,6 +230,11 @@ backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "520768934ed80
 kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "520768934ed805a2c5d8a22a0c20f52f75c8dddc", default-features = false }
 raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "520768934ed805a2c5d8a22a0c20f52f75c8dddc", default-features = false, features = ["grpc"] }
 nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "520768934ed805a2c5d8a22a0c20f52f75c8dddc" }
+# The cluster daemon library entry (`nexus_cluster::run_with_services`),
+# consumed by the nexus-side assembly binary (`rust/nexusd`) that composes
+# the kernel/federation boot with the nexus service set via the
+# ServiceRegistry bring-up seam.
+nexus-cluster = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "520768934ed805a2c5d8a22a0c20f52f75c8dddc" }
 # a2a messaging substrate. `default-features = false` leaves the
 # `install` feature (which pulls raft to arm the stream-wakeup observer)
 # OFF, so nexus-side consumers link only the stamp hook and stay

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -217,19 +217,19 @@ exclude = ["nexus-fuse"]
 #
 # Bump alongside the rest of nexus-vfs updates when a downstream
 # change needs newer kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "1a7fc31c807877879338306d30954b371b92a9ff" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "1a7fc31c807877879338306d30954b371b92a9ff" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "1a7fc31c807877879338306d30954b371b92a9ff" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "1a7fc31c807877879338306d30954b371b92a9ff", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "1a7fc31c807877879338306d30954b371b92a9ff", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "1a7fc31c807877879338306d30954b371b92a9ff", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "1a7fc31c807877879338306d30954b371b92a9ff" }
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "520768934ed805a2c5d8a22a0c20f52f75c8dddc" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "520768934ed805a2c5d8a22a0c20f52f75c8dddc" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "520768934ed805a2c5d8a22a0c20f52f75c8dddc" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "520768934ed805a2c5d8a22a0c20f52f75c8dddc", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "520768934ed805a2c5d8a22a0c20f52f75c8dddc", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "520768934ed805a2c5d8a22a0c20f52f75c8dddc", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "520768934ed805a2c5d8a22a0c20f52f75c8dddc" }
 # a2a messaging substrate. `default-features = false` leaves the
 # `install` feature (which pulls raft to arm the stream-wakeup observer)
 # OFF, so nexus-side consumers link only the stamp hook and stay
 # raft-free — they reach raft through kernel.sys_* (§6.1). The substrate
 # is armed in production at cluster boot in nexus-vfs, not here.
-a2a = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "1a7fc31c807877879338306d30954b371b92a9ff", default-features = false }
+a2a = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "520768934ed805a2c5d8a22a0c20f52f75c8dddc", default-features = false }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ENV CARGO_NET_RETRY=10 \
     CARGO_HTTP_TIMEOUT=120
 # Override for edge/CI or a different pin: --build-arg NEXUS_VFS_REV=<sha|tag>
-ARG NEXUS_VFS_REV=1a7fc31c807877879338306d30954b371b92a9ff
+ARG NEXUS_VFS_REV=520768934ed805a2c5d8a22a0c20f52f75c8dddc
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,id=cargo-install-${TARGETARCH},target=/root/.cargo/target \

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,9 @@ ARG TARGETARCH
 ENV USE_CHINA_MIRROR=${USE_CHINA_MIRROR}
 
 # ---------- 系统依赖 ----------
-# protobuf-compiler is required by raft-proto's protobuf-build step
-# when building nexusd-cluster from nexus-vfs via cargo install.
+# protobuf-compiler is required by raft-proto's protobuf-build step,
+# reached transitively when building the nexus-local nexusd crate
+# (its nexus-vfs raft git-dep compiles the protos).
 RUN set -eux; \
     apt-get update && apt-get install -y --no-install-recommends \
         gcc \
@@ -77,39 +78,41 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=cache,target=/root/.cache/pip \
     uv pip install --system -i "$(cat /tmp/pip_index)" ".[${NEXUS_PROFILE_EXTRAS}]"
 
-# ---------- Install nexusd-full binary from nexus-vfs (Issue #3125, #4259) ----------
-# Kernel-tier Rust (including the cluster binary) migrated to the nexus-vfs
-# repo. Install the pre-built binary via `cargo install` from the git repo.
+# ---------- Build nexusd-full from nexus-local sources (Issue #3125, #4259, #36) ----------
+# The production daemon is `nexusd-full`. Historically this was the nexus-vfs
+# `full` profile (kernel/raft/federation + S3/R2 driver) `cargo install`ed from
+# the git repo. As of the ServiceRegistry bring-up refactor (#36) it is the
+# nexus-local `nexusd` crate (rust/nexusd): the SAME nexus-vfs cluster boot
+# (`nexus_cluster::run_with_services`) PLUS the nexus service set (managed_agent
+# raw-spawn control plane + acp one-shot) composed in at boot via
+# `Kernel::bring_up_services`, PLUS the S3/R2 driver (`backends` `driver-s3`
+# feature — matches the old full profile via feature unification). It is a
+# strict superset of the old binary. The kernel repo can't depend on the nexus
+# service crates, so the composition root lives HERE, next to those crates.
 #
-# We install `nexusd-full` — the `full` profile = `nexusd-cluster` (Raft + IPC +
-# federation) PLUS the S3/R2 object-store driver. Per the nexus-vfs#27 kernel-team
-# review, `driver-s3` is NOT a feature on `nexusd-cluster` (that binary stays pure
-# local+remote and under its size gate); the S3-serving binary is this separate
-# profile. It is symlinked to `nexus-cluster` below so the Python runtime spawns
-# it unchanged.
+# The slim `nexusd-cluster` and the raft server/witness binaries still come from
+# nexus-vfs (dockerfiles/Dockerfile.{minimal,raft-server,raft-witness}) — those
+# deployment tiers legitimately carry no nexus services.
 #
-# REV is a build-arg, NOT a hardcoded edge. `cargo install --locked --git` lives in a
-# Docker RUN layer that caches by command string, so a bare `--branch main`
-# would FREEZE at the first-built binary forever — exactly how the stale,
-# pre-bridge-2 (#4262) cluster shipped (acked DT_MOUNT but never installed it,
-# created=false → edge E2E mount-setup failure). Putting the resolved rev in
-# the command both busts that cache and makes the build reproducible.
-#   - Default below = a known-good rev for reproducible local builds.
-#   - Edge: CI passes `--build-arg NEXUS_VFS_REV=$(git ls-remote …main | sha)`.
-#   - Downstream pins the *image*, not this file.
-# Default = nexus-vfs main rev matching the Cargo.toml pins (keep in sync —
-# this ARG is what the shipped kernel binary is built from; the Cargo.toml
-# pins only sync the plugin/services crates). Includes the durable-metastore
-# boot wiring (#4343) — older revs lose the VFS namespace on every restart.
+# The nexus-vfs pin is no longer a build-arg here: `nexusd` resolves nexus-vfs
+# through its Cargo.toml git-dep `rev` + Cargo.lock (the SSOT). `--locked` builds
+# exactly that resolution. Bump the pin in Cargo.toml/Cargo.lock — the test.yml
+# "Kernel pin consistency preflight" still enforces Cargo == Cargo.lock == the
+# remaining Dockerfile ARGs, and CI's nexusd-full smoke now builds this same
+# nexus-local crate (so the gate tests the exact binary the image ships).
+# nexusd-full is symlinked to nexus-cluster/nexusd-cluster below so the Python
+# runtime spawns it unchanged.
 ENV CARGO_NET_RETRY=10 \
     CARGO_HTTP_TIMEOUT=120
-# Override for edge/CI or a different pin: --build-arg NEXUS_VFS_REV=<sha|tag>
-ARG NEXUS_VFS_REV=520768934ed805a2c5d8a22a0c20f52f75c8dddc
+# The nexus Rust workspace sources (the service crates + the nexusd assembly).
+# Copied AFTER the Python-deps cache layer so a Rust edit doesn't invalidate it;
+# the build below re-runs only when rust/ or the workspace manifests change.
+COPY rust/ ./rust/
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
-    --mount=type=cache,id=cargo-install-${TARGETARCH},target=/root/.cargo/target \
-    cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-full nexus-full && \
-    cp /root/.cargo/bin/nexusd-full /build/nexusd-full
+    --mount=type=cache,id=cargo-target-${TARGETARCH},target=/build/target \
+    cargo build --locked --release -p nexusd --bin nexusd-full && \
+    cp /build/target/release/nexusd-full /build/nexusd-full
 
 # ---------- Copy real application source and reinstall local package ----------
 COPY src/ ./src/

--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir --no-deps --prefix=/install .
 # enforces agreement) — an unpinned install tracks nexus-vfs HEAD and
 # ships an untested kernel (#4343). --locked honors the source tree's
 # Cargo.lock.
-ARG NEXUS_VFS_REV=520768934ed805a2c5d8a22a0c20f52f75c8dddc
+ARG NEXUS_VFS_REV=f9613915b00108e01d2b6e2fb346bdc1ae04481e
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-cluster nexus-cluster
 
 # -- Runtime stage --

--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir --no-deps --prefix=/install .
 # enforces agreement) — an unpinned install tracks nexus-vfs HEAD and
 # ships an untested kernel (#4343). --locked honors the source tree's
 # Cargo.lock.
-ARG NEXUS_VFS_REV=1a7fc31c807877879338306d30954b371b92a9ff
+ARG NEXUS_VFS_REV=520768934ed805a2c5d8a22a0c20f52f75c8dddc
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-cluster nexus-cluster
 
 # -- Runtime stage --

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -25,7 +25,7 @@ WORKDIR /build
 # (CI preflight enforces agreement) — an unpinned install tracks HEAD
 # and can skew the raft contract against the cluster/witness images.
 # --locked honors the source tree's Cargo.lock.
-ARG NEXUS_VFS_REV=520768934ed805a2c5d8a22a0c20f52f75c8dddc
+ARG NEXUS_VFS_REV=f9613915b00108e01d2b6e2fb346bdc1ae04481e
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexus-raft-server raft
 
 # ---------- Production image ----------

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -25,7 +25,7 @@ WORKDIR /build
 # (CI preflight enforces agreement) — an unpinned install tracks HEAD
 # and can skew the raft contract against the cluster/witness images.
 # --locked honors the source tree's Cargo.lock.
-ARG NEXUS_VFS_REV=1a7fc31c807877879338306d30954b371b92a9ff
+ARG NEXUS_VFS_REV=520768934ed805a2c5d8a22a0c20f52f75c8dddc
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexus-raft-server raft
 
 # ---------- Production image ----------

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=520768934ed805a2c5d8a22a0c20f52f75c8dddc
+ARG NEXUS_VFS_REV=f9613915b00108e01d2b6e2fb346bdc1ae04481e
 RUN cargo install \
     --locked \
     --git https://github.com/nexi-lab/nexus-vfs \

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=1a7fc31c807877879338306d30954b371b92a9ff
+ARG NEXUS_VFS_REV=520768934ed805a2c5d8a22a0c20f52f75c8dddc
 RUN cargo install \
     --locked \
     --git https://github.com/nexi-lab/nexus-vfs \

--- a/rust/nexusd/Cargo.toml
+++ b/rust/nexusd/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "nexusd"
+version = "0.1.0"
+edition = "2021"
+description = "Nexus full daemon assembly — nexus-vfs cluster/federation boot composed with the nexus service set (managed_agent, acp) via the ServiceRegistry bring-up seam. Supersedes the pure nexus-vfs nexusd-full as the production daemon."
+authors = ["Nexus Team"]
+publish = false
+
+[[bin]]
+name = "nexusd-full"
+path = "src/main.rs"
+
+[dependencies]
+# Cluster library entry — `nexus_cluster::run_with_services` owns clap
+# parsing, the tokio runtime, and the whole kernel + raft + federation
+# boot. The `driver-s3` feature is opted in via `backends` unification
+# below (matches the nexus-vfs `full` profile) so this binary is a strict
+# superset of the old nexusd-full — plus the nexus services.
+nexus-cluster = { workspace = true }
+backends = { workspace = true, default-features = false, features = ["driver-s3"] }
+# a2a from-stamp hook (its `service_decl`); default-features keeps it
+# raft-free (the stream-wakeup observer is armed in cluster boot, not here).
+a2a = { workspace = true }
+# The nexus service set composed into the daemon at boot.
+services = { workspace = true, features = ["service-managed-agent", "service-acp"] }
+anyhow = "1"

--- a/rust/nexusd/src/main.rs
+++ b/rust/nexusd/src/main.rs
@@ -1,0 +1,30 @@
+//! `nexusd-full` — the nexus full daemon assembly binary.
+//!
+//! The composition root: it hands the kernel the ordered `ServiceDecl`
+//! set — a2a (from-stamp) + managed_agent (raw ACP control plane) + acp
+//! (one-shot) — which `Kernel::bring_up_services` installs after the
+//! kernel + auth are up. All the clap parsing, tokio runtime, and
+//! kernel/raft/federation boot flow through `nexus_cluster::run_with_services`
+//! unchanged; the only delta from the pure nexus-vfs `nexusd-full` is the
+//! service set, which lives HERE (next to the service crates it links)
+//! because the kernel repo can't depend on the nexus service crates.
+//!
+//! Supersedes the nexus-vfs `nexusd-full` (kernel + drivers, no nexus
+//! services) as the production daemon — the Dockerfiles build this binary.
+//! `driver-s3` matches the `full` profile via `backends` feature unification.
+
+fn main() -> anyhow::Result<()> {
+    // The daemon's service set — the SSOT for "which services this daemon
+    // runs", ordered. a2a is installed first (its from-stamp hook must be
+    // armed before agents write mailboxes); managed_agent + acp follow.
+    // `ctx.auth_armed` is boot-derived (true iff sk- auth is armed) and
+    // sets a2a's fail-closed posture; acp's default zone is the node-local
+    // root.
+    nexus_cluster::run_with_services(|ctx| {
+        vec![
+            a2a::service_decl(ctx.auth_armed),
+            services::managed_agent::service_decl(),
+            services::acp::service_decl("root".to_string()),
+        ]
+    })
+}

--- a/rust/services/Cargo.toml
+++ b/rust/services/Cargo.toml
@@ -16,7 +16,13 @@ default = []
 service-audit = []
 service-agents = []
 service-managed-agent = []
-service-acp = []
+# Generic hosted-subprocess primitive (`crate::subprocess`): launch an
+# argv + surface its stdio as VFS DT_PIPEs. Unix-only at the mod gate.
+# `service-acp` pulls it (its one-shot path spawns agents); a
+# managed-agent build that wants the raw ACP control-plane spawn enables
+# it alongside `service-managed-agent`.
+subprocess-host = []
+service-acp = ["subprocess-host"]
 service-tasks = []
 # AuditNode — consumer-side audit collect/gather service for an
 # audit-only federation node. Pulls `service-audit` to reuse

--- a/rust/services/src/acp/connection.rs
+++ b/rust/services/src/acp/connection.rs
@@ -7,7 +7,7 @@
 //! feed every session/update notification into an [`AgentObserver`].
 //!
 //! Owns no subprocess: the kernel-side DT_PIPEs registered by
-//! [`super::subprocess::AcpSubprocess`] hand a generic AsyncRead /
+//! [`crate::subprocess::HostedSubprocess`] hand a generic AsyncRead /
 //! AsyncWrite pair; AcpConnection only sees those.
 //!
 //! Timing-sensitive: `session_load` sleeps **200ms** after the load

--- a/rust/services/src/acp/mod.rs
+++ b/rust/services/src/acp/mod.rs
@@ -16,8 +16,8 @@
 //!     `nexus.contracts.vfs_paths`. The Rust port keeps the same
 //!     conventions so a Python and Rust caller addressing the same
 //!     agent see the same files.
-//!   * [`subprocess`] (unix) — `AcpSubprocess` owns the agent CLI +
-//!     three stdio DT_PIPE registrations.
+//!   * [`subprocess`] (unix) — `spawn_acp` bridge: `AgentConfig` → argv
+//!     over the generic [`crate::subprocess::HostedSubprocess`] host.
 //!   * [`jsonrpc`] — newline-delimited JSON-RPC 2.0 client.
 //!   * [`observer`] — accumulator for `session/update` notifications.
 //!   * [`connection`] — ACP-specific request / notification routing.

--- a/rust/services/src/acp/mod.rs
+++ b/rust/services/src/acp/mod.rs
@@ -42,3 +42,15 @@ pub(crate) mod subprocess;
 
 #[allow(unused_imports)] // commit 21 wires AcpService into the boot path
 pub(crate) use service::{AcpService, AgentRegistry};
+
+/// The ACP one-shot service as a boot declaration for
+/// [`kernel::kernel::Kernel::bring_up_services`] — the uniform path the
+/// assembly uses to hand services to the kernel. Wraps
+/// [`service::AcpService::install`]; `default_zone` is the deployment's
+/// default zone (the assembly passes `"root"` for the node-local daemon).
+pub fn service_decl(default_zone: String) -> kernel::kernel::ServiceDecl {
+    kernel::kernel::ServiceDecl {
+        name: "acp".to_string(),
+        install: Box::new(move |kernel| service::AcpService::install(kernel, &default_zone)),
+    }
+}

--- a/rust/services/src/acp/service.rs
+++ b/rust/services/src/acp/service.rs
@@ -8,7 +8,8 @@
 //! Layered on top of:
 //!   * [`super::agent_config::AgentConfig`] -- VFS-persisted CLI config
 //!   * [`super::paths`]                     -- /{zone}/agents + /{zone}/proc layout
-//!   * [`super::subprocess::AcpSubprocess`] -- tokio Command + DT_PIPE wiring (unix only)
+//!   * [`super::subprocess::spawn_acp`]     -- AgentConfig → argv bridge over
+//!     the generic [`crate::subprocess::HostedSubprocess`] host (unix only)
 //!   * [`super::connection::AcpConnection`] -- ACP JSON-RPC adapter
 //!   * [`super::observer::AgentObserver`]   -- session/update accumulator
 //!
@@ -44,7 +45,9 @@ use super::connection::{AcpConnection, FsRead, FsWrite};
 #[cfg(unix)]
 use super::observer::AgentTurnResult;
 #[cfg(unix)]
-use super::subprocess::AcpSubprocess;
+use super::subprocess::spawn_acp;
+#[cfg(unix)]
+use crate::subprocess::HostedSubprocess;
 #[cfg(unix)]
 use futures::future::BoxFuture;
 #[cfg(unix)]
@@ -446,7 +449,7 @@ impl<K: KernelSyscall> AcpService<K> {
     }
 }
 
-// ── call_agent (unix only — depends on AcpSubprocess) ──────────────────
+// ── call_agent (unix only — depends on HostedSubprocess) ───────────────
 
 #[cfg(unix)]
 impl<K: KernelSyscall> AcpService<K> {
@@ -524,9 +527,7 @@ impl<K: KernelSyscall> AcpService<K> {
 
         // Spawn the agent CLI + register DT_PIPEs.
         let mut subproc =
-            match AcpSubprocess::spawn(&cfg, &host_cwd, self.kernel.as_ref(), &req.zone_id, &pid)
-                .await
-            {
+            match spawn_acp(&cfg, &host_cwd, self.kernel.as_ref(), &req.zone_id, &pid).await {
                 Ok(s) => s,
                 Err(e) => {
                     let _ = reg.kill(&pid, 127);
@@ -666,7 +667,7 @@ impl<K: KernelSyscall> AcpService<K> {
     #[allow(clippy::too_many_arguments)]
     async fn run_session(
         &self,
-        subproc: &mut AcpSubprocess,
+        subproc: &mut HostedSubprocess,
         _cfg: &AgentConfig,
         fs_read: FsRead,
         fs_write: FsWrite,
@@ -838,9 +839,6 @@ fn build_metadata(
     }
     meta
 }
-
-// AcpSubprocess gains take_stdio_for_connection() in this commit too —
-// see subprocess.rs.
 
 // ── RustService dispatch ────────────────────────────────────────────────
 

--- a/rust/services/src/acp/subprocess.rs
+++ b/rust/services/src/acp/subprocess.rs
@@ -1,47 +1,23 @@
-//! `AcpSubprocess` — owns a coding-agent CLI subprocess and the three
-//! DT_PIPE registrations that surface its stdio inside VFS.
+//! ACP subprocess bridge — translates an [`AgentConfig`] into the argv /
+//! env / fd-path layout the generic [`HostedSubprocess`] host expects.
 //!
-//! Lifecycle (success path):
+//! The generic subprocess host ([`crate::subprocess`]) knows nothing
+//! about ACP; this thin module owns the ACP-specific translation
+//! (`AgentConfig` → argv, Electron/npm env sanitising, the acp
+//! `/{zone}/proc/{pid}/fd/{n}` path scheme) and delegates the actual
+//! launch + DT_PIPE wiring to [`HostedSubprocess::spawn_from_argv`].
 //!
-//!   1. `AcpSubprocess::spawn(cfg, cwd, kernel, zone, pid)` — build
-//!      argv + clean env, launch the CLI with all three stdio fds
-//!      piped, take ownership of the parent-side OwnedFds, dup each
-//!      and hand the duplicate to the kernel as a stdio-backed
-//!      DT_PIPE at `/{zone}/proc/{pid}/fd/{0,1,2}`.
-//!   2. ACP traffic flows through the DT_PIPE (kernel-side fds).
-//!   3. `unregister_pipes(kernel)` — `sys_unlink` each path so the
-//!      kernel-side `StdioPipeBackend` drops + closes its dup'd fd,
-//!      then drop the parent-side OwnedFds so the OS pipe collapses
-//!      and the subprocess sees EOF on stdin / read returns 0 on
-//!      stdout/stderr.
-//!   4. `wait()` — block until the child exits; returns the exit code.
-//!   5. `kill()` — best-effort SIGKILL on the child if it didn't exit.
-//!
-//! Owned-fd contract: every parent-side stdio fd has exactly two live
-//! handles — the `OwnedFd` this struct holds and the `StdioPipeBackend`
-//! the kernel holds (created from a `dup`). Both close independently;
-//! the OS pipe only collapses when both are gone, which is how we
-//! deliver EOF to the subprocess.
-//!
-//! Unix-only — the entire module is gated `#[cfg(unix)]` (matches
-//! `stdio_pipe.rs`). Windows port lives somewhere else when it's needed.
+//! Unix-only (matches the generic host + the kernel stdio-pipe support).
 
-#![cfg(unix)]
 #![allow(dead_code)]
 
 use std::collections::HashMap;
-use std::os::fd::AsRawFd;
 use std::path::Path;
-use std::process::Stdio;
-
-use tokio::process::{Child, ChildStderr, ChildStdin, ChildStdout, Command};
 
 use super::agent_config::AgentConfig;
 use super::paths;
+use crate::subprocess::{HostedSubprocess, SubprocessError};
 use kernel::kernel::syscall::KernelSyscall;
-use kernel::kernel::{KernelError, OperationContext};
-
-const PIPE_CAPACITY: usize = 1 << 20;
 
 /// Env vars stripped before spawning agents (mirrors AionUi
 /// `prepareCleanEnv` and the Python `_ENV_STRIP_KEYS`). Prevents
@@ -90,278 +66,28 @@ pub(crate) fn prepare_clean_env(extra: &HashMap<String, String>) -> HashMap<Stri
     env
 }
 
-/// Owned subprocess + the parent-side stdio handles the kernel got
-/// dup'd copies of. The tokio types are kept here (rather than raw
-/// `OwnedFd`) so [`AcpConnection`](super::connection::AcpConnection)
-/// can drive them through `AsyncRead` / `AsyncWrite` directly.
-/// Drop closes everything still open; tokio's `kill_on_drop(true)`
-/// reaps the child process itself.
-pub(crate) struct AcpSubprocess {
-    child: Child,
-    /// Parent-side write end of the subprocess stdin pipe. `Some`
-    /// until `take_stdio_for_connection` hands it off to the
-    /// AcpConnection (or `unregister_pipes` drops it to deliver
-    /// EOF).
-    stdin: Option<ChildStdin>,
-    /// Parent-side read end of the subprocess stdout pipe.
-    stdout: Option<ChildStdout>,
-    /// Parent-side read end of the subprocess stderr pipe.
-    stderr: Option<ChildStderr>,
-    /// VFS paths the kernel registered the dup'd fds at.
-    stdin_path: String,
-    stdout_path: String,
-    stderr_path: String,
-}
-
-#[derive(Debug)]
-pub(crate) enum SubprocessError {
-    Spawn(String),
-    Register(String),
-    Io(String),
-}
-
-impl std::fmt::Display for SubprocessError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Spawn(m) => write!(f, "spawn: {m}"),
-            Self::Register(m) => write!(f, "register pipe: {m}"),
-            Self::Io(m) => write!(f, "io: {m}"),
-        }
-    }
-}
-
-impl std::error::Error for SubprocessError {}
-
-impl AcpSubprocess {
-    /// Spawn the agent CLI for `cfg` under `cwd`, register all three
-    /// stdio fds as DT_PIPEs at `/{zone}/proc/{pid}/fd/{0,1,2}`, and
-    /// return the live handle.
-    ///
-    /// Failure modes:
-    ///   * spawn fails — returns `SubprocessError::Spawn`. No DT_PIPEs
-    ///     created. `agent_registry.kill(pid, 127)` is the caller's
-    ///     responsibility.
-    ///   * register fails partway through — already-registered pipes
-    ///     are unlinked before returning so we don't leak DT_PIPE
-    ///     entries on the failure path.
-    pub(crate) async fn spawn<K: KernelSyscall>(
-        cfg: &AgentConfig,
-        cwd: &Path,
-        kernel: &K,
-        zone: &str,
-        pid: &str,
-    ) -> Result<Self, SubprocessError> {
-        let argv = build_argv(cfg);
-        let env = prepare_clean_env(&cfg.env);
-
-        let mut cmd = Command::new(&argv[0]);
-        cmd.args(&argv[1..])
-            .env_clear()
-            .envs(env)
-            .current_dir(cwd)
-            .stdin(Stdio::piped())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .kill_on_drop(true);
-
-        let mut child = cmd
-            .spawn()
-            .map_err(|e| SubprocessError::Spawn(e.to_string()))?;
-
-        // Take the parent-side stdio handles. tokio's ChildStdin /
-        // ChildStdout / ChildStderr each own a unique pipe fd; we
-        // keep them as the canonical handles so AcpConnection can
-        // drive them through AsyncRead / AsyncWrite, and dup the raw
-        // fds for the kernel's stdio-backed DT_PIPE.
-        let stdin = child
-            .stdin
-            .take()
-            .ok_or_else(|| SubprocessError::Io("subprocess stdin missing".into()))?;
-        let stdout = child
-            .stdout
-            .take()
-            .ok_or_else(|| SubprocessError::Io("subprocess stdout missing".into()))?;
-        let stderr = child
-            .stderr
-            .take()
-            .ok_or_else(|| SubprocessError::Io("subprocess stderr missing".into()))?;
-
-        let stdin_path = paths::proc_fd(zone, pid, 0);
-        let stdout_path = paths::proc_fd(zone, pid, 1);
-        let stderr_path = paths::proc_fd(zone, pid, 2);
-
-        // Register stdin (kernel writes into subprocess stdin).
-        if let Err(e) = register_stdio_pipe(
-            kernel,
-            &stdin_path,
-            /* read_fd */ -1,
-            dup_raw(stdin.as_raw_fd())?,
-        ) {
-            return Err(SubprocessError::Register(e));
-        }
-        // Register stdout (kernel reads from subprocess stdout).
-        if let Err(e) = register_stdio_pipe(
-            kernel,
-            &stdout_path,
-            dup_raw(stdout.as_raw_fd())?,
-            /* write_fd */ -1,
-        ) {
-            let _ = unlink_quiet(kernel, &stdin_path);
-            return Err(SubprocessError::Register(e));
-        }
-        // Register stderr.
-        if let Err(e) = register_stdio_pipe(
-            kernel,
-            &stderr_path,
-            dup_raw(stderr.as_raw_fd())?,
-            /* write_fd */ -1,
-        ) {
-            let _ = unlink_quiet(kernel, &stdin_path);
-            let _ = unlink_quiet(kernel, &stdout_path);
-            return Err(SubprocessError::Register(e));
-        }
-
-        Ok(Self {
-            child,
-            stdin: Some(stdin),
-            stdout: Some(stdout),
-            stderr: Some(stderr),
-            stdin_path,
-            stdout_path,
-            stderr_path,
-        })
-    }
-
-    /// Move the parent-side stdio handles out of the subprocess so
-    /// the AcpConnection can wrap them as AsyncRead / AsyncWrite.
-    /// After this call the kernel-side DT_PIPEs (created in `spawn`)
-    /// remain registered; `unregister_pipes` is still required for
-    /// teardown.
-    pub(crate) fn take_stdio_for_connection(
-        &mut self,
-    ) -> Result<(ChildStdin, ChildStdout, ChildStderr), SubprocessError> {
-        let stdin = self
-            .stdin
-            .take()
-            .ok_or_else(|| SubprocessError::Io("stdin already taken".into()))?;
-        let stdout = self
-            .stdout
-            .take()
-            .ok_or_else(|| SubprocessError::Io("stdout already taken".into()))?;
-        let stderr = self
-            .stderr
-            .take()
-            .ok_or_else(|| SubprocessError::Io("stderr already taken".into()))?;
-        Ok((stdin, stdout, stderr))
-    }
-
-    /// Unlink the three DT_PIPE entries (closing the kernel-side
-    /// dup'd fds) and drop the parent-side stdio handles still held
-    /// by this struct. After this call the OS pipes collapse and the
-    /// subprocess sees EOF on stdin / read returns 0 on stdout /
-    /// stderr — provided the AcpConnection that may have taken
-    /// ownership via `take_stdio_for_connection` has also dropped.
-    ///
-    /// Idempotent: subsequent calls are no-ops.
-    pub(crate) fn unregister_pipes<K: KernelSyscall>(&mut self, kernel: &K) {
-        let _ = unlink_quiet(kernel, &self.stdin_path);
-        let _ = unlink_quiet(kernel, &self.stdout_path);
-        let _ = unlink_quiet(kernel, &self.stderr_path);
-        // Drop any remaining parent-side handles so EOF reaches the
-        // child even if take_stdio_for_connection wasn't called.
-        self.stdin.take();
-        self.stdout.take();
-        self.stderr.take();
-    }
-
-    /// Best-effort SIGKILL on the child. Safe to call even if the
-    /// child has already exited.
-    pub(crate) async fn kill(&mut self) {
-        let _ = self.child.kill().await;
-    }
-
-    /// Wait for the child to exit. Returns the exit code (or 0 on
-    /// signal / unknown status, matching the Python service's
-    /// "no code" fallback).
-    pub(crate) async fn wait(&mut self) -> i32 {
-        match self.child.wait().await {
-            Ok(status) => status.code().unwrap_or(0),
-            Err(_) => -1,
-        }
-    }
-}
-
-// ── Internal helpers ───────────────────────────────────────────────────
-
-/// `dup(2)` the raw fd so the kernel-side StdioPipeBackend holds an
-/// independently-closable handle. Original tokio handle keeps its
-/// own fd number; both close on Drop without colliding.
-fn dup_raw(raw: i32) -> Result<i32, SubprocessError> {
-    // SAFETY: libc::dup is the canonical way to duplicate a file
-    // descriptor; the returned fd is independently closable.
-    let dup = unsafe { libc::dup(raw) };
-    if dup < 0 {
-        return Err(SubprocessError::Io(format!(
-            "dup({raw}): {}",
-            std::io::Error::last_os_error()
-        )));
-    }
-    Ok(dup)
-}
-
-fn register_stdio_pipe<K: KernelSyscall>(
+/// Spawn the agent CLI for `cfg` under `cwd` and register its stdio as
+/// DT_PIPEs at `/{zone}/proc/{pid}/fd/{0,1,2}`. Thin ACP-config wrapper
+/// over [`HostedSubprocess::spawn_from_argv`]: it computes the argv
+/// (`build_argv`), the sanitised inherited env (`prepare_clean_env` —
+/// keeps PATH so a bare command name resolves), and the acp fd-path
+/// scheme, then delegates the launch + fd wiring to the generic host.
+pub(crate) async fn spawn_acp<K: KernelSyscall>(
+    cfg: &AgentConfig,
+    cwd: &Path,
     kernel: &K,
-    path: &str,
-    read_fd: i32,
-    write_fd: i32,
-) -> Result<(), String> {
-    // DT_PIPE create via the generic sys_setattr matrix: entry_type=3
-    // (DT_PIPE), the "stdio" io_profile, and the subprocess's dup'd
-    // read/write fds. The DT_PIPE arm of sys_setattr accepts exactly
-    // these params — no dedicated setattr_pipe syscall needed.
-    kernel
-        .sys_setattr(
-            path,
-            /* entry_type   */ 3, // DT_PIPE
-            /* backend_name */ "",
-            /* backend      */ None,
-            /* metastore    */ None,
-            /* raft_backend */ None,
-            /* io_profile   */ "stdio",
-            /* zone_id      */ "root",
-            /* is_external  */ false,
-            /* capacity     */ PIPE_CAPACITY,
-            /* read_fd      */ Some(read_fd),
-            /* write_fd     */ Some(write_fd),
-            /* mime_type       */ None,
-            /* modified_at_ms  */ None,
-            /* content_id      */ None,
-            /* size            */ None,
-            /* version         */ None,
-            /* created_at_ms   */ None,
-            /* link_target     */ None,
-            /* source          */ None,
-            /* remote_metastore*/ None,
-        )
-        .map(|_| ())
-        .map_err(|e: KernelError| format!("{e:?}"))
+    zone: &str,
+    pid: &str,
+) -> Result<HostedSubprocess, SubprocessError> {
+    let argv = build_argv(cfg);
+    let env = prepare_clean_env(&cfg.env);
+    let fd_paths = [
+        paths::proc_fd(zone, pid, 0),
+        paths::proc_fd(zone, pid, 1),
+        paths::proc_fd(zone, pid, 2),
+    ];
+    HostedSubprocess::spawn_from_argv(argv, env, cwd, kernel, fd_paths).await
 }
-
-fn unlink_quiet<K: KernelSyscall>(kernel: &K, path: &str) -> Result<(), KernelError> {
-    let ctx = OperationContext::new(
-        /* user_id */ "system", /* zone_id */ "root", /* is_admin */ true,
-        /* agent_id */ None, /* is_system */ true,
-    );
-    kernel.sys_unlink(path, &ctx, false).map(|_| ())
-}
-
-// Drop semantics: tokio's ChildStdin / ChildStdout / ChildStderr
-// each close their own fd, so dropping this struct closes the
-// parent-side OS pipe handles still held. The kernel-side
-// StdioPipeBackend keeps its dup'd fd alive until `unregister_pipes`
-// runs; if the caller forgot, the DT_PIPE entry leaks into the
-// metastore. tokio Command's `kill_on_drop(true)` ensures the child
-// process itself is reaped.
 
 #[cfg(test)]
 mod tests {
@@ -452,144 +178,6 @@ mod tests {
                 Some(v) => std::env::set_var("npm_config_loglevel", v),
                 None => std::env::remove_var("npm_config_loglevel"),
             }
-        }
-    }
-
-    // ── fd-lifecycle integration tests (linux/CI only) ──────────────
-
-    use super::AcpSubprocess;
-    use kernel::kernel::Kernel;
-    use std::sync::Arc;
-    use std::time::Duration;
-    use tokio::io::{AsyncReadExt, AsyncWriteExt};
-
-    fn cat_on_path() -> bool {
-        std::process::Command::new("cat")
-            .arg("--version")
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .status()
-            .map(|s| s.success())
-            .unwrap_or(false)
-    }
-
-    fn cat_subprocess_cfg() -> AgentConfig {
-        AgentConfig {
-            agent_id: "cat".to_string(),
-            name: "cat".to_string(),
-            // POSIX `cat` echoes stdin to stdout until EOF.
-            command: "cat".to_string(),
-            prompt_flag: "-p".to_string(),
-            default_system_prompt: None,
-            extra_args: Vec::new(),
-            // Empty acp_args so we don't pass --experimental-acp to cat.
-            env: HashMap::new(),
-            npx_package: None,
-            acp_args: Vec::new(),
-            enabled: true,
-        }
-    }
-
-    /// Smoke: spawn cat, write a line to its stdin, read it back from
-    /// stdout, drop the connection so the subprocess sees EOF, reap.
-    ///
-    /// `#[ignore]` because a bare-kernel test environment doesn't have
-    /// a metastore mount at `/{zone}/proc/...`, so `unregister_pipes`
-    /// can't reach the kernel-side StdioPipeBackend to close its
-    /// dup'd fd, the subprocess never sees EOF on stdin, and `wait`
-    /// hangs. Run this test against a fully-wired kernel (the boot
-    /// path that mounts the proc-tree):
-    ///   `cargo test acp::subprocess::tests::cat_roundtrip -- --ignored`
-    /// The roundtrip portion of the test (write -> read -> assert
-    /// echoed bytes) does pass; only the EOF / wait teardown trips on
-    /// the missing mount.
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    #[ignore]
-    async fn cat_roundtrip_through_acp_subprocess() {
-        if !cat_on_path() {
-            eprintln!("cat not on PATH -- skipping");
-            return;
-        }
-        let kernel = Arc::new(Kernel::new());
-        let cwd = std::env::temp_dir();
-        let mut sub = AcpSubprocess::spawn(
-            &cat_subprocess_cfg(),
-            &cwd,
-            kernel.as_ref(),
-            "root",
-            "pid-cat-roundtrip",
-        )
-        .await
-        .expect("spawn cat");
-
-        let (mut stdin, mut stdout, _stderr) = sub.take_stdio_for_connection().expect("take stdio");
-
-        // Write a line + flush; cat will echo it.
-        stdin
-            .write_all(b"hello acp\n")
-            .await
-            .expect("write to cat stdin");
-        stdin.flush().await.expect("flush");
-
-        // Read a line from cat stdout.
-        let mut buf = vec![0u8; 64];
-        let n = tokio::time::timeout(Duration::from_secs(5), stdout.read(&mut buf))
-            .await
-            .expect("stdout read timed out")
-            .expect("stdout read");
-        assert!(n > 0, "expected echoed bytes");
-        let echoed = std::str::from_utf8(&buf[..n]).unwrap();
-        assert!(echoed.starts_with("hello acp"), "got {echoed:?}");
-
-        // Drop stdin -> cat sees EOF -> exits 0.
-        drop(stdin);
-        drop(stdout);
-
-        sub.unregister_pipes(kernel.as_ref());
-        let exit = tokio::time::timeout(Duration::from_secs(5), sub.wait())
-            .await
-            .expect("wait timed out");
-        // cat exits 0 on clean EOF.
-        assert_eq!(exit, 0, "cat should exit 0 on EOF");
-    }
-
-    /// Stress the spawn / register / write / read / kill path 10x to
-    /// shake out fd leaks + register/unregister ordering bugs.
-    /// Same `#[ignore]` rationale as `cat_roundtrip_through_acp_subprocess`.
-    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-    #[ignore]
-    async fn cat_roundtrip_stress_10x() {
-        if !cat_on_path() {
-            eprintln!("cat not on PATH -- skipping");
-            return;
-        }
-        let kernel = Arc::new(Kernel::new());
-        let cwd = std::env::temp_dir();
-        for i in 0..10 {
-            let pid = format!("pid-stress-{i}");
-            let mut sub =
-                AcpSubprocess::spawn(&cat_subprocess_cfg(), &cwd, kernel.as_ref(), "root", &pid)
-                    .await
-                    .unwrap_or_else(|e| panic!("spawn iter {i}: {e}"));
-            let (mut stdin, mut stdout, _stderr) = sub.take_stdio_for_connection().unwrap();
-            let line = format!("iter {i}\n");
-            stdin.write_all(line.as_bytes()).await.unwrap();
-            stdin.flush().await.unwrap();
-            let mut buf = vec![0u8; 64];
-            let n = tokio::time::timeout(Duration::from_secs(5), stdout.read(&mut buf))
-                .await
-                .unwrap_or_else(|_| panic!("read iter {i} timed out"))
-                .unwrap();
-            let echoed = std::str::from_utf8(&buf[..n]).unwrap();
-            assert!(
-                echoed.starts_with(&format!("iter {i}")),
-                "iter {i}: got {echoed:?}"
-            );
-            drop(stdin);
-            drop(stdout);
-            sub.unregister_pipes(kernel.as_ref());
-            sub.kill().await;
-            let _ = tokio::time::timeout(Duration::from_secs(5), sub.wait()).await;
         }
     }
 

--- a/rust/services/src/lib.rs
+++ b/rust/services/src/lib.rs
@@ -39,6 +39,14 @@
 //!                          +--- backends     (peer; never crosses to services)
 //! ```
 
+// Generic hosted-subprocess primitive: launch an argv + surface its
+// stdio as VFS DT_PIPEs. Shared by `acp` (config-driven ACP one-shot)
+// and `managed_agent` (raw control-plane tunnel); knows nothing about
+// either. Unix-only (dup(2) + stdio-pipe kernel support). `service-acp`
+// pulls it; a managed-agent build that wants the raw spawn path enables
+// it alongside `service-managed-agent`.
+#[cfg(all(unix, feature = "subprocess-host"))]
+pub(crate) mod subprocess;
 // AcpService — subprocess + ACP-over-stdio host for
 // `AgentKind::UNMANAGED` agents (claude / codex / gemini / …).
 #[cfg(feature = "service-acp")]

--- a/rust/services/src/managed_agent/mod.rs
+++ b/rust/services/src/managed_agent/mod.rs
@@ -53,6 +53,14 @@ use kernel::core::agents::registry::{
 use kernel::kernel::syscall::KernelSyscall;
 use kernel::service_registry::{RustCallError, RustService};
 
+// The raw ACP-subprocess control-plane spawner (spawn + memory-DT_STREAM
+// byte tunnel). Kernel-concrete (drives Kernel-inherent stream ops), so
+// it's injected at install and reached through `dyn RawSpawn`; unix +
+// `subprocess-host` only. Slim / non-unix builds leave `raw_spawn = None`
+// and reject `spawn_spec` at runtime with InvalidArgument.
+#[cfg(all(unix, feature = "subprocess-host"))]
+pub(crate) mod raw_spawn;
+
 pub(crate) mod proc_entry;
 pub(crate) mod session;
 pub(crate) mod workspace_boundary_hook;
@@ -112,6 +120,27 @@ pub(crate) struct StartSessionRequest {
     pub owner_id: String,
     #[serde(default)]
     pub zone_id: String,
+    /// Embedder-computed raw spawn spec (ACP control-plane contract, 2026-08-01). When
+    /// set, `start_session` spawns THIS subprocess (stdio surfaced as DT_PIPEs at
+    /// `/{zone}/proc/{pid}/fd/{0,1,2}`) instead of resolving the `agent_id` profile — the
+    /// caller (sudowork/hydra) owns ALL launch logic (auth-mode/env/args/token/model);
+    /// nexus only executes + supervises + exposes the fd pipes for the client's ACP tunnel.
+    #[serde(default)]
+    pub spawn_spec: Option<SpawnSpec>,
+}
+
+/// Raw subprocess spec computed by the embedder. The launch-logic SSOT stays client-side
+/// (e.g. sudowork's `acpConnectors.ts`); nexus executes `cmd`+`args` with `env` in `cwd`,
+/// supervises the child, and surfaces its stdio as fd DT_PIPEs. nexus never parses ACP.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub(crate) struct SpawnSpec {
+    pub cmd: String,
+    #[serde(default)]
+    pub args: Vec<String>,
+    #[serde(default)]
+    pub env: std::collections::HashMap<String, String>,
+    #[serde(default)]
+    pub cwd: String,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -120,6 +149,15 @@ pub(crate) struct StartSessionResponse {
     /// get_session take this back.
     pub session_id: String,
     pub workspace_path: String,
+    /// Real OS pid of the spawned subprocess — set ONLY on the raw ACP
+    /// control-plane path (`spawn_spec` supplied); `None` for the
+    /// runtime-body / procfs-only paths. Surfaced SEPARATELY from
+    /// `session_id` (which stays the synthetic AgentRegistry pid) per
+    /// the frozen contract ④: the embedder (sudowork) keys its
+    /// pid-bound auth-proxy on the OS pid, but the durable session
+    /// handle for cancel / get_session is `session_id`.
+    #[serde(default)]
+    pub os_pid: Option<u32>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -254,6 +292,27 @@ pub trait SpawnTask<K: KernelSyscall>: Send + Sync + 'static {
     ) -> Box<dyn SpawnHandle>;
 }
 
+/// Raw ACP-subprocess control-plane spawner — the DI seam for the
+/// `spawn_spec` path (frozen contract 2026-08-01). Distinct from
+/// [`SpawnTask`] (the in-process LLM runtime body): this launches an
+/// external subprocess and exposes its stdio as a byte tunnel that the
+/// CLIENT drives, whereas `SpawnTask` runs the agent loop in-process.
+///
+/// The concrete impl ([`raw_spawn::KernelRawSpawn`]) drives Kernel-inherent
+/// stream ops that aren't on the `KernelSyscall` trait, so it's Kernel-
+/// concrete and injected at install (Kernel-specific); this trait erases
+/// `K` so the generic `start_session` can call it. `None` in slim /
+/// non-unix builds ⇒ `spawn_spec` is rejected with InvalidArgument.
+pub(crate) trait RawSpawn: Send + Sync {
+    /// Launch `spec`, wire its stdio to node-local memory DT_STREAMs at
+    /// `/proc/{pid}/fd/{0,1,2}`, start the pumps + supervisor, and store
+    /// an abort handle in the shared `spawn_handles` (keyed by `pid`, so
+    /// the `on_terminate` observer tears it down). Returns the real OS pid
+    /// (contract ④). `Err` on bad spec / launch failure — the impl rolls
+    /// back the half-planted session.
+    fn spawn(&self, pid: &str, spec: SpawnSpec) -> Result<Option<u32>, String>;
+}
+
 // ── Service ─────────────────────────────────────────────────────────────
 
 pub(crate) struct ManagedAgentService<K: KernelSyscall> {
@@ -271,11 +330,17 @@ pub(crate) struct ManagedAgentService<K: KernelSyscall> {
     /// `provider.spawn(...)` after `register_proc_entry` and stores
     /// the returned handle in [`Self::spawn_handles`].
     spawn_provider: Option<Arc<dyn SpawnTask<K>>>,
-    /// Per-pid spawn handles populated by `start_session` when a
-    /// provider is wired. The on_terminate observer (registered in
-    /// `install_returning`) removes and aborts the handle on session
-    /// termination so the worker thread leaves cleanly.
+    /// Per-pid spawn handles populated by `start_session` (both the
+    /// `SpawnTask` runtime path and the `RawSpawn` tunnel path). The
+    /// on_terminate observer (registered in `install_returning`) removes
+    /// and aborts the handle on session termination so the worker /
+    /// supervisor leaves cleanly.
     spawn_handles: Arc<dashmap::DashMap<String, Box<dyn SpawnHandle>>>,
+    /// Optional raw-subprocess control-plane spawner for the `spawn_spec`
+    /// path. `Some` only when `install_returning` wired the Kernel-concrete
+    /// [`raw_spawn::KernelRawSpawn`] (unix + `subprocess-host`); `None`
+    /// elsewhere, in which case a `spawn_spec` request is rejected.
+    raw_spawn: Option<Arc<dyn RawSpawn>>,
 }
 
 impl<K: KernelSyscall> ManagedAgentService<K> {
@@ -292,6 +357,7 @@ impl<K: KernelSyscall> ManagedAgentService<K> {
             agent_registry,
             spawn_provider: None,
             spawn_handles: Arc::new(dashmap::DashMap::new()),
+            raw_spawn: None,
         }
     }
 
@@ -311,6 +377,7 @@ impl<K: KernelSyscall> ManagedAgentService<K> {
             agent_registry,
             spawn_provider: Some(spawn_provider),
             spawn_handles: Arc::new(dashmap::DashMap::new()),
+            raw_spawn: None,
         }
     }
 
@@ -328,13 +395,17 @@ impl<K: KernelSyscall> ManagedAgentService<K> {
     /// surface `Internal` so the caller sees a hard error.
     pub(crate) fn start_session(
         &self,
-        req: StartSessionRequest,
+        mut req: StartSessionRequest,
     ) -> Result<StartSessionResponse, ManagedAgentError> {
         if req.agent_id.is_empty() {
             return Err(ManagedAgentError::InvalidArgument(
                 "'agent_id' is required".into(),
             ));
         }
+        // Take the raw spawn spec out early — it selects the spawn
+        // strategy below (raw ACP subprocess vs. runtime body) and the
+        // rest of the descriptor build doesn't touch it.
+        let spawn_spec = req.spawn_spec.take();
         let owner_id = if req.owner_id.is_empty() {
             "system".to_string()
         } else {
@@ -401,24 +472,51 @@ impl<K: KernelSyscall> ManagedAgentService<K> {
         // failed stamp is logged but doesn't abort the session — the
         // AgentRegistry record is already planted and a future
         // re-stamp closes the gap.
+        // Two mutually-exclusive spawn strategies select on the request
+        // shape (a session is one or the other), both fired right after
+        // procfs is stamped so the first sys_read on
+        // `/proc/{pid}/chat-with-me` (or `/proc/{pid}/fd/*`) routes:
+        //
+        //   * `spawn_spec` present → the RAW ACP subprocess control-plane
+        //     path (frozen contract 2026-08-01). The injected `raw_spawn`
+        //     spawner launches the embedder-computed subprocess and pumps
+        //     its stdio through node-local memory DT_STREAMs at
+        //     `/proc/{pid}/fd/{0,1,2}`; the CLIENT (sudowork) drives it
+        //     over that raw-byte tunnel — nexus never frames or parses
+        //     ACP. Returns the real OS pid (contract ④).
+        //
+        //   * else + `spawn_provider` → the managed LLM runtime body
+        //     (sudocode today) nexus runs IN-PROCESS, driven by the
+        //     mailbox. The DI trait `SpawnTask<K>` keeps services rlib
+        //     free of a hard dep on the runtime crate; the concrete
+        //     adapter lives at the binary edge (`profiles/cluster`) and
+        //     monomorphises `spawn_task::<K>` internally — no
+        //     per-`sys_read` vtable cost.
+        //
+        // Slim builds with neither run procfs-only.
+        let mut os_pid: Option<u32> = None;
         if let Some(desc) = self.agent_registry.get(&pid) {
             if let Err(e) = register_proc_entry(self.kernel.as_ref(), &desc) {
                 tracing::warn!(pid=%pid, error=%e, "register_proc_entry failed");
             }
-            // Spawn the per-pid runtime body right after procfs is
-            // ready so the worker sees a routable
-            // `/proc/{pid}/chat-with-me` on its first sys_read.
-            //
-            // The DI trait `SpawnTask<K>` (defined above) keeps
-            // services rlib free of a hard dep on any specific
-            // runtime crate (sudocode today, future runtimes
-            // tomorrow); the concrete adapter lives at the binary
-            // edge (`profiles/cluster`) and
-            // monomorphises `spawn_task::<K>` internally — no
-            // per-`sys_read` vtable cost. Slim builds without a
-            // provider (`spawn_provider: None`) skip the spawn and
-            // run procfs-only.
-            if let Some(provider) = self.spawn_provider.as_ref() {
+            if let Some(spec) = spawn_spec {
+                match self.raw_spawn.as_ref() {
+                    Some(rs) => {
+                        os_pid = rs.spawn(&pid, spec).map_err(ManagedAgentError::Internal)?;
+                    }
+                    None => {
+                        // No raw spawner wired (slim / non-unix). Roll back
+                        // the half-planted session so the caller sees a
+                        // clean failure rather than a zombie record.
+                        let _ = self.agent_registry.kill(&pid, 127);
+                        return Err(ManagedAgentError::InvalidArgument(
+                            "spawn_spec (raw subprocess host) requires a unix build with the \
+                             subprocess-host feature"
+                                .into(),
+                        ));
+                    }
+                }
+            } else if let Some(provider) = self.spawn_provider.as_ref() {
                 // Construct the SSOT state observer. AgentRegistry is
                 // the single writer of AgentState in the runtime path
                 // (see kernel::core::agents::registry::update_state +
@@ -454,6 +552,7 @@ impl<K: KernelSyscall> ManagedAgentService<K> {
         Ok(StartSessionResponse {
             session_id: pid,
             workspace_path,
+            os_pid,
         })
     }
 
@@ -591,13 +690,33 @@ impl ManagedAgentService<kernel::kernel::Kernel> {
         // lifetime — same convention AcpService follows. The procfs
         // dirent stamp in `start_session` and the on_terminate
         // teardown both need the owned Arc.
-        let svc = Arc::new(match spawn_provider {
-            Some(provider) => Self::with_spawn(
-                Arc::clone(kernel),
-                Arc::clone(kernel.agent_registry()),
-                provider,
-            ),
-            None => Self::new(Arc::clone(kernel), Arc::clone(kernel.agent_registry())),
+        //
+        // Built as a struct literal (not `new`/`with_spawn`) so the raw
+        // control-plane spawner can share the SAME `agent_registry` +
+        // `spawn_handles` the service and its on_terminate observer use.
+        let agent_registry = Arc::clone(kernel.agent_registry());
+        let spawn_handles: Arc<dashmap::DashMap<String, Box<dyn SpawnHandle>>> =
+            Arc::new(dashmap::DashMap::new());
+
+        // Raw ACP subprocess control-plane spawner (memory-DT_STREAM byte
+        // tunnel). Kernel-concrete — built here because it drives
+        // Kernel-inherent stream ops off the service surface. Unix +
+        // `subprocess-host` only; `None` elsewhere ⇒ `spawn_spec` rejected.
+        #[cfg(all(unix, feature = "subprocess-host"))]
+        let raw_spawn: Option<Arc<dyn RawSpawn>> = Some(Arc::new(raw_spawn::KernelRawSpawn::new(
+            Arc::clone(kernel),
+            Arc::clone(&agent_registry),
+            Arc::clone(&spawn_handles),
+        )));
+        #[cfg(not(all(unix, feature = "subprocess-host")))]
+        let raw_spawn: Option<Arc<dyn RawSpawn>> = None;
+
+        let svc = Arc::new(ManagedAgentService {
+            kernel: Arc::clone(kernel),
+            agent_registry,
+            spawn_provider,
+            spawn_handles,
+            raw_spawn,
         });
 
         // Tear down the per-pid procfs subtree on out-of-band
@@ -742,6 +861,7 @@ mod tests {
             model: "claude-sonnet-4-6".to_string(),
             owner_id: "ethan".to_string(),
             zone_id: "root".to_string(),
+            spawn_spec: None,
         }
     }
 
@@ -1079,7 +1199,7 @@ mod tests {
             let resp = svc.start_session(req("scode-standard")).unwrap();
 
             assert!(dir_exists(&kernel, &resp.workspace_path));
-            let cwm = format!("{}chat-with-me", &resp.workspace_path);
+            let cwm = format!("{}chat-with-me", resp.workspace_path);
             assert_eq!(
                 link_target_at(&kernel, &cwm).as_deref(),
                 Some(format!("/proc/{}/chat-with-me", resp.session_id).as_str()),
@@ -1111,7 +1231,7 @@ mod tests {
                 ("myrepo", "/host/repos/myrepo"),
                 ("another", "/host/repos/another"),
             ] {
-                let alias_path = format!("{}{}", &resp.workspace_path, alias);
+                let alias_path = format!("{}{alias}", resp.workspace_path);
                 assert_eq!(
                     link_target_at(&kernel, &alias_path).as_deref(),
                     Some(expected),
@@ -1153,7 +1273,7 @@ mod tests {
             let resp = svc.start_session(req("scode-standard")).unwrap();
             svc.cancel(&resp.session_id, CancelMode::Turn).unwrap();
             assert!(dir_exists(&kernel, &resp.workspace_path));
-            let cwm = format!("{}chat-with-me", &resp.workspace_path);
+            let cwm = format!("{}chat-with-me", resp.workspace_path);
             assert!(
                 link_target_at(&kernel, &cwm).is_some(),
                 "chat-with-me DT_LINK should survive turn cancel",
@@ -1171,7 +1291,7 @@ mod tests {
             }];
             let resp = svc.start_session(r).unwrap();
             assert!(dir_exists(&kernel, &resp.workspace_path));
-            let alias_path = format!("{}core", &resp.workspace_path);
+            let alias_path = format!("{}core", resp.workspace_path);
             assert!(entry_exists(&kernel, &alias_path));
 
             kernel
@@ -1201,7 +1321,7 @@ mod tests {
                 .signal(&resp.session_id, AgentSignal::Sigterm, None)
                 .expect("SIGTERM");
             assert!(!dir_exists(&kernel, &resp.workspace_path));
-            let cwm = format!("{}chat-with-me", &resp.workspace_path);
+            let cwm = format!("{}chat-with-me", resp.workspace_path);
             assert!(!entry_exists(&kernel, &cwm));
         }
 
@@ -1235,7 +1355,7 @@ mod tests {
             let svc = install_managed_agent(&kernel);
             let resp = svc.start_session(req("scode-standard")).unwrap();
 
-            let shortcut = format!("{}chat-with-me", &resp.workspace_path);
+            let shortcut = format!("{}chat-with-me", resp.workspace_path);
             let canonical = format!("/proc/{}/chat-with-me", resp.session_id);
             // Pre-stamp the envelope's `from` field with the caller's
             // agent_id so MailboxStampingHook's rewrite is a no-op for
@@ -1304,7 +1424,7 @@ mod tests {
             kernel.register_service_hook(&a2a_handle, Box::new(a2a::MailboxStampingHook::new()));
             let resp = svc.start_session(req("scode-standard")).unwrap();
 
-            let shortcut = format!("{}chat-with-me", &resp.workspace_path);
+            let shortcut = format!("{}chat-with-me", resp.workspace_path);
             let canonical = format!("/proc/{}/chat-with-me", resp.session_id);
             // LLM-authored envelope claims to be from "scode-standard"
             // but the real caller is human-ethan; the hook should
@@ -1350,7 +1470,7 @@ mod tests {
         fn workspace_shortcut_link_targets_canonical_chat_with_me_stream() {
             let (kernel, svc) = svc_with_kernel();
             let resp = svc.start_session(req("scode-standard")).unwrap();
-            let shortcut = format!("{}chat-with-me", &resp.workspace_path);
+            let shortcut = format!("{}chat-with-me", resp.workspace_path);
             let canonical = format!("/proc/{}/chat-with-me", resp.session_id);
 
             // Workspace shortcut is a DT_LINK whose target is the
@@ -1387,11 +1507,367 @@ mod tests {
             let resp = svc.start_session(r).unwrap();
             svc.cancel(&resp.session_id, CancelMode::Session).unwrap();
             assert!(!dir_exists(&kernel, &resp.workspace_path));
-            let alias_path = format!("{}core", &resp.workspace_path);
+            let alias_path = format!("{}core", resp.workspace_path);
             assert!(!entry_exists(&kernel, &alias_path));
             assert!(kernel.agent_registry().get(&resp.session_id).is_none());
             let err = svc.get_session(&resp.session_id).unwrap_err();
             assert!(matches!(err, ManagedAgentError::UnknownSession(_)));
+        }
+    }
+
+    /// Raw ACP-subprocess control-plane path (#36 slice 1, frozen
+    /// contract 2026-08-01). Proves the raw-byte tunnel end-to-end and
+    /// the ③ exit / reap semantics. Unix + subprocess-host only, because
+    /// `HostedSubprocess` is unix-only.
+    #[cfg(all(unix, feature = "subprocess-host"))]
+    mod raw_spawn {
+        use super::*;
+        use kernel::kernel::{Kernel, OperationContext};
+        use std::time::Duration;
+
+        fn cat_on_path() -> bool {
+            std::process::Command::new("cat")
+                .arg("--version")
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .status()
+                .map(|s| s.success())
+                .unwrap_or(false)
+        }
+
+        fn sys_ctx() -> OperationContext {
+            OperationContext::new("system", "root", true, None, true)
+        }
+
+        /// A spawn spec that inherits the runner's PATH so a bare command
+        /// name (`cat`, `sh`) resolves. The raw path runs `spec.env`
+        /// VERBATIM under `env_clear()` (the client owns ALL launch
+        /// logic — contract SSOT), so PATH must be supplied explicitly:
+        /// with an empty env the exec would fail ENOENT. This mirrors
+        /// what sudowork's `acpConnectors.ts` must include per interface
+        /// spec.
+        fn spec(cmd: &str, args: &[&str]) -> SpawnSpec {
+            SpawnSpec {
+                cmd: cmd.to_string(),
+                args: args.iter().map(|s| s.to_string()).collect(),
+                env: std::collections::HashMap::from([(
+                    "PATH".to_string(),
+                    std::env::var("PATH").unwrap_or_else(|_| "/usr/bin:/bin".to_string()),
+                )]),
+                cwd: std::env::temp_dir().to_string_lossy().into_owned(),
+            }
+        }
+
+        /// LIVE tunnel smoke: `start_session(spawn_spec=cat)` spawns
+        /// `cat` and wires its stdio as fd DT_PIPEs; we drive the
+        /// RAW-BYTE tunnel over VFS — write `/proc/{pid}/fd/0`, read the
+        /// echo back from `/proc/{pid}/fd/1` — then `cancel(Session)` and
+        /// assert the supervisor reaped the session. Confirms nexus is a
+        /// pure process host + byte pipe (it never parses ACP).
+        ///
+        /// `#[ignore]`: needs `cat` on PATH + a live multi-thread
+        /// runtime. Run on a unix box:
+        ///   cargo test -p services \
+        ///     --features "service-managed-agent service-acp" \
+        ///     managed_agent::tests::raw_spawn -- --ignored --nocapture
+        #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+        #[ignore]
+        async fn cat_tunnel_roundtrip_through_start_session() {
+            if !cat_on_path() {
+                eprintln!("cat not on PATH — skipping raw_spawn tunnel smoke");
+                return;
+            }
+            let kernel = Arc::new(Kernel::new());
+            let svc = ManagedAgentService::install_returning(&kernel, None)
+                .expect("install ManagedAgentService");
+
+            let start_req = StartSessionRequest {
+                agent_id: "acp-cat".to_string(),
+                spawn_spec: Some(spec("cat", &[])),
+                ..Default::default()
+            };
+
+            // start_session block_on's the async spawn internally, so it
+            // must run on a blocking thread — the gRPC handler does the
+            // same via spawn_blocking.
+            let svc_for_start = Arc::clone(&svc);
+            let resp = tokio::task::spawn_blocking(move || svc_for_start.start_session(start_req))
+                .await
+                .expect("join start_session")
+                .expect("start_session ok");
+
+            assert!(
+                resp.os_pid.is_some(),
+                "raw spawn must surface the real OS pid (contract ④)",
+            );
+            let pid = resp.session_id.clone();
+            let fd0 = format!("/proc/{pid}/fd/0");
+            let fd1 = format!("/proc/{pid}/fd/1");
+
+            // Write into the subprocess stdin over the tunnel — exactly as
+            // the client does: append to the stdin stream.
+            kernel
+                .stream_write_nowait(&fd0, b"hello tunnel\n", &sys_ctx())
+                .expect("append to stdin stream");
+
+            // Read the echo back over the tunnel exactly as the client
+            // does: stream_read_at_blocking(offset) → (data, next_offset);
+            // Err (WouldBlock) = timeout, keep polling. Accumulate until the
+            // line shows up.
+            let read_kernel = Arc::clone(&kernel);
+            let fd1_for_read = fd1.clone();
+            let echoed = tokio::task::spawn_blocking(move || {
+                let mut acc = Vec::new();
+                let mut offset = 0usize;
+                for _ in 0..50 {
+                    // Err = timeout with no new bytes — keep polling.
+                    if let Ok((data, next)) =
+                        read_kernel.stream_read_at_blocking(&fd1_for_read, offset, 200)
+                    {
+                        acc.extend_from_slice(&data);
+                        offset = next;
+                        if acc
+                            .windows(b"hello tunnel".len())
+                            .any(|w| w == b"hello tunnel")
+                        {
+                            break;
+                        }
+                    }
+                }
+                acc
+            })
+            .await
+            .expect("join tunnel read");
+
+            let text = String::from_utf8_lossy(&echoed);
+            assert!(
+                text.contains("hello tunnel"),
+                "tunnel should echo the bytes written to fd/0; got {text:?}",
+            );
+
+            // Terminate the session — the supervisor kills cat, collapses
+            // the tunnel, and reaps the descriptor.
+            let svc_for_cancel = Arc::clone(&svc);
+            let pid_for_cancel = pid.clone();
+            tokio::task::spawn_blocking(move || {
+                svc_for_cancel.cancel(&pid_for_cancel, CancelMode::Session)
+            })
+            .await
+            .expect("join cancel")
+            .expect("cancel ok");
+
+            // Give the detached supervisor a beat to finish teardown.
+            tokio::time::sleep(Duration::from_millis(300)).await;
+            assert!(
+                kernel.agent_registry().get(&pid).is_none(),
+                "session must be reaped after cancel(Session)",
+            );
+        }
+
+        /// ③ exit-event path: a subprocess that exits ON ITS OWN (no
+        /// cancel) drives the supervisor's `wait()` arm, which reaps the
+        /// session. Proves nexus notices process death and tears the
+        /// session down without a client cancel.
+        #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+        #[ignore]
+        async fn self_exit_reaps_session() {
+            if !cat_on_path() {
+                eprintln!("shell not available — skipping self_exit smoke");
+                return;
+            }
+            let kernel = Arc::new(Kernel::new());
+            let svc = ManagedAgentService::install_returning(&kernel, None)
+                .expect("install ManagedAgentService");
+
+            // `sh -c 'exit 7'` terminates immediately with code 7.
+            let start_req = StartSessionRequest {
+                agent_id: "acp-selfexit".to_string(),
+                spawn_spec: Some(spec("sh", &["-c", "exit 7"])),
+                ..Default::default()
+            };
+            let svc_for_start = Arc::clone(&svc);
+            let resp = tokio::task::spawn_blocking(move || svc_for_start.start_session(start_req))
+                .await
+                .expect("join start_session")
+                .expect("start_session ok");
+            let pid = resp.session_id.clone();
+
+            // Poll for the supervisor to observe exit + reap (bounded).
+            let mut reaped = false;
+            for _ in 0..50 {
+                if kernel.agent_registry().get(&pid).is_none() {
+                    reaped = true;
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            }
+            assert!(
+                reaped,
+                "supervisor must reap the session when the subprocess self-exits",
+            );
+        }
+
+        /// Spawn-failure path: an un-resolvable command fails the launch;
+        /// `start_session` surfaces a hard error and the half-planted
+        /// session is rolled back (registry.kill on the error path), so
+        /// no zombie descriptor leaks.
+        #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+        #[ignore]
+        async fn spawn_failure_surfaces_error_and_reaps() {
+            let kernel = Arc::new(Kernel::new());
+            let svc = ManagedAgentService::install_returning(&kernel, None)
+                .expect("install ManagedAgentService");
+
+            let before = kernel.agent_registry().count();
+            let start_req = StartSessionRequest {
+                agent_id: "acp-nope".to_string(),
+                spawn_spec: Some(spec("nexus-no-such-binary-xyz", &[])),
+                ..Default::default()
+            };
+            let svc_for_start = Arc::clone(&svc);
+            let err = tokio::task::spawn_blocking(move || svc_for_start.start_session(start_req))
+                .await
+                .expect("join start_session")
+                .expect_err("spawn of a missing binary must fail");
+            assert!(
+                matches!(err, ManagedAgentError::Internal(_)),
+                "expected Internal spawn error, got {err:?}",
+            );
+            // No net descriptor growth — the error path reaped the pid.
+            let after = kernel.agent_registry().count();
+            assert_eq!(before, after, "spawn-failure must not leak a descriptor");
+        }
+
+        /// Tunnel READ contract + regression guard for the fd-DT_PIPE cut
+        /// this replaced (whose non-blocking read treated "no data yet" as
+        /// EOF and permanently killed the tunnel on the first idle poll):
+        ///   * `Ok((data, next))` → RAW bytes (no framing, no newline
+        ///     injection) → feed the reader, advance `offset`.
+        ///   * `Err` (WouldBlock timeout) → no bytes yet → keep polling;
+        ///     the stream STAYS OPEN across idle polls.
+        ///   * after reap → the stdout stream is closed + drained → read
+        ///     errors = disconnect (the eof signal sudowork keys on).
+        #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+        #[ignore]
+        async fn tunnel_is_raw_byte_and_survives_idle_polls() {
+            if !cat_on_path() {
+                eprintln!("cat not on PATH — skipping tunnel raw-byte smoke");
+                return;
+            }
+            let kernel = Arc::new(Kernel::new());
+            let svc = ManagedAgentService::install_returning(&kernel, None)
+                .expect("install ManagedAgentService");
+            let start_req = StartSessionRequest {
+                agent_id: "acp-frame".to_string(),
+                spawn_spec: Some(spec("cat", &[])),
+                ..Default::default()
+            };
+            let svc_for_start = Arc::clone(&svc);
+            let resp = tokio::task::spawn_blocking(move || svc_for_start.start_session(start_req))
+                .await
+                .expect("join")
+                .expect("start_session ok");
+            let pid = resp.session_id.clone();
+            let fd0 = format!("/proc/{pid}/fd/0");
+            let fd1 = format!("/proc/{pid}/fd/1");
+
+            // Read raw bytes from fd/1 starting at `offset`, accumulating
+            // across timeouts until at least `want` bytes arrive.
+            async fn read_until(
+                k: Arc<Kernel>,
+                path: String,
+                start: usize,
+                want: usize,
+            ) -> (Vec<u8>, usize) {
+                tokio::task::spawn_blocking(move || {
+                    let mut acc = Vec::new();
+                    let mut offset = start;
+                    for _ in 0..40 {
+                        if let Ok((data, next)) = k.stream_read_at_blocking(&path, offset, 200) {
+                            acc.extend_from_slice(&data);
+                            offset = next;
+                            if acc.len() >= want {
+                                break;
+                            }
+                        }
+                    }
+                    (acc, offset)
+                })
+                .await
+                .unwrap()
+            }
+
+            // 1. A payload written WITHOUT a trailing newline comes back
+            //    byte-identical — no line-framing, no `\n` injection.
+            kernel
+                .stream_write_nowait(&fd0, b"chunk-a", &sys_ctx())
+                .expect("append chunk-a");
+            let (got_a, mut offset) =
+                read_until(Arc::clone(&kernel), fd1.clone(), 0, b"chunk-a".len()).await;
+            assert_eq!(
+                got_a,
+                b"chunk-a".to_vec(),
+                "raw passthrough — no framing / no newline injection",
+            );
+
+            // 2. Idle polls while cat is alive with no pending data. Each
+            //    returns Err(WouldBlock); the stream MUST stay open (the
+            //    fd-pipe cut permanently closed here — regression guard).
+            for _ in 0..3 {
+                let k = Arc::clone(&kernel);
+                let p = fd1.clone();
+                let o = offset;
+                let r = tokio::task::spawn_blocking(move || k.stream_read_at_blocking(&p, o, 100))
+                    .await
+                    .unwrap();
+                assert!(
+                    r.is_err(),
+                    "idle poll must return Err(WouldBlock), got data"
+                );
+            }
+
+            // 3. A fresh write STILL flows — proving the stream survived the
+            //    idle polls (the fd-pipe bug would have killed it here).
+            kernel
+                .stream_write_nowait(&fd0, b"chunk-b", &sys_ctx())
+                .expect("append chunk-b");
+            let (got_b, off_b) =
+                read_until(Arc::clone(&kernel), fd1.clone(), offset, b"chunk-b".len()).await;
+            offset = off_b;
+            assert_eq!(
+                got_b,
+                b"chunk-b".to_vec(),
+                "stream must survive idle polls and keep delivering",
+            );
+
+            // 4. Terminate → the supervisor closes the tunnel then reaps.
+            //    Once reaped, the drained+closed stdout stream reads as an
+            //    error — the disconnect signal.
+            let svc_c = Arc::clone(&svc);
+            let pid_c = pid.clone();
+            tokio::task::spawn_blocking(move || svc_c.cancel(&pid_c, CancelMode::Session))
+                .await
+                .unwrap()
+                .unwrap();
+            let mut reaped = false;
+            for _ in 0..60 {
+                if kernel.agent_registry().get(&pid).is_none() {
+                    reaped = true;
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            }
+            assert!(reaped, "session must be reaped after cancel(Session)");
+            let k = Arc::clone(&kernel);
+            let p = fd1.clone();
+            let o = offset;
+            let post = tokio::task::spawn_blocking(move || k.stream_read_at_blocking(&p, o, 100))
+                .await
+                .unwrap();
+            assert!(
+                post.is_err(),
+                "reaped session's stdout stream must read as eof/closed (disconnect)",
+            );
         }
     }
 }

--- a/rust/services/src/managed_agent/mod.rs
+++ b/rust/services/src/managed_agent/mod.rs
@@ -90,6 +90,19 @@ pub fn install_managed_agent(kernel: &Arc<kernel::kernel::Kernel>) -> Result<(),
     ManagedAgentService::<kernel::kernel::Kernel>::install(kernel)
 }
 
+/// The managed-agent service as a boot declaration for
+/// [`kernel::kernel::Kernel::bring_up_services`] — the uniform path by
+/// which the assembly hands services to the kernel. Wraps
+/// [`install_managed_agent`], which wires the session lifecycle, the
+/// workspace/procfs hooks, and (on unix + `subprocess-host`) the raw ACP
+/// control-plane stream-tunnel spawner via `install_returning`.
+pub fn service_decl() -> kernel::kernel::ServiceDecl {
+    kernel::kernel::ServiceDecl {
+        name: "managed_agent".to_string(),
+        install: Box::new(install_managed_agent),
+    }
+}
+
 /// Label key used to stash the LLM model id on the descriptor so
 /// `get_session` can echo it back without a sidecar table.  Read by
 /// `GetSessionResponse.model`; the runtime crate may also read it

--- a/rust/services/src/managed_agent/raw_spawn.rs
+++ b/rust/services/src/managed_agent/raw_spawn.rs
@@ -1,0 +1,319 @@
+//! Raw ACP-subprocess control-plane spawner (frozen contract 2026-08-01).
+//!
+//! When `start_session` is given a `spawn_spec`, nexus launches that
+//! subprocess and gives the client a **raw-byte tunnel** to its stdio via
+//! three node-local `io_profile="memory"` `DT_STREAM`s at
+//! `/proc/{pid}/fd/{0,1,2}`:
+//!
+//!   * `fd/1` (stdout) / `fd/2` (stderr) — a nexus PUMP reads the child's
+//!     handle with tokio async I/O (EAGAIN-correct via the reactor) and
+//!     `stream_write_nowait`s the raw bytes; the client reads with
+//!     `read_at(offset)` (byte chunks; `WouldBlock`→poll; `Closed`→eof).
+//!   * `fd/0` (stdin) — the client appends bytes; a nexus pump reads the
+//!     stream and writes the child's stdin.
+//!
+//! nexus NEVER frames or parses ACP — NDJSON/LSP framing + all protocol
+//! logic stay client-side. The stream primitive is the same offset-based,
+//! non-destructive log the A2A mailboxes use, so `read_at(offset)` cleanly
+//! separates "no data yet" (`WouldBlock`) from "producer gone" (`Closed`
+//! → eof), which a raw stdio pipe read cannot.
+//!
+//! Kernel-concrete: the tunnel drives Kernel-INHERENT stream ops
+//! (`stream_write_nowait` / `stream_read_at` / `close_stream` /
+//! `destroy_stream`) that are deliberately NOT on the `KernelSyscall`
+//! trait (the v2 audit keeps kernel-internal accessors off the
+//! service-facing surface — same reason `install` reaches
+//! `kernel.agent_registry()` Kernel-specifically). So this is injected
+//! into `ManagedAgentService` at install (Kernel-specific) and called by
+//! the generic `start_session` through `dyn RawSpawn` — mirroring the
+//! `SpawnTask` DI. No syscall-ABI change.
+
+#![cfg(all(unix, feature = "subprocess-host"))]
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use dashmap::DashMap;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::process::ChildStdin;
+use tokio::sync::oneshot;
+
+use kernel::core::agents::registry::{AgentRegistry, AgentState};
+use kernel::kernel::{Kernel, OperationContext};
+
+use super::{RawSpawn, SpawnHandle, SpawnSpec};
+use crate::subprocess::HostedSubprocess;
+
+/// DT_STREAM entry type (mirrors `kernel::meta_store::DT_STREAM`), typed
+/// `i32` to match the `sys_setattr` `entry_type` parameter.
+const DT_STREAM: i32 = 4;
+/// Per-stream ring capacity. ACP traffic is low-volume; 1 MiB is ample.
+const STREAM_CAP: usize = 1 << 20;
+/// stdin-pump poll interval when the stream has no pending bytes. Bounds
+/// client→agent latency without busy-spinning (the stdout path is
+/// event-driven, so only stdin polls).
+const STDIN_POLL_MS: u64 = 40;
+/// Grace after `close_stream` before `destroy_stream`, so the client can
+/// drain the last stdout/stderr bytes and observe eof before the streams
+/// vanish.
+const DRAIN_GRACE: Duration = Duration::from_secs(5);
+/// Pump read buffer.
+const PUMP_BUF: usize = 8192;
+
+fn system_ctx() -> OperationContext {
+    OperationContext::new("system", "root", true, None, true)
+}
+
+fn fd_path(pid: &str, n: u8) -> String {
+    format!("/proc/{pid}/fd/{n}")
+}
+
+/// Register a node-local in-memory `DT_STREAM` at `path`.
+fn register_memory_stream(kernel: &Kernel, path: &str) -> Result<(), String> {
+    kernel
+        .sys_setattr(
+            path, /* entry_type   */ DT_STREAM, /* backend_name */ "",
+            /* backend      */ None, /* metastore    */ None,
+            /* raft_backend */ None, /* io_profile   */ "memory",
+            /* zone_id      */ "root", /* is_external  */ false,
+            /* capacity     */ STREAM_CAP, /* read_fd      */ None,
+            /* write_fd     */ None, /* mime_type       */ None,
+            /* modified_at_ms  */ None, /* content_id      */ None,
+            /* size            */ None, /* version         */ None,
+            /* created_at_ms   */ None, /* link_target     */ None,
+            /* source          */ None, /* remote_metastore*/ None,
+        )
+        .map(|_| ())
+        .map_err(|e| format!("{e:?}"))
+}
+
+/// Roll back a partial spawn: destroy any created streams + reap the
+/// half-planted session so a launch failure surfaces as a clean error
+/// rather than leaking a stream or a zombie descriptor.
+fn rollback(kernel: &Kernel, registry: &AgentRegistry, paths: &[String], pid: &str) {
+    for p in paths {
+        let _ = kernel.destroy_stream(p);
+    }
+    let _ = registry.kill(pid, 127);
+}
+
+/// [`SpawnHandle`] for a raw stream tunnel — holds the supervisor's abort
+/// signal. `abort()` is idempotent (the oneshot is taken on first fire).
+struct RawStreamHandle {
+    cancel: parking_lot::Mutex<Option<oneshot::Sender<()>>>,
+}
+
+impl SpawnHandle for RawStreamHandle {
+    fn abort(&self) {
+        if let Some(tx) = self.cancel.lock().take() {
+            let _ = tx.send(());
+        }
+    }
+}
+
+/// Kernel-concrete [`RawSpawn`] provider. Constructed at
+/// `install_returning` with the same `AgentRegistry` + `spawn_handles`
+/// the service and its `on_terminate` observer share.
+pub(crate) struct KernelRawSpawn {
+    kernel: Arc<Kernel>,
+    agent_registry: Arc<AgentRegistry>,
+    spawn_handles: Arc<DashMap<String, Box<dyn SpawnHandle>>>,
+}
+
+impl KernelRawSpawn {
+    pub(crate) fn new(
+        kernel: Arc<Kernel>,
+        agent_registry: Arc<AgentRegistry>,
+        spawn_handles: Arc<DashMap<String, Box<dyn SpawnHandle>>>,
+    ) -> Self {
+        Self {
+            kernel,
+            agent_registry,
+            spawn_handles,
+        }
+    }
+}
+
+impl RawSpawn for KernelRawSpawn {
+    fn spawn(&self, pid: &str, spec: SpawnSpec) -> Result<Option<u32>, String> {
+        if spec.cmd.is_empty() {
+            let _ = self.agent_registry.kill(pid, 127);
+            return Err("spawn_spec.cmd is required".into());
+        }
+        let mut argv = Vec::with_capacity(1 + spec.args.len());
+        argv.push(spec.cmd);
+        argv.extend(spec.args);
+        let cwd = if spec.cwd.is_empty() {
+            PathBuf::from(".")
+        } else {
+            PathBuf::from(&spec.cwd)
+        };
+
+        let stdin_path = fd_path(pid, 0); // client → agent
+        let stdout_path = fd_path(pid, 1); // agent → client
+        let stderr_path = fd_path(pid, 2); // agent → client
+        let paths = [stdin_path.clone(), stdout_path.clone(), stderr_path.clone()];
+        let kernel = self.kernel.as_ref();
+        let registry = self.agent_registry.as_ref();
+
+        for p in &paths {
+            if let Err(e) = register_memory_stream(kernel, p) {
+                rollback(kernel, registry, &paths, pid);
+                return Err(format!("register stream {p}: {e}"));
+            }
+        }
+
+        let rt = tokio::runtime::Handle::try_current().map_err(|_| {
+            rollback(kernel, registry, &paths, pid);
+            "start_session with spawn_spec requires an active tokio runtime".to_string()
+        })?;
+
+        // Spawn the subprocess with NO fd-pipes; we pump the parent-side
+        // handles into the memory streams.
+        let mut sub = rt
+            .block_on(HostedSubprocess::spawn_no_pipes(argv, spec.env, &cwd))
+            .map_err(|e| {
+                rollback(kernel, registry, &paths, pid);
+                format!("spawn_spec subprocess launch failed: {e}")
+            })?;
+        let os_pid = sub.os_pid();
+        let (stdin, stdout, stderr) = sub.take_stdio_for_connection().map_err(|e| {
+            rollback(kernel, registry, &paths, pid);
+            format!("take subprocess stdio: {e}")
+        })?;
+
+        // Client can drive the tunnel immediately (no in-process loop).
+        if let Err(e) = self.agent_registry.update_state(pid, AgentState::Ready) {
+            tracing::warn!(pid = %pid, error = %e, "raw spawn: READY transition rejected");
+        }
+
+        // stdout / stderr pumps: child handle → memory stream (async read,
+        // EAGAIN-correct). Each closes its OWN stream on EOF (see
+        // `pump_out`), so drain-complete → client eof needs no timeout
+        // here. stdin pump: memory stream → child stdin.
+        rt.spawn(pump_out(
+            stdout,
+            Arc::clone(&self.kernel),
+            stdout_path.clone(),
+        ));
+        rt.spawn(pump_out(
+            stderr,
+            Arc::clone(&self.kernel),
+            stderr_path.clone(),
+        ));
+        let (stdin_stop_tx, stdin_stop_rx) = oneshot::channel::<()>();
+        rt.spawn(pump_in(
+            stdin,
+            Arc::clone(&self.kernel),
+            stdin_path.clone(),
+            stdin_stop_rx,
+        ));
+
+        // Supervisor: race the child's exit against the abort signal.
+        let (cancel_tx, cancel_rx) = oneshot::channel::<()>();
+        let kernel = Arc::clone(&self.kernel);
+        let registry = Arc::clone(&self.agent_registry);
+        let pid_owned = pid.to_string();
+        rt.spawn(async move {
+            let mut sub = sub;
+            let self_exit = {
+                let waited = sub.wait();
+                tokio::pin!(waited);
+                tokio::select! {
+                    code = &mut waited => Some(code),
+                    _ = cancel_rx => None,
+                }
+            };
+            let exit_code = match self_exit {
+                Some(code) => code,
+                None => {
+                    sub.kill().await;
+                    sub.wait().await
+                }
+            };
+            // Child is dead ⇒ its stdout/stderr write-ends are closed, so
+            // each output pump reads to EOF, flushes every last byte to
+            // its stream, and closes it (eof) — no timing cutoff here, so
+            // the client never loses the tail (e.g. the final ACP
+            // response). Stop the stdin pump and reap the session
+            // (Terminated → on_terminate tears down the procfs subtree).
+            let _ = stdin_stop_tx.send(());
+            let _ = registry.kill(&pid_owned, exit_code);
+            // Give the client a bounded window to drain the closed streams,
+            // then remove them so they don't leak in the registry. (This
+            // also unwedges a pump if a grandchild kept a write-end open,
+            // so the client still disconnects.)
+            tokio::time::sleep(DRAIN_GRACE).await;
+            for p in &paths {
+                let _ = kernel.destroy_stream(p);
+            }
+            tracing::info!(pid = %pid_owned, exit_code, "raw ACP stream tunnel closed");
+        });
+
+        self.spawn_handles.insert(
+            pid.to_string(),
+            Box::new(RawStreamHandle {
+                cancel: parking_lot::Mutex::new(Some(cancel_tx)),
+            }),
+        );
+
+        Ok(os_pid)
+    }
+}
+
+/// Pump a child output handle (stdout/stderr) into `path` as raw bytes.
+/// Event-driven via the tokio reactor. On child-side EOF (all bytes
+/// drained) it CLOSES the stream, so the client reads every byte and
+/// then observes a clean eof — with no timeout/cutoff on the teardown
+/// path. Exits on error too (e.g. the stream was destroyed).
+async fn pump_out<R>(mut rd: R, kernel: Arc<Kernel>, path: String)
+where
+    R: AsyncReadExt + Unpin + Send + 'static,
+{
+    let ctx = system_ctx();
+    let mut buf = vec![0u8; PUMP_BUF];
+    loop {
+        match rd.read(&mut buf).await {
+            Ok(0) => break, // child closed this stream — drain complete
+            Ok(n) => {
+                if kernel.stream_write_nowait(&path, &buf[..n], &ctx).is_err() {
+                    return; // stream destroyed / gone — nothing to close
+                }
+            }
+            Err(_) => break,
+        }
+    }
+    // Drain complete: signal eof to the client (read_at → Closed once the
+    // client has drained the buffered tail).
+    let _ = kernel.close_stream(&path);
+}
+
+/// Pump the stdin stream into the child's stdin. Polls `read_at` (nowait)
+/// so the async worker is never blocked; stops on the supervisor's signal
+/// or a broken child stdin.
+async fn pump_in(
+    mut wr: ChildStdin,
+    kernel: Arc<Kernel>,
+    path: String,
+    mut stop: oneshot::Receiver<()>,
+) {
+    let mut offset = 0usize;
+    loop {
+        match kernel.stream_read_at(&path, offset) {
+            Ok(Some((data, next))) => {
+                if wr.write_all(&data).await.is_err() || wr.flush().await.is_err() {
+                    break; // child stdin closed
+                }
+                offset = next;
+            }
+            Ok(None) => {
+                tokio::select! {
+                    _ = &mut stop => break,
+                    _ = tokio::time::sleep(Duration::from_millis(STDIN_POLL_MS)) => {}
+                }
+            }
+            Err(_) => break, // stream closed / destroyed
+        }
+    }
+}

--- a/rust/services/src/subprocess.rs
+++ b/rust/services/src/subprocess.rs
@@ -1,0 +1,518 @@
+//! `HostedSubprocess` — a generic hosted OS subprocess whose three
+//! stdio fds are surfaced inside VFS as stdio-backed `DT_PIPE`s.
+//!
+//! This is a service-tier PRIMITIVE, not tied to any one caller: the
+//! ACP one-shot path ([`crate::acp`]) and the managed-agent raw
+//! control-plane path ([`crate::managed_agent`]) both build on it. It
+//! knows nothing about ACP framing, agent configs, or session
+//! lifecycle — it launches an argv, wires the fds, and exposes the
+//! handle. Caller-specific translation (an `AgentConfig` → argv, or an
+//! embedder spawn-spec → argv) lives with the caller.
+//!
+//! Lifecycle (success path):
+//!
+//!   1. [`HostedSubprocess::spawn_from_argv`] — launch `argv[0]` with
+//!      `argv[1..]` under `cwd`/`env`, all three stdio fds piped; take
+//!      ownership of the parent-side handles, dup each and hand the
+//!      duplicate to the kernel as a stdio-backed `DT_PIPE` at the
+//!      caller-supplied `fd_paths`.
+//!   2. Traffic flows through the `DT_PIPE` (kernel-side fds): a driver
+//!      reads/writes the VFS paths, OR takes the parent-side handles via
+//!      [`HostedSubprocess::take_stdio_for_connection`] to drive them
+//!      directly through `AsyncRead` / `AsyncWrite`.
+//!   3. [`HostedSubprocess::unregister_pipes`] — `sys_unlink` each path
+//!      so the kernel-side `StdioPipeBackend` drops + closes its dup'd
+//!      fd, then drop the parent-side handles so the OS pipe collapses
+//!      and the subprocess sees EOF on stdin / read returns 0 on
+//!      stdout/stderr.
+//!   4. [`HostedSubprocess::wait`] — block until the child exits;
+//!      returns the exit code.
+//!   5. [`HostedSubprocess::kill`] — best-effort SIGKILL if it didn't
+//!      exit.
+//!
+//! Owned-fd contract: every parent-side stdio fd has exactly two live
+//! handles — the one this struct holds and the `StdioPipeBackend` the
+//! kernel holds (created from a `dup`). Both close independently; the OS
+//! pipe only collapses when both are gone, which is how we deliver EOF
+//! to the subprocess.
+//!
+//! Unix-only (gated at the `mod` declaration): the module `dup(2)`s raw
+//! fds and depends on `#[cfg(unix)]` stdio-pipe kernel support.
+
+#![allow(dead_code)]
+
+use std::collections::HashMap;
+use std::os::fd::AsRawFd;
+use std::path::Path;
+use std::process::Stdio;
+
+use tokio::process::{Child, ChildStderr, ChildStdin, ChildStdout, Command};
+
+use kernel::kernel::syscall::KernelSyscall;
+use kernel::kernel::{KernelError, OperationContext};
+
+const PIPE_CAPACITY: usize = 1 << 20;
+
+/// Owned subprocess + the parent-side stdio handles the kernel got
+/// dup'd copies of. The tokio types are kept here (rather than raw
+/// `OwnedFd`) so a driver that takes them via
+/// [`Self::take_stdio_for_connection`] can drive them through
+/// `AsyncRead` / `AsyncWrite` directly. Drop closes everything still
+/// open; tokio's `kill_on_drop(true)` reaps the child process itself.
+pub(crate) struct HostedSubprocess {
+    child: Child,
+    /// Parent-side write end of the subprocess stdin pipe. `Some` until
+    /// `take_stdio_for_connection` hands it off (or `unregister_pipes`
+    /// drops it to deliver EOF).
+    stdin: Option<ChildStdin>,
+    /// Parent-side read end of the subprocess stdout pipe.
+    stdout: Option<ChildStdout>,
+    /// Parent-side read end of the subprocess stderr pipe.
+    stderr: Option<ChildStderr>,
+    /// VFS paths the kernel registered the dup'd fds at.
+    stdin_path: String,
+    stdout_path: String,
+    stderr_path: String,
+}
+
+#[derive(Debug)]
+pub(crate) enum SubprocessError {
+    Spawn(String),
+    Register(String),
+    Io(String),
+}
+
+impl std::fmt::Display for SubprocessError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Spawn(m) => write!(f, "spawn: {m}"),
+            Self::Register(m) => write!(f, "register pipe: {m}"),
+            Self::Io(m) => write!(f, "io: {m}"),
+        }
+    }
+}
+
+impl std::error::Error for SubprocessError {}
+
+impl HostedSubprocess {
+    /// Launch `argv[0]` with `argv[1..]` under `cwd`, register the three
+    /// stdio fds as `DT_PIPE`s at `fd_paths` (`[stdin, stdout, stderr]`),
+    /// and return the live handle.
+    ///
+    /// The caller owns the path scheme: acp uses
+    /// `/{zone}/proc/{pid}/fd/{n}`; the managed-agent raw path uses the
+    /// session's zone-free `/proc/{pid}/fd/{n}` subtree.
+    ///
+    /// `env` is used VERBATIM under `env_clear()` — only these vars reach
+    /// the child, so the caller must include everything the binary needs
+    /// (notably `PATH` for a bare command name).
+    ///
+    /// Failure modes:
+    ///   * spawn fails — `SubprocessError::Spawn`. No `DT_PIPE`s created.
+    ///   * register fails partway — already-registered pipes are unlinked
+    ///     before returning so we don't leak `DT_PIPE` entries.
+    pub(crate) async fn spawn_from_argv<K: KernelSyscall>(
+        argv: Vec<String>,
+        env: HashMap<String, String>,
+        cwd: &Path,
+        kernel: &K,
+        fd_paths: [String; 3],
+    ) -> Result<Self, SubprocessError> {
+        let [stdin_path, stdout_path, stderr_path] = fd_paths;
+        // Parent-side handles are kept so a driver can drive them through
+        // AsyncRead / AsyncWrite; we dup the raw fds for the kernel's
+        // stdio-backed DT_PIPE below.
+        let (child, stdin, stdout, stderr) = spawn_child_piped(argv, env, cwd)?;
+
+        // Register stdin (kernel writes into subprocess stdin).
+        if let Err(e) = register_stdio_pipe(
+            kernel,
+            &stdin_path,
+            /* read_fd */ -1,
+            dup_raw(stdin.as_raw_fd())?,
+        ) {
+            return Err(SubprocessError::Register(e));
+        }
+        // Register stdout (kernel reads from subprocess stdout).
+        if let Err(e) = register_stdio_pipe(
+            kernel,
+            &stdout_path,
+            dup_raw(stdout.as_raw_fd())?,
+            /* write_fd */ -1,
+        ) {
+            let _ = unlink_quiet(kernel, &stdin_path);
+            return Err(SubprocessError::Register(e));
+        }
+        // Register stderr.
+        if let Err(e) = register_stdio_pipe(
+            kernel,
+            &stderr_path,
+            dup_raw(stderr.as_raw_fd())?,
+            /* write_fd */ -1,
+        ) {
+            let _ = unlink_quiet(kernel, &stdin_path);
+            let _ = unlink_quiet(kernel, &stdout_path);
+            return Err(SubprocessError::Register(e));
+        }
+
+        Ok(Self {
+            child,
+            stdin: Some(stdin),
+            stdout: Some(stdout),
+            stderr: Some(stderr),
+            stdin_path,
+            stdout_path,
+            stderr_path,
+        })
+    }
+
+    /// Spawn `argv[0]` with `argv[1..]` under `cwd`/`env`, all three
+    /// stdio piped, WITHOUT registering any VFS `DT_PIPE`s. The caller
+    /// drives the parent-side handles directly (via
+    /// [`Self::take_stdio_for_connection`]) — e.g. the managed-agent
+    /// control plane pumps them into node-local memory `DT_STREAM`s for a
+    /// raw-byte tunnel. `unregister_pipes` is a no-op here (no paths).
+    ///
+    /// `env` is used VERBATIM under `env_clear()` (see
+    /// [`Self::spawn_from_argv`]).
+    pub(crate) async fn spawn_no_pipes(
+        argv: Vec<String>,
+        env: HashMap<String, String>,
+        cwd: &Path,
+    ) -> Result<Self, SubprocessError> {
+        let (child, stdin, stdout, stderr) = spawn_child_piped(argv, env, cwd)?;
+        Ok(Self {
+            child,
+            stdin: Some(stdin),
+            stdout: Some(stdout),
+            stderr: Some(stderr),
+            stdin_path: String::new(),
+            stdout_path: String::new(),
+            stderr_path: String::new(),
+        })
+    }
+
+    /// The child's OS pid, or `None` once it has been reaped. The
+    /// managed-agent raw-spawn control plane surfaces this to the
+    /// embedder (pid-bound auth-proxy bookkeeping) while the durable
+    /// session handle stays the synthetic AgentRegistry pid — the two
+    /// identities are deliberately separate (#195 aligned the *agent*
+    /// pid with the OS host_pid, but the managed *session* id is its
+    /// own thing).
+    pub(crate) fn os_pid(&self) -> Option<u32> {
+        self.child.id()
+    }
+
+    /// Move the parent-side stdio handles out so a driver can wrap them
+    /// as `AsyncRead` / `AsyncWrite`. After this call the kernel-side
+    /// `DT_PIPE`s (created in `spawn_from_argv`) remain registered;
+    /// `unregister_pipes` is still required for teardown.
+    pub(crate) fn take_stdio_for_connection(
+        &mut self,
+    ) -> Result<(ChildStdin, ChildStdout, ChildStderr), SubprocessError> {
+        let stdin = self
+            .stdin
+            .take()
+            .ok_or_else(|| SubprocessError::Io("stdin already taken".into()))?;
+        let stdout = self
+            .stdout
+            .take()
+            .ok_or_else(|| SubprocessError::Io("stdout already taken".into()))?;
+        let stderr = self
+            .stderr
+            .take()
+            .ok_or_else(|| SubprocessError::Io("stderr already taken".into()))?;
+        Ok((stdin, stdout, stderr))
+    }
+
+    /// Unlink the three `DT_PIPE` entries (closing the kernel-side dup'd
+    /// fds) and drop the parent-side stdio handles still held. After
+    /// this call the OS pipes collapse and the subprocess sees EOF on
+    /// stdin / read returns 0 on stdout / stderr — provided any driver
+    /// that took ownership via `take_stdio_for_connection` has also
+    /// dropped. Idempotent: subsequent calls are no-ops.
+    pub(crate) fn unregister_pipes<K: KernelSyscall>(&mut self, kernel: &K) {
+        let _ = unlink_quiet(kernel, &self.stdin_path);
+        let _ = unlink_quiet(kernel, &self.stdout_path);
+        let _ = unlink_quiet(kernel, &self.stderr_path);
+        // Drop any remaining parent-side handles so EOF reaches the
+        // child even if take_stdio_for_connection wasn't called.
+        self.stdin.take();
+        self.stdout.take();
+        self.stderr.take();
+    }
+
+    /// Best-effort SIGKILL on the child. Safe to call even if the child
+    /// has already exited.
+    pub(crate) async fn kill(&mut self) {
+        let _ = self.child.kill().await;
+    }
+
+    /// Wait for the child to exit. Returns the exit code (or 0 on
+    /// signal / unknown status, matching the Python service's "no code"
+    /// fallback).
+    pub(crate) async fn wait(&mut self) -> i32 {
+        match self.child.wait().await {
+            Ok(status) => status.code().unwrap_or(0),
+            Err(_) => -1,
+        }
+    }
+}
+
+// ── Internal helpers ───────────────────────────────────────────────────
+
+/// Launch `argv[0]` with `argv[1..]` under `cwd`/`env`, all three stdio
+/// piped with `kill_on_drop(true)`, and take the parent-side handles.
+/// Shared spawn core for [`HostedSubprocess::spawn_from_argv`] (which then
+/// dups the fds into DT_PIPEs) and [`HostedSubprocess::spawn_no_pipes`]
+/// (which pumps the handles into DT_STREAMs). `env` is used VERBATIM under
+/// `env_clear()` — the caller must include everything the child needs.
+///
+/// Must be called from within a tokio runtime context (tokio `Command`).
+#[allow(clippy::type_complexity)]
+fn spawn_child_piped(
+    argv: Vec<String>,
+    env: HashMap<String, String>,
+    cwd: &Path,
+) -> Result<(Child, ChildStdin, ChildStdout, ChildStderr), SubprocessError> {
+    if argv.is_empty() {
+        return Err(SubprocessError::Spawn("empty argv".into()));
+    }
+    let mut cmd = Command::new(&argv[0]);
+    cmd.args(&argv[1..])
+        .env_clear()
+        .envs(env)
+        .current_dir(cwd)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true);
+
+    let mut child = cmd
+        .spawn()
+        .map_err(|e| SubprocessError::Spawn(e.to_string()))?;
+    let stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| SubprocessError::Io("subprocess stdin missing".into()))?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| SubprocessError::Io("subprocess stdout missing".into()))?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| SubprocessError::Io("subprocess stderr missing".into()))?;
+    Ok((child, stdin, stdout, stderr))
+}
+
+/// `dup(2)` the raw fd so the kernel-side StdioPipeBackend holds an
+/// independently-closable handle. Original tokio handle keeps its own
+/// fd number; both close on Drop without colliding.
+fn dup_raw(raw: i32) -> Result<i32, SubprocessError> {
+    // SAFETY: libc::dup is the canonical way to duplicate a file
+    // descriptor; the returned fd is independently closable.
+    let dup = unsafe { libc::dup(raw) };
+    if dup < 0 {
+        return Err(SubprocessError::Io(format!(
+            "dup({raw}): {}",
+            std::io::Error::last_os_error()
+        )));
+    }
+    Ok(dup)
+}
+
+fn register_stdio_pipe<K: KernelSyscall>(
+    kernel: &K,
+    path: &str,
+    read_fd: i32,
+    write_fd: i32,
+) -> Result<(), String> {
+    // DT_PIPE create via the generic sys_setattr matrix: entry_type=3
+    // (DT_PIPE), the "stdio" io_profile, and the subprocess's dup'd
+    // read/write fds. The DT_PIPE arm of sys_setattr accepts exactly
+    // these params — no dedicated setattr_pipe syscall needed.
+    kernel
+        .sys_setattr(
+            path,
+            /* entry_type   */ 3, // DT_PIPE
+            /* backend_name */ "",
+            /* backend      */ None,
+            /* metastore    */ None,
+            /* raft_backend */ None,
+            /* io_profile   */ "stdio",
+            /* zone_id      */ "root",
+            /* is_external  */ false,
+            /* capacity     */ PIPE_CAPACITY,
+            /* read_fd      */ Some(read_fd),
+            /* write_fd     */ Some(write_fd),
+            /* mime_type       */ None,
+            /* modified_at_ms  */ None,
+            /* content_id      */ None,
+            /* size            */ None,
+            /* version         */ None,
+            /* created_at_ms   */ None,
+            /* link_target     */ None,
+            /* source          */ None,
+            /* remote_metastore*/ None,
+        )
+        .map(|_| ())
+        .map_err(|e: KernelError| format!("{e:?}"))
+}
+
+fn unlink_quiet<K: KernelSyscall>(kernel: &K, path: &str) -> Result<(), KernelError> {
+    let ctx = OperationContext::new(
+        /* user_id */ "system", /* zone_id */ "root", /* is_admin */ true,
+        /* agent_id */ None, /* is_system */ true,
+    );
+    kernel.sys_unlink(path, &ctx, false).map(|_| ())
+}
+
+// Drop semantics: tokio's ChildStdin / ChildStdout / ChildStderr each
+// close their own fd, so dropping this struct closes the parent-side OS
+// pipe handles still held. The kernel-side StdioPipeBackend keeps its
+// dup'd fd alive until `unregister_pipes` runs; if the caller forgot,
+// the DT_PIPE entry leaks into the metastore. tokio Command's
+// `kill_on_drop(true)` ensures the child process itself is reaped.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kernel::kernel::Kernel;
+    use std::sync::Arc;
+    use std::time::Duration;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    fn cat_on_path() -> bool {
+        std::process::Command::new("cat")
+            .arg("--version")
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false)
+    }
+
+    /// argv + env for spawning POSIX `cat` (echoes stdin→stdout until
+    /// EOF). `env` carries PATH so the bare `cat` name resolves under
+    /// `env_clear()`.
+    fn cat_argv_env() -> (Vec<String>, HashMap<String, String>) {
+        let env = HashMap::from([(
+            "PATH".to_string(),
+            std::env::var("PATH").unwrap_or_else(|_| "/usr/bin:/bin".to_string()),
+        )]);
+        (vec!["cat".to_string()], env)
+    }
+
+    fn fd_paths_for(pid: &str) -> [String; 3] {
+        [
+            format!("/root/proc/{pid}/fd/0"),
+            format!("/root/proc/{pid}/fd/1"),
+            format!("/root/proc/{pid}/fd/2"),
+        ]
+    }
+
+    /// Smoke: spawn cat, write a line to its stdin, read it back from
+    /// stdout, drop the connection so the subprocess sees EOF, reap.
+    ///
+    /// `#[ignore]` because a bare-kernel test environment doesn't have a
+    /// metastore mount at `/{zone}/proc/...`, so `unregister_pipes`
+    /// can't reach the kernel-side StdioPipeBackend to close its dup'd
+    /// fd, the subprocess never sees EOF on stdin, and `wait` hangs. Run
+    /// against a fully-wired kernel:
+    ///   cargo test subprocess::tests::cat_roundtrip -- --ignored
+    /// The roundtrip portion (write -> read -> assert echoed bytes) does
+    /// pass; only the EOF / wait teardown trips on the missing mount.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[ignore]
+    async fn cat_roundtrip_through_hosted_subprocess() {
+        if !cat_on_path() {
+            eprintln!("cat not on PATH -- skipping");
+            return;
+        }
+        let kernel = Arc::new(Kernel::new());
+        let cwd = std::env::temp_dir();
+        let (argv, env) = cat_argv_env();
+        let mut sub = HostedSubprocess::spawn_from_argv(
+            argv,
+            env,
+            &cwd,
+            kernel.as_ref(),
+            fd_paths_for("pid-cat-roundtrip"),
+        )
+        .await
+        .expect("spawn cat");
+
+        let (mut stdin, mut stdout, _stderr) = sub.take_stdio_for_connection().expect("take stdio");
+
+        stdin
+            .write_all(b"hello acp\n")
+            .await
+            .expect("write to cat stdin");
+        stdin.flush().await.expect("flush");
+
+        let mut buf = vec![0u8; 64];
+        let n = tokio::time::timeout(Duration::from_secs(5), stdout.read(&mut buf))
+            .await
+            .expect("stdout read timed out")
+            .expect("stdout read");
+        assert!(n > 0, "expected echoed bytes");
+        let echoed = std::str::from_utf8(&buf[..n]).unwrap();
+        assert!(echoed.starts_with("hello acp"), "got {echoed:?}");
+
+        drop(stdin);
+        drop(stdout);
+
+        sub.unregister_pipes(kernel.as_ref());
+        let exit = tokio::time::timeout(Duration::from_secs(5), sub.wait())
+            .await
+            .expect("wait timed out");
+        assert_eq!(exit, 0, "cat should exit 0 on EOF");
+    }
+
+    /// Stress the spawn / register / write / read / kill path 10x to
+    /// shake out fd leaks + register/unregister ordering bugs. Same
+    /// `#[ignore]` rationale as `cat_roundtrip_through_hosted_subprocess`.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    #[ignore]
+    async fn cat_roundtrip_stress_10x() {
+        if !cat_on_path() {
+            eprintln!("cat not on PATH -- skipping");
+            return;
+        }
+        let kernel = Arc::new(Kernel::new());
+        let cwd = std::env::temp_dir();
+        for i in 0..10 {
+            let pid = format!("pid-stress-{i}");
+            let (argv, env) = cat_argv_env();
+            let mut sub = HostedSubprocess::spawn_from_argv(
+                argv,
+                env,
+                &cwd,
+                kernel.as_ref(),
+                fd_paths_for(&pid),
+            )
+            .await
+            .unwrap_or_else(|e| panic!("spawn iter {i}: {e}"));
+            let (mut stdin, mut stdout, _stderr) = sub.take_stdio_for_connection().unwrap();
+            let line = format!("iter {i}\n");
+            stdin.write_all(line.as_bytes()).await.unwrap();
+            stdin.flush().await.unwrap();
+            let mut buf = vec![0u8; 64];
+            let n = tokio::time::timeout(Duration::from_secs(5), stdout.read(&mut buf))
+                .await
+                .unwrap_or_else(|_| panic!("read iter {i} timed out"))
+                .unwrap();
+            let echoed = std::str::from_utf8(&buf[..n]).unwrap();
+            assert!(
+                echoed.starts_with(&format!("iter {i}")),
+                "iter {i}: got {echoed:?}"
+            );
+            drop(stdin);
+            drop(stdout);
+            sub.unregister_pipes(kernel.as_ref());
+            sub.kill().await;
+            let _ = tokio::time::timeout(Duration::from_secs(5), sub.wait()).await;
+        }
+    }
+}


### PR DESCRIPTION
Closes the control-plane half of #36: nexus can spawn/host an ACP agent
subprocess and expose a raw byte tunnel to its stdio, and the production
daemon actually brings that service up.

## Commits (granular)

1. `refactor(services)` — hoist a generic `HostedSubprocess` host out of
   `acp/` (spawn + fd handling, reusable by both acp and the raw plane).
2. `feat(managed-agent)` — raw ACP control plane: `spawn_spec` +
   `RawSpawn` DI seam; `KernelRawSpawn` registers three memory
   `DT_STREAM`s at `/proc/{pid}/fd/{0,1,2}` and pumps child stdio ↔
   streams (offset-based, non-destructive; no DT_PIPE — the EAGAIN-as-EOF
   line-framing bug is why). Supervisor reaps + destroys streams on exit.
3. `chore(deps)` — bump the nexus-vfs pin to the ServiceRegistry seam
   branch (nexi-lab/nexus-vfs#200).
4. `feat(nexusd)` — new assembly crate `rust/nexusd` → bin `nexusd-full`
   = `nexus_cluster::run_with_services(|ctx| [a2a, managed_agent, acp])`.
   The composition root lives here (the kernel repo can't depend on the
   nexus service crates); one-way dep, no cycle, no plugin-ABI change.
5. `build(nexusd)` — the production Dockerfile + the CI smoke gate build
   `nexusd-full` from this crate (`cargo build/install -p nexusd`)
   instead of the nexus-vfs `nexus-full` profile, so the shipped binary
   carries managed_agent + acp and the gate tests the exact binary.

## Depends on / merge order

Requires **nexi-lab/nexus-vfs#200** (the `ServiceRegistry` bring-up
seam). #200 merges first; then commit 3's pin is repointed from the
branch rev to the merged-main rev and this PR lands. Kept a **draft**
until then.

## Verification

- managed_agent raw plane: 4 live tests (cat tunnel roundtrip, self-exit
  reap, spawn-failure rollback, raw-byte survives idle polls); clippy
  `-D warnings` clean.
- Live daemon boot (`nexusd-full serve-local`): founder zone + raft
  ConfState, then `service brought up: a2a / managed_agent / acp` (in
  order) + stream-wakeup observer armed, no panic — the control plane is
  installed in a running daemon.
- Production build: cold `cargo build --locked --release -p nexusd`
  green in a clean `rust:1-bookworm`; `nexusd-full --version` exit 0.

## VFS layout

The tunnel's `/proc/{pid}/fd/{0,1,2}` sits under the canonical ephemeral
runtime layer (`/proc/{pid}/`, pid-keyed, node-local) alongside
status/agent-link/chat-with-me — a new runtime leaf, consistent with the
agent-context-storage matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)