### PR TITLE
refactor(search-plugin): P1 retrofits — NEXUS_DATA_DIR + Index E2E + Docker E2E

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -962,27 +962,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs"
-version = "5.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
-dependencies = [
- "libc",
- "option-ext",
- "redox_users",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "displaydoc"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2004,15 +1983,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
-name = "libredox"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2026a5056764a10b2bf5d56488cba40da507f5493a6a429340e2004d9ed085fa"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2252,7 +2222,6 @@ name = "nexus-search-plugin"
 version = "0.1.0"
 dependencies = [
  "bytes",
- "dirs",
  "globset",
  "libloading",
  "nexus-plugin-abi",
@@ -2467,12 +2436,6 @@ name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "option-ext"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ownedbytes"
@@ -3085,17 +3048,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags 2.13.1",
-]
-
-[[package]]
-name = "redox_users"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
-dependencies = [
- "getrandom 0.2.17",
- "libredox",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4736,20 +4688,11 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -4763,33 +4706,18 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
-]
-
-[[package]]
-name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -4803,33 +4731,15 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4845,21 +4755,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4869,21 +4767,9 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/rust/services/search-plugin/Cargo.toml
+++ b/rust/services/search-plugin/Cargo.toml
@@ -58,10 +58,6 @@ bytes = "1"
 # live under `~/.nexus/plugins/search/<zone_id>/fts/`.
 tantivy = "0.22"
 
-# Home-dir resolution for the per-zone index root.  `dirs = 5` follows
-# XDG on Linux, `%APPDATA%` on Windows, `~/Library/Application Support`
-# on macOS — matches how the sibling vault plugin stores per-node state.
-dirs = "5"
 
 # Parking-lot mutex around the per-zone index writer.  tantivy's own
 # IndexWriter is Send + Sync but only allows one writer per index at a

--- a/rust/services/search-plugin/src/index_manager.rs
+++ b/rust/services/search-plugin/src/index_manager.rs
@@ -23,12 +23,19 @@
 //!
 //! # Storage roots
 //!
-//! The directory layout is `<root>/<zone_id>/fts/`.  Root defaults
-//! to `~/.nexus/plugins/search/` (see [`default_root`]); tests pass
-//! a tempdir.  Zone-id sanitisation is minimal — the caller (the
-//! kernel-tier RPC handler) never lets a client-controlled string
-//! reach this API; `zone_id` values are drawn from the raft-managed
-//! zone registry.
+//! The directory layout is `<root>/<zone_id>/fts/`.  Root resolves
+//! from the `NEXUS_DATA_DIR` env var (same convention as
+//! [`nexus-vault`]'s per-node state), falling back to `./nexus-data`
+//! when unset — one SSOT lets operators relocate ALL plugins by
+//! pointing `NEXUS_DATA_DIR` at a data volume.  Tests pass an
+//! explicit tempdir via [`IndexManager::with_root`].
+//!
+//! Zone-id sanitisation is minimal — the caller (the kernel-tier
+//! RPC handler) never lets a client-controlled string reach this
+//! API; `zone_id` values are drawn from the raft-managed zone
+//! registry.
+//!
+//! [`nexus-vault`]: ../../../vault/src/lib.rs
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -43,18 +50,21 @@ use crate::fts_index::{FtsIndex, IndexError};
 /// to this one under the same zone root.
 const FTS_SUBDIR: &str = "fts";
 
-/// Resolve the default per-node storage root.  Follows the same
-/// per-platform convention `dirs::data_local_dir` gives — the
-/// sibling vault plugin uses the same rule for its own state.
-///
-/// Fallback: relative `nexus/plugins/search/` if the home directory
-/// cannot be resolved.  This only fires on a broken user profile;
-/// callers wanting deterministic paths pass their own root to
-/// [`IndexManager::with_root`].
+/// Environment variable that names the per-node state root.  Same
+/// SSOT the sibling `nexus-vault` plugin honours — one variable
+/// relocates all plugin state to a data volume.
+const DATA_DIR_ENV: &str = "NEXUS_DATA_DIR";
+
+/// Resolve the default per-node storage root — `$NEXUS_DATA_DIR` if
+/// set, `./nexus-data` otherwise.  Matches vault's exact fallback so
+/// a fresh dev checkout puts vault + search state under the same
+/// parent (`./nexus-data/{vault,plugins/search}/`) without any
+/// operator setup.
 pub fn default_root() -> PathBuf {
-    dirs::home_dir()
-        .map(|h| h.join(".nexus/plugins/search"))
-        .unwrap_or_else(|| PathBuf::from("nexus/plugins/search"))
+    let data_dir = std::env::var(DATA_DIR_ENV)
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from("./nexus-data"));
+    data_dir.join("plugins/search")
 }
 
 /// Zone-id → `Arc<FtsIndex>` cache; lazily opens per-zone indices.
