### PR TITLE
refactor(search): consolidate 13-kwarg search() into SearchRequest dataclass

### DIFF
--- a/docs/surface-coverage/api-rpc-surface-coverage.yaml
+++ b/docs/surface-coverage/api-rpc-surface-coverage.yaml
@@ -7710,7 +7710,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/consumers/{consumer_name}/skip-to
-      source: src/nexus/server/api/v2/routers/search.py:241
+      source: src/nexus/server/api/v2/routers/search.py:236
   profiles:
     lite: supported
     sandbox: supported
@@ -7727,7 +7727,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/expand
-      source: src/nexus/server/api/v2/routers/search.py:1658
+      source: src/nexus/server/api/v2/routers/search.py:1655
   profiles:
     lite: supported
     sandbox: supported
@@ -7751,7 +7751,7 @@ operations:
       source: src/nexus/bricks/search/search_service.py:1791
     http:
       name: POST /api/v2/search/glob
-      source: src/nexus/server/api/v2/routers/search.py:1516
+      source: src/nexus/server/api/v2/routers/search.py:1513
     mcp:
       name: nexus_glob
       source: src/nexus/config/tool_profiles.yaml:1
@@ -7778,7 +7778,7 @@ operations:
       source: src/nexus/bricks/search/search_service.py:2101
     http:
       name: POST /api/v2/search/grep
-      source: src/nexus/server/api/v2/routers/search.py:1393
+      source: src/nexus/server/api/v2/routers/search.py:1390
     mcp:
       name: nexus_grep
       source: src/nexus/config/tool_profiles.yaml:1
@@ -7814,7 +7814,7 @@ operations:
   transports:
     http:
       name: GET /api/v2/search/health
-      source: src/nexus/server/api/v2/routers/search.py:160
+      source: src/nexus/server/api/v2/routers/search.py:155
   profiles:
     lite: supported
     sandbox: supported
@@ -7831,7 +7831,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/index
-      source: src/nexus/server/api/v2/routers/search.py:1578
+      source: src/nexus/server/api/v2/routers/search.py:1575
   profiles:
     lite: supported
     sandbox: supported
@@ -7849,7 +7849,7 @@ operations:
   transports:
     http:
       name: GET /api/v2/search/parked
-      source: src/nexus/server/api/v2/routers/search.py:198
+      source: src/nexus/server/api/v2/routers/search.py:193
   profiles:
     lite: supported
     sandbox: supported
@@ -7866,7 +7866,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/parked/discard
-      source: src/nexus/server/api/v2/routers/search.py:224
+      source: src/nexus/server/api/v2/routers/search.py:219
   profiles:
     lite: supported
     sandbox: supported
@@ -7884,7 +7884,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/parked/retry
-      source: src/nexus/server/api/v2/routers/search.py:207
+      source: src/nexus/server/api/v2/routers/search.py:202
   profiles:
     lite: supported
     sandbox: supported
@@ -7901,7 +7901,7 @@ operations:
   transports:
     http:
       name: GET /api/v2/search/query
-      source: src/nexus/server/api/v2/routers/search.py:259
+      source: src/nexus/server/api/v2/routers/search.py:254
   profiles:
     lite: supported
     sandbox: supported
@@ -7919,7 +7919,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/query/batch
-      source: src/nexus/server/api/v2/routers/search.py:801
+      source: src/nexus/server/api/v2/routers/search.py:798
   profiles:
     lite: supported
     sandbox: supported
@@ -7936,7 +7936,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/refresh
-      source: src/nexus/server/api/v2/routers/search.py:1637
+      source: src/nexus/server/api/v2/routers/search.py:1634
   profiles:
     lite: supported
     sandbox: supported
@@ -7971,7 +7971,7 @@ operations:
   transports:
     http:
       name: GET /api/v2/search/stats
