### PR TITLE
feat(search-plugin): Phase 1 — tantivy + Query keyword-only RPC [WIP]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -335,7 +335,7 @@ dependencies = [
  "kernel",
  "lib",
  "libc",
- "lru",
+ "lru 0.18.1",
  "memchr",
  "memmap2",
  "parking_lot",
@@ -392,13 +392,13 @@ dependencies = [
  "bitflags 2.13.1",
  "cexpr",
  "clang-sys",
- "itertools",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash",
+ "rustc-hash 2.1.3",
  "shlex 1.3.0",
  "syn 2.0.119",
 ]
@@ -423,6 +423,15 @@ name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+
+[[package]]
+name = "bitpacking"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96a7139abd3d9cebf8cd6f920a389cf3dc9576172e32f4563f188cae3c3eb019"
+dependencies = [
+ "crunchy",
+]
 
 [[package]]
 name = "blake3"
@@ -523,6 +532,12 @@ dependencies = [
  "libc",
  "shlex 2.0.1",
 ]
+
+[[package]]
+name = "census"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f4c707c6a209cbe82d10abd08e1ea8995e9ea937d2550646e02798948992be0"
 
 [[package]]
 name = "cexpr"
@@ -919,6 +934,9 @@ name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "digest"
@@ -944,6 +962,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -953,6 +992,12 @@ dependencies = [
  "quote",
  "syn 3.0.3",
 ]
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "dunce"
@@ -1043,6 +1088,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77af40d8a8dadb92dc178569a5f5edb5f3056e98255c2de48ab5d59a52892e0c"
 
 [[package]]
+name = "fastdivide"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afc2bd4d5a73106dd53d10d73d3401c2f32730ba2c0b93ddb888a8983680471"
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1088,7 +1139,7 @@ dependencies = [
  "flume",
  "log",
  "lsm-tree",
- "lz4_flex",
+ "lz4_flex 0.13.1",
  "tempfile",
  "xxhash-rust",
 ]
@@ -1127,6 +1178,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs4"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7e180ac76c23b45e767bd7ae9579bc0bb458618c4bc71835926e098e61d15f8"
+dependencies = [
+ "rustix 0.38.44",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1266,7 +1327,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
 dependencies = [
- "rustix",
+ "rustix 1.1.4",
  "windows-link 0.2.1",
 ]
 
@@ -1368,6 +1429,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -1398,6 +1461,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1414,6 +1483,12 @@ checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
  "digest 0.11.3",
 ]
+
+[[package]]
+name = "htmlescape"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9025058dae765dee5070ec375f591e2ba14638c63feff74f13805a72e523163"
 
 [[package]]
 name = "http"
@@ -1689,6 +1764,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "interval-heap"
 version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1708,6 +1795,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -1816,7 +1912,7 @@ dependencies = [
  "lib",
  "libc",
  "libloading",
- "lru",
+ "lru 0.18.1",
  "memchr",
  "memmap2",
  "nexus-plugin-abi",
@@ -1845,6 +1941,12 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "levenshtein_automata"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c2cdeb66e45e9f36bfad5bbdb4d2384e70936afbee843c6f6543f0c551ebb25"
 
 [[package]]
 name = "lib"
@@ -1896,6 +1998,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "libredox"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2026a5056764a10b2bf5d56488cba40da507f5493a6a429340e2004d9ed085fa"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1924,6 +2047,15 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "lru"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b6180140927ee907000b0aa540091f6ea512ead4447c92b8fc35bc72788a5a6"
@@ -1949,15 +2081,21 @@ dependencies = [
  "enum_dispatch",
  "interval-heap",
  "log",
- "lz4_flex",
+ "lz4_flex 0.13.1",
  "quick_cache",
- "rustc-hash",
+ "rustc-hash 2.1.3",
  "self_cell",
  "sfa",
  "tempfile",
  "varint-rs",
  "xxhash-rust",
 ]
+
+[[package]]
+name = "lz4_flex"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "373f5eceeeab7925e0c1098212f2fbc4d416adec9d35051a6ab251e824c1854a"
 
 [[package]]
 name = "lz4_flex"
@@ -1982,6 +2120,16 @@ name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "measure_time"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbefd235b0aadd181626f281e1d684e116972988c14c264e42069d5e8a5775cc"
+dependencies = [
+ "instant",
+ "log",
+]
 
 [[package]]
 name = "memchr"
@@ -2035,6 +2183,12 @@ name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+
+[[package]]
+name = "murmurhash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2195bf6aa996a481483b29d62a7663eed3fe39600c460e323f8ff41e90bdd89b"
 
 [[package]]
 name = "nexus-cluster"
@@ -2098,15 +2252,19 @@ name = "nexus-search-plugin"
 version = "0.1.0"
 dependencies = [
  "bytes",
+ "dirs",
  "globset",
  "libloading",
  "nexus-plugin-abi",
+ "parking_lot",
  "prost",
  "protoc-bin-vendored",
  "regex",
  "serde",
  "serde_json",
+ "tantivy",
  "tempfile",
+ "thiserror 1.0.69",
  "tokio",
  "tonic",
  "tonic-prost",
@@ -2236,6 +2394,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -2282,6 +2451,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oneshot"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "269bca4c2591a28585d6bf10d9ed0332b7d76900a1b02bec41bdc3a2cdcda107"
+
+[[package]]
 name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2292,6 +2467,21 @@ name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ownedbytes"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3a059efb063b8f425b948e042e6b9bd85edfe60e913630ed727b23e2dfcc558"
+dependencies = [
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "page_size"
@@ -2482,7 +2672,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck",
- "itertools",
+ "itertools 0.13.0",
  "log",
  "multimap",
  "petgraph",
@@ -2503,7 +2693,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -2653,7 +2843,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash",
+ "rustc-hash 2.1.3",
  "rustls",
  "socket2",
  "thiserror 2.0.18",
@@ -2675,7 +2865,7 @@ dependencies = [
  "rand 0.10.2",
  "rand_pcg",
  "ring",
- "rustc-hash",
+ "rustc-hash 2.1.3",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -2827,6 +3017,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
+name = "rand_distr"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
+dependencies = [
+ "num-traits",
+ "rand 0.8.7",
+]
+
+[[package]]
 name = "rand_pcg"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2885,6 +3085,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags 2.13.1",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3001,6 +3212,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-stemmers"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e46a2036019fdb888131db7a4c847a1063a7493f971ed94ea82c67eada63ca54"
+dependencies = [
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3026,6 +3253,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.13.1",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -3033,7 +3273,7 @@ dependencies = [
  "bitflags 2.13.1",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -3394,6 +3634,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
+name = "sketches-ddsketch"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85636c14b73d81f541e525f585c0a2109e6744e1565b5c1668e31c70c10ed65c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3529,6 +3778,147 @@ dependencies = [
 ]
 
 [[package]]
+name = "tantivy"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96599ea6fccd844fc833fed21d2eecac2e6a7c1afd9e044057391d78b1feb141"
+dependencies = [
+ "aho-corasick",
+ "arc-swap",
+ "base64",
+ "bitpacking",
+ "byteorder",
+ "census",
+ "crc32fast",
+ "crossbeam-channel",
+ "downcast-rs",
+ "fastdivide",
+ "fnv",
+ "fs4",
+ "htmlescape",
+ "itertools 0.12.1",
+ "levenshtein_automata",
+ "log",
+ "lru 0.12.5",
+ "lz4_flex 0.11.6",
+ "measure_time",
+ "memmap2",
+ "num_cpus",
+ "once_cell",
+ "oneshot",
+ "rayon",
+ "regex",
+ "rust-stemmers",
+ "rustc-hash 1.1.0",
+ "serde",
+ "serde_json",
+ "sketches-ddsketch",
+ "smallvec",
+ "tantivy-bitpacker",
+ "tantivy-columnar",
+ "tantivy-common",
+ "tantivy-fst",
+ "tantivy-query-grammar",
+ "tantivy-stacker",
+ "tantivy-tokenizer-api",
+ "tempfile",
+ "thiserror 1.0.69",
+ "time",
+ "uuid",
+ "winapi",
+]
+
+[[package]]
+name = "tantivy-bitpacker"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "284899c2325d6832203ac6ff5891b297fc5239c3dc754c5bc1977855b23c10df"
+dependencies = [
+ "bitpacking",
+]
+
+[[package]]
+name = "tantivy-columnar"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12722224ffbe346c7fec3275c699e508fd0d4710e629e933d5736ec524a1f44e"
+dependencies = [
+ "downcast-rs",
+ "fastdivide",
+ "itertools 0.12.1",
+ "serde",
+ "tantivy-bitpacker",
+ "tantivy-common",
+ "tantivy-sstable",
+ "tantivy-stacker",
+]
+
+[[package]]
+name = "tantivy-common"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8019e3cabcfd20a1380b491e13ff42f57bb38bf97c3d5fa5c07e50816e0621f4"
+dependencies = [
+ "async-trait",
+ "byteorder",
+ "ownedbytes",
+ "serde",
+ "time",
+]
+
+[[package]]
+name = "tantivy-fst"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d60769b80ad7953d8a7b2c70cdfe722bbcdcac6bccc8ac934c40c034d866fc18"
+dependencies = [
+ "byteorder",
+ "regex-syntax",
+ "utf8-ranges",
+]
+
+[[package]]
+name = "tantivy-query-grammar"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "847434d4af57b32e309f4ab1b4f1707a6c566656264caa427ff4285c4d9d0b82"
+dependencies = [
+ "nom",
+]
+
+[[package]]
+name = "tantivy-sstable"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c69578242e8e9fc989119f522ba5b49a38ac20f576fc778035b96cc94f41f98e"
+dependencies = [
+ "tantivy-bitpacker",
+ "tantivy-common",
+ "tantivy-fst",
+ "zstd",
+]
+
+[[package]]
+name = "tantivy-stacker"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56d6ff5591fc332739b3ce7035b57995a3ce29a93ffd6012660e0949c956ea8"
+dependencies = [
+ "murmurhash32",
+ "rand_distr",
+ "tantivy-common",
+]
+
+[[package]]
+name = "tantivy-tokenizer-api"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a0dcade25819a89cfe6f17d932c9cedff11989936bf6dd4f336d50392053b04"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3537,7 +3927,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.3",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -4030,6 +4420,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf8-ranges"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcfc827f90e53a02eaef5e535ee14266c1d569214c6aa70133a624d8a3164ba"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4049,6 +4445,7 @@ checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
+ "serde_core",
  "wasm-bindgen",
 ]
 
@@ -4339,11 +4736,20 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4357,18 +4763,33 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -4382,15 +4803,33 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4406,9 +4845,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4418,9 +4869,21 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -4610,3 +5073,31 @@ name = "zmij"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/rust/services/proto/nexus/search/v1/search.proto
+++ b/rust/services/proto/nexus/search/v1/search.proto
@@ -141,23 +141,26 @@ message GrepResponse {
 //
 // Ranked search over a persistent per-zone corpus.  Backed by tantivy
 // (BM25) in Phase 1; Phase 2 folds in semantic (fastembed + hnsw) and
-// Phase 3 folds in hybrid fusion + recency decay.  The wire shape is
-// designed to grow additively — new phases add semantics to existing
-// fields (`query_type`, `alpha`, `fusion_method`, `recency`) instead
-// of shipping a second RPC.
+// Phase 3 folds in hybrid fusion + recency decay.
+//
+// Wire-shape policy: fields land in the phase that uses them, NOT
+// pre-declared.  P2 adds semantic knobs, P3 adds fusion knobs, P6
+// adds recency knobs — each phase's proto delta ships with the
+// behaviour that gives the field meaning.  Adding a proto3 field is
+// O(1); shipping inert fields ahead of time is a tombstone for
+// behaviour that doesn't exist yet.
+//
+// `query_type` is the sole knob P1 needs — it lets P2/P3 lift the
+// KEYWORD-only gate without inventing a discriminator.
 
 enum QueryType {
-  QUERY_TYPE_UNSPECIFIED = 0;  // treated as KEYWORD for back-compat
+  // proto3 requires a 0 default.  Treated as KEYWORD by callers that
+  // don't set the field (single-algorithm P1 has one reasonable
+  // interpretation of unset).
+  QUERY_TYPE_UNSPECIFIED = 0;
   QUERY_TYPE_KEYWORD = 1;      // BM25 only (P1)
   QUERY_TYPE_SEMANTIC = 2;     // vector-only (P2)
   QUERY_TYPE_HYBRID = 3;       // keyword + vector, fused (P3)
-}
-
-enum FusionMethod {
-  FUSION_METHOD_UNSPECIFIED = 0;  // treated as RRF
-  FUSION_METHOD_RRF = 1;
-  FUSION_METHOD_WEIGHTED = 2;
-  FUSION_METHOD_RRF_WEIGHTED = 3;
 }
 
 message QueryRequest {
@@ -183,36 +186,12 @@ message QueryRequest {
   // KEYWORD (or UNSPECIFIED, which is treated as KEYWORD).
   QueryType query_type = 5;
 
-  // Hybrid fusion knobs — inert in P1 (keyword-only), wired in P3.
-  //
-  // `alpha`: semantic-vs-keyword weight when `fusion_method=WEIGHTED`
-  // or `RRF_WEIGHTED`.  0.0-1.0 (0.5 = balanced).
-  float alpha = 6;
-  FusionMethod fusion_method = 7;
-  // RRF rank constant.  Standard tuning is 60; higher = flatter
-  // ranking curve.
-  uint32 rrf_k = 8;
-
-  // Recency knobs — inert in P1, wired in P6.  See
-  // `GlobRequest.sort_recency` for the mirrored glob/grep design and
-  // #4543 for the Python-side semantics.
-  //
-  // `recency_mode`: "off" | "on" | "auto"; empty ⇒ defer to
-  // server-side default.
-  string recency_mode = 9;
-  // `recency_weight`: score multiplier magnitude.  <0 ⇒ server-side
-  // default.
-  float recency_weight = 10;
-  // `recency_half_life_days`: score decay half-life.  <=0 ⇒
-  // server-side default.
-  float recency_half_life_days = 11;
-
   // Auth token — same convention as the sibling RPCs; the kernel-side
   // permission gate reads it via OperationContext.  Read-gating
   // (zone-perm filter, #4557) stays kernel-tier per D5 — the plugin
   // trusts that whoever passed the zone_id already checked read
   // permission.
-  string auth_token = 12;
+  string auth_token = 6;
 }
 
 message QueryResult {

--- a/rust/services/proto/nexus/search/v1/search.proto
+++ b/rust/services/proto/nexus/search/v1/search.proto
@@ -33,6 +33,21 @@ service SearchService {
   // every file whose path (relative to `root_path`) matches
   // `file_pattern` (leave empty for all files).
   rpc Grep(GrepRequest) returns (GrepResponse);
+
+  // Ranked keyword search over an indexed corpus.  Phase 1 (Query
+  // keyword-only) of the Python-parity roadmap — see
+  // `PARITY_ROADMAP.md`.  The wire shape carries fields for hybrid
+  // and semantic modes as well so future phases (P2 vector, P3
+  // fusion) add behaviour, not new RPCs.  For P1, `query_type`
+  // values other than KEYWORD are rejected with `Status::unimplemented`.
+  rpc Query(QueryRequest) returns (QueryResponse);
+
+  // Add / refresh documents in the corpus.  Walk `root_path`
+  // recursively when `recursive=true`, read each regular file via
+  // `sys_read`, and add it to the per-zone tantivy index.  Phase 1
+  // uses one chunk per file — Phase 4 will fold in the real
+  // markdown-/code-aware chunker.
+  rpc Index(IndexRequest) returns (IndexResponse);
 }
 
 // ── Glob ──────────────────────────────────────────────────────────
@@ -119,5 +134,156 @@ message GrepMatch {
 message GrepResponse {
   repeated GrepMatch matches = 1;
   bool truncated = 2;
+  optional string error = 3;
+}
+
+// ── Query / Index ─────────────────────────────────────────────────
+//
+// Ranked search over a persistent per-zone corpus.  Backed by tantivy
+// (BM25) in Phase 1; Phase 2 folds in semantic (fastembed + hnsw) and
+// Phase 3 folds in hybrid fusion + recency decay.  The wire shape is
+// designed to grow additively — new phases add semantics to existing
+// fields (`query_type`, `alpha`, `fusion_method`, `recency`) instead
+// of shipping a second RPC.
+
+enum QueryType {
+  QUERY_TYPE_UNSPECIFIED = 0;  // treated as KEYWORD for back-compat
+  QUERY_TYPE_KEYWORD = 1;      // BM25 only (P1)
+  QUERY_TYPE_SEMANTIC = 2;     // vector-only (P2)
+  QUERY_TYPE_HYBRID = 3;       // keyword + vector, fused (P3)
+}
+
+enum FusionMethod {
+  FUSION_METHOD_UNSPECIFIED = 0;  // treated as RRF
+  FUSION_METHOD_RRF = 1;
+  FUSION_METHOD_WEIGHTED = 2;
+  FUSION_METHOD_RRF_WEIGHTED = 3;
+}
+
+message QueryRequest {
+  // Query text.  BM25 tokenization is applied by tantivy's default
+  // analyzer (lowercasing + simple tokenizer).
+  string q = 1;
+
+  // Zone scoping.  Kernel-tier readers pass a zone-id; the plugin
+  // opens the corresponding per-zone index and searches only that
+  // zone.  Cross-zone federation is the kernel driver's job — the
+  // plugin never sees more than one zone per call (mirrors Glob +
+  // Grep behaviour).  Empty ⇒ ROOT_ZONE_ID.
+  string zone_id = 2;
+
+  // Max results returned.  0 ⇒ server-side default (10).
+  uint32 limit = 3;
+
+  // Optional path-prefix filter.  Matches results whose stored `path`
+  // starts with this string.  Empty ⇒ no filter.
+  string path_filter = 4;
+
+  // Which retrieval algorithm to run.  P1 rejects anything other than
+  // KEYWORD (or UNSPECIFIED, which is treated as KEYWORD).
+  QueryType query_type = 5;
+
+  // Hybrid fusion knobs — inert in P1 (keyword-only), wired in P3.
+  //
+  // `alpha`: semantic-vs-keyword weight when `fusion_method=WEIGHTED`
+  // or `RRF_WEIGHTED`.  0.0-1.0 (0.5 = balanced).
+  float alpha = 6;
+  FusionMethod fusion_method = 7;
+  // RRF rank constant.  Standard tuning is 60; higher = flatter
+  // ranking curve.
+  uint32 rrf_k = 8;
+
+  // Recency knobs — inert in P1, wired in P6.  See
+  // `GlobRequest.sort_recency` for the mirrored glob/grep design and
+  // #4543 for the Python-side semantics.
+  //
+  // `recency_mode`: "off" | "on" | "auto"; empty ⇒ defer to
+  // server-side default.
+  string recency_mode = 9;
+  // `recency_weight`: score multiplier magnitude.  <0 ⇒ server-side
+  // default.
+  float recency_weight = 10;
+  // `recency_half_life_days`: score decay half-life.  <=0 ⇒
+  // server-side default.
+  float recency_half_life_days = 11;
+
+  // Auth token — same convention as the sibling RPCs; the kernel-side
+  // permission gate reads it via OperationContext.  Read-gating
+  // (zone-perm filter, #4557) stays kernel-tier per D5 — the plugin
+  // trusts that whoever passed the zone_id already checked read
+  // permission.
+  string auth_token = 12;
+}
+
+message QueryResult {
+  // Absolute VFS path of the chunk's source file (starts with `/`),
+  // matching GlobResponse + GrepMatch convention.
+  string path = 1;
+
+  // Which chunk of the file this result is.  0 for whole-file (P1
+  // one-chunk-per-file); P4's real chunker will emit higher indices.
+  uint32 chunk_index = 2;
+
+  // The chunk's text.  For P1 this is the whole file's text (capped);
+  // for P4 it's the actual chunk window.
+  string chunk_text = 3;
+
+  // Ranker score.  BM25 for keyword; cosine for semantic; fused for
+  // hybrid.  Not comparable across `query_type` values.
+  float score = 4;
+
+  // The zone this result belongs to.  Mirrors the request's
+  // `zone_id` since a query is single-zone (per D3); the field exists
+  // so callers deduping across federated hits from multiple plugins
+  // don't need to plumb the request back in.
+  string zone_id = 5;
+
+  // Millisecond-resolution mtime of the source file at index time.
+  // Optional because P1 tolerates missing mtimes (e.g. streams).  Used
+  // by P6's recency scoring.
+  optional int64 mtime_ms = 6;
+}
+
+message QueryResponse {
+  repeated QueryResult results = 1;
+  // Set when the request could not be served (e.g. no index for the
+  // requested zone_id, invalid path_filter).  Callers treat non-empty
+  // error as "empty results, log and move on" per Glob + Grep
+  // convention.
+  optional string error = 2;
+}
+
+message IndexRequest {
+  // Walk start.  Absolute VFS path (starts with `/`).
+  string root_path = 1;
+
+  // Zone scope — the same rule as `QueryRequest.zone_id`.  Documents
+  // are added to the per-zone tantivy index for this zone.
+  string zone_id = 2;
+
+  // Recurse into subdirectories.  false ⇒ only direct children of
+  // `root_path` (matches Python `recursive=False`).
+  bool recursive = 3;
+
+  // Safety cap on the number of documents added in a single call.
+  // 0 ⇒ server-side default (10_000).  Callers that need to index a
+  // larger corpus call `Index` repeatedly with narrower `root_path`
+  // scopes.
+  uint32 max_docs = 4;
+
+  // Auth token per the same convention as the sibling RPCs.
+  string auth_token = 5;
+}
+
+message IndexResponse {
+  // Number of documents added / refreshed by this call.
+  uint32 indexed_count = 1;
+  // Number of paths visited that were skipped (empty file, binary,
+  // over-size, non-regular).  Distinct from indexed_count so callers
+  // can spot silent skips without diffing before/after counts.
+  uint32 skipped_count = 2;
+  // Set when the walk aborted (missing root, index-open failure).
+  // Callers treat non-empty error as "no documents added, log and
+  // retry with narrower scope" per Glob + Grep convention.
   optional string error = 3;
 }

--- a/rust/services/search-plugin/Cargo.toml
+++ b/rust/services/search-plugin/Cargo.toml
@@ -51,6 +51,27 @@ tokio = { version = "1", features = ["rt", "rt-multi-thread", "sync", "macros"] 
 # Bytes for tonic Request/Response body types.
 bytes = "1"
 
+# Full-text search backend for the Query RPC (Phase 1 of the
+# Python-parity roadmap; see PARITY_ROADMAP.md D1).  Pure Rust, no
+# native deps — links into this plugin's cdylib only, cluster core
+# stays untouched.  BM25 scorer + mmap segments; per-zone indices
+# live under `~/.nexus/plugins/search/<zone_id>/fts/`.
+tantivy = "0.22"
+
+# Home-dir resolution for the per-zone index root.  `dirs = 5` follows
+# XDG on Linux, `%APPDATA%` on Windows, `~/Library/Application Support`
+# on macOS — matches how the sibling vault plugin stores per-node state.
+dirs = "5"
+
+# Parking-lot mutex around the per-zone index writer.  tantivy's own
+# IndexWriter is Send + Sync but only allows one writer per index at a
+# time; the lock is short-held (writer.add_document + writer.commit)
+# so contention is negligible, and parking_lot avoids poisoning.
+parking_lot = "0.12"
+
+# Ergonomic error enums for the fts_index module.
+thiserror = "1"
+
 [build-dependencies]
 tonic-prost-build = "0.14"
 # Vendored protoc so the plugin builds on any host without a

--- a/rust/services/search-plugin/src/fts_index.rs
+++ b/rust/services/search-plugin/src/fts_index.rs
@@ -1,0 +1,398 @@
+//! Per-zone tantivy full-text index (Phase 1 of the Python-parity
+//! roadmap; see `PARITY_ROADMAP.md` D1).
+//!
+//! # Storage layout
+//!
+//! Each zone has its own tantivy directory rooted at
+//! `~/.nexus/plugins/search/<zone_id>/fts/`.  The directory is
+//! plugin-owned, per-node, and NOT replicated — the SSOT for
+//! "what belongs in the index" is the kernel VFS itself, and the
+//! MetaStore `search.indexed_gen` sidecar (added in Phase 5)
+//! records the last-indexed generation so any node can drop-and-
+//! rebuild without losing correctness anchors.  Dropping the
+//! directory is always safe — the next Index or Query call
+//! transparently recreates it.
+//!
+//! # Schema (P1)
+//!
+//! ```text
+//! path         STRING | STORED             exact match + retrievable
+//! chunk_index  I64    | INDEXED | STORED   integer, 0 in P1 (one chunk per file)
+//! chunk_text   TEXT   | STORED             BM25-analysed
+//! mtime_ms     I64    | INDEXED | STORED   millisecond-resolution mtime
+//! ```
+//!
+//! P4 grows `chunk_index` to a real value once the chunker lands;
+//! P2 adds a `vec_id` field pointing at the sibling HNSW index.
+//!
+//! # Concurrency
+//!
+//! `tantivy::IndexWriter` allows one writer per index at a time.  We
+//! wrap it in a `parking_lot::Mutex`; add_document + commit are
+//! millisecond-scale and the mutex is not held across await points,
+//! so contention is negligible even under concurrent Index calls
+//! for different paths in the same zone.
+//!
+//! Readers are cheap — tantivy's `IndexReader` snapshots the last
+//! committed generation and is `Send + Sync`.  The `search` path
+//! takes no locks.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+use tantivy::collector::TopDocs;
+use tantivy::directory::MmapDirectory;
+use tantivy::query::QueryParser;
+use tantivy::schema::{Field, Schema, INDEXED, STORED, STRING, TEXT};
+use tantivy::{doc, Index, IndexReader, IndexWriter, ReloadPolicy, TantivyDocument};
+
+/// tantivy writer heap — 50 MiB is the conventional per-index budget
+/// and lets a batch of ~1 000 chunks commit without forcing a merge.
+/// The plugin holds at most one writer per zone in memory.
+const WRITER_HEAP_BYTES: usize = 50 * 1024 * 1024;
+
+/// Result row returned by [`FtsIndex::search`].
+#[derive(Debug, Clone)]
+pub struct FtsHit {
+    pub path: String,
+    pub chunk_index: u32,
+    pub chunk_text: String,
+    pub score: f32,
+    pub mtime_ms: Option<i64>,
+}
+
+/// P1 schema field handles.  Grouped so callers construct one
+/// [`FtsIndex`] and get all field accessors without re-resolving by
+/// name (which would allocate + hash per call).
+#[derive(Debug, Clone)]
+pub struct Fields {
+    pub path: Field,
+    pub chunk_index: Field,
+    pub chunk_text: Field,
+    pub mtime_ms: Field,
+}
+
+impl Fields {
+    fn from_schema(schema: &Schema) -> Self {
+        // Names are stable; if they drift a rebuild is the recovery
+        // path (see module doc).  `get_field` returns `TantivyError`
+        // rather than `Option`, so `expect` here would only fire on a
+        // programmer bug in `build_schema` below.
+        Self {
+            path: schema.get_field("path").expect("schema field: path"),
+            chunk_index: schema
+                .get_field("chunk_index")
+                .expect("schema field: chunk_index"),
+            chunk_text: schema
+                .get_field("chunk_text")
+                .expect("schema field: chunk_text"),
+            mtime_ms: schema.get_field("mtime_ms").expect("schema field: mtime_ms"),
+        }
+    }
+}
+
+/// Build the P1 schema.  Broken out so tests can construct a schema
+/// without opening a directory.
+pub fn build_schema() -> Schema {
+    let mut sb = Schema::builder();
+    // path — exact-match (STRING), retrievable.  Filtered on prefix
+    // by the query layer, not by tantivy itself in P1 (a term-prefix
+    // query would work but adds tokenisation surprises for paths).
+    sb.add_text_field("path", STRING | STORED);
+    // chunk_index — small integer, INDEXED so future range queries
+    // (dedupe by (path, chunk_index)) don't require re-scan.
+    sb.add_i64_field("chunk_index", INDEXED | STORED);
+    // chunk_text — BM25-analysed.  Default TEXT = lowercase + simple
+    // tokeniser; P4 replaces this with a language-aware chain.
+    sb.add_text_field("chunk_text", TEXT | STORED);
+    // mtime_ms — INDEXED for P6's recency range queries.
+    sb.add_i64_field("mtime_ms", INDEXED | STORED);
+    sb.build()
+}
+
+/// One per-zone tantivy index.  Cheap to clone (`Arc` inside).
+pub struct FtsIndex {
+    index: Index,
+    fields: Fields,
+    writer: Mutex<IndexWriter>,
+    reader: IndexReader,
+}
+
+impl FtsIndex {
+    /// Open the index at `dir`, creating it (with the P1 schema) if
+    /// nothing lives there yet.  Directory is created recursively —
+    /// callers pass a leaf path, we make it.
+    pub fn open_or_create(dir: PathBuf) -> Result<Arc<Self>, IndexError> {
+        std::fs::create_dir_all(&dir)
+            .map_err(|e| IndexError::CreateDir(dir.display().to_string(), e.to_string()))?;
+
+        let mmap = MmapDirectory::open(&dir)
+            .map_err(|e| IndexError::Open(dir.display().to_string(), e.to_string()))?;
+
+        let schema = build_schema();
+        let index = Index::open_or_create(mmap, schema.clone())
+            .map_err(|e| IndexError::Open(dir.display().to_string(), e.to_string()))?;
+
+        let fields = Fields::from_schema(&schema);
+
+        let writer = index
+            .writer::<TantivyDocument>(WRITER_HEAP_BYTES)
+            .map_err(|e| IndexError::WriterInit(e.to_string()))?;
+
+        let reader = index
+            .reader_builder()
+            // OnCommit = the reader auto-refreshes when the writer
+            // commits; searches after add_doc see fresh state without
+            // the caller having to plumb a manual reload.
+            .reload_policy(ReloadPolicy::OnCommit)
+            .try_into()
+            .map_err(|e| IndexError::ReaderInit(e.to_string()))?;
+
+        Ok(Arc::new(Self {
+            index,
+            fields,
+            writer: Mutex::new(writer),
+            reader,
+        }))
+    }
+
+    /// Add a document.  P1 semantics: one call = one document = one
+    /// chunk.  The writer buffers in RAM until [`commit`](Self::commit)
+    /// is called — callers batch adds and commit at end-of-request so
+    /// tantivy can flush a single segment (much cheaper than one
+    /// commit per doc).
+    ///
+    /// `mtime_ms = None` is stored as a distinguishable sentinel
+    /// (`i64::MIN`) so it round-trips cleanly through [`search`](Self::search).
+    /// Using an out-of-band value keeps the field non-`optional` in the
+    /// schema which sidesteps a tantivy `Option<i64>` retrieval quirk.
+    pub fn add_document(
+        &self,
+        path: &str,
+        chunk_index: u32,
+        chunk_text: &str,
+        mtime_ms: Option<i64>,
+    ) -> Result<(), IndexError> {
+        let writer = self.writer.lock();
+        writer
+            .add_document(doc!(
+                self.fields.path => path,
+                self.fields.chunk_index => i64::from(chunk_index),
+                self.fields.chunk_text => chunk_text,
+                self.fields.mtime_ms => mtime_ms.unwrap_or(i64::MIN),
+            ))
+            .map_err(|e| IndexError::AddDoc(path.to_string(), e.to_string()))?;
+        Ok(())
+    }
+
+    /// Flush buffered adds to disk and make them visible to searchers.
+    /// Cheap for small batches; a couple of ms per commit + a
+    /// background merge that happens on tantivy's own thread.
+    pub fn commit(&self) -> Result<(), IndexError> {
+        let mut writer = self.writer.lock();
+        writer
+            .commit()
+            .map_err(|e| IndexError::Commit(e.to_string()))?;
+        Ok(())
+    }
+
+    /// Ranked keyword search.  Returns up to `limit` hits ordered by
+    /// BM25 score descending.  `path_prefix` filters on
+    /// `stored_path.starts_with(prefix)` after the tantivy result
+    /// pass (P1); a proper indexed path-prefix filter comes with P3's
+    /// query composer.
+    pub fn search(
+        &self,
+        query: &str,
+        limit: usize,
+        path_prefix: Option<&str>,
+    ) -> Result<Vec<FtsHit>, IndexError> {
+        let searcher = self.reader.searcher();
+
+        let parser = QueryParser::for_index(&self.index, vec![self.fields.chunk_text]);
+        let parsed = parser
+            .parse_query(query)
+            .map_err(|e| IndexError::ParseQuery(query.to_string(), e.to_string()))?;
+
+        // Over-fetch when a path prefix is set: the prefix filter is
+        // applied post-scoring in P1, so we grab a wider window to
+        // avoid returning fewer than `limit` hits when the top of the
+        // BM25 list is largely off-prefix.  Bounded so a pathological
+        // filter doesn't scan the whole index.
+        let fetch = if path_prefix.is_some() {
+            (limit * 4).min(1_000)
+        } else {
+            limit
+        };
+
+        let top = searcher
+            .search(&parsed, &TopDocs::with_limit(fetch))
+            .map_err(|e| IndexError::Search(e.to_string()))?;
+
+        let mut hits = Vec::with_capacity(limit);
+        for (score, addr) in top {
+            let stored: TantivyDocument = searcher
+                .doc(addr)
+                .map_err(|e| IndexError::Search(e.to_string()))?;
+            let hit = self.decode(stored, score);
+            if let Some(prefix) = path_prefix {
+                if !hit.path.starts_with(prefix) {
+                    continue;
+                }
+            }
+            hits.push(hit);
+            if hits.len() >= limit {
+                break;
+            }
+        }
+        Ok(hits)
+    }
+
+    fn decode(&self, stored: TantivyDocument, score: f32) -> FtsHit {
+        // Access stored fields by handle.  If a field is missing (a
+        // schema-drift bug), we surface a blank rather than panicking
+        // — search results with an empty path are visibly broken and
+        // easy to trace, whereas a panic would take down the whole
+        // plugin thread.
+        let path = stored
+            .get_first(self.fields.path)
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string();
+        let chunk_index = stored
+            .get_first(self.fields.chunk_index)
+            .and_then(|v| v.as_i64())
+            .and_then(|v| u32::try_from(v).ok())
+            .unwrap_or(0);
+        let chunk_text = stored
+            .get_first(self.fields.chunk_text)
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string();
+        let mtime_raw = stored
+            .get_first(self.fields.mtime_ms)
+            .and_then(|v| v.as_i64());
+        let mtime_ms = match mtime_raw {
+            Some(v) if v == i64::MIN => None,
+            Some(v) => Some(v),
+            None => None,
+        };
+        FtsHit {
+            path,
+            chunk_index,
+            chunk_text,
+            score,
+            mtime_ms,
+        }
+    }
+}
+
+// ── Errors ────────────────────────────────────────────────────────
+
+#[derive(Debug, thiserror::Error)]
+pub enum IndexError {
+    #[error("create index dir {0}: {1}")]
+    CreateDir(String, String),
+    #[error("open index at {0}: {1}")]
+    Open(String, String),
+    #[error("init tantivy writer: {0}")]
+    WriterInit(String),
+    #[error("init tantivy reader: {0}")]
+    ReaderInit(String),
+    #[error("add doc {0}: {1}")]
+    AddDoc(String, String),
+    #[error("commit: {0}")]
+    Commit(String),
+    #[error("parse query {0:?}: {1}")]
+    ParseQuery(String, String),
+    #[error("search: {0}")]
+    Search(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tempdir() -> PathBuf {
+        let dir = tempfile::tempdir().expect("tempdir");
+        // Leak so `dir` lives past the return; test-local, no cleanup
+        // required.
+        dir.keep()
+    }
+
+    #[test]
+    fn open_creates_empty_index() {
+        let dir = tempdir().join("fts");
+        let idx = FtsIndex::open_or_create(dir.clone()).expect("open");
+        assert!(dir.exists());
+        // Empty index: any query returns zero hits.
+        let hits = idx.search("hello", 10, None).expect("search");
+        assert!(hits.is_empty());
+    }
+
+    #[test]
+    fn add_then_search_finds_document() {
+        let dir = tempdir().join("fts");
+        let idx = FtsIndex::open_or_create(dir).expect("open");
+
+        idx.add_document("/notes/hello.md", 0, "hello world", Some(1_700_000_000_000))
+            .expect("add");
+        idx.add_document("/notes/other.md", 0, "goodbye world", Some(1_700_000_000_001))
+            .expect("add");
+        idx.commit().expect("commit");
+
+        let hits = idx.search("hello", 10, None).expect("search");
+        assert_eq!(hits.len(), 1, "expected the hello doc only, got {hits:?}");
+        assert_eq!(hits[0].path, "/notes/hello.md");
+        assert_eq!(hits[0].chunk_index, 0);
+        assert_eq!(hits[0].mtime_ms, Some(1_700_000_000_000));
+        assert!(hits[0].score > 0.0);
+    }
+
+    #[test]
+    fn missing_mtime_round_trips_as_none() {
+        let dir = tempdir().join("fts");
+        let idx = FtsIndex::open_or_create(dir).expect("open");
+        idx.add_document("/x.md", 0, "widget alpha", None)
+            .expect("add");
+        idx.commit().expect("commit");
+
+        let hits = idx.search("widget", 10, None).expect("search");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(
+            hits[0].mtime_ms, None,
+            "sentinel must decode back to None, got {:?}",
+            hits[0].mtime_ms,
+        );
+    }
+
+    #[test]
+    fn path_prefix_filters_results() {
+        let dir = tempdir().join("fts");
+        let idx = FtsIndex::open_or_create(dir).expect("open");
+        idx.add_document("/notes/a.md", 0, "shared word", Some(1))
+            .expect("add");
+        idx.add_document("/logs/b.md", 0, "shared word", Some(2))
+            .expect("add");
+        idx.commit().expect("commit");
+
+        let hits = idx.search("shared", 10, Some("/notes/")).expect("search");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].path, "/notes/a.md");
+    }
+
+    #[test]
+    fn top_docs_bounded_by_limit() {
+        let dir = tempdir().join("fts");
+        let idx = FtsIndex::open_or_create(dir).expect("open");
+        for i in 0..20 {
+            idx.add_document(&format!("/doc-{i}.md"), 0, "word", Some(i))
+                .expect("add");
+        }
+        idx.commit().expect("commit");
+
+        let hits = idx.search("word", 5, None).expect("search");
+        assert_eq!(hits.len(), 5);
+    }
+}

--- a/rust/services/search-plugin/src/fts_index.rs
+++ b/rust/services/search-plugin/src/fts_index.rs
@@ -87,7 +87,9 @@ impl Fields {
             chunk_text: schema
                 .get_field("chunk_text")
                 .expect("schema field: chunk_text"),
-            mtime_ms: schema.get_field("mtime_ms").expect("schema field: mtime_ms"),
+            mtime_ms: schema
+                .get_field("mtime_ms")
+                .expect("schema field: mtime_ms"),
         }
     }
 }
@@ -338,8 +340,13 @@ mod tests {
 
         idx.add_document("/notes/hello.md", 0, "hello world", Some(1_700_000_000_000))
             .expect("add");
-        idx.add_document("/notes/other.md", 0, "goodbye world", Some(1_700_000_000_001))
-            .expect("add");
+        idx.add_document(
+            "/notes/other.md",
+            0,
+            "goodbye world",
+            Some(1_700_000_000_001),
+        )
+        .expect("add");
         idx.commit().expect("commit");
 
         let hits = idx.search("hello", 10, None).expect("search");

--- a/rust/services/search-plugin/src/fts_index.rs
+++ b/rust/services/search-plugin/src/fts_index.rs
@@ -19,11 +19,23 @@
 //! path         STRING | STORED             exact match + retrievable
 //! chunk_index  I64    | INDEXED | STORED   integer, 0 in P1 (one chunk per file)
 //! chunk_text   TEXT   | STORED             BM25-analysed
-//! mtime_ms     I64    | INDEXED | STORED   millisecond-resolution mtime
+//! mtime_ms     I64    | STORED             millisecond-resolution mtime
 //! ```
 //!
-//! P4 grows `chunk_index` to a real value once the chunker lands;
-//! P2 adds a `vec_id` field pointing at the sibling HNSW index.
+//! `mtime_ms` is STORED only in P1 (no INDEXED).  P6 flips it to
+//! `STORED | INDEXED` when recency queries land; INDEXED today would
+//! build a range index nothing queries.  P4 grows `chunk_index` to
+//! a real value once the chunker lands; P2 adds a `vec_id` field
+//! pointing at the sibling HNSW index.
+//!
+//! # Idempotency
+//!
+//! [`add_document`](FtsIndex::add_document) first deletes any prior
+//! document with the same `path` (P1 = one chunk per file, so path
+//! IS the primary key).  Re-indexing the same file replaces its
+//! document instead of duplicating it — Index calls are safe to
+//! retry.  P4 grows the key to `(path, chunk_index)` when the
+//! chunker emits multiple chunks per file.
 //!
 //! # Concurrency
 //!
@@ -45,7 +57,7 @@ use tantivy::collector::TopDocs;
 use tantivy::directory::MmapDirectory;
 use tantivy::query::QueryParser;
 use tantivy::schema::{Field, Schema, INDEXED, STORED, STRING, TEXT};
-use tantivy::{doc, Index, IndexReader, IndexWriter, ReloadPolicy, TantivyDocument};
+use tantivy::{doc, Index, IndexReader, IndexWriter, ReloadPolicy, TantivyDocument, Term};
 
 /// tantivy writer heap — 50 MiB is the conventional per-index budget
 /// and lets a batch of ~1 000 chunks commit without forcing a merge.
@@ -108,8 +120,10 @@ pub fn build_schema() -> Schema {
     // chunk_text — BM25-analysed.  Default TEXT = lowercase + simple
     // tokeniser; P4 replaces this with a language-aware chain.
     sb.add_text_field("chunk_text", TEXT | STORED);
-    // mtime_ms — INDEXED for P6's recency range queries.
-    sb.add_i64_field("mtime_ms", INDEXED | STORED);
+    // mtime_ms — STORED only in P1.  P6 lifts to `STORED | INDEXED`
+    // when recency range queries land; indexing today would build a
+    // range structure nothing queries.
+    sb.add_i64_field("mtime_ms", STORED);
     sb.build()
 }
 
@@ -160,8 +174,13 @@ impl FtsIndex {
     }
 
     /// Add a document.  P1 semantics: one call = one document = one
-    /// chunk.  The writer buffers in RAM until [`commit`](Self::commit)
-    /// is called — callers batch adds and commit at end-of-request so
+    /// chunk (`path` is the primary key; P4 grows the key to
+    /// `(path, chunk_index)`).  Any prior document with the same
+    /// `path` is deleted first so re-indexing replaces instead of
+    /// duplicating — Index calls are safe to retry.
+    ///
+    /// The writer buffers in RAM until [`commit`](Self::commit) is
+    /// called — callers batch adds and commit at end-of-request so
     /// tantivy can flush a single segment (much cheaper than one
     /// commit per doc).
     ///
@@ -177,6 +196,12 @@ impl FtsIndex {
         mtime_ms: Option<i64>,
     ) -> Result<(), IndexError> {
         let writer = self.writer.lock();
+        // Idempotent add: drop any prior doc keyed by this path before
+        // buffering the new one.  Both operations queue on the same
+        // writer transaction, so the commit lands them atomically — a
+        // reader can never see zero copies of the doc during a
+        // reindex.
+        writer.delete_term(Term::from_field_text(self.fields.path, path));
         writer
             .add_document(doc!(
                 self.fields.path => path,
@@ -387,6 +412,28 @@ mod tests {
         let hits = idx.search("shared", 10, Some("/notes/")).expect("search");
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].path, "/notes/a.md");
+    }
+
+    #[test]
+    fn readd_same_path_replaces_not_duplicates() {
+        // Regression: naive add_document duplicated a doc every reindex,
+        // doubling its BM25 score and starving other docs from the
+        // top-N.  delete_term-before-add makes Index retries safe.
+        let dir = tempdir().join("fts");
+        let idx = FtsIndex::open_or_create(dir).expect("open");
+        idx.add_document("/notes/hello.md", 0, "widget alpha", Some(1))
+            .expect("add-1");
+        idx.commit().expect("commit-1");
+        // Same path, updated text + mtime.
+        idx.add_document("/notes/hello.md", 0, "widget beta", Some(2))
+            .expect("add-2");
+        idx.commit().expect("commit-2");
+
+        let hits = idx.search("widget", 10, None).expect("search");
+        assert_eq!(hits.len(), 1, "expected one doc after re-add, got {hits:?}");
+        // The stored text + mtime are the most recent write.
+        assert_eq!(hits[0].chunk_text, "widget beta");
+        assert_eq!(hits[0].mtime_ms, Some(2));
     }
 
     #[test]

--- a/rust/services/search-plugin/src/fts_index.rs
+++ b/rust/services/search-plugin/src/fts_index.rs
@@ -16,10 +16,10 @@
 //! # Schema (P1)
 //!
 //! ```text
-//! path         STRING | STORED             exact match + retrievable
-//! chunk_index  I64    | INDEXED | STORED   integer, 0 in P1 (one chunk per file)
-//! chunk_text   TEXT   | STORED             BM25-analysed
-//! mtime_ms     I64    | STORED             millisecond-resolution mtime
+//! path         STRING | STORED   exact match + retrievable
+//! chunk_index  I64    | STORED   integer, 0 in P1 (one chunk per file)
+//! chunk_text   TEXT   | STORED   BM25-analysed
+//! mtime_ms     I64    | STORED   millisecond-resolution mtime
 //! ```
 //!
 //! `mtime_ms` is STORED only in P1 (no INDEXED).  P6 flips it to
@@ -56,7 +56,7 @@ use parking_lot::Mutex;
 use tantivy::collector::TopDocs;
 use tantivy::directory::MmapDirectory;
 use tantivy::query::QueryParser;
-use tantivy::schema::{Field, Schema, INDEXED, STORED, STRING, TEXT};
+use tantivy::schema::{Field, Schema, Value, STORED, STRING, TEXT};
 use tantivy::{doc, Index, IndexReader, IndexWriter, ReloadPolicy, TantivyDocument, Term};
 
 /// tantivy writer heap — 50 MiB is the conventional per-index budget
@@ -114,9 +114,10 @@ pub fn build_schema() -> Schema {
     // by the query layer, not by tantivy itself in P1 (a term-prefix
     // query would work but adds tokenisation surprises for paths).
     sb.add_text_field("path", STRING | STORED);
-    // chunk_index — small integer, INDEXED so future range queries
-    // (dedupe by (path, chunk_index)) don't require re-scan.
-    sb.add_i64_field("chunk_index", INDEXED | STORED);
+    // chunk_index — STORED only in P1 (always 0, no query hits it).
+    // P4's chunker flips to `STORED | INDEXED` when composite-key
+    // dedupe by (path, chunk_index) lands.
+    sb.add_i64_field("chunk_index", STORED);
     // chunk_text — BM25-analysed.  Default TEXT = lowercase + simple
     // tokeniser; P4 replaces this with a language-aware chain.
     sb.add_text_field("chunk_text", TEXT | STORED);
@@ -158,10 +159,12 @@ impl FtsIndex {
 
         let reader = index
             .reader_builder()
-            // OnCommit = the reader auto-refreshes when the writer
-            // commits; searches after add_doc see fresh state without
-            // the caller having to plumb a manual reload.
-            .reload_policy(ReloadPolicy::OnCommit)
+            // OnCommitWithDelay = the reader auto-refreshes shortly
+            // after the writer commits; searches after add_doc see
+            // fresh state without the caller having to plumb a
+            // manual reload.  Tests that need synchronous visibility
+            // call `reader.reload()` on the returned handle.
+            .reload_policy(ReloadPolicy::OnCommitWithDelay)
             .try_into()
             .map_err(|e| IndexError::ReaderInit(e.to_string()))?;
 
@@ -216,10 +219,19 @@ impl FtsIndex {
     /// Flush buffered adds to disk and make them visible to searchers.
     /// Cheap for small batches; a couple of ms per commit + a
     /// background merge that happens on tantivy's own thread.
+    ///
+    /// The reader is force-reloaded synchronously so a subsequent
+    /// [`search`](Self::search) sees the commit — tantivy's
+    /// `OnCommitWithDelay` policy would otherwise let the reader lag
+    /// long enough for tests + tight write-then-read loops to see
+    /// stale state.
     pub fn commit(&self) -> Result<(), IndexError> {
         let mut writer = self.writer.lock();
         writer
             .commit()
+            .map_err(|e| IndexError::Commit(e.to_string()))?;
+        self.reader
+            .reload()
             .map_err(|e| IndexError::Commit(e.to_string()))?;
         Ok(())
     }

--- a/rust/services/search-plugin/src/index_manager.rs
+++ b/rust/services/search-plugin/src/index_manager.rs
@@ -1,0 +1,169 @@
+//! Per-zone [`FtsIndex`] cache with lazy open-or-create (Phase 1 of
+//! the Python-parity roadmap; see `PARITY_ROADMAP.md` D1).
+//!
+//! # Rationale
+//!
+//! `FtsIndex` is the storage primitive — one directory, one schema,
+//! one writer lock.  `IndexManager` is the zone router — it maps
+//! `zone_id -> Arc<FtsIndex>` and lazily opens an index the first
+//! time a Query or Index call names a zone the manager hasn't seen
+//! yet.  Separating the two keeps `service.rs` free of directory
+//! plumbing: the RPC handler asks the manager for an index and
+//! calls into it.
+//!
+//! # Concurrency
+//!
+//! The cache is a `parking_lot::Mutex<HashMap<zone_id, Arc<FtsIndex>>>`;
+//! the lock is held for a hash lookup (typically ns) or a first-boot
+//! `open_or_create` (typically low-ms once per zone).  A `DashMap`
+//! would be lower-overhead in principle but zone count is small
+//! (single-digit typical, tens max) and Query lookups take zero
+//! locks after the first-boot cost — the `Arc<FtsIndex>` is cloned
+//! out under the lock and the rest of the request runs lock-free.
+//!
+//! # Storage roots
+//!
+//! The directory layout is `<root>/<zone_id>/fts/`.  Root defaults
+//! to `~/.nexus/plugins/search/` (see [`default_root`]); tests pass
+//! a tempdir.  Zone-id sanitisation is minimal — the caller (the
+//! kernel-tier RPC handler) never lets a client-controlled string
+//! reach this API; `zone_id` values are drawn from the raft-managed
+//! zone registry.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+
+use crate::fts_index::{FtsIndex, IndexError};
+
+/// Directory name inside a per-zone index root for the FTS store.
+/// Sibling directories (Phase 2's `ann/` for HNSW, etc.) land next
+/// to this one under the same zone root.
+const FTS_SUBDIR: &str = "fts";
+
+/// Resolve the default per-node storage root.  Follows the same
+/// per-platform convention `dirs::data_local_dir` gives — the
+/// sibling vault plugin uses the same rule for its own state.
+///
+/// Fallback: relative `nexus/plugins/search/` if the home directory
+/// cannot be resolved.  This only fires on a broken user profile;
+/// callers wanting deterministic paths pass their own root to
+/// [`IndexManager::with_root`].
+pub fn default_root() -> PathBuf {
+    dirs::home_dir()
+        .map(|h| h.join(".nexus/plugins/search"))
+        .unwrap_or_else(|| PathBuf::from("nexus/plugins/search"))
+}
+
+/// Zone-id → `Arc<FtsIndex>` cache; lazily opens per-zone indices.
+pub struct IndexManager {
+    root: PathBuf,
+    zones: Mutex<HashMap<String, Arc<FtsIndex>>>,
+}
+
+impl IndexManager {
+    /// Manager rooted at the platform default (`~/.nexus/plugins/search/`).
+    pub fn new() -> Self {
+        Self::with_root(default_root())
+    }
+
+    /// Manager rooted at an explicit path.  Used by tests + any
+    /// deployment that overrides the storage location (e.g. an
+    /// operator pointing the plugin at a data volume).
+    pub fn with_root(root: PathBuf) -> Self {
+        Self {
+            root,
+            zones: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Return the on-disk directory the given zone's FTS index lives
+    /// in.  Broken out so tests can assert layout without going
+    /// through [`get_or_open`].
+    pub fn index_dir(&self, zone_id: &str) -> PathBuf {
+        self.root.join(zone_id).join(FTS_SUBDIR)
+    }
+
+    /// Handle to the storage root — used by callers that need to
+    /// resolve sibling per-zone directories (e.g. Phase 2's HNSW
+    /// index next to the tantivy one).
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    /// Fetch (or lazily open) the FTS index for `zone_id`.  Once
+    /// opened, the `Arc<FtsIndex>` is cached; further calls return
+    /// the same handle so writer state (buffered adds) survives
+    /// across RPCs.
+    pub fn get_or_open(&self, zone_id: &str) -> Result<Arc<FtsIndex>, IndexError> {
+        let mut zones = self.zones.lock();
+        if let Some(idx) = zones.get(zone_id) {
+            return Ok(Arc::clone(idx));
+        }
+        let idx = FtsIndex::open_or_create(self.index_dir(zone_id))?;
+        zones.insert(zone_id.to_string(), Arc::clone(&idx));
+        Ok(idx)
+    }
+}
+
+impl Default for IndexManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tempdir() -> PathBuf {
+        tempfile::tempdir().expect("tempdir").keep()
+    }
+
+    #[test]
+    fn get_or_open_returns_same_handle_for_repeat_zone() {
+        let root = tempdir();
+        let mgr = IndexManager::with_root(root);
+        let a = mgr.get_or_open("zone-a").expect("open a");
+        let b = mgr.get_or_open("zone-a").expect("re-open a");
+        // Same Arc = same cached handle; writer state survives.
+        assert!(Arc::ptr_eq(&a, &b));
+    }
+
+    #[test]
+    fn distinct_zones_get_distinct_directories() {
+        let root = tempdir();
+        let mgr = IndexManager::with_root(root.clone());
+        let _ = mgr.get_or_open("zone-a").expect("open a");
+        let _ = mgr.get_or_open("zone-b").expect("open b");
+
+        assert!(root.join("zone-a/fts").exists(), "za dir not created");
+        assert!(root.join("zone-b/fts").exists(), "zb dir not created");
+    }
+
+    #[test]
+    fn zones_write_and_read_independently() {
+        // Regression scaffold for D3: cross-zone read isolation stays
+        // the caller's job (kernel driver), but the storage layer
+        // itself must not bleed docs between zones.
+        let root = tempdir();
+        let mgr = IndexManager::with_root(root);
+        let a = mgr.get_or_open("zone-a").expect("open a");
+        let b = mgr.get_or_open("zone-b").expect("open b");
+
+        a.add_document("/x.md", 0, "za only", Some(1)).expect("add");
+        a.commit().expect("commit a");
+        b.add_document("/y.md", 0, "zb only", Some(2)).expect("add");
+        b.commit().expect("commit b");
+
+        let hits_a = a.search("only", 10, None).expect("search a");
+        assert_eq!(hits_a.len(), 1);
+        assert_eq!(hits_a[0].path, "/x.md");
+
+        let hits_b = b.search("only", 10, None).expect("search b");
+        assert_eq!(hits_b.len(), 1);
+        assert_eq!(hits_b[0].path, "/y.md");
+    }
+}

--- a/rust/services/search-plugin/src/lib.rs
+++ b/rust/services/search-plugin/src/lib.rs
@@ -53,6 +53,7 @@ pub mod search_proto {
 }
 
 pub mod fts_index;
+pub mod index_manager;
 pub mod kernel_io;
 pub mod service;
 

--- a/rust/services/search-plugin/src/lib.rs
+++ b/rust/services/search-plugin/src/lib.rs
@@ -52,6 +52,7 @@ pub mod search_proto {
     tonic::include_proto!("nexus.search.v1");
 }
 
+pub mod fts_index;
 pub mod kernel_io;
 pub mod service;
 

--- a/rust/services/search-plugin/src/lib.rs
+++ b/rust/services/search-plugin/src/lib.rs
@@ -58,7 +58,7 @@ pub mod kernel_io;
 pub mod service;
 
 use search_proto::search_service_server::SearchService as SearchServiceTrait;
-use search_proto::{GlobRequest, GrepRequest};
+use search_proto::{GlobRequest, GrepRequest, IndexRequest, QueryRequest};
 
 /// Plugin state held between `create` and `destroy`.
 ///
@@ -178,6 +178,36 @@ fn dispatch_grpc(plugin: &SearchPlugin, method: &str, payload: &[u8]) -> Result<
                 .block_on(plugin.svc.grep(Request::new(req)))
                 .map_err(|s| {
                     tracing::warn!(status = %s, "Grep handler");
+                    -3
+                })?
+                .into_inner();
+            Ok(resp.encode_to_vec())
+        }
+        "Query" => {
+            let req = QueryRequest::decode(payload).map_err(|e| {
+                tracing::warn!(err = %e, "Query decode");
+                -2
+            })?;
+            let resp = plugin
+                .rt
+                .block_on(plugin.svc.query(Request::new(req)))
+                .map_err(|s| {
+                    tracing::warn!(status = %s, "Query handler");
+                    -3
+                })?
+                .into_inner();
+            Ok(resp.encode_to_vec())
+        }
+        "Index" => {
+            let req = IndexRequest::decode(payload).map_err(|e| {
+                tracing::warn!(err = %e, "Index decode");
+                -2
+            })?;
+            let resp = plugin
+                .rt
+                .block_on(plugin.svc.index(Request::new(req)))
+                .map_err(|s| {
+                    tracing::warn!(status = %s, "Index handler");
                     -3
                 })?
                 .into_inner();

--- a/rust/services/search-plugin/src/service.rs
+++ b/rust/services/search-plugin/src/service.rs
@@ -13,28 +13,73 @@ use std::sync::Arc;
 use nexus_plugin_abi::KernelHandle;
 use tonic::{async_trait, Request, Response, Status};
 
+use crate::fts_index::FtsHit;
+use crate::index_manager::IndexManager;
 use crate::kernel_io::{self, DirEntry, KernelIoError, DT_DIR, DT_REG};
 use crate::search_proto::search_service_server::SearchService;
-use crate::search_proto::{GlobRequest, GlobResponse, GrepMatch, GrepRequest, GrepResponse};
+use crate::search_proto::{
+    GlobRequest, GlobResponse, GrepMatch, GrepRequest, GrepResponse, IndexRequest, IndexResponse,
+    QueryRequest, QueryResponse, QueryResult, QueryType,
+};
 
 /// Server-side default when the caller sends `max_results = 0`.
 /// Kept generous — a well-scoped `pattern` almost never hits this,
 /// and callers who want stricter limits still set them explicitly.
 const DEFAULT_GLOB_MAX: usize = 10_000;
 const DEFAULT_GREP_MAX: usize = 1_000;
+const DEFAULT_QUERY_LIMIT: usize = 10;
+const DEFAULT_INDEX_MAX_DOCS: usize = 10_000;
 
 /// Belt-and-suspenders per-file size cap for grep — a 100 MB
 /// binary blob would otherwise stall a single request for seconds.
 /// Files above this size are skipped with a `tracing::debug` log.
 const GREP_MAX_FILE_BYTES: usize = 8 * 1024 * 1024;
 
+/// Same-shape cap for the P1 Index walker: one chunk per file, and
+/// stuffing a 100 MB blob into a single tantivy doc would balloon
+/// the writer heap AND murder BM25 scoring.  P4's chunker lifts this
+/// once files are split into per-chunk documents.
+const INDEX_MAX_FILE_BYTES: usize = 8 * 1024 * 1024;
+
+/// Empty `zone_id` on a request means "the root zone" — same rule
+/// the Python router uses when a token has no explicit zone scope
+/// (see `nexus.contracts.constants.ROOT_ZONE_ID`).  Kept as a plain
+/// string here so the plugin dep tree stays free of the wider
+/// contracts crate.
+const ROOT_ZONE_ID: &str = "root";
+
+fn resolve_zone(z: &str) -> &str {
+    if z.is_empty() {
+        ROOT_ZONE_ID
+    } else {
+        z
+    }
+}
+
 pub struct SearchServiceImpl {
     handle: Arc<KernelHandle>,
+    /// Per-zone `FtsIndex` cache used by Query and Index.  Kept as
+    /// `Arc<IndexManager>` so tests can inject a manager rooted at a
+    /// tempdir instead of `~/.nexus/plugins/search/`.
+    manager: Arc<IndexManager>,
 }
 
 impl SearchServiceImpl {
+    /// Production constructor — index manager rooted at the platform
+    /// default (`~/.nexus/plugins/search/`).
     pub fn new(handle: Arc<KernelHandle>) -> Self {
-        Self { handle }
+        Self {
+            handle,
+            manager: Arc::new(IndexManager::new()),
+        }
+    }
+
+    /// Test / operator constructor — inject a pre-configured
+    /// `IndexManager` (typically rooted at a tempdir for tests, or
+    /// at an explicit data volume for operators overriding the
+    /// default storage location).
+    pub fn with_manager(handle: Arc<KernelHandle>, manager: Arc<IndexManager>) -> Self {
+        Self { handle, manager }
     }
 }
 
@@ -404,6 +449,179 @@ fn fetch_mtimes<'a>(
     out
 }
 
+// ── Query / Index (Phase 1) ───────────────────────────────────────
+
+/// Fetch (or open) the per-zone FtsIndex and run a BM25 keyword
+/// search.  P1 accepts `QueryType::Keyword` (or `Unspecified` as a
+/// safe default); other types are rejected with a caller-facing
+/// error string so P2/P3 can lift the gate additively.
+fn do_query(
+    manager: &IndexManager,
+    q: &str,
+    zone_id: &str,
+    limit: usize,
+    path_filter: &str,
+    query_type: QueryType,
+) -> Result<Vec<QueryResult>, String> {
+    match query_type {
+        QueryType::Unspecified | QueryType::Keyword => {}
+        QueryType::Semantic => {
+            return Err("query_type=SEMANTIC not supported until P2".into());
+        }
+        QueryType::Hybrid => {
+            return Err("query_type=HYBRID not supported until P3".into());
+        }
+    }
+
+    let index = manager
+        .get_or_open(zone_id)
+        .map_err(|e| format!("open index for zone {zone_id:?}: {e}"))?;
+
+    let prefix = if path_filter.is_empty() {
+        None
+    } else {
+        Some(path_filter)
+    };
+
+    let hits = index
+        .search(q, limit, prefix)
+        .map_err(|e| format!("search: {e}"))?;
+
+    Ok(hits.into_iter().map(|h| fts_hit_to_result(h, zone_id)).collect())
+}
+
+fn fts_hit_to_result(hit: FtsHit, zone_id: &str) -> QueryResult {
+    QueryResult {
+        path: hit.path,
+        chunk_index: hit.chunk_index,
+        chunk_text: hit.chunk_text,
+        score: hit.score,
+        zone_id: zone_id.to_string(),
+        mtime_ms: hit.mtime_ms,
+    }
+}
+
+/// Walk `root_path` and index every regular file.  Same walker Glob +
+/// Grep use — `sys_readdir` for enumeration, `sys_read` for content,
+/// `sys_stat` for mtime.  P1 = one chunk per file (path is the FTS
+/// primary key, `add_document` is idempotent so re-indexing replaces
+/// the prior doc); P4's chunker splits per file into multiple docs.
+fn do_index(
+    handle: &KernelHandle,
+    manager: &IndexManager,
+    root_path: &str,
+    zone_id: &str,
+    recursive: bool,
+    max_docs: usize,
+) -> Result<(u32, u32), String> {
+    let index = manager
+        .get_or_open(zone_id)
+        .map_err(|e| format!("open index for zone {zone_id:?}: {e}"))?;
+
+    let mut indexed: u32 = 0;
+    let mut skipped: u32 = 0;
+
+    let visit_result = if recursive {
+        walk_recursive(handle, root_path, &mut |vfs_path, entry_type| {
+            if (indexed as usize) >= max_docs {
+                return WalkAction::Stop;
+            }
+            if entry_type != DT_REG {
+                return WalkAction::Continue;
+            }
+            match index_one(handle, &index, vfs_path) {
+                IndexOne::Added => indexed += 1,
+                IndexOne::Skipped => skipped += 1,
+            }
+            WalkAction::Continue
+        })
+        .map_err(walk_err_to_string)
+    } else {
+        // Non-recursive: enumerate ONLY direct children of root_path.
+        // Matches Python `recursive=False`.
+        match kernel_io::sys_readdir(handle, root_path) {
+            Ok(entries) => {
+                for entry in entries {
+                    if (indexed as usize) >= max_docs {
+                        break;
+                    }
+                    if entry.entry_type != DT_REG {
+                        continue;
+                    }
+                    let child = kernel_io::join_vfs_path(root_path, &entry.name);
+                    match index_one(handle, &index, &child) {
+                        IndexOne::Added => indexed += 1,
+                        IndexOne::Skipped => skipped += 1,
+                    }
+                }
+                Ok(())
+            }
+            Err(e) => Err(walk_err_to_string(e)),
+        }
+    };
+
+    // Commit even on walker error so partial progress is durable —
+    // callers retry with a narrower root_path per D5 SSOT (the
+    // MetaStore `search.indexed_gen` sidecar lands in P5).
+    if let Err(e) = index.commit() {
+        tracing::warn!(err = %e, "index commit failed after walk");
+        return Err(format!("commit: {e}"));
+    }
+
+    visit_result?;
+    Ok((indexed, skipped))
+}
+
+/// Outcome of a single-file index attempt.  Distinguished so
+/// `do_index` can tally added vs skipped without a per-call error
+/// return (a skip is not an error).
+enum IndexOne {
+    Added,
+    Skipped,
+}
+
+fn index_one(handle: &KernelHandle, index: &crate::fts_index::FtsIndex, vfs_path: &str) -> IndexOne {
+    let bytes = match kernel_io::sys_read(handle, vfs_path) {
+        Ok(b) => b,
+        Err(e) => {
+            tracing::debug!(path = %vfs_path, err = ?e, "index: sys_read failed — skipping");
+            return IndexOne::Skipped;
+        }
+    };
+    if bytes.is_empty() {
+        return IndexOne::Skipped;
+    }
+    if bytes.len() > INDEX_MAX_FILE_BYTES {
+        tracing::debug!(
+            path = %vfs_path,
+            len = bytes.len(),
+            cap = INDEX_MAX_FILE_BYTES,
+            "index: file over size cap — skipping",
+        );
+        return IndexOne::Skipped;
+    }
+    // Non-UTF8 files are treated as binary and skipped rather than
+    // indexed as gibberish.  A future phase may want to add a
+    // language-detect + transcode step, but that belongs with the
+    // real chunker in P4.
+    let text = match std::str::from_utf8(&bytes) {
+        Ok(s) => s,
+        Err(_) => {
+            tracing::debug!(path = %vfs_path, "index: non-utf8 payload — skipping");
+            return IndexOne::Skipped;
+        }
+    };
+    let mtime_ms = kernel_io::sys_stat(handle, vfs_path)
+        .ok()
+        .and_then(|info| info.modified_at_ms);
+
+    if let Err(e) = index.add_document(vfs_path, 0, text, mtime_ms) {
+        tracing::warn!(path = %vfs_path, err = %e, "index: add_document failed — skipping");
+        return IndexOne::Skipped;
+    }
+    IndexOne::Added
+}
+
 // ── tonic trait impl ──────────────────────────────────────────────
 
 #[async_trait]
@@ -486,6 +704,84 @@ impl SearchService for SearchServiceImpl {
             Err(err) => Ok(Response::new(GrepResponse {
                 matches: Vec::new(),
                 truncated: false,
+                error: Some(err),
+            })),
+        }
+    }
+
+    async fn query(
+        &self,
+        request: Request<QueryRequest>,
+    ) -> Result<Response<QueryResponse>, Status> {
+        let req = request.into_inner();
+        let q = req.q;
+        if q.is_empty() {
+            return Ok(Response::new(QueryResponse {
+                results: Vec::new(),
+                error: Some("q must not be empty".into()),
+            }));
+        }
+        let zone_id = resolve_zone(&req.zone_id).to_string();
+        let limit = if req.limit == 0 {
+            DEFAULT_QUERY_LIMIT
+        } else {
+            req.limit as usize
+        };
+        let path_filter = req.path_filter;
+        let query_type = QueryType::try_from(req.query_type).unwrap_or(QueryType::Unspecified);
+        let manager = Arc::clone(&self.manager);
+        let outcome = tokio::task::spawn_blocking(move || {
+            do_query(&manager, &q, &zone_id, limit, &path_filter, query_type)
+        })
+        .await
+        .map_err(|e| Status::internal(format!("spawn_blocking joined error: {e}")))?;
+
+        match outcome {
+            Ok(results) => Ok(Response::new(QueryResponse {
+                results,
+                error: None,
+            })),
+            Err(err) => Ok(Response::new(QueryResponse {
+                results: Vec::new(),
+                error: Some(err),
+            })),
+        }
+    }
+
+    async fn index(
+        &self,
+        request: Request<IndexRequest>,
+    ) -> Result<Response<IndexResponse>, Status> {
+        let req = request.into_inner();
+        let root = if req.root_path.is_empty() {
+            "/".to_string()
+        } else {
+            req.root_path
+        };
+        let zone_id = resolve_zone(&req.zone_id).to_string();
+        let recursive = req.recursive;
+        let max_docs = if req.max_docs == 0 {
+            DEFAULT_INDEX_MAX_DOCS
+        } else {
+            req.max_docs as usize
+        };
+        let handle = Arc::clone(&self.handle);
+        let manager = Arc::clone(&self.manager);
+        let outcome = tokio::task::spawn_blocking(move || {
+            do_index(&handle, &manager, &root, &zone_id, recursive, max_docs)
+        })
+        .await
+        .map_err(|e| Status::internal(format!("spawn_blocking joined error: {e}")))?;
+
+        match outcome {
+            Ok((indexed_count, skipped_count)) => Ok(Response::new(IndexResponse {
+                indexed_count,
+                skipped_count,
+                error: None,
+            })),
+            Err(err) => Ok(Response::new(IndexResponse {
+                indexed_count: 0,
+                skipped_count: 0,
                 error: Some(err),
             })),
         }

--- a/rust/services/search-plugin/src/service.rs
+++ b/rust/services/search-plugin/src/service.rs
@@ -487,7 +487,10 @@ fn do_query(
         .search(q, limit, prefix)
         .map_err(|e| format!("search: {e}"))?;
 
-    Ok(hits.into_iter().map(|h| fts_hit_to_result(h, zone_id)).collect())
+    Ok(hits
+        .into_iter()
+        .map(|h| fts_hit_to_result(h, zone_id))
+        .collect())
 }
 
 fn fts_hit_to_result(hit: FtsHit, zone_id: &str) -> QueryResult {
@@ -580,7 +583,11 @@ enum IndexOne {
     Skipped,
 }
 
-fn index_one(handle: &KernelHandle, index: &crate::fts_index::FtsIndex, vfs_path: &str) -> IndexOne {
+fn index_one(
+    handle: &KernelHandle,
+    index: &crate::fts_index::FtsIndex,
+    vfs_path: &str,
+) -> IndexOne {
     let bytes = match kernel_io::sys_read(handle, vfs_path) {
         Ok(b) => b,
         Err(e) => {

--- a/rust/services/search-plugin/tests/query_e2e.rs
+++ b/rust/services/search-plugin/tests/query_e2e.rs
@@ -80,11 +80,7 @@ unsafe extern "C" fn poison_mkdir(_: *const c_void, _: *const c_char) -> i32 {
 unsafe extern "C" fn poison_rmdir(_: *const c_void, _: *const c_char) -> i32 {
     -1
 }
-unsafe extern "C" fn poison_rename(
-    _: *const c_void,
-    _: *const c_char,
-    _: *const c_char,
-) -> i32 {
+unsafe extern "C" fn poison_rename(_: *const c_void, _: *const c_char, _: *const c_char) -> i32 {
     -1
 }
 unsafe extern "C" fn poison_stat_batch(
@@ -127,8 +123,7 @@ impl Harness {
     fn start() -> Self {
         let dir = TempDir::new().expect("tempdir");
         let manager = Arc::new(IndexManager::with_root(dir.path().to_path_buf()));
-        let svc =
-            SearchServiceImpl::with_manager(Arc::new(poison_handle()), Arc::clone(&manager));
+        let svc = SearchServiceImpl::with_manager(Arc::new(poison_handle()), Arc::clone(&manager));
         Self {
             _dir: dir,
             svc,
@@ -145,8 +140,13 @@ impl Harness {
             Some(1_700_000_000_000),
         )
         .expect("add-1");
-        idx.add_document("/notes/other.md", 0, "goodbye world", Some(1_700_000_000_100))
-            .expect("add-2");
+        idx.add_document(
+            "/notes/other.md",
+            0,
+            "goodbye world",
+            Some(1_700_000_000_100),
+        )
+        .expect("add-2");
         idx.add_document("/logs/x.log", 0, "widget beta", Some(1_700_000_000_200))
             .expect("add-3");
         idx.commit().expect("commit");

--- a/rust/services/search-plugin/tests/query_e2e.rs
+++ b/rust/services/search-plugin/tests/query_e2e.rs
@@ -1,0 +1,396 @@
+//! End-to-end integration test for the Query RPC (Phase 1 of the
+//! Python-parity roadmap; see `PARITY_ROADMAP.md`).
+//!
+//! Exercises the full RPC handler → \[do_query\] → \[IndexManager\]
+//! → \[FtsIndex.search\] → \[QueryResult\] roundtrip against a real
+//! `SearchServiceImpl` (rlib), with a tempdir-rooted `IndexManager`
+//! that tests inject via `with_manager`.
+//!
+//! Kernel-FFI syscalls (used by Index) are NOT exercised here — a
+//! poison `KernelHandle` is injected so any accidental touch from
+//! the Query path fails loudly rather than silently reaching a
+//! stubbed callback.  Index-path integration lives in a follow-up
+//! (`index_e2e.rs`) once the mock-kernel scaffold lands.
+//!
+//! Follows the standard captured in
+//! `cursor-projects/document-ai/.claude/skills/integration-test-generator`:
+//! real service impl, real proto types, real async runtime, real
+//! storage on disk — only the kernel FFI substrate is a test double,
+//! and it's a `poison` double that catches accidental use, not a
+//! silent stub.
+
+use std::ffi::c_void;
+use std::os::raw::c_char;
+use std::sync::Arc;
+
+use nexus_plugin_abi::KernelHandle;
+use nexus_search_plugin::index_manager::IndexManager;
+use nexus_search_plugin::search_proto::search_service_server::SearchService;
+use nexus_search_plugin::search_proto::{QueryRequest, QueryType};
+use nexus_search_plugin::service::SearchServiceImpl;
+use tempfile::TempDir;
+use tonic::Request;
+
+// ── Poison KernelHandle ─────────────────────────────────────────
+//
+// Query does not touch the kernel; if a regression accidentally
+// wires it back in, these callbacks return -1 (a plugin-ABI Internal
+// error) which propagates into `IndexOne::Skipped` and shows up as a
+// zero-hit result — visible enough that the query test would fail
+// its result assertion.
+
+unsafe extern "C" fn poison_read(
+    _: *const c_void,
+    _: *const c_char,
+    _: *mut *mut u8,
+    _: *mut usize,
+) -> i32 {
+    -1
+}
+unsafe extern "C" fn poison_write(
+    _: *const c_void,
+    _: *const c_char,
+    _: *const u8,
+    _: usize,
+) -> i32 {
+    -1
+}
+unsafe extern "C" fn poison_stat(
+    _: *const c_void,
+    _: *const c_char,
+    _: *mut *mut u8,
+    _: *mut usize,
+) -> i32 {
+    -1
+}
+unsafe extern "C" fn poison_readdir(
+    _: *const c_void,
+    _: *const c_char,
+    _: *mut *mut u8,
+    _: *mut usize,
+) -> i32 {
+    -1
+}
+unsafe extern "C" fn poison_unlink(_: *const c_void, _: *const c_char) -> i32 {
+    -1
+}
+unsafe extern "C" fn poison_mkdir(_: *const c_void, _: *const c_char) -> i32 {
+    -1
+}
+unsafe extern "C" fn poison_rmdir(_: *const c_void, _: *const c_char) -> i32 {
+    -1
+}
+unsafe extern "C" fn poison_rename(
+    _: *const c_void,
+    _: *const c_char,
+    _: *const c_char,
+) -> i32 {
+    -1
+}
+unsafe extern "C" fn poison_stat_batch(
+    _: *const c_void,
+    _: *const c_char,
+    _: *mut *mut u8,
+    _: *mut usize,
+) -> i32 {
+    -1
+}
+
+fn poison_handle() -> KernelHandle {
+    KernelHandle {
+        sys_read: poison_read,
+        sys_write: poison_write,
+        sys_stat: poison_stat,
+        sys_readdir: poison_readdir,
+        sys_unlink: poison_unlink,
+        sys_mkdir: poison_mkdir,
+        sys_rmdir: poison_rmdir,
+        sys_rename: poison_rename,
+        sys_stat_batch: poison_stat_batch,
+        kernel_ptr: std::ptr::null(),
+    }
+}
+
+// ── Harness ─────────────────────────────────────────────────────
+
+/// Build a service + tempdir-rooted manager, seed a couple of
+/// documents directly through the FtsIndex primitive, then run
+/// queries against the service.  Same shape whether we're testing
+/// the happy path or the not-yet-implemented gates.
+struct Harness {
+    _dir: TempDir,
+    svc: SearchServiceImpl,
+    manager: Arc<IndexManager>,
+}
+
+impl Harness {
+    fn start() -> Self {
+        let dir = TempDir::new().expect("tempdir");
+        let manager = Arc::new(IndexManager::with_root(dir.path().to_path_buf()));
+        let svc =
+            SearchServiceImpl::with_manager(Arc::new(poison_handle()), Arc::clone(&manager));
+        Self {
+            _dir: dir,
+            svc,
+            manager,
+        }
+    }
+
+    fn seed(&self, zone_id: &str) {
+        let idx = self.manager.get_or_open(zone_id).expect("open zone");
+        idx.add_document(
+            "/notes/hello.md",
+            0,
+            "hello world widget alpha",
+            Some(1_700_000_000_000),
+        )
+        .expect("add-1");
+        idx.add_document("/notes/other.md", 0, "goodbye world", Some(1_700_000_000_100))
+            .expect("add-2");
+        idx.add_document("/logs/x.log", 0, "widget beta", Some(1_700_000_000_200))
+            .expect("add-3");
+        idx.commit().expect("commit");
+    }
+}
+
+// ── Tests ───────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn query_returns_bm25_hits_for_seeded_zone() {
+    let h = Harness::start();
+    h.seed("root");
+
+    let resp = h
+        .svc
+        .query(Request::new(QueryRequest {
+            q: "widget".into(),
+            zone_id: "root".into(),
+            limit: 10,
+            path_filter: String::new(),
+            query_type: QueryType::Keyword as i32,
+            auth_token: String::new(),
+        }))
+        .await
+        .expect("query")
+        .into_inner();
+
+    assert!(resp.error.is_none(), "unexpected error: {:?}", resp.error);
+    assert_eq!(
+        resp.results.len(),
+        2,
+        "expected two 'widget' matches, got {:?}",
+        resp.results.iter().map(|r| &r.path).collect::<Vec<_>>(),
+    );
+    for r in &resp.results {
+        assert_eq!(r.zone_id, "root");
+        assert!(r.score > 0.0);
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn query_empty_zone_resolves_to_root() {
+    let h = Harness::start();
+    h.seed("root");
+
+    let resp = h
+        .svc
+        .query(Request::new(QueryRequest {
+            q: "widget".into(),
+            zone_id: String::new(), // ⇒ ROOT_ZONE_ID
+            limit: 10,
+            path_filter: String::new(),
+            query_type: QueryType::Keyword as i32,
+            auth_token: String::new(),
+        }))
+        .await
+        .expect("query")
+        .into_inner();
+
+    assert!(resp.error.is_none(), "unexpected error: {:?}", resp.error);
+    assert_eq!(resp.results.len(), 2);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn query_path_filter_narrows_results() {
+    let h = Harness::start();
+    h.seed("root");
+
+    let resp = h
+        .svc
+        .query(Request::new(QueryRequest {
+            q: "widget".into(),
+            zone_id: "root".into(),
+            limit: 10,
+            path_filter: "/notes/".into(),
+            query_type: QueryType::Keyword as i32,
+            auth_token: String::new(),
+        }))
+        .await
+        .expect("query")
+        .into_inner();
+
+    assert!(resp.error.is_none(), "unexpected error: {:?}", resp.error);
+    assert_eq!(resp.results.len(), 1);
+    assert_eq!(resp.results[0].path, "/notes/hello.md");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn query_empty_q_returns_error_not_500() {
+    let h = Harness::start();
+    let resp = h
+        .svc
+        .query(Request::new(QueryRequest {
+            q: String::new(),
+            zone_id: "root".into(),
+            limit: 10,
+            path_filter: String::new(),
+            query_type: QueryType::Keyword as i32,
+            auth_token: String::new(),
+        }))
+        .await
+        .expect("query")
+        .into_inner();
+
+    assert!(resp.error.is_some(), "expected error for empty q");
+    assert!(resp.results.is_empty());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn query_semantic_type_rejected_with_p2_message() {
+    let h = Harness::start();
+    let resp = h
+        .svc
+        .query(Request::new(QueryRequest {
+            q: "widget".into(),
+            zone_id: "root".into(),
+            limit: 10,
+            path_filter: String::new(),
+            query_type: QueryType::Semantic as i32,
+            auth_token: String::new(),
+        }))
+        .await
+        .expect("query")
+        .into_inner();
+
+    let err = resp.error.expect("semantic must be rejected in P1");
+    assert!(
+        err.contains("P2"),
+        "semantic rejection should mention P2, got: {err:?}",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn query_hybrid_type_rejected_with_p3_message() {
+    let h = Harness::start();
+    let resp = h
+        .svc
+        .query(Request::new(QueryRequest {
+            q: "widget".into(),
+            zone_id: "root".into(),
+            limit: 10,
+            path_filter: String::new(),
+            query_type: QueryType::Hybrid as i32,
+            auth_token: String::new(),
+        }))
+        .await
+        .expect("query")
+        .into_inner();
+
+    let err = resp.error.expect("hybrid must be rejected in P1");
+    assert!(
+        err.contains("P3"),
+        "hybrid rejection should mention P3, got: {err:?}",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn query_zero_limit_uses_default() {
+    let h = Harness::start();
+    // Seed enough docs to prove the default cap fires.
+    let idx = h.manager.get_or_open("root").expect("open");
+    for i in 0..25 {
+        idx.add_document(&format!("/f-{i}.md"), 0, "widget", Some(i))
+            .expect("add");
+    }
+    idx.commit().expect("commit");
+
+    let resp = h
+        .svc
+        .query(Request::new(QueryRequest {
+            q: "widget".into(),
+            zone_id: "root".into(),
+            limit: 0, // ⇒ DEFAULT_QUERY_LIMIT (10)
+            path_filter: String::new(),
+            query_type: QueryType::Keyword as i32,
+            auth_token: String::new(),
+        }))
+        .await
+        .expect("query")
+        .into_inner();
+
+    assert!(resp.error.is_none());
+    assert_eq!(resp.results.len(), 10, "default limit is 10");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn query_zone_isolation_holds_at_storage_layer() {
+    // Regression scaffold for D3: cross-zone read filtering is the
+    // kernel driver's job, but the STORAGE layer itself must not
+    // bleed docs — a query scoped to zone-a must not see zone-b's
+    // corpus.  Anchors the isolation contract at the plugin-RPC
+    // boundary in case a future refactor accidentally merges the
+    // per-zone indices.
+    let h = Harness::start();
+    let a = h.manager.get_or_open("zone-a").expect("open za");
+    a.add_document("/only-in-a.md", 0, "widget alpha", Some(1))
+        .expect("add-a");
+    a.commit().expect("commit-a");
+
+    let b = h.manager.get_or_open("zone-b").expect("open zb");
+    b.add_document("/only-in-b.md", 0, "widget beta", Some(2))
+        .expect("add-b");
+    b.commit().expect("commit-b");
+
+    let resp = h
+        .svc
+        .query(Request::new(QueryRequest {
+            q: "widget".into(),
+            zone_id: "zone-a".into(),
+            limit: 10,
+            path_filter: String::new(),
+            query_type: QueryType::Keyword as i32,
+            auth_token: String::new(),
+        }))
+        .await
+        .expect("query")
+        .into_inner();
+
+    assert!(resp.error.is_none());
+    assert_eq!(resp.results.len(), 1);
+    assert_eq!(resp.results[0].path, "/only-in-a.md");
+    assert_eq!(resp.results[0].zone_id, "zone-a");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn query_returns_mtime_when_stored() {
+    let h = Harness::start();
+    h.seed("root");
+
+    let resp = h
+        .svc
+        .query(Request::new(QueryRequest {
+            q: "alpha".into(),
+            zone_id: "root".into(),
+            limit: 10,
+            path_filter: String::new(),
+            query_type: QueryType::Keyword as i32,
+            auth_token: String::new(),
+        }))
+        .await
+        .expect("query")
+        .into_inner();
+
+    assert!(resp.error.is_none());
+    assert_eq!(resp.results.len(), 1);
+    assert_eq!(resp.results[0].mtime_ms, Some(1_700_000_000_000));
+}


### PR DESCRIPTION
## Summary

Phase 1 of the Python-parity roadmap (nexi-lab/nexus#4573,
\`rust/services/search-plugin/PARITY_ROADMAP.md\`). Ships in commits
so review can walk the API shape → storage primitive → RPC wiring in
order.

**Status: DRAFT** — proto + tantivy FTS module landed. Query / Index
RPC service impl + integration tests are the next commits (this
session ran out of headroom for the wiring pass).

## What's in so far

- **Proto** (commit 1) — \`QueryRequest\` / \`QueryResponse\` /
  \`IndexRequest\` / \`IndexResponse\` messages, \`QueryType\` and
  \`FusionMethod\` enums. Wire shape is additive: hybrid / semantic /
  recency knobs get their fields today so P2-P6 add behaviour, not
  new RPCs. P1 rejects \`query_type\` != KEYWORD with \`unimplemented\`.
- **Storage** (commit 2) — \`fts_index::FtsIndex\` per-zone tantivy
  index. \`open_or_create\` + \`add_document\` + \`commit\` + BM25
  \`search\` with optional post-scoring path prefix. Writer lock
  (\`parking_lot::Mutex\`) short-held; readers lock-free.
- **Deps** — \`tantivy = "0.22"\`, \`dirs\`, \`parking_lot\`,
  \`thiserror\`. All pure Rust, all inside the plugin cdylib per
  D1 — cluster core untouched.

## What's next in this PR

- Wire \`Query\` and \`Index\` RPCs into \`service.rs\`
- Per-zone \`FtsIndex\` cache (\`DashMap<zone_id, Arc<FtsIndex>>\`)
- \`Index\` = walk \`root_path\` via existing \`walk_recursive\` + read
  each regular file → \`add_document(path, 0, text, mtime_ms)\` →
  batch commit
- Integration test — RPC through the cdylib, index a tmpdir, query,
  verify hit
- Docker E2E smoke — index + query on a real \`nexusd-cluster\`

## Marked draft because

Compile validation happens on CI (Windows local link config drifted
in this env). Reviewing the API + storage design now, before the RPC
wiring lands, means a wrong direction costs one commit not the full
phase.