@@ -141,6 +151,43 @@ mod tests {
 
         assert!(root.join("zone-a/fts").exists(), "za dir not created");
         assert!(root.join("zone-b/fts").exists(), "zb dir not created");
+    }
+
+    // NEXUS_DATA_DIR resolution regression tests.  Use `unsafe { set_var }`
+    // per Rust 2024's guard (env is process-global; the tests are
+    // serialised on the DATA_DIR_ENV key so a parallel test observing
+    // `NEXUS_DATA_DIR=/foo` cannot cross-contaminate a test that
+    // expects it unset).  Grouped with a static Mutex so no other test
+    // in this file needs to touch env.
+
+    static ENV_LOCK: parking_lot::Mutex<()> = parking_lot::Mutex::new(());
+
+    #[test]
+    fn default_root_falls_back_to_local_nexus_data_when_env_unset() {
+        let _guard = ENV_LOCK.lock();
+        let saved = std::env::var(DATA_DIR_ENV).ok();
+        // SAFETY: single-threaded test-lock section; no other thread
+        // can race the env read below.
+        unsafe { std::env::remove_var(DATA_DIR_ENV) };
+        let root = default_root();
+        assert_eq!(root, PathBuf::from("./nexus-data").join("plugins/search"));
+        if let Some(v) = saved {
+            unsafe { std::env::set_var(DATA_DIR_ENV, v) };
+        }
+    }
+
+    #[test]
+    fn default_root_honours_nexus_data_dir_env() {
+        let _guard = ENV_LOCK.lock();
+        let saved = std::env::var(DATA_DIR_ENV).ok();
+        // SAFETY: guarded by ENV_LOCK.
+        unsafe { std::env::set_var(DATA_DIR_ENV, "/opt/nexus") };
+        let root = default_root();
+        assert_eq!(root, PathBuf::from("/opt/nexus/plugins/search"));
+        match saved {
+            Some(v) => unsafe { std::env::set_var(DATA_DIR_ENV, v) },
+            None => unsafe { std::env::remove_var(DATA_DIR_ENV) },
+        }
     }
 
     #[test]

