### PR TITLE
fix(search): bounded file_paths projection wait + 409 skip surfacing for POST /search/index (#4566)

### DIFF
--- a/docs/surface-coverage/api-rpc-surface-coverage.yaml
+++ b/docs/surface-coverage/api-rpc-surface-coverage.yaml
@@ -443,7 +443,7 @@ operations:
   transports:
     grpc_expose:
       name: add_mount
-      source: src/nexus/bricks/mount/mount_service.py:873
+      source: src/nexus/bricks/mount/mount_service.py:874
   profiles:
     lite: supported
     sandbox: supported
@@ -2542,7 +2542,7 @@ operations:
   transports:
     grpc_expose:
       name: delete_connector
-      source: src/nexus/bricks/mount/mount_service.py:945
+      source: src/nexus/bricks/mount/mount_service.py:946
   profiles:
     lite: supported
     sandbox: supported
@@ -2578,7 +2578,7 @@ operations:
   transports:
     grpc_expose:
       name: delete_saved_mount
-      source: src/nexus/bricks/mount/mount_service.py:1403
+      source: src/nexus/bricks/mount/mount_service.py:1404
   profiles:
     lite: supported
     sandbox: supported
@@ -4392,7 +4392,7 @@ operations:
   transports:
     grpc_expose:
       name: get_mount
-      source: src/nexus/bricks/mount/mount_service.py:1203
+      source: src/nexus/bricks/mount/mount_service.py:1204
   profiles:
     lite: supported
     sandbox: supported
@@ -4771,7 +4771,7 @@ operations:
   transports:
     grpc_expose:
       name: has_mount
-      source: src/nexus/bricks/mount/mount_service.py:1220
+      source: src/nexus/bricks/mount/mount_service.py:1221
   profiles:
     lite: supported
     sandbox: supported
@@ -5186,7 +5186,7 @@ operations:
   transports:
     grpc_expose:
       name: list_connectors
-      source: src/nexus/bricks/mount/mount_service.py:1003
+      source: src/nexus/bricks/mount/mount_service.py:1004
   profiles:
     lite: supported
     sandbox: supported
@@ -5276,7 +5276,7 @@ operations:
   transports:
     grpc_expose:
       name: list_mounts
-      source: src/nexus/bricks/mount/mount_service.py:1187
+      source: src/nexus/bricks/mount/mount_service.py:1188
     sdk:
       name: MCPClient.list_mounts
       source: src/nexus/remote/domain/mcp.py:43
@@ -5348,7 +5348,7 @@ operations:
   transports:
     grpc_expose:
       name: list_saved_mounts
-      source: src/nexus/bricks/mount/mount_service.py:1307
+      source: src/nexus/bricks/mount/mount_service.py:1308
   profiles:
     lite: supported
     sandbox: supported
@@ -5435,7 +5435,7 @@ operations:
   transports:
     grpc_expose:
       name: load_mount
-      source: src/nexus/bricks/mount/mount_service.py:1355
+      source: src/nexus/bricks/mount/mount_service.py:1356
   profiles:
     lite: supported
     sandbox: supported
@@ -7008,7 +7008,7 @@ operations:
   transports:
     grpc_expose:
       name: reauth_mount
-      source: src/nexus/bricks/mount/mount_service.py:1099
+      source: src/nexus/bricks/mount/mount_service.py:1100
   profiles:
     lite: supported
     sandbox: supported
@@ -7317,7 +7317,7 @@ operations:
   transports:
     grpc_expose:
       name: remove_mount
-      source: src/nexus/bricks/mount/mount_service.py:917
+      source: src/nexus/bricks/mount/mount_service.py:918
   profiles:
     lite: supported
     sandbox: supported
@@ -7589,7 +7589,7 @@ operations:
   transports:
     grpc_expose:
       name: save_mount
-      source: src/nexus/bricks/mount/mount_service.py:1236
+      source: src/nexus/bricks/mount/mount_service.py:1237
   profiles:
     lite: supported
     sandbox: supported
@@ -7727,7 +7727,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/expand
-      source: src/nexus/server/api/v2/routers/search.py:1635
+      source: src/nexus/server/api/v2/routers/search.py:1658
   profiles:
     lite: supported
     sandbox: supported
@@ -7936,7 +7936,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/refresh
-      source: src/nexus/server/api/v2/routers/search.py:1614
+      source: src/nexus/server/api/v2/routers/search.py:1637
   profiles:
     lite: supported
     sandbox: supported
@@ -9518,7 +9518,7 @@ operations:
   transports:
     grpc_expose:
       name: update_mount
-      source: src/nexus/bricks/mount/mount_service.py:1020
+      source: src/nexus/bricks/mount/mount_service.py:1021
   profiles:
     lite: supported
     sandbox: supported

--- a/nexus-stack.yml
+++ b/nexus-stack.yml
@@ -168,6 +168,10 @@ services:
       NEXUS_SEARCH_PAGE_BM25_RRF_K: ${NEXUS_SEARCH_PAGE_BM25_RRF_K:-60}
       NEXUS_SEARCH_INDEX_PRELOAD: ${NEXUS_SEARCH_INDEX_PRELOAD:-false}
       NEXUS_SEARCH_TITLE_ARM: ${NEXUS_SEARCH_TITLE_ARM:-true}
+      # Explicit-index projection wait (#4566): bounded re-poll of file_paths
+      # before a write-then-index doc is surfaced as skipped (409).
+      NEXUS_SEARCH_INDEX_PATH_WAIT_ATTEMPTS: ${NEXUS_SEARCH_INDEX_PATH_WAIT_ATTEMPTS:-5}
+      NEXUS_SEARCH_INDEX_PATH_WAIT_SECONDS: ${NEXUS_SEARCH_INDEX_PATH_WAIT_SECONDS:-2.0}
       # Recency decay (#4543): auto = boost recency-intent queries only
       NEXUS_SEARCH_RECENCY: ${NEXUS_SEARCH_RECENCY:-auto}
       NEXUS_SEARCH_RECENCY_WEIGHT: ${NEXUS_SEARCH_RECENCY_WEIGHT:-0.3}

--- a/src/nexus/bricks/mount/mount_service.py
+++ b/src/nexus/bricks/mount/mount_service.py
@@ -251,12 +251,13 @@ class MountService:
 
                 index_zone = zone_id or ROOT_ZONE_ID
 
-                count = await search_daemon.index_documents(documents, zone_id=index_zone)
+                index_result = await search_daemon.index_documents(documents, zone_id=index_zone)
                 logger.info(
-                    "Indexed %d connector files from %s into search (zone=%s)",
-                    count,
+                    "Indexed %d connector files from %s into search (zone=%s, skipped=%d)",
+                    index_result.indexed,
                     mount_point,
                     index_zone,
+                    len(index_result.skipped),
                 )
 
         except Exception:

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -262,6 +262,10 @@ class DaemonStats:
     # submitting genuinely synthetic paths.
     explicit_index_path_waits: int = 0
     explicit_index_skipped_no_path: int = 0
+    # #4566 follow-up: repairs performed by the post-index guard — a
+    # concurrent consumer/refresh write raced the explicit call inside the
+    # covered-gate window and was re-replaced with the caller's text.
+    explicit_index_repairs: int = 0
     # #4566 follow-up: consumer UPSERTs skipped because the row's current
     # content version was already covered (indexed_content_id ==
     # content_id, stamped by an explicit index call or IndexingService).
@@ -731,6 +735,9 @@ class SearchDaemon:
         # Index refresh task
         self._refresh_task: asyncio.Task | None = None
         self._legacy_refresh_task: asyncio.Task | None = None
+        # #4566: post-explicit-index guard tasks (strong refs so they
+        # aren't garbage-collected mid-flight).
+        self._explicit_guard_tasks: set[asyncio.Task[None]] = set()
         self._mutation_wakeup = asyncio.Event()
         self._pending_refresh_paths: set[str] = set()
         self._pending_delete_paths: set[str] = set()
@@ -3736,15 +3743,16 @@ class SearchDaemon:
 
     async def _resolve_index_path_row(
         self, vp_clean: str, zone_id: str
-    ) -> tuple[str, str | None] | None:
+    ) -> tuple[str, str | None, Any] | None:
         """Look up the live ``file_paths`` row for a zone-stripped path.
 
-        Returns ``(path_id, content_id)`` or ``None`` when no live row
-        exists. The daemon must not CREATE ``file_paths`` rows (structural
-        ownership belongs to the kernel/metastore), so a missing row can
-        only be waited out or surfaced, never healed here. The search-owned
-        tracking columns (``indexed_content_id``, ``last_indexed_at``) are a
-        different matter — see ``_stamp_indexed_content``.
+        Returns ``(path_id, content_id, updated_at)`` or ``None`` when no
+        live row exists. The daemon must not CREATE ``file_paths`` rows
+        (structural ownership belongs to the kernel/metastore), so a missing
+        row can only be waited out or surfaced, never healed here. The
+        search-owned tracking columns (``indexed_content_id``,
+        ``last_indexed_at``) are a different matter — see
+        ``_stamp_indexed_content``.
         """
         if self._async_session is None:
             return None
