### PR TITLE
feat(search-plugin): sort_recency on Glob + Grep (SPIRIT mirror of nexus#4553)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "a2a"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=8fd0289624968def6002b53163f5cb9ae8844b1f#8fd0289624968def6002b53163f5cb9ae8844b1f"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=1a7fc31c807877879338306d30954b371b92a9ff#1a7fc31c807877879338306d30954b371b92a9ff"
 dependencies = [
  "contracts",
  "kernel",
@@ -276,7 +276,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=8fd0289624968def6002b53163f5cb9ae8844b1f#8fd0289624968def6002b53163f5cb9ae8844b1f"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=1a7fc31c807877879338306d30954b371b92a9ff#1a7fc31c807877879338306d30954b371b92a9ff"
 dependencies = [
  "ahash",
  "base64",
@@ -608,7 +608,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=8fd0289624968def6002b53163f5cb9ae8844b1f#8fd0289624968def6002b53163f5cb9ae8844b1f"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=1a7fc31c807877879338306d30954b371b92a9ff#1a7fc31c807877879338306d30954b371b92a9ff"
 dependencies = [
  "parking_lot",
  "serde",
@@ -1423,7 +1423,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=8fd0289624968def6002b53163f5cb9ae8844b1f#8fd0289624968def6002b53163f5cb9ae8844b1f"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=1a7fc31c807877879338306d30954b371b92a9ff#1a7fc31c807877879338306d30954b371b92a9ff"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -1475,7 +1475,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=8fd0289624968def6002b53163f5cb9ae8844b1f#8fd0289624968def6002b53163f5cb9ae8844b1f"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=1a7fc31c807877879338306d30954b371b92a9ff#1a7fc31c807877879338306d30954b371b92a9ff"
 dependencies = [
  "ahash",
  "base64",
@@ -1673,7 +1673,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=8fd0289624968def6002b53163f5cb9ae8844b1f#8fd0289624968def6002b53163f5cb9ae8844b1f"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=1a7fc31c807877879338306d30954b371b92a9ff#1a7fc31c807877879338306d30954b371b92a9ff"
 
 [[package]]
 name = "nexus-search-plugin"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -217,19 +217,19 @@ exclude = ["nexus-fuse"]
 #
 # Bump alongside the rest of nexus-vfs updates when a downstream
 # change needs newer kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "8fd0289624968def6002b53163f5cb9ae8844b1f" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "8fd0289624968def6002b53163f5cb9ae8844b1f" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "8fd0289624968def6002b53163f5cb9ae8844b1f" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "8fd0289624968def6002b53163f5cb9ae8844b1f", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "8fd0289624968def6002b53163f5cb9ae8844b1f", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "8fd0289624968def6002b53163f5cb9ae8844b1f", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "8fd0289624968def6002b53163f5cb9ae8844b1f" }
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "1a7fc31c807877879338306d30954b371b92a9ff" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "1a7fc31c807877879338306d30954b371b92a9ff" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "1a7fc31c807877879338306d30954b371b92a9ff" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "1a7fc31c807877879338306d30954b371b92a9ff", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "1a7fc31c807877879338306d30954b371b92a9ff", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "1a7fc31c807877879338306d30954b371b92a9ff", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "1a7fc31c807877879338306d30954b371b92a9ff" }
 # a2a messaging substrate. `default-features = false` leaves the
 # `install` feature (which pulls raft to arm the stream-wakeup observer)
 # OFF, so nexus-side consumers link only the stamp hook and stay
 # raft-free — they reach raft through kernel.sys_* (§6.1). The substrate
 # is armed in production at cluster boot in nexus-vfs, not here.
-a2a = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "8fd0289624968def6002b53163f5cb9ae8844b1f", default-features = false }
+a2a = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "1a7fc31c807877879338306d30954b371b92a9ff", default-features = false }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ENV CARGO_NET_RETRY=10 \
     CARGO_HTTP_TIMEOUT=120
 # Override for edge/CI or a different pin: --build-arg NEXUS_VFS_REV=<sha|tag>
-ARG NEXUS_VFS_REV=8fd0289624968def6002b53163f5cb9ae8844b1f
+ARG NEXUS_VFS_REV=1a7fc31c807877879338306d30954b371b92a9ff
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,id=cargo-install-${TARGETARCH},target=/root/.cargo/target \

--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir --no-deps --prefix=/install .
 # enforces agreement) — an unpinned install tracks nexus-vfs HEAD and
 # ships an untested kernel (#4343). --locked honors the source tree's
 # Cargo.lock.
-ARG NEXUS_VFS_REV=8fd0289624968def6002b53163f5cb9ae8844b1f
+ARG NEXUS_VFS_REV=1a7fc31c807877879338306d30954b371b92a9ff
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-cluster nexus-cluster
 
 # -- Runtime stage --

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -25,7 +25,7 @@ WORKDIR /build
 # (CI preflight enforces agreement) — an unpinned install tracks HEAD
 # and can skew the raft contract against the cluster/witness images.
 # --locked honors the source tree's Cargo.lock.
-ARG NEXUS_VFS_REV=8fd0289624968def6002b53163f5cb9ae8844b1f
+ARG NEXUS_VFS_REV=1a7fc31c807877879338306d30954b371b92a9ff
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexus-raft-server raft
 
 # ---------- Production image ----------

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=8fd0289624968def6002b53163f5cb9ae8844b1f
+ARG NEXUS_VFS_REV=1a7fc31c807877879338306d30954b371b92a9ff
 RUN cargo install \
     --locked \
     --git https://github.com/nexi-lab/nexus-vfs \

--- a/rust/services/proto/nexus/search/v1/search.proto
+++ b/rust/services/proto/nexus/search/v1/search.proto
@@ -48,6 +48,14 @@ message GlobRequest {
   // Auth token per the same convention as vfs.proto; server-side
   // permission gate reads this via OperationContext.
   string auth_token = 4;
+  // Sort results by containing-file mtime descending (newest first)
+  // BEFORE the `max_results` cap. Requires one `sys_stat` per matched
+  // path — for a bounded cap this is sub-ms. Files with unknown mtime
+  // (kernel returns `null`) sort last, preserving walk order among
+  // themselves. Freshness-aware equivalent of the Python
+  // SearchDaemon `recency=on` mode (nexi-lab/nexus#4553) — no
+  // fusion-score multiplier applies because Glob has no score.
+  bool sort_recency = 5;
 }
 
 message GlobResponse {
@@ -86,6 +94,12 @@ message GrepRequest {
   // Invert: return lines that DO NOT match the pattern.
   bool invert_match = 8;
   string auth_token = 9;
+  // Sort matches by containing-file mtime descending (newest file
+  // first). Matches from the same file keep line-order among
+  // themselves — files are the sort unit, so all hits inside one
+  // file stay contiguous. See `GlobRequest.sort_recency` for the
+  // Python-SearchDaemon mirror context (nexi-lab/nexus#4553).
+  bool sort_recency = 10;
 }
 
 message GrepMatch {

--- a/rust/services/search-plugin/src/kernel_io.rs
+++ b/rust/services/search-plugin/src/kernel_io.rs
@@ -128,6 +128,49 @@ pub fn sys_read(handle: &KernelHandle, path: &str) -> Result<Vec<u8>, KernelIoEr
     }
 }
 
+/// Subset of `StatResult`'s JSON shape that the plugin walker cares
+/// about.  Serde ignores unknown fields (`entry_type`, `size`,
+/// `zone_id`, `path`, …) so this stays additive-compatible with any
+/// future schema growth on the kernel side.  `modified_at_ms` is
+/// `null`-safe: older kernels that predate the field return it as
+/// `null` and the walker degrades to "unknown mtime, sort last".
+#[derive(Debug, Deserialize)]
+pub struct StatInfo {
+    pub modified_at_ms: Option<i64>,
+}
+
+/// Wrap `handle.sys_stat(path)`.
+///
+/// Returns just the field(s) the search walker uses today
+/// (`modified_at_ms`).  Anything else in the JSON is left to serde's
+/// default field-drop behavior so extending the kernel-side schema
+/// stays wire-compatible.
+pub fn sys_stat(handle: &KernelHandle, path: &str) -> Result<StatInfo, KernelIoError> {
+    let c_path = CString::new(path)?;
+    let mut out_ptr: *mut u8 = std::ptr::null_mut();
+    let mut out_len: usize = 0;
+    // SAFETY: same shape as `sys_read` / `sys_readdir` above — kernel-side
+    // callback owns the alloc; we take a snapshot then free.
+    let rc = unsafe {
+        (handle.sys_stat)(
+            handle.kernel_ptr,
+            c_path.as_ptr(),
+            &mut out_ptr as *mut *mut u8,
+            &mut out_len as *mut usize,
+        )
+    };
+    match rc {
+        0 => {
+            let bytes = unsafe { slice::from_raw_parts(out_ptr, out_len) };
+            let parsed: Result<StatInfo, _> = serde_json::from_slice(bytes);
+            unsafe { nexus_free(out_ptr, out_len) };
+            parsed.map_err(KernelIoError::JsonParse)
+        }
+        -1 => Err(KernelIoError::NotFound),
+        other => Err(KernelIoError::Kernel(other)),
+    }
+}
+
 /// Concatenate a parent VFS path and a child entry name into a
 /// canonical child path.  Handles the root special case (`/` +
 /// `foo` = `/foo`) and strips a redundant trailing `/` on the

--- a/rust/services/search-plugin/src/service.rs
+++ b/rust/services/search-plugin/src/service.rs
@@ -45,6 +45,7 @@ fn do_glob(
     root_path: &str,
     pattern: &str,
     max_results: usize,
+    sort_recency: bool,
 ) -> Result<(Vec<String>, bool), String> {
     // Empty pattern ⇒ match everything (walk-and-list mode).  Callers
     // that literally want no matches send an obviously-unmatchable
@@ -91,6 +92,10 @@ fn do_glob(
     })
     .map_err(walk_err_to_string)?;
 
+    if sort_recency {
+        sort_paths_by_mtime_desc(handle, &mut out);
+    }
+
     Ok((out, truncated))
 }
 
@@ -110,6 +115,7 @@ fn do_grep(
     before_context: usize,
     after_context: usize,
     invert_match: bool,
+    sort_recency: bool,
 ) -> Result<(Vec<GrepMatch>, bool), String> {
     if pattern.is_empty() {
         return Err("grep pattern must not be empty".into());
@@ -197,6 +203,10 @@ fn do_grep(
         }
     })
     .map_err(walk_err_to_string)?;
+
+    if sort_recency {
+        sort_matches_by_mtime_desc(handle, &mut matches);
+    }
 
     Ok((matches, truncated))
 }