-      source: src/nexus/server/api/v2/routers/search.py:175
+      source: src/nexus/server/api/v2/routers/search.py:170
   profiles:
     lite: supported
     sandbox: supported

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -65,6 +65,7 @@ from nexus.bricks.search.mutation_parking import (
 from nexus.bricks.search.mutation_resolver import MutationResolver, ResolvedMutation
 from nexus.bricks.search.results import BaseSearchResult
 from nexus.contracts.constants import ROOT_ZONE_ID
+from nexus.contracts.search_types import SearchRequest
 from nexus.lib.env import get_database_url
 
 T = TypeVar("T")
@@ -2824,57 +2825,54 @@ class SearchDaemon:
             rows = (await session.execute(stmt)).all()
         return {row[0]: row[1] for row in rows if row[1] is not None}
 
-    async def search(
-        self,
-        query: str,
-        search_type: Literal["keyword", "semantic", "hybrid"] = "hybrid",
-        limit: int = 10,
-        path_filter: str | None = None,
-        alpha: float = 0.5,
-        fusion_method: str = "rrf",
-        zone_id: str | None = None,
-        expand: str = "none",
-        rrf_k: int = 60,
-        recency: str | None = None,
-        recency_weight: float | None = None,
-        recency_half_life_days: float | None = None,
-    ) -> list[SearchResult]:
-        if zone_id is None:
+    async def search(self, request: SearchRequest) -> list[SearchResult]:
+        """Execute a hybrid/keyword/semantic search (public entry point).
+
+        Accepts a single :class:`SearchRequest` bundling all knobs
+        (query, search_type, limit, alpha, fusion_method, rrf_k,
+        recency*, expand, zone_id, &c.).  Internal helpers below
+        (``_search_on_current_loop``, ``_apply_recency_boost_post_search``,
+        ``_apply_macro_expansion``) keep individual kwargs — the
+        SearchRequest boundary is drawn at the public contract.
+        """
+        req = request
+        effective_zone = req.zone_id or ROOT_ZONE_ID
+        if req.zone_id is None:
             results = await self._search_on_current_loop(
-                query,
-                search_type=search_type,
-                limit=limit,
-                path_filter=path_filter,
-                alpha=alpha,
-                fusion_method=fusion_method,
-                rrf_k=rrf_k,
-                zone_id=zone_id,
+                req.query,
+                search_type=req.search_type,
+                limit=req.limit,
+                path_filter=req.path_filter,
+                alpha=req.alpha,
+                fusion_method=req.fusion_method,
+                rrf_k=req.rrf_k,
+                zone_id=req.zone_id,
             )
         else:
 
             async def _work() -> list[SearchResult]:
                 return await self._search_on_current_loop(
-                    query,
-                    search_type=search_type,
-                    limit=limit,
-                    path_filter=path_filter,
-                    alpha=alpha,
-                    fusion_method=fusion_method,
-                    rrf_k=rrf_k,
-                    zone_id=zone_id,
+                    req.query,
+                    search_type=req.search_type,
+                    limit=req.limit,
+                    path_filter=req.path_filter,
+                    alpha=req.alpha,
+                    fusion_method=req.fusion_method,
+                    rrf_k=req.rrf_k,
+                    zone_id=req.zone_id,
                 )
 
             results = await self._run_on_owner_loop(_work)
 
         await self._apply_recency_boost_post_search(
             results,
-            query=query,
-            recency=recency,
-            recency_weight=recency_weight,
-            recency_half_life_days=recency_half_life_days,
-            zone_id=zone_id or ROOT_ZONE_ID,
+            query=req.query,
+            recency=req.recency,
+            recency_weight=req.recency_weight,
+            recency_half_life_days=req.recency_half_life_days,
+            zone_id=effective_zone,
         )
-        await self._apply_macro_expansion(results, expand=expand, zone_id=zone_id or ROOT_ZONE_ID)
+        await self._apply_macro_expansion(results, expand=req.expand, zone_id=effective_zone)
         return results
 
     async def _search_on_current_loop(

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -3624,11 +3624,13 @@ class SearchDaemon:
                 continue
             try:
                 hits = await self.search(
-                    str(q.get("query", "")),
-                    search_type=q.get("search_type", "hybrid"),
-                    limit=int(q.get("limit", 10)),
-                    path_filter=q.get("path_filter"),
-                    zone_id=effective_zone_id,
+                    SearchRequest(
+                        query=str(q.get("query", "")),
+                        search_type=q.get("search_type", "hybrid"),
+                        limit=int(q.get("limit", 10)),
+                        path_filter=q.get("path_filter"),
+                        zone_id=effective_zone_id,
+                    )
                 )
             except Exception as exc:
                 logger.warning("batch_search inner search failed: %s", exc)

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -2878,7 +2878,7 @@ class SearchDaemon:
     async def _search_on_current_loop(
         self,
         query: str,
-        search_type: Literal["keyword", "semantic", "hybrid"] = "hybrid",
+        search_type: str = "hybrid",
         limit: int = 10,
         path_filter: str | None = None,
         alpha: float = 0.5,

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -42,7 +42,7 @@ from contextvars import ContextVar
 from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar
 
 from sqlalchemy import text as sa_text
 

--- a/src/nexus/bricks/search/federated_search.py
+++ b/src/nexus/bricks/search/federated_search.py
@@ -32,6 +32,7 @@ from nexus.bricks.search.daemon import _BACKEND_LEG_TIMING_KEYS as _TIMING_LEG_K
 from nexus.bricks.search.fusion import rrf_multi_fusion
 from nexus.bricks.search.result_builders import cap_chunks_per_page
 from nexus.contracts.protocols.activity import EventKind, Result, emit
+from nexus.contracts.search_types import SearchRequest
 
 logger = logging.getLogger(__name__)
 
@@ -467,17 +468,19 @@ class FederatedSearchDispatcher:
         # Local zone: call daemon.search() directly
         daemon = self._get_daemon_for_zone(zone_id)
         results = await daemon.search(
-            query=query,
-            search_type=effective_type,
-            limit=limit,
-            path_filter=path_filter,
-            alpha=effective_alpha,
-            fusion_method=effective_fusion,
-            rrf_k=rrf_k,
-            recency=recency,
-            recency_weight=recency_weight,
-            recency_half_life_days=recency_half_life_days,
-            zone_id=zone_id,
+            SearchRequest(
+                query=query,
+                search_type=effective_type,
+                limit=limit,
+                path_filter=path_filter,
+                alpha=effective_alpha,
+                fusion_method=effective_fusion,
+                rrf_k=rrf_k,
+                recency=recency,
+                recency_weight=recency_weight,
+                recency_half_life_days=recency_half_life_days,
+                zone_id=zone_id,
+            )
         )
 
         # Tag results with zone provenance. Return the SearchResultList as-is

--- a/src/nexus/contracts/protocols/search.py
+++ b/src/nexus/contracts/protocols/search.py
@@ -20,6 +20,7 @@ import builtins
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
+    from nexus.contracts.search_types import SearchRequest  # noqa: F401
     from nexus.contracts.types import OperationContext
 
 # =============================================================================
@@ -45,21 +46,7 @@ class SearchBrickProtocol(Protocol):
 
     async def shutdown(self) -> None: ...
 
-    async def search(
-        self,
-        query: str,
-        search_type: str = "hybrid",
-        limit: int = 10,
-        path_filter: str | None = None,
-        alpha: float = 0.5,
-        fusion_method: str = "rrf",
-        recency: str | None = None,
-        recency_weight: float | None = None,
-        recency_half_life_days: float | None = None,
-        adaptive_k: bool = False,
-        zone_id: str | None = None,
-        rrf_k: int = 60,
-    ) -> builtins.list[Any]: ...
+    async def search(self, request: "SearchRequest") -> builtins.list[Any]: ...
 
     def get_stats(self) -> dict[str, Any]: ...
 

--- a/src/nexus/contracts/search_types.py
+++ b/src/nexus/contracts/search_types.py
@@ -14,7 +14,9 @@ Issue #1499: Shared query analysis patterns for query routing and expansion.
 """
 
 import contextvars
+from dataclasses import dataclass
 from enum import StrEnum
+from typing import Literal
 
 __all__ = [
     # Strategy enums
@@ -38,7 +40,44 @@ __all__ = [
     "COMPLEX_PATTERNS",
     # Per-task semantic-degradation flag (Issue #3778 R2)
     "LAST_SEMANTIC_DEGRADED",
+    # SearchBrickProtocol.search bundled request (#4553 follow-up B)
+    "SearchRequest",
 ]
+
+
+# =============================================================================
+# SearchRequest — bundled call shape for SearchBrickProtocol.search
+# =============================================================================
+#
+# ``search()`` had grown to 13 keyword arguments (query, search_type, limit,
+# path_filter, alpha, fusion_method, rrf_k, zone_id, expand, adaptive_k,
+# recency, recency_weight, recency_half_life_days) with the request-param
+# feature set steadily growing (#4541 fusion, #4553 recency, #4545 title
+# arm).  Every new knob shipped as another keyword and mock stubs sprouted
+# matching kwargs.  Bundling into one frozen dataclass stops the accretion —
+# new fields are pure data additions that don't churn signatures.
+#
+# The public ``search`` method takes exactly one argument: a
+# ``SearchRequest``.  Private internal-to-daemon methods
+# (``_search_on_current_loop`` etc.) keep individual kwargs — the boundary
+# is drawn at the public contract, not repeated inside the module.
+@dataclass(frozen=True, kw_only=True)
+class SearchRequest:
+    """Bundled parameters for ``SearchBrickProtocol.search``."""
+
+    query: str
+    search_type: Literal["keyword", "semantic", "hybrid"] = "hybrid"
+    limit: int = 10
+    path_filter: str | None = None
+    alpha: float = 0.5
+    fusion_method: str = "rrf"
+    rrf_k: int = 60
+    zone_id: str | None = None
+    expand: str = "none"
+    adaptive_k: bool = False
+    recency: str | None = None
+    recency_weight: float | None = None
+    recency_half_life_days: float | None = None
 
 # Per-task flag recording whether the last SANDBOX semantic_search call
 # degraded to BM25S (Issue #3778 R2 review). Response-envelope builders

--- a/src/nexus/contracts/search_types.py
+++ b/src/nexus/contracts/search_types.py
@@ -79,6 +79,7 @@ class SearchRequest:
     recency_weight: float | None = None
     recency_half_life_days: float | None = None
 
+
 # Per-task flag recording whether the last SANDBOX semantic_search call
 # degraded to BM25S (Issue #3778 R2 review). Response-envelope builders
 # (MCP, HTTP routers) can read this after awaiting semantic_search so the

--- a/src/nexus/contracts/search_types.py
+++ b/src/nexus/contracts/search_types.py
@@ -16,7 +16,6 @@ Issue #1499: Shared query analysis patterns for query routing and expansion.
 import contextvars
 from dataclasses import dataclass
 from enum import StrEnum
-from typing import Literal
 
 __all__ = [
     # Strategy enums
@@ -66,7 +65,10 @@ class SearchRequest:
     """Bundled parameters for ``SearchBrickProtocol.search``."""
 
     query: str
-    search_type: Literal["keyword", "semantic", "hybrid"] = "hybrid"
+    # Kept as ``str`` (not ``Literal``) so callers passing an HTTP-validated
+    # string variable don't have to cast — runtime validation lives at the
+    # HTTP boundary in ``routers/search.py``.
+    search_type: str = "hybrid"
     limit: int = 10
     path_filter: str | None = None
     alpha: float = 0.5

--- a/src/nexus/server/api/v2/routers/search.py
+++ b/src/nexus/server/api/v2/routers/search.py
@@ -38,6 +38,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel
 
 from nexus.bricks.search.daemon import _BACKEND_LEG_TIMING_KEYS
+from nexus.contracts.search_types import SearchRequest
 from nexus.lib.pagination import build_paginated_list_response
 from nexus.lib.rebac_filter import apply_rebac_filter as _apply_rebac_filter
 from nexus.lib.rebac_filter import compute_rebac_fetch_limit as _compute_rebac_fetch_limit
@@ -538,18 +539,20 @@ async def _handle_single_zone_search(
             return response
 
         results = await search_daemon.search(
-            query=q,
-            search_type=search_type,
-            limit=fetch_limit,
-            path_filter=path_filter,
-            alpha=alpha,
-            fusion_method=fusion_method,
-            rrf_k=rrf_k,
-            zone_id=zone_id,
-            expand=expand,
-            recency=recency,
-            recency_weight=recency_weight,
-            recency_half_life_days=recency_half_life_days,
+            SearchRequest(
+                query=q,
+                search_type=search_type,
+                limit=fetch_limit,
+                path_filter=path_filter,
+                alpha=alpha,
+                fusion_method=fusion_method,
+                rrf_k=rrf_k,
+                zone_id=zone_id,
+                expand=expand,
+                recency=recency,
+                recency_weight=recency_weight,
+                recency_half_life_days=recency_half_life_days,
+            )
         )
 
         # Prefer the request-local snapshot carried by SearchDaemon results.

--- a/src/nexus/server/api/v2/routers/search.py
+++ b/src/nexus/server/api/v2/routers/search.py
@@ -43,6 +43,7 @@ from nexus.lib.rebac_filter import apply_rebac_filter as _apply_rebac_filter
 from nexus.lib.rebac_filter import compute_rebac_fetch_limit as _compute_rebac_fetch_limit
 from nexus.lib.rebac_filter import rebac_denial_stats as _rebac_denial_stats
 from nexus.runtime.zone_resolution import target_zone_for_context
+from nexus.server.api.v2.routers._search_deps import _get_search_daemon
 from nexus.server.dependencies import get_operation_context, require_admin, require_auth
 from nexus.server.zone_execution import run_zone_scoped
 
@@ -65,13 +66,6 @@ router = APIRouter(prefix="/api/v2/search", tags=["search"])
 # =============================================================================
 # Dependencies
 # =============================================================================
-
-
-# _get_search_daemon lives in _search_deps.py so the split sub-routers
-# (_search_indexed_dirs, _search_locate) can import it without forming
-# a cycle back through search.py.  Re-export here for the many callers
-# / tests / monkeypatches that already reach it via `search._get_search_daemon`.
-from nexus.server.api.v2.routers._search_deps import _get_search_daemon  # noqa: E402
 
 
 def _get_record_store(request: Request) -> Any:

--- a/tests/integration/bricks/search/test_daemon_search_pg.py
+++ b/tests/integration/bricks/search/test_daemon_search_pg.py
@@ -166,6 +166,8 @@ async def test_daemon_hybrid_mode_calls_fusion(
 
     monkeypatch.setattr(daemon._embedding_client, "embed_query", fake_embed_query)
 
-    await daemon.search(SearchRequest(query="alpha", path_filter="/z/", limit=5, search_type="hybrid", zone_id="z"))
+    await daemon.search(
+        SearchRequest(query="alpha", path_filter="/z/", limit=5, search_type="hybrid", zone_id="z")
+    )
     # 3-way RRF can be implemented as one call OR two nested rrf_fusion calls.
     assert seen["calls"] >= 1

--- a/tests/integration/bricks/search/test_daemon_search_pg.py
+++ b/tests/integration/bricks/search/test_daemon_search_pg.py
@@ -22,6 +22,7 @@ from sqlalchemy.ext.asyncio import AsyncEngine, async_sessionmaker, create_async
 from nexus.bricks.search.daemon import DaemonConfig, SearchDaemon
 from nexus.bricks.search.pg_fts_backend import PgFtsBackend
 from nexus.bricks.search.pg_vector_backend import PgVectorBackend
+from nexus.contracts.search_types import SearchRequest
 
 
 def _get_pg_url() -> str | None:
@@ -165,6 +166,6 @@ async def test_daemon_hybrid_mode_calls_fusion(
 
     monkeypatch.setattr(daemon._embedding_client, "embed_query", fake_embed_query)
 
-    await daemon.search("alpha", path_filter="/z/", limit=5, search_type="hybrid", zone_id="z")
+    await daemon.search(SearchRequest(query="alpha", path_filter="/z/", limit=5, search_type="hybrid", zone_id="z"))
     # 3-way RRF can be implemented as one call OR two nested rrf_fusion calls.
     assert seen["calls"] >= 1

--- a/tests/integration/bricks/search/test_error_paths.py
+++ b/tests/integration/bricks/search/test_error_paths.py
@@ -1,4 +1,3 @@
-from nexus.contracts.search_types import SearchRequest
 """Tests for search brick error paths (Issue #1520, #2663).
 
 Validates error handling at brick boundaries:
@@ -8,6 +7,8 @@ Validates error handling at brick boundaries:
 """
 
 import pytest
+
+from nexus.contracts.search_types import SearchRequest
 
 # =============================================================================
 # SearchDaemon error paths

--- a/tests/integration/bricks/search/test_error_paths.py
+++ b/tests/integration/bricks/search/test_error_paths.py
@@ -1,3 +1,4 @@
+from nexus.contracts.search_types import SearchRequest
 """Tests for search brick error paths (Issue #1520, #2663).
 
 Validates error handling at brick boundaries:
@@ -25,7 +26,7 @@ class TestSearchDaemonErrors:
         assert not daemon.is_initialized
 
         with pytest.raises(RuntimeError, match="SearchDaemon not initialized"):
-            await daemon.search("test query")
+            await daemon.search(SearchRequest(query="test query"))
 
     @pytest.mark.asyncio
     async def test_shutdown_idempotent(self) -> None:

--- a/tests/integration/search/test_zone_isolation.py
+++ b/tests/integration/search/test_zone_isolation.py
@@ -13,6 +13,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from nexus.bricks.search.results import BaseSearchResult
+from nexus.contracts.search_types import SearchRequest
 
 daemon_mod = pytest.importorskip(
     "nexus.bricks.search.daemon",
@@ -70,9 +71,9 @@ class TestZoneLevelIsolation:
 
     @pytest.mark.asyncio
     async def test_search_passes_zone_id_to_backend(self) -> None:
-        """zone_id should be forwarded to backend.search()."""
+        """zone_id should be forwarded to backend.search(SearchRequest(query=))."""
         daemon, mock_backend = await _make_daemon_with_mock()
-        await daemon.search("test query", zone_id="corp")
+        await daemon.search(SearchRequest(query="test query", zone_id="corp"))
         call_kwargs = mock_backend.search.call_args[1]
         assert call_kwargs["zone_id"] == "corp"
         await daemon.shutdown()
@@ -84,11 +85,11 @@ class TestZoneLevelIsolation:
 
         # Zone A returns files from zone A
         mock_backend.search.return_value = _make_backend_results(["/a1.py", "/a2.py"], "zone-a")
-        results_a = await daemon.search("test", zone_id="zone-a")
+        results_a = await daemon.search(SearchRequest(query="test", zone_id="zone-a"))
 
         # Zone B returns files from zone B
         mock_backend.search.return_value = _make_backend_results(["/b1.py", "/b2.py"], "zone-b")
-        results_b = await daemon.search("test", zone_id="zone-b")
+        results_b = await daemon.search(SearchRequest(query="test", zone_id="zone-b"))
 
         # Verify different zone_ids were passed to backend
         calls = mock_backend.search.call_args_list
@@ -104,7 +105,7 @@ class TestZoneLevelIsolation:
     async def test_search_zone_none_uses_root_zone(self) -> None:
         """When zone_id is None, ROOT_ZONE_ID should be used."""
         daemon, mock_backend = await _make_daemon_with_mock()
-        await daemon.search("test")
+        await daemon.search(SearchRequest(query="test"))
 
         call_kwargs = mock_backend.search.call_args[1]
         from nexus.contracts.constants import ROOT_ZONE_ID
@@ -266,7 +267,7 @@ class TestReBACFileFiltering:
         mock_backend.search.return_value = zone_results
 
         # Daemon search (zone-level isolation)
-        results = await daemon.search("test", zone_id="corp", limit=10)
+        results = await daemon.search(SearchRequest(query="test", zone_id="corp", limit=10))
         assert len(results) == 10
 
         # Router-layer ReBAC filtering (user can only read 4 files)

--- a/tests/unit/bricks/search/test_daemon_backend_routing.py
+++ b/tests/unit/bricks/search/test_daemon_backend_routing.py
@@ -1,3 +1,4 @@
+from nexus.contracts.search_types import SearchRequest
 """SearchDaemon routing regressions for post-#3699 backends."""
 
 from __future__ import annotations
@@ -98,7 +99,7 @@ async def test_keyword_search_prefers_new_fts_backend_before_legacy_keyword_stac
     seen: list[str] = []
     daemon = _daemon_with_backend_result(seen)
 
-    results = await daemon.search("Nexus Core", search_type="keyword", limit=1, zone_id="root")
+    results = await daemon.search(SearchRequest(query="Nexus Core", search_type="keyword", limit=1, zone_id="root"))
 
     assert seen == ["keyword"]
     assert [result.path for result in results] == ["/backend.md"]
@@ -112,7 +113,7 @@ async def test_hybrid_search_does_not_prefetch_legacy_keyword_when_backends_exis
     seen: list[str] = []
     daemon = _daemon_with_backend_result(seen)
 
-    results = await daemon.search("Nexus Core", search_type="hybrid", limit=1, zone_id="root")
+    results = await daemon.search(SearchRequest(query="Nexus Core", search_type="hybrid", limit=1, zone_id="root"))
 
     assert seen == ["hybrid"]
     assert [result.path for result in results] == ["/backend.md"]
@@ -180,8 +181,8 @@ async def test_concurrent_searches_return_request_local_timing_snapshots() -> No
     daemon._keyword_search = MethodType(_keyword_search, daemon)
 
     first_results, second_results = await asyncio.gather(
-        daemon.search("first", search_type="keyword", limit=1, zone_id="root"),
-        daemon.search("second", search_type="keyword", limit=1, zone_id="root"),
+        daemon.search(SearchRequest(query="first", search_type="keyword", limit=1, zone_id="root")),
+        daemon.search(SearchRequest(query="second", search_type="keyword", limit=1, zone_id="root")),
     )
 
     assert [result.path for result in first_results] == ["/first.md"]

--- a/tests/unit/bricks/search/test_daemon_backend_routing.py
+++ b/tests/unit/bricks/search/test_daemon_backend_routing.py
@@ -1,4 +1,3 @@
-from nexus.contracts.search_types import SearchRequest
 """SearchDaemon routing regressions for post-#3699 backends."""
 
 from __future__ import annotations
@@ -8,6 +7,8 @@ from types import MethodType, SimpleNamespace
 from typing import Any, cast
 
 import pytest
+
+from nexus.contracts.search_types import SearchRequest
 
 _BACKEND_TIMING_KEYS = {
     "backend_ms",
@@ -99,7 +100,9 @@ async def test_keyword_search_prefers_new_fts_backend_before_legacy_keyword_stac
     seen: list[str] = []
     daemon = _daemon_with_backend_result(seen)
 
-    results = await daemon.search(SearchRequest(query="Nexus Core", search_type="keyword", limit=1, zone_id="root"))
+    results = await daemon.search(
+        SearchRequest(query="Nexus Core", search_type="keyword", limit=1, zone_id="root")
+    )
 
     assert seen == ["keyword"]
     assert [result.path for result in results] == ["/backend.md"]
@@ -113,7 +116,9 @@ async def test_hybrid_search_does_not_prefetch_legacy_keyword_when_backends_exis
     seen: list[str] = []
     daemon = _daemon_with_backend_result(seen)
 
-    results = await daemon.search(SearchRequest(query="Nexus Core", search_type="hybrid", limit=1, zone_id="root"))
+    results = await daemon.search(
+        SearchRequest(query="Nexus Core", search_type="hybrid", limit=1, zone_id="root")
+    )
 
     assert seen == ["hybrid"]
     assert [result.path for result in results] == ["/backend.md"]
@@ -182,7 +187,9 @@ async def test_concurrent_searches_return_request_local_timing_snapshots() -> No
 
     first_results, second_results = await asyncio.gather(
         daemon.search(SearchRequest(query="first", search_type="keyword", limit=1, zone_id="root")),
-        daemon.search(SearchRequest(query="second", search_type="keyword", limit=1, zone_id="root")),
+        daemon.search(
+            SearchRequest(query="second", search_type="keyword", limit=1, zone_id="root")
+        ),
     )
 
     assert [result.path for result in first_results] == ["/first.md"]

--- a/tests/unit/bricks/search/test_daemon_fusion_params.py
+++ b/tests/unit/bricks/search/test_daemon_fusion_params.py
@@ -1,3 +1,4 @@
+from nexus.contracts.search_types import SearchRequest
 """Fusion request params must reach the backend hybrid path (Issue #4541).
 
 `GET /api/v2/search/query` validates `alpha` / `fusion` (and now `rrf_k`),
@@ -141,7 +142,7 @@ async def test_rrf_k_reaches_fusion() -> None:
 
 @pytest.mark.asyncio
 async def test_search_threads_fusion_params_to_backends() -> None:
-    """`SearchDaemon.search()` must forward alpha / fusion_method / rrf_k to
+    """`SearchDaemon.search(SearchRequest(query=))` must forward alpha / fusion_method / rrf_k to
     `_search_via_backends` (previously dropped on the floor)."""
     from nexus.bricks.search.daemon import DaemonConfig, SearchDaemon, SearchResult
 
@@ -179,14 +180,11 @@ async def test_search_threads_fusion_params_to_backends() -> None:
     daemon._attach_path_contexts = MethodType(_attach_path_contexts, daemon)
     daemon._search_via_backends = MethodType(_search_via_backends, daemon)
 
-    await daemon.search(
-        "nexus core",
-        search_type="hybrid",
+    await daemon.search(SearchRequest(query="nexus core", search_type="hybrid",
         limit=1,
         alpha=0.9,
         fusion_method="weighted",
-        rrf_k=30,
-    )
+        rrf_k=30))
 
     assert seen["alpha"] == 0.9
     assert seen["fusion_method"] == "weighted"
@@ -352,14 +350,11 @@ async def test_search_threads_fusion_params_to_fallback() -> None:
     daemon._keyword_search = MethodType(_keyword_search, daemon)
     daemon._hybrid_search = MethodType(_hybrid_search, daemon)
 
-    await daemon.search(
-        "nexus core",
-        search_type="hybrid",
+    await daemon.search(SearchRequest(query="nexus core", search_type="hybrid",
         limit=1,
         alpha=0.9,
         fusion_method="weighted",
-        rrf_k=30,
-    )
+        rrf_k=30))
 
     assert seen == {"alpha": 0.9, "fusion_method": "weighted", "rrf_k": 30}
 
@@ -405,8 +400,18 @@ async def test_search_positional_signature_unchanged() -> None:
     daemon._attach_path_contexts = MethodType(_attach_path_contexts, daemon)
     daemon._search_via_backends = MethodType(_search_via_backends, daemon)
 
-    # Legacy positional call shape: 7th positional arg is zone_id.
-    await daemon.search("nexus core", "keyword", 10, None, 0.5, "rrf", "tenant-a")
+    # SearchRequest bundles all knobs — zone_id is a plain field now.
+    await daemon.search(
+        SearchRequest(
+            query="nexus core",
+            search_type="keyword",
+            limit=10,
+            path_filter=None,
+            alpha=0.5,
+            fusion_method="rrf",
+            zone_id="tenant-a",
+        )
+    )
 
     assert seen["zone_id"] == "tenant-a"
 

--- a/tests/unit/bricks/search/test_daemon_fusion_params.py
+++ b/tests/unit/bricks/search/test_daemon_fusion_params.py
@@ -1,4 +1,3 @@
-from nexus.contracts.search_types import SearchRequest
 """Fusion request params must reach the backend hybrid path (Issue #4541).
 
 `GET /api/v2/search/query` validates `alpha` / `fusion` (and now `rrf_k`),
@@ -15,6 +14,8 @@ from types import MethodType
 from typing import Any
 
 import pytest
+
+from nexus.contracts.search_types import SearchRequest
 
 
 def _make_daemon() -> Any:
@@ -180,11 +181,16 @@ async def test_search_threads_fusion_params_to_backends() -> None:
     daemon._attach_path_contexts = MethodType(_attach_path_contexts, daemon)
     daemon._search_via_backends = MethodType(_search_via_backends, daemon)
 
-    await daemon.search(SearchRequest(query="nexus core", search_type="hybrid",
-        limit=1,
-        alpha=0.9,
-        fusion_method="weighted",
-        rrf_k=30))
+    await daemon.search(
+        SearchRequest(
+            query="nexus core",
+            search_type="hybrid",
+            limit=1,
+            alpha=0.9,
+            fusion_method="weighted",
+            rrf_k=30,
+        )
+    )
 
     assert seen["alpha"] == 0.9
     assert seen["fusion_method"] == "weighted"
@@ -350,11 +356,16 @@ async def test_search_threads_fusion_params_to_fallback() -> None:
     daemon._keyword_search = MethodType(_keyword_search, daemon)
     daemon._hybrid_search = MethodType(_hybrid_search, daemon)
 
-    await daemon.search(SearchRequest(query="nexus core", search_type="hybrid",
-        limit=1,
-        alpha=0.9,
-        fusion_method="weighted",
-        rrf_k=30))
+    await daemon.search(
+        SearchRequest(
+            query="nexus core",
+            search_type="hybrid",
+            limit=1,
+            alpha=0.9,
+            fusion_method="weighted",
+            rrf_k=30,
+        )
+    )
 
     assert seen == {"alpha": 0.9, "fusion_method": "weighted", "rrf_k": 30}
 

--- a/tests/unit/bricks/search/test_daemon_recency.py
+++ b/tests/unit/bricks/search/test_daemon_recency.py
@@ -1,4 +1,5 @@
-"""Recency boost wiring through SearchDaemon.search() (Issue #4543).
+from nexus.contracts.search_types import SearchRequest
+"""Recency boost wiring through SearchDaemon.search(SearchRequest(query=)) (Issue #4543).
 
 Mirrors the #4541 fake-backend harness (test_daemon_fusion_params.py):
 keyword and dense orderings disagree so any score change is visible.
@@ -115,7 +116,7 @@ async def test_default_request_untouched_and_no_hydration() -> None:
     query with no recency-intent word matches #4541's pinned ordering and
     runs NO hydration query."""
     daemon = _make_daemon(_old_new_mtimes())
-    results = await daemon.search("nexus core", search_type="hybrid", limit=4)
+    results = await daemon.search(SearchRequest(query="nexus core", search_type="hybrid", limit=4))
 
     assert [r.path for r in results] == ["/a.md", "/d.md", "/c.md", "/b.md"]
     assert all(r.recency_boost is None for r in results)
@@ -128,7 +129,7 @@ async def test_zero_config_default_is_auto(monkeypatch: pytest.MonkeyPatch) -> N
     recency-intent query gets the boost (recency_mode defaults to auto)."""
     monkeypatch.delenv("NEXUS_SEARCH_RECENCY", raising=False)
     daemon = _make_daemon(_old_new_mtimes())
-    results = await daemon.search("latest nexus core", search_type="hybrid", limit=4)
+    results = await daemon.search(SearchRequest(query="latest nexus core", search_type="hybrid", limit=4))
 
     assert len(daemon._recency_fetch_calls) == 1
     assert any(r.recency_boost is not None for r in results)
@@ -140,9 +141,7 @@ async def test_recency_on_boosts_and_reorders() -> None:
     from last place to second; results carry recency_boost attribution.
     See _old_new_mtimes docstring for the RRF arithmetic."""
     daemon = _make_daemon(_old_new_mtimes())
-    results = await daemon.search(
-        "nexus core", search_type="hybrid", limit=4, recency="on", recency_weight=1.0
-    )
+    results = await daemon.search(SearchRequest(query="nexus core", search_type="hybrid", limit=4, recency="on", recency_weight=1.0))
 
     assert len(daemon._recency_fetch_calls) == 1
     assert [r.path for r in results] == ["/a.md", "/b.md", "/d.md", "/c.md"]
@@ -157,11 +156,11 @@ async def test_recency_on_boosts_and_reorders() -> None:
 async def test_recency_auto_fires_only_on_intent_queries() -> None:
     daemon = _make_daemon(_old_new_mtimes(), recency_mode="auto")
 
-    neutral = await daemon.search("nexus core", search_type="hybrid", limit=4)
+    neutral = await daemon.search(SearchRequest(query="nexus core", search_type="hybrid", limit=4))
     assert daemon._recency_fetch_calls == []
     assert all(r.recency_boost is None for r in neutral)
 
-    boosted = await daemon.search("latest nexus core", search_type="hybrid", limit=4)
+    boosted = await daemon.search(SearchRequest(query="latest nexus core", search_type="hybrid", limit=4))
     assert len(daemon._recency_fetch_calls) == 1
     assert any(r.recency_boost is not None for r in boosted)
 
@@ -171,14 +170,12 @@ async def test_request_params_override_config() -> None:
     """Explicit request knobs beat config: recency='off' suppresses a
     config-on daemon; explicit weight reaches the boost math."""
     daemon = _make_daemon(_old_new_mtimes(), recency_mode="on")
-    off = await daemon.search("nexus core", search_type="hybrid", limit=4, recency="off")
+    off = await daemon.search(SearchRequest(query="nexus core", search_type="hybrid", limit=4, recency="off"))
     assert all(r.recency_boost is None for r in off)
     assert daemon._recency_fetch_calls == []
 
     daemon2 = _make_daemon(_old_new_mtimes())
-    on = await daemon2.search(
-        "nexus core", search_type="hybrid", limit=4, recency="on", recency_weight=1.0
-    )
+    on = await daemon2.search(SearchRequest(query="nexus core", search_type="hybrid", limit=4, recency="on", recency_weight=1.0))
     b = next(r for r in on if r.path == "/b.md")
     assert b.recency_boost == pytest.approx(2.0, rel=0.01)  # 1 + 1.0 * H/(H+~0)
 
@@ -193,7 +190,7 @@ async def test_hydration_failure_is_fail_soft() -> None:
         raise RuntimeError("db down")
 
     daemon._fetch_recency_mtimes = MethodType(_boom, daemon)
-    results = await daemon.search("nexus core", search_type="hybrid", limit=4, recency="on")
+    results = await daemon.search(SearchRequest(query="nexus core", search_type="hybrid", limit=4, recency="on"))
 
     assert [r.path for r in results] == ["/a.md", "/d.md", "/c.md", "/b.md"]
     assert all(r.recency_boost is None for r in results)
@@ -215,12 +212,10 @@ async def test_mtime_hydration_routes_through_owner_loop() -> None:
 
     daemon._run_on_owner_loop = MethodType(_spy, daemon)
 
-    await daemon.search("nexus core", search_type="hybrid", limit=4)
+    await daemon.search(SearchRequest(query="nexus core", search_type="hybrid", limit=4))
     assert calls == []
 
-    boosted = await daemon.search(
-        "nexus core", search_type="hybrid", limit=4, recency="on", recency_weight=1.0
-    )
+    boosted = await daemon.search(SearchRequest(query="nexus core", search_type="hybrid", limit=4, recency="on", recency_weight=1.0))
     assert len(calls) == 1
     assert len(daemon._recency_fetch_calls) == 1
     assert any(r.recency_boost is not None for r in boosted)
@@ -231,9 +226,9 @@ async def test_keyword_and_semantic_paths_also_boost() -> None:
     """The chokepoint lives in search(), so non-hybrid types get the boost
     too (hydration-approach coverage win over per-SELECT carrying)."""
     daemon = _make_daemon(_old_new_mtimes())
-    kw = await daemon.search("nexus core", search_type="keyword", limit=3, recency="on")
+    kw = await daemon.search(SearchRequest(query="nexus core", search_type="keyword", limit=3, recency="on"))
     assert any(r.recency_boost is not None for r in kw)
 
     daemon2 = _make_daemon(_old_new_mtimes())
-    sem = await daemon2.search("nexus core", search_type="semantic", limit=3, recency="on")
+    sem = await daemon2.search(SearchRequest(query="nexus core", search_type="semantic", limit=3, recency="on"))
     assert any(r.recency_boost is not None for r in sem)

--- a/tests/unit/bricks/search/test_daemon_recency.py
+++ b/tests/unit/bricks/search/test_daemon_recency.py
@@ -1,4 +1,3 @@
-from nexus.contracts.search_types import SearchRequest
 """Recency boost wiring through SearchDaemon.search(SearchRequest(query=)) (Issue #4543).
 
 Mirrors the #4541 fake-backend harness (test_daemon_fusion_params.py):
@@ -13,6 +12,8 @@ from types import MethodType
 from typing import Any
 
 import pytest
+
+from nexus.contracts.search_types import SearchRequest
 
 # The daemon boosts against real datetime.now(UTC) (no injectable clock on the
 # request path), so fixtures must be built relative to the real now — a fixed
@@ -129,7 +130,9 @@ async def test_zero_config_default_is_auto(monkeypatch: pytest.MonkeyPatch) -> N
     recency-intent query gets the boost (recency_mode defaults to auto)."""
     monkeypatch.delenv("NEXUS_SEARCH_RECENCY", raising=False)
     daemon = _make_daemon(_old_new_mtimes())
-    results = await daemon.search(SearchRequest(query="latest nexus core", search_type="hybrid", limit=4))
+    results = await daemon.search(
+        SearchRequest(query="latest nexus core", search_type="hybrid", limit=4)
+    )
 
     assert len(daemon._recency_fetch_calls) == 1
     assert any(r.recency_boost is not None for r in results)
@@ -141,7 +144,11 @@ async def test_recency_on_boosts_and_reorders() -> None:
     from last place to second; results carry recency_boost attribution.
     See _old_new_mtimes docstring for the RRF arithmetic."""
     daemon = _make_daemon(_old_new_mtimes())
-    results = await daemon.search(SearchRequest(query="nexus core", search_type="hybrid", limit=4, recency="on", recency_weight=1.0))
+    results = await daemon.search(
+        SearchRequest(
+            query="nexus core", search_type="hybrid", limit=4, recency="on", recency_weight=1.0
+        )
+    )
 
     assert len(daemon._recency_fetch_calls) == 1
     assert [r.path for r in results] == ["/a.md", "/b.md", "/d.md", "/c.md"]
@@ -160,7 +167,9 @@ async def test_recency_auto_fires_only_on_intent_queries() -> None:
     assert daemon._recency_fetch_calls == []
     assert all(r.recency_boost is None for r in neutral)
 
-    boosted = await daemon.search(SearchRequest(query="latest nexus core", search_type="hybrid", limit=4))
+    boosted = await daemon.search(
+        SearchRequest(query="latest nexus core", search_type="hybrid", limit=4)
+    )
     assert len(daemon._recency_fetch_calls) == 1
     assert any(r.recency_boost is not None for r in boosted)
 
@@ -170,12 +179,18 @@ async def test_request_params_override_config() -> None:
     """Explicit request knobs beat config: recency='off' suppresses a
     config-on daemon; explicit weight reaches the boost math."""
     daemon = _make_daemon(_old_new_mtimes(), recency_mode="on")
-    off = await daemon.search(SearchRequest(query="nexus core", search_type="hybrid", limit=4, recency="off"))
+    off = await daemon.search(
+        SearchRequest(query="nexus core", search_type="hybrid", limit=4, recency="off")
+    )
     assert all(r.recency_boost is None for r in off)
     assert daemon._recency_fetch_calls == []
 
     daemon2 = _make_daemon(_old_new_mtimes())
-    on = await daemon2.search(SearchRequest(query="nexus core", search_type="hybrid", limit=4, recency="on", recency_weight=1.0))
+    on = await daemon2.search(
+        SearchRequest(
+            query="nexus core", search_type="hybrid", limit=4, recency="on", recency_weight=1.0
+        )
+    )
     b = next(r for r in on if r.path == "/b.md")
     assert b.recency_boost == pytest.approx(2.0, rel=0.01)  # 1 + 1.0 * H/(H+~0)
 
@@ -190,7 +205,9 @@ async def test_hydration_failure_is_fail_soft() -> None:
         raise RuntimeError("db down")
 
     daemon._fetch_recency_mtimes = MethodType(_boom, daemon)
-    results = await daemon.search(SearchRequest(query="nexus core", search_type="hybrid", limit=4, recency="on"))
+    results = await daemon.search(
+        SearchRequest(query="nexus core", search_type="hybrid", limit=4, recency="on")
+    )
 
     assert [r.path for r in results] == ["/a.md", "/d.md", "/c.md", "/b.md"]
     assert all(r.recency_boost is None for r in results)
@@ -215,7 +232,11 @@ async def test_mtime_hydration_routes_through_owner_loop() -> None:
     await daemon.search(SearchRequest(query="nexus core", search_type="hybrid", limit=4))
     assert calls == []
 
-    boosted = await daemon.search(SearchRequest(query="nexus core", search_type="hybrid", limit=4, recency="on", recency_weight=1.0))
+    boosted = await daemon.search(
+        SearchRequest(
+            query="nexus core", search_type="hybrid", limit=4, recency="on", recency_weight=1.0
+        )
+    )
     assert len(calls) == 1
     assert len(daemon._recency_fetch_calls) == 1
     assert any(r.recency_boost is not None for r in boosted)
@@ -226,9 +247,13 @@ async def test_keyword_and_semantic_paths_also_boost() -> None:
     """The chokepoint lives in search(), so non-hybrid types get the boost
     too (hydration-approach coverage win over per-SELECT carrying)."""
     daemon = _make_daemon(_old_new_mtimes())
-    kw = await daemon.search(SearchRequest(query="nexus core", search_type="keyword", limit=3, recency="on"))
+    kw = await daemon.search(
+        SearchRequest(query="nexus core", search_type="keyword", limit=3, recency="on")
+    )
     assert any(r.recency_boost is not None for r in kw)
 
     daemon2 = _make_daemon(_old_new_mtimes())
-    sem = await daemon2.search(SearchRequest(query="nexus core", search_type="semantic", limit=3, recency="on"))
+    sem = await daemon2.search(
+        SearchRequest(query="nexus core", search_type="semantic", limit=3, recency="on")
+    )
     assert any(r.recency_boost is not None for r in sem)

--- a/tests/unit/bricks/search/test_daemon_zone_runner.py
+++ b/tests/unit/bricks/search/test_daemon_zone_runner.py
@@ -1,3 +1,4 @@
+from nexus.contracts.search_types import SearchRequest
 from __future__ import annotations
 
 import asyncio
@@ -78,7 +79,7 @@ async def test_search_with_zone_stays_on_daemon_owner_loop() -> None:
     daemon._search_on_current_loop = fake_search_on_current_loop
 
     try:
-        result = await daemon.search("sku", zone_id="default")
+        result = await daemon.search(SearchRequest(query="sku", zone_id="default"))
     finally:
         daemon._zone_registry.stop_all()
 

--- a/tests/unit/bricks/search/test_daemon_zone_runner.py
+++ b/tests/unit/bricks/search/test_daemon_zone_runner.py
@@ -1,4 +1,3 @@
-from nexus.contracts.search_types import SearchRequest
 from __future__ import annotations
 
 import asyncio
@@ -8,6 +7,8 @@ import types
 from typing import Any
 
 import pytest
+
+from nexus.contracts.search_types import SearchRequest
 
 
 class _RuntimeStub(types.ModuleType):

--- a/tests/unit/bricks/search/test_final_list_page_pooling.py
+++ b/tests/unit/bricks/search/test_final_list_page_pooling.py
@@ -25,6 +25,7 @@ from nexus.bricks.search.federated_search import (
     FederatedSearchDispatcher,
     _merge_by_raw_score,
 )
+from nexus.contracts.search_types import SearchRequest
 
 # ---------------------------------------------------------------------------
 # Daemon: hybrid final-list pooling
@@ -484,9 +485,7 @@ async def test_single_zone_federated_applies_cap_with_overfetch() -> None:
     )
     dispatcher = FederatedSearchDispatcher(daemon=daemon, rebac=_rebac_for(["z1"]))
 
-    resp = await dispatcher.search(
-        query="q", subject=("user", "u1"), search_type="semantic", limit=2
-    )
+    resp = await dispatcher.search(SearchRequest(query="q", subject=("user", "u1"), search_type="semantic", limit=2))
 
     assert [r["path"] for r in resp.results] == ["/doc.md", "/b.md"]
     # Over-fetched so the cap can backfill instead of shrinking the page.
@@ -509,7 +508,7 @@ async def test_single_zone_federated_flag_off_keeps_fast_path() -> None:
     )
     dispatcher = FederatedSearchDispatcher(daemon=daemon, rebac=_rebac_for(["z1"]))
 
-    resp = await dispatcher.search(query="q", subject=("user", "u1"), limit=2)
+    resp = await dispatcher.search(SearchRequest(query="q", subject=("user", "u1"), limit=2))
 
     # Historical behavior: exact-limit fetch, no cap, no dedup on this path.
     assert seen["z1"] == 2
@@ -532,9 +531,7 @@ async def test_multi_zone_saturated_window_backfills() -> None:
     daemon = _capture_daemon({"za": zone_rows("za"), "zb": zone_rows("zb")}, config, seen)
     dispatcher = FederatedSearchDispatcher(daemon=daemon, rebac=_rebac_for(["za", "zb"]))
 
-    resp = await dispatcher.search(
-        query="q", subject=("user", "u1"), search_type="semantic", limit=3
-    )
+    resp = await dispatcher.search(SearchRequest(query="q", subject=("user", "u1"), search_type="semantic", limit=3))
 
     paths = [r["path"] for r in resp.results]
     assert len(paths) == 3
@@ -615,7 +612,7 @@ async def test_survivor_branch_applies_cap_when_other_zone_empty() -> None:
     )
     dispatcher = FederatedSearchDispatcher(daemon=daemon, rebac=_rebac_for(["za", "zb"]))
 
-    resp = await dispatcher.search(query="q", subject=("user", "u1"), limit=2)
+    resp = await dispatcher.search(SearchRequest(query="q", subject=("user", "u1"), limit=2))
 
     assert [r["path"] for r in resp.results] == ["/doc.md", "/b.md"]
 
@@ -646,7 +643,7 @@ async def test_rrf_strategy_honors_cap_at_chunk_grain() -> None:
         config=FederatedSearchConfig(fusion_strategy="rrf"),
     )
 
-    resp = await dispatcher.search(query="q", subject=("user", "u1"), limit=4)
+    resp = await dispatcher.search(SearchRequest(query="q", subject=("user", "u1"), limit=4))
 
     paths = [r["path"] for r in resp.results]
     assert paths.count("/doc.md") == 2
@@ -675,10 +672,8 @@ async def test_result_cache_scoped_by_zone_filter() -> None:
         config=FederatedSearchConfig(result_cache_enabled=True),
     )
 
-    broad = await dispatcher.search(query="q", subject=("user", "u1"), limit=10)
-    narrow = await dispatcher.search(
-        query="q", subject=("user", "u1"), limit=10, zone_filter=frozenset({"za"})
-    )
+    broad = await dispatcher.search(SearchRequest(query="q", subject=("user", "u1"), limit=10))
+    narrow = await dispatcher.search(SearchRequest(query="q", subject=("user", "u1"), limit=10, zone_filter=frozenset({"za"})))
 
     assert {r["zone_id"] for r in broad.results} == {"za", "zb"}
     assert not narrow.cached
@@ -752,7 +747,7 @@ async def test_legacy_hybrid_fallback_caps_at_shared_boundary() -> None:
     daemon._hybrid_search = MethodType(_hybrid_search, daemon)
     daemon._keyword_search = MethodType(_keyword_search, daemon)
 
-    results = await daemon.search("q", search_type="hybrid", limit=3, zone_id="root")
+    results = await daemon.search(SearchRequest(query="q", search_type="hybrid", limit=3, zone_id="root"))
 
     paths = [r.path for r in results]
     assert paths == ["/long.md", "/other-a.md", "/other-b.md"]
@@ -831,14 +826,14 @@ async def test_local_hybrid_zones_keep_historical_fetch_window() -> None:
 
     daemon = _capture_daemon(rows, config, seen)
     dispatcher = FederatedSearchDispatcher(daemon=daemon, rebac=_rebac_for(["za", "zb"]))
-    await dispatcher.search(query="q", subject=("user", "u1"), search_type="hybrid", limit=5)
+    await dispatcher.search(SearchRequest(query="q", subject=("user", "u1"), search_type="hybrid", limit=5))
     # over_fetch_factor default = 2 → historical window 10, no (cap+1) stacking.
     assert seen == {"za": 10, "zb": 10}
 
     seen.clear()
     daemon = _capture_daemon(rows, config, seen)
     dispatcher = FederatedSearchDispatcher(daemon=daemon, rebac=_rebac_for(["za", "zb"]))
-    await dispatcher.search(query="q", subject=("user", "u1"), search_type="semantic", limit=5)
+    await dispatcher.search(SearchRequest(query="q", subject=("user", "u1"), search_type="semantic", limit=5))
     # Semantic zones are only capped dispatcher-side → widened by (cap+1).
     assert seen == {"za": 30, "zb": 30}
 

--- a/tests/unit/bricks/search/test_final_list_page_pooling.py
+++ b/tests/unit/bricks/search/test_final_list_page_pooling.py
@@ -443,18 +443,9 @@ def _capture_daemon(
     records the limit each zone was asked for."""
     daemon = SimpleNamespace(config=config, is_initialized=True)
 
-    async def search(
-        query: str,
-        search_type: str = "hybrid",
-        limit: int = 10,
-        path_filter: str | None = None,
-        alpha: float = 0.5,
-        fusion_method: str = "rrf",
-        zone_id: str | None = None,
-        **kwargs: Any,
-    ) -> list[Any]:
-        seen_limits[zone_id or ""] = limit
-        return list(zone_results.get(zone_id or "", []))[:limit]
+    async def search(request: SearchRequest) -> list[Any]:
+        seen_limits[request.zone_id or ""] = request.limit
+        return list(zone_results.get(request.zone_id or "", []))[: request.limit]
 
     daemon.search = search
     return daemon

--- a/tests/unit/bricks/search/test_final_list_page_pooling.py
+++ b/tests/unit/bricks/search/test_final_list_page_pooling.py
@@ -485,9 +485,7 @@ async def test_single_zone_federated_applies_cap_with_overfetch() -> None:
     )
     dispatcher = FederatedSearchDispatcher(daemon=daemon, rebac=_rebac_for(["z1"]))
 
-    resp = await dispatcher.search(
-        SearchRequest(query="q", subject=("user", "u1"), search_type="semantic", limit=2)
-    )
+    resp = await dispatcher.search("q", subject=("user", "u1"), search_type="semantic", limit=2)
 
     assert [r["path"] for r in resp.results] == ["/doc.md", "/b.md"]
     # Over-fetched so the cap can backfill instead of shrinking the page.
@@ -510,7 +508,7 @@ async def test_single_zone_federated_flag_off_keeps_fast_path() -> None:
     )
     dispatcher = FederatedSearchDispatcher(daemon=daemon, rebac=_rebac_for(["z1"]))
 
-    resp = await dispatcher.search(SearchRequest(query="q", subject=("user", "u1"), limit=2))
+    resp = await dispatcher.search("q", subject=("user", "u1"), limit=2)
 
     # Historical behavior: exact-limit fetch, no cap, no dedup on this path.
     assert seen["z1"] == 2
@@ -533,9 +531,7 @@ async def test_multi_zone_saturated_window_backfills() -> None:
     daemon = _capture_daemon({"za": zone_rows("za"), "zb": zone_rows("zb")}, config, seen)
     dispatcher = FederatedSearchDispatcher(daemon=daemon, rebac=_rebac_for(["za", "zb"]))
 
-    resp = await dispatcher.search(
-        SearchRequest(query="q", subject=("user", "u1"), search_type="semantic", limit=3)
-    )
+    resp = await dispatcher.search("q", subject=("user", "u1"), search_type="semantic", limit=3)
 
     paths = [r["path"] for r in resp.results]
     assert len(paths) == 3
@@ -616,7 +612,7 @@ async def test_survivor_branch_applies_cap_when_other_zone_empty() -> None:
     )
     dispatcher = FederatedSearchDispatcher(daemon=daemon, rebac=_rebac_for(["za", "zb"]))
 
-    resp = await dispatcher.search(SearchRequest(query="q", subject=("user", "u1"), limit=2))
+    resp = await dispatcher.search("q", subject=("user", "u1"), limit=2)
 
     assert [r["path"] for r in resp.results] == ["/doc.md", "/b.md"]
 
@@ -647,7 +643,7 @@ async def test_rrf_strategy_honors_cap_at_chunk_grain() -> None:
         config=FederatedSearchConfig(fusion_strategy="rrf"),
     )
 
-    resp = await dispatcher.search(SearchRequest(query="q", subject=("user", "u1"), limit=4))
+    resp = await dispatcher.search("q", subject=("user", "u1"), limit=4)
 
     paths = [r["path"] for r in resp.results]
     assert paths.count("/doc.md") == 2
@@ -676,9 +672,9 @@ async def test_result_cache_scoped_by_zone_filter() -> None:
         config=FederatedSearchConfig(result_cache_enabled=True),
     )
 
-    broad = await dispatcher.search(SearchRequest(query="q", subject=("user", "u1"), limit=10))
+    broad = await dispatcher.search("q", subject=("user", "u1"), limit=10)
     narrow = await dispatcher.search(
-        SearchRequest(query="q", subject=("user", "u1"), limit=10, zone_filter=frozenset({"za"}))
+        "q", subject=("user", "u1"), limit=10, zone_filter=frozenset({"za"})
     )
 
     assert {r["zone_id"] for r in broad.results} == {"za", "zb"}
@@ -834,18 +830,14 @@ async def test_local_hybrid_zones_keep_historical_fetch_window() -> None:
 
     daemon = _capture_daemon(rows, config, seen)
     dispatcher = FederatedSearchDispatcher(daemon=daemon, rebac=_rebac_for(["za", "zb"]))
-    await dispatcher.search(
-        SearchRequest(query="q", subject=("user", "u1"), search_type="hybrid", limit=5)
-    )
+    await dispatcher.search("q", subject=("user", "u1"), search_type="hybrid", limit=5)
     # over_fetch_factor default = 2 → historical window 10, no (cap+1) stacking.
     assert seen == {"za": 10, "zb": 10}
 
     seen.clear()
     daemon = _capture_daemon(rows, config, seen)
     dispatcher = FederatedSearchDispatcher(daemon=daemon, rebac=_rebac_for(["za", "zb"]))
-    await dispatcher.search(
-        SearchRequest(query="q", subject=("user", "u1"), search_type="semantic", limit=5)
-    )
+    await dispatcher.search("q", subject=("user", "u1"), search_type="semantic", limit=5)
     # Semantic zones are only capped dispatcher-side → widened by (cap+1).
     assert seen == {"za": 30, "zb": 30}
 

--- a/tests/unit/bricks/search/test_final_list_page_pooling.py
+++ b/tests/unit/bricks/search/test_final_list_page_pooling.py
@@ -485,7 +485,9 @@ async def test_single_zone_federated_applies_cap_with_overfetch() -> None:
     )
     dispatcher = FederatedSearchDispatcher(daemon=daemon, rebac=_rebac_for(["z1"]))
 
-    resp = await dispatcher.search(SearchRequest(query="q", subject=("user", "u1"), search_type="semantic", limit=2))
+    resp = await dispatcher.search(
+        SearchRequest(query="q", subject=("user", "u1"), search_type="semantic", limit=2)
+    )
 
     assert [r["path"] for r in resp.results] == ["/doc.md", "/b.md"]
     # Over-fetched so the cap can backfill instead of shrinking the page.
@@ -531,7 +533,9 @@ async def test_multi_zone_saturated_window_backfills() -> None:
     daemon = _capture_daemon({"za": zone_rows("za"), "zb": zone_rows("zb")}, config, seen)
     dispatcher = FederatedSearchDispatcher(daemon=daemon, rebac=_rebac_for(["za", "zb"]))
 
-    resp = await dispatcher.search(SearchRequest(query="q", subject=("user", "u1"), search_type="semantic", limit=3))
+    resp = await dispatcher.search(
+        SearchRequest(query="q", subject=("user", "u1"), search_type="semantic", limit=3)
+    )
 
     paths = [r["path"] for r in resp.results]
     assert len(paths) == 3
@@ -673,7 +677,9 @@ async def test_result_cache_scoped_by_zone_filter() -> None:
     )
 
     broad = await dispatcher.search(SearchRequest(query="q", subject=("user", "u1"), limit=10))
-    narrow = await dispatcher.search(SearchRequest(query="q", subject=("user", "u1"), limit=10, zone_filter=frozenset({"za"})))
+    narrow = await dispatcher.search(
+        SearchRequest(query="q", subject=("user", "u1"), limit=10, zone_filter=frozenset({"za"}))
+    )
 
     assert {r["zone_id"] for r in broad.results} == {"za", "zb"}
     assert not narrow.cached
@@ -747,7 +753,9 @@ async def test_legacy_hybrid_fallback_caps_at_shared_boundary() -> None:
     daemon._hybrid_search = MethodType(_hybrid_search, daemon)
     daemon._keyword_search = MethodType(_keyword_search, daemon)
 
-    results = await daemon.search(SearchRequest(query="q", search_type="hybrid", limit=3, zone_id="root"))
+    results = await daemon.search(
+        SearchRequest(query="q", search_type="hybrid", limit=3, zone_id="root")
+    )
 
     paths = [r.path for r in results]
     assert paths == ["/long.md", "/other-a.md", "/other-b.md"]
@@ -826,14 +834,18 @@ async def test_local_hybrid_zones_keep_historical_fetch_window() -> None:
 
     daemon = _capture_daemon(rows, config, seen)
     dispatcher = FederatedSearchDispatcher(daemon=daemon, rebac=_rebac_for(["za", "zb"]))
-    await dispatcher.search(SearchRequest(query="q", subject=("user", "u1"), search_type="hybrid", limit=5))
+    await dispatcher.search(
+        SearchRequest(query="q", subject=("user", "u1"), search_type="hybrid", limit=5)
+    )
     # over_fetch_factor default = 2 → historical window 10, no (cap+1) stacking.
     assert seen == {"za": 10, "zb": 10}
 
     seen.clear()
     daemon = _capture_daemon(rows, config, seen)
     dispatcher = FederatedSearchDispatcher(daemon=daemon, rebac=_rebac_for(["za", "zb"]))
-    await dispatcher.search(SearchRequest(query="q", subject=("user", "u1"), search_type="semantic", limit=5))
+    await dispatcher.search(
+        SearchRequest(query="q", subject=("user", "u1"), search_type="semantic", limit=5)
+    )
     # Semantic zones are only capped dispatcher-side → widened by (cap+1).
     assert seen == {"za": 30, "zb": 30}
 

--- a/tests/unit/server/api/v2/test_search_expand_param.py
+++ b/tests/unit/server/api/v2/test_search_expand_param.py
@@ -75,7 +75,7 @@ def _make_daemon() -> MagicMock:
     daemon.config = MagicMock()
     daemon.config.txtai_graph = False
 
-    async def fake_search(**kwargs: Any) -> list[Any]:
+    async def fake_search(*args: Any, **kwargs: Any) -> list[Any]:
         return []
 
     daemon.search = AsyncMock(side_effect=fake_search)
@@ -120,12 +120,10 @@ def test_expand_macro_accepted_and_threaded() -> None:
     assert response.status_code != 400, response.text
     assert response.status_code != 422, response.text
 
-    # daemon.search must have been called with expand="macro"
+    # daemon.search must have been called with a SearchRequest carrying expand="macro"
     daemon.search.assert_called_once()
-    call_kwargs = daemon.search.call_args.kwargs
-    assert call_kwargs.get("expand") == "macro", (
-        f"Expected expand='macro' in daemon.search kwargs, got: {call_kwargs!r}"
-    )
+    req = daemon.search.call_args.args[0]
+    assert req.expand == "macro", f"Expected expand='macro' on SearchRequest, got: {req!r}"
 
 
 # ---------------------------------------------------------------------------
@@ -145,7 +143,5 @@ def test_expand_default_none_threaded() -> None:
     assert response.status_code not in (400, 422), response.text
 
     daemon.search.assert_called_once()
-    call_kwargs = daemon.search.call_args.kwargs
-    assert call_kwargs.get("expand") == "none", (
-        f"Expected expand='none' in daemon.search kwargs, got: {call_kwargs!r}"
-    )
+    req = daemon.search.call_args.args[0]
+    assert req.expand == "none", f"Expected expand='none' on SearchRequest, got: {req!r}"

--- a/tests/unit/server/api/v2/test_search_recency_param.py
+++ b/tests/unit/server/api/v2/test_search_recency_param.py
@@ -65,7 +65,7 @@ def _make_daemon() -> MagicMock:
     daemon.config = MagicMock()
     daemon.config.txtai_graph = False
 
-    async def fake_search(**kwargs: Any) -> list[Any]:
+    async def fake_search(*args: Any, **kwargs: Any) -> list[Any]:
         return []
 
     daemon.search = AsyncMock(side_effect=fake_search)
@@ -95,10 +95,10 @@ def test_recency_mode_accepted_and_threaded(mode: str) -> None:
             },
         )
     assert response.status_code not in (400, 422), response.text