--- a/rust/services/search-plugin/tests/index_e2e.rs
+++ b/rust/services/search-plugin/tests/index_e2e.rs
@@ -1,0 +1,509 @@
+//! End-to-end integration test for the Index RPC (Phase 1).
+//!
+//! Companion to `query_e2e.rs` — where that test poisons the
+//! kernel callbacks (Query is read-only, must not touch them), this
+//! test wires a **mock KernelHandle** whose callbacks read from an
+//! in-memory filesystem.  Exercises the whole Index path:
+//!
+//!   RPC handler → do_index → walk_recursive (sys_readdir + sys_stat)
+//!   → index_one (sys_read) → FtsIndex.add_document → commit
+//!
+//! Then a follow-up Query verifies the docs indexed are searchable.
+//!
+//! Same integration-test-generator standard as query_e2e.rs: real
+//! service impl, real proto types, real async runtime, real tantivy
+//! segments on disk.  Only the kernel FFI is a test double, and it
+//! speaks the same JSON contract as the real nexus-vfs callbacks —
+//! `sys_readdir` returns `[{"name","entry_type"}, ...]` and
+//! `sys_stat` returns `{path, entry_type, size, zone_id, modified_at_ms}`.
+
+use std::collections::HashMap;
+use std::ffi::{c_void, CStr};
+use std::os::raw::c_char;
+use std::sync::Arc;
+
+use nexus_plugin_abi::KernelHandle;
+use nexus_search_plugin::index_manager::IndexManager;
+use nexus_search_plugin::search_proto::search_service_server::SearchService;
+use nexus_search_plugin::search_proto::{IndexRequest, QueryRequest, QueryType};
+use nexus_search_plugin::service::SearchServiceImpl;
+use tempfile::TempDir;
+use tonic::Request;
+
+// ── Mock kernel ─────────────────────────────────────────────────
+//
+// The plugin's kernel_io wrappers use these extern "C" callbacks to
+// enumerate + read files.  The mock is a Box'd MockKernel whose raw
+// pointer lives in `KernelHandle.kernel_ptr`; every callback casts
+// the pointer back and answers from the in-memory maps.
+//
+// Memory contract: buffers returned via `out_buf` must be `Vec`s
+// with `cap == len` because the plugin frees via `nexus_free`, which
+// does `Vec::from_raw_parts(ptr, len, len)`.  We `shrink_to_fit()`
+// before `mem::forget` to match.
+
+/// Entry type: 0 = regular file, 1 = directory.  Same constants the
+/// kernel_io module uses (DT_REG / DT_DIR).
+struct FileEntry {
+    bytes: Vec<u8>,
+    mtime_ms: i64,
+}
+
+pub struct MockKernel {
+    // path → file (regular files only; dirs are implicit in `dirs`).
+    files: HashMap<String, FileEntry>,
+    // parent dir → children (name + entry_type).
+    dirs: HashMap<String, Vec<(String, u8)>>,
+}
+
+impl MockKernel {
+    fn new() -> Self {
+        Self {
+            files: HashMap::new(),
+            dirs: HashMap::new(),
+        }
+    }
+
+    fn add_file(&mut self, path: &str, bytes: &[u8], mtime_ms: i64) {
+        self.files.insert(
+            path.to_string(),
+            FileEntry {
+                bytes: bytes.to_vec(),
+                mtime_ms,
+            },
+        );
+        // Splice into parent dir listing.
+        let (parent, name) = split_parent(path);
+        self.dirs
+            .entry(parent)
+            .or_default()
+            .push((name, 0 /* DT_REG */));
+    }
+
+    fn add_dir(&mut self, path: &str) {
+        if !self.dirs.contains_key(path) {
+            self.dirs.insert(path.to_string(), Vec::new());
+        }
+        if path == "/" {
+            return;
+        }
+        let (parent, name) = split_parent(path);
+        // Idempotent: don't double-splice if the dir was already
+        // registered via a nested add_file call.
+        let entries = self.dirs.entry(parent).or_default();
+        if !entries.iter().any(|(n, _)| n == &name) {
+            entries.push((name, 1 /* DT_DIR */));
+        }
+    }
+}
+
+/// Split `/a/b/c.md` into (`/a/b`, `c.md`).  `/foo` yields (`/`, `foo`).
+fn split_parent(path: &str) -> (String, String) {
+    match path.rsplit_once('/') {
+        Some(("", name)) => ("/".to_string(), name.to_string()),
+        Some((parent, name)) => (parent.to_string(), name.to_string()),
+        None => ("/".to_string(), path.to_string()),
+    }
+}
+
+fn into_out_buf(mut v: Vec<u8>, out_buf: *mut *mut u8, out_len: *mut usize) {
+    v.shrink_to_fit();
+    let len = v.len();
+    let ptr = v.as_mut_ptr();
+    std::mem::forget(v);
+    unsafe {
+        *out_buf = ptr;
+        *out_len = len;
+    }
+}
+
+unsafe extern "C" fn mock_sys_read(
+    k: *const c_void,
+    path: *const c_char,
+    out_buf: *mut *mut u8,
+    out_len: *mut usize,
+) -> i32 {
+    let kernel = &*(k as *const MockKernel);
+    let p = match CStr::from_ptr(path).to_str() {
+        Ok(s) => s,
+        Err(_) => return -2,
+    };
+    match kernel.files.get(p) {
+        Some(entry) => {
+            into_out_buf(entry.bytes.clone(), out_buf, out_len);
+            0
+        }
+        None => -404, // NotFound sentinel per plugin-ABI convention
+    }
+}
+
+unsafe extern "C" fn mock_sys_readdir(
+    k: *const c_void,
+    parent_path: *const c_char,
+    out_json: *mut *mut u8,
+    out_len: *mut usize,
+) -> i32 {
+    let kernel = &*(k as *const MockKernel);
+    let p = match CStr::from_ptr(parent_path).to_str() {
+        Ok(s) => s,
+        Err(_) => return -2,
+    };
+    match kernel.dirs.get(p) {
+        Some(entries) => {
+            // JSON encoded per the plugin ABI: [{"name":str,"entry_type":u8}].
+            let payload: Vec<serde_json::Value> = entries
+                .iter()
+                .map(|(name, et)| serde_json::json!({ "name": name, "entry_type": et }))
+                .collect();
+            let json = serde_json::to_vec(&payload).expect("mock readdir json");
+            into_out_buf(json, out_json, out_len);
+            0
+        }
+        None => -404,
+    }
+}
+
+unsafe extern "C" fn mock_sys_stat(
+    k: *const c_void,
+    path: *const c_char,
+    out_json: *mut *mut u8,
+    out_len: *mut usize,
+) -> i32 {
+    let kernel = &*(k as *const MockKernel);
+    let p = match CStr::from_ptr(path).to_str() {
+        Ok(s) => s,
+        Err(_) => return -2,
+    };
+    if let Some(entry) = kernel.files.get(p) {
+        let payload = serde_json::json!({
+            "path": p,
+            "entry_type": 0,
+            "size": entry.bytes.len(),
+            "zone_id": "root",
+            "modified_at_ms": entry.mtime_ms,
+        });
+        into_out_buf(serde_json::to_vec(&payload).unwrap(), out_json, out_len);
+        0
+    } else if kernel.dirs.contains_key(p) {
+        let payload = serde_json::json!({
+            "path": p,
+            "entry_type": 1,
+            "size": 0,
+            "zone_id": "root",
+            "modified_at_ms": null,
+        });
+        into_out_buf(serde_json::to_vec(&payload).unwrap(), out_json, out_len);
+        0
+    } else {
+        -404
+    }
+}
+
+// The write-side callbacks are unused by Index but the plugin ABI
+// requires the full KernelHandle table.  Same poison shape as
+// query_e2e.rs — return -1 so any accidental use fails loudly.
+unsafe extern "C" fn unused_sys_write(
+    _: *const c_void,
+    _: *const c_char,
+    _: *const u8,
+    _: usize,
+) -> i32 {
+    -1
+}
+unsafe extern "C" fn unused_sys_unlink(_: *const c_void, _: *const c_char) -> i32 {
+    -1
+}
+unsafe extern "C" fn unused_sys_mkdir(_: *const c_void, _: *const c_char) -> i32 {
+    -1
+}
+unsafe extern "C" fn unused_sys_rmdir(_: *const c_void, _: *const c_char) -> i32 {
+    -1
+}
+unsafe extern "C" fn unused_sys_rename(
+    _: *const c_void,
+    _: *const c_char,
+    _: *const c_char,
+) -> i32 {
+    -1
+}
+unsafe extern "C" fn unused_sys_stat_batch(
+    _: *const c_void,
+    _: *const c_char,
+    _: *mut *mut u8,
+    _: *mut usize,
+) -> i32 {
+    -1
+}
+
+fn handle_for(kernel: *const MockKernel) -> KernelHandle {
+    KernelHandle {
+        sys_read: mock_sys_read,
+        sys_write: unused_sys_write,
+        sys_stat: mock_sys_stat,
+        sys_readdir: mock_sys_readdir,
+        sys_unlink: unused_sys_unlink,
+        sys_mkdir: unused_sys_mkdir,
+        sys_rmdir: unused_sys_rmdir,
+        sys_rename: unused_sys_rename,
+        sys_stat_batch: unused_sys_stat_batch,
+        kernel_ptr: kernel as *const c_void,
+    }
+}
+
+// ── Harness ─────────────────────────────────────────────────────
+
+/// Owns the boxed MockKernel + tempdir root; hands out a
+/// SearchServiceImpl whose KernelHandle points into the mock.
+///
+/// Drop cleans up both the boxed kernel and the tempdir.
+struct Harness {
+    _dir: TempDir,
+    mock: *mut MockKernel,
+    svc: SearchServiceImpl,
+    manager: Arc<IndexManager>,
+}
+
+impl Harness {
+    fn start() -> Self {
+        let dir = TempDir::new().expect("tempdir");
+        let mock = Box::into_raw(Box::new(MockKernel::new()));
+        let handle = handle_for(mock);
+        let manager = Arc::new(IndexManager::with_root(dir.path().to_path_buf()));
+        let svc = SearchServiceImpl::with_manager(Arc::new(handle), Arc::clone(&manager));
+        Self {
+            _dir: dir,
+            mock,
+            svc,
+            manager,
+        }
+    }
+
+    fn mock_mut(&self) -> &mut MockKernel {
+        // SAFETY: `self` owns the box; no other reference exists
+        // (tests are single-threaded per-test).
+        unsafe { &mut *self.mock }
+    }
+}
+
+impl Drop for Harness {
+    fn drop(&mut self) {
+        // SAFETY: `mock` came from `Box::into_raw`; the box owns the
+        // memory and no callback holds a lingering pointer past the
+        // last RPC.
+        unsafe {
+            drop(Box::from_raw(self.mock));
+        }
+    }
+}
+
+async fn index_root(svc: &SearchServiceImpl) -> nexus_search_plugin::search_proto::IndexResponse {
+    svc.index(Request::new(IndexRequest {
+        root_path: "/".into(),
+        zone_id: "root".into(),
+        recursive: true,
+        max_docs: 0,
+        auth_token: String::new(),
+    }))
+    .await
+    .expect("index")
+    .into_inner()
+}
+
+async fn query(
+    svc: &SearchServiceImpl,
+    q: &str,
+) -> nexus_search_plugin::search_proto::QueryResponse {
+    svc.query(Request::new(QueryRequest {
+        q: q.into(),
+        zone_id: "root".into(),
+        limit: 10,
+        path_filter: String::new(),
+        query_type: QueryType::Keyword as i32,
+        auth_token: String::new(),
+    }))
+    .await
+    .expect("query")
+    .into_inner()
+}
+
+// ── Tests ───────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn index_then_query_roundtrip() {
+    let h = Harness::start();
+    let mock = h.mock_mut();
+    mock.add_dir("/");
+    mock.add_dir("/notes");
+    mock.add_file(
+        "/notes/hello.md",
+        b"hello world widget alpha",
+        1_700_000_000_000,
+    );
+    mock.add_file("/notes/other.md", b"goodbye world", 1_700_000_000_100);
+    mock.add_file("/README.md", b"widget project overview", 1_700_000_000_200);
+
+    let r = index_root(&h.svc).await;
+    assert!(r.error.is_none(), "unexpected index error: {:?}", r.error);
+    assert_eq!(r.indexed_count, 3, "expected 3 docs indexed");
+    assert_eq!(r.skipped_count, 0);
+
+    let q = query(&h.svc, "widget").await;
+    assert!(q.error.is_none());
+    assert_eq!(
+        q.results.len(),
+        2,
+        "'widget' should hit hello.md + README.md"
+    );
+    let paths: Vec<&str> = q.results.iter().map(|r| r.path.as_str()).collect();
+    assert!(paths.contains(&"/notes/hello.md"));
+    assert!(paths.contains(&"/README.md"));
+    // mtime round-trip through the walker.
+    let hello = q
+        .results
+        .iter()
+        .find(|r| r.path == "/notes/hello.md")
+        .unwrap();
+    assert_eq!(hello.mtime_ms, Some(1_700_000_000_000));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn reindex_is_idempotent() {
+    // Regression for the delete_term-before-add idempotency contract:
+    // running Index twice on the same corpus must NOT duplicate the
+    // documents (BM25 inflation) — proven end-to-end through the
+    // walker + writer + reader path.
+    let h = Harness::start();
+    let mock = h.mock_mut();
+    mock.add_dir("/");
+    mock.add_file("/x.md", b"widget", 1);
+    mock.add_file("/y.md", b"widget", 2);
+
+    let r1 = index_root(&h.svc).await;
+    assert_eq!(r1.indexed_count, 2);
+    let r2 = index_root(&h.svc).await;
+    assert_eq!(r2.indexed_count, 2);
+
+    let q = query(&h.svc, "widget").await;
+    assert_eq!(q.results.len(), 2, "after two Index calls, still 2 docs");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn non_recursive_index_only_touches_direct_children() {
+    let h = Harness::start();
+    let mock = h.mock_mut();
+    mock.add_dir("/");
+    mock.add_dir("/nested");
+    mock.add_file("/top.md", b"widget", 1);
+    mock.add_file("/nested/deep.md", b"widget", 2);
+
+    let r = h
+        .svc
+        .index(Request::new(IndexRequest {
+            root_path: "/".into(),
+            zone_id: "root".into(),
+            recursive: false,
+            max_docs: 0,
+            auth_token: String::new(),
+        }))
+        .await
+        .expect("index")
+        .into_inner();
+    assert!(r.error.is_none());
+    assert_eq!(r.indexed_count, 1, "non-recursive must NOT index nested/");
+    assert_eq!(r.skipped_count, 0);
+
+    let q = query(&h.svc, "widget").await;
+    assert_eq!(q.results.len(), 1);
+    assert_eq!(q.results[0].path, "/top.md");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn skip_empty_binary_and_oversized_files() {
+    let h = Harness::start();
+    let mock = h.mock_mut();
+    mock.add_dir("/");
+    // Empty file — skipped, count = 0.
+    mock.add_file("/empty.md", b"", 1);
+    // Non-UTF8 payload — skipped (P1 is text-only).
+    mock.add_file("/binary.bin", &[0xff, 0xfe, 0xfd], 2);
+    // Oversize — skipped (> INDEX_MAX_FILE_BYTES = 8 MiB).
+    let big = vec![b'a'; 9 * 1024 * 1024];
+    mock.add_file("/big.md", &big, 3);
+    // Valid file — indexed.
+    mock.add_file("/ok.md", b"widget alpha", 4);
+
+    let r = index_root(&h.svc).await;
+    assert!(r.error.is_none());
+    assert_eq!(r.indexed_count, 1);
+    assert_eq!(r.skipped_count, 3, "empty + binary + oversize = 3 skips");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn max_docs_caps_walker() {
+    let h = Harness::start();
+    let mock = h.mock_mut();
+    mock.add_dir("/");
+    for i in 0..10 {
+        mock.add_file(&format!("/f{i}.md"), b"widget", i as i64);
+    }
+
+    let r = h
+        .svc
+        .index(Request::new(IndexRequest {
+            root_path: "/".into(),
+            zone_id: "root".into(),
+            recursive: true,
+            max_docs: 3,
+            auth_token: String::new(),
+        }))
+        .await
+        .expect("index")
+        .into_inner();
+    assert!(r.error.is_none());
+    assert_eq!(r.indexed_count, 3);
+
+    let q = query(&h.svc, "widget").await;
+    assert_eq!(q.results.len(), 3);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn nested_walk_indexes_deep_files() {
+    let h = Harness::start();
+    let mock = h.mock_mut();
+    mock.add_dir("/");
+    mock.add_dir("/a");
+    mock.add_dir("/a/b");
+    mock.add_dir("/a/b/c");
+    mock.add_file("/a/b/c/deep.md", b"widget deeply nested", 1);
+    mock.add_file("/root.md", b"widget top level", 2);
+
+    let r = index_root(&h.svc).await;
+    assert!(r.error.is_none());
+    assert_eq!(r.indexed_count, 2);
+
+    let q = query(&h.svc, "widget").await;
+    assert_eq!(q.results.len(), 2);
+    let paths: Vec<&str> = q.results.iter().map(|r| r.path.as_str()).collect();
+    assert!(paths.contains(&"/a/b/c/deep.md"));
+    assert!(paths.contains(&"/root.md"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn missing_root_returns_error_not_500() {
+    let h = Harness::start();
+    // mock has no dirs registered — root is missing.
+    let r = h
+        .svc
+        .index(Request::new(IndexRequest {
+            root_path: "/does-not-exist".into(),
+            zone_id: "root".into(),
+            recursive: true,
+            max_docs: 0,
+            auth_token: String::new(),
+        }))
+        .await
+        .expect("index")
+        .into_inner();
+    assert!(r.error.is_some());
+    assert_eq!(r.indexed_count, 0);
+}

--- a/rust/services/search-plugin/tests/index_e2e.rs
+++ b/rust/services/search-plugin/tests/index_e2e.rs
@@ -260,7 +260,6 @@ struct Harness {
     _dir: TempDir,
     mock: *mut MockKernel,
     svc: SearchServiceImpl,
-    manager: Arc<IndexManager>,
 }
 
 impl Harness {
@@ -269,12 +268,11 @@ impl Harness {
         let mock = Box::into_raw(Box::new(MockKernel::new()));
         let handle = handle_for(mock);
         let manager = Arc::new(IndexManager::with_root(dir.path().to_path_buf()));
-        let svc = SearchServiceImpl::with_manager(Arc::new(handle), Arc::clone(&manager));
+        let svc = SearchServiceImpl::with_manager(Arc::new(handle), manager);
         Self {
             _dir: dir,
             mock,
             svc,
-            manager,
         }
     }
 

--- a/tests/e2e/docker/search_helpers.py
+++ b/tests/e2e/docker/search_helpers.py
@@ -73,6 +73,114 @@ def search_glob(
         channel.close()
 
 
+def search_index(
+    target: str,
+    root_path: str,
+    *,
+    zone_id: str = "",
+    recursive: bool = True,
+    max_docs: int = 0,
+    api_key: str = ADMIN_API_KEY,
+    timeout: float = 120,
+) -> dict:
+    """Typed Index RPC (P1 keyword-only).
+
+    Returns ``{"result": {"indexed_count": int, "skipped_count": int}}``
+    on success or ``{"error": str}`` when the plugin sets the response's
+    optional `error` field.  ``max_docs=0`` uses the plugin's server-side
+    default (10_000 per the proto contract).
+    """
+    from nexus.grpc.search.v1 import search_pb2
+
+    channel, stub = _open_search_stub(target)
+    try:
+        req = search_pb2.IndexRequest(
+            root_path=root_path,
+            zone_id=zone_id,
+            recursive=recursive,
+            max_docs=max_docs,
+            auth_token=api_key,
+        )
+        resp = stub.Index(req, timeout=timeout)
+        if resp.HasField("error"):
+            return {"error": resp.error}
+        return {
+            "result": {
+                "indexed_count": resp.indexed_count,
+                "skipped_count": resp.skipped_count,
+            }
+        }
+    finally:
+        channel.close()
+
+
+def search_query(
+    target: str,
+    q: str,
+    *,
+    zone_id: str = "",
+    limit: int = 0,
+    path_filter: str = "",
+    query_type: str = "keyword",
+    api_key: str = ADMIN_API_KEY,
+    timeout: float = 30,
+) -> dict:
+    """Typed Query RPC (P1 keyword-only).
+
+    Returns ``{"result": {"results": [...]}}`` on success or
+    ``{"error": str}``.  Each result is
+    ``{"path": str, "chunk_index": int, "chunk_text": str,
+    "score": float, "zone_id": str, "mtime_ms": int | None}``.
+
+    ``query_type`` accepts the string forms mirrored from the
+    Python router: ``"keyword"``, ``"semantic"``, ``"hybrid"``.
+    P1 rejects the latter two with an error message referencing
+    the phase that will lift the gate.  ``limit=0`` uses the
+    plugin's server-side default (10 per the proto contract).
+    """
+    from nexus.grpc.search.v1 import search_pb2
+
+    qt_map = {
+        "": search_pb2.QUERY_TYPE_UNSPECIFIED,
+        "keyword": search_pb2.QUERY_TYPE_KEYWORD,
+        "semantic": search_pb2.QUERY_TYPE_SEMANTIC,
+        "hybrid": search_pb2.QUERY_TYPE_HYBRID,
+    }
+    if query_type not in qt_map:
+        raise ValueError(f"unknown query_type: {query_type!r}")
+
+    channel, stub = _open_search_stub(target)
+    try:
+        req = search_pb2.QueryRequest(
+            q=q,
+            zone_id=zone_id,
+            limit=limit,
+            path_filter=path_filter,
+            query_type=qt_map[query_type],
+            auth_token=api_key,
+        )
+        resp = stub.Query(req, timeout=timeout)
+        if resp.HasField("error"):
+            return {"error": resp.error}
+        return {
+            "result": {
+                "results": [
+                    {
+                        "path": r.path,
+                        "chunk_index": r.chunk_index,
+                        "chunk_text": r.chunk_text,
+                        "score": r.score,
+                        "zone_id": r.zone_id,
+                        "mtime_ms": r.mtime_ms if r.HasField("mtime_ms") else None,
+                    }
+                    for r in resp.results
+                ]
+            }
+        }
+    finally:
+        channel.close()
+
+
 def search_grep(
     target: str,
     root_path: str,

--- a/tests/e2e/docker/test_search_plugin.py
+++ b/tests/e2e/docker/test_search_plugin.py
@@ -37,7 +37,7 @@ from tests.e2e.docker.runbook_helpers import (
     vfs_write,
     wait_healthy,
 )
-from tests.e2e.docker.search_helpers import search_glob, search_grep
+from tests.e2e.docker.search_helpers import search_glob, search_grep, search_index, search_query
 
 pytestmark = [
     pytest.mark.xdist_group("search-plugin-e2e"),
@@ -242,3 +242,112 @@ class TestSearchGrep:
             "binary file must be silently skipped by the plugin's UTF-8 sniff."
         )
         assert matches[0]["path"].endswith("text.txt"), matches
+
+
+# ===========================================================================
+# TestSearchIndexQuery — P1 keyword-only ranked search
+# ===========================================================================
+class TestSearchIndexQuery:
+    """End-to-end coverage for the P1 Index + Query RPCs.
+
+    The unit + Rust integration tests (query_e2e.rs, index_e2e.rs)
+    already exercise these RPCs against a real ``SearchServiceImpl``
+    with a tempdir index — this suite runs the same contract through
+    the LOADED cdylib inside a real ``nexusd-cluster`` process, so
+    the plugin-ABI dispatch layer, the tantivy on-disk index under
+    the resolved ``NEXUS_DATA_DIR``, and the tonic client wire all
+    stay honest against the shipping binary.
+    """
+
+    def test_index_then_query_roundtrip(self, api_key: str) -> None:
+        """Seed a small tree via vfs_write, Index it, Query — verify hits."""
+        u = uid()
+        base = f"/search-idx-{u}"
+        vfs_mkdir(NODE_GRPC, base, parents=True, api_key=api_key)
+        # Two hits for `widget`, one distractor.
+        r = vfs_write(NODE_GRPC, f"{base}/a.md", b"widget alpha docs\n", api_key=api_key)
+        assert "error" not in r, r
+        r = vfs_write(NODE_GRPC, f"{base}/b.md", b"widget beta manual\n", api_key=api_key)
+        assert "error" not in r, r
+        r = vfs_write(NODE_GRPC, f"{base}/c.md", b"unrelated content\n", api_key=api_key)
+        assert "error" not in r, r
+
+        r = search_index(NODE_GRPC, base, api_key=api_key)
+        assert "error" not in r, f"index returned error: {r}"
+        assert r["result"]["indexed_count"] == 3, r
+        assert r["result"]["skipped_count"] == 0, r
+
+        r = search_query(NODE_GRPC, "widget", path_filter=base, api_key=api_key)
+        assert "error" not in r, f"query returned error: {r}"
+        results = r["result"]["results"]
+        assert len(results) == 2, f"expected two 'widget' hits, got {results}"
+        paths = {res["path"] for res in results}
+        assert paths == {f"{base}/a.md", f"{base}/b.md"}, paths
+        # Scores are BM25 — both positive.
+        for res in results:
+            assert res["score"] > 0.0, res
+
+    def test_reindex_is_idempotent(self, api_key: str) -> None:
+        """Running Index twice must NOT duplicate documents in the corpus.
+
+        Regression for the ``delete_term(path)``-before-add contract in
+        ``FtsIndex.add_document`` — a naive add-only path would double
+        the doc's BM25 score and inflate the result count.
+        """
+        u = uid()
+        base = f"/search-reidx-{u}"
+        vfs_mkdir(NODE_GRPC, base, parents=True, api_key=api_key)
+        r = vfs_write(NODE_GRPC, f"{base}/f.md", b"widget only\n", api_key=api_key)
+        assert "error" not in r, r
+
+        for _ in range(2):
+            r = search_index(NODE_GRPC, base, api_key=api_key)
+            assert "error" not in r, r
+            assert r["result"]["indexed_count"] == 1, r
+
+        r = search_query(NODE_GRPC, "widget", path_filter=base, api_key=api_key)
+        assert "error" not in r, r
+        assert len(r["result"]["results"]) == 1, (
+            f"reindex must not duplicate the doc; got {r['result']['results']}"
+        )
+
+    def test_query_semantic_rejected_with_p2_message(self, api_key: str) -> None:
+        """Non-keyword query_type must fail loudly in P1 with a phase hint.
+
+        Locks the contract Phase 2 will lift — a silent fall-through to
+        keyword ranking would silently mis-serve callers who expected
+        vector recall.
+        """
+        r = search_query(NODE_GRPC, "widget", query_type="semantic", api_key=api_key)
+        assert "error" in r, f"semantic must be rejected in P1, got {r}"
+        assert "P2" in r["error"], f"semantic rejection should mention P2, got {r}"
+
+    def test_query_hybrid_rejected_with_p3_message(self, api_key: str) -> None:
+        r = search_query(NODE_GRPC, "widget", query_type="hybrid", api_key=api_key)
+        assert "error" in r, f"hybrid must be rejected in P1, got {r}"
+        assert "P3" in r["error"], f"hybrid rejection should mention P3, got {r}"
+
+    def test_query_skips_binary_and_oversized_files_at_index_time(self, api_key: str) -> None:
+        """Same skip filter grep uses — non-utf8 payload + oversize must
+        never enter the FTS corpus, so a keyword Query returns nothing
+        for those files even though `widget` is in their bytes.
+        """
+        u = uid()
+        base = f"/search-idx-skip-{u}"
+        vfs_mkdir(NODE_GRPC, base, parents=True, api_key=api_key)
+        # Non-UTF-8 payload containing the pattern — must be skipped.
+        r = vfs_write(NODE_GRPC, f"{base}/blob.bin", b"\x00\xffwidget\x80\xff", api_key=api_key)
+        assert "error" not in r, r
+        # Valid neighbour.
+        r = vfs_write(NODE_GRPC, f"{base}/ok.md", b"widget textual\n", api_key=api_key)
+        assert "error" not in r, r
+
+        r = search_index(NODE_GRPC, base, api_key=api_key)
+        assert "error" not in r, r
+        assert r["result"]["indexed_count"] == 1, r
+        assert r["result"]["skipped_count"] == 1, r
+
+        r = search_query(NODE_GRPC, "widget", path_filter=base, api_key=api_key)
+        assert "error" not in r, r
+        assert len(r["result"]["results"]) == 1
+        assert r["result"]["results"][0]["path"] == f"{base}/ok.md"


### PR DESCRIPTION
## Summary

Three audit-driven retrofits on top of merged P1 (#4575). Grouped
into one PR since they're independent commits addressing findings
from the same audit pass — reviewing together shows the storage
SSOT + testing depth story end to end.

## R1 — NEXUS_DATA_DIR alignment (commit 1)

**Finding**: \`index_manager::default_root()\` resolved via
\`dirs::home_dir()\` → \`~/.nexus/plugins/search/\`, while the
sibling \`nexus-vault\` plugin honoured \`\$NEXUS_DATA_DIR\` with
a \`./nexus-data\` fallback. An operator moving \`NEXUS_DATA_DIR\`
to a data volume would drag vault along and leave search behind
— cross-plugin SSOT drift.

**Fix**: read \`\$NEXUS_DATA_DIR\`, fall back to \`./nexus-data\`.
Layout becomes \`\$NEXUS_DATA_DIR/plugins/search/<zone>/fts/\`
— vault's neighbour. Dropped the \`dirs\` dep since env-var
lookup replaces the home-dir resolution. Two tests pin the
resolution contract via a serialised env-mutation lock.

## R2 — Index E2E via mock KernelHandle (commit 2)

**Finding**: Query had 9 end-to-end cases in \`query_e2e.rs\`, but
Index had NO integration coverage — only \`fts_index\` unit tests
exercised \`add_document\` directly, leaving \`walk_recursive\`
→ \`sys_readdir\` → \`sys_read\` → \`sys_stat\` → \`add_document\`
→ \`commit\` untested at the handler boundary.

**Fix**: new \`index_e2e.rs\` with a MockKernel (\`HashMap\`-backed
files + dirs, extern \"C\" callbacks that speak the exact JSON
contract \`kernel_io\` expects). 7 cases pin the Index contract:

- index → query roundtrip (3 files, recursive, mtime survives)
- reindex idempotency (\`delete_term\`-before-add regression: 2
  Index calls, still 2 docs, no BM25 inflation)
- non-recursive mode (nested dir untouched)
- skip empty / non-utf8 / >8 MiB files
- \`max_docs\` walker cap
- deep nested walk (\`/a/b/c/deep.md\` indexed)
- missing root returns error, not 500

Write-side syscalls are poison stubs — Index never touches them.

## R3 — Docker E2E extended to Query + Index (commit 3)

**Finding**: the docker E2E suite (\`test_search_plugin.py\`)
covered Glob + Grep only — the P1 Query and Index RPCs had no
coverage from a LOADED cdylib inside a real \`nexusd-cluster\`.
The Rust integration tests exercise the service impl end-to-end
but through an rlib + tempdir; they don't validate the cdylib
plugin-ABI dispatch, the on-disk index under the resolved
\`NEXUS_DATA_DIR\`, or the tonic wire.

**Fix**: added \`search_index()\` + \`search_query()\` typed
wrappers, plus a \`TestSearchIndexQuery\` class with 5 cases:

1. index → query roundtrip via \`vfs_write\`-seeded corpus
2. reindex idempotency
3. query_type=SEMANTIC rejected with a P2-mentioning error
4. query_type=HYBRID rejected with a P3-mentioning error
5. index-time skip of non-utf8 blob

Runs under the same \`NEXUS_SEARCH_PLUGIN_E2E=1\` gate and
compose file the existing suite uses — no new infra.

## Test plan

- [ ] Rust CI: \`cargo test -p nexus-search-plugin\` (adds
      \`index_e2e.rs\` + \`default_root\` env tests)
- [ ] Docker E2E: \`search-plugin E2E (Docker)\` (adds
      \`TestSearchIndexQuery\` — 5 new cases)
- [ ] Manual: run docker E2E locally with
      \`NEXUS_DATA_DIR=/tmp/nexus-data\`, verify tantivy index
      lands under \`/tmp/nexus-data/plugins/search/root/fts/\`