### PR TITLE
feat(search-plugin): Phase 2 — fastembed + hnsw + SemanticQuery [WIP]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,7 +55,9 @@ checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
  "const-random",
+ "getrandom 0.3.4",
  "once_cell",
+ "serde",
  "version_check",
  "zerocopy",
 ]
@@ -338,7 +340,7 @@ version = "0.1.0"
 source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5f8b898e84166bdc9cf7b75c077b604c4f9d2ee1#5f8b898e84166bdc9cf7b75c077b604c4f9d2ee1"
 dependencies = [
  "ahash",
- "base64",
+ "base64 0.22.1",
  "blake3",
  "chrono",
  "contracts",
@@ -378,6 +380,12 @@ name = "base32"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "022dfe9eb35f19ebbcb51e0b40a5ab759f46ad60cadf7297e0bd085afb50e076"
+
+[[package]]
+name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
@@ -539,6 +547,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c53ba0f290bfc610084c05582d9c5d421662128fc69f4bf236707af6fd321b9"
 
 [[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -617,7 +634,7 @@ checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
 dependencies = [
  "glob",
  "libc",
- "libloading",
+ "libloading 0.8.9",
 ]
 
 [[package]]
@@ -689,6 +706,21 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "compact_str"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "serde",
+ "static_assertions",
 ]
 
 [[package]]
@@ -913,6 +945,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "dary_heap"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1e3a325bc115f096c8b77bbf027a7c2592230e70be2d985be950d3d5e60ebe"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "dashmap"
 version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -994,6 +1070,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1154,6 +1261,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "esaxx-rs"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
+
+[[package]]
 name = "fastcdc"
 version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1164,6 +1277,21 @@ name = "fastdivide"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9afc2bd4d5a73106dd53d10d73d3401c2f32730ba2c0b93ddb888a8983680471"
+
+[[package]]
+name = "fastembed"
+version = "5.17.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4539f4a2c4472269adc227587b935c0a973e6b5fc4a03e14bbe62608e06c2298"
+dependencies = [
+ "anyhow",
+ "ndarray",
+ "ort",
+ "safetensors",
+ "serde",
+ "serde_json",
+ "tokenizers",
+]
 
 [[package]]
 name = "fastrand"
@@ -1524,7 +1652,11 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.2.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1709,7 +1841,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -1833,6 +1965,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1919,6 +2057,15 @@ name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -2042,7 +2189,7 @@ source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5f8b898e84166bdc9cf7b75c
 dependencies = [
  "ahash",
  "arc-swap",
- "base64",
+ "base64 0.22.1",
  "blake3",
  "bloomfilter",
  "bytes",
@@ -2056,7 +2203,7 @@ dependencies = [
  "globset",
  "lib",
  "libc",
- "libloading",
+ "libloading 0.8.9",
  "lru 0.18.1",
  "memchr",
  "memmap2",
@@ -2099,7 +2246,7 @@ version = "0.1.0"
 source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5f8b898e84166bdc9cf7b75c077b604c4f9d2ee1#5f8b898e84166bdc9cf7b75c077b604c4f9d2ee1"
 dependencies = [
  "ahash",
- "base64",
+ "base64 0.22.1",
  "blake3",
  "contracts",
  "crc32fast",
@@ -2137,6 +2284,16 @@ name = "libloading"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "libloading"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60"
 dependencies = [
  "cfg-if",
  "windows-link 0.2.1",
@@ -2252,6 +2409,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "macro_rules_attribute"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3ae8f6d608c795738406608304d30a2dfbdc8e58e44f7ba43236da5208ded3c"
+dependencies = [
+ "macro_rules_attribute-proc_macro",
+ "pastey",
+]
+
+[[package]]
+name = "macro_rules_attribute-proc_macro"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc04a4c58212d57930a24bf47d3fa87485264a3a054e9c10e042eb373573ad3c"
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2265,6 +2438,16 @@ name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "matrixmultiply"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f607c237553f086e7043417a51df26b2eb899d3caff94e6a67592ff992fedc7"
+dependencies = [
+ "autocfg",
+ "rawpointer",
+]
 
 [[package]]
 name = "measure_time"
@@ -2341,6 +2524,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "monostate"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3341a273f6c9d5bef1908f17b7267bbab0e95c9bf69a0d4dcf8e9e1b2c76ef67"
+dependencies = [
+ "monostate-impl",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "monostate-impl"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4db6d5580af57bf992f59068d4ea26fd518574ff48d7639b255a36f9de6e7e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2351,6 +2556,21 @@ name = "murmurhash32"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2195bf6aa996a481483b29d62a7663eed3fe39600c460e323f8ff41e90bdd89b"
+
+[[package]]
+name = "ndarray"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520080814a7a6b4a6e9070823bb24b4531daac8c4627e08ba5de8c5ef2f2752d"
+dependencies = [
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "portable-atomic",
+ "portable-atomic-util",
+ "rawpointer",
+]
 
 [[package]]
 name = "nexus-cluster"
@@ -2415,10 +2635,12 @@ version = "0.1.0"
 dependencies = [
  "anndists",
  "bytes",
+ "fastembed",
  "globset",
  "hnsw_rs",
- "libloading",
+ "libloading 0.8.9",
  "nexus-plugin-abi",
+ "ort",
  "parking_lot",
  "prost",
  "protoc-bin-vendored",
@@ -2442,7 +2664,7 @@ dependencies = [
  "backends",
  "clap",
  "kernel",
- "libloading",
+ "libloading 0.8.9",
  "nexus-plugin-abi",
  "prost",
  "services",
@@ -2521,6 +2743,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
  "num-traits",
 ]
 
@@ -2620,6 +2851,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "269bca4c2591a28585d6bf10d9ed0332b7d76900a1b02bec41bdc3a2cdcda107"
 
 [[package]]
+name = "onig"
+version = "6.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc3cbf698f9438986c11a880c90a6d04b9de27575afd28bbf45b154b6c709e2"
+dependencies = [
+ "bitflags 2.13.1",
+ "libc",
+ "once_cell",
+ "onig_sys",
+]
+
+[[package]]
+name = "onig_sys"
+version = "69.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e68317604e77e53b85896388e1a803c1d21b74c899ec9e5e1112db90735edd7"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
 name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2630,6 +2883,25 @@ name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "ort"
+version = "2.0.0-rc.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4336a1e2b38848325241c72889086886004e589b7c74f335e60a8e8db5138a0b"
+dependencies = [
+ "libloading 0.9.0",
+ "ndarray",
+ "ort-sys",
+ "smallvec",
+ "tracing",
+]
+
+[[package]]
+name = "ort-sys"
+version = "2.0.0-rc.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf211e3776eea6aec988552fa118dd746d70e1b1e5e244058d1c98015f3e5872"
 
 [[package]]
 name = "ownedbytes"
@@ -2680,12 +2952,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
+
+[[package]]
 name = "pem"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "serde_core",
 ]
 
@@ -3087,7 +3365,7 @@ name = "raft"
 version = "0.1.0"
 source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5f8b898e84166bdc9cf7b75c077b604c4f9d2ee1#5f8b898e84166bdc9cf7b75c077b604c4f9d2ee1"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bincode",
  "bytes",
  "contracts",
@@ -3243,6 +3521,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
+
+[[package]]
 name = "rayon"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3250,6 +3534,17 @@ checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
+]
+
+[[package]]
+name = "rayon-cond"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2964d0cf57a3e7a06e8183d14a8b527195c706b7983549cd5462d5aa3747438f"
+dependencies = [
+ "either",
+ "itertools 0.14.0",
+ "rayon",
 ]
 
 [[package]]
@@ -3349,7 +3644,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -3561,6 +3856,19 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "safetensors"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79b079b829cb27a1c3c374341345ed2e8b2c0c839034522cee576c140bd7f846"
+dependencies = [
+ "hashbrown 0.16.1",
+ "libc",
+ "serde",
+ "serde_json",
+ "tempfile",
+]
 
 [[package]]
 name = "same-file"
@@ -3892,6 +4200,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "spm_precompiled"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5851699c4033c63636f7ea4cf7b7c1f1bf06d0cc03cfb42e711de5a5c46cf326"
+dependencies = [
+ "base64 0.13.1",
+ "nom",
+ "serde",
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3995,7 +4315,7 @@ checksum = "96599ea6fccd844fc833fed21d2eecac2e6a7c1afd9e044057391d78b1feb141"
 dependencies = [
  "aho-corasick",
  "arc-swap",
- "base64",
+ "base64 0.22.1",
  "bitpacking",
  "byteorder",
  "census",
@@ -4255,6 +4575,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "tokenizers"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b238e22d44a15349529690fb07bd645cf58149a1b1e44d6cb5bd1641ff1a6223"
+dependencies = [
+ "ahash",
+ "aho-corasick",
+ "compact_str",
+ "dary_heap",
+ "derive_builder",
+ "esaxx-rs",
+ "getrandom 0.3.4",
+ "itertools 0.14.0",
+ "log",
+ "macro_rules_attribute",
+ "monostate",
+ "onig",
+ "paste",
+ "rand 0.9.5",
+ "rayon",
+ "rayon-cond",
+ "regex",
+ "regex-syntax",
+ "serde",
+ "serde_json",
+ "spm_precompiled",
+ "thiserror 2.0.18",
+ "unicode-normalization-alignments",
+ "unicode-segmentation",
+ "unicode_categories",
+]
+
+[[package]]
 name = "tokio"
 version = "1.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4353,7 +4706,7 @@ checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
  "async-trait",
  "axum",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "h2",
  "http",
@@ -4544,7 +4897,7 @@ source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5f8b898e84166bdc9cf7b75c
 dependencies = [
  "axum",
  "backends",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "chrono",
  "contracts",
@@ -4600,6 +4953,27 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization-alignments"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43f613e4fa046e69818dd287fdc4bc78175ff20331479dab6e1b0f98d57062de"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "unicode_categories"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
 name = "universal-hash"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,6 +85,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "anndists"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8396b473aa0bceed68fb32462505387ea39fa47c7029417e0a49f10592b036"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "cpu-time",
+ "env_logger",
+ "lazy_static",
+ "log",
+ "num-traits",
+ "num_cpus",
+ "rayon",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -744,6 +761,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpu-time"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9e393a7668fe1fad3075085b86c781883000b4ede868f43627b34a87c8b7ded"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -906,6 +933,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1024,6 +1082,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum-as-inner"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "enum_dispatch"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1033,6 +1103,29 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "env_filter"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900d271a03799a1ee8d1ca9b19893b48ca674a9284fefcfb85f05e74ed314217"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de671bd27a75a797dc9ae289ba1e77276e75e2026408aab65185384e2d5cd3f6"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
 ]
 
 [[package]]
@@ -1325,6 +1418,18 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
@@ -1332,7 +1437,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "rand_core 0.10.1",
  "wasm-bindgen",
 ]
@@ -1461,6 +1566,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
  "digest 0.11.3",
+]
+
+[[package]]
+name = "hnsw_rs"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a5258f079b97bf2e8311ff9579e903c899dcbac0d9a138d62e9a066778bd07"
+dependencies = [
+ "anndists",
+ "anyhow",
+ "bincode",
+ "cfg-if",
+ "cpu-time",
+ "env_logger",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "lazy_static",
+ "log",
+ "mmap-rs",
+ "num-traits",
+ "num_cpus",
+ "parking_lot",
+ "rand 0.9.5",
+ "rayon",
+ "serde",
 ]
 
 [[package]]
@@ -1800,6 +1930,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jiff"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
+dependencies = [
+ "defmt",
+ "jiff-core",
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+]
+
+[[package]]
+name = "jiff-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
+dependencies = [
+ "defmt",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
+dependencies = [
+ "jiff-core",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "jni"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2077,6 +2243,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "mach2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2146,6 +2321,23 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "mmap-rs"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ecce9d566cb9234ae3db9e249c8b55665feaaf32b0859ff1e27e310d2beb3d8"
+dependencies = [
+ "bitflags 2.13.1",
+ "combine",
+ "libc",
+ "mach2",
+ "nix",
+ "sysctl",
+ "thiserror 2.0.18",
+ "widestring",
+ "windows 0.48.0",
 ]
 
 [[package]]
@@ -2221,8 +2413,10 @@ source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5f8b898e84166bdc9cf7b75c
 name = "nexus-search-plugin"
 version = "0.1.0"
 dependencies = [
+ "anndists",
  "bytes",
  "globset",
+ "hnsw_rs",
  "libloading",
  "nexus-plugin-abi",
  "parking_lot",
@@ -2567,6 +2761,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2863,6 +3072,12 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
@@ -2939,8 +3154,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
- "rand_chacha",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2965,12 +3190,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -3730,6 +3974,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysctl"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01198a2debb237c62b6826ec7081082d951f46dbb64b0e8c7649a452230d1dfc"
+dependencies = [
+ "bitflags 2.13.1",
+ "byteorder",
+ "enum-as-inner",
+ "libc",
+ "thiserror 1.0.69",
+ "walkdir",
+]
+
+[[package]]
 name = "tantivy"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4445,6 +4703,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4580,6 +4847,15 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows"
 version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
@@ -4692,7 +4968,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4706,18 +4982,33 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -4731,15 +5022,33 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4755,9 +5064,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4767,9 +5088,21 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -4789,7 +5122,7 @@ dependencies = [
  "static_assertions",
  "thiserror 2.0.18",
  "widestring",
- "windows",
+ "windows 0.61.3",
  "winfsp-sys",
 ]
 
@@ -4810,6 +5143,12 @@ checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "writeable"

--- a/rust/services/search-plugin/Cargo.toml
+++ b/rust/services/search-plugin/Cargo.toml
@@ -58,6 +58,18 @@ bytes = "1"
 # live under `~/.nexus/plugins/search/<zone_id>/fts/`.
 tantivy = "0.22"
 
+# ANN vector store for SemanticQuery (Phase 2).  Pure Rust HNSW;
+# lives per-zone at `<data>/plugins/search/<zone_id>/ann-<model>-<version>/`.
+# Distance = cosine.  Same dylib-boundary story as tantivy — the plugin
+# cdylib is where the vector index code lands, cluster core stays lean.
+hnsw_rs = "0.3"
+
+# `anndists` is `hnsw_rs`'s distance-metric crate — kept as an explicit
+# direct dep because the plugin references `DistCosine` in its own code
+# (not as a re-export shim), so a `hnsw_rs` major bump that trims its
+# re-export surface would fail LOUD here instead of at a distant callsite.
+anndists = "0.1"
+
 
 # Parking-lot mutex around the per-zone index writer.  tantivy's own
 # IndexWriter is Send + Sync but only allows one writer per index at a

--- a/rust/services/search-plugin/Cargo.toml
+++ b/rust/services/search-plugin/Cargo.toml
@@ -13,6 +13,17 @@ name = "nexus_search_plugin"
 # through the C ABI.
 crate-type = ["cdylib", "rlib"]
 
+[features]
+# `semantic` = fastembed + ort dylib for vector-embedding-driven
+# SemanticQuery.  Default-on for cluster profile.  With the feature
+# OFF, the plugin still ships Query (keyword / BM25) + Glob + Grep;
+# SemanticQuery returns a plain error and the AnnIndex primitive
+# stays reachable to callers who bring their own vectors.  Graceful
+# degradation is deliberate — a missing model / dylib must not take
+# down keyword search too.
+default = ["semantic"]
+semantic = ["dep:fastembed", "dep:ort"]
+
 [dependencies]
 # Plugin ABI — stable C ABI contract for dylib plugins.  The
 # `declare_service_plugin!` macro + KernelHandle live here.
@@ -69,6 +80,28 @@ hnsw_rs = "0.3"
 # (not as a re-export shim), so a `hnsw_rs` major bump that trims its
 # re-export surface would fail LOUD here instead of at a distant callsite.
 anndists = "0.1"
+
+# ── semantic (feature-gated) ──────────────────────────────────────
+# fastembed = the sentence-transformer runtime; ships tokenizer +
+# pooling + normalization + model catalogue (BGE, mE5, MiniLM) atop
+# `ort`.  Pinned to =5.17.4 per D2 — 5.15..5.17 have no known
+# regressions; a fastembed major bump forcing an ort ABI change would
+# fail loud here.  `ort-load-dynamic` = ship onnxruntime.{dll,dylib,so}
+# alongside the plugin cdylib rather than static-linking (matches
+# signed-release + swap-model-without-resign posture).
+fastembed = { version = "=5.17.4", default-features = false, features = [
+    "ort-load-dynamic",
+], optional = true }
+
+# `ort` is fastembed's transitive dep, but we take a direct pin so
+# `ort::init_from(dylib_path)` is in scope at plugin startup.  Version
+# range compatible with fastembed 5.17.x (which itself pins
+# `ort = 2.0.0-rc.10`); the caret constraint is deliberate — a
+# fastembed bump moving to a newer rc must be caught by an explicit
+# range bump here, not silently accepted.
+ort = { version = "2.0.0-rc.10", default-features = false, features = [
+    "load-dynamic",
+], optional = true }
 
 
 # Parking-lot mutex around the per-zone index writer.  tantivy's own

--- a/rust/services/search-plugin/src/ann_index.rs
+++ b/rust/services/search-plugin/src/ann_index.rs
@@ -302,10 +302,21 @@ impl AnnIndex {
 
     /// Persist the graph + sidecar to disk.  Callers batch adds and
     /// commit once at end-of-request — same pattern as `FtsIndex`.
+    ///
+    /// Skips the hnsw file dump entirely when the index is empty —
+    /// `hnsw_rs::file_dump` errors on a graph with zero points, and
+    /// that's not a useful failure mode for an Index call that
+    /// happened to walk a corpus with no valid text (e.g. all files
+    /// binary / oversize / empty).  The sidecar still writes so the
+    /// next open_or_create knows the manager has seen this zone;
+    /// the graph files reappear the next time a real doc arrives.
     pub fn commit(&self) -> Result<(), AnnError> {
-        self.hnsw
-            .file_dump(&self.dir, HNSW_BASENAME)
-            .map_err(|e| AnnError::Commit(format!("hnsw file_dump: {e}")))?;
+        let live = self.sidecar.read().path_to_id.len();
+        if live > 0 {
+            self.hnsw
+                .file_dump(&self.dir, HNSW_BASENAME)
+                .map_err(|e| AnnError::Commit(format!("hnsw file_dump: {e}")))?;
+        }
         let sidecar_path = self.dir.join(SIDECAR_FILE);
         let side = self.sidecar.read();
         let bytes = serde_json::to_vec_pretty(&*side)

--- a/rust/services/search-plugin/src/ann_index.rs
+++ b/rust/services/search-plugin/src/ann_index.rs
@@ -1,0 +1,497 @@
+//! Per-zone HNSW vector index for semantic search (Phase 2 of the
+//! Python-parity roadmap; see `PARITY_ROADMAP.md` D1).
+//!
+//! # Storage layout
+//!
+//! Each zone's ANN index lives at
+//! `<root>/<zone_id>/ann-<model>-<version>/`:
+//!
+//! - `hnsw.hnsw.graph` — graph structure written by `Hnsw::file_dump`
+//! - `hnsw.hnsw.data`  — flat vector store, same source
+//! - `sidecar.json`    — id → path + shadowed-id set (see below)
+//!
+//! The model tag in the directory name (`ann-mE5-small-v1`) ties the
+//! index to the embedder version — a model swap creates a NEW
+//! directory alongside the old one, so operators can roll back by
+//! pointing the manager at either.  Directories are per-node derived
+//! state; the kernel VFS is the corpus SSOT (same rule as the FTS
+//! index in `fts_index.rs`).
+//!
+//! # Id + path mapping
+//!
+//! HNSW works on `usize` ids.  We assign monotonic ids and keep
+//! `path → id` + `id → path` in the sidecar so:
+//!
+//! 1. **Search results carry paths.** `hnsw_rs::Neighbour` returns
+//!    only the id; the sidecar's reverse map turns each id back into
+//!    a path.
+//!
+//! 2. **Re-indexing the same path is idempotent.** `hnsw_rs` has no
+//!    delete primitive — inserting `path_A` twice would leave two
+//!    graph nodes, doubling `path_A`'s recall weight.  Instead we
+//!    move the OLD id to a `shadowed` set and insert with a new id;
+//!    search post-filters shadowed hits before returning.  The
+//!    shadowed entries stay in the graph (waste memory), so a
+//!    periodic full rebuild is deferred to P5's indexing pipeline —
+//!    the same MetaStore-checkpoint moment that already schedules a
+//!    tantivy segment merge.
+//!
+//! # Concurrency
+//!
+//! `hnsw_rs::Hnsw` takes `&self` for insert AND search (interior
+//! parking_lot locks), so multiple threads can call either freely.
+//! Our sidecar is behind a `parking_lot::RwLock<Sidecar>`:
+//!
+//! - Search takes a read lock to look up paths + filter shadows.
+//! - Add takes a write lock to bump the counter + rotate mappings.
+//!
+//! The lock is not held across the HNSW call itself, so a slow
+//! search does not stall a concurrent add on the sidecar.
+
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use anndists::dist::DistCosine;
+use hnsw_rs::hnsw::{Hnsw, Neighbour};
+use hnsw_rs::hnswio::{HnswIo, ReloadOptions};
+use hnsw_rs::prelude::AnnT;
+use parking_lot::RwLock;
+use serde::{Deserialize, Serialize};
+
+/// Basename used by `Hnsw::file_dump` — produces
+/// `<basename>.hnsw.graph` + `<basename>.hnsw.data`.  Matched by
+/// [`HnswIo::new`] on reload.
+const HNSW_BASENAME: &str = "hnsw";
+
+/// Sidecar filename holding the id/path mapping + shadowed ids.
+const SIDECAR_FILE: &str = "sidecar.json";
+
+/// HNSW `M` — max out-edges per node.  16 is the standard tuning
+/// from the original paper for cosine distance on ≤10 M points.
+const HNSW_M: usize = 16;
+
+/// HNSW `max_layer` — 16 accommodates ~10 M inserts (ceiling ~ log_M N).
+const HNSW_MAX_LAYER: usize = 16;
+
+/// HNSW `ef_construction` — build-time neighbour width.  200 is the
+/// paper's balanced tuning; increases recall @ index-build cost.
+const HNSW_EF_CONSTRUCTION: usize = 200;
+
+/// HNSW `capacity` hint (soft-cap on pre-alloc).  Not a hard limit —
+/// inserts past this pay reallocation cost.
+const DEFAULT_CAPACITY: usize = 100_000;
+
+/// Result row returned by [`AnnIndex::search`].  Distance is the raw
+/// cosine distance (0.0 = identical, 2.0 = opposite); callers convert
+/// to a similarity score via `1.0 - distance` if they want the
+/// familiar "higher is better" shape.
+#[derive(Debug, Clone, PartialEq)]
+pub struct AnnHit {
+    pub path: String,
+    pub distance: f32,
+}
+
+/// On-disk state that survives restarts.  `Hnsw` itself is dumped by
+/// hnsw_rs into its own two files; this JSON captures everything
+/// else (id counter, path ↔ id mappings, shadowed-id set).
+#[derive(Debug, Serialize, Deserialize, Default)]
+struct Sidecar {
+    next_id: usize,
+    path_to_id: HashMap<String, usize>,
+    /// Ids no longer valid — their doc was re-indexed under a new
+    /// id.  Search post-filter drops these before returning hits.
+    shadowed: HashSet<usize>,
+}
+
+impl Sidecar {
+    /// Rebuild the reverse map (`id → path`) from `path_to_id`.  Not
+    /// stored to disk — cheap to derive on load, and keeping it out
+    /// of the JSON avoids the two mappings drifting when the file is
+    /// hand-edited (a debug/support workflow we want to preserve).
+    fn id_to_path(&self) -> HashMap<usize, String> {
+        self.path_to_id
+            .iter()
+            .map(|(p, id)| (*id, p.clone()))
+            .collect()
+    }
+}
+
+/// One per-zone HNSW vector index.  Cheap to clone (`Arc` inside).
+pub struct AnnIndex {
+    dim: usize,
+    dir: PathBuf,
+    hnsw: Hnsw<'static, f32, DistCosine>,
+    sidecar: RwLock<Sidecar>,
+    /// Cached reverse map — regenerated on every write to keep search
+    /// path lookups O(1) without holding the sidecar RwLock for the
+    /// whole search.
+    id_to_path: RwLock<HashMap<usize, String>>,
+}
+
+impl AnnIndex {
+    /// Open the index at `dir` if a prior dump exists, otherwise
+    /// create a fresh empty one.  `dim` MUST match what the embedder
+    /// produces — hnsw_rs does not validate dimensionality on insert
+    /// and a mismatch reads past the end of the input slice.
+    pub fn open_or_create(dir: PathBuf, dim: usize) -> Result<Arc<Self>, AnnError> {
+        assert!(dim > 0, "AnnIndex dim must be > 0");
+        std::fs::create_dir_all(&dir)
+            .map_err(|e| AnnError::CreateDir(dir.display().to_string(), e.to_string()))?;
+
+        let graph = dir.join(format!("{HNSW_BASENAME}.hnsw.graph"));
+        let sidecar_path = dir.join(SIDECAR_FILE);
+
+        let (hnsw, sidecar) = if graph.exists() && sidecar_path.exists() {
+            let mut io = HnswIo::new(&dir, HNSW_BASENAME);
+            io.set_options(ReloadOptions::default());
+            let hnsw = io
+                .load_hnsw::<f32, DistCosine>()
+                .map_err(|e| AnnError::Open(dir.display().to_string(), e.to_string()))?;
+            let bytes = std::fs::read(&sidecar_path)
+                .map_err(|e| AnnError::Open(sidecar_path.display().to_string(), e.to_string()))?;
+            let sidecar: Sidecar = serde_json::from_slice(&bytes)
+                .map_err(|e| AnnError::Open(sidecar_path.display().to_string(), e.to_string()))?;
+            (hnsw, sidecar)
+        } else {
+            let hnsw = Hnsw::<f32, DistCosine>::new(
+                HNSW_M,
+                DEFAULT_CAPACITY,
+                HNSW_MAX_LAYER,
+                HNSW_EF_CONSTRUCTION,
+                DistCosine {},
+            );
+            (hnsw, Sidecar::default())
+        };
+
+        let id_to_path = sidecar.id_to_path();
+        Ok(Arc::new(Self {
+            dim,
+            dir,
+            hnsw,
+            sidecar: RwLock::new(sidecar),
+            id_to_path: RwLock::new(id_to_path),
+        }))
+    }
+
+    /// Add / replace the embedding for `path`.  Idempotent — a prior
+    /// vector under the same path is shadowed instead of duplicated
+    /// (see the "Id + path mapping" section of the module doc).
+    ///
+    /// Errors on:
+    /// - `vector.len() != dim`
+    /// - all-zero vector (cosine distance is undefined; would NaN
+    ///   propagate through the graph)
+    pub fn add_vector(&self, path: &str, vector: &[f32]) -> Result<(), AnnError> {
+        if vector.len() != self.dim {
+            return Err(AnnError::DimMismatch {
+                path: path.to_string(),
+                got: vector.len(),
+                expected: self.dim,
+            });
+        }
+        if is_all_zero(vector) {
+            return Err(AnnError::ZeroVector(path.to_string()));
+        }
+
+        // Rotate mappings under the write lock.  Short-held — no
+        // HNSW ops inside.
+        let new_id = {
+            let mut side = self.sidecar.write();
+            let id = side.next_id;
+            side.next_id += 1;
+            if let Some(prior) = side.path_to_id.insert(path.to_string(), id) {
+                // Old id survives in the graph but no longer
+                // resolves to a live path — mark it shadowed so
+                // search's post-filter drops it.
+                side.shadowed.insert(prior);
+            }
+            id
+        };
+
+        // HNSW insert is thread-safe on `&self`; no lock needed here.
+        self.hnsw.insert((vector, new_id));
+
+        // Refresh the cached reverse map so search's path lookup
+        // sees the new id immediately.  Cheap on typical zone sizes;
+        // a smarter incremental update is a follow-up if this ever
+        // shows up on a profile.
+        let map = self.sidecar.read().id_to_path();
+        *self.id_to_path.write() = map;
+
+        Ok(())
+    }
+
+    /// Nearest-`k` search.  Returns hits sorted by cosine distance
+    /// ascending (nearest first), with shadowed ids filtered out.
+    ///
+    /// `ef` (search-time neighbour width) is derived from `k` per
+    /// hnsw_rs's guidance: `ef = max(k, HNSW_M * 2)` — high enough
+    /// to keep recall stable, low enough to stay sub-ms on ≤100 K
+    /// points.  Callers with recall-vs-latency preferences reach
+    /// down to [`search_with_ef`](Self::search_with_ef).
+    pub fn search(&self, query: &[f32], k: usize) -> Result<Vec<AnnHit>, AnnError> {
+        let ef = std::cmp::max(k, HNSW_M * 2);
+        self.search_with_ef(query, k, ef)
+    }
+
+    pub fn search_with_ef(
+        &self,
+        query: &[f32],
+        k: usize,
+        ef: usize,
+    ) -> Result<Vec<AnnHit>, AnnError> {
+        if query.len() != self.dim {
+            return Err(AnnError::DimMismatch {
+                path: "<query>".to_string(),
+                got: query.len(),
+                expected: self.dim,
+            });
+        }
+        if is_all_zero(query) {
+            return Err(AnnError::ZeroVector("<query>".to_string()));
+        }
+        if k == 0 {
+            return Ok(Vec::new());
+        }
+
+        // Over-fetch so the shadow filter can drop stale hits and
+        // still return `k` live results in the typical case (few
+        // shadows).  Bounded so a heavily-reindexed zone doesn't
+        // scan the whole graph.
+        let overfetch = std::cmp::min(k * 4, k + 100);
+        let effective_ef = std::cmp::max(ef, overfetch);
+
+        let neighbours: Vec<Neighbour> = self.hnsw.search(query, overfetch, effective_ef);
+
+        let side = self.sidecar.read();
+        let id_map = self.id_to_path.read();
+
+        let mut out = Vec::with_capacity(k);
+        for n in neighbours {
+            if side.shadowed.contains(&n.d_id) {
+                continue;
+            }
+            let Some(path) = id_map.get(&n.d_id) else {
+                // Defensive: mapping missing for a live id would
+                // mean sidecar drift.  Drop the hit and log rather
+                // than surface a bogus "" path.
+                tracing::warn!(
+                    id = n.d_id,
+                    "ann: id in graph but not in sidecar — dropping"
+                );
+                continue;
+            };
+            out.push(AnnHit {
+                path: path.clone(),
+                distance: n.distance,
+            });
+            if out.len() >= k {
+                break;
+            }
+        }
+        Ok(out)
+    }
+
+    /// Persist the graph + sidecar to disk.  Callers batch adds and
+    /// commit once at end-of-request — same pattern as `FtsIndex`.
+    pub fn commit(&self) -> Result<(), AnnError> {
+        self.hnsw
+            .file_dump(&self.dir, HNSW_BASENAME)
+            .map_err(|e| AnnError::Commit(format!("hnsw file_dump: {e}")))?;
+        let sidecar_path = self.dir.join(SIDECAR_FILE);
+        let side = self.sidecar.read();
+        let bytes = serde_json::to_vec_pretty(&*side)
+            .map_err(|e| AnnError::Commit(format!("sidecar encode: {e}")))?;
+        // Atomic swap via write-and-rename so a mid-write crash
+        // never leaves a truncated sidecar file that would break
+        // the next open_or_create.
+        let tmp = sidecar_path.with_extension("json.tmp");
+        std::fs::write(&tmp, &bytes)
+            .map_err(|e| AnnError::Commit(format!("sidecar tmp write: {e}")))?;
+        std::fs::rename(&tmp, &sidecar_path)
+            .map_err(|e| AnnError::Commit(format!("sidecar rename: {e}")))?;
+        Ok(())
+    }
+
+    /// Number of live documents (indexed, not shadowed).  Used by
+    /// tests + operator diagnostics.
+    pub fn live_count(&self) -> usize {
+        let side = self.sidecar.read();
+        // path_to_id holds one entry per live path, so its size IS
+        // the live count.  `shadowed` is orthogonal (old ids no
+        // longer referenced by any path).
+        side.path_to_id.len()
+    }
+
+    /// Dimensionality this index was created with.  Callers embed
+    /// with the model that produced this dim.
+    pub fn dim(&self) -> usize {
+        self.dim
+    }
+
+    /// Absolute path to the on-disk directory.  Tests use this to
+    /// verify the layout contract; operators use it to size zones.
+    pub fn dir(&self) -> &Path {
+        &self.dir
+    }
+}
+
+fn is_all_zero(v: &[f32]) -> bool {
+    v.iter().all(|&x| x == 0.0)
+}
+
+// ── Errors ────────────────────────────────────────────────────────
+
+#[derive(Debug, thiserror::Error)]
+pub enum AnnError {
+    #[error("create ann dir {0}: {1}")]
+    CreateDir(String, String),
+    #[error("open ann index at {0}: {1}")]
+    Open(String, String),
+    #[error("dimension mismatch for {path}: got {got}, expected {expected}")]
+    DimMismatch {
+        path: String,
+        got: usize,
+        expected: usize,
+    },
+    #[error("zero vector for {0}: cosine distance is undefined")]
+    ZeroVector(String),
+    #[error("commit: {0}")]
+    Commit(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tempdir() -> PathBuf {
+        tempfile::tempdir().expect("tempdir").keep()
+    }
+
+    /// Trivial deterministic vector — component `i` = `seed * (i+1)`,
+    /// scaled to unit-ish magnitude so the cosine distances between
+    /// distinct seeds are non-degenerate.
+    fn vec_seed(dim: usize, seed: f32) -> Vec<f32> {
+        (0..dim).map(|i| (seed + (i as f32) * 0.01).sin()).collect()
+    }
+
+    #[test]
+    fn open_creates_empty_index() {
+        let dir = tempdir().join("ann");
+        let idx = AnnIndex::open_or_create(dir.clone(), 8).expect("open");
+        assert!(dir.exists());
+        assert_eq!(idx.live_count(), 0);
+        assert_eq!(idx.dim(), 8);
+        // Search on an empty index returns zero hits, not a panic.
+        let hits = idx.search(&vec_seed(8, 1.0), 5).expect("search");
+        assert!(hits.is_empty());
+    }
+
+    #[test]
+    fn add_then_search_finds_nearest() {
+        let dir = tempdir().join("ann");
+        let idx = AnnIndex::open_or_create(dir, 4).expect("open");
+        idx.add_vector("/a", &vec_seed(4, 1.0)).expect("add a");
+        idx.add_vector("/b", &vec_seed(4, 5.0)).expect("add b");
+        idx.add_vector("/c", &vec_seed(4, 9.0)).expect("add c");
+        assert_eq!(idx.live_count(), 3);
+
+        // Query with /b's exact vector — nearest hit must be /b at
+        // distance ~0.
+        let hits = idx.search(&vec_seed(4, 5.0), 3).expect("search");
+        assert_eq!(hits.len(), 3);
+        assert_eq!(hits[0].path, "/b");
+        assert!(
+            hits[0].distance < 0.001,
+            "nearest hit distance too high: {hits:?}"
+        );
+        // Order is nearest → farthest.
+        for pair in hits.windows(2) {
+            assert!(
+                pair[0].distance <= pair[1].distance,
+                "hits not sorted by distance ascending: {hits:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn dim_mismatch_is_rejected_not_undefined() {
+        let dir = tempdir().join("ann");
+        let idx = AnnIndex::open_or_create(dir, 4).expect("open");
+        let err = idx
+            .add_vector("/x", &vec_seed(3, 1.0))
+            .expect_err("must reject wrong dim");
+        assert!(
+            matches!(err, AnnError::DimMismatch { .. }),
+            "unexpected: {err:?}"
+        );
+    }
+
+    #[test]
+    fn zero_vector_is_rejected() {
+        let dir = tempdir().join("ann");
+        let idx = AnnIndex::open_or_create(dir, 4).expect("open");
+        let err = idx
+            .add_vector("/x", &vec![0.0; 4])
+            .expect_err("must reject zero vec");
+        assert!(
+            matches!(err, AnnError::ZeroVector(_)),
+            "unexpected: {err:?}"
+        );
+    }
+
+    #[test]
+    fn readd_same_path_shadows_old_and_returns_new_vector() {
+        // Idempotency regression: hnsw_rs has no delete, so a naive
+        // re-add would leave TWO graph nodes for the same path.  The
+        // shadow-filter path in search must drop the old id and
+        // return the new vector's distance.
+        let dir = tempdir().join("ann");
+        let idx = AnnIndex::open_or_create(dir, 4).expect("open");
+        idx.add_vector("/a", &vec_seed(4, 1.0)).expect("add-1");
+        idx.add_vector("/other", &vec_seed(4, 10.0))
+            .expect("add-other");
+        idx.add_vector("/a", &vec_seed(4, 20.0)).expect("re-add");
+        assert_eq!(idx.live_count(), 2, "path count stays at 2 after re-add");
+
+        // Query with the NEW vector — /a must come first at ~0
+        // distance; the OLD /a id must not appear.
+        let hits = idx.search(&vec_seed(4, 20.0), 5).expect("search");
+        assert_eq!(
+            hits.iter().filter(|h| h.path == "/a").count(),
+            1,
+            "shadowed dup leaked: {hits:?}"
+        );
+        assert_eq!(hits[0].path, "/a");
+        assert!(hits[0].distance < 0.001);
+    }
+
+    #[test]
+    fn commit_then_reopen_survives_restart() {
+        let dir = tempdir().join("ann");
+        {
+            let idx = AnnIndex::open_or_create(dir.clone(), 4).expect("open");
+            idx.add_vector("/a", &vec_seed(4, 1.0)).expect("add-a");
+            idx.add_vector("/b", &vec_seed(4, 5.0)).expect("add-b");
+            idx.commit().expect("commit");
+        }
+        // Fresh open — the graph + sidecar files come back to life.
+        let idx2 = AnnIndex::open_or_create(dir, 4).expect("reopen");
+        assert_eq!(idx2.live_count(), 2);
+        let hits = idx2.search(&vec_seed(4, 5.0), 2).expect("search");
+        assert_eq!(hits[0].path, "/b");
+    }
+
+    #[test]
+    fn top_k_bounded_by_request() {
+        let dir = tempdir().join("ann");
+        let idx = AnnIndex::open_or_create(dir, 4).expect("open");
+        for i in 0..20 {
+            idx.add_vector(&format!("/p{i}"), &vec_seed(4, i as f32 + 1.0))
+                .expect("add");
+        }
+        let hits = idx.search(&vec_seed(4, 3.0), 5).expect("search");
+        assert_eq!(hits.len(), 5, "search must not exceed requested k");
+    }
+}

--- a/rust/services/search-plugin/src/ann_index.rs
+++ b/rust/services/search-plugin/src/ann_index.rs
@@ -143,7 +143,14 @@ impl AnnIndex {
         let sidecar_path = dir.join(SIDECAR_FILE);
 
         let (hnsw, sidecar) = if graph.exists() && sidecar_path.exists() {
-            let mut io = HnswIo::new(&dir, HNSW_BASENAME);
+            // Leak the HnswIo so its buffer lives 'static — hnsw_rs's
+            // `load_hnsw` returns a `Hnsw<'a>` tied to the loader's
+            // internal storage, and Hnsw needs to outlive this function
+            // (it's owned by the returned Arc<AnnIndex>).  Leaking
+            // costs one struct per zone open, permanent — negligible
+            // for a long-running daemon.  A more surgical fix would
+            // switch to an owning reload API when hnsw_rs exposes one.
+            let io = Box::leak(Box::new(HnswIo::new(&dir, HNSW_BASENAME)));
             io.set_options(ReloadOptions::default());
             let hnsw = io
                 .load_hnsw::<f32, DistCosine>()

--- a/rust/services/search-plugin/src/embedder.rs
+++ b/rust/services/search-plugin/src/embedder.rs
@@ -146,8 +146,8 @@ impl Embedder for MockEmbedder {
     }
 }
 
-/// FNV-1a → per-dim golden-ratio shuffle.  Deterministic + non-zero
-/// + spread across [-1, 1].  Non-cryptographic; the goal is
+/// FNV-1a → per-dim golden-ratio shuffle.  Deterministic, non-zero,
+/// spread across `[-1, 1]`.  Non-cryptographic; the goal is
 /// reproducibility, not distributional quality — tests care that
 /// same input maps to same output and different inputs map to
 /// different outputs.

--- a/rust/services/search-plugin/src/embedder.rs
+++ b/rust/services/search-plugin/src/embedder.rs
@@ -221,9 +221,14 @@ mod fast {
         /// at plugin startup or you get a stale runtime.
         pub fn load(dir: &Path, tag: &str, dylib_path: &Path) -> Result<Self, EmbedError> {
             // ort init is process-global; first successful call wins.
-            // If a prior plugin already ran init the ok() branch is
-            // hit and this is a no-op.
-            let _ = ort::init_from(dylib_path.to_string_lossy().into_owned()).commit();
+            // `init_from` returns a Result — a prior failing init (e.g.
+            // dylib not found) surfaces here; we swallow and let the
+            // TextEmbedding constructor below fail with a more actionable
+            // "load failed" message.  If a prior plugin already ran init
+            // successfully, `commit()` on the builder is a no-op.
+            if let Ok(builder) = ort::init_from(dylib_path.to_string_lossy().into_owned()) {
+                let _ = builder.commit();
+            }
 
             let read = |name: &str| -> Result<Vec<u8>, EmbedError> {
                 std::fs::read(dir.join(name)).map_err(|e| {

--- a/rust/services/search-plugin/src/embedder.rs
+++ b/rust/services/search-plugin/src/embedder.rs
@@ -1,0 +1,437 @@
+//! Text-to-vector embedding abstraction for SemanticQuery (Phase 2
+//! of the Python-parity roadmap; see `PARITY_ROADMAP.md` D2).
+//!
+//! # Two impls
+//!
+//! - [`MockEmbedder`] — deterministic hash-projection.  Always
+//!   compiled; used by unit + integration tests so they never
+//!   download a real model or link ONNX Runtime.  Same text →
+//!   same vector, so exact-match queries return the seed doc at
+//!   cosine distance 0.
+//!
+//! - [`FastEmbedder`] — behind the `semantic` Cargo feature (default
+//!   on).  Wraps `fastembed::TextEmbedding` with ort `load-dynamic`
+//!   so onnxruntime.{dll,dylib,so} is shipped alongside the plugin
+//!   cdylib rather than statically linked.  Model files live under
+//!   `$NEXUS_SEARCH_MODEL_DIR` (falls back to
+//!   `$NEXUS_DATA_DIR/plugins/search/models/`).
+//!
+//! # Concurrency
+//!
+//! [`Embedder`] takes `&self` for `embed_batch` so callers can share
+//! an `Arc<dyn Embedder>` across the tokio pool.  `MockEmbedder` is
+//! stateless and thread-safe by construction.  `FastEmbedder`
+//! serialises internally via a `parking_lot::Mutex` — fastembed's
+//! own `embed` is `&mut self` (ort session state), and holding the
+//! mutex across the CPU-bound embed call is fine because the plugin
+//! runs on a `spawn_blocking` worker.  A future phase can grow a
+//! pool of session handles if concurrent throughput becomes a
+//! bottleneck.
+//!
+//! # Cold-start
+//!
+//! `FastEmbedder::load` is 300 ms – 1 s on typical hosts (mmap +
+//! ort session build + graph opt).  The service wires a
+//! `OnceCell<Arc<dyn Embedder>>` so the cost lands on the first
+//! SemanticQuery rather than at plugin creation — a slim / lite
+//! deployment that never issues SemanticQuery pays nothing.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+/// Batch text-embedding contract.  One trait so the RPC handler
+/// can hand out an `Arc<dyn Embedder>` and the storage layer stays
+/// oblivious to whether the vectors came from a real ONNX session
+/// or a mock hash.
+pub trait Embedder: Send + Sync {
+    /// Embed a batch of texts.  Returns one vector per input in the
+    /// same order.  Empty input yields empty output — callers do
+    /// not need to short-circuit.
+    fn embed_batch(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>, EmbedError>;
+
+    /// Embedding dimensionality.  Callers pin their AnnIndex to
+    /// this value at open-or-create time (see `AnnIndex::dim`).
+    fn dim(&self) -> usize;
+
+    /// Short model identifier for the AnnIndex directory tag
+    /// (`ann-<tag>-v<n>` per D4).  Same embedder ⇒ same vector
+    /// space ⇒ same index directory; a model swap changes the tag
+    /// so the new index gets its own directory alongside the old.
+    fn tag(&self) -> &str;
+
+    /// Human-readable name for logs + operator diagnostics.  May
+    /// contain spaces, punctuation, model-version hints.  Distinct
+    /// from `tag()` which lands in filesystem paths.
+    fn display_name(&self) -> &str {
+        self.tag()
+    }
+}
+
+/// Errors surfaced from embedding a batch.
+#[derive(Debug, thiserror::Error)]
+pub enum EmbedError {
+    /// The embedder was never wired up (e.g. `semantic` feature
+    /// off, or the model files couldn't be located at startup).
+    /// Callers surface this as an HTTP 503-ish "semantic search
+    /// unavailable" — keyword search stays available.
+    #[error("embedder not available: {0}")]
+    NotAvailable(String),
+
+    /// The model file / tokenizer file was found but failed to
+    /// load.  Bad ONNX opset, corrupt bytes, tokenizer format
+    /// mismatch, etc.  Distinct from `NotAvailable` so operators
+    /// know to inspect the model directory rather than turn a
+    /// feature flag on.
+    #[error("embedder load failed: {0}")]
+    Load(String),
+
+    /// The embed call itself failed — session run error, OOM, etc.
+    /// Rare in practice on validated models.
+    #[error("embed runtime failed: {0}")]
+    Runtime(String),
+}
+
+// ── MockEmbedder (always compiled) ────────────────────────────────
+//
+// Deterministic per-text projection.  Same text produces the same
+// vector, so a query embed of `X` and an add_vector under the doc
+// whose text is `X` land at cosine distance 0 — exactly what
+// integration tests want to assert.  Two hash rounds mix the byte
+// stream into a 64-bit seed, then each dimension gets a
+// golden-ratio-shifted derivative for spatial spread; a small
+// constant bias (`+ 0.001`) guarantees non-zero vectors so
+// AnnIndex's zero-guard does not reject empty strings.
+
+/// Deterministic hash-projection embedder.  Fixed 384-dim by
+/// default to match `multilingual-e5-small`'s output so a test
+/// harness can swap Mock → Fast without changing the AnnIndex
+/// directory shape.
+pub struct MockEmbedder {
+    dim: usize,
+}
+
+impl MockEmbedder {
+    /// Fresh mock at the default 384-dim (matches mE5-small).
+    pub fn new() -> Self {
+        Self::with_dim(384)
+    }
+
+    /// Custom dim — used by tests that want small vectors so the
+    /// assertion output stays readable.  Panics on `dim == 0` so a
+    /// misconfigured caller fails at construction, not at first
+    /// embed.
+    pub fn with_dim(dim: usize) -> Self {
+        assert!(dim > 0, "MockEmbedder dim must be > 0");
+        Self { dim }
+    }
+}
+
+impl Default for MockEmbedder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Embedder for MockEmbedder {
+    fn embed_batch(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>, EmbedError> {
+        Ok(texts.iter().map(|t| mock_vec(t, self.dim)).collect())
+    }
+
+    fn dim(&self) -> usize {
+        self.dim
+    }
+
+    fn tag(&self) -> &str {
+        "mock"
+    }
+}
+
+/// FNV-1a → per-dim golden-ratio shuffle.  Deterministic + non-zero
+/// + spread across [-1, 1].  Non-cryptographic; the goal is
+/// reproducibility, not distributional quality — tests care that
+/// same input maps to same output and different inputs map to
+/// different outputs.
+fn mock_vec(text: &str, dim: usize) -> Vec<f32> {
+    const FNV_OFFSET: u64 = 14_695_981_039_346_656_037;
+    const FNV_PRIME: u64 = 1_099_511_628_211;
+    const GOLDEN: u64 = 0x9E37_79B9_7F4A_7C15;
+
+    let mut hash: u64 = FNV_OFFSET;
+    for b in text.bytes() {
+        hash ^= b as u64;
+        hash = hash.wrapping_mul(FNV_PRIME);
+    }
+
+    (0..dim)
+        .map(|i| {
+            let mixed = hash.wrapping_add((i as u64).wrapping_mul(GOLDEN));
+            // Map high 32 bits into (-1, 1); +0.001 bias keeps the
+            // vector strictly non-zero for AnnIndex's cosine guard.
+            let raw = (mixed >> 32) as u32 as f32 / u32::MAX as f32;
+            0.001 + raw - 0.5
+        })
+        .collect()
+}
+
+// ── FastEmbedder (feature-gated) ──────────────────────────────────
+
+#[cfg(feature = "semantic")]
+mod fast {
+    use super::*;
+
+    use parking_lot::Mutex;
+
+    /// Directory-based fastembed wrapper.  Constructed by
+    /// [`FastEmbedder::load`] which locates model + tokenizer
+    /// files under `dir` and initialises ort's load-dynamic path.
+    ///
+    /// The dir layout matches what a `huggingface-cli download`
+    /// produces for e.g. `intfloat/multilingual-e5-small`:
+    ///
+    /// ```text
+    /// <dir>/
+    ///   model.onnx
+    ///   tokenizer.json
+    ///   config.json
+    ///   special_tokens_map.json
+    ///   tokenizer_config.json
+    /// ```
+    ///
+    /// Missing any of these produces a typed `Load` error at
+    /// construction time — the plugin surfaces that as "SemanticQuery
+    /// unavailable, model files not found in $NEXUS_SEARCH_MODEL_DIR"
+    /// so operators immediately see the fix.
+    pub struct FastEmbedder {
+        inner: Mutex<fastembed::TextEmbedding>,
+        dim: usize,
+        tag: String,
+    }
+
+    impl FastEmbedder {
+        /// Load the model at `dir`, tagging the resulting index with
+        /// `tag` (typically `mE5-small-v1`).  See the module doc for
+        /// the expected on-disk layout.
+        ///
+        /// `dylib_path` names the ONNX Runtime library the ort crate
+        /// will `dlopen`.  Must be an absolute path to a
+        /// `.so`/`.dylib`/`.dll` that matches ort's expected version
+        /// (`onnxruntime` 1.19+ for ort 2.0.0-rc.10).  Init happens
+        /// exactly once per process; subsequent calls with a
+        /// different path are silently ignored — set this correctly
+        /// at plugin startup or you get a stale runtime.
+        pub fn load(dir: &Path, tag: &str, dylib_path: &Path) -> Result<Self, EmbedError> {
+            // ort init is process-global; first successful call wins.
+            // If a prior plugin already ran init the ok() branch is
+            // hit and this is a no-op.
+            let _ = ort::init_from(dylib_path.to_string_lossy().into_owned()).commit();
+
+            let read = |name: &str| -> Result<Vec<u8>, EmbedError> {
+                std::fs::read(dir.join(name)).map_err(|e| {
+                    EmbedError::Load(format!("read {} in {}: {}", name, dir.display(), e))
+                })
+            };
+
+            let tokenizer_files = fastembed::TokenizerFiles {
+                tokenizer_file: read("tokenizer.json")?,
+                config_file: read("config.json")?,
+                special_tokens_map_file: read("special_tokens_map.json")?,
+                tokenizer_config_file: read("tokenizer_config.json")?,
+            };
+            let model_bytes = read("model.onnx")?;
+
+            let udm = fastembed::UserDefinedEmbeddingModel::new(model_bytes, tokenizer_files);
+            let mut model = fastembed::TextEmbedding::try_new_from_user_defined(
+                udm,
+                fastembed::InitOptionsUserDefined::default(),
+            )
+            .map_err(|e| EmbedError::Load(format!("TextEmbedding init: {e}")))?;
+
+            // Probe dim — fastembed 5.x has no dim() accessor; run
+            // a one-doc embed to discover it.  Cached for later
+            // calls so the probe is amortised to zero.  We embed a
+            // literal so an empty-string quirk in the model can't
+            // trip the probe.
+            let probe = model
+                .embed(vec!["probe"], None)
+                .map_err(|e| EmbedError::Load(format!("dim probe: {e}")))?;
+            let dim = probe
+                .first()
+                .ok_or_else(|| EmbedError::Load("dim probe: empty result".to_string()))?
+                .len();
+            if dim == 0 {
+                return Err(EmbedError::Load(
+                    "dim probe: zero-length vector".to_string(),
+                ));
+            }
+
+            Ok(Self {
+                inner: Mutex::new(model),
+                dim,
+                tag: tag.to_string(),
+            })
+        }
+    }
+
+    impl Embedder for FastEmbedder {
+        fn embed_batch(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>, EmbedError> {
+            if texts.is_empty() {
+                return Ok(Vec::new());
+            }
+            // fastembed::embed takes ownership of the batch — allocate
+            // once here so callers can keep their `&[&str]` shape.
+            let owned: Vec<String> = texts.iter().map(|s| (*s).to_owned()).collect();
+            let mut lock = self.inner.lock();
+            lock.embed(owned, None)
+                .map_err(|e| EmbedError::Runtime(e.to_string()))
+        }
+
+        fn dim(&self) -> usize {
+            self.dim
+        }
+
+        fn tag(&self) -> &str {
+            &self.tag
+        }
+    }
+}
+
+#[cfg(feature = "semantic")]
+pub use fast::FastEmbedder;
+
+// ── Discovery helpers ─────────────────────────────────────────────
+
+/// Env var that overrides the default model directory.
+pub const MODEL_DIR_ENV: &str = "NEXUS_SEARCH_MODEL_DIR";
+
+/// Env var that overrides the default ONNX Runtime dylib path.
+/// Same convention `ort` itself honours — kept as a plugin-level
+/// constant so operators only set one place.
+pub const ORT_DYLIB_ENV: &str = "ORT_DYLIB_PATH";
+
+/// Resolve the model directory — `$NEXUS_SEARCH_MODEL_DIR` if set,
+/// falling back to `<data_root>/models/`.  `data_root` is what
+/// [`crate::index_manager::default_root`] returns (i.e. the plugin's
+/// per-node state root).
+pub fn resolve_model_dir(data_root: &Path) -> PathBuf {
+    std::env::var(MODEL_DIR_ENV)
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| data_root.join("models"))
+}
+
+/// Best-effort embedder factory — used by the service to lazily
+/// build the embedder on first SemanticQuery.  Returns
+/// `NotAvailable` when the `semantic` feature is off or the
+/// discovery step didn't find a usable model / dylib.
+///
+/// The concrete return type is `Arc<dyn Embedder>` so tests can
+/// swap in `MockEmbedder` without a compile-time cfg.
+pub fn build_default_embedder(data_root: &Path) -> Result<Arc<dyn Embedder>, EmbedError> {
+    #[cfg(feature = "semantic")]
+    {
+        let dir = resolve_model_dir(data_root);
+        let dylib = std::env::var(ORT_DYLIB_ENV).map_err(|_| {
+            EmbedError::NotAvailable(format!(
+                "{ORT_DYLIB_ENV} not set — cluster boot must point at the shipped onnxruntime library",
+            ))
+        })?;
+        Ok(Arc::new(FastEmbedder::load(
+            &dir,
+            "mE5-small-v1",
+            Path::new(&dylib),
+        )?))
+    }
+    #[cfg(not(feature = "semantic"))]
+    {
+        let _ = data_root;
+        Err(EmbedError::NotAvailable(
+            "search-plugin compiled without the `semantic` feature".to_string(),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mock_same_text_same_vector() {
+        let e = MockEmbedder::with_dim(8);
+        let v1 = &e.embed_batch(&["hello"]).unwrap()[0];
+        let v2 = &e.embed_batch(&["hello"]).unwrap()[0];
+        assert_eq!(v1, v2, "mock must be deterministic per text");
+    }
+
+    #[test]
+    fn mock_different_text_different_vector() {
+        let e = MockEmbedder::with_dim(8);
+        let v1 = &e.embed_batch(&["hello"]).unwrap()[0];
+        let v2 = &e.embed_batch(&["world"]).unwrap()[0];
+        assert_ne!(v1, v2, "distinct texts must map to distinct vectors");
+    }
+
+    #[test]
+    fn mock_never_produces_zero_vector() {
+        // AnnIndex rejects zero vectors — the mock must never trip
+        // that guard on any text, including the empty string.
+        let e = MockEmbedder::with_dim(16);
+        for text in ["", " ", "a", "hello world", "\0"] {
+            let v = &e.embed_batch(&[text]).unwrap()[0];
+            let all_zero = v.iter().all(|&x| x == 0.0);
+            assert!(!all_zero, "mock produced zero vector for {text:?}");
+        }
+    }
+
+    #[test]
+    fn mock_dim_stable() {
+        let e = MockEmbedder::with_dim(384);
+        for text in ["x", "widget alpha", "α β γ"] {
+            let v = &e.embed_batch(&[text]).unwrap()[0];
+            assert_eq!(v.len(), 384, "dim wrong for {text:?}");
+        }
+    }
+
+    #[test]
+    fn empty_batch_returns_empty() {
+        let e = MockEmbedder::with_dim(8);
+        let out = e.embed_batch(&[]).unwrap();
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn resolve_model_dir_falls_back_to_data_root() {
+        // Guard the env in case the user has NEXUS_SEARCH_MODEL_DIR
+        // set in their shell.
+        let saved = std::env::var(MODEL_DIR_ENV).ok();
+        // SAFETY: this test does not run in parallel with any other
+        // test that reads MODEL_DIR_ENV.
+        unsafe { std::env::remove_var(MODEL_DIR_ENV) };
+        let root = PathBuf::from("/opt/nexus-data/plugins/search");
+        let dir = resolve_model_dir(&root);
+        assert_eq!(dir, root.join("models"));
+        if let Some(v) = saved {
+            unsafe { std::env::set_var(MODEL_DIR_ENV, v) };
+        }
+    }
+
+    #[test]
+    fn resolve_model_dir_honours_env() {
+        let saved = std::env::var(MODEL_DIR_ENV).ok();
+        unsafe { std::env::set_var(MODEL_DIR_ENV, "/mnt/models") };
+        let dir = resolve_model_dir(&PathBuf::from("/opt/nexus-data/plugins/search"));
+        assert_eq!(dir, PathBuf::from("/mnt/models"));
+        match saved {
+            Some(v) => unsafe { std::env::set_var(MODEL_DIR_ENV, v) },
+            None => unsafe { std::env::remove_var(MODEL_DIR_ENV) },
+        }
+    }
+
+    #[cfg(not(feature = "semantic"))]
+    #[test]
+    fn build_default_returns_not_available_when_feature_off() {
+        let root = PathBuf::from("/tmp");
+        match build_default_embedder(&root) {
+            Err(EmbedError::NotAvailable(msg)) => assert!(msg.contains("semantic")),
+            other => panic!("expected NotAvailable, got {other:?}"),
+        }
+    }
+}

--- a/rust/services/search-plugin/src/fts_index.rs
+++ b/rust/services/search-plugin/src/fts_index.rs
@@ -56,7 +56,8 @@ use parking_lot::Mutex;
 use tantivy::collector::TopDocs;
 use tantivy::directory::MmapDirectory;
 use tantivy::query::QueryParser;
-use tantivy::schema::{Field, Schema, Value, STORED, STRING, TEXT};
+use tantivy::query::TermQuery;
+use tantivy::schema::{Field, IndexRecordOption, Schema, Value, STORED, STRING, TEXT};
 use tantivy::{doc, Index, IndexReader, IndexWriter, ReloadPolicy, TantivyDocument, Term};
 
 /// tantivy writer heap — 50 MiB is the conventional per-index budget
@@ -286,6 +287,29 @@ impl FtsIndex {
             }
         }
         Ok(hits)
+    }
+
+    /// Exact-path lookup — resolves a single doc by its `path`
+    /// field.  Uses a `TermQuery` against the STRING-indexed `path`
+    /// field so it doesn't depend on the BM25 tokenisation matching
+    /// the query text (which the older
+    /// `.search(basename, limit, Some(path))` shim did).  Returns
+    /// `None` when no doc has that exact path — no-op for callers
+    /// materialising ANN hits into the full QueryResult shape.
+    pub fn get_by_path(&self, path: &str) -> Result<Option<FtsHit>, IndexError> {
+        let searcher = self.reader.searcher();
+        let term = Term::from_field_text(self.fields.path, path);
+        let query = TermQuery::new(term, IndexRecordOption::Basic);
+        let top = searcher
+            .search(&query, &TopDocs::with_limit(1))
+            .map_err(|e| IndexError::Search(e.to_string()))?;
+        let Some((score, addr)) = top.into_iter().next() else {
+            return Ok(None);
+        };
+        let stored: TantivyDocument = searcher
+            .doc(addr)
+            .map_err(|e| IndexError::Search(e.to_string()))?;
+        Ok(Some(self.decode(stored, score)))
     }
 
     fn decode(&self, stored: TantivyDocument, score: f32) -> FtsHit {

--- a/rust/services/search-plugin/src/index_manager.rs
+++ b/rust/services/search-plugin/src/index_manager.rs
@@ -43,6 +43,7 @@ use std::sync::Arc;
 
 use parking_lot::Mutex;
 
+use crate::ann_index::{AnnError, AnnIndex};
 use crate::fts_index::{FtsIndex, IndexError};
 
 /// Directory name inside a per-zone index root for the FTS store.
@@ -67,14 +68,28 @@ pub fn default_root() -> PathBuf {
     data_dir.join("plugins/search")
 }
 
-/// Zone-id → `Arc<FtsIndex>` cache; lazily opens per-zone indices.
+/// Zone-id → `Arc<FtsIndex>` + `Arc<AnnIndex>` caches; lazily opens
+/// per-zone indices.  ANN indices are keyed by `(zone_id,
+/// embedder_tag)` so a model swap (D4) opens a new directory
+/// alongside the old one — the manager holds both in memory as
+/// long as either is referenced.
 pub struct IndexManager {
     root: PathBuf,
     zones: Mutex<HashMap<String, Arc<FtsIndex>>>,
+    ann_zones: Mutex<HashMap<AnnKey, Arc<AnnIndex>>>,
+}
+
+/// Cache key for the ANN index — one entry per `(zone, embedder tag)`.
+/// Different tags = different vector spaces, so a model swap gets its
+/// own cached handle without evicting the old one.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct AnnKey {
+    zone_id: String,
+    embedder_tag: String,
 }
 
 impl IndexManager {
-    /// Manager rooted at the platform default (`~/.nexus/plugins/search/`).
+    /// Manager rooted at the platform default (`$NEXUS_DATA_DIR/plugins/search/`).
     pub fn new() -> Self {
         Self::with_root(default_root())
     }
@@ -86,6 +101,7 @@ impl IndexManager {
         Self {
             root,
             zones: Mutex::new(HashMap::new()),
+            ann_zones: Mutex::new(HashMap::new()),
         }
     }
 
@@ -94,6 +110,19 @@ impl IndexManager {
     /// through [`get_or_open`].
     pub fn index_dir(&self, zone_id: &str) -> PathBuf {
         self.root.join(zone_id).join(FTS_SUBDIR)
+    }
+
+    /// Return the on-disk directory the given zone's ANN index lives
+    /// in for the given embedder tag.  Same shape as [`index_dir`]
+    /// but under `ann-<tag>-v1/`.  Version suffix is fixed at `v1`
+    /// for now; a future breaking change (schema of `sidecar.json`,
+    /// hnsw_rs upgrade that reads a different disk layout) bumps to
+    /// `v2` so the two live side-by-side and operators can roll
+    /// back.
+    pub fn ann_dir(&self, zone_id: &str, embedder_tag: &str) -> PathBuf {
+        self.root
+            .join(zone_id)
+            .join(format!("ann-{embedder_tag}-v1"))
     }
 
     /// Handle to the storage root — used by callers that need to
@@ -114,6 +143,33 @@ impl IndexManager {
         }
         let idx = FtsIndex::open_or_create(self.index_dir(zone_id))?;
         zones.insert(zone_id.to_string(), Arc::clone(&idx));
+        Ok(idx)
+    }
+
+    /// Fetch (or lazily open) the ANN index for `zone_id` under the
+    /// given embedder tag + dimensionality.  Cached per
+    /// `(zone, tag)` so multiple SemanticQuery calls reuse the same
+    /// on-disk graph.  `dim` must match the embedder that produced
+    /// the vectors in that graph — a mismatch on a fresh index seeds
+    /// the wrong dimensionality; on a reload, the underlying
+    /// [`AnnIndex::open_or_create`] trusts the caller (no runtime
+    /// check because hnsw_rs doesn't expose one).
+    pub fn get_or_open_ann(
+        &self,
+        zone_id: &str,
+        embedder_tag: &str,
+        dim: usize,
+    ) -> Result<Arc<AnnIndex>, AnnError> {
+        let key = AnnKey {
+            zone_id: zone_id.to_string(),
+            embedder_tag: embedder_tag.to_string(),
+        };
+        let mut zones = self.ann_zones.lock();
+        if let Some(idx) = zones.get(&key) {
+            return Ok(Arc::clone(idx));
+        }
+        let idx = AnnIndex::open_or_create(self.ann_dir(zone_id, embedder_tag), dim)?;
+        zones.insert(key, Arc::clone(&idx));
         Ok(idx)
     }
 }
@@ -188,6 +244,38 @@ mod tests {
             Some(v) => unsafe { std::env::set_var(DATA_DIR_ENV, v) },
             None => unsafe { std::env::remove_var(DATA_DIR_ENV) },
         }
+    }
+
+    #[test]
+    fn ann_dir_versioned_by_embedder_tag() {
+        // A model swap must NOT clobber the existing index — new tag
+        // = new directory alongside the old.  Manager holds both in
+        // memory as long as either is referenced.
+        let root = tempdir();
+        let mgr = IndexManager::with_root(root.clone());
+        let d_a = mgr.ann_dir("za", "mock");
+        let d_b = mgr.ann_dir("za", "mE5-small-v1");
+        assert_eq!(d_a, root.join("za/ann-mock-v1"));
+        assert_eq!(d_b, root.join("za/ann-mE5-small-v1-v1"));
+        assert_ne!(d_a, d_b);
+    }
+
+    #[test]
+    fn get_or_open_ann_caches_by_zone_and_tag() {
+        let root = tempdir();
+        let mgr = IndexManager::with_root(root);
+        let a1 = mgr.get_or_open_ann("za", "mock", 8).expect("open a-mock");
+        let a2 = mgr
+            .get_or_open_ann("za", "mock", 8)
+            .expect("re-open a-mock");
+        // Same (zone, tag) → same Arc.
+        assert!(Arc::ptr_eq(&a1, &a2));
+
+        // Different tag on same zone → different index.
+        let b = mgr
+            .get_or_open_ann("za", "other-tag", 8)
+            .expect("open other");
+        assert!(!Arc::ptr_eq(&a1, &b));
     }
 
     #[test]

--- a/rust/services/search-plugin/src/lib.rs
+++ b/rust/services/search-plugin/src/lib.rs
@@ -53,6 +53,7 @@ pub mod search_proto {
 }
 
 pub mod ann_index;
+pub mod embedder;
 pub mod fts_index;
 pub mod index_manager;
 pub mod kernel_io;

--- a/rust/services/search-plugin/src/lib.rs
+++ b/rust/services/search-plugin/src/lib.rs
@@ -52,6 +52,7 @@ pub mod search_proto {
     tonic::include_proto!("nexus.search.v1");
 }
 
+pub mod ann_index;
 pub mod fts_index;
 pub mod index_manager;
 pub mod kernel_io;

--- a/rust/services/search-plugin/src/service.rs
+++ b/rust/services/search-plugin/src/service.rs
@@ -11,8 +11,11 @@
 use std::sync::Arc;
 
 use nexus_plugin_abi::KernelHandle;
+use parking_lot::Mutex;
 use tonic::{async_trait, Request, Response, Status};
 
+use crate::ann_index::AnnHit;
+use crate::embedder::{build_default_embedder, EmbedError, Embedder};
 use crate::fts_index::FtsHit;
 use crate::index_manager::IndexManager;
 use crate::kernel_io::{self, DirEntry, KernelIoError, DT_DIR, DT_REG};
@@ -58,28 +61,80 @@ fn resolve_zone(z: &str) -> &str {
 
 pub struct SearchServiceImpl {
     handle: Arc<KernelHandle>,
-    /// Per-zone `FtsIndex` cache used by Query and Index.  Kept as
-    /// `Arc<IndexManager>` so tests can inject a manager rooted at a
-    /// tempdir instead of `~/.nexus/plugins/search/`.
+    /// Per-zone `FtsIndex` + `AnnIndex` caches used by Query, Index,
+    /// and SemanticQuery.  `Arc<IndexManager>` so tests can inject a
+    /// manager rooted at a tempdir instead of the default.
     manager: Arc<IndexManager>,
+    /// Lazy embedder slot.  `None` until the first SemanticQuery
+    /// attempts to initialise; `Some(Arc<dyn Embedder>)` on success.
+    /// Failed init leaves it `None` and is retried on the next call
+    /// so an operator setting `NEXUS_SEARCH_MODEL_DIR` mid-run
+    /// unblocks semantic search without a plugin restart.
+    embedder_slot: Arc<Mutex<Option<Arc<dyn Embedder>>>>,
 }
 
 impl SearchServiceImpl {
     /// Production constructor — index manager rooted at the platform
-    /// default (`~/.nexus/plugins/search/`).
+    /// default (`$NEXUS_DATA_DIR/plugins/search/`).  Embedder init
+    /// is deferred to the first SemanticQuery (D3).
     pub fn new(handle: Arc<KernelHandle>) -> Self {
         Self {
             handle,
             manager: Arc::new(IndexManager::new()),
+            embedder_slot: Arc::new(Mutex::new(None)),
         }
     }
 
     /// Test / operator constructor — inject a pre-configured
     /// `IndexManager` (typically rooted at a tempdir for tests, or
     /// at an explicit data volume for operators overriding the
-    /// default storage location).
+    /// default storage location).  Embedder init is deferred to the
+    /// first SemanticQuery.
     pub fn with_manager(handle: Arc<KernelHandle>, manager: Arc<IndexManager>) -> Self {
-        Self { handle, manager }
+        Self {
+            handle,
+            manager,
+            embedder_slot: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    /// Test / operator constructor — inject BOTH a pre-configured
+    /// `IndexManager` and an [`Embedder`].  Bypasses the
+    /// [`build_default_embedder`] discovery step so integration tests
+    /// can use a [`MockEmbedder`](crate::embedder::MockEmbedder)
+    /// without pointing at real model files.
+    pub fn with_manager_and_embedder(
+        handle: Arc<KernelHandle>,
+        manager: Arc<IndexManager>,
+        embedder: Arc<dyn Embedder>,
+    ) -> Self {
+        Self {
+            handle,
+            manager,
+            embedder_slot: Arc::new(Mutex::new(Some(embedder))),
+        }
+    }
+
+    /// Fetch (or lazily initialise) the embedder.  Fast path: read
+    /// the mutex, clone the Arc, return.  Slow path (first call, or
+    /// after a failed init): build via [`build_default_embedder`]
+    /// OUTSIDE the mutex so a 300 ms – 1 s ONNX session build does
+    /// not block concurrent Query / Index requests.  Two concurrent
+    /// first-callers duplicate work but both succeed — a rare cost
+    /// worth paying to keep the lock's critical section short.
+    fn get_or_init_embedder(&self) -> Result<Arc<dyn Embedder>, EmbedError> {
+        if let Some(e) = self.embedder_slot.lock().as_ref() {
+            return Ok(Arc::clone(e));
+        }
+        let data_root = self.manager.root().to_path_buf();
+        let built = build_default_embedder(&data_root)?;
+        // Race-check: another thread may have won.
+        let mut slot = self.embedder_slot.lock();
+        if let Some(existing) = slot.as_ref() {
+            return Ok(Arc::clone(existing));
+        }
+        *slot = Some(Arc::clone(&built));
+        Ok(built)
     }
 }
 
@@ -449,30 +504,16 @@ fn fetch_mtimes<'a>(
     out
 }
 
-// ── Query / Index (Phase 1) ───────────────────────────────────────
+// ── Query / SemanticQuery / Index ─────────────────────────────────
 
-/// Fetch (or open) the per-zone FtsIndex and run a BM25 keyword
-/// search.  P1 accepts `QueryType::Keyword` (or `Unspecified` as a
-/// safe default); other types are rejected with a caller-facing
-/// error string so P2/P3 can lift the gate additively.
-fn do_query(
+/// BM25 keyword search over the per-zone FTS index (Phase 1).
+fn do_keyword_query(
     manager: &IndexManager,
     q: &str,
     zone_id: &str,
     limit: usize,
     path_filter: &str,
-    query_type: QueryType,
 ) -> Result<Vec<QueryResult>, String> {
-    match query_type {
-        QueryType::Unspecified | QueryType::Keyword => {}
-        QueryType::Semantic => {
-            return Err("query_type=SEMANTIC not supported until P2".into());
-        }
-        QueryType::Hybrid => {
-            return Err("query_type=HYBRID not supported until P3".into());
-        }
-    }
-
     let index = manager
         .get_or_open(zone_id)
         .map_err(|e| format!("open index for zone {zone_id:?}: {e}"))?;
@@ -493,6 +534,100 @@ fn do_query(
         .collect())
 }
 
+/// Vector-similarity search over the per-zone HNSW index (Phase 2).
+/// Embeds `q` via the caller-supplied embedder, opens the ANN index
+/// tagged with the embedder's `tag()`, runs top-k, and materialises
+/// the FTS-stored fields (chunk_text, mtime_ms) so results carry the
+/// same shape as keyword hits.
+fn do_semantic_query(
+    manager: &IndexManager,
+    embedder: &Arc<dyn Embedder>,
+    q: &str,
+    zone_id: &str,
+    limit: usize,
+    path_filter: &str,
+) -> Result<Vec<QueryResult>, String> {
+    let ann = manager
+        .get_or_open_ann(zone_id, embedder.tag(), embedder.dim())
+        .map_err(|e| format!("open ann for zone {zone_id:?}: {e}"))?;
+
+    let query_vec = embedder
+        .embed_batch(&[q])
+        .map_err(|e| format!("embed query: {e}"))?
+        .into_iter()
+        .next()
+        .ok_or_else(|| "embed query: empty result".to_string())?;
+
+    // Over-fetch when a path prefix is set — the post-scoring
+    // filter would otherwise underfill the response.
+    let fetch = if path_filter.is_empty() {
+        limit
+    } else {
+        limit.saturating_mul(4).max(limit)
+    };
+    let ann_hits = ann
+        .search(&query_vec, fetch)
+        .map_err(|e| format!("ann search: {e}"))?;
+
+    // Materialise chunk_text + mtime via the FTS index — the ANN
+    // stores only vectors + paths, but the RPC contract carries the
+    // full QueryResult shape so callers don't need a follow-up read.
+    // A missing FTS row (drift scenario) leaves chunk_text empty;
+    // the path itself is still meaningful.
+    let fts = manager.get_or_open(zone_id).ok();
+
+    let mut out = Vec::with_capacity(limit);
+    for hit in ann_hits {
+        if !path_filter.is_empty() && !hit.path.starts_with(path_filter) {
+            continue;
+        }
+        out.push(enrich_ann_hit(fts.as_deref(), hit, zone_id));
+        if out.len() >= limit {
+            break;
+        }
+    }
+    Ok(out)
+}
+
+fn enrich_ann_hit(
+    fts: Option<&crate::fts_index::FtsIndex>,
+    hit: AnnHit,
+    zone_id: &str,
+) -> QueryResult {
+    // Score = 1 - cosine distance so higher = closer, matching the
+    // BM25 "higher is better" convention keyword callers already
+    // rely on.  ANN returns distance in [0, 2]; score falls in [-1, 1].
+    let score = 1.0 - hit.distance;
+    let (chunk_text, mtime_ms) = fts
+        .and_then(|f| lookup_fts_by_path(f, &hit.path))
+        .unwrap_or((String::new(), None));
+    QueryResult {
+        path: hit.path,
+        chunk_index: 0,
+        chunk_text,
+        score,
+        zone_id: zone_id.to_string(),
+        mtime_ms,
+    }
+}
+
+/// Look up an FTS row by exact path.  P4's chunker will add a
+/// proper indexed path-term lookup; today we run a keyword search
+/// with the path's basename as the query and the full path as the
+/// prefix filter — cheap because P1 is one-chunk-per-file so the
+/// path segments overlap the chunk_text field.  Returns `None` on
+/// miss (e.g. drift where ANN has the path but FTS was pruned).
+fn lookup_fts_by_path(
+    fts: &crate::fts_index::FtsIndex,
+    path: &str,
+) -> Option<(String, Option<i64>)> {
+    let basename = path.rsplit('/').next().unwrap_or(path);
+    let hits = fts.search(basename, 10, Some(path)).ok()?;
+    hits.into_iter()
+        .find(|h| h.path == path)
+        .map(|h| (h.chunk_text, h.mtime_ms))
+}
+
 fn fts_hit_to_result(hit: FtsHit, zone_id: &str) -> QueryResult {
     QueryResult {
         path: hit.path,
@@ -504,22 +639,58 @@ fn fts_hit_to_result(hit: FtsHit, zone_id: &str) -> QueryResult {
     }
 }
 
+/// Sinks the Index walker writes into.  `fts` is required (Index
+/// always populates the keyword index); `ann` + `embedder` are
+/// optional so a slim deployment or a mid-boot with no embedder
+/// still gets keyword search — semantic just returns zero hits
+/// until Index is retried with the embedder wired up.
+struct IndexSinks<'a> {
+    fts: &'a Arc<crate::fts_index::FtsIndex>,
+    ann: Option<&'a Arc<crate::ann_index::AnnIndex>>,
+    embedder: Option<&'a Arc<dyn Embedder>>,
+}
+
 /// Walk `root_path` and index every regular file.  Same walker Glob +
 /// Grep use — `sys_readdir` for enumeration, `sys_read` for content,
 /// `sys_stat` for mtime.  P1 = one chunk per file (path is the FTS
 /// primary key, `add_document` is idempotent so re-indexing replaces
 /// the prior doc); P4's chunker splits per file into multiple docs.
+///
+/// When `embedder` + `ann` are both present the walker also embeds
+/// the file's text and adds it to the vector index — semantic +
+/// keyword stay in sync from one call.  Missing embedder ⇒ FTS-only
+/// (log a debug once per Index call so operators see it).
 fn do_index(
     handle: &KernelHandle,
     manager: &IndexManager,
+    embedder: Option<&Arc<dyn Embedder>>,
     root_path: &str,
     zone_id: &str,
     recursive: bool,
     max_docs: usize,
 ) -> Result<(u32, u32), String> {
-    let index = manager
+    let fts = manager
         .get_or_open(zone_id)
         .map_err(|e| format!("open index for zone {zone_id:?}: {e}"))?;
+
+    // Only open the ANN if the embedder is around; otherwise we'd
+    // create an empty ann-* directory on disk that would confuse
+    // operators inspecting the layout.
+    let ann = if let Some(e) = embedder {
+        Some(
+            manager
+                .get_or_open_ann(zone_id, e.tag(), e.dim())
+                .map_err(|err| format!("open ann for zone {zone_id:?}: {err}"))?,
+        )
+    } else {
+        None
+    };
+
+    let sinks = IndexSinks {
+        fts: &fts,
+        ann: ann.as_ref(),
+        embedder,
+    };
 
     let mut indexed: u32 = 0;
     let mut skipped: u32 = 0;
@@ -532,7 +703,7 @@ fn do_index(
             if entry_type != DT_REG {
                 return WalkAction::Continue;
             }
-            match index_one(handle, &index, vfs_path) {
+            match index_one(handle, &sinks, vfs_path) {
                 IndexOne::Added => indexed += 1,
                 IndexOne::Skipped => skipped += 1,
             }
@@ -552,7 +723,7 @@ fn do_index(
                         continue;
                     }
                     let child = kernel_io::join_vfs_path(root_path, &entry.name);
-                    match index_one(handle, &index, &child) {
+                    match index_one(handle, &sinks, &child) {
                         IndexOne::Added => indexed += 1,
                         IndexOne::Skipped => skipped += 1,
                     }
@@ -563,12 +734,17 @@ fn do_index(
         }
     };
 
-    // Commit even on walker error so partial progress is durable —
-    // callers retry with a narrower root_path per D5 SSOT (the
-    // MetaStore `search.indexed_gen` sidecar lands in P5).
-    if let Err(e) = index.commit() {
-        tracing::warn!(err = %e, "index commit failed after walk");
-        return Err(format!("commit: {e}"));
+    // Commit BOTH sinks even on walker error so partial progress is
+    // durable — callers retry with a narrower root_path per D5 SSOT.
+    if let Err(e) = fts.commit() {
+        tracing::warn!(err = %e, "fts commit failed after walk");
+        return Err(format!("fts commit: {e}"));
+    }
+    if let Some(a) = ann.as_ref() {
+        if let Err(e) = a.commit() {
+            tracing::warn!(err = %e, "ann commit failed after walk");
+            return Err(format!("ann commit: {e}"));
+        }
     }
 
     visit_result?;
@@ -583,11 +759,7 @@ enum IndexOne {
     Skipped,
 }
 
-fn index_one(
-    handle: &KernelHandle,
-    index: &crate::fts_index::FtsIndex,
-    vfs_path: &str,
-) -> IndexOne {
+fn index_one(handle: &KernelHandle, sinks: &IndexSinks<'_>, vfs_path: &str) -> IndexOne {
     let bytes = match kernel_io::sys_read(handle, vfs_path) {
         Ok(b) => b,
         Err(e) => {
@@ -622,10 +794,39 @@ fn index_one(
         .ok()
         .and_then(|info| info.modified_at_ms);
 
-    if let Err(e) = index.add_document(vfs_path, 0, text, mtime_ms) {
-        tracing::warn!(path = %vfs_path, err = %e, "index: add_document failed — skipping");
+    if let Err(e) = sinks.fts.add_document(vfs_path, 0, text, mtime_ms) {
+        tracing::warn!(path = %vfs_path, err = %e, "index: fts add_document failed — skipping");
         return IndexOne::Skipped;
     }
+
+    // ANN side — best-effort.  A failure to embed / add does NOT
+    // fail the whole file; keyword still works, semantic just
+    // misses this doc until the next Index retries.  Real batching
+    // (embed 32 files at a time) lands in P4/P5 when the chunker
+    // makes it worthwhile.
+    if let (Some(ann), Some(embedder)) = (sinks.ann, sinks.embedder) {
+        match embedder.embed_batch(&[text]) {
+            Ok(mut vecs) => {
+                if let Some(v) = vecs.pop() {
+                    if let Err(e) = ann.add_vector(vfs_path, &v) {
+                        tracing::warn!(
+                            path = %vfs_path,
+                            err = %e,
+                            "index: ann add_vector failed — semantic misses this doc",
+                        );
+                    }
+                }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    path = %vfs_path,
+                    err = %e,
+                    "index: embed failed — semantic misses this doc",
+                );
+            }
+        }
+    }
+
     IndexOne::Added
 }
 
@@ -737,11 +938,35 @@ impl SearchService for SearchServiceImpl {
         let path_filter = req.path_filter;
         let query_type = QueryType::try_from(req.query_type).unwrap_or(QueryType::Unspecified);
         let manager = Arc::clone(&self.manager);
-        let outcome = tokio::task::spawn_blocking(move || {
-            do_query(&manager, &q, &zone_id, limit, &path_filter, query_type)
-        })
-        .await
-        .map_err(|e| Status::internal(format!("spawn_blocking joined error: {e}")))?;
+
+        let outcome = match query_type {
+            QueryType::Unspecified | QueryType::Keyword => tokio::task::spawn_blocking(move || {
+                do_keyword_query(&manager, &q, &zone_id, limit, &path_filter)
+            })
+            .await
+            .map_err(|e| Status::internal(format!("spawn_blocking joined error: {e}")))?,
+            QueryType::Semantic => {
+                // Initialise the embedder BEFORE spawn_blocking so a
+                // Load / NotAvailable error surfaces synchronously
+                // with an actionable message instead of getting
+                // wrapped as an opaque JoinError.
+                let embedder = match self.get_or_init_embedder() {
+                    Ok(e) => e,
+                    Err(e) => {
+                        return Ok(Response::new(QueryResponse {
+                            results: Vec::new(),
+                            error: Some(format!("semantic unavailable: {e}")),
+                        }));
+                    }
+                };
+                tokio::task::spawn_blocking(move || {
+                    do_semantic_query(&manager, &embedder, &q, &zone_id, limit, &path_filter)
+                })
+                .await
+                .map_err(|e| Status::internal(format!("spawn_blocking joined error: {e}")))?
+            }
+            QueryType::Hybrid => Err("query_type=HYBRID not supported until P3".into()),
+        };
 
         match outcome {
             Ok(results) => Ok(Response::new(QueryResponse {
@@ -774,8 +999,22 @@ impl SearchService for SearchServiceImpl {
         };
         let handle = Arc::clone(&self.handle);
         let manager = Arc::clone(&self.manager);
+        // Best-effort embedder init.  A NotAvailable / Load error
+        // does NOT fail Index — keyword indexing runs anyway, ANN
+        // just stays empty until an operator wires the embedder up
+        // and re-runs Index.  This matches the "graceful degradation"
+        // posture SemanticQuery uses.
+        let embedder = self.get_or_init_embedder().ok();
         let outcome = tokio::task::spawn_blocking(move || {
-            do_index(&handle, &manager, &root, &zone_id, recursive, max_docs)
+            do_index(
+                &handle,
+                &manager,
+                embedder.as_ref(),
+                &root,
+                &zone_id,
+                recursive,
+                max_docs,
+            )
         })
         .await
         .map_err(|e| Status::internal(format!("spawn_blocking joined error: {e}")))?;

--- a/rust/services/search-plugin/src/service.rs
+++ b/rust/services/search-plugin/src/service.rs
@@ -611,20 +611,18 @@ fn enrich_ann_hit(
     }
 }
 
-/// Look up an FTS row by exact path.  P4's chunker will add a
-/// proper indexed path-term lookup; today we run a keyword search
-/// with the path's basename as the query and the full path as the
-/// prefix filter — cheap because P1 is one-chunk-per-file so the
-/// path segments overlap the chunk_text field.  Returns `None` on
-/// miss (e.g. drift where ANN has the path but FTS was pruned).
+/// Look up an FTS row by exact path via the STRING-indexed `path`
+/// field's `TermQuery` (see `FtsIndex::get_by_path`).  Returns
+/// `None` on miss (e.g. drift where ANN has the path but FTS was
+/// pruned).  Cheap term-lookup — does not depend on the BM25
+/// tokenisation matching any part of the path.
 fn lookup_fts_by_path(
     fts: &crate::fts_index::FtsIndex,
     path: &str,
 ) -> Option<(String, Option<i64>)> {
-    let basename = path.rsplit('/').next().unwrap_or(path);
-    let hits = fts.search(basename, 10, Some(path)).ok()?;
-    hits.into_iter()
-        .find(|h| h.path == path)
+    fts.get_by_path(path)
+        .ok()
+        .flatten()
         .map(|h| (h.chunk_text, h.mtime_ms))
 }
 

--- a/rust/services/search-plugin/tests/query_e2e.rs
+++ b/rust/services/search-plugin/tests/query_e2e.rs
@@ -256,7 +256,15 @@ async fn query_empty_q_returns_error_not_500() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn query_semantic_type_rejected_with_p2_message() {
+async fn query_semantic_gracefully_degrades_when_no_embedder() {
+    // Post-P2: SEMANTIC is a supported query_type but requires an
+    // embedder.  The default Harness uses `with_manager` (no
+    // embedder pre-injected) → build_default_embedder tries and
+    // fails because NEXUS_SEARCH_MODEL_DIR / ORT_DYLIB_PATH aren't
+    // set in the test env.  The RPC must return a clean error
+    // ("semantic unavailable: ...") rather than 500 or hang — that
+    // preserves the D2 graceful-degradation contract: keyword still
+    // works when semantic is unwired.
     let h = Harness::start();
     let resp = h
         .svc
@@ -272,11 +280,12 @@ async fn query_semantic_type_rejected_with_p2_message() {
         .expect("query")
         .into_inner();
 
-    let err = resp.error.expect("semantic must be rejected in P1");
+    let err = resp.error.expect("semantic without embedder must error, not succeed");
     assert!(
-        err.contains("P2"),
-        "semantic rejection should mention P2, got: {err:?}",
+        err.contains("semantic unavailable"),
+        "semantic degradation message should mention unavailability, got: {err:?}",
     );
+    assert!(resp.results.is_empty(), "no results when unavailable");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/rust/services/search-plugin/tests/query_e2e.rs
+++ b/rust/services/search-plugin/tests/query_e2e.rs
@@ -280,7 +280,9 @@ async fn query_semantic_gracefully_degrades_when_no_embedder() {
         .expect("query")
         .into_inner();
 
-    let err = resp.error.expect("semantic without embedder must error, not succeed");
+    let err = resp
+        .error
+        .expect("semantic without embedder must error, not succeed");
     assert!(
         err.contains("semantic unavailable"),
         "semantic degradation message should mention unavailability, got: {err:?}",

--- a/rust/services/search-plugin/tests/semantic_query_e2e.rs
+++ b/rust/services/search-plugin/tests/semantic_query_e2e.rs
@@ -315,6 +315,12 @@ async fn semantic_finds_exact_match_after_index() {
     let h = Harness::start();
     let mock = h.mock_mut();
     mock.add_dir("/");
+    // Splice /notes into / explicitly — MockKernel's add_file only
+    // registers the file with its own parent, it doesn't chain up
+    // to the grandparent, so the walker at / never sees /notes
+    // without this call.  index_e2e.rs's nested walk test has the
+    // same shape.
+    mock.add_dir("/notes");
     mock.add_file("/notes/alpha.md", b"widget alpha payload", 1);
     mock.add_file("/notes/beta.md", b"orange banana grape", 2);
     mock.add_file("/notes/gamma.md", b"widget alpha payload extra", 3);

--- a/rust/services/search-plugin/tests/semantic_query_e2e.rs
+++ b/rust/services/search-plugin/tests/semantic_query_e2e.rs
@@ -1,0 +1,500 @@
+//! End-to-end integration test for the SemanticQuery path (P2 step 4).
+//!
+//! Sibling of `query_e2e.rs` (keyword) and `index_e2e.rs` (Index).
+//! Exercises the full RPC handler → \[do_semantic_query\] →
+//! \[Embedder.embed_batch\] → \[AnnIndex.search\] → \[QueryResult\]
+//! roundtrip using an injected \[MockEmbedder\] so the test never
+//! downloads a real model or links ONNX Runtime.
+//!
+//! Coverage:
+//! - happy path: index some files (Index RPC populates both FTS +
+//!   ANN via the same MockEmbedder), then SemanticQuery for one
+//!   file's text — the seed file must come back first at score ≈ 1
+//! - path-prefix filter
+//! - re-index idempotency also holds on the ANN side (no
+//!   duplicated hits for the same path)
+//! - empty q → clean error
+//! - zone isolation on ANN (a mirror of the FTS isolation test in
+//!   query_e2e.rs)
+//!
+//! The MockEmbedder is deterministic per text (same text → same
+//! vector → cosine distance 0), which is exactly the shape a
+//! "user searches for a phrase in a doc they just indexed" flow
+//! wants to pin at the E2E level.
+
+use std::collections::HashMap;
+use std::ffi::{c_void, CStr};
+use std::os::raw::c_char;
+use std::sync::Arc;
+
+use nexus_plugin_abi::KernelHandle;
+use nexus_search_plugin::embedder::MockEmbedder;
+use nexus_search_plugin::index_manager::IndexManager;
+use nexus_search_plugin::search_proto::search_service_server::SearchService;
+use nexus_search_plugin::search_proto::{IndexRequest, QueryRequest, QueryType};
+use nexus_search_plugin::service::SearchServiceImpl;
+use tempfile::TempDir;
+use tonic::Request;
+
+// ── Mock kernel (same shape as index_e2e.rs) ────────────────────
+//
+// Duplicated inline rather than extracted to tests/common because
+// Cargo's shared-test-module story requires each caller to
+// `mod common;` and the extra plumbing costs more than the
+// duplication does at this size.  P4/P5 can consolidate if a third
+// integration test wants the same scaffold.
+
+struct FileEntry {
+    bytes: Vec<u8>,
+    mtime_ms: i64,
+}
+
+pub struct MockKernel {
+    files: HashMap<String, FileEntry>,
+    dirs: HashMap<String, Vec<(String, u8)>>,
+}
+
+impl MockKernel {
+    fn new() -> Self {
+        Self {
+            files: HashMap::new(),
+            dirs: HashMap::new(),
+        }
+    }
+    fn add_file(&mut self, path: &str, bytes: &[u8], mtime_ms: i64) {
+        self.files.insert(
+            path.to_string(),
+            FileEntry {
+                bytes: bytes.to_vec(),
+                mtime_ms,
+            },
+        );
+        let (parent, name) = split_parent(path);
+        self.dirs
+            .entry(parent)
+            .or_default()
+            .push((name, 0 /* DT_REG */));
+    }
+    fn add_dir(&mut self, path: &str) {
+        if !self.dirs.contains_key(path) {
+            self.dirs.insert(path.to_string(), Vec::new());
+        }
+        if path == "/" {
+            return;
+        }
+        let (parent, name) = split_parent(path);
+        let entries = self.dirs.entry(parent).or_default();
+        if !entries.iter().any(|(n, _)| n == &name) {
+            entries.push((name, 1 /* DT_DIR */));
+        }
+    }
+}
+
+fn split_parent(path: &str) -> (String, String) {
+    match path.rsplit_once('/') {
+        Some(("", name)) => ("/".to_string(), name.to_string()),
+        Some((parent, name)) => (parent.to_string(), name.to_string()),
+        None => ("/".to_string(), path.to_string()),
+    }
+}
+
+fn into_out_buf(mut v: Vec<u8>, out_buf: *mut *mut u8, out_len: *mut usize) {
+    v.shrink_to_fit();
+    let len = v.len();
+    let ptr = v.as_mut_ptr();
+    std::mem::forget(v);
+    unsafe {
+        *out_buf = ptr;
+        *out_len = len;
+    }
+}
+
+unsafe extern "C" fn mock_sys_read(
+    k: *const c_void,
+    path: *const c_char,
+    out_buf: *mut *mut u8,
+    out_len: *mut usize,
+) -> i32 {
+    let kernel = &*(k as *const MockKernel);
+    let p = match CStr::from_ptr(path).to_str() {
+        Ok(s) => s,
+        Err(_) => return -2,
+    };
+    match kernel.files.get(p) {
+        Some(entry) => {
+            into_out_buf(entry.bytes.clone(), out_buf, out_len);
+            0
+        }
+        None => -404,
+    }
+}
+
+unsafe extern "C" fn mock_sys_readdir(
+    k: *const c_void,
+    parent_path: *const c_char,
+    out_json: *mut *mut u8,
+    out_len: *mut usize,
+) -> i32 {
+    let kernel = &*(k as *const MockKernel);
+    let p = match CStr::from_ptr(parent_path).to_str() {
+        Ok(s) => s,
+        Err(_) => return -2,
+    };
+    match kernel.dirs.get(p) {
+        Some(entries) => {
+            let payload: Vec<serde_json::Value> = entries
+                .iter()
+                .map(|(name, et)| serde_json::json!({ "name": name, "entry_type": et }))
+                .collect();
+            let json = serde_json::to_vec(&payload).expect("mock readdir json");
+            into_out_buf(json, out_json, out_len);
+            0
+        }
+        None => -404,
+    }
+}
+
+unsafe extern "C" fn mock_sys_stat(
+    k: *const c_void,
+    path: *const c_char,
+    out_json: *mut *mut u8,
+    out_len: *mut usize,
+) -> i32 {
+    let kernel = &*(k as *const MockKernel);
+    let p = match CStr::from_ptr(path).to_str() {
+        Ok(s) => s,
+        Err(_) => return -2,
+    };
+    if let Some(entry) = kernel.files.get(p) {
+        let payload = serde_json::json!({
+            "path": p,
+            "entry_type": 0,
+            "size": entry.bytes.len(),
+            "zone_id": "root",
+            "modified_at_ms": entry.mtime_ms,
+        });
+        into_out_buf(serde_json::to_vec(&payload).unwrap(), out_json, out_len);
+        0
+    } else if kernel.dirs.contains_key(p) {
+        let payload = serde_json::json!({
+            "path": p,
+            "entry_type": 1,
+            "size": 0,
+            "zone_id": "root",
+            "modified_at_ms": null,
+        });
+        into_out_buf(serde_json::to_vec(&payload).unwrap(), out_json, out_len);
+        0
+    } else {
+        -404
+    }
+}
+
+unsafe extern "C" fn unused_sys_write(
+    _: *const c_void,
+    _: *const c_char,
+    _: *const u8,
+    _: usize,
+) -> i32 {
+    -1
+}
+unsafe extern "C" fn unused_sys_unlink(_: *const c_void, _: *const c_char) -> i32 {
+    -1
+}
+unsafe extern "C" fn unused_sys_mkdir(_: *const c_void, _: *const c_char) -> i32 {
+    -1
+}
+unsafe extern "C" fn unused_sys_rmdir(_: *const c_void, _: *const c_char) -> i32 {
+    -1
+}
+unsafe extern "C" fn unused_sys_rename(
+    _: *const c_void,
+    _: *const c_char,
+    _: *const c_char,
+) -> i32 {
+    -1
+}
+unsafe extern "C" fn unused_sys_stat_batch(
+    _: *const c_void,
+    _: *const c_char,
+    _: *mut *mut u8,
+    _: *mut usize,
+) -> i32 {
+    -1
+}
+
+fn handle_for(kernel: *const MockKernel) -> KernelHandle {
+    KernelHandle {
+        sys_read: mock_sys_read,
+        sys_write: unused_sys_write,
+        sys_stat: mock_sys_stat,
+        sys_readdir: mock_sys_readdir,
+        sys_unlink: unused_sys_unlink,
+        sys_mkdir: unused_sys_mkdir,
+        sys_rmdir: unused_sys_rmdir,
+        sys_rename: unused_sys_rename,
+        sys_stat_batch: unused_sys_stat_batch,
+        kernel_ptr: kernel as *const c_void,
+    }
+}
+
+// ── Harness ─────────────────────────────────────────────────────
+
+struct Harness {
+    _dir: TempDir,
+    mock: *mut MockKernel,
+    svc: SearchServiceImpl,
+}
+
+impl Harness {
+    /// Start with a MockEmbedder pre-injected so SemanticQuery is
+    /// functional without needing NEXUS_SEARCH_MODEL_DIR / ort dylib.
+    /// Uses a small (16-dim) mock so assertion output stays readable.
+    fn start() -> Self {
+        let dir = TempDir::new().expect("tempdir");
+        let mock = Box::into_raw(Box::new(MockKernel::new()));
+        let handle = handle_for(mock);
+        let manager = Arc::new(IndexManager::with_root(dir.path().to_path_buf()));
+        let embedder = Arc::new(MockEmbedder::with_dim(16));
+        let svc = SearchServiceImpl::with_manager_and_embedder(Arc::new(handle), manager, embedder);
+        Self {
+            _dir: dir,
+            mock,
+            svc,
+        }
+    }
+
+    fn mock_mut(&self) -> &mut MockKernel {
+        unsafe { &mut *self.mock }
+    }
+}
+
+impl Drop for Harness {
+    fn drop(&mut self) {
+        unsafe {
+            drop(Box::from_raw(self.mock));
+        }
+    }
+}
+
+async fn index_root(svc: &SearchServiceImpl) -> nexus_search_plugin::search_proto::IndexResponse {
+    svc.index(Request::new(IndexRequest {
+        root_path: "/".into(),
+        zone_id: "root".into(),
+        recursive: true,
+        max_docs: 0,
+        auth_token: String::new(),
+    }))
+    .await
+    .expect("index")
+    .into_inner()
+}
+
+async fn semantic_query(
+    svc: &SearchServiceImpl,
+    q: &str,
+    path_filter: &str,
+) -> nexus_search_plugin::search_proto::QueryResponse {
+    svc.query(Request::new(QueryRequest {
+        q: q.into(),
+        zone_id: "root".into(),
+        limit: 10,
+        path_filter: path_filter.into(),
+        query_type: QueryType::Semantic as i32,
+        auth_token: String::new(),
+    }))
+    .await
+    .expect("query")
+    .into_inner()
+}
+
+// ── Tests ───────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn semantic_finds_exact_match_after_index() {
+    let h = Harness::start();
+    let mock = h.mock_mut();
+    mock.add_dir("/");
+    mock.add_file("/notes/alpha.md", b"widget alpha payload", 1);
+    mock.add_file("/notes/beta.md", b"orange banana grape", 2);
+    mock.add_file("/notes/gamma.md", b"widget alpha payload extra", 3);
+
+    let idx = index_root(&h.svc).await;
+    assert!(
+        idx.error.is_none(),
+        "unexpected index error: {:?}",
+        idx.error
+    );
+    assert_eq!(idx.indexed_count, 3);
+
+    // Query for the EXACT text of /notes/alpha.md — mock embedder
+    // is deterministic per text, so distance is 0 and score = 1.
+    let q = semantic_query(&h.svc, "widget alpha payload", "").await;
+    assert!(
+        q.error.is_none(),
+        "unexpected semantic error: {:?}",
+        q.error
+    );
+    assert!(!q.results.is_empty(), "expected at least one hit");
+    assert_eq!(q.results[0].path, "/notes/alpha.md");
+    // Score ≈ 1 for the exact-text match (mock embed distance ≈ 0
+    // → score = 1 - distance ≈ 1).
+    assert!(
+        (q.results[0].score - 1.0).abs() < 0.001,
+        "exact-text hit should score ≈ 1, got {}",
+        q.results[0].score,
+    );
+    // FTS enrichment brings back chunk_text from the sibling index.
+    assert_eq!(q.results[0].chunk_text, "widget alpha payload");
+    // mtime survives the roundtrip.
+    assert_eq!(q.results[0].mtime_ms, Some(1));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn semantic_honours_path_prefix_filter() {
+    let h = Harness::start();
+    let mock = h.mock_mut();
+    mock.add_dir("/");
+    mock.add_dir("/notes");
+    mock.add_dir("/logs");
+    mock.add_file("/notes/a.md", b"shared query text", 1);
+    mock.add_file("/logs/b.log", b"shared query text", 2);
+
+    let idx = index_root(&h.svc).await;
+    assert!(idx.error.is_none(), "{idx:?}");
+
+    let q = semantic_query(&h.svc, "shared query text", "/notes/").await;
+    assert!(q.error.is_none(), "{q:?}");
+    let paths: Vec<&str> = q.results.iter().map(|r| r.path.as_str()).collect();
+    assert!(
+        !paths.is_empty(),
+        "prefix filter dropped every hit: {paths:?}"
+    );
+    assert!(
+        paths.iter().all(|p| p.starts_with("/notes/")),
+        "prefix filter leaked non-/notes/ paths: {paths:?}",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn semantic_reindex_stays_idempotent() {
+    // Same D3 idempotency contract the FTS + ANN primitives assert
+    // individually — pin at the RPC handler that a repeat Index
+    // does NOT duplicate the doc in either backing store.
+    let h = Harness::start();
+    let mock = h.mock_mut();
+    mock.add_dir("/");
+    mock.add_file("/x.md", b"unique widget marker", 1);
+
+    for _ in 0..2 {
+        let r = index_root(&h.svc).await;
+        assert!(r.error.is_none(), "{r:?}");
+        assert_eq!(r.indexed_count, 1);
+    }
+
+    let q = semantic_query(&h.svc, "unique widget marker", "").await;
+    assert!(q.error.is_none(), "{q:?}");
+    let matches: Vec<&str> = q.results.iter().map(|r| r.path.as_str()).collect();
+    assert_eq!(
+        matches.iter().filter(|p| **p == "/x.md").count(),
+        1,
+        "reindex duplicated the doc in semantic results: {matches:?}",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn semantic_empty_query_returns_error() {
+    let h = Harness::start();
+    let mock = h.mock_mut();
+    mock.add_dir("/");
+    mock.add_file("/x.md", b"seed", 1);
+    let _ = index_root(&h.svc).await;
+
+    let q = h
+        .svc
+        .query(Request::new(QueryRequest {
+            q: String::new(),
+            zone_id: "root".into(),
+            limit: 10,
+            path_filter: String::new(),
+            query_type: QueryType::Semantic as i32,
+            auth_token: String::new(),
+        }))
+        .await
+        .expect("query")
+        .into_inner();
+
+    assert!(q.error.is_some(), "empty q must return error");
+    assert!(q.results.is_empty());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn semantic_zone_isolation_holds() {
+    // D3 storage-layer isolation, mirrored for the ANN path.  A
+    // semantic query scoped to zone-a must not see zone-b's corpus,
+    // regardless of how the mock embeds shared text.
+    let dir = TempDir::new().expect("tempdir");
+    let mock = Box::into_raw(Box::new(MockKernel::new()));
+    let handle = handle_for(mock);
+    // Seed BOTH zones with shared text.
+    unsafe {
+        (*mock).add_dir("/");
+        (*mock).add_file("/only-in-a.md", b"shared widget", 1);
+        (*mock).add_file("/only-in-b.md", b"shared widget", 2);
+    }
+    let manager = Arc::new(IndexManager::with_root(dir.path().to_path_buf()));
+    let embedder = Arc::new(MockEmbedder::with_dim(16));
+    let svc = SearchServiceImpl::with_manager_and_embedder(Arc::new(handle), manager, embedder);
+
+    // Index into zone-a only.
+    let idx_a = svc
+        .index(Request::new(IndexRequest {
+            root_path: "/only-in-a.md".into(),
+            zone_id: "zone-a".into(),
+            recursive: false,
+            max_docs: 0,
+            auth_token: String::new(),
+        }))
+        .await
+        .expect("index-a")
+        .into_inner();
+    // Non-recursive on a single file path — the walker enumerates
+    // its parent's direct children; the mock puts only-in-a.md at
+    // /, so pointing recursive=false at the file itself yields 0.
+    // Fall back to indexing the whole root with recursive=true and
+    // scoping the query by path_filter later.
+    let _ = idx_a;
+    let idx_a = svc
+        .index(Request::new(IndexRequest {
+            root_path: "/".into(),
+            zone_id: "zone-a".into(),
+            recursive: true,
+            max_docs: 0,
+            auth_token: String::new(),
+        }))
+        .await
+        .expect("index-a-root")
+        .into_inner();
+    assert!(idx_a.error.is_none(), "{idx_a:?}");
+
+    let q = svc
+        .query(Request::new(QueryRequest {
+            q: "shared widget".into(),
+            zone_id: "zone-a".into(),
+            limit: 10,
+            path_filter: String::new(),
+            query_type: QueryType::Semantic as i32,
+            auth_token: String::new(),
+        }))
+        .await
+        .expect("query")
+        .into_inner();
+    assert!(q.error.is_none(), "{q:?}");
+    for r in &q.results {
+        assert_eq!(r.zone_id, "zone-a", "zone-b bled into zone-a: {r:?}");
+    }
+
+    unsafe {
+        drop(Box::from_raw(mock));
+    }
+}

--- a/tests/e2e/docker/test_search_plugin.py
+++ b/tests/e2e/docker/test_search_plugin.py
@@ -311,16 +311,19 @@ class TestSearchIndexQuery:
             f"reindex must not duplicate the doc; got {r['result']['results']}"
         )
 
-    def test_query_semantic_rejected_with_p2_message(self, api_key: str) -> None:
-        """Non-keyword query_type must fail loudly in P1 with a phase hint.
-
-        Locks the contract Phase 2 will lift — a silent fall-through to
-        keyword ranking would silently mis-serve callers who expected
-        vector recall.
+    def test_query_semantic_gracefully_degrades_without_embedder(self, api_key: str) -> None:
+        """Post-P2: SEMANTIC is a supported query_type but requires a
+        loaded embedder. When the docker image is not shipped with a
+        model + onnxruntime dylib (which is the current CI shape —
+        model bundling is a P8 concern), SemanticQuery must return
+        a clean "semantic unavailable" error, NOT crash or hang.
+        Preserves the D2 graceful-degradation contract.
         """
         r = search_query(NODE_GRPC, "widget", query_type="semantic", api_key=api_key)
-        assert "error" in r, f"semantic must be rejected in P1, got {r}"
-        assert "P2" in r["error"], f"semantic rejection should mention P2, got {r}"
+        assert "error" in r, f"semantic without embedder must error, got {r}"
+        assert "semantic unavailable" in r["error"], (
+            f"semantic degradation message should mention unavailability, got {r}"
+        )
 
     def test_query_hybrid_rejected_with_p3_message(self, api_key: str) -> None:
         r = search_query(NODE_GRPC, "widget", query_type="hybrid", api_key=api_key)


### PR DESCRIPTION
## Summary

Phase 2 of the Python-parity roadmap (\`rust/services/search-plugin/PARITY_ROADMAP.md\`).
Adds semantic (vector-similarity) search alongside the P1 keyword
path. Ships in commits so review can walk the storage primitive →
embedder trait → orchestration in order.

**Status: DRAFT** — Step 1 (AnnIndex primitive) landed. Embedder
trait + FastEmbedder wrapper + SemanticQuery RPC wiring + integration
tests + docker E2E gate come in the remaining commits.

## Step 1 (this commit): AnnIndex primitive

- **hnsw_rs 0.3** + **anndists** (cosine distance). Pure Rust, no C
  deps — lives in the plugin cdylib only, cluster core untouched
  per D1.
- Idempotent add via shadow-set (hnsw_rs has no delete primitive).
- Per-zone layout: \`<root>/<zone_id>/ann-<model>-<version>/\`
  with \`hnsw.hnsw.graph\` + \`hnsw.hnsw.data\` + \`sidecar.json\`.
- 7 unit tests: empty-open, nearest-neighbour, dim/zero rejection,
  re-add shadow, restart survival, top-k bound.

## What's coming in the remaining commits

- **Step 2**: \`Embedder\` trait + \`MockEmbedder\` (tests) +
  feature-gated \`FastEmbedder\` (fastembed-rs 5 with ort
  \`load-dynamic\`).
- **Step 3**: \`IndexManager.get_or_open_ann(zone)\` + wire
  \`SemanticQuery\` in \`service.rs\`. \`do_index\` grows to embed +
  add-to-ANN under the \`semantic\` feature.
- **Step 4**: \`semantic_query_e2e.rs\` integration test (mock
  embedder, no model download needed). Docker E2E extended.
- **Step 5**: model + dylib discovery (env vars per D1) + graceful
  degradation (keyword still works when semantic dep is absent).

## Design decisions (all locked in PARITY_ROADMAP.md and prior audit)

- **D1 storage**: HNSW + tantivy inside plugin cdylib
- **D2 dylib missing**: graceful — SemanticQuery errors, Query
  (keyword) keeps working
- **D3 cold-start**: \`Arc<OnceCell>\` lazy embedder init on first
  SemanticQuery
- **D4 model versioning**: index dir tags model + version, swap =
  new dir alongside old

## Marked draft because

Only the storage primitive lands here; SemanticQuery still returns
\"not supported until P2\" until step 3. Reviewing the AnnIndex
schema + concurrency contract before the orchestration lands means
a wrong direction costs one commit not the whole phase.