### PR TITLE
fix(nexusd): production ships the slim cluster profile, not full+S3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -596,14 +596,15 @@ jobs:
           fi
 
   # ── nexusd-cluster boot smoke test ──────────────────────────────────
-  # Kernel-tier Rust (including nexusd-cluster) migrated to nexus-vfs (#4259).
-  # Install from nexus-vfs git and smoke-test the binary.
+  # Builds the nexus-local `nexusd-cluster` (the shipped production binary:
+  # nexus-vfs cluster profile + the managed_agent control plane, #36) and
+  # gates it — boot smoke, restart-survival, and the raw ACP tunnel E2E.
   nexusd-cluster-smoke:
     name: nexusd-cluster Smoke Test
     needs: detect-changes
     runs-on: ubuntu-latest
-    # Two pinned cargo installs (slim + full profile) plus the Python
-    # restart-survival gate; rust-cache keeps warm runs well under this.
+    # One `--path` cargo install plus the Python restart-survival +
+    # tunnel gates; rust-cache keeps warm runs well under this.
     timeout-minutes: 30
     steps:
       - name: Skip notice (no code changes)
@@ -629,7 +630,7 @@ jobs:
         # Every nexus-vfs pin in the repo must agree: the Cargo.toml
         # crate pins, the Cargo.lock resolution, and the remaining image
         # ARGs (dockerfiles/Dockerfile.{minimal,raft-server,raft-witness}).
-        # The main image's nexusd-full now pins nexus-vfs THROUGH
+        # The main image's nexusd-cluster now pins nexus-vfs THROUGH
         # Cargo.lock (it builds the nexus-local `nexusd` crate, #36), not
         # an ARG. A partial bump ships a kernel the gate below never
         # tested — the exact drift class behind #4343.
@@ -695,34 +696,40 @@ jobs:
             exit 1
           fi
 
-      - name: Install cluster kernels (nexusd-cluster from nexus-vfs, nexusd-full nexus-local)
+      - name: Install nexusd-cluster (the shipped production binary)
         if: needs.detect-changes.outputs.code_changed == 'true'
-        # Two binaries, two sources — both gated because both ship:
-        #   * nexusd-cluster = the slim federation kernel, still built
-        #     straight from nexus-vfs at the Cargo.toml-pinned rev. The
-        #     preflight above guarantees Cargo.toml == Cargo.lock == every
-        #     remaining Dockerfile ARG, so extracting from Cargo.toml IS
-        #     the shipping rev.
-        #   * nexusd-full = the binary the Docker image actually ships
-        #     (symlinked to nexus-cluster). As of #36 it is the
-        #     nexus-local `nexusd` crate (nexus-vfs cluster boot PLUS the
-        #     managed_agent/acp service set), NOT the nexus-vfs
-        #     `nexus-full` profile, so it must be built from THIS tree
-        #     (`--path rust/nexusd`) or the gate would test a binary the
-        #     image no longer ships.
-        # --locked honors the source tree's Cargo.lock (fresh dep
-        # resolution drifts on upstream releases); an unpinned install
-        # tracks nexus-vfs HEAD.
+        # Production ships the nexus-local `nexusd` crate as `nexusd-cluster`
+        # — the KERNEL-ARCHITECTURE §7 `cluster` profile PLUS the
+        # managed_agent control plane. It composes nexus-vfs cluster boot +
+        # managed_agent, so it must be built from THIS tree (`--path
+        # rust/nexusd`) — the gate then tests the EXACT binary the image
+        # ships. The pure nexus-vfs `nexusd-cluster` (no services) is gated
+        # in nexus-vfs CI (cluster-binary-build.yml, incl. its ≤15.5 MiB size
+        # budget), so it is not re-installed here. `--locked` honors the
+        # source tree's Cargo.lock (the nexus-vfs pin the preflight validated).
         run: |
