### PR TITLE
chore(deps): daemon Call-readiness gate (nexus-vfs#201) + drop E2E workaround

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "a2a"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=f9613915b00108e01d2b6e2fb346bdc1ae04481e#f9613915b00108e01d2b6e2fb346bdc1ae04481e"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5f8b898e84166bdc9cf7b75c077b604c4f9d2ee1#5f8b898e84166bdc9cf7b75c077b604c4f9d2ee1"
 dependencies = [
  "contracts",
  "kernel",
@@ -220,7 +220,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 [[package]]
 name = "auth"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=f9613915b00108e01d2b6e2fb346bdc1ae04481e#f9613915b00108e01d2b6e2fb346bdc1ae04481e"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5f8b898e84166bdc9cf7b75c077b604c4f9d2ee1#5f8b898e84166bdc9cf7b75c077b604c4f9d2ee1"
 dependencies = [
  "contracts",
  "dashmap",
@@ -318,7 +318,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=f9613915b00108e01d2b6e2fb346bdc1ae04481e#f9613915b00108e01d2b6e2fb346bdc1ae04481e"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5f8b898e84166bdc9cf7b75c077b604c4f9d2ee1#5f8b898e84166bdc9cf7b75c077b604c4f9d2ee1"
 dependencies = [
  "ahash",
  "base64",
@@ -706,7 +706,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=f9613915b00108e01d2b6e2fb346bdc1ae04481e#f9613915b00108e01d2b6e2fb346bdc1ae04481e"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5f8b898e84166bdc9cf7b75c077b604c4f9d2ee1#5f8b898e84166bdc9cf7b75c077b604c4f9d2ee1"
 dependencies = [
  "parking_lot",
  "serde",
@@ -1797,7 +1797,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=f9613915b00108e01d2b6e2fb346bdc1ae04481e#f9613915b00108e01d2b6e2fb346bdc1ae04481e"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5f8b898e84166bdc9cf7b75c077b604c4f9d2ee1#5f8b898e84166bdc9cf7b75c077b604c4f9d2ee1"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -1849,7 +1849,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=f9613915b00108e01d2b6e2fb346bdc1ae04481e#f9613915b00108e01d2b6e2fb346bdc1ae04481e"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5f8b898e84166bdc9cf7b75c077b604c4f9d2ee1#5f8b898e84166bdc9cf7b75c077b604c4f9d2ee1"
 dependencies = [
  "ahash",
  "base64",
@@ -2039,7 +2039,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 [[package]]
 name = "nexus-cluster"
 version = "0.1.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=f9613915b00108e01d2b6e2fb346bdc1ae04481e#f9613915b00108e01d2b6e2fb346bdc1ae04481e"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5f8b898e84166bdc9cf7b75c077b604c4f9d2ee1#5f8b898e84166bdc9cf7b75c077b604c4f9d2ee1"
 dependencies = [
  "a2a",
  "anyhow",
@@ -2091,7 +2091,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=f9613915b00108e01d2b6e2fb346bdc1ae04481e#f9613915b00108e01d2b6e2fb346bdc1ae04481e"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5f8b898e84166bdc9cf7b75c077b604c4f9d2ee1#5f8b898e84166bdc9cf7b75c077b604c4f9d2ee1"
 
 [[package]]
 name = "nexus-search-plugin"
@@ -2717,7 +2717,7 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 [[package]]
 name = "raft"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=f9613915b00108e01d2b6e2fb346bdc1ae04481e#f9613915b00108e01d2b6e2fb346bdc1ae04481e"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5f8b898e84166bdc9cf7b75c077b604c4f9d2ee1#5f8b898e84166bdc9cf7b75c077b604c4f9d2ee1"
 dependencies = [
  "base64",
  "bincode",
@@ -3940,7 +3940,7 @@ dependencies = [
 [[package]]
 name = "transport"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=f9613915b00108e01d2b6e2fb346bdc1ae04481e#f9613915b00108e01d2b6e2fb346bdc1ae04481e"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5f8b898e84166bdc9cf7b75c077b604c4f9d2ee1#5f8b898e84166bdc9cf7b75c077b604c4f9d2ee1"
 dependencies = [
  "axum",
  "backends",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -223,24 +223,24 @@ exclude = ["nexus-fuse"]
 #
 # Bump alongside the rest of nexus-vfs updates when a downstream
 # change needs newer kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "f9613915b00108e01d2b6e2fb346bdc1ae04481e" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "f9613915b00108e01d2b6e2fb346bdc1ae04481e" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "f9613915b00108e01d2b6e2fb346bdc1ae04481e" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "f9613915b00108e01d2b6e2fb346bdc1ae04481e", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "f9613915b00108e01d2b6e2fb346bdc1ae04481e", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "f9613915b00108e01d2b6e2fb346bdc1ae04481e", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "f9613915b00108e01d2b6e2fb346bdc1ae04481e" }
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5f8b898e84166bdc9cf7b75c077b604c4f9d2ee1" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5f8b898e84166bdc9cf7b75c077b604c4f9d2ee1" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5f8b898e84166bdc9cf7b75c077b604c4f9d2ee1" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5f8b898e84166bdc9cf7b75c077b604c4f9d2ee1", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5f8b898e84166bdc9cf7b75c077b604c4f9d2ee1", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5f8b898e84166bdc9cf7b75c077b604c4f9d2ee1", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5f8b898e84166bdc9cf7b75c077b604c4f9d2ee1" }
 # The cluster daemon library entry (`nexus_cluster::run_with_services`),
 # consumed by the nexus-side assembly binary (`rust/nexusd`) that composes
 # the kernel/federation boot with the nexus service set via the
 # ServiceRegistry bring-up seam.
-nexus-cluster = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "f9613915b00108e01d2b6e2fb346bdc1ae04481e" }
+nexus-cluster = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5f8b898e84166bdc9cf7b75c077b604c4f9d2ee1" }
 # a2a messaging substrate. `default-features = false` leaves the
 # `install` feature (which pulls raft to arm the stream-wakeup observer)
 # OFF, so nexus-side consumers link only the stamp hook and stay
 # raft-free — they reach raft through kernel.sys_* (§6.1). The substrate
 # is armed in production at cluster boot in nexus-vfs, not here.
-a2a = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "f9613915b00108e01d2b6e2fb346bdc1ae04481e", default-features = false }
+a2a = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5f8b898e84166bdc9cf7b75c077b604c4f9d2ee1", default-features = false }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir --no-deps --prefix=/install .
 # enforces agreement) — an unpinned install tracks nexus-vfs HEAD and
 # ships an untested kernel (#4343). --locked honors the source tree's
 # Cargo.lock.
-ARG NEXUS_VFS_REV=f9613915b00108e01d2b6e2fb346bdc1ae04481e
+ARG NEXUS_VFS_REV=5f8b898e84166bdc9cf7b75c077b604c4f9d2ee1
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-cluster nexus-cluster
 
 # -- Runtime stage --

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -25,7 +25,7 @@ WORKDIR /build
 # (CI preflight enforces agreement) — an unpinned install tracks HEAD
 # and can skew the raft contract against the cluster/witness images.
 # --locked honors the source tree's Cargo.lock.
-ARG NEXUS_VFS_REV=f9613915b00108e01d2b6e2fb346bdc1ae04481e
+ARG NEXUS_VFS_REV=5f8b898e84166bdc9cf7b75c077b604c4f9d2ee1
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexus-raft-server raft
 
 # ---------- Production image ----------

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=f9613915b00108e01d2b6e2fb346bdc1ae04481e
+ARG NEXUS_VFS_REV=5f8b898e84166bdc9cf7b75c077b604c4f9d2ee1
 RUN cargo install \
     --locked \
     --git https://github.com/nexi-lab/nexus-vfs \

--- a/tests/integration/test_managed_agent_tunnel_e2e.py
+++ b/tests/integration/test_managed_agent_tunnel_e2e.py
@@ -63,36 +63,19 @@ def _open_kernel(data_dir: Path) -> KernelClient:
     return client
 
 
-def _start_session_when_ready(client: KernelClient, spec: dict, timeout_s: float = 25.0):
-    """Call start_session, tolerating the daemon boot window.
-
-    ``KernelClient._wait_ready`` returns as soon as the gRPC server answers
-    ``Ping`` — but that server binds (for raft consensus) BEFORE
-    ``bring_up_services`` registers managed_agent, so an immediate call can
-    land in a ~1–2s window where the service isn't registered yet and the
-    dot-notation ``Call`` returns a terminal "service not found". A client
-    that spawns the daemon must wait for it to finish booting; poll until
-    the control plane resolves.
-    """
-    deadline = time.monotonic() + timeout_s
-    last_err: Exception | None = None
-    while time.monotonic() < deadline:
-        try:
-            return client._call("managed_agent.start_session_v1", spec)
-        except Exception as exc:  # noqa: BLE001 — boot-window miss ⇒ retry
-            if "service not found" not in str(exc):
-                raise
-            last_err = exc
-            time.sleep(0.25)
-    raise AssertionError(f"managed_agent never became ready within {timeout_s}s: {last_err}")
-
-
 def test_managed_agent_tunnel_roundtrip(tmp_path: Path) -> None:
-    """spawn_spec → real subprocess → bidi raw-byte tunnel round-trips."""
+    """spawn_spec → real subprocess → bidi raw-byte tunnel round-trips.
+
+    Calls start_session directly with no client-side boot-window retry: the
+    daemon holds a service ``Call`` that arrives before ``bring_up_services``
+    has enlisted the services (nexus-vfs `Call` readiness gate), so a
+    spawn-then-immediately-connect client no longer needs to poll for the
+    control plane to appear.
+    """
     client = _open_kernel(tmp_path)
     try:
-        resp = _start_session_when_ready(
-            client,
+        resp = client._call(
+            "managed_agent.start_session_v1",
             {
                 "agent_id": "e2e-tunnel",
                 # Line-buffered self-terminating echo: reads one line from the


### PR DESCRIPTION
Pairs with **nexi-lab/nexus-vfs#201**. Closes the daemon-readiness race the
#36 tunnel E2E surfaced.

- Bumps the nexus-vfs pin `f9613915b` → `5f8b898e` (the `Call` readiness
  gate: the client-facing gRPC server binds early for raft consensus, so
  the `Call` handler now holds a dot-notation service call until
  `bring_up_services` has enlisted the services, instead of returning a
  terminal "service not found"). Cargo.toml == Cargo.lock == remaining
  Dockerfile ARGs (test.yml pin preflight).
- Drops the client-side boot-window workaround in the managed_agent tunnel
  E2E — the daemon holds the call now, so the test calls `start_session`
  once, directly (no tombstone).

## Verification

Tunnel E2E green against `nexusd-full` @ `5f8b898e` with **no** client-side
retry: `1 passed in 5.51s` (real `start_session` + bidi tunnel roundtrip,
Docker `python:3.14-slim`).

## Merge order

nexus-vfs#201 merges first (`--merge` keeps `5f8b898e` reachable on main →
this pin stays valid), then this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)