### PR TITLE
feat(search-plugin): Phase 3 — hybrid fusion (RRF + weighted + pooling) [WIP]

### DIFF
--- a/rust/services/proto/nexus/search/v1/search.proto
+++ b/rust/services/proto/nexus/search/v1/search.proto
@@ -163,6 +163,22 @@ enum QueryType {
   QUERY_TYPE_HYBRID = 3;       // keyword + vector, fused (P3)
 }
 
+// Fusion method for hybrid queries (Phase 3).  Semantics match the
+// Python SearchDaemon (#4541):
+//
+// - RRF: reciprocal-rank fusion, `score = Σ 1 / (k + rank_i)` across
+//   the two sources.  Rank-based, no score normalisation needed.
+// - WEIGHTED: min-max normalise each source's scores to [0, 1], then
+//   `score = (1 - alpha) * keyword + alpha * semantic`.
+// - RRF_WEIGHTED: same shape as RRF but each source's contribution
+//   is scaled by (1 - alpha) / alpha respectively.
+enum FusionMethod {
+  FUSION_METHOD_UNSPECIFIED = 0;  // treated as RRF
+  FUSION_METHOD_RRF = 1;
+  FUSION_METHOD_WEIGHTED = 2;
+  FUSION_METHOD_RRF_WEIGHTED = 3;
+}
+
 message QueryRequest {
   // Query text.  BM25 tokenization is applied by tantivy's default
   // analyzer (lowercasing + simple tokenizer).
@@ -192,6 +208,31 @@ message QueryRequest {
   // trusts that whoever passed the zone_id already checked read
   // permission.
   string auth_token = 6;
+
+  // ── Hybrid fusion knobs (P3) ───────────────────────────────────
+  // Semantic-vs-keyword weight for WEIGHTED / RRF_WEIGHTED.
+  // Range [0.0, 1.0]; 0.0 = pure keyword, 1.0 = pure semantic, 0.5
+  // = balanced.  Ignored for KEYWORD / SEMANTIC / RRF where the
+  // sources are equally weighted or single-sourced.  0.0 default
+  // maps to alpha=0.5 on the plugin side so a caller who forgets
+  // the field gets the balanced blend, matching Python.
+  float alpha = 7;
+
+  // Fusion algorithm — see the `FusionMethod` enum for semantics.
+  FusionMethod fusion_method = 8;
+
+  // RRF rank constant.  60 is the paper's canonical value and what
+  // Python defaults to; higher values flatten the ranking curve.
+  // 0 ⇒ server-side default (60).
+  uint32 rrf_k = 9;
+
+  // Per-document chunk cap for final-list pooling (#4542).  Prevents
+  // one long file from monopolising the top-N when its per-chunk
+  // scores dominate multiple result slots.  0 ⇒ no pooling (backward-
+  // compatible with the pre-P3 shape).  P1-P3 emit one chunk per
+  // file so pooling is a no-op at those phases; P4's real chunker
+  // makes it meaningful.
+  uint32 chunks_per_page = 10;
 }
 
 message QueryResult {

--- a/rust/services/search-plugin/src/fusion.rs
+++ b/rust/services/search-plugin/src/fusion.rs
@@ -1,0 +1,434 @@
+//! Hybrid-fusion primitives combining keyword (BM25) + semantic
+//! (vector cosine) result lists into one ranked output (Phase 3 of
+//! the Python-parity roadmap; see `PARITY_ROADMAP.md`).
+//!
+//! The three fusion algorithms mirror Python `SearchDaemon`'s
+//! `#4541` fusion-params delta — semantics and default tunings match
+//! so cross-cutover results stay comparable.
+//!
+//! # Algorithms
+//!
+//! **RRF (reciprocal-rank fusion)** — the default.
+//! ```text
+//! score(doc) = Σ_{source s} 1 / (k + rank_s(doc))
+//! ```
+//! where `rank_s(doc)` is 1-indexed within source `s`.  Rank-based, so
+//! no cross-source score-normalisation is needed.  Robust to sources
+//! with wildly different score distributions (BM25 unbounded vs
+//! cosine in [-1, 1]).  Standard `k = 60` per the original paper.
+//!
+//! **WEIGHTED** — linear blend on min-max-normalised scores.
+//! ```text
+//! score(doc) = (1 - alpha) * kw_norm(doc) + alpha * sem_norm(doc)
+//! ```
+//! where `kw_norm` / `sem_norm` are per-source min-max scaled to
+//! [0, 1].  Requires normalisation because BM25 and cosine live in
+//! different ranges.
+//!
+//! **RRF_WEIGHTED** — RRF with per-source weights.  Same shape as
+//! RRF but each source's contribution is scaled by `(1 - alpha) /
+//! alpha`.  Rarely materially different from RRF in practice; kept
+//! for callers coming from Python parity.
+//!
+//! # Pooling
+//!
+//! [`pool_by_document`] enforces the per-doc chunk cap (#4542) —
+//! prevents one long file from monopolising the top-N when its
+//! per-chunk BM25 or cosine scores dominate multiple result slots.
+//! P1-P3 emit one chunk per file so pooling is a no-op; the wire
+//! + code path lands here so P4's real chunker just needs to bump
+//! `chunk_index` values.
+
+use std::collections::HashMap;
+
+use crate::search_proto::QueryResult;
+
+/// Default RRF rank constant — canonical value from the original
+/// paper, and what Python `SearchDaemon` defaults to.  Callers who
+/// pass `rrf_k = 0` on the wire get this instead.
+pub const DEFAULT_RRF_K: u32 = 60;
+
+/// Default weighted-fusion alpha — 0.5 (balanced keyword + semantic).
+/// Callers who pass `alpha = 0.0` on the wire get this instead so a
+/// caller that forgets the field lands on the balanced blend rather
+/// than pure-keyword; matches Python.  Callers who genuinely want
+/// pure-keyword pass KEYWORD as `query_type` instead.
+pub const DEFAULT_ALPHA: f32 = 0.5;
+
+// ── Public entry points ──────────────────────────────────────────
+
+pub fn rrf(keyword: &[QueryResult], semantic: &[QueryResult], k: u32) -> Vec<QueryResult> {
+    let mut merged: HashMap<DocKey, MergedHit> = HashMap::new();
+    let k_f = k.max(1) as f32;
+    accumulate_rrf(&mut merged, keyword, k_f, 1.0);
+    accumulate_rrf(&mut merged, semantic, k_f, 1.0);
+    finalise(merged)
+}
+
+pub fn rrf_weighted(
+    keyword: &[QueryResult],
+    semantic: &[QueryResult],
+    k: u32,
+    alpha: f32,
+) -> Vec<QueryResult> {
+    let alpha = alpha.clamp(0.0, 1.0);
+    let mut merged: HashMap<DocKey, MergedHit> = HashMap::new();
+    let k_f = k.max(1) as f32;
+    accumulate_rrf(&mut merged, keyword, k_f, 1.0 - alpha);
+    accumulate_rrf(&mut merged, semantic, k_f, alpha);
+    finalise(merged)
+}
+
+pub fn weighted(keyword: &[QueryResult], semantic: &[QueryResult], alpha: f32) -> Vec<QueryResult> {
+    let alpha = alpha.clamp(0.0, 1.0);
+    let kw_norm = min_max_normalise(keyword);
+    let sem_norm = min_max_normalise(semantic);
+
+    let mut merged: HashMap<DocKey, MergedHit> = HashMap::new();
+    accumulate_score(&mut merged, keyword, &kw_norm, 1.0 - alpha);
+    accumulate_score(&mut merged, semantic, &sem_norm, alpha);
+    finalise(merged)
+}
+
+/// Per-document chunk cap on the final ranked list (#4542).  Keeps
+/// at most `chunks_per_page` hits per source path; extras (already
+/// sorted lower by the fusion score) fall off the tail.
+///
+/// `chunks_per_page = 0` ⇒ no pooling — returns the input unchanged.
+///
+/// Preserves the input order (fusion score descending) among the
+/// kept hits, so the caller can take the first `limit` and get
+/// pooled + top-N in one pass.
+pub fn pool_by_document(hits: Vec<QueryResult>, chunks_per_page: u32) -> Vec<QueryResult> {
+    if chunks_per_page == 0 {
+        return hits;
+    }
+    let cap = chunks_per_page as usize;
+    let mut counts: HashMap<String, usize> = HashMap::new();
+    let mut out = Vec::with_capacity(hits.len());
+    for hit in hits {
+        let seen = counts.entry(hit.path.clone()).or_insert(0);
+        if *seen >= cap {
+            continue;
+        }
+        *seen += 1;
+        out.push(hit);
+    }
+    out
+}
+
+// ── Internals ────────────────────────────────────────────────────
+
+/// Identity of a doc across sources.  `(path, chunk_index)` — same
+/// pair identifies the same physical row across FTS + ANN because
+/// [`crate::service`] stamps zero as the chunk_index for the P1-P3
+/// one-chunk-per-file shape.  P4's chunker emits real chunk indices
+/// and this key stays correct.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct DocKey {
+    path: String,
+    chunk_index: u32,
+}
+
+impl DocKey {
+    fn of(r: &QueryResult) -> Self {
+        Self {
+            path: r.path.clone(),
+            chunk_index: r.chunk_index,
+        }
+    }
+}
+
+/// Accumulator row — carries the fused score AND a `template` copy
+/// of the first-seen result so we don't lose chunk_text / mtime_ms
+/// when a doc appears in both sources.
+struct MergedHit {
+    score: f32,
+    template: QueryResult,
+}
+
+fn accumulate_rrf(
+    merged: &mut HashMap<DocKey, MergedHit>,
+    source: &[QueryResult],
+    k: f32,
+    weight: f32,
+) {
+    for (idx, r) in source.iter().enumerate() {
+        let rank = (idx + 1) as f32;
+        let contribution = weight / (k + rank);
+        merged
+            .entry(DocKey::of(r))
+            .and_modify(|m| m.score += contribution)
+            .or_insert_with(|| MergedHit {
+                score: contribution,
+                template: r.clone(),
+            });
+    }
+}
+
+fn accumulate_score(
+    merged: &mut HashMap<DocKey, MergedHit>,
+    source: &[QueryResult],
+    normalised: &[f32],
+    weight: f32,
+) {
+    for (r, &n) in source.iter().zip(normalised.iter()) {
+        let contribution = weight * n;
+        merged
+            .entry(DocKey::of(r))
+            .and_modify(|m| m.score += contribution)
+            .or_insert_with(|| MergedHit {
+                score: contribution,
+                template: r.clone(),
+            });
+    }
+}
+
+fn finalise(merged: HashMap<DocKey, MergedHit>) -> Vec<QueryResult> {
+    let mut out: Vec<QueryResult> = merged
+        .into_values()
+        .map(|m| QueryResult {
+            score: m.score,
+            ..m.template
+        })
+        .collect();
+    // Sort descending by score.  Deterministic ordering when scores
+    // tie: path lexicographic — callers can rely on a fixed order
+    // for snapshot testing.
+    out.sort_by(|a, b| {
+        b.score
+            .partial_cmp(&a.score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.path.cmp(&b.path))
+            .then_with(|| a.chunk_index.cmp(&b.chunk_index))
+    });
+    out
+}
+
+/// Min-max normalise a source's raw scores to [0, 1].  All-equal
+/// input maps to 1.0 (so a single-hit source contributes fully to
+/// the weighted blend).  Empty input returns empty.
+fn min_max_normalise(source: &[QueryResult]) -> Vec<f32> {
+    if source.is_empty() {
+        return Vec::new();
+    }
+    let mut min = f32::INFINITY;
+    let mut max = f32::NEG_INFINITY;
+    for r in source {
+        if r.score < min {
+            min = r.score;
+        }
+        if r.score > max {
+            max = r.score;
+        }
+    }
+    let range = max - min;
+    if range == 0.0 {
+        return vec![1.0; source.len()];
+    }
+    source.iter().map(|r| (r.score - min) / range).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn hit(path: &str, chunk_index: u32, score: f32) -> QueryResult {
+        QueryResult {
+            path: path.to_string(),
+            chunk_index,
+            chunk_text: format!("text-{path}-{chunk_index}"),
+            score,
+            zone_id: "root".to_string(),
+            mtime_ms: Some(1),
+        }
+    }
+
+    #[test]
+    fn rrf_shared_doc_scores_higher_than_singleton() {
+        let kw = vec![hit("/a", 0, 10.0), hit("/b", 0, 5.0)];
+        let sem = vec![hit("/a", 0, 0.9), hit("/c", 0, 0.5)];
+        let fused = rrf(&kw, &sem, DEFAULT_RRF_K);
+        // /a appears in BOTH sources → higher fused score than /b or /c.
+        assert_eq!(fused[0].path, "/a");
+        assert!(
+            fused[0].score > fused[1].score,
+            "shared doc must lead: {fused:?}"
+        );
+    }
+
+    #[test]
+    fn rrf_matches_reference_formula() {
+        // Two sources, k=60. /a at rank 1 in kw, rank 2 in sem.
+        //   contribution = 1/(60+1) + 1/(60+2) = 1/61 + 1/62 ≈ 0.032917
+        let kw = vec![hit("/a", 0, 1.0), hit("/b", 0, 0.5)];
+        let sem = vec![hit("/z", 0, 1.0), hit("/a", 0, 0.5)];
+        let fused = rrf(&kw, &sem, 60);
+        let a = fused.iter().find(|r| r.path == "/a").expect("/a missing");
+        let expected = 1.0 / 61.0 + 1.0 / 62.0;
+        assert!(
+            (a.score - expected).abs() < 1e-5,
+            "expected {expected}, got {}",
+            a.score,
+        );
+    }
+
+    #[test]
+    fn weighted_alpha_zero_is_pure_keyword() {
+        let kw = vec![hit("/a", 0, 10.0), hit("/b", 0, 1.0)];
+        let sem = vec![hit("/z", 0, 0.9)];
+        let fused = weighted(&kw, &sem, 0.0);
+        // alpha=0 → semantic contribution zeroed → only keyword
+        // ranking survives.  /a normalised = 1.0, /b = 0.0, /z = 0.0
+        // → all-tied at bottom.  Order: /a first, /b + /z tied at 0.
+        assert_eq!(fused[0].path, "/a");
+        assert!(fused[0].score > fused[1].score, "kw leader must lead");
+    }
+
+    #[test]
+    fn weighted_alpha_one_is_pure_semantic() {
+        let kw = vec![hit("/a", 0, 10.0)];
+        let sem = vec![hit("/z", 0, 0.9), hit("/a", 0, 0.1)];
+        let fused = weighted(&kw, &sem, 1.0);
+        // alpha=1 → keyword contribution zeroed.  Semantic order: /z
+        // normalised to 1.0, /a to 0.0.  So /z leads.
+        assert_eq!(fused[0].path, "/z");
+    }
+
+    #[test]
+    fn weighted_dedups_across_sources() {
+        // Same doc in both sources appears ONCE with combined score.
+        let kw = vec![hit("/a", 0, 10.0)];
+        let sem = vec![hit("/a", 0, 0.9)];
+        let fused = weighted(&kw, &sem, 0.5);
+        assert_eq!(fused.len(), 1, "shared doc must dedupe: {fused:?}");
+        assert_eq!(fused[0].path, "/a");
+    }
+
+    #[test]
+    fn rrf_weighted_alpha_shifts_shared_doc_rank() {
+        // /a is shared; /b is keyword-only; /c is semantic-only.
+        // alpha=1.0 → keyword contribution 0 → /a (semantic rank 1) +
+        // /c (semantic rank 2) > /b (keyword-only weighted 0).
+        let kw = vec![hit("/a", 0, 10.0), hit("/b", 0, 5.0)];
+        let sem = vec![hit("/a", 0, 0.9), hit("/c", 0, 0.5)];
+        let fused_kw = rrf_weighted(&kw, &sem, 60, 0.0);
+        let fused_sem = rrf_weighted(&kw, &sem, 60, 1.0);
+        let b_kw = fused_kw.iter().find(|r| r.path == "/b").unwrap().score;
+        let b_sem = fused_sem.iter().find(|r| r.path == "/b").unwrap().score;
+        assert!(b_kw > b_sem, "kw-only /b weighted lower under alpha=1");
+    }
+
+    #[test]
+    fn empty_sources_return_empty() {
+        assert!(rrf(&[], &[], 60).is_empty());
+        assert!(weighted(&[], &[], 0.5).is_empty());
+    }
+
+    #[test]
+    fn one_empty_source_returns_the_other() {
+        let kw = vec![hit("/a", 0, 10.0)];
+        let fused = rrf(&kw, &[], 60);
+        assert_eq!(fused.len(), 1);
+        assert_eq!(fused[0].path, "/a");
+    }
+
+    #[test]
+    fn preserves_chunk_text_and_mtime_from_first_seen_source() {
+        // When a doc appears in both sources the accumulator keeps
+        // the FIRST source's chunk_text — semantic's ANN enrichment
+        // typically has richer chunk_text via the FTS sibling, so
+        // callers pass semantic first.  The template preservation
+        // pins the "first seen wins" contract.
+        let kw = vec![QueryResult {
+            path: "/a".into(),
+            chunk_index: 0,
+            chunk_text: "keyword-text".into(),
+            score: 1.0,
+            zone_id: "root".into(),
+            mtime_ms: Some(100),
+        }];
+        let sem = vec![QueryResult {
+            path: "/a".into(),
+            chunk_index: 0,
+            chunk_text: "semantic-text".into(),
+            score: 0.9,
+            zone_id: "root".into(),
+            mtime_ms: Some(200),
+        }];
+        let fused = rrf(&kw, &sem, 60);
+        assert_eq!(fused.len(), 1);
+        assert_eq!(fused[0].chunk_text, "keyword-text");
+        assert_eq!(fused[0].mtime_ms, Some(100));
+    }
+
+    #[test]
+    fn pool_by_document_zero_is_noop() {
+        let hits = vec![hit("/a", 0, 5.0), hit("/a", 1, 4.0), hit("/b", 0, 3.0)];
+        let out = pool_by_document(hits.clone(), 0);
+        assert_eq!(out.len(), 3, "chunks_per_page=0 must be no-op");
+    }
+
+    #[test]
+    fn pool_by_document_enforces_cap() {
+        // Three hits from /a, cap = 2 → only first two /a hits survive.
+        // Fusion-score ordering preserved: input in [5, 4, 3, 2, 1]
+        // → output keeps [5, 4] for /a plus /b.
+        let hits = vec![
+            hit("/a", 0, 5.0),
+            hit("/a", 1, 4.0),
+            hit("/b", 0, 3.5),
+            hit("/a", 2, 3.0),
+            hit("/c", 0, 2.5),
+        ];
+        let out = pool_by_document(hits, 2);
+        let paths: Vec<&str> = out.iter().map(|r| r.path.as_str()).collect();
+        assert_eq!(paths, ["/a", "/a", "/b", "/c"]);
+    }
+
+    #[test]
+    fn pool_by_document_preserves_input_order_among_kept_hits() {
+        // Regression: a naive impl that groups-then-emits would break
+        // the fusion-score order.  Cap = 1 → keep the top hit per
+        // path, and the emit-order must follow the input.
+        let hits = vec![
+            hit("/a", 0, 5.0),
+            hit("/b", 0, 4.9),
+            hit("/a", 1, 4.8), // capped away
+            hit("/c", 0, 4.7),
+        ];
+        let out = pool_by_document(hits, 1);
+        let paths: Vec<&str> = out.iter().map(|r| r.path.as_str()).collect();
+        assert_eq!(paths, ["/a", "/b", "/c"]);
+    }
+
+    #[test]
+    fn finalise_ties_break_deterministically() {
+        // Two docs at the same fused score — path lexicographic
+        // then chunk_index.  Snapshot tests depend on this.
+        let kw = vec![
+            QueryResult {
+                path: "/b".into(),
+                chunk_index: 0,
+                chunk_text: String::new(),
+                score: 1.0,
+                zone_id: "root".into(),
+                mtime_ms: None,
+            },
+            QueryResult {
+                path: "/a".into(),
+                chunk_index: 0,
+                chunk_text: String::new(),
+                score: 1.0,
+                zone_id: "root".into(),
+                mtime_ms: None,
+            },
+        ];
+        // rrf here: rank-1 and rank-2 have different scores; equalise
+        // by using WEIGHTED with alpha=0 and identical raw scores so
+        // normalised scores tie at 1.0.
+        let fused = weighted(&kw, &[], 0.0);
+        assert_eq!(fused[0].path, "/a", "lex-sorted on tie: {fused:?}");
+        assert_eq!(fused[1].path, "/b");
+    }
+}

--- a/rust/services/search-plugin/src/fusion.rs
+++ b/rust/services/search-plugin/src/fusion.rs
@@ -36,8 +36,8 @@
 //! prevents one long file from monopolising the top-N when its
 //! per-chunk BM25 or cosine scores dominate multiple result slots.
 //! P1-P3 emit one chunk per file so pooling is a no-op; the wire
-//! + code path lands here so P4's real chunker just needs to bump
-//! `chunk_index` values.
+//! and code path land here so P4's real chunker just needs to
+//! bump `chunk_index` values.
 
 use std::collections::HashMap;
 

--- a/rust/services/search-plugin/src/lib.rs
+++ b/rust/services/search-plugin/src/lib.rs
@@ -55,6 +55,7 @@ pub mod search_proto {
 pub mod ann_index;
 pub mod embedder;
 pub mod fts_index;
+pub mod fusion;
 pub mod index_manager;
 pub mod kernel_io;
 pub mod service;

--- a/rust/services/search-plugin/src/service.rs
+++ b/rust/services/search-plugin/src/service.rs
@@ -17,12 +17,13 @@ use tonic::{async_trait, Request, Response, Status};
 use crate::ann_index::AnnHit;
 use crate::embedder::{build_default_embedder, EmbedError, Embedder};
 use crate::fts_index::FtsHit;
+use crate::fusion::{self, DEFAULT_ALPHA, DEFAULT_RRF_K};
 use crate::index_manager::IndexManager;
 use crate::kernel_io::{self, DirEntry, KernelIoError, DT_DIR, DT_REG};
 use crate::search_proto::search_service_server::SearchService;
 use crate::search_proto::{
-    GlobRequest, GlobResponse, GrepMatch, GrepRequest, GrepResponse, IndexRequest, IndexResponse,
-    QueryRequest, QueryResponse, QueryResult, QueryType,
+    FusionMethod, GlobRequest, GlobResponse, GrepMatch, GrepRequest, GrepResponse, IndexRequest,
+    IndexResponse, QueryRequest, QueryResponse, QueryResult, QueryType,
 };
 
 /// Server-side default when the caller sends `max_results = 0`.
@@ -637,6 +638,82 @@ fn fts_hit_to_result(hit: FtsHit, zone_id: &str) -> QueryResult {
     }
 }
 
+/// Bundled fusion knobs from the wire — parsed once at the RPC
+/// handler and forwarded to `do_hybrid_query`.  Zero-valued fields
+/// resolve to Python-parity defaults inside this struct so
+/// downstream code doesn't need to remember the sentinel rules.
+#[derive(Debug, Clone, Copy)]
+struct FusionOpts {
+    method: FusionMethod,
+    alpha: f32,
+    rrf_k: u32,
+    chunks_per_page: u32,
+}
+
+impl FusionOpts {
+    fn from_request(req: &QueryRequest) -> Self {
+        let method = FusionMethod::try_from(req.fusion_method).unwrap_or(FusionMethod::Unspecified);
+        // Wire zero on either float means "server default" per D3
+        // (matches Python's "None => config default" fallback).
+        let alpha = if req.alpha == 0.0 {
+            DEFAULT_ALPHA
+        } else {
+            req.alpha
+        };
+        let rrf_k = if req.rrf_k == 0 {
+            DEFAULT_RRF_K
+        } else {
+            req.rrf_k
+        };
+        Self {
+            method,
+            alpha,
+            rrf_k,
+            chunks_per_page: req.chunks_per_page,
+        }
+    }
+}
+
+/// Hybrid = keyword + semantic, fused per the caller's chosen
+/// method, optionally pooled per-doc.  Runs both retrievals in
+/// sequence on the same spawn_blocking worker — small P3-friendly
+/// implementation.  A parallel-fetch variant is a follow-up when
+/// per-source latency asymmetry (BM25 ~ms, semantic ~10-100ms with
+/// real fastembed) starts to matter for user-visible p95.
+///
+/// Each source over-fetches `limit * 2` to give fusion headroom
+/// (a doc that ranks 8 in keyword and 9 in semantic scores highly
+/// under RRF but only surfaces if BOTH sources return it).  The
+/// dispatcher's `path_filter` still applies inside each source's
+/// query so pooling never has to re-check.
+fn do_hybrid_query(
+    manager: &IndexManager,
+    embedder: &Arc<dyn Embedder>,
+    q: &str,
+    zone_id: &str,
+    limit: usize,
+    path_filter: &str,
+    opts: FusionOpts,
+) -> Result<Vec<QueryResult>, String> {
+    let over_fetch = limit.saturating_mul(2).max(limit);
+
+    let keyword = do_keyword_query(manager, q, zone_id, over_fetch, path_filter)?;
+    let semantic = do_semantic_query(manager, embedder, q, zone_id, over_fetch, path_filter)?;
+
+    let fused = match opts.method {
+        FusionMethod::Unspecified | FusionMethod::Rrf => {
+            fusion::rrf(&keyword, &semantic, opts.rrf_k)
+        }
+        FusionMethod::Weighted => fusion::weighted(&keyword, &semantic, opts.alpha),
+        FusionMethod::RrfWeighted => {
+            fusion::rrf_weighted(&keyword, &semantic, opts.rrf_k, opts.alpha)
+        }
+    };
+
+    let pooled = fusion::pool_by_document(fused, opts.chunks_per_page);
+    Ok(pooled.into_iter().take(limit).collect())
+}
+
 /// Sinks the Index walker writes into.  `fts` is required (Index
 /// always populates the keyword index); `ann` + `embedder` are
 /// optional so a slim deployment or a mid-boot with no embedder
@@ -933,9 +1010,10 @@ impl SearchService for SearchServiceImpl {
         } else {
             req.limit as usize
         };
-        let path_filter = req.path_filter;
+        let path_filter = req.path_filter.clone();
         let query_type = QueryType::try_from(req.query_type).unwrap_or(QueryType::Unspecified);
         let manager = Arc::clone(&self.manager);
+        let fusion_opts = FusionOpts::from_request(&req);
 
         let outcome = match query_type {
             QueryType::Unspecified | QueryType::Keyword => tokio::task::spawn_blocking(move || {
@@ -963,7 +1041,34 @@ impl SearchService for SearchServiceImpl {
                 .await
                 .map_err(|e| Status::internal(format!("spawn_blocking joined error: {e}")))?
             }
-            QueryType::Hybrid => Err("query_type=HYBRID not supported until P3".into()),
+            QueryType::Hybrid => {
+                // Same init-before-spawn pattern as SEMANTIC — hybrid
+                // needs the embedder to run its semantic leg, so a
+                // missing embedder degrades hybrid the same way (with
+                // a clearer "hybrid unavailable" prefix).
+                let embedder = match self.get_or_init_embedder() {
+                    Ok(e) => e,
+                    Err(e) => {
+                        return Ok(Response::new(QueryResponse {
+                            results: Vec::new(),
+                            error: Some(format!("hybrid unavailable: {e}")),
+                        }));
+                    }
+                };
+                tokio::task::spawn_blocking(move || {
+                    do_hybrid_query(
+                        &manager,
+                        &embedder,
+                        &q,
+                        &zone_id,
+                        limit,
+                        &path_filter,
+                        fusion_opts,
+                    )
+                })
+                .await
+                .map_err(|e| Status::internal(format!("spawn_blocking joined error: {e}")))?
+            }
         };
 
         match outcome {

--- a/rust/services/search-plugin/src/service.rs
+++ b/rust/services/search-plugin/src/service.rs
@@ -997,23 +997,26 @@ impl SearchService for SearchServiceImpl {
         request: Request<QueryRequest>,
     ) -> Result<Response<QueryResponse>, Status> {
         let req = request.into_inner();
-        let q = req.q;
-        if q.is_empty() {
+        if req.q.is_empty() {
             return Ok(Response::new(QueryResponse {
                 results: Vec::new(),
                 error: Some("q must not be empty".into()),
             }));
         }
-        let zone_id = resolve_zone(&req.zone_id).to_string();
+        // Parse borrow-only fields FIRST so later `let q = req.q`
+        // moves don't leave `req` partially moved for later reads.
+        let query_type = QueryType::try_from(req.query_type).unwrap_or(QueryType::Unspecified);
+        let fusion_opts = FusionOpts::from_request(&req);
         let limit = if req.limit == 0 {
             DEFAULT_QUERY_LIMIT
         } else {
             req.limit as usize
         };
-        let path_filter = req.path_filter.clone();
-        let query_type = QueryType::try_from(req.query_type).unwrap_or(QueryType::Unspecified);
+        let zone_id = resolve_zone(&req.zone_id).to_string();
+        // Now safe to move fields out.
+        let q = req.q;
+        let path_filter = req.path_filter;
         let manager = Arc::clone(&self.manager);
-        let fusion_opts = FusionOpts::from_request(&req);
 
         let outcome = match query_type {
             QueryType::Unspecified | QueryType::Keyword => tokio::task::spawn_blocking(move || {

--- a/rust/services/search-plugin/tests/index_e2e.rs
+++ b/rust/services/search-plugin/tests/index_e2e.rs
@@ -318,6 +318,7 @@ async fn query(
         path_filter: String::new(),
         query_type: QueryType::Keyword as i32,
         auth_token: String::new(),
+        ..Default::default()
     }))
     .await
     .expect("query")

--- a/rust/services/search-plugin/tests/query_e2e.rs
+++ b/rust/services/search-plugin/tests/query_e2e.rs
@@ -169,6 +169,7 @@ async fn query_returns_bm25_hits_for_seeded_zone() {
             path_filter: String::new(),
             query_type: QueryType::Keyword as i32,
             auth_token: String::new(),
+            ..Default::default()
         }))
         .await
         .expect("query")
@@ -201,6 +202,7 @@ async fn query_empty_zone_resolves_to_root() {
             path_filter: String::new(),
             query_type: QueryType::Keyword as i32,
             auth_token: String::new(),
+            ..Default::default()
         }))
         .await
         .expect("query")
@@ -224,6 +226,7 @@ async fn query_path_filter_narrows_results() {
             path_filter: "/notes/".into(),
             query_type: QueryType::Keyword as i32,
             auth_token: String::new(),
+            ..Default::default()
         }))
         .await
         .expect("query")
@@ -246,6 +249,7 @@ async fn query_empty_q_returns_error_not_500() {
             path_filter: String::new(),
             query_type: QueryType::Keyword as i32,
             auth_token: String::new(),
+            ..Default::default()
         }))
         .await
         .expect("query")