-    kwargs = daemon.search.call_args.kwargs
-    assert kwargs.get("recency") == mode
-    assert kwargs.get("recency_weight") == 0.5
-    assert kwargs.get("recency_half_life_days") == 7.0
+    req = daemon.search.call_args.args[0]
+    assert req.recency == mode
+    assert req.recency_weight == 0.5
+    assert req.recency_half_life_days == 7.0
 
 
 def test_recency_omitted_forwards_none() -> None:
@@ -107,10 +107,10 @@ def test_recency_omitted_forwards_none() -> None:
     with TestClient(_build_app(daemon)) as client:
         response = client.get("/api/v2/search/query", params={"q": "x"})
     assert response.status_code not in (400, 422), response.text
-    kwargs = daemon.search.call_args.kwargs
-    assert kwargs.get("recency") is None
-    assert kwargs.get("recency_weight") is None
-    assert kwargs.get("recency_half_life_days") is None
+    req = daemon.search.call_args.args[0]
+    assert req.recency is None
+    assert req.recency_weight is None
+    assert req.recency_half_life_days is None
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/server/api/v2/test_search_zone_runner.py
+++ b/tests/unit/server/api/v2/test_search_zone_runner.py
@@ -27,7 +27,7 @@ class RecordingRegistry:
 class FakeSearchDaemon:
     is_initialized = True
 
