### PR TITLE
chore: bump nexus-vfs pin to merged JoinZone/stream-inode/identity fixes (#203)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "a2a"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5f8b898e84166bdc9cf7b75c077b604c4f9d2ee1#5f8b898e84166bdc9cf7b75c077b604c4f9d2ee1"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=ebb394f2d601dbef72e1ecdf0b235b3993a4f1ef#ebb394f2d601dbef72e1ecdf0b235b3993a4f1ef"
 dependencies = [
  "contracts",
  "kernel",
@@ -239,7 +239,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 [[package]]
 name = "auth"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5f8b898e84166bdc9cf7b75c077b604c4f9d2ee1#5f8b898e84166bdc9cf7b75c077b604c4f9d2ee1"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=ebb394f2d601dbef72e1ecdf0b235b3993a4f1ef#ebb394f2d601dbef72e1ecdf0b235b3993a4f1ef"
 dependencies = [
  "contracts",
  "dashmap",
@@ -337,7 +337,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5f8b898e84166bdc9cf7b75c077b604c4f9d2ee1#5f8b898e84166bdc9cf7b75c077b604c4f9d2ee1"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=ebb394f2d601dbef72e1ecdf0b235b3993a4f1ef#ebb394f2d601dbef72e1ecdf0b235b3993a4f1ef"
 dependencies = [
  "ahash",
  "base64 0.22.1",
@@ -770,7 +770,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5f8b898e84166bdc9cf7b75c077b604c4f9d2ee1#5f8b898e84166bdc9cf7b75c077b604c4f9d2ee1"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=ebb394f2d601dbef72e1ecdf0b235b3993a4f1ef#ebb394f2d601dbef72e1ecdf0b235b3993a4f1ef"
 dependencies = [
  "parking_lot",
  "serde",
@@ -2185,7 +2185,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5f8b898e84166bdc9cf7b75c077b604c4f9d2ee1#5f8b898e84166bdc9cf7b75c077b604c4f9d2ee1"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=ebb394f2d601dbef72e1ecdf0b235b3993a4f1ef#ebb394f2d601dbef72e1ecdf0b235b3993a4f1ef"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -2243,7 +2243,7 @@ checksum = "0c2cdeb66e45e9f36bfad5bbdb4d2384e70936afbee843c6f6543f0c551ebb25"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5f8b898e84166bdc9cf7b75c077b604c4f9d2ee1#5f8b898e84166bdc9cf7b75c077b604c4f9d2ee1"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=ebb394f2d601dbef72e1ecdf0b235b3993a4f1ef#ebb394f2d601dbef72e1ecdf0b235b3993a4f1ef"
 dependencies = [
  "ahash",
  "base64 0.22.1",
@@ -2575,7 +2575,7 @@ dependencies = [
 [[package]]
 name = "nexus-cluster"
 version = "0.1.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5f8b898e84166bdc9cf7b75c077b604c4f9d2ee1#5f8b898e84166bdc9cf7b75c077b604c4f9d2ee1"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=ebb394f2d601dbef72e1ecdf0b235b3993a4f1ef#ebb394f2d601dbef72e1ecdf0b235b3993a4f1ef"
 dependencies = [
  "a2a",
  "anyhow",
@@ -2627,7 +2627,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5f8b898e84166bdc9cf7b75c077b604c4f9d2ee1#5f8b898e84166bdc9cf7b75c077b604c4f9d2ee1"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=ebb394f2d601dbef72e1ecdf0b235b3993a4f1ef#ebb394f2d601dbef72e1ecdf0b235b3993a4f1ef"
 
 [[package]]
 name = "nexus-search-plugin"
@@ -3363,7 +3363,7 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 [[package]]
 name = "raft"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5f8b898e84166bdc9cf7b75c077b604c4f9d2ee1#5f8b898e84166bdc9cf7b75c077b604c4f9d2ee1"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=ebb394f2d601dbef72e1ecdf0b235b3993a4f1ef#ebb394f2d601dbef72e1ecdf0b235b3993a4f1ef"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -4893,7 +4893,7 @@ dependencies = [
 [[package]]
 name = "transport"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5f8b898e84166bdc9cf7b75c077b604c4f9d2ee1#5f8b898e84166bdc9cf7b75c077b604c4f9d2ee1"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=ebb394f2d601dbef72e1ecdf0b235b3993a4f1ef#ebb394f2d601dbef72e1ecdf0b235b3993a4f1ef"
 dependencies = [
  "axum",
  "backends",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -224,24 +224,24 @@ exclude = ["nexus-fuse"]
 #
 # Bump alongside the rest of nexus-vfs updates when a downstream
 # change needs newer kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5f8b898e84166bdc9cf7b75c077b604c4f9d2ee1" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5f8b898e84166bdc9cf7b75c077b604c4f9d2ee1" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5f8b898e84166bdc9cf7b75c077b604c4f9d2ee1" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5f8b898e84166bdc9cf7b75c077b604c4f9d2ee1", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5f8b898e84166bdc9cf7b75c077b604c4f9d2ee1", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5f8b898e84166bdc9cf7b75c077b604c4f9d2ee1", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5f8b898e84166bdc9cf7b75c077b604c4f9d2ee1" }
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ebb394f2d601dbef72e1ecdf0b235b3993a4f1ef" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ebb394f2d601dbef72e1ecdf0b235b3993a4f1ef" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ebb394f2d601dbef72e1ecdf0b235b3993a4f1ef" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ebb394f2d601dbef72e1ecdf0b235b3993a4f1ef", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ebb394f2d601dbef72e1ecdf0b235b3993a4f1ef", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ebb394f2d601dbef72e1ecdf0b235b3993a4f1ef", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ebb394f2d601dbef72e1ecdf0b235b3993a4f1ef" }
 # The cluster daemon library entry (`nexus_cluster::run_with_services`),
 # consumed by the nexus-side assembly binary (`rust/nexusd`) that composes
 # the kernel/federation boot with the nexus service set via the
 # ServiceRegistry bring-up seam.
-nexus-cluster = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5f8b898e84166bdc9cf7b75c077b604c4f9d2ee1" }
+nexus-cluster = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ebb394f2d601dbef72e1ecdf0b235b3993a4f1ef" }
 # a2a messaging substrate. `default-features = false` leaves the
 # `install` feature (which pulls raft to arm the stream-wakeup observer)
 # OFF, so nexus-side consumers link only the stamp hook and stay
 # raft-free — they reach raft through kernel.sys_* (§6.1). The substrate
 # is armed in production at cluster boot in nexus-vfs, not here.
-a2a = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5f8b898e84166bdc9cf7b75c077b604c4f9d2ee1", default-features = false }
+a2a = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ebb394f2d601dbef72e1ecdf0b235b3993a4f1ef", default-features = false }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir --no-deps --prefix=/install .
 # enforces agreement) — an unpinned install tracks nexus-vfs HEAD and
 # ships an untested kernel (#4343). --locked honors the source tree's
 # Cargo.lock.
-ARG NEXUS_VFS_REV=5f8b898e84166bdc9cf7b75c077b604c4f9d2ee1
+ARG NEXUS_VFS_REV=ebb394f2d601dbef72e1ecdf0b235b3993a4f1ef
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-cluster nexus-cluster
 
 # -- Runtime stage --

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -25,7 +25,7 @@ WORKDIR /build
 # (CI preflight enforces agreement) — an unpinned install tracks HEAD
 # and can skew the raft contract against the cluster/witness images.
 # --locked honors the source tree's Cargo.lock.
-ARG NEXUS_VFS_REV=5f8b898e84166bdc9cf7b75c077b604c4f9d2ee1
+ARG NEXUS_VFS_REV=ebb394f2d601dbef72e1ecdf0b235b3993a4f1ef
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexus-raft-server raft
 
 # ---------- Production image ----------

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=5f8b898e84166bdc9cf7b75c077b604c4f9d2ee1
+ARG NEXUS_VFS_REV=ebb394f2d601dbef72e1ecdf0b235b3993a4f1ef
 RUN cargo install \
     --locked \
     --git https://github.com/nexi-lab/nexus-vfs \


### PR DESCRIPTION
Bumps nexus-vfs pin to ebb394f2d (nexus-vfs #203, merged). Three cross-machine A2A substrate root-cause fixes, all validated LIVE Win↔Mac + CI-regression-tested:

| fix | what it fixes |
|---|---|
| raft: JoinZone learner-then-promote | "not leader" deadlock + zombie voter on a 2-node join |
| kernel: DT_STREAM inode → path's routed zone | A2A mailbox content never replicating cross-machine |
| identity: persist role INTENT not achieved-role | stuck-learner on reboot; now self-heals |

Live proof: Mac join → learner → voter (~2s); reboot → still voter (self-heal); bidirectional /agents mailbox replication. Cargo.toml + Cargo.lock only (Dockerfile builds from the lock).