-          REV=$(grep 'nexus-vfs' Cargo.toml | grep -m1 -oE 'rev = "[a-f0-9]{40}"' | cut -d'"' -f2)
-          if [ -z "$REV" ]; then
-            echo "::error::could not extract nexus-vfs rev pin from Cargo.toml"
+          echo "Installing nexusd-cluster from the nexus-local crate rust/nexusd"
+          cargo install --locked --path rust/nexusd --bin nexusd-cluster
+
+      - name: nexusd-cluster size budget (cluster profile purity)
+        if: needs.detect-changes.outputs.code_changed == 'true'
+        # The production cluster binary is size-gated (KERNEL-ARCHITECTURE §7;
+        # mirrors nexus-vfs cluster-binary-build.yml's linux budget). The
+        # nexus-vfs gate only covers the PURE cluster binary; production ships
+        # this nexus-local one (cluster profile + managed_agent), so it needs
+        # its own guard. managed_agent is a small control-plane addition
+        # (~14.9 MiB release/stripped); driver-s3 / connectors must NOT leak
+        # into the default (slim) build — that leak is the #36 regression this
+        # gate exists to catch.
+        run: |
+          BIN="$HOME/.cargo/bin/nexusd-cluster"
+          MAX=16252928  # 15.5 MiB — matches the nexus-vfs linux cluster budget
+          actual=$(stat -c%s "$BIN")
+          echo "nexusd-cluster size: $actual bytes (max: $MAX)"
+          if [ "$actual" -gt "$MAX" ]; then
+            echo "::error::nexusd-cluster ($actual bytes) exceeds the cluster size budget ($MAX). A driver/connector likely leaked into the default slim build — keep driver-s3 & connectors behind opt-in features (KERNEL-ARCHITECTURE §7)."
             exit 1
           fi
-          echo "Installing nexusd-cluster (slim) at pinned nexus-vfs rev $REV"
-          cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "$REV" --bin nexusd-cluster nexus-cluster
-          echo "Installing nexusd-full from the nexus-local crate rust/nexusd (the shipped binary)"
-          cargo install --locked --path rust/nexusd --bin nexusd-full
 
       - name: Boot smoke test
         if: needs.detect-changes.outputs.code_changed == 'true'
@@ -783,34 +790,30 @@ jobs:
         if: needs.detect-changes.outputs.code_changed == 'true'
         run: uv pip install -e ".[dev,test]"
 