@@ -334,6 +344,64 @@ fn walk_err_to_string(e: KernelIoError) -> String {
     }
 }
 
+// ── Recency sort (Issue #4553 mirror — the SPIRIT of the Python
+// SearchDaemon's recency=on mode adapted to a scoreless enumeration
+// API).  Glob has no fusion score to multiplicatively boost, so
+// "freshness" here means "newer files sort first".  One sys_stat per
+// UNIQUE path (grep may return many matches per file); paths with
+// unknown mtime sort last so they never leapfrog dated results.
+// Stable Timsort inside `sort_by` preserves encounter order among
+// same-mtime items — matches from one file stay contiguous under
+// grep even after the sort. ──────────────────────────────────────
+
+/// Sort file paths by containing-file mtime descending (newest first).
+/// Unknown-mtime paths sort last.
+fn sort_paths_by_mtime_desc(handle: &KernelHandle, paths: &mut [String]) {
+    let mtimes = fetch_mtimes(handle, paths.iter().map(|p| p.as_str()));
+    // i64::MIN sinks unknown-mtime items to the end when sorting DESC.
+    paths.sort_by_key(|p| std::cmp::Reverse(mtimes.get(p.as_str()).copied().unwrap_or(i64::MIN)));
+}
+
+/// Sort grep matches by containing-file mtime descending.  Matches
+/// from the same file share an mtime key; stable sort preserves
+/// their encounter (line) order.
+fn sort_matches_by_mtime_desc(handle: &KernelHandle, matches: &mut [GrepMatch]) {
+    let mtimes = fetch_mtimes(handle, matches.iter().map(|m| m.path.as_str()));
+    matches.sort_by_key(|m| std::cmp::Reverse(mtimes.get(m.path.as_str()).copied().unwrap_or(i64::MIN)));
+}
+
+/// Batch-fetch `modified_at_ms` for a set of paths.  Deduplicates via
+/// the returned HashMap.  Failures (NotFound, kernel error, JSON
+/// parse error, null mtime) silently drop the path — the sort then
+/// bins it into the unknown-mtime tail rather than aborting.
+fn fetch_mtimes<'a>(
+    handle: &KernelHandle,
+    paths: impl IntoIterator<Item = &'a str>,
+) -> std::collections::HashMap<String, i64> {
+    let mut seen: std::collections::HashSet<&str> = std::collections::HashSet::new();
+    let mut out: std::collections::HashMap<String, i64> = std::collections::HashMap::new();
+    for path in paths {
+        if !seen.insert(path) {
+            continue;
+        }
+        match kernel_io::sys_stat(handle, path) {
+            Ok(info) => {
+                if let Some(ms) = info.modified_at_ms {
+                    out.insert(path.to_string(), ms);
+                }
+            }
+            Err(e) => {
+                tracing::debug!(
+                    path = %path,
+                    err = ?e,
+                    "recency sort: sys_stat failed — treating as unknown mtime",
+                );
+            }
+        }
+    }
+    out
+}
+
 // ── tonic trait impl ──────────────────────────────────────────────
 
 #[async_trait]