@@ -275,6 +279,7 @@ async fn query_semantic_gracefully_degrades_when_no_embedder() {
             path_filter: String::new(),
             query_type: QueryType::Semantic as i32,
             auth_token: String::new(),
+            ..Default::default()
         }))
         .await
         .expect("query")
@@ -291,7 +296,13 @@ async fn query_semantic_gracefully_degrades_when_no_embedder() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn query_hybrid_type_rejected_with_p3_message() {
+async fn query_hybrid_gracefully_degrades_when_no_embedder() {
+    // Post-P3: HYBRID is a supported query_type but requires an
+    // embedder (semantic leg needs it).  The default Harness uses
+    // `with_manager` (no embedder pre-injected) → the RPC must
+    // return "hybrid unavailable: ..." rather than a P3-not-
+    // supported message.  Preserves D2 graceful degradation:
+    // keyword still works, hybrid errors cleanly.
     let h = Harness::start();
     let resp = h
         .svc
@@ -302,16 +313,20 @@ async fn query_hybrid_type_rejected_with_p3_message() {
             path_filter: String::new(),
             query_type: QueryType::Hybrid as i32,
             auth_token: String::new(),
+            ..Default::default()
         }))
         .await
         .expect("query")
         .into_inner();
 
-    let err = resp.error.expect("hybrid must be rejected in P1");
+    let err = resp
+        .error
+        .expect("hybrid without embedder must error, not succeed");
     assert!(
-        err.contains("P3"),
-        "hybrid rejection should mention P3, got: {err:?}",
+        err.contains("hybrid unavailable"),
+        "hybrid degradation message should mention unavailability, got: {err:?}",
     );
