### PR TITLE
test(#36): daemon-level raw ACP tunnel E2E + managed_agent feature self-containment

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -798,6 +798,21 @@ jobs:
             uv run --no-sync python -m pytest tests/integration/test_kernel_restart_survival.py -v -o "addopts="
           done
 
+      - name: Managed-agent raw ACP tunnel E2E (nexusd-full, #36)
+        if: needs.detect-changes.outputs.code_changed == 'true'
+        timeout-minutes: 10
+        # The raw ACP control-plane spawn + DT_STREAM stdio tunnel live only
+        # in nexusd-full (it brings up the managed_agent service). Boot it via
+        # the same KernelClient spawn harness and drive
+        # start_session(spawn_spec) + StreamWriteNowait/StreamReadAt end to
+        # end over gRPC — the exact wire path an embedder (sudowork grpc-js)
+        # uses. Guards the daemon-level tunnel the in-process raw_spawn unit
+        # tests can't reach.
+        run: |
+          export NEXUS_KERNEL_BINARY="/home/runner/.cargo/bin/nexusd-full"
+          test -x "$NEXUS_KERNEL_BINARY" || { echo "::error::nexusd-full missing at $NEXUS_KERNEL_BINARY"; exit 1; }
+          uv run --no-sync python -m pytest tests/integration/test_managed_agent_tunnel_e2e.py -v -o "addopts="
+
   migration-test:
     name: Migration Tests (SQLite)
     needs: [detect-changes]

--- a/rust/services/Cargo.toml
+++ b/rust/services/Cargo.toml
@@ -15,12 +15,14 @@ default = []
 # slim Rust binaries (nexus-cluster) link only the services they want.
 service-audit = []
 service-agents = []
-service-managed-agent = []
+service-managed-agent = ["subprocess-host"]
 # Generic hosted-subprocess primitive (`crate::subprocess`): launch an
-# argv + surface its stdio as VFS DT_PIPEs. Unix-only at the mod gate.
-# `service-acp` pulls it (its one-shot path spawns agents); a
-# managed-agent build that wants the raw ACP control-plane spawn enables
-# it alongside `service-managed-agent`.
+# argv + surface its stdio to the VFS. Unix-only at the mod gate, so
+# enabling it on a non-unix target is a harmless no-op (the mods are
+# `cfg(unix)`-gated). BOTH spawning services pull it directly so each is
+# self-contained: `service-acp` (one-shot ACP) and `service-managed-agent`
+# (the raw ACP control-plane tunnel — its DEFINING capability, so it must
+# not silently depend on `service-acp` being co-enabled to get spawn).
 subprocess-host = []
 service-acp = ["subprocess-host"]
 service-tasks = []

--- a/rust/services/src/managed_agent/mod.rs
+++ b/rust/services/src/managed_agent/mod.rs
@@ -134,17 +134,20 @@ pub(crate) struct StartSessionRequest {
     #[serde(default)]
     pub zone_id: String,
     /// Embedder-computed raw spawn spec (ACP control-plane contract, 2026-08-01). When
-    /// set, `start_session` spawns THIS subprocess (stdio surfaced as DT_PIPEs at
-    /// `/{zone}/proc/{pid}/fd/{0,1,2}`) instead of resolving the `agent_id` profile — the
-    /// caller (sudowork/hydra) owns ALL launch logic (auth-mode/env/args/token/model);
-    /// nexus only executes + supervises + exposes the fd pipes for the client's ACP tunnel.
+    /// set, `start_session` spawns THIS subprocess (stdio surfaced as node-local
+    /// `io_profile="memory"` `DT_STREAM`s at `/proc/{session_id}/fd/{0,1,2}`, where
+    /// `session_id` is the returned AgentRegistry pid — see [`raw_spawn`]) instead of
+    /// resolving the `agent_id` profile — the caller (sudowork/hydra) owns ALL launch
+    /// logic (auth-mode/env/args/token/model); nexus only executes + supervises + pumps
+    /// the child's stdio through those streams for the client's raw-byte ACP tunnel.
     #[serde(default)]
     pub spawn_spec: Option<SpawnSpec>,
 }
 
 /// Raw subprocess spec computed by the embedder. The launch-logic SSOT stays client-side
 /// (e.g. sudowork's `acpConnectors.ts`); nexus executes `cmd`+`args` with `env` in `cwd`,
-/// supervises the child, and surfaces its stdio as fd DT_PIPEs. nexus never parses ACP.
+/// supervises the child, and pumps its stdio through node-local memory `DT_STREAM`s
+/// (`/proc/{session_id}/fd/{0,1,2}`). nexus never frames or parses ACP.
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub(crate) struct SpawnSpec {
     pub cmd: String,

--- a/tests/integration/test_managed_agent_tunnel_e2e.py
+++ b/tests/integration/test_managed_agent_tunnel_e2e.py
@@ -1,0 +1,139 @@
+"""E2E: managed_agent raw ACP control-plane tunnel over gRPC (task #36).
+
+Boots a real ``nexusd-full`` daemon (same ``KernelClient`` spawn harness as
+the restart-survival smoke) and drives the raw-byte stdio tunnel end to end
+over the *actual* wire path an embedder (sudowork's grpc-js client) uses:
+
+  1. ``ManagedAgentService.start_session(spawn_spec)`` via the ``Call`` RPC
+     (``managed_agent.start_session_v1``, JSON payload) — spawns a subprocess
+     and returns ``{session_id, os_pid}``.
+  2. write stdin bytes to the ``/proc/{session_id}/fd/0`` DT_STREAM
+     (``StreamWriteNowait``).
+  3. read the echoed bytes back off ``/proc/{session_id}/fd/1``
+     (``StreamReadAt``, non-blocking poll).
+
+The subprocess is ``sh -c 'read line; printf ...'`` — a line-buffered,
+self-terminating echo, so a single line round-trips promptly (``cat`` would
+block-buffer its stdout on a pipe and never flush until EOF) and the child
+exits on its own, exercising the supervisor reap path too.
+
+This is the gap the in-process ``raw_spawn`` unit tests don't cover: the
+gRPC ``Call`` routing to the Rust service + the ``StreamReadAt`` /
+``StreamWriteNowait`` typed RPCs, through a booted daemon. Requires the
+``nexusd-full`` binary (which brings up ``managed_agent``); a slim
+``nexusd-cluster`` has no such service, so the test skips there.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from nexus.remote.kernel_client import KernelClient
+
+pytestmark = pytest.mark.skipif(
+    os.name == "nt",
+    reason="raw ACP subprocess host is unix-only (subprocess-host feature)",
+)
+
+# The tunnel + managed_agent service only exist in nexusd-full. Point the
+# spawn harness at it explicitly; if it (or any cluster binary) is missing,
+# skip rather than fail — matches the restart-survival smoke's contract.
+_KERNEL_BIN = os.environ.get("NEXUS_KERNEL_BINARY")
+
+_PROBE = b"hello-nexus-tunnel\n"
+_ROUNDTRIP_TIMEOUT_S = 15.0
+
+
+def _open_kernel(data_dir: Path) -> KernelClient:
+    client = KernelClient(metadata_path=str(data_dir))
+    try:
+        client.open()
+    except Exception:  # noqa: BLE001 — boot failure ⇒ skip unless pinned
+        client.close()
+        if _KERNEL_BIN:
+            raise
+        pytest.skip(
+            "nexusd-full binary unavailable; set NEXUS_KERNEL_BINARY to the "
+            "full daemon (it hosts managed_agent) to run this E2E."
+        )
+    return client
+
+
+def _start_session_when_ready(client: KernelClient, spec: dict, timeout_s: float = 25.0):
+    """Call start_session, tolerating the daemon boot window.
+
+    ``KernelClient._wait_ready`` returns as soon as the gRPC server answers
+    ``Ping`` — but that server binds (for raft consensus) BEFORE
+    ``bring_up_services`` registers managed_agent, so an immediate call can
+    land in a ~1–2s window where the service isn't registered yet and the
+    dot-notation ``Call`` returns a terminal "service not found". A client
+    that spawns the daemon must wait for it to finish booting; poll until
+    the control plane resolves.
+    """
+    deadline = time.monotonic() + timeout_s
+    last_err: Exception | None = None
+    while time.monotonic() < deadline:
+        try:
+            return client._call("managed_agent.start_session_v1", spec)
+        except Exception as exc:  # noqa: BLE001 — boot-window miss ⇒ retry
+            if "service not found" not in str(exc):
+                raise
+            last_err = exc
+            time.sleep(0.25)
+    raise AssertionError(f"managed_agent never became ready within {timeout_s}s: {last_err}")
+
+
+def test_managed_agent_tunnel_roundtrip(tmp_path: Path) -> None:
+    """spawn_spec → real subprocess → bidi raw-byte tunnel round-trips."""
+    client = _open_kernel(tmp_path)
+    try:
+        resp = _start_session_when_ready(
+            client,
+            {
+                "agent_id": "e2e-tunnel",
+                # Line-buffered self-terminating echo: reads one line from the
+                # stdin stream, writes it (+newline) to stdout, exits.
+                "spawn_spec": {
+                    "cmd": "sh",
+                    "args": ["-c", 'read line; printf "%s\\n" "$line"'],
+                    "env": {"PATH": os.environ.get("PATH", "/usr/bin:/bin")},
+                    "cwd": "/tmp",
+                },
+            },
+        )
+        session_id = resp["session_id"]
+        assert session_id, f"no session_id in start_session response: {resp!r}"
+        # os_pid is set ONLY on the raw control-plane (spawn_spec) path —
+        # its presence proves the RawSpawn provider (subprocess-host) is wired
+        # into the shipped daemon, not just the mailbox/workspace core.
+        assert resp.get("os_pid"), f"raw spawn must return a real os_pid: {resp!r}"
+
+        fd_stdin = f"/proc/{session_id}/fd/0"
+        fd_stdout = f"/proc/{session_id}/fd/1"
+
+        client.stream_write_nowait(fd_stdin, _PROBE)
+
+        # Poll fd/1 non-blocking until the echo comes back. `None` == no data
+        # yet (stream still open) — keep polling; the child flushes + exits
+        # after echoing, which drains the tail and closes the stream.
+        got = b""
+        offset = 0
+        deadline = time.monotonic() + _ROUNDTRIP_TIMEOUT_S
+        while time.monotonic() < deadline and got != _PROBE:
+            chunk = client.stream_read_at(fd_stdout, offset)
+            if chunk and chunk["data"]:
+                got += bytes(chunk["data"])
+                offset = chunk["next_offset"]
+            else:
+                time.sleep(0.05)
+
+        assert got == _PROBE, (
+            f"tunnel round-trip mismatch: wrote {_PROBE!r}, read back {got!r} "
+            f"(session_id={session_id})"
+        )
+    finally:
+        client.close()


### PR DESCRIPTION
Follow-up to #4561 (the #36 control plane). Closes the last owned nexus-side
gaps: a real daemon-level E2E for the raw ACP tunnel, a feature-coupling fix
the E2E surfaced, and a docstring correction.

## Commits

1. **docs(managed-agent)** — `spawn_spec`/`SpawnSpec` docstrings still described
   the pre-rebuild `DT_PIPEs at /{zone}/proc/...` surface; corrected to the
   actual node-local memory `DT_STREAM`s at un-zoned `/proc/{session_id}/fd/{0,1,2}`
   (matches `raw_spawn.rs`, the SSOT).

2. **fix(services)** — `service-managed-agent` now pulls `subprocess-host`
   directly. The raw ACP control-plane spawn (managed_agent's defining
   capability) is `cfg(feature = "subprocess-host")`-gated, but the feature
   only enabled it via `service-acp` co-enablement — so a managed-agent-only
   build silently rejected `spawn_spec`. `nexusd-full` worked only by that
   accident (it enables acp too). Now self-contained.

3. **test(managed-agent)** — daemon-level tunnel E2E over gRPC, wired into the
   nexusd-cluster smoke job (nexusd-full only). Boots a real daemon and drives
   `start_session(spawn_spec)` via `Call` → `StreamWriteNowait` fd/0 →
   `StreamReadAt` fd/1 echo — the exact wire path an embedder (sudowork
   grpc-js) uses. Covers what the in-process `raw_spawn` unit tests can't:
   the `Call` routing + typed stream RPCs through a booted daemon.

## Finding: daemon readiness window (pre-existing)

The E2E surfaced that the combined raft+VFS gRPC server binds (for consensus)
~1–2s **before** `bring_up_services` registers the services, so a
spawn-then-immediately-connect client (like `KernelClient`) can briefly get a
terminal `service not found` on a service `Call`. Pre-existing (a2a installed
at the same post-serve point before the SR refactor); production embedders
connect to an already-running daemon so they don't hit it. The test waits out
the window (correct hygiene when the client spawns the daemon). A daemon-side
readiness gate (retriable-not-found or serve-after-bring-up) is a recommended
separate nexus-vfs follow-up — flagged rather than hacked into the raft boot
ordering.

## Verification

- `cargo check -p services --features service-managed-agent` (alone) compiles
  the raw-spawn path (feature self-containment).
- Tunnel E2E green in Docker (`python:3.14-slim` + built `nexusd-full`):
  `1 passed in 8.93s` — real `start_session` + bidi tunnel roundtrip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)