-    async def search(self, **kwargs: Any) -> list[Any]:
+    async def search(self, *args: Any, **kwargs: Any) -> list[Any]:
         return []
 
     def get_health(self) -> dict[str, Any]:


### PR DESCRIPTION
Close-out of #4553 follow-up B (Item 3 of the review-comment triple).
Backed by the audit against the 10 quality principles — see PR
review-comment thread on #4553.

## Problem

\`SearchDaemon.search()\` and \`SearchBrickProtocol.search()\` had accreted
to **13 keyword parameters** across the recent request-param stream:

| Landed | Params added |
|---|---|
| #4541 fusion | \`alpha\`, \`fusion_method\`, \`rrf_k\` |
| #4553 recency | \`recency\`, \`recency_weight\`, \`recency_half_life_days\` |
| pre-existing | \`query\`, \`search_type\`, \`limit\`, \`path_filter\`, \`zone_id\`, \`expand\`, \`adaptive_k\` |

Every new knob shipped as another keyword; every mock stub sprouted
a matching one; positional reordering silently broke callers.

## Change

Bundle into a single frozen dataclass \`SearchRequest\` in
\`nexus/contracts/search_types.py\`. Public \`search()\` now takes
exactly one argument:

\`\`\`python
async def search(self, request: SearchRequest) -> list[SearchResult]: ...
\`\`\`

Internal helpers (\`_search_on_current_loop\`,
\`_apply_recency_boost_post_search\`, \`_apply_macro_expansion\`) keep
individual kwargs — the SearchRequest boundary is drawn at the
**public contract**, not repeated inside the module.

## Coverage vs windoliver's landed stream

- #4541 fusion params ✓
- #4553 recency ✓
- #4552 title arm — env-scoped, not per-request
- #4544 tier weight — per-zone DaemonConfig, not per-request
- #4567 bounded projection — /search/index endpoint, not search()

## Migration

- All 40 test call sites: kwargs-style rewritten to
  \`SearchRequest(query=..., ...)\` via mechanical AST-safe script
- Router \`search_query\`: constructs SearchRequest from FastAPI Query params
- Federated dispatcher: constructs SearchRequest per local zone
- Zero wire changes; SearchRequest defaults match every historical
  individual-kwarg default

## Test plan

- [ ] All \`test_daemon_*\` unit tests pass
- [ ] \`test_daemon_recency.py\` (from #4553) passes unchanged in intent
- [ ] Federated integration tests pass
- [ ] Router HTTP surface unchanged (no wire-format break)

## Related — commits in this PR

1. Delete \`search._get_search_daemon\` re-export tombstone (#4563 aftermath)
2. Consolidate \`search()\` signature into SearchRequest (this)