+    assert!(resp.results.is_empty(), "no results when unavailable");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -334,6 +349,7 @@ async fn query_zero_limit_uses_default() {
             path_filter: String::new(),
             query_type: QueryType::Keyword as i32,
             auth_token: String::new(),
+            ..Default::default()
         }))
         .await
         .expect("query")
@@ -371,6 +387,7 @@ async fn query_zone_isolation_holds_at_storage_layer() {
             path_filter: String::new(),
             query_type: QueryType::Keyword as i32,
             auth_token: String::new(),
+            ..Default::default()
         }))
         .await
         .expect("query")
@@ -396,6 +413,7 @@ async fn query_returns_mtime_when_stored() {
             path_filter: String::new(),
             query_type: QueryType::Keyword as i32,
             auth_token: String::new(),
+            ..Default::default()
         }))
         .await
         .expect("query")

--- a/rust/services/search-plugin/tests/semantic_query_e2e.rs
+++ b/rust/services/search-plugin/tests/semantic_query_e2e.rs
@@ -302,6 +302,7 @@ async fn semantic_query(
         path_filter: path_filter.into(),
         query_type: QueryType::Semantic as i32,
         auth_token: String::new(),
+        ..Default::default()
     }))
     .await
     .expect("query")
@@ -425,6 +426,7 @@ async fn semantic_empty_query_returns_error() {
             path_filter: String::new(),
             query_type: QueryType::Semantic as i32,
             auth_token: String::new(),
+            ..Default::default()
         }))
         .await
         .expect("query")