-      - name: Restart-survival regression test (pinned kernels, both profiles)
+      - name: Restart-survival regression test (#4343)
         if: needs.detect-changes.outputs.code_changed == 'true'
         timeout-minutes: 15
         run: |
-          # nexusd-cluster = slim federation binary; nexusd-full = the
-          # binary the Docker image ships (symlinked to nexus-cluster).
-          # Both reuse cluster/src/main.rs — gate both so neither a
-          # slim- nor a full-profile regression ships untested.
-          for BIN in nexusd-cluster nexusd-full; do
-            export NEXUS_KERNEL_BINARY="/home/runner/.cargo/bin/$BIN"
-            test -x "$NEXUS_KERNEL_BINARY" || { echo "::error::pinned kernel binary missing at $NEXUS_KERNEL_BINARY"; exit 1; }
-            echo "Restart-survival against $BIN"
-            uv run --no-sync python -m pytest tests/integration/test_kernel_restart_survival.py -v -o "addopts="
-          done
+          # The VFS namespace must outlive a kernel restart. Runs against the
+          # exact production binary installed above (NEXUS_KERNEL_BINARY
+          # bypasses PATH lookup), so a rev bump that loses durable-metastore
+          # wiring fails this job.
+          export NEXUS_KERNEL_BINARY="/home/runner/.cargo/bin/nexusd-cluster"
+          test -x "$NEXUS_KERNEL_BINARY" || { echo "::error::nexusd-cluster missing at $NEXUS_KERNEL_BINARY"; exit 1; }
+          uv run --no-sync python -m pytest tests/integration/test_kernel_restart_survival.py -v -o "addopts="
 
-      - name: Managed-agent raw ACP tunnel E2E (nexusd-full, #36)
+      - name: Managed-agent raw ACP tunnel E2E (#36)
         if: needs.detect-changes.outputs.code_changed == 'true'
         timeout-minutes: 10
-        # The raw ACP control-plane spawn + DT_STREAM stdio tunnel live only
-        # in nexusd-full (it brings up the managed_agent service). Boot it via
-        # the same KernelClient spawn harness and drive
-        # start_session(spawn_spec) + StreamWriteNowait/StreamReadAt end to
-        # end over gRPC — the exact wire path an embedder (sudowork grpc-js)
-        # uses. Guards the daemon-level tunnel the in-process raw_spawn unit
-        # tests can't reach.
+        # The raw ACP control-plane spawn + DT_STREAM stdio tunnel live in
+        # nexusd-cluster (it brings up the managed_agent service). Boot it via
+        # the KernelClient spawn harness and drive start_session(spawn_spec) +
+        # StreamWriteNowait/StreamReadAt end to end over gRPC — the exact wire
+        # path an embedder (sudowork grpc-js) uses. Guards the daemon-level
+        # tunnel the in-process raw_spawn unit tests can't reach.
         run: |
-          export NEXUS_KERNEL_BINARY="/home/runner/.cargo/bin/nexusd-full"
-          test -x "$NEXUS_KERNEL_BINARY" || { echo "::error::nexusd-full missing at $NEXUS_KERNEL_BINARY"; exit 1; }
+          export NEXUS_KERNEL_BINARY="/home/runner/.cargo/bin/nexusd-cluster"
+          test -x "$NEXUS_KERNEL_BINARY" || { echo "::error::nexusd-cluster missing at $NEXUS_KERNEL_BINARY"; exit 1; }
           uv run --no-sync python -m pytest tests/integration/test_managed_agent_tunnel_e2e.py -v -o "addopts="
 
   migration-test:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,11 +27,12 @@ members = [
     # walk over `sys_readdir` + `sys_read` in v1, trigram / streaming
     # / adaptive-strategy variants land in v2.
     "rust/services/search-plugin",
-    # nexusd — the nexus full daemon assembly binary (`nexusd-full`).
-    # Composes the nexus-vfs cluster boot (`nexus_cluster::run_with_services`)
-    # with the nexus service set (managed_agent, acp) via the
-    # ServiceRegistry bring-up seam. Supersedes the pure nexus-vfs
-    # `nexusd-full` (no nexus services) as the production daemon.
+    # nexusd — the nexus cluster-profile daemon assembly binary
+    # (`nexusd-cluster`). Composes the nexus-vfs cluster boot
+    # (`nexus_cluster::run_with_services`) with the managed_agent control
+    # plane via the ServiceRegistry bring-up seam. This IS the production
+    # `cluster` profile (KERNEL-ARCHITECTURE §7) plus the agent control
+    # plane; the full/S3 superset is the opt-in `driver-s3` feature.
     "rust/nexusd",
 ]
 # nexus-fuse excluded: standalone FUSE daemon with different dependency versions

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,29 +78,30 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=cache,target=/root/.cache/pip \
     uv pip install --system -i "$(cat /tmp/pip_index)" ".[${NEXUS_PROFILE_EXTRAS}]"
 
-# ---------- Build nexusd-full from nexus-local sources (Issue #3125, #4259, #36) ----------
-# The production daemon is `nexusd-full`. Historically this was the nexus-vfs
-# `full` profile (kernel/raft/federation + S3/R2 driver) `cargo install`ed from
-# the git repo. As of the ServiceRegistry bring-up refactor (#36) it is the
-# nexus-local `nexusd` crate (rust/nexusd): the SAME nexus-vfs cluster boot
-# (`nexus_cluster::run_with_services`) PLUS the nexus service set (managed_agent
-# raw-spawn control plane + acp one-shot) composed in at boot via
-# `Kernel::bring_up_services`, PLUS the S3/R2 driver (`backends` `driver-s3`
-# feature — matches the old full profile via feature unification). It is a
-# strict superset of the old binary. The kernel repo can't depend on the nexus
-# service crates, so the composition root lives HERE, next to those crates.
+# ---------- Build nexusd-cluster from nexus-local sources (Issue #3125, #4259, #36) ----------
+# The production daemon is `nexusd-cluster` — the `cluster` deployment
+# profile (KERNEL-ARCHITECTURE §7: slim ⊂ cluster ⊂ … ⊂ full) PLUS the
+# agent control plane. As of the ServiceRegistry bring-up refactor (#36)
+# it is the nexus-local `nexusd` crate (rust/nexusd): the SAME nexus-vfs
+# cluster boot (`nexus_cluster::run_with_services`) plus managed_agent
+# composed in at boot via `Kernel::bring_up_services`. The kernel repo
+# can't depend on the nexus service crates, so the composition root lives
+# HERE, next to them.
 #
-# The slim `nexusd-cluster` and the raft server/witness binaries still come from
-# nexus-vfs (dockerfiles/Dockerfile.{minimal,raft-server,raft-witness}) — those
-# deployment tiers legitimately carry no nexus services.
+# PROFILE PURITY (§7): this is the SLIM cluster — backends = path-local +
+# remote only (via `nexus-cluster`); NO S3, no connectors — so it holds
+# the size gate (nexus-vfs cluster-binary-build.yml: linux ≤ 15.5 MiB;
+# cluster + managed_agent measures ~14.9 MiB). The full/S3 superset is the
+# OPT-IN `driver-s3` feature (~+4 MiB AWS SDK), never the default — an
+# S3-serving tier builds `-p nexusd --features driver-s3`.
 #
-# The nexus-vfs pin is no longer a build-arg here: `nexusd` resolves nexus-vfs
-# through its Cargo.toml git-dep `rev` + Cargo.lock (the SSOT). `--locked` builds
-# exactly that resolution. Bump the pin in Cargo.toml/Cargo.lock — the test.yml
-# "Kernel pin consistency preflight" still enforces Cargo == Cargo.lock == the
-# remaining Dockerfile ARGs, and CI's nexusd-full smoke now builds this same
-# nexus-local crate (so the gate tests the exact binary the image ships).
-# nexusd-full is symlinked to nexus-cluster/nexusd-cluster below so the Python
+# The nexus-vfs pin is not a build-arg here: `nexusd` resolves nexus-vfs
+# through its Cargo.toml git-dep `rev` + Cargo.lock (the SSOT). `--locked`
+# builds exactly that resolution. Bump the pin in Cargo.toml/Cargo.lock —
+# the test.yml "Kernel pin consistency preflight" enforces Cargo ==
+# Cargo.lock == the remaining Dockerfile ARGs, and CI's nexusd-cluster
+# smoke builds this same nexus-local crate (so the gate tests the exact
+# binary the image ships). Symlinked to nexus-cluster below so the Python
 # runtime spawns it unchanged.
 ENV CARGO_NET_RETRY=10 \
     CARGO_HTTP_TIMEOUT=120
@@ -111,8 +112,8 @@ COPY rust/ ./rust/
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,id=cargo-target-${TARGETARCH},target=/build/target \
-    cargo build --locked --release -p nexusd --bin nexusd-full && \
-    cp /build/target/release/nexusd-full /build/nexusd-full
+    cargo build --locked --release -p nexusd --bin nexusd-cluster && \
+    cp /build/target/release/nexusd-cluster /build/nexusd-cluster
 
 # ---------- Copy real application source and reinstall local package ----------
 COPY src/ ./src/
@@ -199,23 +200,18 @@ COPY --from=builder /usr/local/lib/python3.14/site-packages /usr/local/lib/pytho
 COPY --from=builder /usr/local/bin/nexus /usr/local/bin/nexus
 COPY --from=builder /usr/local/bin/nexusd /usr/local/bin/nexusd
 COPY --from=builder /usr/local/bin/alembic /usr/local/bin/alembic
-COPY --from=builder /build/nexusd-full /usr/local/bin/nexusd-full
-# Python factory boot spawns "nexus-cluster" (without d) via subprocess; point
-# that name at the full binary (cluster + S3/R2 driver) so usage is unchanged.
-RUN ln -s /usr/local/bin/nexusd-full /usr/local/bin/nexus-cluster
-# Back-compat: preserve the historic `nexusd-cluster` name. Repo consumers still
-# exec it directly (e.g. the federation E2E joiner entrypoint), and nexusd-full
-# is a strict superset of the old slim cluster binary, so the alias is
-# behaviorally identical.
-RUN ln -s /usr/local/bin/nexusd-full /usr/local/bin/nexusd-cluster
+COPY --from=builder /build/nexusd-cluster /usr/local/bin/nexusd-cluster
+# Python factory boot spawns "nexus-cluster" (without the d) via subprocess;
+# point that name at the cluster binary so the runtime spawns it unchanged.
+RUN ln -s /usr/local/bin/nexusd-cluster /usr/local/bin/nexus-cluster
 
 
 # ---------- Build-time smoke tests (Issue #3125, #3134) ----------
-# Fail the build if any expected cluster binary name is missing or not on PATH
-# (don't mask failures with `|| echo`), then verify the binary actually runs.
-RUN for b in nexusd-full nexus-cluster nexusd-cluster; do \
+# Fail the build if the cluster binary (or its spawn alias) is missing or not
+# on PATH (don't mask failures with `|| echo`), then verify it actually runs.
+RUN for b in nexusd-cluster nexus-cluster; do \
         command -v "$b" >/dev/null 2>&1 || { echo "missing cluster binary: $b" >&2; exit 1; }; \
-    done && nexusd-full --version
+    done && nexusd-cluster --version
 # Extras-gated imports.
 # SANDBOX profile deliberately excludes pgvector/docker/fastembed/psutil (Issue #3778).
 RUN set -eux; \

--- a/rust/nexusd/Cargo.toml
+++ b/rust/nexusd/Cargo.toml
@@ -2,25 +2,38 @@
 name = "nexusd"
 version = "0.1.0"
 edition = "2021"
-description = "Nexus full daemon assembly — nexus-vfs cluster/federation boot composed with the nexus service set (managed_agent, acp) via the ServiceRegistry bring-up seam. Supersedes the pure nexus-vfs nexusd-full as the production daemon."
+description = "Nexus cluster-profile daemon assembly — nexus-vfs cluster/federation boot composed with the nexus managed_agent control plane via the ServiceRegistry bring-up seam. This IS the `cluster` deployment profile (KERNEL-ARCHITECTURE §7) plus the agent control plane: the slim, size-gated production binary. driver-s3 / the full superset is an opt-in feature, never the default."
 authors = ["Nexus Team"]
 publish = false
 
 [[bin]]
-name = "nexusd-full"
+name = "nexusd-cluster"
 path = "src/main.rs"
+
+[features]
+default = []
+# Opt UP to the full/S3 superset (KERNEL-ARCHITECTURE §7: cluster ⊂ … ⊂ full):
+# adds the S3 / R2 object-store driver via `backends` feature unification.
+# Default builds stay the slim `cluster` profile (path-local + remote only)
+# so the shipped binary keeps the sudowork/edge size budget; only an
+# S3-serving tier builds `--features driver-s3`.
+driver-s3 = ["dep:backends", "backends/driver-s3"]
 
 [dependencies]
 # Cluster library entry — `nexus_cluster::run_with_services` owns clap
-# parsing, the tokio runtime, and the whole kernel + raft + federation
-# boot. The `driver-s3` feature is opted in via `backends` unification
-# below (matches the nexus-vfs `full` profile) so this binary is a strict
-# superset of the old nexusd-full — plus the nexus services.
+# parsing, the tokio runtime, and the whole kernel + raft + federation boot.
+# It already pulls the slim `cluster` backends slice (path-local + remote);
+# this crate adds NO extra drivers by default (profile purity — §7).
 nexus-cluster = { workspace = true }
-backends = { workspace = true, default-features = false, features = ["driver-s3"] }
 # a2a from-stamp hook (its `service_decl`); default-features keeps it
 # raft-free (the stream-wakeup observer is armed in cluster boot, not here).
 a2a = { workspace = true }
-# The nexus service set composed into the daemon at boot.
-services = { workspace = true, features = ["service-managed-agent", "service-acp"] }
+# The nexus control plane composed into the daemon at boot. ONLY
+# managed_agent — the `cluster` profile's agent control plane (§7); `acp`
+# (nexus-drives-ACP one-shot) is NOT a cluster service.
+services = { workspace = true, features = ["service-managed-agent"] }
+# Present ONLY to thread the optional `driver-s3` feature into the shared
+# `backends` compilation for the full superset; nexusd calls no backends API,
+# so it is not pulled at all in the default (slim cluster) build.
+backends = { workspace = true, default-features = false, optional = true }
 anyhow = "1"

--- a/rust/nexusd/src/main.rs
+++ b/rust/nexusd/src/main.rs
@@ -1,30 +1,34 @@
-//! `nexusd-full` — the nexus full daemon assembly binary.
+//! `nexusd-cluster` — the nexus cluster-profile daemon assembly binary.
 //!
-//! The composition root: it hands the kernel the ordered `ServiceDecl`
-//! set — a2a (from-stamp) + managed_agent (raw ACP control plane) + acp
-//! (one-shot) — which `Kernel::bring_up_services` installs after the
-//! kernel + auth are up. All the clap parsing, tokio runtime, and
-//! kernel/raft/federation boot flow through `nexus_cluster::run_with_services`
-//! unchanged; the only delta from the pure nexus-vfs `nexusd-full` is the
-//! service set, which lives HERE (next to the service crates it links)
-//! because the kernel repo can't depend on the nexus service crates.
+//! This IS the `cluster` deployment profile (KERNEL-ARCHITECTURE §7:
+//! slim ⊂ cluster ⊂ … ⊂ full) plus the agent control plane. The
+//! composition root hands the kernel the ordered `ServiceDecl` set —
+//! a2a (from-stamp) + managed_agent (raw ACP control plane) — which
+//! `Kernel::bring_up_services` installs after the kernel + auth are up.
+//! All clap parsing, the tokio runtime, and kernel/raft/federation boot
+//! flow through `nexus_cluster::run_with_services` unchanged; the only
+//! delta from the pure nexus-vfs `nexusd-cluster` is the service set,
+//! which lives HERE (next to the service crates it links) because the
+//! kernel repo can't depend on the nexus service crates.
 //!
-//! Supersedes the nexus-vfs `nexusd-full` (kernel + drivers, no nexus
-//! services) as the production daemon — the Dockerfiles build this binary.
-//! `driver-s3` matches the `full` profile via `backends` feature unification.
+//! Profile purity (§7): the DEFAULT build stays the slim cluster —
+//! backends = path-local + remote only (via `nexus-cluster`), no S3, no
+//! connectors — so the shipped binary keeps the sudowork/edge size
+//! budget. The full/S3 superset is the opt-in `driver-s3` feature, never
+//! the default. managed_agent is the one control-plane service cluster
+//! adds; supersets inherit it. `acp` (nexus-drives-ACP one-shot) is NOT a
+//! cluster service.
 
 fn main() -> anyhow::Result<()> {
     // The daemon's service set — the SSOT for "which services this daemon
     // runs", ordered. a2a is installed first (its from-stamp hook must be
-    // armed before agents write mailboxes); managed_agent + acp follow.
+    // armed before agents write mailboxes); managed_agent follows.
     // `ctx.auth_armed` is boot-derived (true iff sk- auth is armed) and
-    // sets a2a's fail-closed posture; acp's default zone is the node-local
-    // root.
+    // sets a2a's fail-closed posture.
     nexus_cluster::run_with_services(|ctx| {
         vec![
             a2a::service_decl(ctx.auth_armed),
             services::managed_agent::service_decl(),
-            services::acp::service_decl("root".to_string()),
         ]
     })
 }

--- a/tests/integration/test_managed_agent_tunnel_e2e.py
+++ b/tests/integration/test_managed_agent_tunnel_e2e.py
@@ -1,8 +1,8 @@
 """E2E: managed_agent raw ACP control-plane tunnel over gRPC (task #36).
 
-Boots a real ``nexusd-full`` daemon (same ``KernelClient`` spawn harness as
-the restart-survival smoke) and drives the raw-byte stdio tunnel end to end
-over the *actual* wire path an embedder (sudowork's grpc-js client) uses:
+Boots a real ``nexusd-cluster`` daemon (same ``KernelClient`` spawn harness
+as the restart-survival smoke) and drives the raw-byte stdio tunnel end to
+end over the *actual* wire path an embedder (sudowork's grpc-js client) uses:
 
   1. ``ManagedAgentService.start_session(spawn_spec)`` via the ``Call`` RPC
      (``managed_agent.start_session_v1``, JSON payload) — spawns a subprocess
@@ -20,8 +20,8 @@ exits on its own, exercising the supervisor reap path too.
 This is the gap the in-process ``raw_spawn`` unit tests don't cover: the
 gRPC ``Call`` routing to the Rust service + the ``StreamReadAt`` /
 ``StreamWriteNowait`` typed RPCs, through a booted daemon. Requires the
-``nexusd-full`` binary (which brings up ``managed_agent``); a slim
-``nexusd-cluster`` has no such service, so the test skips there.
+nexus-local ``nexusd-cluster`` (which brings up ``managed_agent``); the
+pure nexus-vfs cluster binary has no such service, so the test skips there.
 """
 
 from __future__ import annotations
@@ -39,9 +39,9 @@ pytestmark = pytest.mark.skipif(
     reason="raw ACP subprocess host is unix-only (subprocess-host feature)",
 )
 
-# The tunnel + managed_agent service only exist in nexusd-full. Point the
-# spawn harness at it explicitly; if it (or any cluster binary) is missing,
-# skip rather than fail — matches the restart-survival smoke's contract.
+# The tunnel + managed_agent service live in the nexus-local nexusd-cluster.
+# Point the spawn harness at it explicitly; if it (or any cluster binary) is
+# missing, skip rather than fail — matches the restart-survival smoke.
 _KERNEL_BIN = os.environ.get("NEXUS_KERNEL_BINARY")
 
 _PROBE = b"hello-nexus-tunnel\n"
@@ -57,8 +57,9 @@ def _open_kernel(data_dir: Path) -> KernelClient:
         if _KERNEL_BIN:
             raise
         pytest.skip(
-            "nexusd-full binary unavailable; set NEXUS_KERNEL_BINARY to the "
-            "full daemon (it hosts managed_agent) to run this E2E."
+            "nexusd-cluster binary unavailable; set NEXUS_KERNEL_BINARY to "
+            "the nexus-local nexusd-cluster (it hosts managed_agent) to run "
+            "this E2E."
         )
     return client
 


### PR DESCRIPTION
## Regression

#4561 made the production daemon the nexus-local `nexusd` crate but shaped it
as the `full` profile: `backends` `driver-s3` (multi-MB AWS SDK) unconditionally,
binary named `nexusd-full`. Per **KERNEL-ARCHITECTURE §7** the production binary
is the **`cluster`** profile (slim: path-local + remote, no S3, no connectors),
size-gated to **≤15.5 MiB** (nexus-vfs `cluster-binary-build.yml`). `driver-s3`
blew straight past that.

## Fix — `nexusd` = the `cluster` profile + the managed_agent control plane

(the one service cluster adds per §7; supersets inherit it)

- bin renamed `nexusd-full` → **`nexusd-cluster`**; default build is the slim
  cluster.
- `driver-s3` demoted to an **opt-in cargo feature** (full/S3 superset only).
- dropped `service-acp` from the daemon (nexus-drives-ACP one-shot isn't a
  cluster service; #36's control plane is managed_agent's raw spawn + tunnel).
- Dockerfile builds/ships `nexusd-cluster` (`nexus-cluster` symlink); the
  confusing `nexusd-full` name is gone (nothing execs it).
- test.yml smoke installs/tests only the nexus-local `nexusd-cluster` + a new
  **≤15.5 MiB size gate** on it (the guard this regression proves we need — the
  nexus-vfs gate only covers the pure nexus-vfs binary).
- cleaned confusing "full profile / supersedes nexusd-full / driver-s3 matches
  full" language across the crate, Dockerfile, CI, workspace Cargo.toml, E2E.

## Verification (Docker, release/stripped)

- slim `nexusd-cluster` + managed_agent = **14.9 MiB** (fits the 15.5 MiB gate)
- `--features driver-s3` = 19 MiB and compiles
- tunnel E2E green against the slim binary: `1 passed in 8.85s`

Pairs with nexus-vfs `docs/ch7-cluster-managed-agent`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)