@@ -3752,7 +3760,7 @@ class SearchDaemon:
             row = (
                 await session.execute(
                     sa_text(
-                        "SELECT path_id, content_id FROM file_paths "
+                        "SELECT path_id, content_id, updated_at FROM file_paths "
                         "WHERE virtual_path = :vp "
                         "  AND zone_id = :zid "
                         "  AND deleted_at IS NULL "
@@ -3763,23 +3771,29 @@ class SearchDaemon:
             ).first()
         if row is None:
             return None
-        return str(row[0]), (str(row[1]) if row[1] is not None else None)
+        return str(row[0]), (str(row[1]) if row[1] is not None else None), row[2]
 
-    async def _stamp_indexed_content(self, path_id: str, content_id: str | None) -> None:
-        """Mark ``content_id`` as covered by the index for ``path_id`` (#4566).
+    async def _stamp_indexed_content(
+        self, path_id: str, content_id: str | None, observed_updated_at: Any
+    ) -> None:
+        """Mark the current content version as covered for ``path_id`` (#4566).
 
         After an explicit index call persists caller-provided text, advance
         the search-owned tracking columns on ``file_paths`` — the same
         columns ``IndexingService.index_document`` maintains — so mutation
-        consumers know this content version is already covered and don't
-        clobber the explicit text with raw blob bytes (see
-        ``_upsert_covered_by_index``).
+        consumers and the legacy refresh loop know this content version is
+        already covered and don't clobber the explicit text with raw blob
+        bytes (see ``_upsert_covered_by_index``).
 
-        CAS on ``content_id``: if the file was overwritten between our read
-        and this update, the stamp is dropped and the consumer indexes the
-        newer version normally. Fail-soft: the text IS indexed at this
-        point, so a stamp failure must not fail the request — worst case
-        the consumer re-indexes blob bytes (pre-#4566 behavior).
+        CAS on ``content_id`` AND ``updated_at``: ``content_id`` alone is
+        NOT a version discriminator on every backend — the local backend
+        stores an identity-style content_id (the path) that never changes
+        across rewrites — so a rewrite that lands between our resolution
+        read and this update must void the stamp via the ``updated_at``
+        guard, letting consumers index the newer bytes. Fail-soft: the text
+        IS indexed at this point, so a stamp failure must not fail the
+        request — worst case the consumers re-index blob bytes
+        (pre-#4566 behavior).
         """
         if content_id is None or self._async_session is None:
             return
@@ -3791,12 +3805,14 @@ class SearchDaemon:
                         "SET indexed_content_id = :cid, last_indexed_at = :now "
                         "WHERE path_id = :pid "
                         "  AND deleted_at IS NULL "
-                        "  AND content_id = :cid"
+                        "  AND content_id = :cid "
+                        "  AND updated_at = :observed_updated_at"
                     ),
                     {
                         "cid": content_id,
                         "pid": path_id,
                         "now": datetime.now(UTC).replace(tzinfo=None),
+                        "observed_updated_at": observed_updated_at,
                     },
                 )
                 await session.commit()
@@ -3810,18 +3826,22 @@ class SearchDaemon:
     async def _upsert_covered_by_index(self, path_id: str) -> bool:
         """Whether ``path_id``'s CURRENT content version is already indexed.
 
-        Issue #4566 follow-up: mutation consumers used to index blob bytes
-        unconditionally, clobbering text supplied via ``POST /search/index``
-        (extracted text for PDFs, OCR output, sidecar markdown). When
-        ``indexed_content_id`` matches the row's live ``content_id`` —
-        stamped by the explicit index call or by ``IndexingService`` — the
-        consumer's UPSERT has nothing to add for this version and must not
-        overwrite the richer chunks. A later real write advances
-        ``content_id``, the marker stops matching, and consumers index the
-        new version normally.
+        Issue #4566 follow-up: the mutation consumers and the legacy refresh
+        loop used to index blob bytes unconditionally, clobbering text
+        supplied via ``POST /search/index`` (extracted text for PDFs, OCR
+        output, sidecar markdown). Covered means BOTH:
 
-        Fail-open: any lookup error returns ``False`` so consumer indexing
-        proceeds exactly as before this gate existed.
+        - ``indexed_content_id == content_id`` (the marker stamped by the
+          explicit index call or by ``IndexingService``), AND
+        - ``last_indexed_at >= updated_at`` — the freshness guard. On
+          backends whose ``content_id`` is identity-style (the local
+          backend stores the path, unchanged across rewrites) marker
+          equality alone would latch coverage forever and edits would stop
+          being re-indexed; ``updated_at`` bumps on every write, so a real
+          edit always un-covers the row.
+
+        Fail-open: any lookup/comparison error returns ``False`` so
+        indexing proceeds exactly as before this gate existed.
         """
         if self._async_session is None:
             return False
@@ -3830,26 +3850,150 @@ class SearchDaemon:
                 row = (
                     await session.execute(
                         sa_text(
-                            "SELECT content_id, indexed_content_id FROM file_paths "
+                            "SELECT content_id, indexed_content_id, updated_at, "
+                            "       last_indexed_at "
+                            "FROM file_paths "
                             "WHERE path_id = :pid AND deleted_at IS NULL "
                             "LIMIT 1"
                         ),
                         {"pid": path_id},
                     )
                 ).first()
+            return (
+                row is not None
+                and row[0] is not None
+                and row[1] is not None
+                and str(row[0]) == str(row[1])
+                and row[2] is not None
+                and row[3] is not None
+                and row[3] >= row[2]
+            )
         except Exception as exc:
             logger.warning(
-                "mutation consumer: covered-version check failed for path_id=%s: %s",
+                "search indexer: covered-version check failed for path_id=%s: %s",
                 path_id,
                 exc,
             )
             return False
-        return (
-            row is not None
-            and row[0] is not None
-            and row[1] is not None
-            and str(row[0]) == str(row[1])
+
+    async def _chunk_write_watermark(self, path_id: str) -> tuple[int, Any] | None:
+        """Cheap fingerprint of the chunk rows currently stored for a path.
+
+        Fail-soft: the watermark only powers the post-index guard, so a
+        lookup error degrades to ``None`` (guard sees no change) instead of
+        failing the explicit index request that already persisted its text.
+        """
+        if self._async_session is None:
+            return None
+        try:
+            async with self._async_session() as session:
+                row = (
+                    await session.execute(
+                        sa_text(
+                            "SELECT COUNT(*), MAX(created_at) FROM document_chunks "
+                            "WHERE path_id = :pid"
+                        ),
+                        {"pid": path_id},
+                    )
+                ).first()
+            if row is None:
+                return None
+            return int(row[0]), row[1]
+        except Exception as exc:
+            logger.warning("chunk watermark lookup failed for path_id=%s: %s", path_id, exc)
+            return None
+
+    async def _explicit_index_guard(
+        self,
+        scoped_path: str,
+        text_clean: str,
+        path_row: tuple[str, str | None, Any],
+        baseline: tuple[int, Any] | None,
+    ) -> None:
+        """Bounded verify-repair watch after an explicit index write (#4566).
+
+        The covered gate stops writers that CHECK after the stamp lands, but
+        a consumer/refresh pass already past its gate check when the stamp
+        commits can still interleave its blob-bytes replace with ours —
+        observed live as two chunk writes 3ms apart leaving a mixed set.
+        Each such actor processes the triggering write event exactly once,
+        so a bounded watch is deterministic: poll the chunk watermark on the
+        explicit-index wait cadence; if a foreign write dirtied it, replace
+        with the caller's text once more and re-stamp.
+
+        A REAL new write must win, never the guard: before repairing we
+        re-read the row and stand down unless it still holds exactly the
+        (content_id, updated_at) version this call indexed.
+        """
+        path_id, content_id, observed_updated_at = path_row
+        attempts = max(0, self.config.index_path_wait_attempts)
+        delay = max(0.0, self.config.index_path_wait_seconds)
+        try:
+            for _ in range(attempts):
+                await asyncio.sleep(delay)
+                watermark = await self._chunk_write_watermark(path_id)
+                if watermark == baseline:
+                    continue
+                if self._async_session is None or self._indexing_pipeline is None:
+                    return
+                async with self._async_session() as session:
+                    row = (
+                        await session.execute(
+                            sa_text(
+                                "SELECT content_id, updated_at FROM file_paths "
+                                "WHERE path_id = :pid AND deleted_at IS NULL "
+                                "LIMIT 1"
+                            ),
+                            {"pid": path_id},
+                        )
+                    ).first()
+                if (
+                    row is None
+                    or (str(row[0]) if row[0] is not None else None) != content_id
+                    or row[1] != observed_updated_at
+                ):
+                    # The file moved on to a newer version — its indexing
+                    # belongs to the consumers now.
+                    return
+                repair = await self._indexing_pipeline.index_document(
+                    scoped_path, text_clean, path_id
+                )
+                if repair.error:
+                    logger.warning(
+                        "explicit index guard: repair failed for %s: %s",
+                        scoped_path,
+                        repair.error,
+                    )
+                    return
+                await self._stamp_indexed_content(path_id, content_id, observed_updated_at)
+                self.stats.explicit_index_repairs += 1
+                logger.info(
+                    "explicit index guard: re-replaced raced chunk write for %s",
+                    scoped_path,
+                )
+                baseline = await self._chunk_write_watermark(path_id)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            logger.warning(
+                "explicit index guard failed for %s: %s — caller text may have "
+                "been overwritten by a concurrent blob index",
+                scoped_path,
+                exc,
+            )
+
+    def _spawn_explicit_index_guard(
+        self,
+        scoped_path: str,
+        text_clean: str,
+        path_row: tuple[str, str | None, Any],
+        baseline: tuple[int, Any] | None,
+    ) -> None:
+        task = asyncio.create_task(
+            self._explicit_index_guard(scoped_path, text_clean, path_row, baseline)
         )
+        self._explicit_guard_tasks.add(task)
+        task.add_done_callback(self._explicit_guard_tasks.discard)
 
     async def _index_documents_on_current_loop(
         self,
@@ -3904,8 +4048,9 @@ class SearchDaemon:
             return value.replace("\x00", "") if "\x00" in value else value
 
         async def _index_one(
-            vp_clean: str, text_clean: str, path_id: str, content_id: str | None
+            vp_clean: str, text_clean: str, path_row: tuple[str, str | None, Any]
         ) -> None:
+            path_id, content_id, observed_updated_at = path_row
             # Drive the canonical write path. Pass the zone-scoped form
             # so the pipeline's scope filter sees the same shape mutation
             # consumers use.
@@ -3920,13 +4065,23 @@ class SearchDaemon:
                 )
             result.indexed += 1
             # #4566 follow-up: mark this content version as covered so the
-            # mutation consumers don't clobber caller-provided text with
-            # raw blob bytes. Only when chunks actually landed — the
-            # pipeline's scope gate returns chunks_indexed=0 without error
-            # for out-of-scope paths, and stamping those would wrongly
-            # block the FTS consumer's naive-chunk fallback.
+            # mutation consumers / refresh loop don't clobber caller-provided
+            # text with raw blob bytes. Only when chunks actually landed —
+            # the pipeline's scope gate returns chunks_indexed=0 without
+            # error for out-of-scope paths, and stamping those would wrongly
+            # block the FTS consumer's naive-chunk fallback. The guard task
+            # then watches for writers that were already past their gate
+            # check when the stamp landed and re-replaces their raced write.
             if pipeline_result.chunks_indexed > 0:
-                await self._stamp_indexed_content(path_id, content_id)
+                await self._stamp_indexed_content(path_id, content_id, observed_updated_at)
+                if self.config.index_path_wait_attempts > 0 and self._async_session is not None:
+                    baseline = await self._chunk_write_watermark(path_id)
+                    self._spawn_explicit_index_guard(
+                        scoped_path,
+                        text_clean,
+                        (path_id, content_id, observed_updated_at),
+                        baseline,
+                    )
 
         pending: list[tuple[str, str]] = []  # (vp_clean, text_clean) awaiting a row
         for doc in documents:
@@ -3946,7 +4101,7 @@ class SearchDaemon:
             if path_row is None:
                 pending.append((vp_clean, text_clean))
                 continue
-            await _index_one(vp_clean, text_clean, path_row[0], path_row[1])
+            await _index_one(vp_clean, text_clean, path_row)
 
         # Issue #4566: bounded wait for the projection row. The wait budget is
         # per BATCH, not per document — each round re-polls every unresolved
@@ -3965,7 +4120,7 @@ class SearchDaemon:
                         still_pending.append((vp_clean, text_clean))
                         continue
                     self.stats.explicit_index_path_waits += 1
-                    await _index_one(vp_clean, text_clean, path_row[0], path_row[1])
+                    await _index_one(vp_clean, text_clean, path_row)
                 pending = still_pending
                 if not pending:
                     break
@@ -5736,6 +5891,22 @@ class SearchDaemon:
                                 path_id_resolved = True
                     except Exception as e:
                         logger.debug("path_id lookup failed for %s: %s", virtual_path, e)
+
+                # #4566 follow-up: the legacy refresh loop fires on EVERY
+                # VFS write (the post-write hook enqueues unconditionally),
+                # so it was the live clobberer of explicit /search/index
+                # text — the debounced tick re-read the blob bytes and
+                # overwrote the caller-provided chunks ~5-10s later. Same
+                # covered-version gate as the mutation consumers: skip when
+                # the row's current version is already indexed; a real edit
+                # bumps updated_at and un-covers the row.
+                if path_id_resolved and await self._upsert_covered_by_index(str(path_id)):
+                    self.stats.mutation_upserts_skipped_covered += 1
+                    logger.debug(
+                        "refresh: skipping %s — current content version already indexed",
+                        path,
+                    )
+                    continue
 
                 # Single-writer policy for document_chunks (Issue #3708):
                 # when embedding pipeline is active AND the path is in

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -262,6 +262,12 @@ class DaemonStats:
     # submitting genuinely synthetic paths.
     explicit_index_path_waits: int = 0
     explicit_index_skipped_no_path: int = 0
+    # #4566 follow-up: consumer UPSERTs skipped because the row's current
+    # content version was already covered (indexed_content_id ==
+    # content_id, stamped by an explicit index call or IndexingService).
+    # These skips are what keeps caller-provided text (PDF/OCR extraction,
+    # sidecar markdown) from being clobbered by raw blob bytes.
+    mutation_upserts_skipped_covered: int = 0
 
 
 @dataclass
@@ -3728,13 +3734,17 @@ class SearchDaemon:
             submitted.cancel()
             raise
 
-    async def _resolve_index_path_id(self, vp_clean: str, zone_id: str) -> str | None:
+    async def _resolve_index_path_row(
+        self, vp_clean: str, zone_id: str
+    ) -> tuple[str, str | None] | None:
         """Look up the live ``file_paths`` row for a zone-stripped path.
 
-        The search daemon is a READER of filesystem metadata — it must not
-        create or modify ``file_paths`` rows (that ownership belongs to the
-        kernel/metastore), so a missing row can only be waited out or
-        surfaced, never healed here.
+        Returns ``(path_id, content_id)`` or ``None`` when no live row
+        exists. The daemon must not CREATE ``file_paths`` rows (structural
+        ownership belongs to the kernel/metastore), so a missing row can
+        only be waited out or surfaced, never healed here. The search-owned
+        tracking columns (``indexed_content_id``, ``last_indexed_at``) are a
+        different matter — see ``_stamp_indexed_content``.
         """
         if self._async_session is None:
             return None
@@ -3742,7 +3752,7 @@ class SearchDaemon:
             row = (
                 await session.execute(
                     sa_text(
-                        "SELECT path_id FROM file_paths "
+                        "SELECT path_id, content_id FROM file_paths "
                         "WHERE virtual_path = :vp "
                         "  AND zone_id = :zid "
                         "  AND deleted_at IS NULL "
@@ -3751,7 +3761,95 @@ class SearchDaemon:
                     {"vp": vp_clean, "zid": zone_id},
                 )
             ).first()
-        return str(row[0]) if row is not None else None
+        if row is None:
+            return None
+        return str(row[0]), (str(row[1]) if row[1] is not None else None)
+
+    async def _stamp_indexed_content(self, path_id: str, content_id: str | None) -> None:
+        """Mark ``content_id`` as covered by the index for ``path_id`` (#4566).
+
+        After an explicit index call persists caller-provided text, advance
+        the search-owned tracking columns on ``file_paths`` — the same
+        columns ``IndexingService.index_document`` maintains — so mutation
+        consumers know this content version is already covered and don't
+        clobber the explicit text with raw blob bytes (see
+        ``_upsert_covered_by_index``).
+
+        CAS on ``content_id``: if the file was overwritten between our read
+        and this update, the stamp is dropped and the consumer indexes the
+        newer version normally. Fail-soft: the text IS indexed at this
+        point, so a stamp failure must not fail the request — worst case
+        the consumer re-indexes blob bytes (pre-#4566 behavior).
+        """
+        if content_id is None or self._async_session is None:
+            return
+        try:
+            async with self._async_session() as session:
+                await session.execute(
+                    sa_text(
+                        "UPDATE file_paths "
+                        "SET indexed_content_id = :cid, last_indexed_at = :now "
+                        "WHERE path_id = :pid "
+                        "  AND deleted_at IS NULL "
+                        "  AND content_id = :cid"
+                    ),
+                    {
+                        "cid": content_id,
+                        "pid": path_id,
+                        "now": datetime.now(UTC).replace(tzinfo=None),
+                    },
+                )
+                await session.commit()
+        except Exception as exc:
+            logger.warning(
+                "index_documents: failed to stamp indexed_content_id for path_id=%s: %s",
+                path_id,
+                exc,
+            )
+
+    async def _upsert_covered_by_index(self, path_id: str) -> bool:
+        """Whether ``path_id``'s CURRENT content version is already indexed.
+
+        Issue #4566 follow-up: mutation consumers used to index blob bytes
+        unconditionally, clobbering text supplied via ``POST /search/index``
+        (extracted text for PDFs, OCR output, sidecar markdown). When
+        ``indexed_content_id`` matches the row's live ``content_id`` —
+        stamped by the explicit index call or by ``IndexingService`` — the
+        consumer's UPSERT has nothing to add for this version and must not
+        overwrite the richer chunks. A later real write advances
+        ``content_id``, the marker stops matching, and consumers index the
+        new version normally.
+
+        Fail-open: any lookup error returns ``False`` so consumer indexing
+        proceeds exactly as before this gate existed.
+        """
+        if self._async_session is None:
+            return False
+        try:
+            async with self._async_session() as session:
+                row = (
+                    await session.execute(
+                        sa_text(
+                            "SELECT content_id, indexed_content_id FROM file_paths "
+                            "WHERE path_id = :pid AND deleted_at IS NULL "
+                            "LIMIT 1"
+                        ),
+                        {"pid": path_id},
+                    )
+                ).first()
+        except Exception as exc:
+            logger.warning(
+                "mutation consumer: covered-version check failed for path_id=%s: %s",
+                path_id,
+                exc,
+            )
+            return False
+        return (
+            row is not None
+            and row[0] is not None
+            and row[1] is not None
+            and str(row[0]) == str(row[1])
+        )
 
     async def _index_documents_on_current_loop(
         self,
@@ -3780,6 +3878,11 @@ class SearchDaemon:
         ``skipped`` — never silently dropped from the count. Documents with
         no usable ``text``/``path`` fields are ignored as before (malformed
         input, not a projection race).
+
+        After a successful write the row's ``indexed_content_id`` is stamped
+        to the current ``content_id`` (see ``_stamp_indexed_content``) so
+        mutation consumers treat this content version as covered and the
+        caller-provided text survives the consumer's own blob indexing.
         """
         if not self._initialized:
             raise RuntimeError("SearchDaemon not initialized. Call startup() first.")
@@ -3800,7 +3903,9 @@ class SearchDaemon:
         def _scrub(value: str) -> str:
             return value.replace("\x00", "") if "\x00" in value else value
 
-        async def _index_one(vp_clean: str, text_clean: str, path_id: str) -> None:
+        async def _index_one(
+            vp_clean: str, text_clean: str, path_id: str, content_id: str | None
+        ) -> None:
             # Drive the canonical write path. Pass the zone-scoped form
             # so the pipeline's scope filter sees the same shape mutation
             # consumers use.
@@ -3814,6 +3919,14 @@ class SearchDaemon:
                     f"index_documents: pipeline failed for {vp_clean!r}: {pipeline_result.error}"
                 )
             result.indexed += 1
+            # #4566 follow-up: mark this content version as covered so the
+            # mutation consumers don't clobber caller-provided text with
+            # raw blob bytes. Only when chunks actually landed — the
+            # pipeline's scope gate returns chunks_indexed=0 without error
+            # for out-of-scope paths, and stamping those would wrongly
+            # block the FTS consumer's naive-chunk fallback.
+            if pipeline_result.chunks_indexed > 0:
+                await self._stamp_indexed_content(path_id, content_id)
 
         pending: list[tuple[str, str]] = []  # (vp_clean, text_clean) awaiting a row
         for doc in documents:
@@ -3829,11 +3942,11 @@ class SearchDaemon:
             text_clean = _scrub(text_field)
             vp_clean = strip_zone_prefix(virtual_path)
 
-            path_id = await self._resolve_index_path_id(vp_clean, target_zone)
-            if path_id is None:
+            path_row = await self._resolve_index_path_row(vp_clean, target_zone)
+            if path_row is None:
                 pending.append((vp_clean, text_clean))
                 continue
-            await _index_one(vp_clean, text_clean, path_id)
+            await _index_one(vp_clean, text_clean, path_row[0], path_row[1])
 
         # Issue #4566: bounded wait for the projection row. The wait budget is
         # per BATCH, not per document — each round re-polls every unresolved
@@ -3847,12 +3960,12 @@ class SearchDaemon:
                 await asyncio.sleep(wait_seconds)
                 still_pending: list[tuple[str, str]] = []
                 for vp_clean, text_clean in pending:
-                    path_id = await self._resolve_index_path_id(vp_clean, target_zone)
-                    if path_id is None:
+                    path_row = await self._resolve_index_path_row(vp_clean, target_zone)
+                    if path_row is None:
                         still_pending.append((vp_clean, text_clean))
                         continue
                     self.stats.explicit_index_path_waits += 1
-                    await _index_one(vp_clean, text_clean, path_id)
+                    await _index_one(vp_clean, text_clean, path_row[0], path_row[1])
                 pending = still_pending
                 if not pending:
                     break
@@ -5413,6 +5526,17 @@ class SearchDaemon:
                 # scope-generation token would close this gap if needed.
                 if embedding_active and self._is_path_in_scope(mutation.event.path):
                     continue
+                # #4566 follow-up: don't overwrite chunks for a content
+                # version that is already covered in the index (explicit
+                # /search/index text or an IndexingService pass) — raw
+                # blob bytes must not clobber richer caller-provided text.
+                if await self._upsert_covered_by_index(mutation.path_id):
+                    self.stats.mutation_upserts_skipped_covered += 1
+                    logger.debug(
+                        "fts consumer: skipping %s — current content version already indexed",
+                        mutation.event.path,
+                    )
+                    continue
                 await self._index_to_document_chunks(
                     mutation.path_id,
                     mutation.event.path,
@@ -5456,6 +5580,22 @@ class SearchDaemon:
             # gate in IndexingPipeline.index_documents would also catch
             # this, but filtering here avoids the pipeline overhead.
             if not self._is_path_in_scope(mutation.event.path):
+                continue
+            # #4566 follow-up: skip when this exact content version is
+            # already covered in the index (indexed_content_id ==
+            # content_id) — an explicit /search/index call supplied text
+            # for this version (e.g. PDF extraction) and re-indexing the
+            # raw bytes here would clobber it. A real content change
+            # advances content_id and indexes normally. NOTE: a consumer
+            # pass that started before the explicit stamp landed can still
+            # win the write race — the gate shrinks the clobber window to
+            # the pipeline's own duration, it does not eliminate it.
+            if await self._upsert_covered_by_index(mutation.path_id):
+                self.stats.mutation_upserts_skipped_covered += 1
+                logger.debug(
+                    "embedding consumer: skipping %s — current content version already indexed",
+                    mutation.event.path,
+                )
                 continue
             # The pipeline can fail via IndexResult.error OR by raising
             # (e.g. provider/network failures). In both cases, fall back to

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -254,6 +254,14 @@ class DaemonStats:
     # boost errors must never fail a search, but persistent failures should
     # be visible via /search/stats rather than only in log lines.
     recency_attach_failures: int = 0
+    # Explicit-index projection wait (Issue #4566): docs that needed at least
+    # one wait round before their file_paths row landed, and docs dropped
+    # because the row never landed within the bounded wait. A growing skip
+    # counter means callers are indexing paths that are not (yet) backed by
+    # NexusFS — either a projection-lag budget that is too small or a client
+    # submitting genuinely synthetic paths.
+    explicit_index_path_waits: int = 0
+    explicit_index_skipped_no_path: int = 0
 
 
 @dataclass
@@ -558,6 +566,39 @@ class DaemonConfig:
     recency_half_life_days: float = field(
         default_factory=lambda: _get_env_float("NEXUS_SEARCH_RECENCY_HALF_LIFE_DAYS", 30.0)
     )
+
+    # Bounded wait for the file_paths projection row on explicit indexing
+    # (Issue #4566). ``POST /search/index`` right after ``files.write`` lands
+    # inside the operation-log consumer's projection lag (~5-10s observed),
+    # so the path_id lookup finds no row yet. Instead of silently dropping
+    # the document, the daemon re-polls the projection up to
+    # ``index_path_wait_attempts`` times, sleeping ``index_path_wait_seconds``
+    # between rounds (defaults cover the observed lag: 5 × 2s = 10s worst
+    # case). Documents whose row never lands are reported as skipped so the
+    # HTTP boundary can fail closed instead of returning a silent count=0.
+    # Set attempts to 0 to disable the wait (pre-#4566 lookup behavior,
+    # but skips are still surfaced).
+    index_path_wait_attempts: int = field(
+        default_factory=lambda: _get_env_int("NEXUS_SEARCH_INDEX_PATH_WAIT_ATTEMPTS", 5)
+    )
+    index_path_wait_seconds: float = field(
+        default_factory=lambda: _get_env_float("NEXUS_SEARCH_INDEX_PATH_WAIT_SECONDS", 2.0)
+    )
+
+
+@dataclass(slots=True)
+class ExplicitIndexResult:
+    """Outcome of an explicit ``index_documents`` call (Issue #4566).
+
+    ``indexed`` is the number of documents persisted through the indexing
+    pipeline. ``skipped`` lists the zone-stripped virtual paths that had no
+    live ``file_paths`` row even after the bounded projection wait — their
+    text was NOT indexed and the caller must retry (or accept the loss for
+    genuinely synthetic paths that will never be backed by NexusFS).
+    """
+
+    indexed: int = 0
+    skipped: list[str] = field(default_factory=list)
 
 
 class SearchDaemon:
@@ -3656,11 +3697,11 @@ class SearchDaemon:
         documents: list[dict[str, Any]],
         *,
         zone_id: str | None = None,
-    ) -> int:
+    ) -> ExplicitIndexResult:
         if zone_id is None:
             return await self._index_documents_on_current_loop(documents, zone_id=zone_id)
 
-        async def _work() -> int:
+        async def _work() -> ExplicitIndexResult:
             return await self._index_documents_on_current_loop(documents, zone_id=zone_id)
 
         return await self._run_on_owner_loop(_work)
@@ -3687,12 +3728,37 @@ class SearchDaemon:
             submitted.cancel()
             raise
 
+    async def _resolve_index_path_id(self, vp_clean: str, zone_id: str) -> str | None:
+        """Look up the live ``file_paths`` row for a zone-stripped path.
+
+        The search daemon is a READER of filesystem metadata — it must not
+        create or modify ``file_paths`` rows (that ownership belongs to the
+        kernel/metastore), so a missing row can only be waited out or
+        surfaced, never healed here.
+        """
+        if self._async_session is None:
+            return None
+        async with self._async_session() as session:
+            row = (
+                await session.execute(
+                    sa_text(
+                        "SELECT path_id FROM file_paths "
+                        "WHERE virtual_path = :vp "
+                        "  AND zone_id = :zid "
+                        "  AND deleted_at IS NULL "
+                        "LIMIT 1"
+                    ),
+                    {"vp": vp_clean, "zid": zone_id},
+                )
+            ).first()
+        return str(row[0]) if row is not None else None
+
     async def _index_documents_on_current_loop(
         self,
         documents: list[dict[str, Any]],
         *,
         zone_id: str | None = None,
-    ) -> int:
+    ) -> ExplicitIndexResult:
         """Explicitly upsert documents into the active search backend.
 
         This powers ``POST /api/v2/search/index`` for synthetic or externally
@@ -3702,17 +3768,28 @@ class SearchDaemon:
         via the indexing pipeline. Each document is treated as ``(path,
         text)`` — we resolve ``path_id`` from ``file_paths`` and dispatch to
         ``IndexingPipeline.index_document`` which chunks, embeds, and
-        bulk-inserts into ``document_chunks``. Failures bubble up so the
-        HTTP boundary returns 500 (Decision #18) instead of silently returning
-        count=0.
+        bulk-inserts into ``document_chunks``. Pipeline failures bubble up so
+        the HTTP boundary returns 500 (Decision #18) instead of silently
+        returning count=0.
+
+        Issue #4566: the ``file_paths`` projection is populated asynchronously
+        by the operation-log consumer, so write-then-index callers always race
+        it. Documents whose row is missing get a bounded wait
+        (``index_path_wait_attempts`` × ``index_path_wait_seconds``, shared by
+        the whole batch); anything still unresolved is returned in
+        ``skipped`` — never silently dropped from the count. Documents with
+        no usable ``text``/``path`` fields are ignored as before (malformed
+        input, not a projection race).
         """
         if not self._initialized:
             raise RuntimeError("SearchDaemon not initialized. Call startup() first.")
 
+        result = ExplicitIndexResult()
         if not documents:
-            return 0
+            return result
 
-        if self._indexing_pipeline is None:
+        pipeline = self._indexing_pipeline
+        if pipeline is None:
             raise RuntimeError(
                 "index_documents: indexing pipeline is not initialised. "
                 "Daemon must complete startup() before serving writes."
@@ -3723,7 +3800,22 @@ class SearchDaemon:
         def _scrub(value: str) -> str:
             return value.replace("\x00", "") if "\x00" in value else value
 
-        indexed = 0
+        async def _index_one(vp_clean: str, text_clean: str, path_id: str) -> None:
+            # Drive the canonical write path. Pass the zone-scoped form
+            # so the pipeline's scope filter sees the same shape mutation
+            # consumers use.
+            scoped_path = (
+                f"/zone/{target_zone}{vp_clean}" if target_zone != ROOT_ZONE_ID else vp_clean
+            )
+            pipeline_result = await pipeline.index_document(scoped_path, text_clean, path_id)
+            if pipeline_result.error:
+                # Surface pipeline errors so the router returns 500.
+                raise RuntimeError(
+                    f"index_documents: pipeline failed for {vp_clean!r}: {pipeline_result.error}"
+                )
+            result.indexed += 1
+
+        pending: list[tuple[str, str]] = []  # (vp_clean, text_clean) awaiting a row
         for doc in documents:
             if not isinstance(doc, dict):
                 continue
@@ -3737,57 +3829,52 @@ class SearchDaemon:
             text_clean = _scrub(text_field)
             vp_clean = strip_zone_prefix(virtual_path)
 
-            # Resolve path_id from file_paths so the indexing pipeline can
-            # write document_chunks. Without a path_id we cannot persist —
-            # skip rather than fail so best-effort callers in mount/connector
-            # wiring don't error out. The search daemon is a READER of
-            # filesystem metadata — it must not create or modify file_paths
-            # rows (that ownership belongs to the kernel/metastore).
-            path_id: str | None = None
-            if self._async_session is not None:
-                async with self._async_session() as session:
-                    row = (
-                        await session.execute(
-                            sa_text(
-                                "SELECT path_id FROM file_paths "
-                                "WHERE virtual_path = :vp "
-                                "  AND zone_id = :zid "
-                                "  AND deleted_at IS NULL "
-                                "LIMIT 1"
-                            ),
-                            {"vp": vp_clean, "zid": target_zone},
-                        )
-                    ).first()
-                    if row is not None:
-                        path_id = str(row[0])
-
+            path_id = await self._resolve_index_path_id(vp_clean, target_zone)
             if path_id is None:
-                # No file_paths row — this happens for synthetic docs
-                # (skill READMEs, connector schemas) that aren't backed
-                # by NexusFS. Skip rather than fail so best-effort callers
-                # in mount/connector wiring don't error out.
-                logger.debug(
-                    "index_documents: no file_paths row for %s in zone %s; skipping",
-                    vp_clean,
-                    target_zone,
-                )
+                pending.append((vp_clean, text_clean))
                 continue
+            await _index_one(vp_clean, text_clean, path_id)
 
-            # Drive the canonical write path. Pass the zone-scoped form
-            # so the pipeline's scope filter sees the same shape mutation
-            # consumers use.
-            scoped_path = (
-                f"/zone/{target_zone}{vp_clean}" if target_zone != ROOT_ZONE_ID else vp_clean
+        # Issue #4566: bounded wait for the projection row. The wait budget is
+        # per BATCH, not per document — each round re-polls every unresolved
+        # path once, so the worst-case added latency is attempts × delay
+        # regardless of batch size. Without a session the lookup can never
+        # succeed, so skip the wait entirely instead of sleeping for nothing.
+        wait_rounds = max(0, self.config.index_path_wait_attempts)
+        wait_seconds = max(0.0, self.config.index_path_wait_seconds)
+        if pending and wait_rounds > 0 and self._async_session is not None:
+            for _round in range(wait_rounds):
+                await asyncio.sleep(wait_seconds)
+                still_pending: list[tuple[str, str]] = []
+                for vp_clean, text_clean in pending:
+                    path_id = await self._resolve_index_path_id(vp_clean, target_zone)
+                    if path_id is None:
+                        still_pending.append((vp_clean, text_clean))
+                        continue
+                    self.stats.explicit_index_path_waits += 1
+                    await _index_one(vp_clean, text_clean, path_id)
+                pending = still_pending
+                if not pending:
+                    break
+
+        if pending:
+            # No file_paths row even after the bounded wait — synthetic docs
+            # (connector-backed mount content) or a projection lag beyond the
+            # configured budget. Surface the paths instead of silently
+            # shrinking the count: the HTTP route fails closed on these and
+            # best-effort callers (mount/connector wiring) just log.
+            result.skipped = [vp for vp, _ in pending]
+            self.stats.explicit_index_skipped_no_path += len(pending)
+            logger.warning(
+                "index_documents: %d document(s) had no file_paths row after %d wait "
+                "round(s) in zone %s — text NOT indexed: %s",
+                len(pending),
+                wait_rounds if self._async_session is not None else 0,
+                target_zone,
+                result.skipped[:10],
             )
-            result = await self._indexing_pipeline.index_document(scoped_path, text_clean, path_id)
-            if result.error:
-                # Surface pipeline errors so the router returns 500.
-                raise RuntimeError(
-                    f"index_documents: pipeline failed for {vp_clean!r}: {result.error}"
-                )
-            indexed += 1
 
-        return indexed
+        return result
 
     async def delete_documents(
         self,

--- a/src/nexus/server/api/v2/routers/search.py
+++ b/src/nexus/server/api/v2/routers/search.py
@@ -1588,6 +1588,13 @@ async def search_index_documents(
     Fails closed with HTTP 500 if the underlying backend cannot persist
     (e.g., config path unwritable, PostgreSQL commit failed), so clients
     can retry instead of silently losing data.
+
+    Issue #4566: documents whose ``file_paths`` projection row hasn't landed
+    yet (write-then-index races the operation-log consumer) get a bounded
+    server-side wait; anything still unresolved fails closed with HTTP 409
+    and ``detail.skipped`` listing the affected paths. Indexing is
+    idempotent, so retrying the whole batch after a 409 is safe — documents
+    indexed before the 409 stay indexed.
     """
     from nexus.contracts.constants import ROOT_ZONE_ID
 
@@ -1599,13 +1606,29 @@ async def search_index_documents(
 
     async def _work() -> dict[str, Any]:
         try:
-            count = await search_daemon.index_documents(documents, zone_id=zone_id)
+            result = await search_daemon.index_documents(documents, zone_id=zone_id)
         except Exception as exc:
             logger.error("index_documents failed: %s", exc, exc_info=True)
             raise HTTPException(
                 status_code=500,
                 detail=f"Index persistence failed: {type(exc).__name__}: {exc}",
             ) from exc
+        # ``getattr`` fallbacks keep int-returning test doubles working.
+        count = getattr(result, "indexed", result)
+        skipped = list(getattr(result, "skipped", []) or [])
+        if skipped:
+            raise HTTPException(
+                status_code=409,
+                detail={
+                    "error": (
+                        "documents skipped: no live file_paths row after the bounded "
+                        "projection wait — retry once the write is visible"
+                    ),
+                    "count": count,
+                    "skipped": skipped,
+                    "zone_id": zone_id,
+                },
+            )
         return {"status": "indexed", "count": count, "zone_id": zone_id}
 
     return await run_zone_scoped(_get_zone_registry(request), _auth_target_zone(auth_result), _work)

--- a/tests/integration/search/test_connector_search_indexing.py
+++ b/tests/integration/search/test_connector_search_indexing.py
@@ -1,337 +1,245 @@
-"""Integration test: connector sync → search indexing → semantic search.
+"""Integration test: connector sync → search indexing submission.
 
-Validates the full e2e flow from Issue #3148:
-  mount connector → sync → _index_mount_content → search_daemon.index_documents → search
+Validates the mount-side half of the Issue #3148 flow:
+  mount connector → _index_mount_content → SearchDaemon.index_documents
 
-Uses mock connector backend + real SearchDaemon with mock txtai backend.
+Rewritten for the post-#3699/#4566 architecture (was asserting the old
+txtai ``_backend.upsert`` daemon shape and a MountService constructor that
+no longer exists):
+
+- files are enumerated via the Rust kernel's ``sys_readdir`` BFS, read via
+  the SYNC ``nx.sys_read``, and submitted to ``SearchDaemon.index_documents``;
+- the daemon returns ``ExplicitIndexResult {indexed, skipped}`` (#4566) —
+  connector-backed paths with no ``file_paths`` row come back in ``skipped``
+  and the mount hook logs them instead of failing (best-effort contract);
+- what happens INSIDE the daemon (path_id resolution, bounded projection
+  wait, pipeline write) is covered by
+  ``tests/unit/bricks/search/test_daemon_explicit_index_path_wait.py``.
 """
 
+from __future__ import annotations
+
+import logging
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from nexus.bricks.search.daemon import SearchDaemon
+from nexus.bricks.search.daemon import ExplicitIndexResult
 from nexus.contracts.constants import ROOT_ZONE_ID
+
+DT_DIR = 1  # kernel entry_type constant mirrored in mount_service BFS
 
 # ── Helpers ──────────────────────────────────────────────────────────
 
 
-def _make_search_daemon(search_results=None):
-    """Create a SearchDaemon with a mock txtai backend."""
-    daemon = SearchDaemon()
-    daemon._initialized = True
-    daemon._backend = AsyncMock()
-    daemon._backend.upsert.return_value = 3
-    daemon._backend.last_rerank_ms = 0.0
-
-    if search_results is not None:
-        daemon._backend.search.return_value = search_results
-    else:
-        from nexus.bricks.search.results import BaseSearchResult
-
-        daemon._backend.search.return_value = [
-            BaseSearchResult(
-                path="/mnt/gmail/INBOX/tid1-mid1.yaml",
-                chunk_text="subject: Project Update\nfrom: alice@example.com\nsnippet: Q1 results",
-                score=0.92,
-            ),
-        ]
+def _make_daemon(result: ExplicitIndexResult | None = None) -> MagicMock:
+    daemon = MagicMock()
+    daemon.index_documents = AsyncMock(
+        return_value=result if result is not None else ExplicitIndexResult(indexed=0, skipped=[])
+    )
     return daemon
 
 
-def _make_mock_backend(dir_tree: dict[str, list[str]]):
-    """Create a mock connector backend with list_dir returning the given tree.
+def _make_search_service(daemon: Any) -> MagicMock:
+    search_svc = MagicMock()
+    search_svc._search_daemon = daemon
+    return search_svc
+
+
+def _make_nexus_fs(
+    dir_tree: dict[str, list[tuple[str, int]]],
+    file_contents: dict[str, str],
+) -> MagicMock:
+    """Mock NexusFS with a kernel readdir BFS and a SYNC sys_read.
 
     Args:
-        dir_tree: Mapping of backend_path → list of entries.
-            Directories end with '/'. Root is ''.
-            Example: {'': ['INBOX/', 'SENT/'], 'INBOX': ['msg1.yaml', 'msg2.yaml']}
+        dir_tree: Mapping of directory path → [(child_path, entry_type)].
+        file_contents: Mapping of file path → text content.
     """
-    backend = MagicMock()
+    nx = MagicMock()
 
-    def list_dir(path="", context=None):
-        return dir_tree.get(path.strip("/") if path else "", [])
+    def _sys_readdir(prefix: str, zone_id: str) -> list[tuple[str, int]]:
+        if prefix not in dir_tree:
+            raise FileNotFoundError(prefix)
+        return dir_tree[prefix]
 
-    backend.list_dir = list_dir
-    return backend
+    nx._kernel.sys_readdir = MagicMock(side_effect=_sys_readdir)
 
+    def _sys_read(path: str, context: Any = None) -> bytes:
+        return file_contents.get(path, "").encode("utf-8")
 
-def _make_mock_router(backend):
-    """Create a mock router that returns the given backend for any path."""
-    route = MagicMock()
-    route.backend = backend
-
-    router = MagicMock()
-    router.route.return_value = route
-    return router
-
-
-def _make_mock_nexus_fs(file_contents):
-    """Create a mock NexusFS that returns content for sys_read."""
-
-    async def mock_sys_read(path, context=None):
-        content = file_contents.get(path, "")
-        if isinstance(content, str):
-            content = content.encode("utf-8")
-        return content
-
-    nx = AsyncMock()
-    nx.sys_read = mock_sys_read
+    nx.sys_read = MagicMock(side_effect=_sys_read)
     return nx
 
+
+def _make_mount_service(nx: Any, search_svc: Any) -> Any:
+    from nexus.bricks.mount.mount_service import MountService
+
+    return MountService(
+        mount_manager=MagicMock(),
+        nexus_fs=nx,
+        search_service=search_svc,
+    )
+
+
+_GMAIL_TREE: dict[str, list[tuple[str, int]]] = {
+    "/mnt/gmail": [("/mnt/gmail/INBOX", DT_DIR), ("/mnt/gmail/SENT", DT_DIR)],
+    "/mnt/gmail/INBOX": [
+        ("/mnt/gmail/INBOX/tid1-mid1.yaml", 0),
+        ("/mnt/gmail/INBOX/tid2-mid2.yaml", 0),
+    ],
+    "/mnt/gmail/SENT": [("/mnt/gmail/SENT/tid3-mid3.yaml", 0)],
+}
+
+_GMAIL_CONTENTS = {
+    "/mnt/gmail/INBOX/tid1-mid1.yaml": (
+        "subject: Project Update\nfrom: alice@example.com\nsnippet: Q1 results are in"
+    ),
+    "/mnt/gmail/INBOX/tid2-mid2.yaml": (
+        "subject: Meeting Notes\nfrom: bob@example.com\nsnippet: Action items from standup"
+    ),
+    "/mnt/gmail/SENT/tid3-mid3.yaml": (
+        "subject: Re: Budget\nto: carol@example.com\nsnippet: Approved the budget request"
+    ),
+}
 
 # ── Tests ────────────────────────────────────────────────────────────
 
 
 class TestConnectorSearchIndexing:
-    """Test connector content gets indexed and is searchable."""
+    """Mount-content indexing submits the right documents to the daemon."""
 
     @pytest.mark.asyncio
-    async def test_index_mount_content_indexes_connector_files(self):
-        """_index_mount_content uses list_dir BFS and indexes via search daemon."""
-        from nexus.bricks.mount.mount_service import MountService
+    async def test_index_mount_content_indexes_connector_files(self) -> None:
+        """BFS enumeration + content read → one index_documents call."""
+        daemon = _make_daemon(ExplicitIndexResult(indexed=3, skipped=[]))
+        nx = _make_nexus_fs(_GMAIL_TREE, _GMAIL_CONTENTS)
+        mount_svc = _make_mount_service(nx, _make_search_service(daemon))
 
-        file_contents = {
-            "/mnt/gmail/INBOX/tid1-mid1.yaml": (
-                "subject: Project Update\nfrom: alice@example.com\nsnippet: Q1 results are in"
-            ),
-            "/mnt/gmail/INBOX/tid2-mid2.yaml": (
-                "subject: Meeting Notes\nfrom: bob@example.com\nsnippet: Action items from standup"
-            ),
-            "/mnt/gmail/SENT/tid3-mid3.yaml": (
-                "subject: Re: Budget\nto: carol@example.com\nsnippet: Approved the budget request"
-            ),
-        }
+        await mount_svc._index_mount_content("/mnt/gmail")
 
-        backend = _make_mock_backend(
-            {
-                "": ["INBOX/", "SENT/"],
-                "INBOX": ["tid1-mid1.yaml", "tid2-mid2.yaml"],
-                "SENT": ["tid3-mid3.yaml"],
-            }
-        )
-        router = _make_mock_router(backend)
-        nx = _make_mock_nexus_fs(file_contents)
-        daemon = _make_search_daemon()
-
-        search_svc = MagicMock()
-        search_svc._search_daemon = daemon
-
-        mount_svc = MountService(
-            router=router,
-            mount_manager=MagicMock(),
-            nexus_fs=nx,
-            gateway=MagicMock(),
-            sync_service=MagicMock(),
-            search_service=search_svc,
-        )
-
-        await mount_svc._index_mount_content(
-            "/mnt/gmail",
-        )
-
-        # Assert: search daemon received 3 documents in correct format
-        daemon._backend.upsert.assert_awaited_once()
-        call_args = daemon._backend.upsert.call_args
-        documents = call_args[0][0]
-
-        assert len(documents) == 3
-        for doc in documents:
-            assert "id" in doc
-            assert "text" in doc
-            assert "path" in doc
-            assert doc["id"] == doc["path"]
-            assert doc["id"].startswith("/mnt/gmail/")
-            assert len(doc["text"]) > 10
-
+        daemon.index_documents.assert_awaited_once()
+        documents = daemon.index_documents.call_args[0][0]
+        assert daemon.index_documents.call_args.kwargs["zone_id"] == ROOT_ZONE_ID
+        assert {d["id"] for d in documents} == set(_GMAIL_CONTENTS)
+        assert all(d["path"] == d["id"] for d in documents)
         inbox_docs = [d for d in documents if "INBOX" in d["id"]]
-        assert len(inbox_docs) == 2
-        assert any("Project Update" in d["text"] for d in inbox_docs)
         assert any("Meeting Notes" in d["text"] for d in inbox_docs)
 
     @pytest.mark.asyncio
-    async def test_index_mount_content_skips_non_text_files(self):
-        """Only .yaml/.json/.md/.txt files should be indexed."""
-        from nexus.bricks.mount.mount_service import MountService
-
-        file_contents = {
+    async def test_index_mount_content_skips_non_text_files(self) -> None:
+        """Only .yaml/.json/.md/.txt files should be submitted."""
+        tree = {
+            "/mnt/gmail": [("/mnt/gmail/INBOX", DT_DIR)],
+            "/mnt/gmail/INBOX": [
+                ("/mnt/gmail/INBOX/msg1.yaml", 0),
+                ("/mnt/gmail/INBOX/msg2.png", 0),
+                ("/mnt/gmail/INBOX/msg3.bin", 0),
+                ("/mnt/gmail/INBOX/notes.md", 0),
+            ],
+        }
+        contents = {
             "/mnt/gmail/INBOX/msg1.yaml": "subject: Test email\nsnippet: Hello world",
             "/mnt/gmail/INBOX/notes.md": "# Meeting notes\nDiscussed project timeline",
         }
-
-        backend = _make_mock_backend(
-            {
-                "": ["INBOX/"],
-                "INBOX": ["msg1.yaml", "msg2.png", "msg3.bin", "notes.md"],
-            }
-        )
-        router = _make_mock_router(backend)
-        nx = _make_mock_nexus_fs(file_contents)
-        daemon = _make_search_daemon()
-
-        search_svc = MagicMock()
-        search_svc._search_daemon = daemon
-
-        mount_svc = MountService(
-            router=router,
-            mount_manager=MagicMock(),
-            nexus_fs=nx,
-            gateway=MagicMock(),
-            sync_service=MagicMock(),
-            search_service=search_svc,
+        daemon = _make_daemon(ExplicitIndexResult(indexed=2, skipped=[]))
+        mount_svc = _make_mount_service(
+            _make_nexus_fs(tree, contents), _make_search_service(daemon)
         )
 
-        await mount_svc._index_mount_content(
-            "/mnt/gmail",
-        )
+        await mount_svc._index_mount_content("/mnt/gmail")
 
-        call_args = daemon._backend.upsert.call_args
-        documents = call_args[0][0]
-        assert len(documents) == 2
-        paths = {d["id"] for d in documents}
-        assert "/mnt/gmail/INBOX/msg1.yaml" in paths
-        assert "/mnt/gmail/INBOX/notes.md" in paths
-
-    @pytest.mark.asyncio
-    async def test_index_then_search_finds_connector_content(self):
-        """Full round-trip: index connector content → search finds it."""
-        from nexus.bricks.search.results import BaseSearchResult
-
-        daemon = _make_search_daemon()
-
-        docs = [
-            {
-                "id": "/mnt/gmail/INBOX/tid1-mid1.yaml",
-                "text": "subject: Q1 Budget Review\nfrom: cfo@company.com\nsnippet: Please review the Q1 budget numbers",
-                "path": "/mnt/gmail/INBOX/tid1-mid1.yaml",
-            },
-            {
-                "id": "/mnt/gmail/INBOX/tid2-mid2.yaml",
-                "text": "subject: Standup Notes\nfrom: pm@company.com\nsnippet: Sprint retrospective action items",
-                "path": "/mnt/gmail/INBOX/tid2-mid2.yaml",
-            },
-            {
-                "id": "/mnt/gmail/SENT/tid3-mid3.yaml",
-                "text": "subject: Re: Q1 Budget\nto: cfo@company.com\nsnippet: Budget approved with modifications",
-                "path": "/mnt/gmail/SENT/tid3-mid3.yaml",
-            },
-        ]
-
-        count = await daemon.index_documents(docs)
-        assert count == 3
-
-        daemon._backend.search.return_value = [
-            BaseSearchResult(
-                path="/mnt/gmail/INBOX/tid1-mid1.yaml",
-                chunk_text="Q1 Budget Review",
-                score=0.95,
-            ),
-            BaseSearchResult(
-                path="/mnt/gmail/SENT/tid3-mid3.yaml",
-                chunk_text="Budget approved with modifications",
-                score=0.88,
-            ),
-        ]
-
-        results = await daemon.search("budget review Q1", zone_id=ROOT_ZONE_ID)
-        assert len(results) == 2
-        assert results[0].path == "/mnt/gmail/INBOX/tid1-mid1.yaml"
-        assert results[0].score > results[1].score
-
-        await daemon.shutdown()
-
-    @pytest.mark.asyncio
-    async def test_delta_sync_new_emails_get_indexed(self):
-        """After delta sync adds new emails, they should be indexed."""
-        from nexus.bricks.mount.mount_service import MountService
-
-        file_contents = {
-            "/mnt/gmail/INBOX/tid1-mid1.yaml": "subject: Old email\nsnippet: Already indexed content",
-            "/mnt/gmail/INBOX/tid2-mid2.yaml": "subject: Another old email\nsnippet: Previously indexed",
-            "/mnt/gmail/INBOX/tid3-mid3.yaml": "subject: New email just arrived\nsnippet: Fresh content from delta sync",
+        documents = daemon.index_documents.call_args[0][0]
+        assert {d["id"] for d in documents} == {
+            "/mnt/gmail/INBOX/msg1.yaml",
+            "/mnt/gmail/INBOX/notes.md",
         }
 
-        # Backend now lists 3 files (including the new one after delta sync)
-        backend = _make_mock_backend(
-            {
-                "": ["INBOX/"],
-                "INBOX": ["tid1-mid1.yaml", "tid2-mid2.yaml", "tid3-mid3.yaml"],
-            }
-        )
-        router = _make_mock_router(backend)
-        nx = _make_mock_nexus_fs(file_contents)
-        daemon = _make_search_daemon()
+    @pytest.mark.asyncio
+    async def test_zone_id_threaded_to_daemon(self) -> None:
+        """The sync-context zone must reach index_documents so zone-isolated
+        search queries can find the indexed content."""
+        daemon = _make_daemon(ExplicitIndexResult(indexed=3, skipped=[]))
+        nx = _make_nexus_fs(_GMAIL_TREE, _GMAIL_CONTENTS)
+        mount_svc = _make_mount_service(nx, _make_search_service(daemon))
 
-        search_svc = MagicMock()
-        search_svc._search_daemon = daemon
+        await mount_svc._index_mount_content("/mnt/gmail", zone_id="corp")
 
-        mount_svc = MountService(
-            router=router,
-            mount_manager=MagicMock(),
-            nexus_fs=nx,
-            gateway=MagicMock(),
-            sync_service=MagicMock(),
-            search_service=search_svc,
-        )
-
-        await mount_svc._index_mount_content(
-            "/mnt/gmail",
-        )
-
-        call_args = daemon._backend.upsert.call_args
-        documents = call_args[0][0]
-        assert len(documents) == 3
-        new_doc = [d for d in documents if "tid3-mid3" in d["id"]]
-        assert len(new_doc) == 1
-        assert "Fresh content from delta sync" in new_doc[0]["text"]
+        assert daemon.index_documents.call_args.kwargs["zone_id"] == "corp"
+        # BFS must also enumerate in the same zone.
+        assert nx._kernel.sys_readdir.call_args_list[0][0][1] == "corp"
 
     @pytest.mark.asyncio
-    async def test_fallback_to_semantic_search_index_when_no_daemon(self):
-        """When _search_daemon is None, falls back to semantic_search_index."""
-        from nexus.bricks.mount.mount_service import MountService
+    async def test_skipped_documents_are_logged_not_raised(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """#4566: connector paths without file_paths rows come back in
+        ``skipped``. The mount hook is best-effort — it must log the skip
+        count and keep the mount alive, never raise."""
+        daemon = _make_daemon(
+            ExplicitIndexResult(indexed=1, skipped=["/mnt/gmail/INBOX/tid2-mid2.yaml"])
+        )
+        nx = _make_nexus_fs(_GMAIL_TREE, _GMAIL_CONTENTS)
+        mount_svc = _make_mount_service(nx, _make_search_service(daemon))
 
+        with caplog.at_level(logging.INFO, logger="nexus.bricks.mount.mount_service"):
+            await mount_svc._index_mount_content("/mnt/gmail")
+
+        assert any("skipped=1" in record.getMessage() for record in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_no_files_found_returns_without_indexing(self) -> None:
+        """Unreadable mount root (readdir raises) → no daemon call, no crash."""
+        daemon = _make_daemon()
+        nx = _make_nexus_fs({}, {})  # every readdir raises FileNotFoundError
+        mount_svc = _make_mount_service(nx, _make_search_service(daemon))
+
+        await mount_svc._index_mount_content("/mnt/gmail")
+
+        daemon.index_documents.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_fallback_to_semantic_search_index_when_no_daemon(self) -> None:
+        """When _search_daemon is None, falls back to semantic_search_index."""
         search_svc = MagicMock()
         search_svc._search_daemon = None
         search_svc.semantic_search_index = AsyncMock(return_value={"/mnt/gmail": 50})
+        mount_svc = _make_mount_service(_make_nexus_fs({}, {}), search_svc)
 
-        mount_svc = MountService(
-            router=MagicMock(),
-            mount_manager=MagicMock(),
-            gateway=MagicMock(),
-            sync_service=MagicMock(),
-            search_service=search_svc,
-        )
-
-        await mount_svc._index_mount_content(
-            "/mnt/gmail",
-        )
+        await mount_svc._index_mount_content("/mnt/gmail")
 
         search_svc.semantic_search_index.assert_awaited_once_with("/mnt/gmail", recursive=True)
 
     @pytest.mark.asyncio
-    async def test_index_mount_content_no_backend_returns_early(self):
-        """When router can't resolve a backend, indexing returns without error."""
-        from nexus.bricks.mount.mount_service import MountService
-
-        router = MagicMock()
-        router.route.return_value = None  # No route found
-
-        daemon = _make_search_daemon()
-        search_svc = MagicMock()
-        search_svc._search_daemon = daemon
-
-        mount_svc = MountService(
-            router=router,
-            mount_manager=MagicMock(),
-            nexus_fs=_make_mock_nexus_fs({}),
-            gateway=MagicMock(),
-            sync_service=MagicMock(),
-            search_service=search_svc,
+    async def test_delta_sync_new_emails_get_submitted(self) -> None:
+        """After delta sync adds a new email, the next indexing pass submits
+        all listed files — the daemon's chunk upsert is idempotent, so
+        re-submitting already-indexed docs is safe."""
+        tree = {
+            "/mnt/gmail": [("/mnt/gmail/INBOX", DT_DIR)],
+            "/mnt/gmail/INBOX": [
+                ("/mnt/gmail/INBOX/tid1-mid1.yaml", 0),
+                ("/mnt/gmail/INBOX/tid2-mid2.yaml", 0),
+                ("/mnt/gmail/INBOX/tid3-mid3.yaml", 0),
+            ],
+        }
+        contents = {
+            "/mnt/gmail/INBOX/tid1-mid1.yaml": "subject: Old email\nsnippet: Already indexed",
+            "/mnt/gmail/INBOX/tid2-mid2.yaml": "subject: Another old\nsnippet: Previously done",
+            "/mnt/gmail/INBOX/tid3-mid3.yaml": (
+                "subject: New email just arrived\nsnippet: Fresh content from delta sync"
+            ),
+        }
+        daemon = _make_daemon(ExplicitIndexResult(indexed=3, skipped=[]))
+        mount_svc = _make_mount_service(
+            _make_nexus_fs(tree, contents), _make_search_service(daemon)
         )
 
-        await mount_svc._index_mount_content(
-            "/mnt/gmail",
-        )
+        await mount_svc._index_mount_content("/mnt/gmail")
 
-        # Should not crash; upsert should not be called
-        daemon._backend.upsert.assert_not_awaited()
+        documents = daemon.index_documents.call_args[0][0]
+        assert len(documents) == 3
+        new_doc = [d for d in documents if "tid3-mid3" in d["id"]]
+        assert len(new_doc) == 1
+        assert "Fresh content from delta sync" in new_doc[0]["text"]

--- a/tests/unit/bricks/search/test_daemon_consumer_covered_gate.py
+++ b/tests/unit/bricks/search/test_daemon_consumer_covered_gate.py
@@ -1,12 +1,16 @@
-"""Unit tests for the covered-version consumer gate (Issue #4566 follow-up).
+"""Unit tests for the covered-version indexer gate (Issue #4566 follow-up).
 
 Explicit ``POST /search/index`` calls stamp ``file_paths.indexed_content_id``
-after a successful write. The mutation consumers must skip an UPSERT whose
-row's CURRENT ``content_id`` already matches that marker — otherwise the
-consumer's blob-bytes indexing clobbers the richer caller-provided text
-(PDF extraction, OCR output, sidecar markdown). A real content change
-advances ``content_id``, the marker stops matching, and consumers index the
-new version normally.
+and ``last_indexed_at`` after a successful write. The mutation consumers AND
+the legacy refresh loop must skip an UPSERT whose row is covered — otherwise
+their blob-bytes indexing clobbers the richer caller-provided text (PDF
+extraction, OCR output, sidecar markdown). Covered means BOTH:
+
+- ``indexed_content_id == content_id`` (the marker), AND
+- ``last_indexed_at >= updated_at`` (freshness) — required because some
+  backends store an identity-style ``content_id`` (the local backend uses
+  the path, unchanged across rewrites), where marker equality alone would
+  latch coverage forever and edits would silently stop being re-indexed.
 """
 
 from __future__ import annotations
@@ -104,17 +108,23 @@ def _stub_resolution(daemon: SearchDaemon, mutations: list[Any]) -> None:
 class TestUpsertCoveredByIndex:
     @pytest.mark.asyncio
     async def test_covered_when_marker_matches_current_content(self) -> None:
-        daemon = _covered_daemon(("cid-1", "cid-1"))
+        daemon = _covered_daemon(("cid-1", "cid-1", 100, 150))
         assert await daemon._upsert_covered_by_index("pid-1") is True
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "row",
         [
-            ("cid-2", "cid-1"),  # content advanced past the marker
-            ("cid-1", None),  # never stamped
-            (None, None),  # no content at all
-            (None, "cid-1"),  # marker without content (defensive)
+            ("cid-2", "cid-1", 100, 150),  # content advanced past the marker
+            ("cid-1", None, 100, 150),  # never stamped
+            (None, None, 100, 150),  # no content at all
+            (None, "cid-1", 100, 150),  # marker without content (defensive)
+            # THE EDIT CASE: marker still equals content_id (identity-style
+            # content_id backends never change it) but the row was written
+            # AFTER the last index pass — must re-index, not skip.
+            ("cid-1", "cid-1", 200, 150),
+            ("cid-1", "cid-1", 100, None),  # marker set but never time-stamped
+            ("cid-1", "cid-1", None, 150),  # no updated_at (defensive)
             None,  # row deleted under us
         ],
     )
@@ -132,7 +142,7 @@ class TestUpsertCoveredByIndex:
     @pytest.mark.asyncio
     async def test_lookup_error_fails_open(self) -> None:
         """DB errors must not block consumer indexing (pre-gate behavior)."""
-        daemon = _covered_daemon(("cid-1", "cid-1"), raise_on_execute=True)
+        daemon = _covered_daemon(("cid-1", "cid-1", 100, 150), raise_on_execute=True)
         assert await daemon._upsert_covered_by_index("pid-1") is False
 
 
@@ -144,7 +154,7 @@ class TestUpsertCoveredByIndex:
 class TestEmbeddingConsumerGate:
     @pytest.mark.asyncio
     async def test_covered_upsert_skips_pipeline(self) -> None:
-        daemon = _covered_daemon(("cid-1", "cid-1"))
+        daemon = _covered_daemon(("cid-1", "cid-1", 100, 150))
         daemon._indexing_pipeline = MagicMock(index_document=AsyncMock())
         daemon._embedding_provider = MagicMock()
         daemon._chunk_store = MagicMock(replace_document_chunks=AsyncMock())
@@ -159,7 +169,7 @@ class TestEmbeddingConsumerGate:
 
     @pytest.mark.asyncio
     async def test_uncovered_upsert_reaches_pipeline(self) -> None:
-        daemon = _covered_daemon(("cid-2", "cid-1"))
+        daemon = _covered_daemon(("cid-2", "cid-1", 100, 150))
         pipeline_result = MagicMock(error=None, chunks_indexed=1)
         daemon._indexing_pipeline = MagicMock(
             index_document=AsyncMock(return_value=pipeline_result)
@@ -194,14 +204,75 @@ class TestFtsConsumerGate:
 
     @pytest.mark.asyncio
     async def test_covered_upsert_skips_chunk_write(self) -> None:
-        daemon, chunk_writes = self._fts_daemon(("cid-1", "cid-1"))
+        daemon, chunk_writes = self._fts_daemon(("cid-1", "cid-1", 100, 150))
         await daemon._consume_fts_mutations([MagicMock()])
         assert chunk_writes == []
         assert daemon.stats.mutation_upserts_skipped_covered == 1
 
     @pytest.mark.asyncio
     async def test_uncovered_upsert_writes_chunks(self) -> None:
-        daemon, chunk_writes = self._fts_daemon(("cid-2", "cid-1"))
+        daemon, chunk_writes = self._fts_daemon(("cid-2", "cid-1", 100, 150))
         await daemon._consume_fts_mutations([MagicMock()])
         assert chunk_writes == [("pid-1", "/zone/z1/doc.pdf", "raw blob bytes")]
+        assert daemon.stats.mutation_upserts_skipped_covered == 0
+
+
+class _DispatchSession:
+    """Session for _refresh_indexes: routes each query shape to its row."""
+
+    def __init__(self, covered_row: tuple[Any, ...] | None) -> None:
+        self._covered_row = covered_row
+
+    async def __aenter__(self) -> "_DispatchSession":
+        return self
+
+    async def __aexit__(self, *exc_info: Any) -> None:
+        return None
+
+    async def execute(self, stmt: Any, params: dict[str, Any] | None = None) -> _Result:
+        sql = str(stmt)
+        if "indexed_content_id" in sql:
+            return _Result(self._covered_row)
+        if "SELECT fp.path_id" in sql:
+            return _Result(("pid-1",))
+        return _Result(None)
+
+
+class _FakeFileReader:
+    async def read_text(self, path: str) -> str:
+        return "raw blob bytes from refresh"
+
+
+class TestLegacyRefreshGate:
+    """The legacy refresh loop fires on EVERY VFS write (post-write hook),
+    so it was the live clobberer of explicit /search/index text — it must
+    honor the same covered gate as the consumers."""
+
+    def _refresh_daemon(self, covered_row: tuple[Any, ...] | None) -> SearchDaemon:
+        daemon = SearchDaemon.__new__(SearchDaemon)
+        daemon.stats = DaemonStats()
+        daemon._async_session = lambda: _DispatchSession(covered_row)
+        daemon._file_reader = _FakeFileReader()
+        pipeline_result = MagicMock(error=None, chunks_indexed=1)
+        daemon._indexing_pipeline = MagicMock(
+            index_document=AsyncMock(return_value=pipeline_result)
+        )
+        daemon._embedding_provider = MagicMock()
+        setattr(daemon, "_is_path_in_scope", lambda p: True)  # noqa: B010
+        return daemon
+
+    @pytest.mark.asyncio
+    async def test_covered_path_skips_refresh_reindex(self) -> None:
+        daemon = self._refresh_daemon(("cid-1", "cid-1", 100, 150))
+        await daemon._refresh_indexes(["/doc.pdf"])
+        daemon._indexing_pipeline.index_document.assert_not_called()
+        assert daemon.stats.mutation_upserts_skipped_covered == 1
+
+    @pytest.mark.asyncio
+    async def test_edited_path_still_reindexed(self) -> None:
+        """updated_at newer than last_indexed_at (a real edit) → refresh
+        must re-index even though the identity-style marker still matches."""
+        daemon = self._refresh_daemon(("cid-1", "cid-1", 200, 150))
+        await daemon._refresh_indexes(["/doc.pdf"])
+        daemon._indexing_pipeline.index_document.assert_awaited_once()
         assert daemon.stats.mutation_upserts_skipped_covered == 0

--- a/tests/unit/bricks/search/test_daemon_consumer_covered_gate.py
+++ b/tests/unit/bricks/search/test_daemon_consumer_covered_gate.py
@@ -1,0 +1,207 @@
+"""Unit tests for the covered-version consumer gate (Issue #4566 follow-up).
+
+Explicit ``POST /search/index`` calls stamp ``file_paths.indexed_content_id``
+after a successful write. The mutation consumers must skip an UPSERT whose
+row's CURRENT ``content_id`` already matches that marker — otherwise the
+consumer's blob-bytes indexing clobbers the richer caller-provided text
+(PDF extraction, OCR output, sidecar markdown). A real content change
+advances ``content_id``, the marker stops matching, and consumers index the
+new version normally.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from nexus.bricks.search.daemon import DaemonStats, SearchDaemon
+from nexus.bricks.search.mutation_events import SearchMutationOp
+
+# =============================================================================
+# Fakes
+# =============================================================================
+
+
+class _Result:
+    def __init__(self, row: tuple[Any, ...] | None) -> None:
+        self._row = row
+
+    def first(self) -> tuple[Any, ...] | None:
+        return self._row
+
+
+class _Session:
+    def __init__(self, row: tuple[Any, ...] | None, *, raise_on_execute: bool = False) -> None:
+        self._row = row
+        self._raise = raise_on_execute
+        self.calls: list[dict[str, Any]] = []
+
+    async def __aenter__(self) -> "_Session":
+        return self
+
+    async def __aexit__(self, *exc_info: Any) -> None:
+        return None
+
+    async def execute(self, stmt: Any, params: dict[str, Any] | None = None) -> _Result:
+        if self._raise:
+            raise RuntimeError("db down")
+        self.calls.append(dict(params or {}))
+        return _Result(self._row)
+
+
+@dataclass
+class _FakeMutEvent:
+    path: str
+    op: Any
+    event_id: str = "test-event"
+
+
+@dataclass
+class _FakeResolvedMutation:
+    event: _FakeMutEvent
+    path_id: str | None = None
+    content: str | None = None
+    zone_id: str | None = None
+    virtual_path: str = ""
+    content_resolved: bool = True
+
+
+def _covered_daemon(row: tuple[Any, ...] | None, *, raise_on_execute: bool = False) -> SearchDaemon:
+    daemon = SearchDaemon.__new__(SearchDaemon)
+    daemon.stats = DaemonStats()
+    daemon._async_session = lambda: _Session(row, raise_on_execute=raise_on_execute)
+    return daemon
+
+
+def _upsert_mutation(path: str = "/zone/z1/doc.pdf") -> _FakeResolvedMutation:
+    return _FakeResolvedMutation(
+        event=_FakeMutEvent(path=path, op=SearchMutationOp.UPSERT),
+        path_id="pid-1",
+        content="raw blob bytes",
+        zone_id="z1",
+        virtual_path="/doc.pdf",
+    )
+
+
+def _stub_resolution(daemon: SearchDaemon, mutations: list[Any]) -> None:
+    async def _resolve(_consumer: Any, _events: Any) -> list[Any]:
+        return mutations
+
+    # setattr keeps mypy quiet without a type:ignore (project policy).
+    setattr(daemon, "_resolve_mutations", _resolve)  # noqa: B010
+    setattr(daemon, "_has_resolved_path_id", lambda m: True)  # noqa: B010
+    setattr(daemon, "_is_path_in_scope", lambda p: True)  # noqa: B010
+
+
+# =============================================================================
+# _upsert_covered_by_index truth table
+# =============================================================================
+
+
+class TestUpsertCoveredByIndex:
+    @pytest.mark.asyncio
+    async def test_covered_when_marker_matches_current_content(self) -> None:
+        daemon = _covered_daemon(("cid-1", "cid-1"))
+        assert await daemon._upsert_covered_by_index("pid-1") is True
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "row",
+        [
+            ("cid-2", "cid-1"),  # content advanced past the marker
+            ("cid-1", None),  # never stamped
+            (None, None),  # no content at all
+            (None, "cid-1"),  # marker without content (defensive)
+            None,  # row deleted under us
+        ],
+    )
+    async def test_not_covered(self, row: tuple[Any, ...] | None) -> None:
+        daemon = _covered_daemon(row)
+        assert await daemon._upsert_covered_by_index("pid-1") is False
+
+    @pytest.mark.asyncio
+    async def test_no_session_is_not_covered(self) -> None:
+        daemon = SearchDaemon.__new__(SearchDaemon)
+        daemon.stats = DaemonStats()
+        daemon._async_session = None
+        assert await daemon._upsert_covered_by_index("pid-1") is False
+
+    @pytest.mark.asyncio
+    async def test_lookup_error_fails_open(self) -> None:
+        """DB errors must not block consumer indexing (pre-gate behavior)."""
+        daemon = _covered_daemon(("cid-1", "cid-1"), raise_on_execute=True)
+        assert await daemon._upsert_covered_by_index("pid-1") is False
+
+
+# =============================================================================
+# Consumer wiring
+# =============================================================================
+
+
+class TestEmbeddingConsumerGate:
+    @pytest.mark.asyncio
+    async def test_covered_upsert_skips_pipeline(self) -> None:
+        daemon = _covered_daemon(("cid-1", "cid-1"))
+        daemon._indexing_pipeline = MagicMock(index_document=AsyncMock())
+        daemon._embedding_provider = MagicMock()
+        daemon._chunk_store = MagicMock(replace_document_chunks=AsyncMock())
+        daemon._sqlite_vec_backend = None
+        _stub_resolution(daemon, [_upsert_mutation()])
+
+        await daemon._consume_embedding_mutations([MagicMock()])
+
+        daemon._indexing_pipeline.index_document.assert_not_called()
+        daemon._chunk_store.replace_document_chunks.assert_not_called()
+        assert daemon.stats.mutation_upserts_skipped_covered == 1
+
+    @pytest.mark.asyncio
+    async def test_uncovered_upsert_reaches_pipeline(self) -> None:
+        daemon = _covered_daemon(("cid-2", "cid-1"))
+        pipeline_result = MagicMock(error=None, chunks_indexed=1)
+        daemon._indexing_pipeline = MagicMock(
+            index_document=AsyncMock(return_value=pipeline_result)
+        )
+        daemon._embedding_provider = MagicMock()
+        daemon._chunk_store = MagicMock(replace_document_chunks=AsyncMock())
+        daemon._sqlite_vec_backend = None
+        _stub_resolution(daemon, [_upsert_mutation()])
+
+        await daemon._consume_embedding_mutations([MagicMock()])
+
+        daemon._indexing_pipeline.index_document.assert_awaited_once()
+        assert daemon.stats.mutation_upserts_skipped_covered == 0
+
+
+class TestFtsConsumerGate:
+    def _fts_daemon(self, row: tuple[Any, ...] | None) -> tuple[SearchDaemon, list[Any]]:
+        daemon = _covered_daemon(row)
+        # Embedding inactive → FTS consumer is the chunk writer.
+        daemon._indexing_pipeline = None
+        daemon._embedding_provider = None
+        daemon._chunk_store = MagicMock(delete_document_chunks=AsyncMock())
+        daemon._sqlite_vec_backend = None
+        _stub_resolution(daemon, [_upsert_mutation()])
+        chunk_writes: list[Any] = []
+
+        async def _record_chunks(path_id: str, path: str, content: str) -> None:
+            chunk_writes.append((path_id, path, content))
+
+        setattr(daemon, "_index_to_document_chunks", _record_chunks)  # noqa: B010
+        return daemon, chunk_writes
+
+    @pytest.mark.asyncio
+    async def test_covered_upsert_skips_chunk_write(self) -> None:
+        daemon, chunk_writes = self._fts_daemon(("cid-1", "cid-1"))
+        await daemon._consume_fts_mutations([MagicMock()])
+        assert chunk_writes == []
+        assert daemon.stats.mutation_upserts_skipped_covered == 1
+
+    @pytest.mark.asyncio
+    async def test_uncovered_upsert_writes_chunks(self) -> None:
+        daemon, chunk_writes = self._fts_daemon(("cid-2", "cid-1"))
+        await daemon._consume_fts_mutations([MagicMock()])
+        assert chunk_writes == [("pid-1", "/zone/z1/doc.pdf", "raw blob bytes")]
+        assert daemon.stats.mutation_upserts_skipped_covered == 0

--- a/tests/unit/bricks/search/test_daemon_explicit_index_path_wait.py
+++ b/tests/unit/bricks/search/test_daemon_explicit_index_path_wait.py
@@ -8,7 +8,9 @@ from "lost". These tests pin the fixed contract:
 
 - a row that lands within the bounded wait window is indexed;
 - a row that never lands is reported in ``skipped`` (not silently dropped);
-- a daemon without a DB session skips immediately without burning the wait.
+- a daemon without a DB session skips immediately without burning the wait;
+- a successful write stamps ``indexed_content_id`` so mutation consumers
+  treat the content version as covered (clobber-race follow-up).
 """
 
 from __future__ import annotations
@@ -34,11 +36,13 @@ class _Result:
 
 
 class _Session:
-    """Async session whose path_id lookups replay a scripted row sequence."""
+    """Async session that replays scripted SELECT rows and records UPDATEs."""
 
     def __init__(self, rows_by_call: list[tuple[Any, ...] | None]) -> None:
         self._rows_by_call = rows_by_call
-        self.calls: list[dict[str, Any]] = []
+        self.select_calls: list[dict[str, Any]] = []
+        self.update_calls: list[dict[str, Any]] = []
+        self.commits = 0
 
     async def __aenter__(self) -> "_Session":
         return self
@@ -47,9 +51,15 @@ class _Session:
         return None
 
     async def execute(self, stmt: Any, params: dict[str, Any] | None = None) -> _Result:
-        self.calls.append(dict(params or {}))
-        idx = min(len(self.calls) - 1, len(self._rows_by_call) - 1)
+        if str(stmt).lstrip().upper().startswith("UPDATE"):
+            self.update_calls.append(dict(params or {}))
+            return _Result(None)
+        self.select_calls.append(dict(params or {}))
+        idx = min(len(self.select_calls) - 1, len(self._rows_by_call) - 1)
         return _Result(self._rows_by_call[idx])
+
+    async def commit(self) -> None:
+        self.commits += 1
 
 
 class _SessionFactory:
@@ -61,18 +71,19 @@ class _SessionFactory:
 
 
 class _PipelineResult:
-    def __init__(self) -> None:
+    def __init__(self, chunks_indexed: int = 1) -> None:
         self.error: str | None = None
-        self.chunks_indexed = 1
+        self.chunks_indexed = chunks_indexed
 
 
 class _Pipeline:
-    def __init__(self) -> None:
+    def __init__(self, chunks_indexed: int = 1) -> None:
         self.calls: list[tuple[str, str, str]] = []
+        self._chunks_indexed = chunks_indexed
 
     async def index_document(self, path: str, content: str, path_id: str) -> _PipelineResult:
         self.calls.append((path, content, path_id))
-        return _PipelineResult()
+        return _PipelineResult(self._chunks_indexed)
 
 
 def _make_daemon(
@@ -80,6 +91,7 @@ def _make_daemon(
     *,
     attempts: int = 3,
     delay: float = 0.001,
+    chunks_indexed: int = 1,
 ) -> tuple[SearchDaemon, _Pipeline, _SessionFactory | None]:
     config = DaemonConfig(
         index_path_wait_attempts=attempts,
@@ -87,7 +99,7 @@ def _make_daemon(
     )
     factory = _SessionFactory(rows_by_call) if rows_by_call is not None else None
     daemon = SearchDaemon(config, async_session_factory=factory)
-    pipeline = _Pipeline()
+    pipeline = _Pipeline(chunks_indexed)
     daemon._indexing_pipeline = cast(Any, pipeline)
     daemon._initialized = True
     return daemon, pipeline, factory
@@ -118,7 +130,7 @@ class TestExplicitIndexPathWait:
         self, sleep_recorder: list[float]
     ) -> None:
         """Write-then-index: row missing on first lookup, lands on the second."""
-        daemon, pipeline, factory = _make_daemon([None, ("pid-1",)], attempts=3)
+        daemon, pipeline, factory = _make_daemon([None, ("pid-1", "cid-1")], attempts=3)
 
         result = await daemon.index_documents(
             [{"id": "1", "text": "zuluxx probe", "path": "/probe.md"}], zone_id="root"
@@ -144,7 +156,7 @@ class TestExplicitIndexPathWait:
         assert pipeline.calls == []
         # Initial lookup + one per wait round.
         assert factory is not None
-        assert len(factory.session.calls) == 3
+        assert len(factory.session.select_calls) == 3
         assert len(sleep_recorder) == 2
 
     @pytest.mark.asyncio
@@ -153,7 +165,7 @@ class TestExplicitIndexPathWait:
     ) -> None:
         daemon, pipeline, _ = _make_daemon(
             # /ok.md resolves immediately; /ghost.md never does.
-            [("pid-ok",), None, None, None],
+            [("pid-ok", "cid-ok"), None, None, None],
             attempts=2,
         )
 
@@ -198,7 +210,7 @@ class TestExplicitIndexPathWait:
 
     @pytest.mark.asyncio
     async def test_stats_counters_track_waits_and_skips(self, sleep_recorder: list[float]) -> None:
-        daemon, _, _ = _make_daemon([None, ("pid-1",), None, None], attempts=1)
+        daemon, _, _ = _make_daemon([None, ("pid-1", "cid-1")], attempts=1)
 
         await daemon.index_documents(
             [{"id": "1", "text": "late row", "path": "/late.md"}], zone_id="root"
@@ -222,3 +234,74 @@ class TestExplicitIndexPathWait:
         overridden = DaemonConfig()
         assert overridden.index_path_wait_attempts == 7
         assert overridden.index_path_wait_seconds == 0.5
+
+
+class TestExplicitIndexStampsCoveredVersion:
+    """#4566 follow-up: successful explicit index marks the content version
+    as covered (indexed_content_id = content_id) so mutation consumers do
+    not clobber the caller-provided text with raw blob bytes."""
+
+    @pytest.mark.asyncio
+    async def test_successful_index_stamps_indexed_content_id(self) -> None:
+        daemon, _, factory = _make_daemon([("pid-1", "cid-1")], attempts=0)
+
+        await daemon.index_documents(
+            [{"id": "1", "text": "extracted pdf text", "path": "/doc.pdf"}], zone_id="root"
+        )
+
+        assert factory is not None
+        assert len(factory.session.update_calls) == 1
+        stamp = factory.session.update_calls[0]
+        assert stamp["pid"] == "pid-1"
+        assert stamp["cid"] == "cid-1"
+        assert factory.session.commits == 1
+
+    @pytest.mark.asyncio
+    async def test_no_stamp_when_row_has_no_content_id(self) -> None:
+        daemon, _, factory = _make_daemon([("pid-1", None)], attempts=0)
+
+        result = await daemon.index_documents(
+            [{"id": "1", "text": "text", "path": "/a.md"}], zone_id="root"
+        )
+
+        assert result.indexed == 1
+        assert factory is not None
+        assert factory.session.update_calls == []
+
+    @pytest.mark.asyncio
+    async def test_no_stamp_when_pipeline_indexed_zero_chunks(self) -> None:
+        """Scope-gated no-op (chunks_indexed=0, no error) must NOT stamp —
+        stamping would wrongly block the FTS consumer's naive-chunk
+        fallback for out-of-scope paths."""
+        daemon, pipeline, factory = _make_daemon([("pid-1", "cid-1")], attempts=0, chunks_indexed=0)
+
+        result = await daemon.index_documents(
+            [{"id": "1", "text": "text", "path": "/outside-scope.md"}], zone_id="root"
+        )
+
+        assert result.indexed == 1  # pre-existing contract: no error → counted
+        assert pipeline.calls != []
+        assert factory is not None
+        assert factory.session.update_calls == []
+
+    @pytest.mark.asyncio
+    async def test_stamp_failure_is_fail_soft(self) -> None:
+        """A stamp error must not fail the request — the text IS indexed."""
+        daemon, _, factory = _make_daemon([("pid-1", "cid-1")], attempts=0)
+        assert factory is not None
+
+        original_execute = factory.session.execute
+
+        async def _failing_execute(stmt: Any, params: dict[str, Any] | None = None) -> _Result:
+            if str(stmt).lstrip().upper().startswith("UPDATE"):
+                raise RuntimeError("db down")
+            return await original_execute(stmt, params)
+
+        # setattr keeps mypy quiet without a type:ignore (project policy).
+        setattr(factory.session, "execute", _failing_execute)  # noqa: B010
+
+        result = await daemon.index_documents(
+            [{"id": "1", "text": "text", "path": "/a.md"}], zone_id="root"
+        )
+        assert result.indexed == 1
+        assert result.skipped == []

--- a/tests/unit/bricks/search/test_daemon_explicit_index_path_wait.py
+++ b/tests/unit/bricks/search/test_daemon_explicit_index_path_wait.py
@@ -51,9 +51,13 @@ class _Session:
         return None
 
     async def execute(self, stmt: Any, params: dict[str, Any] | None = None) -> _Result:
-        if str(stmt).lstrip().upper().startswith("UPDATE"):
+        sql = str(stmt)
+        if sql.lstrip().upper().startswith("UPDATE"):
             self.update_calls.append(dict(params or {}))
             return _Result(None)
+        if "document_chunks" in sql:
+            # Post-index guard watermark: stable so the guard never repairs.
+            return _Result((1, "t1"))
         self.select_calls.append(dict(params or {}))
         idx = min(len(self.select_calls) - 1, len(self._rows_by_call) - 1)
         return _Result(self._rows_by_call[idx])
@@ -130,7 +134,7 @@ class TestExplicitIndexPathWait:
         self, sleep_recorder: list[float]
     ) -> None:
         """Write-then-index: row missing on first lookup, lands on the second."""
-        daemon, pipeline, factory = _make_daemon([None, ("pid-1", "cid-1")], attempts=3)
+        daemon, pipeline, factory = _make_daemon([None, ("pid-1", "cid-1", 100)], attempts=3)
 
         result = await daemon.index_documents(
             [{"id": "1", "text": "zuluxx probe", "path": "/probe.md"}], zone_id="root"
@@ -165,7 +169,7 @@ class TestExplicitIndexPathWait:
     ) -> None:
         daemon, pipeline, _ = _make_daemon(
             # /ok.md resolves immediately; /ghost.md never does.
-            [("pid-ok", "cid-ok"), None, None, None],
+            [("pid-ok", "cid-ok", 100), None, None, None],
             attempts=2,
         )
 
@@ -210,7 +214,7 @@ class TestExplicitIndexPathWait:
 
     @pytest.mark.asyncio
     async def test_stats_counters_track_waits_and_skips(self, sleep_recorder: list[float]) -> None:
-        daemon, _, _ = _make_daemon([None, ("pid-1", "cid-1")], attempts=1)
+        daemon, _, _ = _make_daemon([None, ("pid-1", "cid-1", 100)], attempts=1)
 
         await daemon.index_documents(
             [{"id": "1", "text": "late row", "path": "/late.md"}], zone_id="root"
@@ -243,7 +247,7 @@ class TestExplicitIndexStampsCoveredVersion:
 
     @pytest.mark.asyncio
     async def test_successful_index_stamps_indexed_content_id(self) -> None:
-        daemon, _, factory = _make_daemon([("pid-1", "cid-1")], attempts=0)
+        daemon, _, factory = _make_daemon([("pid-1", "cid-1", 100)], attempts=0)
 
         await daemon.index_documents(
             [{"id": "1", "text": "extracted pdf text", "path": "/doc.pdf"}], zone_id="root"
@@ -254,11 +258,14 @@ class TestExplicitIndexStampsCoveredVersion:
         stamp = factory.session.update_calls[0]
         assert stamp["pid"] == "pid-1"
         assert stamp["cid"] == "cid-1"
+        # CAS must carry the updated_at observed at resolution time so a
+        # mid-flight rewrite (which bumps updated_at) voids the stamp.
+        assert stamp["observed_updated_at"] == 100
         assert factory.session.commits == 1
 
     @pytest.mark.asyncio
     async def test_no_stamp_when_row_has_no_content_id(self) -> None:
-        daemon, _, factory = _make_daemon([("pid-1", None)], attempts=0)
+        daemon, _, factory = _make_daemon([("pid-1", None, 100)], attempts=0)
 
         result = await daemon.index_documents(
             [{"id": "1", "text": "text", "path": "/a.md"}], zone_id="root"
@@ -273,7 +280,9 @@ class TestExplicitIndexStampsCoveredVersion:
         """Scope-gated no-op (chunks_indexed=0, no error) must NOT stamp —
         stamping would wrongly block the FTS consumer's naive-chunk
         fallback for out-of-scope paths."""
-        daemon, pipeline, factory = _make_daemon([("pid-1", "cid-1")], attempts=0, chunks_indexed=0)
+        daemon, pipeline, factory = _make_daemon(
+            [("pid-1", "cid-1", 100)], attempts=0, chunks_indexed=0
+        )
 
         result = await daemon.index_documents(
             [{"id": "1", "text": "text", "path": "/outside-scope.md"}], zone_id="root"
@@ -287,7 +296,7 @@ class TestExplicitIndexStampsCoveredVersion:
     @pytest.mark.asyncio
     async def test_stamp_failure_is_fail_soft(self) -> None:
         """A stamp error must not fail the request — the text IS indexed."""
-        daemon, _, factory = _make_daemon([("pid-1", "cid-1")], attempts=0)
+        daemon, _, factory = _make_daemon([("pid-1", "cid-1", 100)], attempts=0)
         assert factory is not None
 
         original_execute = factory.session.execute
@@ -305,3 +314,106 @@ class TestExplicitIndexStampsCoveredVersion:
         )
         assert result.indexed == 1
         assert result.skipped == []
+
+
+class _GuardSession:
+    """Session for the guard: routes each query shape to scripted answers."""
+
+    def __init__(
+        self,
+        watermarks: list[tuple[int, Any] | None],
+        row_version: tuple[Any, Any] | None,
+    ) -> None:
+        self._watermarks = watermarks
+        self._wm_idx = 0
+        self._row_version = row_version
+        self.update_calls: list[dict[str, Any]] = []
+
+    async def __aenter__(self) -> "_GuardSession":
+        return self
+
+    async def __aexit__(self, *exc_info: Any) -> None:
+        return None
+
+    async def execute(self, stmt: Any, params: dict[str, Any] | None = None) -> _Result:
+        sql = str(stmt)
+        if sql.lstrip().upper().startswith("UPDATE"):
+            self.update_calls.append(dict(params or {}))
+            return _Result(None)
+        if "document_chunks" in sql:
+            idx = min(self._wm_idx, len(self._watermarks) - 1)
+            self._wm_idx += 1
+            return _Result(self._watermarks[idx])
+        return _Result(self._row_version)
+
+    async def commit(self) -> None:
+        return None
+
+
+class TestExplicitIndexGuard:
+    """#4566: a writer already past its covered-gate check when the stamp
+    lands can interleave its blob replace with ours (observed live: two
+    chunk writes 3ms apart, mixed set). The guard watches the chunk
+    watermark and re-replaces the raced write with the caller's text."""
+
+    def _guard_daemon(
+        self,
+        watermarks: list[tuple[int, Any] | None],
+        row_version: tuple[Any, Any] | None,
+    ) -> tuple[SearchDaemon, _Pipeline, _GuardSession]:
+        config = DaemonConfig(index_path_wait_attempts=2, index_path_wait_seconds=0.001)
+        session = _GuardSession(watermarks, row_version)
+        daemon = SearchDaemon(config, async_session_factory=lambda: session)
+        pipeline = _Pipeline()
+        daemon._indexing_pipeline = cast(Any, pipeline)
+        daemon._initialized = True
+        return daemon, pipeline, session
+
+    @pytest.mark.asyncio
+    async def test_guard_repairs_raced_chunk_write(self, sleep_recorder: list[float]) -> None:
+        # Watermark moves off the baseline (a foreign write landed), and the
+        # row still holds the version we indexed -> repair + re-stamp.
+        daemon, pipeline, session = self._guard_daemon(
+            watermarks=[(3, "t2"), (2, "t3")],
+            row_version=("cid-1", 100),
+        )
+
+        await daemon._explicit_index_guard(
+            "/doc.pdf", "explicit text", ("pid-1", "cid-1", 100), baseline=(1, "t1")
+        )
+
+        assert pipeline.calls == [("/doc.pdf", "explicit text", "pid-1")]
+        assert len(session.update_calls) == 1  # re-stamp
+        assert daemon.stats.explicit_index_repairs == 1
+
+    @pytest.mark.asyncio
+    async def test_guard_noop_when_watermark_stable(self, sleep_recorder: list[float]) -> None:
+        daemon, pipeline, session = self._guard_daemon(
+            watermarks=[(1, "t1")],
+            row_version=("cid-1", 100),
+        )
+
+        await daemon._explicit_index_guard(
+            "/doc.pdf", "explicit text", ("pid-1", "cid-1", 100), baseline=(1, "t1")
+        )
+
+        assert pipeline.calls == []
+        assert session.update_calls == []
+        assert daemon.stats.explicit_index_repairs == 0
+
+    @pytest.mark.asyncio
+    async def test_guard_stands_down_when_file_moved_on(self, sleep_recorder: list[float]) -> None:
+        """A REAL new write owns the index — the guard must never clobber
+        the newer version with stale explicit text."""
+        daemon, pipeline, session = self._guard_daemon(
+            watermarks=[(5, "t9")],
+            row_version=("cid-1", 999),  # updated_at advanced past what we indexed
+        )
+
+        await daemon._explicit_index_guard(
+            "/doc.pdf", "explicit text", ("pid-1", "cid-1", 100), baseline=(1, "t1")
+        )
+
+        assert pipeline.calls == []
+        assert session.update_calls == []
+        assert daemon.stats.explicit_index_repairs == 0

--- a/tests/unit/bricks/search/test_daemon_explicit_index_path_wait.py
+++ b/tests/unit/bricks/search/test_daemon_explicit_index_path_wait.py
@@ -1,0 +1,224 @@
+"""Unit tests for explicit-index bounded projection wait (Issue #4566).
+
+``POST /api/v2/search/index`` immediately after ``files.write`` used to land
+inside the operation-log consumer's ``file_paths`` projection lag: the
+``path_id`` lookup found no row, the doc was silently dropped, and the call
+returned ``count=0`` with no way for the client to distinguish "indexed"
+from "lost". These tests pin the fixed contract:
+
+- a row that lands within the bounded wait window is indexed;
+- a row that never lands is reported in ``skipped`` (not silently dropped);
+- a daemon without a DB session skips immediately without burning the wait.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, cast
+
+import pytest
+
+from nexus.bricks.search.daemon import DaemonConfig, SearchDaemon
+
+# =============================================================================
+# Fakes
+# =============================================================================
+
+
+class _Result:
+    def __init__(self, row: tuple[Any, ...] | None) -> None:
+        self._row = row
+
+    def first(self) -> tuple[Any, ...] | None:
+        return self._row
+
+
+class _Session:
+    """Async session whose path_id lookups replay a scripted row sequence."""
+
+    def __init__(self, rows_by_call: list[tuple[Any, ...] | None]) -> None:
+        self._rows_by_call = rows_by_call
+        self.calls: list[dict[str, Any]] = []
+
+    async def __aenter__(self) -> "_Session":
+        return self
+
+    async def __aexit__(self, *exc_info: Any) -> None:
+        return None
+
+    async def execute(self, stmt: Any, params: dict[str, Any] | None = None) -> _Result:
+        self.calls.append(dict(params or {}))
+        idx = min(len(self.calls) - 1, len(self._rows_by_call) - 1)
+        return _Result(self._rows_by_call[idx])
+
+
+class _SessionFactory:
+    def __init__(self, rows_by_call: list[tuple[Any, ...] | None]) -> None:
+        self.session = _Session(rows_by_call)
+
+    def __call__(self) -> _Session:
+        return self.session
+
+
+class _PipelineResult:
+    def __init__(self) -> None:
+        self.error: str | None = None
+        self.chunks_indexed = 1
+
+
+class _Pipeline:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, str]] = []
+
+    async def index_document(self, path: str, content: str, path_id: str) -> _PipelineResult:
+        self.calls.append((path, content, path_id))
+        return _PipelineResult()
+
+
+def _make_daemon(
+    rows_by_call: list[tuple[Any, ...] | None] | None,
+    *,
+    attempts: int = 3,
+    delay: float = 0.001,
+) -> tuple[SearchDaemon, _Pipeline, _SessionFactory | None]:
+    config = DaemonConfig(
+        index_path_wait_attempts=attempts,
+        index_path_wait_seconds=delay,
+    )
+    factory = _SessionFactory(rows_by_call) if rows_by_call is not None else None
+    daemon = SearchDaemon(config, async_session_factory=factory)
+    pipeline = _Pipeline()
+    daemon._indexing_pipeline = cast(Any, pipeline)
+    daemon._initialized = True
+    return daemon, pipeline, factory
+
+
+@pytest.fixture
+def sleep_recorder(monkeypatch: pytest.MonkeyPatch) -> list[float]:
+    """Record daemon wait sleeps without actually waiting."""
+    delays: list[float] = []
+    real_sleep = asyncio.sleep
+
+    async def _fake_sleep(delay: float, *args: Any, **kwargs: Any) -> None:
+        delays.append(delay)
+        await real_sleep(0)
+
+    monkeypatch.setattr(asyncio, "sleep", _fake_sleep)
+    return delays
+
+
+# =============================================================================
+# Tests
+# =============================================================================
+
+
+class TestExplicitIndexPathWait:
+    @pytest.mark.asyncio
+    async def test_row_landing_within_wait_window_is_indexed(
+        self, sleep_recorder: list[float]
+    ) -> None:
+        """Write-then-index: row missing on first lookup, lands on the second."""
+        daemon, pipeline, factory = _make_daemon([None, ("pid-1",)], attempts=3)
+
+        result = await daemon.index_documents(
+            [{"id": "1", "text": "zuluxx probe", "path": "/probe.md"}], zone_id="root"
+        )
+
+        assert result.indexed == 1
+        assert result.skipped == []
+        assert pipeline.calls == [("/probe.md", "zuluxx probe", "pid-1")]
+        # One wait round was needed before the row landed.
+        assert len(sleep_recorder) == 1
+
+    @pytest.mark.asyncio
+    async def test_row_never_landing_is_reported_skipped(self, sleep_recorder: list[float]) -> None:
+        """Synthetic doc with no backing file: surfaced in skipped, not dropped."""
+        daemon, pipeline, factory = _make_daemon([None], attempts=2)
+
+        result = await daemon.index_documents(
+            [{"id": "1", "text": "ghost text", "path": "/ghost.md"}], zone_id="root"
+        )
+
+        assert result.indexed == 0
+        assert result.skipped == ["/ghost.md"]
+        assert pipeline.calls == []
+        # Initial lookup + one per wait round.
+        assert factory is not None
+        assert len(factory.session.calls) == 3
+        assert len(sleep_recorder) == 2
+
+    @pytest.mark.asyncio
+    async def test_mixed_batch_indexes_resolved_and_skips_missing(
+        self, sleep_recorder: list[float]
+    ) -> None:
+        daemon, pipeline, _ = _make_daemon(
+            # /ok.md resolves immediately; /ghost.md never does.
+            [("pid-ok",), None, None, None],
+            attempts=2,
+        )
+
+        result = await daemon.index_documents(
+            [
+                {"id": "1", "text": "ok text", "path": "/ok.md"},
+                {"id": "2", "text": "ghost text", "path": "/ghost.md"},
+            ],
+            zone_id="root",
+        )
+
+        assert result.indexed == 1
+        assert result.skipped == ["/ghost.md"]
+        assert [c[2] for c in pipeline.calls] == ["pid-ok"]
+
+    @pytest.mark.asyncio
+    async def test_no_session_skips_immediately_without_waiting(
+        self, sleep_recorder: list[float]
+    ) -> None:
+        """No DB session → resolution can never succeed; don't burn the wait."""
+        daemon, pipeline, _ = _make_daemon(None, attempts=5)
+
+        result = await daemon.index_documents(
+            [{"id": "1", "text": "text", "path": "/a.md"}], zone_id="root"
+        )
+
+        assert result.indexed == 0
+        assert result.skipped == ["/a.md"]
+        assert sleep_recorder == []
+
+    @pytest.mark.asyncio
+    async def test_wait_disabled_with_zero_attempts(self, sleep_recorder: list[float]) -> None:
+        daemon, pipeline, _ = _make_daemon([None], attempts=0)
+
+        result = await daemon.index_documents(
+            [{"id": "1", "text": "text", "path": "/a.md"}], zone_id="root"
+        )
+
+        assert result.indexed == 0
+        assert result.skipped == ["/a.md"]
+        assert sleep_recorder == []
+
+    @pytest.mark.asyncio
+    async def test_stats_counters_track_waits_and_skips(self, sleep_recorder: list[float]) -> None:
+        daemon, _, _ = _make_daemon([None, ("pid-1",), None, None], attempts=1)
+
+        await daemon.index_documents(
+            [{"id": "1", "text": "late row", "path": "/late.md"}], zone_id="root"
+        )
+        assert daemon.stats.explicit_index_path_waits == 1
+        assert daemon.stats.explicit_index_skipped_no_path == 0
+
+        daemon2, _, _ = _make_daemon([None], attempts=1)
+        await daemon2.index_documents(
+            [{"id": "1", "text": "ghost", "path": "/ghost.md"}], zone_id="root"
+        )
+        assert daemon2.stats.explicit_index_skipped_no_path == 1
+
+    def test_config_defaults_and_env_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        config = DaemonConfig()
+        assert config.index_path_wait_attempts == 5
+        assert config.index_path_wait_seconds == 2.0
+
+        monkeypatch.setenv("NEXUS_SEARCH_INDEX_PATH_WAIT_ATTEMPTS", "7")
+        monkeypatch.setenv("NEXUS_SEARCH_INDEX_PATH_WAIT_SECONDS", "0.5")
+        overridden = DaemonConfig()
+        assert overridden.index_path_wait_attempts == 7
+        assert overridden.index_path_wait_seconds == 0.5

--- a/tests/unit/server/api/v2/test_search_index_skipped_409.py
+++ b/tests/unit/server/api/v2/test_search_index_skipped_409.py
@@ -1,0 +1,110 @@
+"""Unit tests for POST /api/v2/search/index skip surfacing (Issue #4566).
+
+The daemon now reports documents whose ``file_paths`` projection row never
+landed within the bounded wait. The route must fail closed on those —
+HTTP 409 with the skipped paths in ``detail`` — instead of returning a
+silent ``count=0`` the client cannot distinguish from success.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+try:
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    _HAS_FASTAPI = True
+except ImportError:
+    _HAS_FASTAPI = False
+
+pytestmark = pytest.mark.skipif(not _HAS_FASTAPI, reason="fastapi test client unavailable")
+
+_AUTH = {
+    "authenticated": True,
+    "subject_type": "user",
+    "subject_id": "alice",
+    "zone_id": "eng",
+    "zone_perms": [["eng", "rw"]],
+    "is_admin": False,
+}
+
+
+class _Runner:
+    async def call(self, work: Any) -> Any:
+        return await work()
+
+
+class _Registry:
+    def runner_for(self, zone_id: str) -> _Runner:
+        return _Runner()
+
+
+def _build_app(daemon: Any) -> "FastAPI":
+    from nexus.server.api.v2.routers.search import router
+    from nexus.server.dependencies import require_auth
+
+    app = FastAPI()
+    app.state.search_daemon = daemon
+    app.state.zone_registry = _Registry()
+    app.dependency_overrides[require_auth] = lambda: _AUTH
+    app.include_router(router)
+    return app
+
+
+def _make_daemon(index_result: Any) -> MagicMock:
+    daemon = MagicMock()
+    daemon.index_documents = AsyncMock(return_value=index_result)
+    return daemon
+
+
+_DOCS = {
+    "documents": [
+        {"id": "1", "text": "alpha", "path": "/a.md"},
+        {"id": "2", "text": "zulu", "path": "/b.md"},
+    ]
+}
+
+
+def test_all_indexed_returns_200_with_count() -> None:
+    daemon = _make_daemon(SimpleNamespace(indexed=2, skipped=[]))
+    with TestClient(_build_app(daemon)) as client:
+        response = client.post("/api/v2/search/index", json=_DOCS)
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["status"] == "indexed"
+    assert body["count"] == 2
+    assert body["zone_id"] == "eng"
+
+
+def test_skipped_documents_return_409_with_paths() -> None:
+    daemon = _make_daemon(SimpleNamespace(indexed=1, skipped=["/b.md"]))
+    with TestClient(_build_app(daemon)) as client:
+        response = client.post("/api/v2/search/index", json=_DOCS)
+    assert response.status_code == 409, response.text
+    detail = response.json()["detail"]
+    assert detail["skipped"] == ["/b.md"]
+    assert detail["count"] == 1
+    assert detail["zone_id"] == "eng"
+
+
+def test_int_returning_daemon_double_still_gets_200() -> None:
+    """Legacy/mocked daemons that return a bare int keep the old contract."""
+    daemon = _make_daemon(2)
+    with TestClient(_build_app(daemon)) as client:
+        response = client.post("/api/v2/search/index", json=_DOCS)
+    assert response.status_code == 200, response.text
+    assert response.json()["count"] == 2
+
+
+def test_daemon_error_returns_500() -> None:
+    daemon = MagicMock()
+    daemon.index_documents = AsyncMock(side_effect=RuntimeError("pipeline failed"))
+    with TestClient(_build_app(daemon)) as client:
+        response = client.post("/api/v2/search/index", json=_DOCS)
+    assert response.status_code == 500, response.text
+    assert "pipeline failed" in response.json()["detail"]


### PR DESCRIPTION
Closes #4566

## Problem

`POST /api/v2/search/index` immediately after `files.write` for the same path returns `{"status":"indexed","count":0}` and the submitted text never becomes searchable. `_index_documents_on_current_loop` resolves `path_id` from the `file_paths` projection, which the operation-log consumer populates asynchronously — a write-then-index call always lands inside that lag (~5–10s observed), hits the `path_id is None` branch, and silently `continue`s. This contradicts the fail-closed docstrings on both the route and the daemon method (Decision #18).

## Fix (options 1 + 2 from the issue, combined)

**Daemon — bounded projection wait.** Docs whose row is missing are collected and re-polled up to `NEXUS_SEARCH_INDEX_PATH_WAIT_ATTEMPTS` (default 5) rounds, sleeping `NEXUS_SEARCH_INDEX_PATH_WAIT_SECONDS` (default 2.0s) between rounds. Defaults cover the observed 5–10s lag. The budget is per **batch**, not per doc — worst-case added latency is `attempts × delay` regardless of batch size. A daemon with no DB session skips the wait entirely (the lookup can never succeed). Set attempts to `0` to disable the wait.

**Daemon — no more silent drops.** `index_documents` now returns `ExplicitIndexResult {indexed, skipped}`. Anything unresolved after the wait lands in `skipped` (zone-stripped virtual paths) plus a WARNING log and two new `DaemonStats` counters (`explicit_index_path_waits`, `explicit_index_skipped_no_path`). The reader-only ownership rule is preserved — the daemon never creates `file_paths` rows.

**Route — fail closed.** Any skipped doc ⇒ HTTP 409 with `detail = {error, count, skipped, zone_id}` so clients can retry deterministically. Indexing is idempotent (`replace_document_chunks` upsert), so retrying the whole batch after a 409 is safe; docs indexed before the 409 stay indexed. The 200 response shape is unchanged.

**Callers.** `mount_service` logs `indexed`/`skipped` from the result; connector wiring and the RPC `semantic_search_index` handler discard the result as before, so their best-effort semantics are unchanged (skips log instead of raising). Side benefit: skill README indexing in `connectors.py` (nx.write → immediate index) was racing the same projection lag and silently dropping — the bounded wait now covers it.

## Notes for review

- **Not addressed here:** option 3 from the issue (staging text keyed by `virtual_path` for the consumer to attach). The bounded wait narrows the race but a consumer content-index landing *after* a successful explicit index can still overwrite the explicit text with blob bytes; that ordering question is the same one the pre-#4553 daemon had and is left as a follow-up if it bites in practice.
- Invalid docs (missing/empty `text` or `path`) are still silently ignored, as before — that's malformed input, not a projection race; tightening it to a 400 would change the lenient contract mount/connector callers rely on.
- `tests/integration/search/test_connector_search_indexing.py` fails 6/6 **identically on develop** (stale pre-#3699 `_backend.upsert` expectations, same as the self-skipping `test_zone_isolation.py`); not a regression from this change.

## Testing

- New: `tests/unit/bricks/search/test_daemon_explicit_index_path_wait.py` (7 tests: row lands mid-wait, never lands → skipped, no-session fast path, attempts=0, mixed batch, stats counters, env-knob defaults/overrides).
- New: `tests/unit/server/api/v2/test_search_index_skipped_409.py` (4 tests: 200 all-indexed, 409 with skipped detail, int-returning double compat, 500 on daemon error).
- `tests/unit/bricks/search` + `tests/unit/server/api/v2` + `tests/unit/server/routers` + RPC handler test: **623 passed, 8 skipped** (pre-existing PG-URL skips).
- mypy clean on the three changed source files; surface-coverage YAML regenerated (line-ref shifts only) and validator exits 0.
- `nexus-stack.yml` passes through the two new env knobs.