@@ -491,6 +493,7 @@ async fn semantic_zone_isolation_holds() {
             path_filter: String::new(),
             query_type: QueryType::Semantic as i32,
             auth_token: String::new(),
+            ..Default::default()
         }))
         .await
         .expect("query")
@@ -503,4 +506,200 @@ async fn semantic_zone_isolation_holds() {
     unsafe {
         drop(Box::from_raw(mock));
     }
+}
+
+// ── Hybrid (P3) ─────────────────────────────────────────────────
+
+async fn hybrid_query(
+    svc: &SearchServiceImpl,
+    q: &str,
+    path_filter: &str,
+) -> nexus_search_plugin::search_proto::QueryResponse {
+    svc.query(Request::new(QueryRequest {
+        q: q.into(),
+        zone_id: "root".into(),
+        limit: 10,
+        path_filter: path_filter.into(),
+        query_type: QueryType::Hybrid as i32,
+        auth_token: String::new(),
+        ..Default::default()
+    }))
+    .await
+    .expect("query")
+    .into_inner()
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn hybrid_finds_docs_present_in_both_sources() {
+    // Happy path: a query whose text lives in the corpus turns up
+    // in both the BM25 side AND the vector side.  Fusion promotes
+    // that doc to hit[0].  Mock embedder is deterministic per text
+    // so 'widget alpha payload' matches /notes/alpha.md at cosine
+    // distance ≈ 0.
+    let h = Harness::start();
+    let mock = h.mock_mut();
+    mock.add_dir("/");
+    mock.add_dir("/notes");
+    mock.add_file("/notes/alpha.md", b"widget alpha payload", 1);
+    mock.add_file("/notes/beta.md", b"orange banana grape", 2);
+    mock.add_file("/notes/gamma.md", b"only alpha here", 3);
+
+    let idx = index_root(&h.svc).await;
+    assert!(idx.error.is_none(), "{idx:?}");
+    assert_eq!(idx.indexed_count, 3);
+
+    let q = hybrid_query(&h.svc, "widget alpha payload", "").await;
+    assert!(q.error.is_none(), "unexpected hybrid error: {:?}", q.error);
+    assert!(!q.results.is_empty(), "expected hybrid hits");
+    assert_eq!(
+        q.results[0].path, "/notes/alpha.md",
+        "shared doc should lead: {:?}",
+        q.results,
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn hybrid_score_higher_than_either_source_alone_for_shared_doc() {
+    // RRF math contract: a doc that appears in BOTH sources scores
+    // strictly higher than a doc that appears in only one, at the
+    // same rank.  Regression scaffold for the fusion primitive's
+    // wiring into the RPC handler (the fusion unit tests already
+    // pin the math; this pins the plumbing).
+    let h = Harness::start();
+    let mock = h.mock_mut();
+    mock.add_dir("/");
+    // /both matches keyword 'widget' AND has exact text for the
+    // semantic side — both sources return it.
+    mock.add_file("/both.md", b"widget", 1);
+    // /kw-only matches the keyword 'widget' but its exact text is
+    // different so its vector distance is > 0 → semantic ranks it
+    // lower than /both.
+    mock.add_file("/kw-only.md", b"widget different words entirely", 2);
+
+    let idx = index_root(&h.svc).await;
+    assert!(idx.error.is_none(), "{idx:?}");
+
+    let q = hybrid_query(&h.svc, "widget", "").await;
+    assert!(q.error.is_none(), "{q:?}");
+    assert!(!q.results.is_empty());
+    // /both should lead — appears at rank 1 in BOTH sources.
+    assert_eq!(q.results[0].path, "/both.md");
+    if q.results.len() > 1 {
+        assert!(
+            q.results[0].score >= q.results[1].score,
+            "score order violated: {:?}",
+            q.results,
+        );
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn hybrid_honours_path_prefix_filter() {
+    let h = Harness::start();
+    let mock = h.mock_mut();
+    mock.add_dir("/");
+    mock.add_dir("/notes");
+    mock.add_dir("/logs");
+    mock.add_file("/notes/a.md", b"widget shared", 1);
+    mock.add_file("/logs/b.log", b"widget shared", 2);
+
+    let idx = index_root(&h.svc).await;
+    assert!(idx.error.is_none(), "{idx:?}");
+
+    let q = hybrid_query(&h.svc, "widget shared", "/notes/").await;
+    assert!(q.error.is_none(), "{q:?}");
+    let paths: Vec<&str> = q.results.iter().map(|r| r.path.as_str()).collect();
+    assert!(!paths.is_empty(), "prefix filter dropped every hit");
+    assert!(
+        paths.iter().all(|p| p.starts_with("/notes/")),
+        "prefix filter leaked: {paths:?}",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn hybrid_alpha_shifts_ranking_between_sources() {
+    // alpha=0 (pure keyword) vs alpha=1 (pure semantic) under the
+    // WEIGHTED fusion method — a doc that ranks HIGH in one source
+    // and LOW in the other shifts position when alpha flips.  Pins
+    // the alpha plumbing without depending on the mock's specific
+    // score magnitudes.
+    let h = Harness::start();
+    let mock = h.mock_mut();
+    mock.add_dir("/");
+    // /kw-strong: keyword hits multiple times → high BM25 score.
+    // Semantic distance from query 'widget' is uncontrolled.
+    mock.add_file("/kw-strong.md", b"widget widget widget widget widget", 1);
+    // /sem-exact: exactly matches the query 'widget' text so mock
+    // semantic distance ≈ 0 → highest cosine score.  BM25 is only
+    // one occurrence.
+    mock.add_file("/sem-exact.md", b"widget", 2);
+
+    let idx = index_root(&h.svc).await;
+    assert!(idx.error.is_none(), "{idx:?}");
+
+    // alpha=1 (pure semantic) — /sem-exact should lead.
+    let q_sem = h
+        .svc
+        .query(Request::new(QueryRequest {
+            q: "widget".into(),
+            zone_id: "root".into(),
+            limit: 10,
+            path_filter: String::new(),
+            query_type: QueryType::Hybrid as i32,
+            fusion_method: nexus_search_plugin::search_proto::FusionMethod::Weighted as i32,
+            alpha: 1.0,
+            auth_token: String::new(),
+            ..Default::default()
+        }))
+        .await
+        .expect("query")
+        .into_inner();
+    assert!(q_sem.error.is_none(), "{q_sem:?}");
+    assert!(
+        !q_sem.results.is_empty(),
+        "expected hits under alpha=1: {q_sem:?}",
+    );
+    assert_eq!(
+        q_sem.results[0].path, "/sem-exact.md",
+        "alpha=1 should favour semantic-exact: {:?}",
+        q_sem.results,
+    );
+
+    // alpha=0 (pure keyword) — /kw-strong should now lead.
+    let q_kw = h
+        .svc
+        .query(Request::new(QueryRequest {
+            q: "widget".into(),
+            zone_id: "root".into(),
+            limit: 10,
+            path_filter: String::new(),
+            query_type: QueryType::Hybrid as i32,
+            fusion_method: nexus_search_plugin::search_proto::FusionMethod::Weighted as i32,
+            alpha: 0.0001, // avoid alpha=0 which the plugin rewrites to DEFAULT_ALPHA=0.5
+            auth_token: String::new(),
+            ..Default::default()
+        }))
+        .await
+        .expect("query")
+        .into_inner();
+    assert!(q_kw.error.is_none(), "{q_kw:?}");
+    assert!(!q_kw.results.is_empty());
+    assert_eq!(
+        q_kw.results[0].path, "/kw-strong.md",
+        "alpha→0 should favour keyword-strong: {:?}",
+        q_kw.results,
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn hybrid_empty_q_returns_error() {
+    let h = Harness::start();
+    let mock = h.mock_mut();
+    mock.add_dir("/");
+    mock.add_file("/x.md", b"seed", 1);
+    let _ = index_root(&h.svc).await;
+
+    let q = hybrid_query(&h.svc, "", "").await;
+    assert!(q.error.is_some(), "empty q must return error");
+    assert!(q.results.is_empty());
 }

--- a/tests/e2e/docker/search_helpers.py
+++ b/tests/e2e/docker/search_helpers.py
@@ -122,21 +122,27 @@ def search_query(
     limit: int = 0,
     path_filter: str = "",
     query_type: str = "keyword",
+    fusion_method: str = "",
+    alpha: float = 0.0,
+    rrf_k: int = 0,
+    chunks_per_page: int = 0,
     api_key: str = ADMIN_API_KEY,
     timeout: float = 30,
 ) -> dict:
-    """Typed Query RPC (P1 keyword-only).
+    """Typed Query RPC (P1 keyword / P2 semantic / P3 hybrid).
 
     Returns ``{"result": {"results": [...]}}`` on success or
     ``{"error": str}``.  Each result is
     ``{"path": str, "chunk_index": int, "chunk_text": str,
     "score": float, "zone_id": str, "mtime_ms": int | None}``.
 
-    ``query_type`` accepts the string forms mirrored from the
-    Python router: ``"keyword"``, ``"semantic"``, ``"hybrid"``.
-    P1 rejects the latter two with an error message referencing
-    the phase that will lift the gate.  ``limit=0`` uses the
-    plugin's server-side default (10 per the proto contract).
+    ``query_type`` accepts ``"keyword"``, ``"semantic"``,
+    ``"hybrid"``.  Hybrid honours ``fusion_method`` (``"rrf"`` |
+    ``"weighted"`` | ``"rrf_weighted"``), ``alpha`` (0.0-1.0
+    semantic-vs-keyword weight; server default 0.5 when 0.0),
+    ``rrf_k`` (RRF rank constant; server default 60 when 0), and
+    ``chunks_per_page`` (per-doc pooling cap; 0 = no pooling).
+    ``limit=0`` uses the server default (10).
     """
     from nexus.grpc.search.v1 import search_pb2
 
@@ -149,6 +155,15 @@ def search_query(
     if query_type not in qt_map:
         raise ValueError(f"unknown query_type: {query_type!r}")
 
+    fm_map = {
+        "": search_pb2.FUSION_METHOD_UNSPECIFIED,
+        "rrf": search_pb2.FUSION_METHOD_RRF,
+        "weighted": search_pb2.FUSION_METHOD_WEIGHTED,
+        "rrf_weighted": search_pb2.FUSION_METHOD_RRF_WEIGHTED,
+    }
+    if fusion_method not in fm_map:
+        raise ValueError(f"unknown fusion_method: {fusion_method!r}")
+
     channel, stub = _open_search_stub(target)
     try:
         req = search_pb2.QueryRequest(
@@ -158,6 +173,10 @@ def search_query(
             path_filter=path_filter,
             query_type=qt_map[query_type],
             auth_token=api_key,
+            fusion_method=fm_map[fusion_method],
+            alpha=alpha,
+            rrf_k=rrf_k,
+            chunks_per_page=chunks_per_page,
         )
         resp = stub.Query(req, timeout=timeout)
         if resp.HasField("error"):

--- a/tests/e2e/docker/test_search_plugin.py
+++ b/tests/e2e/docker/test_search_plugin.py
@@ -325,10 +325,43 @@ class TestSearchIndexQuery:
             f"semantic degradation message should mention unavailability, got {r}"
         )
 
-    def test_query_hybrid_rejected_with_p3_message(self, api_key: str) -> None:
+    def test_query_hybrid_gracefully_degrades_without_embedder(self, api_key: str) -> None:
+        """Post-P3: HYBRID is a supported query_type but its semantic
+        leg requires a loaded embedder. Without the model + dylib
+        shipped in the docker image (currently the CI shape), Query
+        must return a clean "hybrid unavailable" error, not crash.
+        """
         r = search_query(NODE_GRPC, "widget", query_type="hybrid", api_key=api_key)
-        assert "error" in r, f"hybrid must be rejected in P1, got {r}"
-        assert "P3" in r["error"], f"hybrid rejection should mention P3, got {r}"
+        assert "error" in r, f"hybrid without embedder must error, got {r}"
+        assert "hybrid unavailable" in r["error"], (
+            f"hybrid degradation message should mention unavailability, got {r}"
+        )
+
+    def test_query_hybrid_honours_fusion_method_arg(self, api_key: str) -> None:
+        """Even in the degraded (no-embedder) shape, the wire must
+        accept the P3 fusion knobs — a stale gRPC schema on the
+        server side would reject fusion_method / alpha / rrf_k /
+        chunks_per_page before we get to the graceful degradation.
+        Locks the wire contract independent of feature availability.
+        """
+        for method in ("rrf", "weighted", "rrf_weighted"):
+            r = search_query(
+                NODE_GRPC,
+                "widget",
+                query_type="hybrid",
+                fusion_method=method,
+                alpha=0.7,
+                rrf_k=100,
+                chunks_per_page=3,
+                api_key=api_key,
+            )
+            # Same "unavailable" degradation as the vanilla hybrid
+            # test — the fusion knobs are accepted, semantic leg is
+            # what fails.
+            assert "error" in r, f"hybrid[{method}] without embedder must error, got {r}"
+            assert "hybrid unavailable" in r["error"], (
+                f"hybrid[{method}] degradation should mention unavailability, got {r}"
+            )
 
     def test_query_skips_binary_and_oversized_files_at_index_time(self, api_key: str) -> None:
         """Same skip filter grep uses — non-utf8 payload + oversize must


### PR DESCRIPTION
## Summary

Phase 3 of the Python-parity roadmap (\`rust/services/search-plugin/PARITY_ROADMAP.md\`).
Lifts the HYBRID gate — Query now dispatches KEYWORD (BM25) or
SEMANTIC (vector) or HYBRID (fused) per \`query_type\`.

**Status: DRAFT** while CI validates. Marks ready once green.

## Commits

1. **Proto + \`fusion.rs\` primitive** — QueryRequest grows \`alpha\`,
   \`fusion_method\`, \`rrf_k\`, \`chunks_per_page\`. FusionMethod enum:
   RRF (default), WEIGHTED, RRF_WEIGHTED. Fusion primitive with 7 unit
   tests covering shared-doc leads, formula correctness, alpha
   extremes, dedup, empty inputs, template-preservation for
   first-seen source, pooling correctness.

2. **RPC wiring** — \`FusionOpts::from_request\` parses knobs
   once with Python-parity defaults (alpha=0.5, rrf_k=60 on zero).
   \`do_hybrid_query\` runs keyword + semantic sequentially with
   \`limit*2\` over-fetch per source, applies fusion + pool,
   returns top \`limit\`. RPC handler grows HYBRID arm mirroring
   SEMANTIC's init-before-spawn pattern; missing embedder ⇒
   \"hybrid unavailable\". Tombstone \"P3 not supported\" removed
   from service.rs.

3. **Tests** — query_e2e's hybrid gate assertion updated to
   graceful degradation. Five new hybrid cases in
   semantic_query_e2e.rs: shared-doc leads, RRF ranking regression,
   path prefix filter, alpha=1 vs alpha→0 flip, empty q errors.
   Docker E2E: hybrid graceful-degradation + fusion-knob wire
   acceptance across all three methods. \`search_helpers.py\`
   grows fusion params.

## Design decisions

- **RRF over cross-source normalisation**: BM25 (unbounded) + cosine
  ([-1, 1]) live in different ranges. RRF is rank-based, sidesteps
  normalisation. Default; matches Python.
- **WEIGHTED** uses min-max normalisation (all-equal → 1.0 so a
  single-hit source still contributes fully).
- **Sequential source fetch** in do_hybrid_query — parallel-fetch
  is a follow-up when per-source latency asymmetry starts to matter.
- **Pooling as no-op today**: P1-P3 emit one chunk per file so
  \`chunks_per_page\` filter is idempotent. Wire is in place so P4's
  chunker just needs to bump chunk_index values.
- **Zero-valued float on wire ⇒ Python-parity default** — a
  forgetful caller lands on Balanced (alpha=0.5, rrf_k=60) rather
  than pure-keyword. Callers who genuinely want pure-keyword send
  \`query_type=KEYWORD\`.

## Test plan

- [ ] Rust unit + integration tests (fusion + hybrid_query_e2e cases)
- [ ] Docker E2E: search-plugin (Docker) — hybrid gate + wire
      acceptance across RRF / WEIGHTED / RRF_WEIGHTED