### PR TITLE
feat(managed-agent): surface child exit event (code+signal) — frozen-contract ③

### DIFF
--- a/rust/services/src/managed_agent/raw_spawn.rs
+++ b/rust/services/src/managed_agent/raw_spawn.rs
@@ -12,6 +12,11 @@
 //!   * `fd/0` (stdin) — the client appends bytes; a nexus pump reads the
 //!     stream and writes the child's stdin.
 //!
+//! Plus a fourth stream `/proc/{pid}/exit` carrying the frozen-contract ③
+//! exit event: on child exit the supervisor writes `{"code":…,"signal":…}`
+//! and closes it, so a client that saw `fd/1` close can read WHY the agent
+//! exited (clean vs signal death) to drive reconnect/resume.
+//!
 //! nexus NEVER frames or parses ACP — NDJSON/LSP framing + all protocol
 //! logic stay client-side. The stream primitive is the same offset-based,
 //! non-destructive log the A2A mailboxes use, so `read_at(offset)` cleanly
@@ -153,7 +158,20 @@ impl RawSpawn for KernelRawSpawn {
         let stdin_path = fd_path(pid, 0); // client → agent
         let stdout_path = fd_path(pid, 1); // agent → client
         let stderr_path = fd_path(pid, 2); // agent → client
-        let paths = [stdin_path.clone(), stdout_path.clone(), stderr_path.clone()];
+                                           // Frozen-contract ③: a node-local stream the supervisor writes the
+                                           // child's exit `{code, signal}` to (then closes) so a client that
+                                           // saw fd/1 close can read WHY the agent exited (clean vs signal
+                                           // death) to drive reconnect/resume. Same memory-DT_STREAM lifecycle
+                                           // as the fd tunnels — registered here, destroyed after the drain
+                                           // grace — so the reap teardown (which removes only the stamped
+                                           // procfs dirents, not these streams) leaves it readable meanwhile.
+        let exit_path = format!("/proc/{pid}/exit");
+        let paths = [
+            stdin_path.clone(),
+            stdout_path.clone(),
+            stderr_path.clone(),
+            exit_path.clone(),
+        ];
         let kernel = self.kernel.as_ref();
         let registry = self.agent_registry.as_ref();
 
@@ -215,18 +233,19 @@ impl RawSpawn for KernelRawSpawn {
         let kernel = Arc::clone(&self.kernel);
         let registry = Arc::clone(&self.agent_registry);
         let pid_owned = pid.to_string();
+        let exit_path_owned = exit_path.clone();
         rt.spawn(async move {
             let mut sub = sub;
             let self_exit = {
                 let waited = sub.wait();
                 tokio::pin!(waited);
                 tokio::select! {
-                    code = &mut waited => Some(code),
+                    st = &mut waited => Some(st),
                     _ = cancel_rx => None,
                 }
             };
-            let exit_code = match self_exit {
-                Some(code) => code,
+            let exit = match self_exit {
+                Some(st) => st,
                 None => {
                     sub.kill().await;
                     sub.wait().await
@@ -239,7 +258,24 @@ impl RawSpawn for KernelRawSpawn {
             // response). Stop the stdin pump and reap the session
             // (Terminated → on_terminate tears down the procfs subtree).
             let _ = stdin_stop_tx.send(());
-            let _ = registry.kill(&pid_owned, exit_code);
+            // ③ Surface the exit event on the handle: write `{code,signal}`
+            // to the exit stream + close it, so a client that saw fd/1
+            // close can read WHY the agent exited (clean vs signal death)
+            // to drive reconnect/resume. Best-effort — a destroyed stream
+            // just means the client already disconnected.
+            let exit_json = format!(
+                "{{\"code\":{},\"signal\":{}}}",
+                exit.code
+                    .map(|c| c.to_string())
+                    .unwrap_or_else(|| "null".to_string()),
+                exit.signal
+                    .map(|s| s.to_string())
+                    .unwrap_or_else(|| "null".to_string()),
+            );
+            let _ =
+                kernel.stream_write_nowait(&exit_path_owned, exit_json.as_bytes(), &system_ctx());
+            let _ = kernel.close_stream(&exit_path_owned);
+            let _ = registry.kill(&pid_owned, exit.as_reap_code());
             // Give the client a bounded window to drain the closed streams,
             // then remove them so they don't leak in the registry. (This
             // also unwedges a pump if a grandchild kept a write-end open,
@@ -248,7 +284,7 @@ impl RawSpawn for KernelRawSpawn {
             for p in &paths {
                 let _ = kernel.destroy_stream(p);
             }
-            tracing::info!(pid = %pid_owned, exit_code, "raw ACP stream tunnel closed");
+            tracing::info!(pid = %pid_owned, code = ?exit.code, signal = ?exit.signal, "raw ACP stream tunnel closed");
         });
 
         self.spawn_handles.insert(

--- a/rust/services/src/subprocess.rs
+++ b/rust/services/src/subprocess.rs
@@ -43,6 +43,7 @@
 
 use std::collections::HashMap;
 use std::os::fd::AsRawFd;
+use std::os::unix::process::ExitStatusExt;
 use std::path::Path;
 use std::process::Stdio;
 
@@ -248,13 +249,40 @@ impl HostedSubprocess {
         let _ = self.child.kill().await;
     }
 
-    /// Wait for the child to exit. Returns the exit code (or 0 on
-    /// signal / unknown status, matching the Python service's "no code"
-    /// fallback).
-    pub(crate) async fn wait(&mut self) -> i32 {
+    /// Wait for the child to exit. Returns the full terminal status —
+    /// exit `code` for a normal exit, or the terminating `signal` (unix)
+    /// if it was killed by a signal. The frozen-contract ③ exit event
+    /// needs BOTH: a signal death (`code == None`) must not be flattened
+    /// to a fake `0`, or the client can't tell a clean exit from a crash.
+    pub(crate) async fn wait(&mut self) -> ProcessExit {
         match self.child.wait().await {
-            Ok(status) => status.code().unwrap_or(0),
-            Err(_) => -1,
+            Ok(status) => ProcessExit {
+                code: status.code(),
+                signal: status.signal(),
+            },
+            Err(_) => ProcessExit::default(),
+        }
+    }
+}
+
+/// Terminal status of a hosted child (frozen-contract ③). Exactly one of
+/// `code` / `signal` is `Some` for a real exit; both `None` means the
+/// wait itself failed (status indeterminable).
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) struct ProcessExit {
+    pub code: Option<i32>,
+    pub signal: Option<i32>,
+}
+
+impl ProcessExit {
+    /// Collapse to the shell single-integer convention for the callers
+    /// that need one `i32` (AgentRegistry reap code, logs): the exit code,
+    /// else `128 + signal` for a signal death, else `-1` when unknown.
+    pub(crate) fn as_reap_code(&self) -> i32 {
+        match (self.code, self.signal) {
+            (Some(c), _) => c,
+            (None, Some(s)) => 128 + s,
+            (None, None) => -1,
         }
     }
 }
@@ -467,7 +495,7 @@ mod tests {
         let exit = tokio::time::timeout(Duration::from_secs(5), sub.wait())
             .await
             .expect("wait timed out");
-        assert_eq!(exit, 0, "cat should exit 0 on EOF");
+        assert_eq!(exit.code, Some(0), "cat should exit 0 on EOF");
     }
 
     /// Stress the spawn / register / write / read / kill path 10x to

--- a/tests/integration/test_managed_agent_tunnel_e2e.py
+++ b/tests/integration/test_managed_agent_tunnel_e2e.py
@@ -26,6 +26,7 @@ pure nexus-vfs cluster binary has no such service, so the test skips there.
 
 from __future__ import annotations
 
+import json
 import os
 import time
 from pathlib import Path
@@ -119,5 +120,27 @@ def test_managed_agent_tunnel_roundtrip(tmp_path: Path) -> None:
             f"tunnel round-trip mismatch: wrote {_PROBE!r}, read back {got!r} "
             f"(session_id={session_id})"
         )
+
+        # Frozen-contract ③: after the child echoes and exits, its exit
+        # event (code + signal) is surfaced on the handle at
+        # /proc/{session_id}/exit. Poll it — the supervisor writes
+        # {"code":…,"signal":…} then closes the stream, concurrently with
+        # fd/1's close, so it may land just after the roundtrip read.
+        exit_path = f"/proc/{session_id}/exit"
+        exit_raw = b""
+        offset = 0
+        deadline = time.monotonic() + 10.0
+        while time.monotonic() < deadline and not exit_raw:
+            chunk = client.stream_read_at(exit_path, offset)
+            if chunk and chunk["data"]:
+                exit_raw += bytes(chunk["data"])
+            else:
+                time.sleep(0.05)
+        assert exit_raw, f"no ③ exit event written to {exit_path}"
+        exit_info = json.loads(exit_raw)
+        # `sh -c 'read line; printf …'` echoes one line then exits 0 — a
+        # clean exit, so code=0 and no terminating signal.
+        assert exit_info["code"] == 0, f"expected clean exit 0, got {exit_info!r}"
+        assert exit_info["signal"] is None, f"clean exit has no signal: {exit_info!r}"
     finally:
         client.close()


### PR DESCRIPTION
Completes point ③ of the raw ACP tunnel frozen contract (#36). Before this,
a client could detect a disconnect (fd/1 stream close) but couldn't learn
**why** the agent exited — `get_session` drops the reaped descriptor, and
`HostedSubprocess::wait()` flattened a signal death to a fake exit code `0`.

## Change

- **subprocess.rs**: `wait()` returns `ProcessExit { code, signal }` — a
  signal death (`code == None`) is no longer masked as `0`. `as_reap_code()`
  collapses to the shell convention (`code`, else `128 + signal`) for the
  AgentRegistry reap.
- **raw_spawn.rs**: a 4th node-local memory `DT_STREAM`
  `/proc/{session_id}/exit`; on child exit the supervisor writes
  `{"code":…,"signal":…}` and closes it. Same lifecycle as the fd tunnels
  (destroyed after the drain grace), so the reap teardown — which removes
  only the stamped procfs dirents, not these streams — leaves it readable.
  A client that saw fd/1 close reads it via `StreamReadAt` (exactly like
  fd/1) to drive reconnect/resume.

nexus-only — reuses existing kernel stream ops
(register/write/close/destroy); no nexus-vfs change.

## Verification

- clippy `-D warnings` clean; `cargo build -p nexusd` green.
- Tunnel E2E **deepened** to assert the exit event
  (`/proc/{session_id}/exit` → `{"code":0,"signal":null}` for a clean
  echo-and-exit), green in Docker (`python:3.14-slim` + built
  `nexusd-full`): `1 passed in 7.28s`.

## sudowork contract

The exit event is read the same way as fd/1 — `StreamReadAt` on
`/proc/{session_id}/exit` after fd/1 closes, JSON `{code, signal}` (either
may be `null`). Relayed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)