@@ -355,10 +423,13 @@ impl SearchService for SearchServiceImpl {
         // Send + Sync per the plugin ABI's unsafe impl; the Arc
         // keeps the underlying callback table alive for as long as
         // any request is in flight.
+        let sort_recency = req.sort_recency;
         let handle = Arc::clone(&self.handle);
-        let outcome = tokio::task::spawn_blocking(move || do_glob(&handle, &root, &pattern, cap))
-            .await
-            .map_err(|e| Status::internal(format!("spawn_blocking joined error: {e}")))?;
+        let outcome = tokio::task::spawn_blocking(move || {
+            do_glob(&handle, &root, &pattern, cap, sort_recency)
+        })
+        .await
+        .map_err(|e| Status::internal(format!("spawn_blocking joined error: {e}")))?;
 
         match outcome {
             Ok((paths, truncated)) => Ok(Response::new(GlobResponse {
@@ -398,6 +469,7 @@ impl SearchService for SearchServiceImpl {
                 req.before_context as usize,
                 req.after_context as usize,
                 req.invert_match,
+                req.sort_recency,
             )
         })
         .await

--- a/rust/services/search-plugin/src/service.rs
+++ b/rust/services/search-plugin/src/service.rs
@@ -367,7 +367,9 @@ fn sort_paths_by_mtime_desc(handle: &KernelHandle, paths: &mut [String]) {
 /// their encounter (line) order.
 fn sort_matches_by_mtime_desc(handle: &KernelHandle, matches: &mut [GrepMatch]) {
     let mtimes = fetch_mtimes(handle, matches.iter().map(|m| m.path.as_str()));
-    matches.sort_by_key(|m| std::cmp::Reverse(mtimes.get(m.path.as_str()).copied().unwrap_or(i64::MIN)));
+    matches.sort_by_key(|m| {
+        std::cmp::Reverse(mtimes.get(m.path.as_str()).copied().unwrap_or(i64::MIN))
+    });
 }
 
 /// Batch-fetch `modified_at_ms` for a set of paths.  Deduplicates via

--- a/tests/e2e/docker/search_helpers.py
+++ b/tests/e2e/docker/search_helpers.py
@@ -38,6 +38,7 @@ def search_glob(
     pattern: str,
     *,
     max_results: int = 0,
+    sort_recency: bool = False,
     api_key: str = ADMIN_API_KEY,
     timeout: float = 30,
 ) -> dict:
@@ -57,6 +58,7 @@ def search_glob(
             pattern=pattern,
             max_results=max_results,
             auth_token=api_key,
+            sort_recency=sort_recency,
         )
         resp = stub.Glob(req, timeout=timeout)
         if resp.HasField("error"):
@@ -82,6 +84,7 @@ def search_grep(
     before_context: int = 0,
     after_context: int = 0,
     invert_match: bool = False,
+    sort_recency: bool = False,
     api_key: str = ADMIN_API_KEY,
     timeout: float = 60,
 ) -> dict:
@@ -106,6 +109,7 @@ def search_grep(
             after_context=after_context,
             invert_match=invert_match,
             auth_token=api_key,
+            sort_recency=sort_recency,
         )
         resp = stub.Grep(req, timeout=timeout)
         if resp.HasField("error"):

--- a/tests/e2e/docker/test_search_plugin.py
+++ b/tests/e2e/docker/test_search_plugin.py
@@ -143,6 +143,39 @@ class TestSearchGlob:
         )
         assert len(r["result"]["paths"]) == 3
 
+    def test_glob_sort_recency_ranks_newest_first(self, api_key: str) -> None:
+        """Seed 3 files with a spacing wide enough for the metastore
+        mtime tick to advance, then glob with ``sort_recency=True`` and
+        assert paths come back newest-first.
+
+        Uses vfs_write's inherent write ordering + a small sleep between
+        writes to guarantee mtime monotonicity — the plugin's sort key
+        is the containing-file mtime returned by the kernel's ``sys_stat``
+        callback (which now exposes ``modified_at_ms``).
+        """
+        import time as _time
+
+        u = uid()
+        base = f"/search-recency-{u}"
+        vfs_mkdir(NODE_GRPC, base, parents=True, api_key=api_key)
+
+        # Seed oldest first, sleep between writes, newest last.
+        for name in ("oldest.txt", "middle.txt", "newest.txt"):
+            r = vfs_write(NODE_GRPC, f"{base}/{name}", b"seed\n", api_key=api_key)
+            assert "error" not in r, f"seed write failed for {name}: {r}"
+            _time.sleep(1.1)
+
+        r = search_glob(NODE_GRPC, base, "*.txt", sort_recency=True, api_key=api_key)
+        assert "error" not in r, f"glob returned error: {r}"
+        paths = r["result"]["paths"]
+        assert len(paths) == 3, f"expected 3 paths, got {paths}"
+        # Newest-first — reverse of write order.
+        assert paths == [
+            f"{base}/newest.txt",
+            f"{base}/middle.txt",
+            f"{base}/oldest.txt",
+        ], f"recency sort violated newest-first order: {paths}"
+
 
 # ===========================================================================
 # TestSearchGrep


### PR DESCRIPTION
Mirrors the SPIRIT of the Python \`SearchDaemon\` recency decay
(nexi-lab/nexus#4553) into the Rust \`nexus-search-plugin\` cdylib.

## Why not 1:1

nexi-lab/nexus#4553 does \`score *= 1 + w·H/(H+age_days)\` post-fusion.
\`nexus.search.v1.SearchService\` has no fusion score to multiply —
Glob returns paths, Grep returns line matches; both are scoreless
enumerations. The 1:1 shape doesn't cross the tier.

The SPIRIT (freshness-aware ordering) does — expressed as an
explicit \`sort_recency: bool\` on the request. When true, results
come back newest-first sorted by containing-file mtime.

## Wire (non-breaking)

- \`GlobRequest.sort_recency = 5\` (bool, default false)
- \`GrepRequest.sort_recency = 10\` (bool, default false)

Default false = current behavior byte-identical.

## Impl

- New \`kernel_io::sys_stat\` wrapper reads \`modified_at_ms\` from the
  plugin-ABI callback's JSON (nexi-lab/nexus-vfs#199, merged as \`1a7fc31\`).
- \`sort_paths_by_mtime_desc\` / \`sort_matches_by_mtime_desc\` batch
  \`sys_stat\` per UNIQUE path (grep may return many hits per file),
  then \`sort_by_key(std::cmp::Reverse(...))\` with \`i64::MIN\`
  sentinel so unknown-mtime paths bin into the tail.
- Stable Timsort preserves encounter order among same-mtime items —
  grep matches from one file stay line-ordered.
- Fail-soft: \`sys_stat\` errors log at debug and drop the path from
  the mtime map; sort still completes.

## Pin bump

- \`Cargo.toml\` + \`Cargo.lock\` + 3 Dockerfiles bumped
  \`8fd028962... -> 1a7fc31c8...\` for nexus-vfs#199
- Older kernels that predate the \`modified_at_ms\` field degrade to
  null mtime (unknown → sort last) — no crash

## Test plan

- [ ] search-plugin E2E Docker workflow adds
      \`test_glob_sort_recency_ranks_newest_first\`
- [ ] Federation E2E, cargo test, cluster-binary builds all green
- [ ] Follow-up: rev-bump to search-v0.2.0 once merged

## Companion PRs

- nexi-lab/nexus-vfs#199 (MERGED) — sys_stat JSON exposes modified_at_ms