### PR TITLE
search: restore /query/batch contract — concurrent execution, embed-once, /query parity, per-query errors

### DIFF
--- a/docs/superpowers/plans/2026-08-04-batch-search-hardening.md
+++ b/docs/superpowers/plans/2026-08-04-batch-search-hardening.md
@@ -1,0 +1,1247 @@
+# Batch Search Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restore `POST /api/v2/search/query/batch` to its documented contract: concurrent inner searches, one embedding call per batch of unique query texts, full single-`/query` param + serializer parity, and per-query error surfacing.
+
+**Architecture:** Router-side parsing/validation moves to a new `_search_batch.py` helper (router is at ~1750 of the 2000-line cap). The daemon's `_batch_search_on_current_loop` pre-embeds unique query texts with one `embed_batch` call, threads each vector through a new `SearchRequest.query_vector` field, runs inner searches under `asyncio.gather` bounded by a semaphore, and returns per-query failures positionally as `BatchQueryFailure` instead of silent `[]`.
+
+**Tech Stack:** Python 3.12, FastAPI, pytest (`uv run pytest`), pre-commit (ruff + mypy + file-size caps).
+
+**Spec:** `docs/superpowers/specs/2026-08-04-batch-search-hardening-design.md` (approved).
+
+## Global Constraints
+
+- Worktree: `/Users/tafeng/nexus/.claude/worktrees/batch-search-hardening`, branch `feat/batch-search-hardening`, base `origin/develop`. All commands run from the worktree root.
+- Test runner: `uv run pytest <path> -v` (first run resolves the env from `uv.lock`).
+- `src/nexus/server/api/v2/routers/search.py` must stay under the repo's 2000-line file cap (currently ~1753 lines) — new batch logic goes in `_search_batch.py`.
+- Response changes must be **additive only**; request aliases `query`/`search_type`/`path_filter` must keep working (existing callers: `scripts/test_read_gate_e2e.py`, `tests/integration/services/test_search_zone_set.py::TestBatchReadGate`).
+- Numeric validation bounds mirror the single `/query` route exactly: `limit` 1..100, `alpha` 0.0..1.0, `rrf_k` 1..1000, `recency_weight` 0.0..5.0, `recency_half_life_days` >0.0..3650.0. String params (`type`, `fusion`, `expand`, `recency`) pass through unvalidated (single-route parity — the daemon handles unknown values).
+- Per-query problems (invalid spec, inner search failure) become per-entry `error` fields; batch-level failures stay whole-request: 400 (no queries), 401/403 (auth/read gate), 503 (daemon initializing).
+- Do NOT reference a GitHub issue number in code comments (the upstream issue is filed at PR time, Task 6); describe rationale in prose instead.
+- Pre-commit runs on every commit (ruff format, mypy on changed files) — keep code typed.
+
+---
+
+### Task 1: `SearchRequest.query_vector` + daemon plumbing
+
+**Files:**
+- Modify: `src/nexus/contracts/search_types.py` (SearchRequest, ~line 64)
+- Modify: `src/nexus/bricks/search/daemon.py`:
+  - `search()` ~line 2828 (two `_search_on_current_loop` calls)
+  - `_search_on_current_loop` signature ~line 2878 and its semantic/hybrid `_search_via_backends` call ~line 3045
+  - `_search_via_backends` signature ~line 3157 and its two `self._embed_query(query)` legs ~lines 3212 (semantic) and 3239 (hybrid)
+- Test: Create `tests/unit/bricks/search/test_daemon_batch_search.py`
+
+**Interfaces:**
+- Produces: `SearchRequest.query_vector: list[float] | None = None` (new frozen-dataclass field); `_search_via_backends(..., query_vector: list[float] | None = None)`; `_search_on_current_loop(..., query_vector: list[float] | None = None)`. Task 2 relies on `SearchRequest(query_vector=...)` skipping the embed step.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/bricks/search/test_daemon_batch_search.py`. Copy the module preamble (nexus_runtime stub) and `_make_daemon` harness from `tests/unit/bricks/search/test_daemon_fusion_params.py` verbatim, then add:
+
+```python
+class _CountingEmbed:
+    """Records embed calls made through daemon._embed_query."""
+
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    async def __call__(self, daemon: Any, query: str) -> list[float]:
+        self.calls.append(query)
+        return [0.1, 0.2]
+
+
+@pytest.mark.asyncio
+async def test_query_vector_override_skips_embed() -> None:
+    daemon = _make_daemon()
+    counter = _CountingEmbed()
+    daemon._embed_query = MethodType(counter.__call__, daemon)
+
+    results = await daemon._search_via_backends(
+        "hello",
+        search_type="hybrid",
+        limit=5,
+        path_filter=None,
+        zone_id="root",
+        query_vector=[0.3, 0.4],
+    )
+
+    assert counter.calls == []
+    assert results  # fused hybrid results still produced
+
+
+@pytest.mark.asyncio
+async def test_no_query_vector_still_embeds() -> None:
+    daemon = _make_daemon()
+    counter = _CountingEmbed()
+    daemon._embed_query = MethodType(counter.__call__, daemon)
+
+    await daemon._search_via_backends(
+        "hello",
+        search_type="hybrid",
+        limit=5,
+        path_filter=None,
+        zone_id="root",
+    )
+
+    assert counter.calls == ["hello"]
+```
+
+(If the fusion-params harness marks tests with a different async marker — e.g. `pytest.mark.anyio` or plain async supported by config — match whatever that file uses instead of `pytest.mark.asyncio`.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/unit/bricks/search/test_daemon_batch_search.py -v`
+Expected: FAIL — `TypeError: _search_via_backends() got an unexpected keyword argument 'query_vector'`
+
+- [ ] **Step 3: Implement the plumbing**
+
+In `src/nexus/contracts/search_types.py`, add to the end of `SearchRequest`'s fields:
+
+```python
+    # Pre-computed query embedding. When set, the daemon uses this vector
+    # for the dense leg instead of embedding the query text itself — the
+    # batch endpoint embeds all unique query texts in one embed_batch call
+    # and hands each inner search its vector.
+    query_vector: list[float] | None = None
+```
+
+In `daemon.py` `_search_via_backends` (~3157), add `query_vector: list[float] | None = None,` after `rrf_k: int = 60,` in the signature. Change BOTH embed legs (semantic ~3212, hybrid ~3239) from:
+
+```python
+        qvec = await timed_leg("embed_ms", self._embed_query(query))
+```
+
+to:
+
+```python
+        qvec = (
+            query_vector
+            if query_vector is not None
+            else await timed_leg("embed_ms", self._embed_query(query))
+        )
+```
+
+In `_search_on_current_loop` (~2878), add `query_vector: list[float] | None = None,` after `rrf_k: int = 60,`. In its semantic/hybrid `_search_via_backends` call (~3045), add `query_vector=query_vector,` after `rrf_k=rrf_k,`. (The keyword-branch call at ~2955 does not embed — leave it unchanged.)
+
+In `search()` (~2828), add `query_vector=req.query_vector,` after `rrf_k=req.rrf_k,` in BOTH `_search_on_current_loop` calls (the `zone_id is None` branch and the `_work()` closure).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/unit/bricks/search/test_daemon_batch_search.py -v`
+Expected: PASS (both tests)
+
+- [ ] **Step 5: Run neighboring regression tests**
+
+Run: `uv run pytest tests/unit/bricks/search/test_daemon_fusion_params.py tests/unit/bricks/search/test_daemon_recency.py -q`
+Expected: PASS (signature additions are default-valued — nothing changes for existing callers)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/nexus/contracts/search_types.py src/nexus/bricks/search/daemon.py tests/unit/bricks/search/test_daemon_batch_search.py
+git commit -m "feat(search): thread optional pre-computed query_vector through SearchRequest"
+```
+
+---
+
+### Task 2: Concurrent batch execution + embed-once + `BatchQueryFailure`
+
+**Files:**
+- Modify: `src/nexus/contracts/search_types.py` (add `BatchQueryFailure` below `SearchRequest`)
+- Modify: `src/nexus/bricks/search/daemon.py`:
+  - `DaemonConfig` (~line 409, "Performance settings" block ~441): add `batch_search_concurrency: int = 8`
+  - `batch_search` (~line 3587) and `_batch_search_on_current_loop` (~line 3599): rewrite
+- Modify: `src/nexus/server/lifespan/search.py` (~line 209 `DaemonConfig(...)` construction): parse `NEXUS_SEARCH_BATCH_CONCURRENCY`
+- Test: `tests/unit/bricks/search/test_daemon_batch_search.py` (extend)
+
+**Interfaces:**
+- Consumes: `SearchRequest.query_vector` (Task 1).
+- Produces: `BatchQueryFailure(error: str)` frozen dataclass in `nexus.contracts.search_types`; `batch_search(queries, *, zone_id) -> list[list[Any] | BatchQueryFailure]` where each element maps positionally to the input and is either a result list or a failure marker. Daemon reads spec keys: `query`, `search_type`, `limit`, `path_filter`, `alpha`, `fusion_method`, `rrf_k`, `expand`, `recency`, `recency_weight`, `recency_half_life_days`. Task 4's router relies on exactly these names.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/unit/bricks/search/test_daemon_batch_search.py`:
+
+```python
+def _make_batch_daemon(concurrency: int = 8) -> Any:
+    """Bare daemon for _batch_search_on_current_loop: search() is stubbed
+    per-test; only batch orchestration fields are real."""
+    from unittest.mock import AsyncMock
+
+    from nexus.bricks.search.daemon import DaemonConfig, SearchDaemon
+
+    daemon: Any = SearchDaemon.__new__(SearchDaemon)
+    daemon._initialized = True
+    daemon._embedding_client = None
+    daemon.config = DaemonConfig(batch_search_concurrency=concurrency)
+    # Path-context attach is exercised elsewhere; resolve to None (= skip).
+    daemon._resolve_path_context_cache = AsyncMock(return_value=None)
+    return daemon
+
+
+class _FakeEmbeddingClient:
+    def __init__(self, fail: bool = False) -> None:
+        self.calls: list[list[str]] = []
+        self.fail = fail
+
+    async def embed_batch(self, texts: Any) -> list[list[float]]:
+        self.calls.append(list(texts))
+        if self.fail:
+            raise RuntimeError("embed down")
+        return [[0.1, 0.2] for _ in texts]
+
+
+@pytest.mark.asyncio
+async def test_batch_pre_embeds_unique_texts_once() -> None:
+    daemon = _make_batch_daemon()
+    client = _FakeEmbeddingClient()
+    daemon._embedding_client = client
+    seen_vectors: list[Any] = []
+
+    async def fake_search(self: Any, request: Any) -> list[Any]:
+        seen_vectors.append(request.query_vector)
+        return []
+
+    daemon.search = MethodType(fake_search, daemon)
+    specs = [{"query": "same text", "search_type": "hybrid", "limit": 5} for _ in range(24)]
+
+    out = await daemon._batch_search_on_current_loop(specs, zone_id="root")
+
+    assert client.calls == [["same text"]]  # ONE embed_batch call, unique texts only
+    assert seen_vectors == [[0.1, 0.2]] * 24
+    assert out == [[] for _ in range(24)]
+
+
+@pytest.mark.asyncio
+async def test_batch_keyword_only_never_embeds() -> None:
+    daemon = _make_batch_daemon()
+    client = _FakeEmbeddingClient()
+    daemon._embedding_client = client
+
+    async def fake_search(self: Any, request: Any) -> list[Any]:
+        return []
+
+    daemon.search = MethodType(fake_search, daemon)
+
+    await daemon._batch_search_on_current_loop(
+        [{"query": "kw", "search_type": "keyword"}], zone_id="root"
+    )
+
+    assert client.calls == []
+
+
+@pytest.mark.asyncio
+async def test_batch_embed_failure_falls_back_to_per_query() -> None:
+    daemon = _make_batch_daemon()
+    daemon._embedding_client = _FakeEmbeddingClient(fail=True)
+    seen_vectors: list[Any] = []
+
+    async def fake_search(self: Any, request: Any) -> list[Any]:
+        seen_vectors.append(request.query_vector)
+        return []
+
+    daemon.search = MethodType(fake_search, daemon)
+
+    out = await daemon._batch_search_on_current_loop(
+        [{"query": "a", "search_type": "hybrid"}], zone_id="root"
+    )
+
+    assert out == [[]]           # fail-soft: search still ran
+    assert seen_vectors == [None]  # ...and embeds for itself downstream
+
+
+@pytest.mark.asyncio
+async def test_batch_failure_isolated_per_query() -> None:
+    from nexus.contracts.search_types import BatchQueryFailure
+
+    daemon = _make_batch_daemon()
+
+    async def fake_search(self: Any, request: Any) -> list[Any]:
+        if request.query == "poison":
+            raise RuntimeError("boom")
+        return []
+
+    daemon.search = MethodType(fake_search, daemon)
+
+    out = await daemon._batch_search_on_current_loop(
+        [{"query": "ok1"}, {"query": "poison"}, {"query": "ok2"}], zone_id="root"
+    )
+
+    assert out[0] == [] and out[2] == []
+    assert isinstance(out[1], BatchQueryFailure)
+    assert "boom" in out[1].error
+
+
+@pytest.mark.asyncio
+async def test_batch_respects_concurrency_bound() -> None:
+    import asyncio
+
+    daemon = _make_batch_daemon(concurrency=2)
+    peak = 0
+    active = 0
+
+    async def fake_search(self: Any, request: Any) -> list[Any]:
+        nonlocal peak, active
+        active += 1
+        peak = max(peak, active)
+        await asyncio.sleep(0.01)
+        active -= 1
+        return []
+
+    daemon.search = MethodType(fake_search, daemon)
+
+    await daemon._batch_search_on_current_loop(
+        [{"query": f"q{i}"} for i in range(10)], zone_id="root"
+    )
+
+    assert peak <= 2
+
+
+@pytest.mark.asyncio
+async def test_batch_forwards_tuning_params() -> None:
+    daemon = _make_batch_daemon()
+    captured: list[Any] = []
+
+    async def fake_search(self: Any, request: Any) -> list[Any]:
+        captured.append(request)
+        return []
+
+    daemon.search = MethodType(fake_search, daemon)
+
+    await daemon._batch_search_on_current_loop(
+        [
+            {
+                "query": "tuned",
+                "search_type": "hybrid",
+                "limit": 7,
+                "path_filter": "/ws/",
+                "alpha": 0.3,
+                "fusion_method": "weighted",
+                "rrf_k": 90,
+                "expand": "macro",
+                "recency": "on",
+                "recency_weight": 1.5,
+                "recency_half_life_days": 30.0,
+            }
+        ],
+        zone_id="root",
+    )
+
+    req = captured[0]
+    assert (req.alpha, req.fusion_method, req.rrf_k) == (0.3, "weighted", 90)
+    assert (req.expand, req.recency, req.recency_weight) == ("macro", "on", 1.5)
+    assert req.recency_half_life_days == 30.0
+    assert (req.limit, req.path_filter, req.zone_id) == (7, "/ws/", "root")
+
+
+@pytest.mark.asyncio
+async def test_batch_non_dict_spec_becomes_failure() -> None:
+    from nexus.contracts.search_types import BatchQueryFailure
+
+    daemon = _make_batch_daemon()
+
+    async def fake_search(self: Any, request: Any) -> list[Any]:
+        return []
+
+    daemon.search = MethodType(fake_search, daemon)
+
+    out = await daemon._batch_search_on_current_loop(["not a dict"], zone_id="root")
+
+    assert isinstance(out[0], BatchQueryFailure)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/unit/bricks/search/test_daemon_batch_search.py -v`
+Expected: Task-1 tests PASS; new tests FAIL (`ImportError: cannot import name 'BatchQueryFailure'`, `TypeError: DaemonConfig.__init__() got an unexpected keyword argument 'batch_search_concurrency'`, param-forwarding assertions).
+
+- [ ] **Step 3: Implement**
+
+In `src/nexus/contracts/search_types.py`, below `SearchRequest`:
+
+```python
+@dataclass(frozen=True, kw_only=True)
+class BatchQueryFailure:
+    """Positional per-query failure marker returned by ``batch_search``.
+
+    The batch endpoint historically collapsed inner exceptions to ``[]``,
+    making a backend failure indistinguishable from a genuine empty result.
+    Returning this marker instead lets callers with fail-closed coverage
+    contracts (e.g. cross-workspace fan-out) count the query as FAILED
+    rather than "searched, no matches".
+    """
+
+    error: str
+```
+
+In `daemon.py` `DaemonConfig` (~441, "Performance settings"):
+
+```python
+    # Bounded fan-out width for POST /query/batch inner searches. 1 restores
+    # strictly sequential execution (ops fallback).
+    batch_search_concurrency: int = 8
+```
+
+Update `batch_search` (~3587) return annotations from `list[list[Any]]` to `list[list[Any] | BatchQueryFailure]` (import `BatchQueryFailure` alongside the existing `SearchRequest` import at the top of `daemon.py`).
+
+Rewrite `_batch_search_on_current_loop` (~3599) — keep the initialization guard and the trailing path-context attach block, replace the middle:
+
+```python
+    async def _batch_search_on_current_loop(
+        self,
+        queries: list[dict[str, Any]],
+        *,
+        zone_id: str | None = None,
+    ) -> list[list[Any] | BatchQueryFailure]:
+        """Batch search: one shared embed call + bounded-concurrency fan-out.
+
+        Powers ``POST /api/v2/search/query/batch``. All unique query texts
+        that need a dense leg (search_type != "keyword") are embedded in ONE
+        ``embed_batch`` call; each inner search then runs concurrently under
+        ``DaemonConfig.batch_search_concurrency``. A failed inner query is
+        returned positionally as :class:`BatchQueryFailure` instead of being
+        collapsed to ``[]``, so callers can tell "no matches" from "backend
+        fell over".
+        """
+        if not self._initialized:
+            raise RuntimeError("SearchDaemon not initialized. Call startup() first.")
+
+        from nexus.contracts.constants import ROOT_ZONE_ID
+
+        effective_zone_id = zone_id or ROOT_ZONE_ID
+
+        # Pre-embed unique texts once. Fail-soft: on any error fall back to
+        # per-query embedding inside each inner search (hybrid degrades to
+        # keyword-only on embed failure exactly as a single /query does).
+        vector_by_text: dict[str, list[float]] = {}
+        if self._embedding_client is not None:
+            unique_texts = sorted(
+                {
+                    str(q.get("query", ""))
+                    for q in queries
+                    if isinstance(q, dict)
+                    and str(q.get("query", ""))
+                    and q.get("search_type", "hybrid") != "keyword"
+                }
+            )
+            if unique_texts:
+                try:
+                    vectors = await self._embedding_client.embed_batch(unique_texts)
+                    vector_by_text = dict(zip(unique_texts, vectors, strict=True))
+                except Exception as exc:
+                    logger.warning(
+                        "batch pre-embed failed; falling back to per-query embedding: %s",
+                        exc,
+                    )
+
+        semaphore = asyncio.Semaphore(max(1, self.config.batch_search_concurrency))
+
+        async def _run_one(q: Any) -> list[Any] | BatchQueryFailure:
+            if not isinstance(q, dict):
+                return BatchQueryFailure(error="invalid query spec: expected an object")
+            query_text = str(q.get("query", ""))
+            async with semaphore:
+                try:
+                    return await self.search(
+                        SearchRequest(
+                            query=query_text,
+                            search_type=q.get("search_type", "hybrid"),
+                            limit=int(q.get("limit", 10)),
+                            path_filter=q.get("path_filter"),
+                            alpha=float(q.get("alpha", 0.5)),
+                            fusion_method=q.get("fusion_method", "rrf"),
+                            rrf_k=int(q.get("rrf_k", 60)),
+                            expand=q.get("expand", "none"),
+                            recency=q.get("recency"),
+                            recency_weight=q.get("recency_weight"),
+                            recency_half_life_days=q.get("recency_half_life_days"),
+                            zone_id=effective_zone_id,
+                            query_vector=vector_by_text.get(query_text),
+                        )
+                    )
+                except Exception as exc:
+                    logger.warning("batch_search inner search failed: %s", exc)
+                    return BatchQueryFailure(error=str(exc) or exc.__class__.__name__)
+
+        results: list[list[Any] | BatchQueryFailure] = list(
+            await asyncio.gather(*(_run_one(q) for q in queries))
+        )
+```
+
+In the retained path-context attach block at the end of the method, guard the per-result loop:
+
+```python
+                for inner in results:
+                    if isinstance(inner, BatchQueryFailure):
+                        continue
+                    for r in inner:
+```
+
+(keep the rest of that block byte-identical) and keep `return results` at the end.
+
+In `src/nexus/server/lifespan/search.py`, next to the other env parses (~195):
+
+```python
+        _batch_concurrency_env = os.environ.get("NEXUS_SEARCH_BATCH_CONCURRENCY", "")
+        _batch_concurrency = 8
+        if _batch_concurrency_env:
+            try:
+                _batch_concurrency = max(1, int(_batch_concurrency_env))
+            except ValueError:
+                logger.warning(
+                    "Invalid NEXUS_SEARCH_BATCH_CONCURRENCY=%r — falling back to 8",
+                    _batch_concurrency_env,
+                )
+```
+
+and add `batch_search_concurrency=_batch_concurrency,` to the `DaemonConfig(...)` construction (~209).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/unit/bricks/search/test_daemon_batch_search.py -v`
+Expected: PASS (all)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/nexus/contracts/search_types.py src/nexus/bricks/search/daemon.py src/nexus/server/lifespan/search.py tests/unit/bricks/search/test_daemon_batch_search.py
+git commit -m "feat(search): concurrent batch_search with one shared embed call and per-query failure markers"
+```
+
+---
+
+### Task 3: Batch spec parser (`_search_batch.py`)
+
+**Files:**
+- Create: `src/nexus/server/api/v2/routers/_search_batch.py`
+- Test: Create `tests/integration/services/test_search_query_batch.py`
+
+**Interfaces:**
+- Produces: `ParsedBatchSpec` (frozen dataclass: `query, search_type, limit, path_filter, alpha, fusion_method, rrf_k, expand, recency, recency_weight, recency_half_life_days`), `parse_batch_query_spec(raw: Any) -> ParsedBatchSpec | str` (str = error message), `spec_query_text(raw: Any) -> str` (best-effort echo for error entries). Task 4's route consumes all three.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/integration/services/test_search_query_batch.py`. Copy the `nexus_runtime` stub preamble and `_MockResult` dataclass from `tests/integration/services/test_search_zone_set.py` verbatim (Task 4 reuses them), then add:
+
+```python
+from nexus.server.api.v2.routers._search_batch import (
+    ParsedBatchSpec,
+    parse_batch_query_spec,
+    spec_query_text,
+)
+
+
+class TestParseBatchQuerySpec:
+    def test_defaults(self):
+        spec = parse_batch_query_spec({"q": "hello"})
+        assert spec == ParsedBatchSpec(query="hello")
+        assert (spec.search_type, spec.limit, spec.alpha) == ("hybrid", 10, 0.5)
+        assert (spec.fusion_method, spec.rrf_k, spec.expand) == ("rrf", 60, "none")
+        assert (spec.recency, spec.recency_weight, spec.recency_half_life_days) == (
+            None,
+            None,
+            None,
+        )
+
+    def test_public_names_win_over_legacy_aliases(self):
+        spec = parse_batch_query_spec(
+            {
+                "q": "public",
+                "query": "legacy",
+                "type": "semantic",
+                "search_type": "keyword",
+                "path": "/a/",
+                "path_filter": "/b/",
+                "fusion": "weighted",
+                "fusion_method": "rrf",
+            }
+        )
+        assert isinstance(spec, ParsedBatchSpec)
+        assert spec.query == "public"
+        assert spec.search_type == "semantic"
+        assert spec.path_filter == "/a/"
+        assert spec.fusion_method == "weighted"
+
+    def test_legacy_aliases_still_accepted(self):
+        spec = parse_batch_query_spec(
+            {"query": "legacy", "search_type": "keyword", "path_filter": "/b/"}
+        )
+        assert isinstance(spec, ParsedBatchSpec)
+        assert (spec.query, spec.search_type, spec.path_filter) == ("legacy", "keyword", "/b/")
+
+    def test_tuning_params_parsed(self):
+        spec = parse_batch_query_spec(
+            {
+                "q": "tuned",
+                "alpha": 0.3,
+                "fusion": "weighted",
+                "rrf_k": 90,
+                "expand": "macro",
+                "recency": "on",
+                "recency_weight": 1.5,
+                "recency_half_life_days": 30,
+            }
+        )
+        assert isinstance(spec, ParsedBatchSpec)
+        assert (spec.alpha, spec.fusion_method, spec.rrf_k) == (0.3, "weighted", 90)
+        assert (spec.expand, spec.recency) == ("macro", "on")
+        assert (spec.recency_weight, spec.recency_half_life_days) == (1.5, 30.0)
+
+    @pytest.mark.parametrize(
+        ("raw", "fragment"),
+        [
+            ("not a dict", "expected an object"),
+            ({}, "query text"),
+            ({"q": ""}, "query text"),
+            ({"q": "x", "limit": 0}, "limit"),
+            ({"q": "x", "limit": 101}, "limit"),
+            ({"q": "x", "limit": "ten"}, "limit"),
+            ({"q": "x", "alpha": 1.5}, "alpha"),
+            ({"q": "x", "alpha": -0.1}, "alpha"),
+            ({"q": "x", "rrf_k": 0}, "rrf_k"),
+            ({"q": "x", "rrf_k": 1001}, "rrf_k"),
+            ({"q": "x", "recency_weight": 5.1}, "recency_weight"),
+            ({"q": "x", "recency_half_life_days": 0}, "recency_half_life_days"),
+            ({"q": "x", "recency_half_life_days": 3651}, "recency_half_life_days"),
+            ({"q": "x", "path": 42}, "path"),
+        ],
+    )
+    def test_invalid_specs_return_error_message(self, raw, fragment):
+        err = parse_batch_query_spec(raw)
+        assert isinstance(err, str)
+        assert fragment in err
+
+    def test_spec_query_text_best_effort(self):
+        assert spec_query_text({"q": "a"}) == "a"
+        assert spec_query_text({"query": "b"}) == "b"
+        assert spec_query_text({"q": "a", "query": "b"}) == "a"
+        assert spec_query_text("junk") == ""
+        assert spec_query_text({}) == ""
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/integration/services/test_search_query_batch.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'nexus.server.api.v2.routers._search_batch'`
+
+- [ ] **Step 3: Implement the parser**
+
+Create `src/nexus/server/api/v2/routers/_search_batch.py`:
+
+```python
+"""Batch search request parsing (`POST /query/batch`).
+
+Extracted from ``routers/search.py`` the same way ``_search_serialize.py``
+was (the router sits near the repo's 2000-line file cap). This module owns
+the pure per-query spec contract; the route keeps auth, the read gate, and
+daemon wiring.
+
+Each spec mirrors the single ``/query`` route's public parameter names and
+keeps the legacy batch aliases (``query``/``search_type``/``path_filter``).
+The public name wins when both are present. Numeric bounds mirror the
+single route's FastAPI ``Query()`` validation exactly; string params pass
+through unvalidated (single-route parity — the daemon handles unknown
+values). Invalid specs return an error MESSAGE rather than raising: the
+route maps them to per-entry ``error`` fields so one bad query cannot fail
+a whole batch.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True, kw_only=True)
+class ParsedBatchSpec:
+    """One validated batch query, normalized to daemon spec key names."""
+
+    query: str
+    search_type: str = "hybrid"
+    limit: int = 10
+    path_filter: str | None = None
+    alpha: float = 0.5
+    fusion_method: str = "rrf"
+    rrf_k: int = 60
+    expand: str = "none"
+    recency: str | None = None
+    recency_weight: float | None = None
+    recency_half_life_days: float | None = None
+
+
+def spec_query_text(raw: Any) -> str:
+    """Best-effort query-text echo for error entries (public name wins)."""
+    if not isinstance(raw, dict):
+        return ""
+    return str(raw.get("q") or raw.get("query") or "")
+
+
+def _pick(raw: dict[str, Any], public: str, legacy: str) -> Any:
+    """Resolve a public-name/legacy-alias pair; public wins when present."""
+    if public in raw:
+        return raw[public]
+    return raw.get(legacy)
+
+
+def _as_int(value: Any, name: str, lo: int, hi: int) -> int | str:
+    try:
+        # bool is an int subclass; reject it explicitly so `limit: true`
+        # doesn't silently parse as 1.
+        if isinstance(value, bool):
+            raise ValueError
+        out = int(value)
+    except (TypeError, ValueError):
+        return f"{name} must be an integer"
+    if not lo <= out <= hi:
+        return f"{name} must be between {lo} and {hi}"
+    return out
+
+
+def _as_float(value: Any, name: str, lo: float, hi: float, *, exclusive_lo: bool = False) -> float | str:
+    try:
+        if isinstance(value, bool):
+            raise ValueError
+        out = float(value)
+    except (TypeError, ValueError):
+        return f"{name} must be a number"
+    if exclusive_lo and out <= lo:
+        return f"{name} must be greater than {lo} and at most {hi}"
+    if not exclusive_lo and not lo <= out <= hi:
+        return f"{name} must be between {lo} and {hi}"
+    if out > hi:
+        return f"{name} must be greater than {lo} and at most {hi}"
+    return out
+
+
+def parse_batch_query_spec(raw: Any) -> ParsedBatchSpec | str:
+    """Parse one raw batch query spec.
+
+    Returns a :class:`ParsedBatchSpec` on success or an error message on
+    invalid input. Bounds mirror the single ``/query`` route: ``limit``
+    1..100, ``alpha`` 0.0..1.0, ``rrf_k`` 1..1000, ``recency_weight``
+    0.0..5.0, ``recency_half_life_days`` >0.0..3650.0.
+    """
+    if not isinstance(raw, dict):
+        return "invalid query spec: expected an object"
+
+    query = spec_query_text(raw)
+    if not query:
+        return "query text required (q)"
+
+    path = _pick(raw, "path", "path_filter")
+    if path is not None and not isinstance(path, str):
+        return "path must be a string"
+
+    limit = _as_int(raw.get("limit", 10), "limit", 1, 100)
+    if isinstance(limit, str):
+        return limit
+    alpha = _as_float(raw.get("alpha", 0.5), "alpha", 0.0, 1.0)
+    if isinstance(alpha, str):
+        return alpha
+    rrf_k = _as_int(raw.get("rrf_k", 60), "rrf_k", 1, 1000)
+    if isinstance(rrf_k, str):
+        return rrf_k
+
+    recency_weight: float | None = None
+    if raw.get("recency_weight") is not None:
+        parsed_weight = _as_float(raw["recency_weight"], "recency_weight", 0.0, 5.0)
+        if isinstance(parsed_weight, str):
+            return parsed_weight
+        recency_weight = parsed_weight
+
+    recency_half_life: float | None = None
+    if raw.get("recency_half_life_days") is not None:
+        parsed_half_life = _as_float(
+            raw["recency_half_life_days"],
+            "recency_half_life_days",
+            0.0,
+            3650.0,
+            exclusive_lo=True,
+        )
+        if isinstance(parsed_half_life, str):
+            return parsed_half_life
+        recency_half_life = parsed_half_life
+
+    recency = raw.get("recency")
+
+    return ParsedBatchSpec(
+        query=query,
+        search_type=str(_pick(raw, "type", "search_type") or "hybrid"),
+        limit=limit,
+        path_filter=path,
+        alpha=alpha,
+        fusion_method=str(_pick(raw, "fusion", "fusion_method") or "rrf"),
+        rrf_k=rrf_k,
+        expand=str(raw.get("expand") or "none"),
+        recency=str(recency) if recency is not None else None,
+        recency_weight=recency_weight,
+        recency_half_life_days=recency_half_life,
+    )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/integration/services/test_search_query_batch.py -v`
+Expected: PASS (all parser tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/nexus/server/api/v2/routers/_search_batch.py tests/integration/services/test_search_query_batch.py
+git commit -m "feat(search): batch query spec parser with single-/query param parity"
+```
+
+---
+
+### Task 4: Rewrite the `/query/batch` route
+
+**Files:**
+- Modify: `src/nexus/server/api/v2/routers/search.py:798-925` (`search_query_batch`)
+- Test: `tests/integration/services/test_search_query_batch.py` (extend)
+
+**Interfaces:**
+- Consumes: `parse_batch_query_spec` / `ParsedBatchSpec` / `spec_query_text` (Task 3); `batch_search -> list[list[Any] | BatchQueryFailure]` with daemon spec keys `query/search_type/limit/path_filter/alpha/fusion_method/rrf_k/expand/recency/recency_weight/recency_half_life_days` (Task 2); existing `_serialize_search_result`, `_apply_rebac_filter`, `_compute_rebac_fetch_limit` (already imported in `search.py`).
+- Produces: the wire contract from the spec — per-entry `{"query", "results", "total"}` plus additive `"error"`; unchanged top-level fields.
+
+- [ ] **Step 1: Write the failing route tests**
+
+Append to `tests/integration/services/test_search_query_batch.py`:
+
+```python
+def _build_batch_app(mock_daemon):
+    from fastapi import FastAPI
+
+    from nexus.server.api.v2.routers.search import router
+
+    app = FastAPI()
+    app.include_router(router)
+    mock_daemon.is_initialized = True
+    app.state.search_daemon = mock_daemon
+    app.state.search_daemon_enabled = True
+    app.state.record_store = MagicMock()
+    app.state.async_session_factory = MagicMock()
+    app.state.async_read_session_factory = MagicMock()
+
+    from nexus.server.dependencies import require_auth
+
+    app.dependency_overrides[require_auth] = lambda: {
+        "authenticated": True,
+        "user_id": "u",
+        "zone_id": "eng",
+        "zone_set": ["eng"],
+        "zone_perms": [["eng", "r"]],
+    }
+    return app
+
+
+@pytest.mark.skipif(not _HAS_FASTAPI_TESTCLIENT, reason="fastapi test client not available")
+class TestBatchRoute:
+    def test_params_forwarded_to_daemon(self):
+        daemon = MagicMock()
+        daemon.batch_search = AsyncMock(return_value=[[]])
+        app = _build_batch_app(daemon)
+
+        resp = TestClient(app).post(
+            "/api/v2/search/query/batch",
+            json={
+                "queries": [
+                    {
+                        "q": "tuned",
+                        "type": "hybrid",
+                        "limit": 7,
+                        "path": "/ws/",
+                        "alpha": 0.3,
+                        "fusion": "weighted",
+                        "rrf_k": 90,
+                        "expand": "macro",
+                        "recency": "on",
+                        "recency_weight": 1.5,
+                        "recency_half_life_days": 30,
+                    }
+                ]
+            },
+        )
+
+        assert resp.status_code == 200, resp.text
+        (specs,) = daemon.batch_search.call_args.args
+        assert daemon.batch_search.call_args.kwargs == {"zone_id": "eng"}
+        spec = specs[0]
+        assert spec["query"] == "tuned"
+        assert spec["search_type"] == "hybrid"
+        assert spec["path_filter"] == "/ws/"
+        assert (spec["alpha"], spec["fusion_method"], spec["rrf_k"]) == (0.3, "weighted", 90)
+        assert (spec["expand"], spec["recency"]) == ("macro", "on")
+        assert (spec["recency_weight"], spec["recency_half_life_days"]) == (1.5, 30.0)
+        # No enforcer on this app -> fetch limit == requested limit.
+        assert spec["limit"] == 7
+
+    def test_serializer_parity_with_single_query(self):
+        from nexus.server.api.v2.routers._search_serialize import _serialize_search_result
+
+        result = _MockResult(
+            path="/ws/doc.md",
+            chunk_text="hello",
+            score=0.9123456,
+            chunk_index=3,
+            line_start=10,
+            line_end=14,
+            keyword_score=1.25,
+            vector_score=0.75,
+        )
+        daemon = MagicMock()
+        daemon.batch_search = AsyncMock(return_value=[[result]])
+        app = _build_batch_app(daemon)
+
+        resp = TestClient(app).post(
+            "/api/v2/search/query/batch", json={"queries": [{"q": "hello"}]}
+        )
+
+        assert resp.status_code == 200, resp.text
+        entry = resp.json()["queries"][0]
+        assert "error" not in entry
+        assert entry["total"] == 1
+        assert entry["results"][0] == _serialize_search_result(result)
+        assert entry["results"][0]["chunk_index"] == 3
+        assert entry["results"][0]["line_start"] == 10
+
+    def test_daemon_failure_becomes_error_entry(self):
+        from nexus.contracts.search_types import BatchQueryFailure
+
+        daemon = MagicMock()
+        daemon.batch_search = AsyncMock(
+            return_value=[[], BatchQueryFailure(error="backend fell over")]
+        )
+        app = _build_batch_app(daemon)
+
+        resp = TestClient(app).post(
+            "/api/v2/search/query/batch",
+            json={"queries": [{"q": "ok"}, {"q": "doomed"}]},
+        )
+
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert "error" not in body["queries"][0]
+        assert body["queries"][1] == {
+            "query": "doomed",
+            "results": [],
+            "total": 0,
+            "error": "backend fell over",
+        }
+
+    def test_invalid_spec_gets_error_entry_and_is_not_sent_to_daemon(self):
+        daemon = MagicMock()
+        daemon.batch_search = AsyncMock(return_value=[[]])
+        app = _build_batch_app(daemon)
+
+        resp = TestClient(app).post(
+            "/api/v2/search/query/batch",
+            json={"queries": [{"q": "bad-limit", "limit": 0}, {"q": "fine"}]},
+        )
+
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["total_queries"] == 2
+        assert body["queries"][0]["query"] == "bad-limit"
+        assert "limit" in body["queries"][0]["error"]
+        assert body["queries"][0]["results"] == []
+        assert "error" not in body["queries"][1]
+        # Only the valid spec reached the daemon.
+        (specs,) = daemon.batch_search.call_args.args
+        assert [s["query"] for s in specs] == ["fine"]
+
+    def test_all_specs_invalid_skips_daemon_entirely(self):
+        daemon = MagicMock()
+        daemon.batch_search = AsyncMock(return_value=[])
+        app = _build_batch_app(daemon)
+
+        resp = TestClient(app).post(
+            "/api/v2/search/query/batch", json={"queries": [{"q": "x", "limit": 9999}]}
+        )
+
+        assert resp.status_code == 200, resp.text
+        assert "limit" in resp.json()["queries"][0]["error"]
+        daemon.batch_search.assert_not_called()
+
+    def test_empty_queries_still_400(self):
+        daemon = MagicMock()
+        daemon.batch_search = AsyncMock(return_value=[])
+        app = _build_batch_app(daemon)
+
+        resp = TestClient(app).post("/api/v2/search/query/batch", json={"queries": []})
+
+        assert resp.status_code == 400
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/integration/services/test_search_query_batch.py -v`
+Expected: parser tests PASS; route tests FAIL (old route drops tuning params, formats entries inline without `chunk_index`, has no `error` entries).
+
+- [ ] **Step 3: Rewrite the route**
+
+In `search.py`, add to the imports near the other router-helper imports:
+
+```python
+from nexus.server.api.v2.routers._search_batch import (
+    ParsedBatchSpec,
+    parse_batch_query_spec,
+    spec_query_text,
+)
+```
+
+Replace the body of `search_query_batch` (KEEP: the decorator/signature, `ROOT_ZONE_ID` import + `zone_id` line, the 400 guard, the #4557 read-gate block, the 503 daemon-init check, and the `permission_enforcer`/`op_context` lines — replace everything from the old over-fetch loop down to the return):
+
+```python
+    """Batch search: run N queries through the full hybrid pipeline.
+
+    Body: ``{"queries": [{...}]}`` where each entry mirrors the single
+    ``/query`` route's public parameter names (``q``, ``type``, ``limit``,
+    ``path``, ``alpha``, ``fusion``, ``rrf_k``, ``expand``, ``recency``,
+    ``recency_weight``, ``recency_half_life_days``); the legacy batch
+    aliases ``query``/``search_type``/``path_filter`` stay accepted (see
+    ``_search_batch.py`` for the exact contract).
+
+    Returns ``{"queries": [{"query", "results", "total"[, "error"]}], ...}``.
+    Results use the same serialization as single ``/query``. A failed or
+    invalid query yields a per-entry additive ``error`` message instead of
+    failing the batch (absence of ``error`` means the result set is
+    genuine); batch-level auth/read-gate/daemon-init failures still fail
+    the whole request.
+
+    Applies the same ReBAC file-level permission filter as ``/query``
+    (Decision #17), over-fetching via ``_compute_rebac_fetch_limit`` and
+    trimming to each query's requested ``limit`` after filtering. All
+    unique query texts are embedded in ONE ``embed_batch`` call and the
+    inner searches run concurrently (``NEXUS_SEARCH_BATCH_CONCURRENCY``,
+    default 8).
+    """
+```
+
+then:
+
+```python
+    parsed = [parse_batch_query_spec(raw) for raw in raw_queries]
+    valid: list[tuple[int, ParsedBatchSpec]] = [
+        (i, p) for i, p in enumerate(parsed) if isinstance(p, ParsedBatchSpec)
+    ]
+    fetch_specs = [
+        {
+            "query": spec.query,
+            "search_type": spec.search_type,
+            "limit": _compute_rebac_fetch_limit(
+                spec.limit, has_enforcer=permission_enforcer is not None
+            ),
+            "path_filter": spec.path_filter,
+            "alpha": spec.alpha,
+            "fusion_method": spec.fusion_method,
+            "rrf_k": spec.rrf_k,
+            "expand": spec.expand,
+            "recency": spec.recency,
+            "recency_weight": spec.recency_weight,
+            "recency_half_life_days": spec.recency_half_life_days,
+        }
+        for _, spec in valid
+    ]
+
+    t0 = time.perf_counter()
+    raw_results = (
+        await search_daemon.batch_search(fetch_specs, zone_id=zone_id) if fetch_specs else []
+    )
+    elapsed_ms = (time.perf_counter() - t0) * 1000
+
+    result_by_index: dict[int, Any] = {
+        i: result for (i, _), result in zip(valid, raw_results, strict=True)
+    }
+
+    filter_ms_total = 0.0
+    response_queries: list[dict[str, Any]] = []
+    for i, p in enumerate(parsed):
+        if isinstance(p, str):
+            response_queries.append(
+                {
+                    "query": spec_query_text(raw_queries[i]),
+                    "results": [],
+                    "total": 0,
+                    "error": p,
+                }
+            )
+            continue
+        inner = result_by_index[i]
+        if isinstance(inner, BatchQueryFailure):
+            response_queries.append(
+                {"query": p.query, "results": [], "total": 0, "error": inner.error}
+            )
+            continue
+        # File-level ReBAC filtering (Decision #17) — same enforcement as /query.
+        filtered, filter_ms = _apply_rebac_filter(
+            inner,
+            permission_enforcer,
+            auth_result,
+            zone_id,
+            operation_context=op_context,
+        )
+        filter_ms_total += filter_ms
+        trimmed = filtered[: p.limit]
+        response_queries.append(
+            {
+                "query": p.query,
+                "results": [_serialize_search_result(r) for r in trimmed],
+                "total": len(trimmed),
+            }
+        )
+
+    return {
+        "queries": response_queries,
+        "total_queries": len(raw_queries),
+        "latency_ms": round(elapsed_ms, 2),
+        "avg_per_query_ms": round(elapsed_ms / max(len(raw_queries), 1), 2),
+        "permission_filter_ms": round(filter_ms_total, 2),
+    }
+```
+
+`BatchQueryFailure` import: add `from nexus.contracts.search_types import BatchQueryFailure` inside the function next to the existing `ROOT_ZONE_ID` local import (or at module top if ruff prefers — match the file's existing style: `ROOT_ZONE_ID` is imported locally). The old `overfetch_multiplier`/`requested_limits` loop and the inline `formatted` serialization block are deleted. Confirm `_serialize_search_result` is already imported/re-exported in `search.py` (the `_search_serialize.py` docstring says the router re-exports it); if it's not in scope, import it from `._search_serialize`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/integration/services/test_search_query_batch.py -v`
+Expected: PASS (all)
+
+- [ ] **Step 5: Run the batch read-gate + zone-set regressions**
+
+Run: `uv run pytest tests/integration/services/test_search_zone_set.py -v`
+Expected: PASS unchanged — the read-gate tests POST `{"queries": [{"q": "alpha"}]}` against a mock `batch_search = AsyncMock(return_value=[[]])`; the rewritten route parses that spec, calls the mock once, serializes `[]`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/nexus/server/api/v2/routers/search.py tests/integration/services/test_search_query_batch.py
+git commit -m "feat(search): /query/batch param+serializer parity with /query and per-query errors"
+```
+
+---
+
+### Task 5: E2E extension (live-server parity)
+
+**Files:**
+- Modify: `tests/e2e/self_contained/test_search_surface_live_e2e.py` (batch block, ~line 240)
+
+**Interfaces:**
+- Consumes: the deployed route contract from Task 4. Uses the file's existing `_request(live, method, path, ...)` helper and `_assert_endpoint_latency`.
+
+- [ ] **Step 1: Extend the batch block**
+
+Directly after the existing batch assertions (`_assert_endpoint_latency(batch_body)`), add:
+
+```python
+    # Hardened batch contract: single-/query serializer parity, tuning
+    # params accepted, healthy entries carry no error field.
+    parity_response, parity_body = _request(
+        live,
+        "post",
+        "/api/v2/search/query/batch",
+        json={
+            "queries": [
+                {"q": "needle", "type": "keyword", "limit": 5},
+                {"q": "needle", "type": "hybrid", "limit": 5, "alpha": 0.3, "fusion": "weighted"},
+                {"q": "needle", "type": "semantic", "limit": 5},
+            ]
+        },
+    )
+    assert parity_response.status_code == 200
+    assert parity_body["total_queries"] == 3
+    for entry in parity_body["queries"]:
+        assert "error" not in entry, entry
+    single_response, single_body = _request(
+        live,
+        "get",
+        "/api/v2/search/query",
+        params={"q": "needle", "type": "keyword", "limit": 5},
+    )
+    assert single_response.status_code == 200
+    batch_keyword_results = parity_body["queries"][0]["results"]
+    single_results = single_body["results"]
+    assert [r["path"] for r in batch_keyword_results] == [r["path"] for r in single_results]
+    # Field-shape parity: every key the single route emits appears in the
+    # batch entry with the same value (single may add response-envelope
+    # keys, so compare per-hit dicts directly).
+    for batch_hit, single_hit in zip(batch_keyword_results, single_results, strict=True):
+        assert batch_hit == single_hit
+
+    # Per-query error isolation: an invalid spec errors alone.
+    mixed_response, mixed_body = _request(
+        live,
+        "post",
+        "/api/v2/search/query/batch",
+        json={"queries": [{"q": "needle", "limit": 0}, {"q": "needle", "limit": 2}]},
+    )
+    assert mixed_response.status_code == 200
+    assert "limit" in mixed_body["queries"][0]["error"]
+    assert "error" not in mixed_body["queries"][1]
+```
+
+- [ ] **Step 2: Run the e2e module**
+
+Run: `uv run pytest tests/e2e/self_contained/test_search_surface_live_e2e.py -v`
+Expected: PASS. (This suite boots a self-contained live server; if the module has skip conditions that trip in this environment, run whatever subset executes and note honestly in the PR which legs ran.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/e2e/self_contained/test_search_surface_live_e2e.py
+git commit -m "test(search): live e2e parity + error-isolation coverage for hardened /query/batch"
+```
+
+---
+
+### Task 6: Full-suite regression, bench evidence, push + PR
+
+**Files:**
+- No new committed files (bench script goes in the session scratchpad, not the repo).
+
+**Interfaces:**
+- Consumes: everything above.
+
+- [ ] **Step 1: Full search-scoped test sweep**
+
+Run:
+```bash
+uv run pytest tests/unit/bricks/search/ tests/integration/services/test_search_zone_set.py tests/integration/services/test_search_query_batch.py tests/integration/bricks/search/ -q
+```
+Expected: PASS (pre-existing failures unrelated to search batch, if any, noted honestly).
+
+- [ ] **Step 2: Pre-commit over the branch diff**
+
+Run: `uv run pre-commit run --from-ref origin/develop --to-ref HEAD`
+Expected: all hooks pass (ruff, mypy, file-size caps — `search.py` must still be <2000 lines: `wc -l src/nexus/server/api/v2/routers/search.py`).
+
+- [ ] **Step 3: Bench evidence**
+
+Write a scratch script (session scratchpad, NOT committed) that POSTs to a locally booted server (reuse the self-contained e2e harness boot, or `uv run nexus serve` equivalent used by that suite):
+1. One batch of 24 specs sharing one query text (`type: "hybrid"`, distinct `path` filters) — record `latency_ms` from the response.
+2. The same 24 as sequential single `/query` GETs — record summed wall-clock.
+Repeat 3× on the feature branch, then 3× on `origin/develop` (check out `origin/develop` in a scratch worktree or `git stash`-free switch, since the branch has no uncommitted state). Record medians in the PR body. Also cite the embed-once unit test as the embedding-amortisation evidence (local stacks without an embedding key exercise the keyword fallback, so wall-clock alone understates the win on prod-like deployments).
+
+- [ ] **Step 4: File the upstream issue + open the PR**
+
+```bash
+git push -u origin feat/batch-search-hardening
+gh issue create --repo nexi-lab/nexus \
+  --title "search: /query/batch lost its batched-embedding contract (#3699) — sequential, drops tuning params, silent per-query failures" \
+  --body "<summary of the 5 gaps from docs/superpowers/specs/2026-08-04-batch-search-hardening-design.md, noting the endpoint docstring still promises one-call embedding>"
+gh pr create --repo nexi-lab/nexus --base develop --head feat/batch-search-hardening \
+  --title "search: restore /query/batch contract — concurrent execution, embed-once, /query parity, per-query errors" \
+  --body "<spec summary + Fixes #<issue> + test list + bench medians + compat notes (additive response, aliases kept, NEXUS_SEARCH_BATCH_CONCURRENCY=1 ops fallback)>"
+```
+
+- [ ] **Step 5: Koodle follow-up note**
+
+Comment on DeepBuildAI/koodle#2050: upstream PR link, adoption remains deferred until the fix is deployed to prod nexus; list what the koodle side will need (SDK `search.queryBatch`, fold of the 3 sub-path queries, coverage-contract mapping of per-query errors → degradable failures).
+
+---
+
+## Verification checklist (post-plan self-review)
+
+- Spec coverage: concurrency (Task 2), embed-once (Tasks 1+2), param parity (Tasks 3+4), serializer parity (Task 4), per-query errors (Tasks 2+4), env knob (Task 2), ReBAC fetch-limit helper (Task 4), e2e (Task 5), bench + PR + koodle note (Task 6). Non-goals untouched.
+- Type consistency: `BatchQueryFailure(error: str)` used identically in Tasks 2 and 4; daemon spec keys in Task 2's `_run_one` match Task 4's `fetch_specs` exactly; `query_vector` name identical across SearchRequest/`_search_on_current_loop`/`_search_via_backends`.

--- a/docs/superpowers/plans/2026-08-04-batch-search-hardening.md
+++ b/docs/superpowers/plans/2026-08-04-batch-search-hardening.md
@@ -248,7 +248,7 @@ async def test_batch_embed_failure_falls_back_to_per_query() -> None:
         [{"query": "a", "search_type": "hybrid"}], zone_id="root"
     )
 
-    assert out == [[]]           # fail-soft: search still ran
+    assert out == [[]]  # fail-soft: search still ran
     assert seen_vectors == [None]  # ...and embeds for itself downstream
 
 
@@ -699,7 +699,9 @@ def _as_int(value: Any, name: str, lo: int, hi: int) -> int | str:
     return out
 
 
-def _as_float(value: Any, name: str, lo: float, hi: float, *, exclusive_lo: bool = False) -> float | str:
+def _as_float(
+    value: Any, name: str, lo: float, hi: float, *, exclusive_lo: bool = False
+) -> float | str:
     try:
         if isinstance(value, bool):
             raise ValueError
@@ -1022,83 +1024,79 @@ Replace the body of `search_query_batch` (KEEP: the decorator/signature, `ROOT_Z
 then:
 
 ```python
-    parsed = [parse_batch_query_spec(raw) for raw in raw_queries]
-    valid: list[tuple[int, ParsedBatchSpec]] = [
-        (i, p) for i, p in enumerate(parsed) if isinstance(p, ParsedBatchSpec)
-    ]
-    fetch_specs = [
-        {
-            "query": spec.query,
-            "search_type": spec.search_type,
-            "limit": _compute_rebac_fetch_limit(
-                spec.limit, has_enforcer=permission_enforcer is not None
-            ),
-            "path_filter": spec.path_filter,
-            "alpha": spec.alpha,
-            "fusion_method": spec.fusion_method,
-            "rrf_k": spec.rrf_k,
-            "expand": spec.expand,
-            "recency": spec.recency,
-            "recency_weight": spec.recency_weight,
-            "recency_half_life_days": spec.recency_half_life_days,
-        }
-        for _, spec in valid
-    ]
-
-    t0 = time.perf_counter()
-    raw_results = (
-        await search_daemon.batch_search(fetch_specs, zone_id=zone_id) if fetch_specs else []
-    )
-    elapsed_ms = (time.perf_counter() - t0) * 1000
-
-    result_by_index: dict[int, Any] = {
-        i: result for (i, _), result in zip(valid, raw_results, strict=True)
+parsed = [parse_batch_query_spec(raw) for raw in raw_queries]
+valid: list[tuple[int, ParsedBatchSpec]] = [
+    (i, p) for i, p in enumerate(parsed) if isinstance(p, ParsedBatchSpec)
+]
+fetch_specs = [
+    {
+        "query": spec.query,
+        "search_type": spec.search_type,
+        "limit": _compute_rebac_fetch_limit(
+            spec.limit, has_enforcer=permission_enforcer is not None
+        ),
+        "path_filter": spec.path_filter,
+        "alpha": spec.alpha,
+        "fusion_method": spec.fusion_method,
+        "rrf_k": spec.rrf_k,
+        "expand": spec.expand,
+        "recency": spec.recency,
+        "recency_weight": spec.recency_weight,
+        "recency_half_life_days": spec.recency_half_life_days,
     }
+    for _, spec in valid
+]
 
-    filter_ms_total = 0.0
-    response_queries: list[dict[str, Any]] = []
-    for i, p in enumerate(parsed):
-        if isinstance(p, str):
-            response_queries.append(
-                {
-                    "query": spec_query_text(raw_queries[i]),
-                    "results": [],
-                    "total": 0,
-                    "error": p,
-                }
-            )
-            continue
-        inner = result_by_index[i]
-        if isinstance(inner, BatchQueryFailure):
-            response_queries.append(
-                {"query": p.query, "results": [], "total": 0, "error": inner.error}
-            )
-            continue
-        # File-level ReBAC filtering (Decision #17) — same enforcement as /query.
-        filtered, filter_ms = _apply_rebac_filter(
-            inner,
-            permission_enforcer,
-            auth_result,
-            zone_id,
-            operation_context=op_context,
-        )
-        filter_ms_total += filter_ms
-        trimmed = filtered[: p.limit]
+t0 = time.perf_counter()
+raw_results = await search_daemon.batch_search(fetch_specs, zone_id=zone_id) if fetch_specs else []
+elapsed_ms = (time.perf_counter() - t0) * 1000
+
+result_by_index: dict[int, Any] = {
+    i: result for (i, _), result in zip(valid, raw_results, strict=True)
+}
+
+filter_ms_total = 0.0
+response_queries: list[dict[str, Any]] = []
+for i, p in enumerate(parsed):
+    if isinstance(p, str):
         response_queries.append(
             {
-                "query": p.query,
-                "results": [_serialize_search_result(r) for r in trimmed],
-                "total": len(trimmed),
+                "query": spec_query_text(raw_queries[i]),
+                "results": [],
+                "total": 0,
+                "error": p,
             }
         )
+        continue
+    inner = result_by_index[i]
+    if isinstance(inner, BatchQueryFailure):
+        response_queries.append({"query": p.query, "results": [], "total": 0, "error": inner.error})
+        continue
+    # File-level ReBAC filtering (Decision #17) — same enforcement as /query.
+    filtered, filter_ms = _apply_rebac_filter(
+        inner,
+        permission_enforcer,
+        auth_result,
+        zone_id,
+        operation_context=op_context,
+    )
+    filter_ms_total += filter_ms
+    trimmed = filtered[: p.limit]
+    response_queries.append(
+        {
+            "query": p.query,
+            "results": [_serialize_search_result(r) for r in trimmed],
+            "total": len(trimmed),
+        }
+    )
 
-    return {
-        "queries": response_queries,
-        "total_queries": len(raw_queries),
-        "latency_ms": round(elapsed_ms, 2),
-        "avg_per_query_ms": round(elapsed_ms / max(len(raw_queries), 1), 2),
-        "permission_filter_ms": round(filter_ms_total, 2),
-    }
+return {
+    "queries": response_queries,
+    "total_queries": len(raw_queries),
+    "latency_ms": round(elapsed_ms, 2),
+    "avg_per_query_ms": round(elapsed_ms / max(len(raw_queries), 1), 2),
+    "permission_filter_ms": round(filter_ms_total, 2),
+}
 ```
 
 `BatchQueryFailure` import: add `from nexus.contracts.search_types import BatchQueryFailure` inside the function next to the existing `ROOT_ZONE_ID` local import (or at module top if ruff prefers — match the file's existing style: `ROOT_ZONE_ID` is imported locally). The old `overfetch_multiplier`/`requested_limits` loop and the inline `formatted` serialization block are deleted. Confirm `_serialize_search_result` is already imported/re-exported in `search.py` (the `_search_serialize.py` docstring says the router re-exports it); if it's not in scope, import it from `._search_serialize`.

--- a/docs/superpowers/specs/2026-08-04-batch-search-hardening-design.md
+++ b/docs/superpowers/specs/2026-08-04-batch-search-hardening-design.md
@@ -1,0 +1,197 @@
+# Batch search hardening — restore `/query/batch` to its documented contract
+
+**Date:** 2026-08-04
+**Status:** Approved design
+**Driver:** DeepBuildAI/koodle#2050 (adopt batch search for koodle's cross-workspace
+fan-out — deferred until this lands; koodle currently fires 3 path-scoped
+queries × N workspaces of single `/query` calls under a 7s deadline).
+
+## Problem
+
+`POST /api/v2/search/query/batch` promises (its own docstring): "embeds all
+query texts in ONE OpenAI API call, then runs each through the full hybrid
+pipeline". Since #3699 removed the txtai backend, the implementation no longer
+delivers any of that:
+
+1. **Sequential execution.** `_batch_search_on_current_loop` awaits each inner
+   `self.search(...)` in a `for` loop. A batch of N hybrid queries costs
+   N × single-query latency — strictly worse than N parallel `/query` calls.
+2. **No embedding amortisation.** Each inner search embeds its own query text.
+   A batch of 24 queries sharing one text (the koodle fan-out shape: same
+   query, 24 path scopes) pays 24 embedding API calls.
+3. **Tuning params silently dropped.** Only `search_type`/`limit`/`path_filter`
+   are forwarded into `SearchRequest`. `alpha`, `fusion_method`, `rrf_k`,
+   `expand`, `recency*` are ignored — a caller using the measured
+   weighted/α0.3 hybrid tuning (+20% MRR on koodle prod data) loses it on the
+   batch path with no error.
+4. **Response-shape drift.** Batch formats hits with its own inline dict and
+   omits `chunk_index`, `line_start`/`line_end`, `splade_score`,
+   `reranker_score`, `semantic_degraded`, `macro_*`, `recency_boost` — all
+   present on single `/query` via `_serialize_search_result`.
+5. **Failures indistinguishable from empty.** Inner exceptions are swallowed
+   into `hits = []`. A caller with a fail-closed coverage contract (koodle's
+   `searched/failed/partial`) cannot tell "no matches" from "backend fell
+   over".
+
+## Goals
+
+- Batch of N queries ≈ wall-clock of the slowest inner query (bounded
+  concurrency), not the sum.
+- One `embed_batch` call per batch covering unique query texts.
+- Full single-`/query` param parity (public names + legacy aliases).
+- Byte-parity hit serialization with single `/query`.
+- Per-query error surfacing; batch-level failures unchanged.
+- Purely additive response changes; existing callers keep working.
+
+## Non-goals
+
+- Federated / cross-zone batch (endpoint stays single-zone by design, #4557).
+- `graph_mode` in batch.
+- Koodle-side adoption (tracked in koodle#2050, explicitly deferred).
+- Query-count cap (existing 470-query benchmark usage; revisit if abused).
+- Prod deploy/repoint (rides the next routine release train).
+
+## API contract
+
+### Request
+
+Each entry in `queries` mirrors single-`/query` public parameter names.
+Legacy batch aliases stay accepted:
+
+```json
+{
+  "queries": [
+    {
+      "q": "quarterly revenue",            // alias: "query"
+      "type": "hybrid",                    // alias: "search_type"; keyword|semantic|hybrid
+      "limit": 10,                          // 1..100; violations → per-query error (single-query parity)
+      "path": "/workspaces/x/documents/",  // alias: "path_filter"
+      "alpha": 0.3,                         // 0.0..1.0
+      "fusion": "weighted",                // alias: "fusion_method"; rrf|weighted|rrf_weighted
+      "rrf_k": 60,                          // 1..1000
+      "expand": "none",                    // none|macro
+      "recency": "auto",                   // off|on|auto
+      "recency_weight": 0.5,               // 0.0..5.0
+      "recency_half_life_days": 30         // >0..3650
+    }
+  ]
+}
+```
+
+Public name wins when both a public name and its alias are present.
+Out-of-range values are a **per-query error entry**, not a batch-level 400 —
+batch-level 400 stays reserved for a missing/empty/non-list `queries` array.
+`adaptive_k` is not exposed (internal knob, not on the single route either).
+
+### Response
+
+Top level unchanged: `queries`, `total_queries`, `latency_ms`,
+`avg_per_query_ms`, `permission_filter_ms`. Per-entry:
+
+- `results` serialized via the shared `_serialize_search_result` — entries
+  gain `chunk_index`, `line_start`, `line_end`, `splade_score`,
+  `reranker_score`, and the conditional `title_score` / `context` /
+  `tier_boost` / `recency_boost` / `semantic_degraded` / `macro_*` fields.
+  Exact single-query parity, including its rounding and None semantics.
+- A failed query yields `{"query": ..., "results": [], "total": 0,
+  "error": "<message>"}`. `error` is additive and present **only** on
+  failure — absence of `error` means the result set is genuine.
+- Batch-level failures unchanged: 401/403 (auth/read gate), 503 (daemon
+  initializing), 400 (no queries).
+
+ReBAC policy unchanged; the over-fetch switches from a hardcoded ×3 to the
+same `_compute_rebac_fetch_limit` helper single `/query` uses.
+
+## Design
+
+### Router (`src/nexus/server/api/v2/routers/search.py` + new helper)
+
+`search.py` sits at ~1750 lines against the 2000-line file cap, so batch spec
+parsing/validation and response shaping move to a sibling helper module
+`_search_batch.py` (same pattern as `_search_serialize.py`):
+
+- `parse_batch_query_specs(raw) -> list[ParsedSpec | SpecError]` — alias
+  resolution, type/range validation mirroring the single route's Query
+  bounds, defaults.
+- Response assembly: per-entry serialization via `_serialize_search_result`,
+  error-entry shaping, ReBAC trim (unchanged policy).
+
+The route keeps: auth, #4557 read gate, daemon-init check, permission
+enforcer resolution, top-level timing fields.
+
+### Daemon (`_batch_search_on_current_loop`)
+
+1. **Pre-embed once.** Collect unique query texts among valid specs whose
+   effective type ≠ `keyword`, when `self._embedding_client` is present.
+   One `embed_batch(unique_texts)` call → `text → vector` map. Fail-soft:
+   on exception, log and proceed with an empty map (inner searches embed
+   individually — exactly today's degradation, where hybrid falls back to
+   keyword-only if embedding fails).
+2. **`query_vector` rides `SearchRequest`.** New optional field
+   `query_vector: list[float] | None = None` on the frozen dataclass
+   (`contracts/search_types.py`) — the dataclass was introduced precisely so
+   new knobs are pure data additions. `search()` forwards it;
+   `_search_on_current_loop` uses it in the two legs that currently call
+   `self._embed_query(query)` (semantic + hybrid):
+   `qvec = request-provided vector if set, else await _embed_query(query)`.
+   `embed_ms` timing reads 0 for pre-embedded queries.
+3. **Bounded concurrency.** Replace the sequential loop with
+   `asyncio.gather(*tasks, return_exceptions=True)` where each task runs
+   under an `asyncio.Semaphore` of size
+   `NEXUS_SEARCH_BATCH_CONCURRENCY` (new `SearchConfig` field via
+   `get_env_int`, default 8). Concurrent inner searches are the normal prod
+   condition already (concurrent `/query` HTTP requests); `_run_on_owner_loop`
+   has a same-loop shortcut, so gathering on the owner loop cannot deadlock.
+4. **Per-query failure isolation.** A raised inner exception becomes that
+   entry's `error`; other entries unaffected. The path-context attach pass
+   (#3773) skips error entries.
+
+Return contract of the daemon method becomes
+`list[list[SearchResult] | BatchQueryFailure]` (a tiny dataclass carrying the
+message), preserving 1:1 positional mapping with the request.
+
+### Net effect for the koodle fan-out shape (deferred adopter)
+
+24 queries (8 workspaces × 3 sub-paths, one query text): 1 HTTP request,
+1 embedding call, 8-wide server-side parallelism, full weighted/α0.3 tuning,
+chunk-level fidelity, and per-query failures that map cleanly onto koodle's
+fail-closed `searched/failed/partial` coverage contract.
+
+## Testing
+
+- **Daemon unit** (`tests/unit/bricks/search/`): embed-once (mock embedding
+  client; 24 same-text hybrid queries → exactly 1 `embed_batch` call);
+  `query_vector` set → `_embed_query` not called; keyword-only batch → no
+  embedding at all; per-query exception isolation (one poisoned query, others
+  succeed); semaphore bound respected (peak concurrent inner searches ≤
+  configured); embed-batch failure degrades to per-query embedding.
+- **Router** (mock daemon, existing pattern): alias + public-name parsing
+  (public wins); tuning params reach `SearchRequest` (alpha/fusion/rrf_k/
+  expand/recency trio); serializer parity (batch entry == single-query
+  serialization for the same `SearchResult`); per-query error entries for
+  invalid specs and daemon-reported failures; limit range check; ReBAC over-fetch
+  via `_compute_rebac_fetch_limit`; #4557 read-gate tests stay green
+  unchanged.
+- **E2E** (`tests/e2e/self_contained/test_search_surface_live_e2e.py`):
+  extend the existing batch block — mixed-type batch (keyword + semantic +
+  hybrid), assert hit-shape parity against a single `/query` for the same
+  query, assert `error` absent on healthy entries.
+- **Bench evidence for the PR:** local instance, 24 × same-text hybrid batch:
+  wall-clock + embedding-call count, before vs after.
+
+## Compatibility & rollback
+
+- Response changes additive; request aliases preserved — existing callers
+  (`scripts/test_read_gate_e2e.py`, benchmark harnesses) unaffected.
+- No schema/alembic delta → plain-image rollback stays valid.
+- New env `NEXUS_SEARCH_BATCH_CONCURRENCY` optional (default 8). Setting it
+  to 1 restores sequential execution (ops fallback) while keeping the other
+  fixes.
+
+## References
+
+- koodle#2050 (driver; koodle-side adoption deferred there)
+- #3699 (txtai removal that degraded batch to a sequential loop)
+- #4557 (batch read gate — policy preserved)
+- #4544 (batch/single parity precedent for `tier_boost`)
+- #4541/#4551/#4553 (the tuning/recency params batch must forward)

--- a/docs/surface-coverage/api-rpc-surface-coverage.yaml
+++ b/docs/surface-coverage/api-rpc-surface-coverage.yaml
@@ -3411,7 +3411,7 @@ operations:
       source: src/nexus/server/_kernel_syscall_dispatch.py:52
     grpc_expose:
       name: list
-      source: src/nexus/bricks/search/search_service.py:463
+      source: src/nexus/bricks/search/search_service.py:464
   profiles:
     lite: supported
     sandbox: supported
@@ -4600,7 +4600,7 @@ operations:
   transports:
     grpc_expose:
       name: glob_batch
-      source: src/nexus/bricks/search/search_service.py:2044
+      source: src/nexus/bricks/search/search_service.py:2045
   profiles:
     lite: supported
     sandbox: supported
@@ -4994,7 +4994,7 @@ operations:
   transports:
     grpc_expose:
       name: initialize_semantic_search
-      source: src/nexus/bricks/search/search_service.py:4841
+      source: src/nexus/bricks/search/search_service.py:4848
   profiles:
     lite: supported
     sandbox: supported
@@ -7710,7 +7710,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/consumers/{consumer_name}/skip-to
-      source: src/nexus/server/api/v2/routers/search.py:236
+      source: src/nexus/server/api/v2/routers/search.py:241
   profiles:
     lite: supported
     sandbox: supported
@@ -7727,7 +7727,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/expand
-      source: src/nexus/server/api/v2/routers/search.py:1655
+      source: src/nexus/server/api/v2/routers/search.py:1687
   profiles:
     lite: supported
     sandbox: supported
@@ -7748,10 +7748,10 @@ operations:
       source: src/nexus/cli/commands/search.py:1
     grpc_expose:
       name: glob
-      source: src/nexus/bricks/search/search_service.py:1791
+      source: src/nexus/bricks/search/search_service.py:1792
     http:
       name: POST /api/v2/search/glob
-      source: src/nexus/server/api/v2/routers/search.py:1513
+      source: src/nexus/server/api/v2/routers/search.py:1545
     mcp:
       name: nexus_glob
       source: src/nexus/config/tool_profiles.yaml:1
@@ -7775,10 +7775,10 @@ operations:
       source: src/nexus/cli/commands/search.py:1
     grpc_expose:
       name: grep
-      source: src/nexus/bricks/search/search_service.py:2101
+      source: src/nexus/bricks/search/search_service.py:2102
     http:
       name: POST /api/v2/search/grep
-      source: src/nexus/server/api/v2/routers/search.py:1390
+      source: src/nexus/server/api/v2/routers/search.py:1422
     mcp:
       name: nexus_grep
       source: src/nexus/config/tool_profiles.yaml:1
@@ -7814,7 +7814,7 @@ operations:
   transports:
     http:
       name: GET /api/v2/search/health
-      source: src/nexus/server/api/v2/routers/search.py:155
+      source: src/nexus/server/api/v2/routers/search.py:160
   profiles:
     lite: supported
     sandbox: supported
@@ -7831,7 +7831,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/index
-      source: src/nexus/server/api/v2/routers/search.py:1575
+      source: src/nexus/server/api/v2/routers/search.py:1607
   profiles:
     lite: supported
     sandbox: supported
@@ -7849,7 +7849,7 @@ operations:
   transports:
     http:
       name: GET /api/v2/search/parked
-      source: src/nexus/server/api/v2/routers/search.py:193
+      source: src/nexus/server/api/v2/routers/search.py:198
   profiles:
     lite: supported
     sandbox: supported
@@ -7866,7 +7866,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/parked/discard
-      source: src/nexus/server/api/v2/routers/search.py:219
+      source: src/nexus/server/api/v2/routers/search.py:224
   profiles:
     lite: supported
     sandbox: supported
@@ -7884,7 +7884,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/parked/retry
-      source: src/nexus/server/api/v2/routers/search.py:202
+      source: src/nexus/server/api/v2/routers/search.py:207
   profiles:
     lite: supported
     sandbox: supported
@@ -7901,7 +7901,7 @@ operations:
   transports:
     http:
       name: GET /api/v2/search/query
-      source: src/nexus/server/api/v2/routers/search.py:254
+      source: src/nexus/server/api/v2/routers/search.py:259
   profiles:
     lite: supported
     sandbox: supported
@@ -7919,7 +7919,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/query/batch
-      source: src/nexus/server/api/v2/routers/search.py:798
+      source: src/nexus/server/api/v2/routers/search.py:803
   profiles:
     lite: supported
     sandbox: supported
@@ -7936,7 +7936,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/refresh
-      source: src/nexus/server/api/v2/routers/search.py:1634
+      source: src/nexus/server/api/v2/routers/search.py:1666
   profiles:
     lite: supported
     sandbox: supported
@@ -7971,7 +7971,7 @@ operations:
   transports:
     http:
       name: GET /api/v2/search/stats
-      source: src/nexus/server/api/v2/routers/search.py:170
+      source: src/nexus/server/api/v2/routers/search.py:175
   profiles:
     lite: supported
     sandbox: supported
@@ -8023,7 +8023,7 @@ operations:
   transports:
     grpc_expose:
       name: semantic_search
-      source: src/nexus/bricks/search/search_service.py:4428
+      source: src/nexus/bricks/search/search_service.py:4433
     mcp:
       name: nexus_semantic_search
       source: src/nexus/config/tool_profiles.yaml:1
@@ -8044,7 +8044,7 @@ operations:
   transports:
     grpc_expose:
       name: semantic_search_index
-      source: src/nexus/bricks/search/search_service.py:4756
+      source: src/nexus/bricks/search/search_service.py:4763
   profiles:
     lite: supported
     sandbox: supported
@@ -8061,7 +8061,7 @@ operations:
   transports:
     grpc_expose:
       name: semantic_search_stats
-      source: src/nexus/bricks/search/search_service.py:4793
+      source: src/nexus/bricks/search/search_service.py:4800
   profiles:
     lite: supported
     sandbox: supported

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -65,7 +65,7 @@ from nexus.bricks.search.mutation_parking import (
 from nexus.bricks.search.mutation_resolver import MutationResolver, ResolvedMutation
 from nexus.bricks.search.results import BaseSearchResult
 from nexus.contracts.constants import ROOT_ZONE_ID
-from nexus.contracts.search_types import SearchRequest
+from nexus.contracts.search_types import BatchQueryFailure, SearchRequest
 from nexus.lib.env import get_database_url
 
 T = TypeVar("T")
@@ -440,6 +440,9 @@ class DaemonConfig:
     # Performance settings
     query_timeout_seconds: float = 10.0
     max_indexing_concurrency: int = 10  # Issue #2071: from ProfileTuning.search
+    # Bounded fan-out width for POST /query/batch inner searches. 1 restores
+    # strictly sequential execution (ops fallback).
+    batch_search_concurrency: int = 8
 
     # Entropy-aware filtering (Issue #1024)
     entropy_filtering: bool = False
@@ -3600,11 +3603,11 @@ class SearchDaemon:
         queries: list[dict[str, Any]],
         *,
         zone_id: str | None = None,
-    ) -> list[list[Any]]:
+    ) -> list[list[Any] | BatchQueryFailure]:
         if zone_id is None:
             return await self._batch_search_on_current_loop(queries, zone_id=zone_id)
 
-        async def _work() -> list[list[Any]]:
+        async def _work() -> list[list[Any] | BatchQueryFailure]:
             return await self._batch_search_on_current_loop(queries, zone_id=zone_id)
 
         return await self._run_on_owner_loop(_work)
@@ -3614,11 +3617,16 @@ class SearchDaemon:
         queries: list[dict[str, Any]],
         *,
         zone_id: str | None = None,
-    ) -> list[list[Any]]:
-        """Batch search: embed N queries in ONE API call.
+    ) -> list[list[Any] | BatchQueryFailure]:
+        """Batch search: one shared embed call + bounded-concurrency fan-out.
 
-        Powers ``POST /api/v2/search/query/batch`` for benchmarks and bulk
-        evaluations. ~30s for 470 queries instead of ~16 min sequential.
+        Powers ``POST /api/v2/search/query/batch``. All unique query texts
+        that need a dense leg (search_type != "keyword") are embedded in ONE
+        ``embed_batch`` call; each inner search then runs concurrently under
+        ``DaemonConfig.batch_search_concurrency``. A failed inner query is
+        returned positionally as :class:`BatchQueryFailure` instead of being
+        collapsed to ``[]``, so callers can tell "no matches" from "backend
+        fell over".
         """
         if not self._initialized:
             raise RuntimeError("SearchDaemon not initialized. Call startup() first.")
@@ -3626,29 +3634,63 @@ class SearchDaemon:
         from nexus.contracts.constants import ROOT_ZONE_ID
 
         effective_zone_id = zone_id or ROOT_ZONE_ID
-        # Issue #3699: dedicated backend.batch_search is gone with txtai; we
-        # fan out per-query through the new backend stack instead. This is
-        # functionally equivalent for callers, just without the single-call
-        # embedding amortisation. T9 keeps the API surface intact.
-        results: list[list[Any]] = []
-        for q in queries:
-            if not isinstance(q, dict):
-                results.append([])
-                continue
-            try:
-                hits = await self.search(
-                    SearchRequest(
-                        query=str(q.get("query", "")),
-                        search_type=q.get("search_type", "hybrid"),
-                        limit=int(q.get("limit", 10)),
-                        path_filter=q.get("path_filter"),
-                        zone_id=effective_zone_id,
+
+        # Pre-embed unique texts once. Fail-soft: on any error fall back to
+        # per-query embedding inside each inner search (hybrid degrades to
+        # keyword-only on embed failure exactly as a single /query does).
+        vector_by_text: dict[str, list[float]] = {}
+        if self._embedding_client is not None:
+            unique_texts = sorted(
+                {
+                    str(q.get("query", ""))
+                    for q in queries
+                    if isinstance(q, dict)
+                    and str(q.get("query", ""))
+                    and q.get("search_type", "hybrid") != "keyword"
+                }
+            )
+            if unique_texts:
+                try:
+                    vectors = await self._embedding_client.embed_batch(unique_texts)
+                    vector_by_text = dict(zip(unique_texts, vectors, strict=True))
+                except Exception as exc:
+                    logger.warning(
+                        "batch pre-embed failed; falling back to per-query embedding: %s",
+                        exc,
                     )
-                )
-            except Exception as exc:
-                logger.warning("batch_search inner search failed: %s", exc)
-                hits = []
-            results.append(hits)
+
+        semaphore = asyncio.Semaphore(max(1, self.config.batch_search_concurrency))
+
+        async def _run_one(q: Any) -> list[Any] | BatchQueryFailure:
+            if not isinstance(q, dict):
+                return BatchQueryFailure(error="invalid query spec: expected an object")
+            query_text = str(q.get("query", ""))
+            async with semaphore:
+                try:
+                    return await self.search(
+                        SearchRequest(
+                            query=query_text,
+                            search_type=q.get("search_type", "hybrid"),
+                            limit=int(q.get("limit", 10)),
+                            path_filter=q.get("path_filter"),
+                            alpha=float(q.get("alpha", 0.5)),
+                            fusion_method=q.get("fusion_method", "rrf"),
+                            rrf_k=int(q.get("rrf_k", 60)),
+                            expand=q.get("expand", "none"),
+                            recency=q.get("recency"),
+                            recency_weight=q.get("recency_weight"),
+                            recency_half_life_days=q.get("recency_half_life_days"),
+                            zone_id=effective_zone_id,
+                            query_vector=vector_by_text.get(query_text),
+                        )
+                    )
+                except Exception as exc:
+                    logger.warning("batch_search inner search failed: %s", exc)
+                    return BatchQueryFailure(error=str(exc) or exc.__class__.__name__)
+
+        results: list[list[Any] | BatchQueryFailure] = list(
+            await asyncio.gather(*(_run_one(q) for q in queries))
+        )
         # Issue #3773: attach admin-configured path contexts. The whole batch
         # is single-zone by design (``zone_id=effective_zone_id`` above), so
         # refresh once against that zone and do pure in-memory lookups on
@@ -3704,6 +3746,8 @@ class SearchDaemon:
                 # boost previously-gated results. This block only backfills
                 # ``context`` for legacy/mocked daemons.
                 for inner in results:
+                    if isinstance(inner, BatchQueryFailure):
+                        continue
                     for r in inner:
                         try:
                             record = lookup_record_in_records(records, r.path)

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -3701,6 +3701,51 @@ class SearchDaemon:
 
         return await self._run_on_owner_loop(_work)
 
+    def _batch_semaphore(self) -> asyncio.Semaphore:
+        """Daemon-scoped fan-out permit pool for /query/batch.
+
+        Deliberately NOT per-request: a cancelled batch can leave
+        cancellation-resistant searches still running, and a batch-local
+        semaphore would hand the next request fresh permits while that work
+        is still hitting the DB / provider. Keyed by running loop so a
+        daemon serving more than one loop never shares a bound primitive.
+        """
+        loop = asyncio.get_running_loop()
+        limit = max(1, self.config.batch_search_concurrency)
+        cached = getattr(self, "_batch_semaphore_cache", None)
+        if cached is not None and cached[0] is loop and cached[1] == limit:
+            semaphore: asyncio.Semaphore = cached[2]
+            return semaphore
+        semaphore = asyncio.Semaphore(limit)
+        self._batch_semaphore_cache = (loop, limit, semaphore)
+        return semaphore
+
+    def _track_abandoned_batch_tasks(self, tasks: Iterable[asyncio.Task[Any]]) -> None:
+        """Keep undrained batch tasks referenced until they actually finish.
+
+        They still hold their semaphore permits (the pool is daemon-scoped),
+        so abandoned work keeps consuming capacity rather than silently
+        accumulating. Holding the reference also prevents mid-flight GC and
+        retrieves the eventual exception so asyncio does not log it as
+        never-retrieved.
+        """
+        tracked = getattr(self, "_abandoned_batch_tasks", None)
+        if tracked is None:
+            tracked = set()
+            self._abandoned_batch_tasks = tracked
+
+        def _done(task: asyncio.Task[Any]) -> None:
+            tracked.discard(task)
+            if not task.cancelled():
+                with contextlib.suppress(BaseException):
+                    task.exception()
+
+        for task in tasks:
+            if task.done():
+                continue
+            tracked.add(task)
+            task.add_done_callback(_done)
+
     async def _embed_batch_texts(
         self,
         texts: list[str],
@@ -3743,21 +3788,27 @@ class SearchDaemon:
         except Exception as exc:
             logger.warning("batch pre-embed failed (%d texts); isolating: %s", len(texts), exc)
 
-        async def _isolate(chunk: list[str]) -> bool:
-            """Bisect ``chunk``; False means "provider looks down"."""
+        async def _isolate(chunk: list[str]) -> str:
+            """Bisect ``chunk``; returns "input" or "down".
+
+            "down" means the provider itself looks unavailable (both halves
+            of a split failed outright, or the probe budget ran out with no
+            success anywhere) — the caller degrades the whole batch once.
+            "input" means the failures were isolated to specific texts,
+            recorded in ``failed_texts``, leaving healthy siblings usable.
+            """
             nonlocal probes_left
             if len(chunk) == 1:
                 failed_texts.add(chunk[0])
-                return True
+                return "input"
             mid = len(chunk) // 2
             halves = [chunk[:mid], chunk[mid:]]
-            outcomes: list[bool] = []
+            # Probe BOTH halves before recursing: a provider-wide outage is
+            # then two probes deep, not a full descent.
+            outcomes: list[bool | None] = []
             for half in halves:
                 if probes_left <= 0 or remaining() <= 0:
-                    # Out of probe budget or wall clock: treat the rest as
-                    # unembeddable rather than probing further.
-                    failed_texts.update(half)
-                    outcomes.append(False)
+                    outcomes.append(None)
                     continue
                 probes_left -= 1
                 try:
@@ -3766,14 +3817,28 @@ class SearchDaemon:
                 except asyncio.CancelledError:
                     raise
                 except Exception:
-                    outcomes.append(await _isolate(half))
-            # Both halves failed outright at this level -> provider-wide.
-            return any(outcomes)
+                    outcomes.append(False)
+            if all(o is False for o in outcomes):
+                return "down"
+            if all(o is None for o in outcomes):
+                # No budget left to learn anything — treat conservatively as
+                # a provider problem rather than blaming these texts.
+                return "down"
+            for half, outcome in zip(halves, outcomes, strict=True):
+                if outcome is True:
+                    continue
+                if outcome is None:
+                    # Unprobed under budget pressure: mark unembeddable
+                    # rather than probing further.
+                    failed_texts.update(half)
+                    continue
+                if await _isolate(half) == "down":
+                    return "down"
+            return "input"
 
-        healthy = await _isolate(texts)
-        if not healthy and not vector_by_text:
-            # Nothing embedded anywhere: treat as a provider outage so the
-            # whole batch degrades once instead of per query.
+        if await _isolate(texts) == "down":
+            # Provider outage: degrade the whole batch once instead of
+            # blaming (and failing) individual texts.
             return {}, set(), True
         return vector_by_text, failed_texts, False
 
@@ -3838,7 +3903,7 @@ class SearchDaemon:
                     remaining=_remaining,
                 )
 
-        semaphore = asyncio.Semaphore(max(1, self.config.batch_search_concurrency))
+        semaphore = self._batch_semaphore()
 
         async def _run_one(q: Any) -> list[Any] | BatchQueryFailure:
             if not isinstance(q, dict):
@@ -3850,57 +3915,75 @@ class SearchDaemon:
                 # No embedding for THIS text — don't burn a per-query retry
                 # cycle just to fail the same way.
                 return BatchQueryFailure(error=_BATCH_EMBED_UNAVAILABLE_MESSAGE)
-            async with semaphore:
-                try:
-                    # Bounded per query: asyncio.gather waits for EVERY entry,
-                    # so a hung embedding/backend call would otherwise withhold
-                    # all completed siblings and never produce the advertised
-                    # per-query timeout failure. wait_for cancels the hung
-                    # inner search and the except below converts it.
-                    inner_result = await asyncio.wait_for(
-                        self.search(
-                            SearchRequest(
-                                query=query_text,
-                                search_type=search_type,
-                                limit=int(q.get("limit", 10)),
-                                path_filter=q.get("path_filter"),
-                                alpha=float(q.get("alpha", 0.5)),
-                                fusion_method=q.get("fusion_method", "rrf"),
-                                rrf_k=int(q.get("rrf_k", 60)),
-                                expand=q.get("expand", "none"),
-                                recency=q.get("recency"),
-                                recency_weight=q.get("recency_weight"),
-                                recency_half_life_days=q.get("recency_half_life_days"),
-                                zone_id=effective_zone_id,
-                                query_vector=vector_by_text.get(query_text),
-                                propagate_failures=True,
-                                embedding_unavailable=text_embed_failed,
-                            )
-                        ),
-                        timeout=_remaining(self.config.query_timeout_seconds),
+            # Permits follow REAL in-flight work: acquired here and released
+            # by the search task's own completion callback, so a search that
+            # outlives its timeout (cancellation-resistant backend) keeps
+            # consuming capacity instead of silently accumulating behind a
+            # released permit.
+            await semaphore.acquire()
+            search_task: asyncio.Task[list[SearchResult]] = asyncio.ensure_future(
+                self.search(
+                    SearchRequest(
+                        query=query_text,
+                        search_type=search_type,
+                        limit=int(q.get("limit", 10)),
+                        path_filter=q.get("path_filter"),
+                        alpha=float(q.get("alpha", 0.5)),
+                        fusion_method=q.get("fusion_method", "rrf"),
+                        rrf_k=int(q.get("rrf_k", 60)),
+                        expand=q.get("expand", "none"),
+                        recency=q.get("recency"),
+                        recency_weight=q.get("recency_weight"),
+                        recency_half_life_days=q.get("recency_half_life_days"),
+                        zone_id=effective_zone_id,
+                        query_vector=vector_by_text.get(query_text),
+                        propagate_failures=True,
+                        embedding_unavailable=text_embed_failed,
                     )
-                    # A search that suppresses its cancellation can return a
-                    # value AFTER the deadline (wait_for then yields that
-                    # value instead of raising). It was unfinished when the
-                    # budget ran out, so settle it as a timeout rather than
-                    # reporting a healthy late result.
-                    if time.monotonic() >= batch_deadline:
-                        return BatchQueryFailure(error=_BATCH_TIMEOUT_MESSAGE)
-                    return inner_result
-                except EmbeddingUnavailableError:
-                    return BatchQueryFailure(error=_BATCH_EMBED_UNAVAILABLE_MESSAGE)
-                except VectorBackendUnavailableError:
-                    return BatchQueryFailure(error=_BATCH_VECTOR_BACKEND_MESSAGE)
-                except TimeoutError:
-                    logger.warning("batch_search inner search timed out: %r", query_text)
+                )
+            )
+            search_task.add_done_callback(lambda _task: semaphore.release())
+            try:
+                # Bounded per query: asyncio.wait waits for EVERY entry, so a
+                # hung backend would otherwise withhold all completed siblings
+                # and never produce the advertised per-query timeout failure.
+                # shield keeps the timeout from silently detaching the task —
+                # it is cancelled and accounted for explicitly below.
+                inner_result = await asyncio.wait_for(
+                    asyncio.shield(search_task),
+                    timeout=_remaining(self.config.query_timeout_seconds),
+                )
+                # A search that suppresses its cancellation can return a
+                # value AFTER the deadline (wait_for then yields that value
+                # instead of raising). It was unfinished when the budget ran
+                # out, so settle it as a timeout rather than reporting a
+                # healthy late result.
+                if time.monotonic() >= batch_deadline:
                     return BatchQueryFailure(error=_BATCH_TIMEOUT_MESSAGE)
-                except Exception:
-                    # Full diagnostics stay server-side; the wire gets a stable
-                    # sanitized message (raw backend exception text can leak
-                    # SQL, hosts, or provider internals to authenticated
-                    # callers — the single /query route is equally generic).
-                    logger.exception("batch_search inner search failed: %r", query_text)
-                    return BatchQueryFailure(error=_BATCH_FAILURE_MESSAGE)
+                return inner_result
+            except asyncio.CancelledError:
+                search_task.cancel()
+                self._track_abandoned_batch_tasks({search_task})
+                raise
+            except EmbeddingUnavailableError:
+                return BatchQueryFailure(error=_BATCH_EMBED_UNAVAILABLE_MESSAGE)
+            except VectorBackendUnavailableError:
+                return BatchQueryFailure(error=_BATCH_VECTOR_BACKEND_MESSAGE)
+            except TimeoutError:
+                logger.warning("batch_search inner search timed out: %r", query_text)
+                # The task is still running: cancel it and keep it charged
+                # (its permit is released by the done-callback only when it
+                # actually finishes).
+                search_task.cancel()
+                self._track_abandoned_batch_tasks({search_task})
+                return BatchQueryFailure(error=_BATCH_TIMEOUT_MESSAGE)
+            except Exception:
+                # Full diagnostics stay server-side; the wire gets a stable
+                # sanitized message (raw backend exception text can leak
+                # SQL, hosts, or provider internals to authenticated
+                # callers — the single /query route is equally generic).
+                logger.exception("batch_search inner search failed: %r", query_text)
+                return BatchQueryFailure(error=_BATCH_FAILURE_MESSAGE)
 
         # Absolute batch deadline on top of the per-query bounds: gather-style
         # waiting alone lets N hung queries consume ceil(N/concurrency)
@@ -3916,8 +3999,17 @@ class SearchDaemon:
             # not strand this task forever), then always re-raise.
             for task in tasks:
                 task.cancel()
-            with contextlib.suppress(TimeoutError, asyncio.CancelledError):
-                await asyncio.wait(tasks, timeout=_BATCH_CANCEL_DRAIN_SECONDS)
+            undrained: set[asyncio.Task[Any]] = set(tasks)
+            with contextlib.suppress(asyncio.CancelledError):
+                _drained, undrained = await asyncio.wait(tasks, timeout=_BATCH_CANCEL_DRAIN_SECONDS)
+            if undrained:
+                logger.warning(
+                    "batch_search cancellation left %d task(s) undrained after %.1fs; "
+                    "they keep their concurrency permits until they finish",
+                    len(undrained),
+                    _BATCH_CANCEL_DRAIN_SECONDS,
+                )
+                self._track_abandoned_batch_tasks(undrained)
             raise
         # The set pending AT EXPIRY is authoritative for settlement: a task
         # that finishes during cancellation cleanup (or suppresses the
@@ -3936,18 +4028,21 @@ class SearchDaemon:
             # Bounded drain: a backend that swallows cancellation must not
             # hold the request open past its deadline. Un-drained tasks are
             # abandoned (already settled as timeouts below).
-            try:
-                await asyncio.wait(pending_tasks, timeout=_BATCH_CANCEL_DRAIN_SECONDS)
-            except asyncio.CancelledError:
-                # Caller cancellation during cleanup is NOT a batch outcome —
-                # never convert it into per-query failures.
-                raise
-            except TimeoutError:
+            # asyncio.wait does NOT raise on timeout — it returns the still
+            # pending set, which is what tells us what to charge as abandoned.
+            # Caller cancellation during cleanup is not a batch outcome and
+            # propagates rather than becoming per-query failures.
+            _drained, undrained = await asyncio.wait(
+                pending_tasks, timeout=_BATCH_CANCEL_DRAIN_SECONDS
+            )
+            if undrained:
                 logger.warning(
-                    "batch_search cancellation drain exceeded %.1fs; abandoning %d task(s)",
+                    "batch_search cancellation drain exceeded %.1fs; %d task(s) still running "
+                    "and holding concurrency permits",
                     _BATCH_CANCEL_DRAIN_SECONDS,
-                    len(pending_tasks),
+                    len(undrained),
                 )
+                self._track_abandoned_batch_tasks(undrained)
         results: list[list[Any] | BatchQueryFailure] = [
             BatchQueryFailure(error=_BATCH_TIMEOUT_MESSAGE)
             if i in timed_out_positions

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -3757,7 +3757,8 @@ class SearchDaemon:
         self,
         make_coro: Callable[[], Awaitable[T]],
         *,
-        timeout: float,
+        remaining: Callable[[], float],
+        exec_cap: float,
     ) -> T:
         """Run one batch-phase operation under a permit and a hard bound.
 
@@ -3775,19 +3776,21 @@ class SearchDaemon:
         :meth:`_track_abandoned_batch_tasks` — which keeps it charged against
         the daemon-scoped permit pool until it genuinely finishes.
         """
-        started = time.monotonic()
-        budget = max(0.0, timeout)
         semaphore = self._batch_semaphore()
-        # No coroutine exists yet: a timeout here cannot leak one.
-        await asyncio.wait_for(semaphore.acquire(), timeout=budget)
-        remaining_budget = budget - (time.monotonic() - started)
-        if remaining_budget <= 0:
+        # Queue time is charged to the BATCH deadline, not to the operation's
+        # own budget: a query that waits behind a full pool must still get a
+        # full execution window once admitted, or healthy multi-wave batches
+        # would time out under normal latency. No coroutine exists yet, so a
+        # timeout here cannot leak one.
+        await asyncio.wait_for(semaphore.acquire(), timeout=max(0.0, remaining()))
+        exec_budget = min(exec_cap, remaining())
+        if exec_budget <= 0:
             semaphore.release()
-            raise TimeoutError("batch operation budget exhausted while waiting for a permit")
+            raise TimeoutError("batch deadline exhausted before the operation could start")
         task: asyncio.Task[T] = asyncio.ensure_future(make_coro())
         task.add_done_callback(lambda _task: semaphore.release())
         try:
-            return await asyncio.wait_for(asyncio.shield(task), timeout=remaining_budget)
+            return await asyncio.wait_for(asyncio.shield(task), timeout=exec_budget)
         except (TimeoutError, asyncio.CancelledError):
             task.cancel()
             self._track_abandoned_batch_tasks({task})
@@ -3826,11 +3829,17 @@ class SearchDaemon:
             probes_done += 1
             vectors = await self._run_bounded_batch_op(
                 lambda: self._embedding_client.embed_batch(chunk),
-                timeout=remaining(self.config.query_timeout_seconds),
+                remaining=remaining,
+                exec_cap=self.config.query_timeout_seconds,
             )
             vector_by_text.update(dict(zip(chunk, vectors, strict=True)))
 
         control_verdict: bool | None = None
+        # A probe that TIMED OUT (rather than being rejected) may have left a
+        # cancellation-resistant provider task holding a permit. Launching
+        # more probes after that drains the daemon-scoped pool, so isolation
+        # stops at the first one.
+        probe_timed_out = False
 
         async def _looks_like_outage() -> bool:
             """Is the PROVIDER down, or are these texts simply bad?
@@ -3850,7 +3859,8 @@ class SearchDaemon:
             try:
                 await self._run_bounded_batch_op(
                     lambda: self._embedding_client.embed_batch([_BATCH_EMBED_CONTROL_TEXT]),
-                    timeout=remaining(self.config.query_timeout_seconds),
+                    remaining=remaining,
+                    exec_cap=self.config.query_timeout_seconds,
                 )
                 control_verdict = False
             except asyncio.CancelledError:
@@ -3865,12 +3875,18 @@ class SearchDaemon:
             return vector_by_text, failed_texts, False
         except asyncio.CancelledError:
             raise
+        except TimeoutError:
+            # Never probed successfully and the provider is unresponsive:
+            # degrade the batch once rather than launching more probes at a
+            # provider that is already holding an abandoned task.
+            logger.warning("batch pre-embed timed out (%d texts); degrading batch", len(texts))
+            return {}, set(), True
         except Exception as exc:
             logger.warning("batch pre-embed failed (%d texts); isolating: %s", len(texts), exc)
 
         async def _isolate(chunk: list[str]) -> str:
             """Bisect ``chunk``; returns "input" or "down"."""
-            nonlocal probes_left
+            nonlocal probes_left, probe_timed_out
             if await _looks_like_outage():
                 return "down"
             if len(chunk) == 1:
@@ -3891,10 +3907,23 @@ class SearchDaemon:
                     outcomes.append(True)
                 except asyncio.CancelledError:
                     raise
+                except TimeoutError:
+                    probe_timed_out = True
+                    outcomes.append(None)
+                    break
                 except Exception:
                     outcomes.append(False)
             if await _looks_like_outage():
                 return "down"
+            if probe_timed_out:
+                # Stop here: mark whatever is still unresolved as unembeddable
+                # and keep every vector already obtained.
+                for half, outcome in zip(
+                    halves, outcomes + [None] * (len(halves) - len(outcomes)), strict=True
+                ):
+                    if outcome is not True:
+                        failed_texts.update(half)
+                return "input"
             for half, outcome in zip(halves, outcomes, strict=True):
                 if outcome is True:
                     continue
@@ -3910,7 +3939,12 @@ class SearchDaemon:
                     return "down"
             return "input"
 
-        if await _isolate(texts) == "down":
+        isolation = await _isolate(texts)
+        if isolation == "input" and probe_timed_out and not vector_by_text:
+            # Nothing embedded and the provider stopped responding mid-walk:
+            # one shared degradation beats per-text failures.
+            return {}, set(), True
+        if isolation == "down":
             # Provider outage: degrade the whole batch once instead of
             # blaming (and failing) individual texts.
             return {}, set(), True
@@ -4013,7 +4047,8 @@ class SearchDaemon:
                 # instead of accumulating silently.
                 inner_result = await self._run_bounded_batch_op(
                     lambda: self.search(request),
-                    timeout=_remaining(self.config.query_timeout_seconds),
+                    remaining=_remaining,
+                    exec_cap=self.config.query_timeout_seconds,
                 )
                 # A search that suppresses its cancellation can return a
                 # value AFTER the deadline (wait_for then yields that value
@@ -4127,12 +4162,17 @@ class SearchDaemon:
             # transient DB error still yields the last successfully-loaded
             # records instead of silently erasing context for the whole batch.
             try:
-                # Bounded: the refresh's DB calls must not hold the whole
-                # batch open past its deadline; a timeout falls through to
-                # the stale-snapshot fail-soft path below.
-                await asyncio.wait_for(
-                    cache.refresh_if_stale(effective_zone_id),
-                    timeout=_remaining(self.config.query_timeout_seconds),
+                # Hard-bounded like every other batch phase: plain wait_for
+                # would cancel the DB call and then WAIT for that cancellation,
+                # so a resistant operation could hold the response past the
+                # deadline. With no budget left the refresh is skipped
+                # entirely and the stale snapshot below is used.
+                if _remaining() <= 0:
+                    raise TimeoutError("batch deadline exhausted before path-context refresh")
+                await self._run_bounded_batch_op(
+                    lambda: cache.refresh_if_stale(effective_zone_id),
+                    remaining=_remaining,
+                    exec_cap=self.config.query_timeout_seconds,
                 )
             except Exception as exc:
                 self.stats.path_context_attach_failures += 1

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -3700,7 +3700,10 @@ class SearchDaemon:
             )
             if unique_texts:
                 try:
-                    vectors = await self._embedding_client.embed_batch(unique_texts)
+                    vectors = await asyncio.wait_for(
+                        self._embedding_client.embed_batch(unique_texts),
+                        timeout=self.config.query_timeout_seconds,
+                    )
                     vector_by_text = dict(zip(unique_texts, vectors, strict=True))
                 except Exception as exc:
                     pre_embed_failed = True
@@ -3722,24 +3725,32 @@ class SearchDaemon:
                 return BatchQueryFailure(error=_BATCH_EMBED_UNAVAILABLE_MESSAGE)
             async with semaphore:
                 try:
-                    return await self.search(
-                        SearchRequest(
-                            query=query_text,
-                            search_type=search_type,
-                            limit=int(q.get("limit", 10)),
-                            path_filter=q.get("path_filter"),
-                            alpha=float(q.get("alpha", 0.5)),
-                            fusion_method=q.get("fusion_method", "rrf"),
-                            rrf_k=int(q.get("rrf_k", 60)),
-                            expand=q.get("expand", "none"),
-                            recency=q.get("recency"),
-                            recency_weight=q.get("recency_weight"),
-                            recency_half_life_days=q.get("recency_half_life_days"),
-                            zone_id=effective_zone_id,
-                            query_vector=vector_by_text.get(query_text),
-                            propagate_failures=True,
-                            embedding_unavailable=pre_embed_failed,
-                        )
+                    # Bounded per query: asyncio.gather waits for EVERY entry,
+                    # so a hung embedding/backend call would otherwise withhold
+                    # all completed siblings and never produce the advertised
+                    # per-query timeout failure. wait_for cancels the hung
+                    # inner search and the except below converts it.
+                    return await asyncio.wait_for(
+                        self.search(
+                            SearchRequest(
+                                query=query_text,
+                                search_type=search_type,
+                                limit=int(q.get("limit", 10)),
+                                path_filter=q.get("path_filter"),
+                                alpha=float(q.get("alpha", 0.5)),
+                                fusion_method=q.get("fusion_method", "rrf"),
+                                rrf_k=int(q.get("rrf_k", 60)),
+                                expand=q.get("expand", "none"),
+                                recency=q.get("recency"),
+                                recency_weight=q.get("recency_weight"),
+                                recency_half_life_days=q.get("recency_half_life_days"),
+                                zone_id=effective_zone_id,
+                                query_vector=vector_by_text.get(query_text),
+                                propagate_failures=True,
+                                embedding_unavailable=pre_embed_failed,
+                            )
+                        ),
+                        timeout=self.config.query_timeout_seconds,
                     )
                 except EmbeddingUnavailableError:
                     return BatchQueryFailure(error=_BATCH_EMBED_UNAVAILABLE_MESSAGE)

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -3836,7 +3836,18 @@ class SearchDaemon:
         total probes either way; every vector obtained along the way is
         kept.
         """
-        probes_left = _BATCH_EMBED_PROBE_LIMIT
+        # Budget must be large enough to actually ISOLATE a bad input at the
+        # configured batch cardinality: bisection costs ~2 probes per level,
+        # i.e. 2*ceil(log2(n)) for one offender (18 at the documented 470-500
+        # query workload). A fixed floor silently ran out mid-walk on large
+        # batches and marked whole unresolved halves as unembeddable, failing
+        # healthy siblings. The factor leaves room for a few independent
+        # offenders; a genuine outage is still cut short by the control probe,
+        # and every probe remains under the batch deadline.
+        probes_left = max(
+            _BATCH_EMBED_PROBE_LIMIT,
+            4 * math.ceil(math.log2(max(2, len(texts)))),
+        )
         probes_done = 0
         vector_by_text: dict[str, list[float]] = {}
         failed_texts: set[str] = set()

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -463,6 +463,12 @@ class DaemonConfig:
     # Bounded fan-out width for POST /query/batch inner searches. 1 restores
     # strictly sequential execution (ops fallback).
     batch_search_concurrency: int = 8
+    # Absolute wall-clock ceiling for one /query/batch request's search
+    # phase. Per-query timeouts alone cannot bound the batch: N hung queries
+    # occupy semaphore slots for ceil(N/concurrency) consecutive timeout
+    # windows. On expiry, unfinished queries are cancelled and reported as
+    # per-query timeout failures; completed siblings keep their results.
+    batch_search_timeout_seconds: float = 120.0
 
     # Entropy-aware filtering (Issue #1024)
     entropy_filtering: bool = False
@@ -3150,6 +3156,7 @@ class SearchDaemon:
                     zone_id=zone_id,
                     query_vector=query_vector,
                     embedding_unavailable=embedding_unavailable,
+                    propagate_failures=propagate_failures,
                 )
                 if pooled_legacy:
                     from nexus.bricks.search.result_builders import cap_chunks_per_page
@@ -3408,6 +3415,7 @@ class SearchDaemon:
                     "vector_ms",
                     self._vector_backend.semantic_search(qvec, path, leg_limit, zone_id),
                 ),
+                propagate_failures=propagate_failures,
             )
         else:
             chunk_kw, dense = await self._gather_legs_fail_soft_dense(
@@ -3421,6 +3429,7 @@ class SearchDaemon:
                     "vector_ms",
                     self._vector_backend.semantic_search(qvec, path, leg_limit, zone_id),
                 ),
+                propagate_failures=propagate_failures,
             )
             page_kw = []
 
@@ -3502,6 +3511,8 @@ class SearchDaemon:
     async def _gather_legs_fail_soft_dense(
         kw_awaitable: Awaitable[T],
         dense_awaitable: Awaitable[list[Any]],
+        *,
+        propagate_failures: bool = False,
     ) -> tuple[T, list[Any]]:
         """Run the keyword and dense legs concurrently with asymmetric failure
         handling (#4541 review R8/R9).
@@ -3524,6 +3535,13 @@ class SearchDaemon:
         try:
             dense_result: list[Any] = await dense_task
         except Exception as exc:
+            # Batch mode reports dense INFRASTRUCTURE failures per query
+            # instead of silently serving keyword-only hits as a full
+            # success. A missing embedding is legitimate degradation (the
+            # hybrid contract serves keyword-only then) and stays fail-soft
+            # in both modes.
+            if propagate_failures and not isinstance(exc, EmbeddingUnavailableError):
+                raise
             logger.warning("hybrid dense leg failed; continuing keyword-only: %s", exc)
             dense_result = []
         return kw_result, dense_result
@@ -3765,9 +3783,38 @@ class SearchDaemon:
                     logger.exception("batch_search inner search failed: %r", query_text)
                     return BatchQueryFailure(error=_BATCH_FAILURE_MESSAGE)
 
-        results: list[list[Any] | BatchQueryFailure] = list(
-            await asyncio.gather(*(_run_one(q) for q in queries))
-        )
+        # Absolute batch deadline on top of the per-query bounds: gather-style
+        # waiting alone lets N hung queries consume ceil(N/concurrency)
+        # consecutive per-query timeout windows. Unfinished tasks are
+        # cancelled, drained, and settled positionally as timeout failures;
+        # completed siblings keep their results.
+        tasks = [asyncio.ensure_future(_run_one(q)) for q in queries]
+        try:
+            _done_tasks, pending_tasks = await asyncio.wait(
+                tasks, timeout=max(0.0, self.config.batch_search_timeout_seconds)
+            )
+        except BaseException:
+            for task in tasks:
+                task.cancel()
+            await asyncio.gather(*tasks, return_exceptions=True)
+            raise
+        if pending_tasks:
+            logger.warning(
+                "batch_search deadline (%.1fs) expired with %d of %d queries unfinished",
+                self.config.batch_search_timeout_seconds,
+                len(pending_tasks),
+                len(tasks),
+            )
+            for task in pending_tasks:
+                task.cancel()
+            await asyncio.gather(*pending_tasks, return_exceptions=True)
+        # After the cancel+drain every task is done; a task that slipped in a
+        # normal completion between the deadline and the cancel keeps its
+        # result rather than being misreported as timed out.
+        results: list[list[Any] | BatchQueryFailure] = [
+            BatchQueryFailure(error=_BATCH_TIMEOUT_MESSAGE) if task.cancelled() else task.result()
+            for task in tasks
+        ]
         # Issue #3773: attach admin-configured path contexts. The whole batch
         # is single-zone by design (``zone_id=effective_zone_id`` above), so
         # refresh once against that zone and do pure in-memory lookups on
@@ -3791,7 +3838,13 @@ class SearchDaemon:
             # transient DB error still yields the last successfully-loaded
             # records instead of silently erasing context for the whole batch.
             try:
-                await cache.refresh_if_stale(effective_zone_id)
+                # Bounded: the refresh's DB calls must not hold the whole
+                # batch open past its deadline; a timeout falls through to
+                # the stale-snapshot fail-soft path below.
+                await asyncio.wait_for(
+                    cache.refresh_if_stale(effective_zone_id),
+                    timeout=self.config.query_timeout_seconds,
+                )
             except Exception as exc:
                 self.stats.path_context_attach_failures += 1
                 logger.warning(
@@ -4452,6 +4505,7 @@ class SearchDaemon:
         zone_id: str | None = None,
         query_vector: list[float] | None = None,
         embedding_unavailable: bool = False,
+        propagate_failures: bool = False,
     ) -> list[SearchResult]:
         """Hybrid search combining keyword and semantic results (legacy fallback).
 
@@ -4480,7 +4534,12 @@ class SearchDaemon:
                 zone_id=zone_id,
                 query_vector=query_vector,
                 embedding_unavailable=embedding_unavailable,
+                # Raise real backend errors so the gather helper can apply
+                # the batch policy; missing-embedding degradation is carved
+                # out there (hybrid legitimately serves keyword-only then).
+                propagate_failures=propagate_failures,
             ),
+            propagate_failures=propagate_failures,
         )
 
         fusion_config = FusionConfig(

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -101,6 +101,10 @@ _BATCH_EMBED_UNAVAILABLE_MESSAGE = "Query embedding unavailable"
 # cleanup so it cannot hold the request open indefinitely.
 _BATCH_VECTOR_BACKEND_MESSAGE = "Vector backend unavailable"
 _BATCH_CANCEL_DRAIN_SECONDS = 5.0
+# Cap on bisection probes used to isolate an input-specific embedding
+# failure. Bounds the degenerate case (many independently-bad inputs) so a
+# batch can never turn into a per-text retry storm against the provider.
+_BATCH_EMBED_PROBE_LIMIT = 16
 
 
 class VectorBackendUnavailableError(RuntimeError):
@@ -485,6 +489,11 @@ class DaemonConfig:
     # windows. On expiry, unfinished queries are cancelled and reported as
     # per-query timeout failures; completed siblings keep their results.
     batch_search_timeout_seconds: float = 120.0
+    # Hard ceiling on queries per /query/batch request. Every accepted query
+    # becomes an asyncio task before the concurrency semaphore applies, so
+    # cardinality — not concurrency — is what bounds task/memory allocation.
+    # Default keeps the documented 470-query benchmark workload working.
+    batch_search_max_queries: int = 500
 
     # Entropy-aware filtering (Issue #1024)
     entropy_filtering: bool = False
@@ -3692,6 +3701,82 @@ class SearchDaemon:
 
         return await self._run_on_owner_loop(_work)
 
+    async def _embed_batch_texts(
+        self,
+        texts: list[str],
+        *,
+        remaining: Callable[..., float],
+    ) -> tuple[dict[str, list[float]], set[str], bool]:
+        """Embed unique batch query texts, isolating input-specific failures.
+
+        Returns ``(vector_by_text, failed_texts, provider_down)``.
+
+        One shared ``embed_batch`` call covers the happy path. When it
+        fails, the cause is either ONE bad input (e.g. a text the provider
+        rejects) or a provider-wide outage — and the two need opposite
+        handling: a bad input must not fail its healthy siblings, while an
+        outage must not turn into a per-text retry storm. A bounded binary
+        search separates them: halves are probed until the offender is
+        isolated (O(log n) probes), and if BOTH halves fail at the first
+        split the provider is treated as down (2 extra probes, no storm).
+        ``_BATCH_EMBED_PROBE_LIMIT`` caps total probe calls.
+        """
+        probes_left = _BATCH_EMBED_PROBE_LIMIT
+        vector_by_text: dict[str, list[float]] = {}
+        failed_texts: set[str] = set()
+
+        async def _probe(chunk: list[str]) -> bool:
+            """Embed one chunk; True on success (vectors recorded)."""
+            nonlocal probes_left
+            budget = remaining(self.config.query_timeout_seconds)
+            vectors = await asyncio.wait_for(
+                self._embedding_client.embed_batch(chunk), timeout=budget
+            )
+            vector_by_text.update(dict(zip(chunk, vectors, strict=True)))
+            return True
+
+        try:
+            await _probe(texts)
+            return vector_by_text, failed_texts, False
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            logger.warning("batch pre-embed failed (%d texts); isolating: %s", len(texts), exc)
+
+        async def _isolate(chunk: list[str]) -> bool:
+            """Bisect ``chunk``; False means "provider looks down"."""
+            nonlocal probes_left
+            if len(chunk) == 1:
+                failed_texts.add(chunk[0])
+                return True
+            mid = len(chunk) // 2
+            halves = [chunk[:mid], chunk[mid:]]
+            outcomes: list[bool] = []
+            for half in halves:
+                if probes_left <= 0 or remaining() <= 0:
+                    # Out of probe budget or wall clock: treat the rest as
+                    # unembeddable rather than probing further.
+                    failed_texts.update(half)
+                    outcomes.append(False)
+                    continue
+                probes_left -= 1
+                try:
+                    await _probe(half)
+                    outcomes.append(True)
+                except asyncio.CancelledError:
+                    raise
+                except Exception:
+                    outcomes.append(await _isolate(half))
+            # Both halves failed outright at this level -> provider-wide.
+            return any(outcomes)
+
+        healthy = await _isolate(texts)
+        if not healthy and not vector_by_text:
+            # Nothing embedded anywhere: treat as a provider outage so the
+            # whole batch degrades once instead of per query.
+            return {}, set(), True
+        return vector_by_text, failed_texts, False
+
     async def _batch_search_on_current_loop(
         self,
         queries: list[dict[str, Any]],
@@ -3733,6 +3818,9 @@ class SearchDaemon:
         # failed shared operation into N concurrent retry cycles against an
         # already degraded provider.
         vector_by_text: dict[str, list[float]] = {}
+        # Texts the provider rejected individually (bad input) — only those
+        # queries fail; healthy siblings keep their vectors.
+        failed_texts: set[str] = set()
         pre_embed_failed = False
         if self._embedding_client is not None:
             unique_texts = sorted(
@@ -3745,18 +3833,10 @@ class SearchDaemon:
                 }
             )
             if unique_texts:
-                try:
-                    vectors = await asyncio.wait_for(
-                        self._embedding_client.embed_batch(unique_texts),
-                        timeout=_remaining(self.config.query_timeout_seconds),
-                    )
-                    vector_by_text = dict(zip(unique_texts, vectors, strict=True))
-                except Exception as exc:
-                    pre_embed_failed = True
-                    logger.warning(
-                        "batch pre-embed failed; semantic queries fail, hybrid degrades to keyword-only: %s",
-                        exc,
-                    )
+                vector_by_text, failed_texts, pre_embed_failed = await self._embed_batch_texts(
+                    unique_texts,
+                    remaining=_remaining,
+                )
 
         semaphore = asyncio.Semaphore(max(1, self.config.batch_search_concurrency))
 
@@ -3765,9 +3845,10 @@ class SearchDaemon:
                 return BatchQueryFailure(error="invalid query spec: expected an object")
             query_text = str(q.get("query", ""))
             search_type = q.get("search_type", "hybrid")
-            if pre_embed_failed and search_type == "semantic":
-                # The shared embed already failed — don't burn a per-query
-                # retry cycle just to fail the same way.
+            text_embed_failed = pre_embed_failed or query_text in failed_texts
+            if text_embed_failed and search_type == "semantic":
+                # No embedding for THIS text — don't burn a per-query retry
+                # cycle just to fail the same way.
                 return BatchQueryFailure(error=_BATCH_EMBED_UNAVAILABLE_MESSAGE)
             async with semaphore:
                 try:
@@ -3793,7 +3874,7 @@ class SearchDaemon:
                                 zone_id=effective_zone_id,
                                 query_vector=vector_by_text.get(query_text),
                                 propagate_failures=True,
-                                embedding_unavailable=pre_embed_failed,
+                                embedding_unavailable=text_embed_failed,
                             )
                         ),
                         timeout=_remaining(self.config.query_timeout_seconds),
@@ -3830,9 +3911,13 @@ class SearchDaemon:
         try:
             _done_tasks, pending_tasks = await asyncio.wait(tasks, timeout=_remaining())
         except BaseException:
+            # Caller cancellation / shutdown: cancel children, make a BOUNDED
+            # best-effort drain (a backend that suppresses CancelledError must
+            # not strand this task forever), then always re-raise.
             for task in tasks:
                 task.cancel()
-            await asyncio.gather(*tasks, return_exceptions=True)
+            with contextlib.suppress(TimeoutError, asyncio.CancelledError):
+                await asyncio.wait(tasks, timeout=_BATCH_CANCEL_DRAIN_SECONDS)
             raise
         # The set pending AT EXPIRY is authoritative for settlement: a task
         # that finishes during cancellation cleanup (or suppresses the
@@ -3851,10 +3936,13 @@ class SearchDaemon:
             # Bounded drain: a backend that swallows cancellation must not
             # hold the request open past its deadline. Un-drained tasks are
             # abandoned (already settled as timeouts below).
-            drain = asyncio.gather(*pending_tasks, return_exceptions=True)
             try:
-                await asyncio.wait_for(asyncio.shield(drain), timeout=_BATCH_CANCEL_DRAIN_SECONDS)
-            except (TimeoutError, asyncio.CancelledError):
+                await asyncio.wait(pending_tasks, timeout=_BATCH_CANCEL_DRAIN_SECONDS)
+            except asyncio.CancelledError:
+                # Caller cancellation during cleanup is NOT a batch outcome —
+                # never convert it into per-query failures.
+                raise
+            except TimeoutError:
                 logger.warning(
                     "batch_search cancellation drain exceeded %.1fs; abandoning %d task(s)",
                     _BATCH_CANCEL_DRAIN_SECONDS,

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -88,6 +88,26 @@ _MAX_CAP_WIDEN = 4
 # Durable mutation consumer names (#4337): single source for the refresh
 # loop, startup reconciliation, parked-event re-drive, and admin skip-to.
 MUTATION_CONSUMER_NAMES: tuple[str, ...] = ("fts", "embedding")
+
+
+# Stable sanitized wire messages for per-query batch failures. Raw exception
+# text never crosses the API boundary (information disclosure); full detail
+# is logged server-side at the failure site.
+_BATCH_FAILURE_MESSAGE = "Search query failed"
+_BATCH_TIMEOUT_MESSAGE = "Search timed out"
+_BATCH_EMBED_UNAVAILABLE_MESSAGE = "Query embedding unavailable"
+
+
+class EmbeddingUnavailableError(RuntimeError):
+    """A semantic-only search could not obtain a query embedding.
+
+    Raised only on the batch path (``SearchRequest.propagate_failures``)
+    so the batch endpoint reports a per-query failure instead of the
+    interactive path's degrade-to-empty behavior. The message is the
+    query text — callers must map it to a sanitized wire message.
+    """
+
+
 LEGACY_REFRESH_CONSUMER = "legacy-refresh"
 
 # Title arm safety bounds (#4545 review rounds 3-4).
@@ -2851,6 +2871,8 @@ class SearchDaemon:
                 rrf_k=req.rrf_k,
                 zone_id=req.zone_id,
                 query_vector=req.query_vector,
+                propagate_failures=req.propagate_failures,
+                embedding_unavailable=req.embedding_unavailable,
             )
         else:
 
@@ -2865,6 +2887,8 @@ class SearchDaemon:
                     rrf_k=req.rrf_k,
                     zone_id=req.zone_id,
                     query_vector=req.query_vector,
+                    propagate_failures=req.propagate_failures,
+                    embedding_unavailable=req.embedding_unavailable,
                 )
 
             results = await self._run_on_owner_loop(_work)
@@ -2891,6 +2915,8 @@ class SearchDaemon:
         zone_id: str | None = None,
         rrf_k: int = 60,
         query_vector: list[float] | None = None,
+        propagate_failures: bool = False,
+        embedding_unavailable: bool = False,
     ) -> list[SearchResult]:
         """Execute a search query with pre-warmed indexes.
 
@@ -3058,6 +3084,8 @@ class SearchDaemon:
                     rrf_k=rrf_k,
                     zone_id=effective_zone_id,
                     query_vector=query_vector,
+                    propagate_failures=propagate_failures,
+                    embedding_unavailable=embedding_unavailable,
                 )
                 backend_ms = (time.perf_counter() - backend_start) * 1000
                 self.last_search_timing = _merge_backend_timing(backend_ms, self.last_search_timing)
@@ -3093,7 +3121,13 @@ class SearchDaemon:
             fallback_start = time.perf_counter()
             if search_type == "semantic":
                 results = await self._semantic_search(
-                    query, internal_limit, path_filter, zone_id=zone_id
+                    query,
+                    internal_limit,
+                    path_filter,
+                    zone_id=zone_id,
+                    query_vector=query_vector,
+                    propagate_failures=propagate_failures,
+                    embedding_unavailable=embedding_unavailable,
                 )
             else:  # hybrid
                 # Issue #4542 (round-5 review): the legacy hybrid stack must
@@ -3114,6 +3148,8 @@ class SearchDaemon:
                     fusion_method,
                     rrf_k,
                     zone_id=zone_id,
+                    query_vector=query_vector,
+                    embedding_unavailable=embedding_unavailable,
                 )
                 if pooled_legacy:
                     from nexus.bricks.search.result_builders import cap_chunks_per_page
@@ -3158,6 +3194,12 @@ class SearchDaemon:
             return self._with_search_timing(results)
 
         except TimeoutError:
+            # Batch mode must not misreport a timed-out search as a healthy
+            # empty result — the batch layer converts this into a per-query
+            # failure entry. The interactive path keeps its degrade-to-empty
+            # contract.
+            if propagate_failures:
+                raise
             logger.warning(f"Search timeout after {self.config.query_timeout_seconds}s")
             return self._with_search_timing([])
 
@@ -3173,6 +3215,8 @@ class SearchDaemon:
         fusion_method: str = "rrf",
         rrf_k: int = 60,
         query_vector: list[float] | None = None,
+        propagate_failures: bool = False,
+        embedding_unavailable: bool = False,
     ) -> list[SearchResult]:
         """Run keyword / semantic / hybrid via the new search backends.
 
@@ -3217,13 +3261,15 @@ class SearchDaemon:
             return [self._coerce_to_search_result(r, search_type=search_type) for r in results]
 
         if search_type == "semantic":
-            qvec = (
-                query_vector
-                if query_vector is not None
-                else await timed_leg("embed_ms", self._embed_query(query))
-            )
+            qvec = query_vector
+            if qvec is None and not embedding_unavailable:
+                qvec = await timed_leg("embed_ms", self._embed_query(query))
             if qvec is None:
                 record_total()
+                # A semantic-only search without an embedding served nothing —
+                # batch mode reports that as a failure, not a healthy empty.
+                if propagate_failures:
+                    raise EmbeddingUnavailableError(query)
                 return []
             results = await timed_leg(
                 "vector_ms",
@@ -3248,11 +3294,9 @@ class SearchDaemon:
         widen = min(self.config.chunks_per_page, _MAX_CAP_WIDEN) + 1
         leg_limit = limit * 2 * widen if pooled else limit * 2
 
-        qvec = (
-            query_vector
-            if query_vector is not None
-            else await timed_leg("embed_ms", self._embed_query(query))
-        )
+        qvec = query_vector
+        if qvec is None and not embedding_unavailable:
+            qvec = await timed_leg("embed_ms", self._embed_query(query))
         if qvec is None:
             # Without an embedding we still want a useful result — fall back
             # to keyword-only and let the caller decide if that's enough.
@@ -3635,10 +3679,15 @@ class SearchDaemon:
 
         effective_zone_id = zone_id or ROOT_ZONE_ID
 
-        # Pre-embed unique texts once. Fail-soft: on any error fall back to
-        # per-query embedding inside each inner search (hybrid degrades to
-        # keyword-only on embed failure exactly as a single /query does).
+        # Pre-embed unique texts once. When the ONE shared embed_batch call
+        # fails (after the client's own retries), the whole batch treats the
+        # embedding provider as down for this request: semantic-only queries
+        # fail typed, hybrid queries degrade to keyword-only immediately.
+        # Letting every inner search retry its own embedding would turn one
+        # failed shared operation into N concurrent retry cycles against an
+        # already degraded provider.
         vector_by_text: dict[str, list[float]] = {}
+        pre_embed_failed = False
         if self._embedding_client is not None:
             unique_texts = sorted(
                 {
@@ -3654,8 +3703,9 @@ class SearchDaemon:
                     vectors = await self._embedding_client.embed_batch(unique_texts)
                     vector_by_text = dict(zip(unique_texts, vectors, strict=True))
                 except Exception as exc:
+                    pre_embed_failed = True
                     logger.warning(
-                        "batch pre-embed failed; falling back to per-query embedding: %s",
+                        "batch pre-embed failed; semantic queries fail, hybrid degrades to keyword-only: %s",
                         exc,
                     )
 
@@ -3665,12 +3715,17 @@ class SearchDaemon:
             if not isinstance(q, dict):
                 return BatchQueryFailure(error="invalid query spec: expected an object")
             query_text = str(q.get("query", ""))
+            search_type = q.get("search_type", "hybrid")
+            if pre_embed_failed and search_type == "semantic":
+                # The shared embed already failed — don't burn a per-query
+                # retry cycle just to fail the same way.
+                return BatchQueryFailure(error=_BATCH_EMBED_UNAVAILABLE_MESSAGE)
             async with semaphore:
                 try:
                     return await self.search(
                         SearchRequest(
                             query=query_text,
-                            search_type=q.get("search_type", "hybrid"),
+                            search_type=search_type,
                             limit=int(q.get("limit", 10)),
                             path_filter=q.get("path_filter"),
                             alpha=float(q.get("alpha", 0.5)),
@@ -3682,11 +3737,22 @@ class SearchDaemon:
                             recency_half_life_days=q.get("recency_half_life_days"),
                             zone_id=effective_zone_id,
                             query_vector=vector_by_text.get(query_text),
+                            propagate_failures=True,
+                            embedding_unavailable=pre_embed_failed,
                         )
                     )
-                except Exception as exc:
-                    logger.warning("batch_search inner search failed: %s", exc)
-                    return BatchQueryFailure(error=str(exc) or exc.__class__.__name__)
+                except EmbeddingUnavailableError:
+                    return BatchQueryFailure(error=_BATCH_EMBED_UNAVAILABLE_MESSAGE)
+                except TimeoutError:
+                    logger.warning("batch_search inner search timed out: %r", query_text)
+                    return BatchQueryFailure(error=_BATCH_TIMEOUT_MESSAGE)
+                except Exception:
+                    # Full diagnostics stay server-side; the wire gets a stable
+                    # sanitized message (raw backend exception text can leak
+                    # SQL, hosts, or provider internals to authenticated
+                    # callers — the single /query route is equally generic).
+                    logger.exception("batch_search inner search failed: %r", query_text)
+                    return BatchQueryFailure(error=_BATCH_FAILURE_MESSAGE)
 
         results: list[list[Any] | BatchQueryFailure] = list(
             await asyncio.gather(*(_run_one(q) for q in queries))
@@ -4295,6 +4361,9 @@ class SearchDaemon:
         path_filter: str | None,
         *,
         zone_id: str | None = None,
+        query_vector: list[float] | None = None,
+        propagate_failures: bool = False,
+        embedding_unavailable: bool = False,
     ) -> list[SearchResult]:
         """Vector similarity search via the active ``_vector_backend`` (Issue #3699).
 
@@ -4305,12 +4374,18 @@ class SearchDaemon:
         :meth:`search`) work unchanged.
         """
         if self._vector_backend is None:
+            if propagate_failures:
+                raise EmbeddingUnavailableError(query)
             return []
 
         try:
-            embedding = await self._embed_query(query)
+            embedding = query_vector
+            if embedding is None and not embedding_unavailable:
+                embedding = await self._embed_query(query)
             if not embedding:
                 logger.debug("Semantic search: no query embedding available")
+                if propagate_failures:
+                    raise EmbeddingUnavailableError(query)
                 return []
 
             from nexus.contracts.constants import ROOT_ZONE_ID
@@ -4323,6 +4398,10 @@ class SearchDaemon:
             return [self._coerce_to_search_result(r, search_type="semantic") for r in results]
         except Exception as e:
             logger.error(f"Semantic search error: {e}")
+            # Batch mode reports legacy-backend failures per query instead of
+            # collapsing them into a healthy empty result.
+            if propagate_failures:
+                raise
             return []
 
     async def _splade_search(
@@ -4360,6 +4439,8 @@ class SearchDaemon:
         rrf_k: int = 60,
         *,
         zone_id: str | None = None,
+        query_vector: list[float] | None = None,
+        embedding_unavailable: bool = False,
     ) -> list[SearchResult]:
         """Hybrid search combining keyword and semantic results (legacy fallback).
 
@@ -4381,7 +4462,14 @@ class SearchDaemon:
         # are stamped below for non-default fusion requests.
         kw_results, sem_results = await self._gather_legs_fail_soft_dense(
             self._keyword_search(query, limit * 3, path_filter, zone_id=zone_id),
-            self._semantic_search(query, limit * 3, path_filter, zone_id=zone_id),
+            self._semantic_search(
+                query,
+                limit * 3,
+                path_filter,
+                zone_id=zone_id,
+                query_vector=query_vector,
+                embedding_unavailable=embedding_unavailable,
+            ),
         )
 
         fusion_config = FusionConfig(

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -112,6 +112,10 @@ _BATCH_EMBED_OUTAGE_PROBES = 4
 # Known-valid text used to settle "is the provider down, or are these inputs
 # bad?" once several probes have failed with no success anywhere.
 _BATCH_EMBED_CONTROL_TEXT = "nexus embedding health probe"
+# Ancillary batch pools, sized independently of the query-execution pool so a
+# stuck embedding call or path-context refresh can never consume the permits
+# that batch searches (including the keyword-only fallback) need.
+_BATCH_POOL_LIMITS: dict[str, int] = {"embed": 4, "refresh": 2}
 
 
 class VectorBackendUnavailableError(RuntimeError):
@@ -3708,23 +3712,36 @@ class SearchDaemon:
 
         return await self._run_on_owner_loop(_work)
 
-    def _batch_semaphore(self) -> asyncio.Semaphore:
-        """Daemon-scoped fan-out permit pool for /query/batch.
+    def _batch_semaphore(self, pool: str = "search") -> asyncio.Semaphore:
+        """Daemon-scoped permit pool for one class of batch work.
 
         Deliberately NOT per-request: a cancelled batch can leave
-        cancellation-resistant searches still running, and a batch-local
-        semaphore would hand the next request fresh permits while that work
-        is still hitting the DB / provider. Keyed by running loop so a
-        daemon serving more than one loop never shares a bound primitive.
+        cancellation-resistant work running, and a batch-local semaphore
+        would hand the next request fresh permits while that work still
+        hits the DB / provider.
+
+        Pools are also SEPARATE PER CLASS. Query execution, embedding-provider
+        calls, and path-context refreshes have different failure modes; on a
+        shared pool one resistant ancillary operation could retain a query
+        permit and disable batch search entirely (at concurrency 1, a single
+        stuck embed would block even the keyword-only fallback it exists to
+        enable). Keyed by running loop so a daemon serving more than one loop
+        never shares a bound primitive.
         """
         loop = asyncio.get_running_loop()
-        limit = max(1, self.config.batch_search_concurrency)
-        cached = getattr(self, "_batch_semaphore_cache", None)
+        limit = _BATCH_POOL_LIMITS.get(pool) or max(1, self.config.batch_search_concurrency)
+        cache: dict[str, tuple[Any, int, asyncio.Semaphore]] | None = getattr(
+            self, "_batch_semaphore_cache", None
+        )
+        if cache is None:
+            cache = {}
+            self._batch_semaphore_cache = cache
+        cached = cache.get(pool)
         if cached is not None and cached[0] is loop and cached[1] == limit:
             semaphore: asyncio.Semaphore = cached[2]
             return semaphore
         semaphore = asyncio.Semaphore(limit)
-        self._batch_semaphore_cache = (loop, limit, semaphore)
+        cache[pool] = (loop, limit, semaphore)
         return semaphore
 
     def _track_abandoned_batch_tasks(self, tasks: Iterable[asyncio.Task[Any]]) -> None:
@@ -3759,6 +3776,7 @@ class SearchDaemon:
         *,
         remaining: Callable[[], float],
         exec_cap: float,
+        pool: str = "search",
     ) -> T:
         """Run one batch-phase operation under a permit and a hard bound.
 
@@ -3776,7 +3794,7 @@ class SearchDaemon:
         :meth:`_track_abandoned_batch_tasks` — which keeps it charged against
         the daemon-scoped permit pool until it genuinely finishes.
         """
-        semaphore = self._batch_semaphore()
+        semaphore = self._batch_semaphore(pool)
         # Queue time is charged to the BATCH deadline, not to the operation's
         # own budget: a query that waits behind a full pool must still get a
         # full execution window once admitted, or healthy multi-wave batches
@@ -3831,6 +3849,7 @@ class SearchDaemon:
                 lambda: self._embedding_client.embed_batch(chunk),
                 remaining=remaining,
                 exec_cap=self.config.query_timeout_seconds,
+                pool="embed",
             )
             vector_by_text.update(dict(zip(chunk, vectors, strict=True)))
 
@@ -3861,6 +3880,7 @@ class SearchDaemon:
                     lambda: self._embedding_client.embed_batch([_BATCH_EMBED_CONTROL_TEXT]),
                     remaining=remaining,
                     exec_cap=self.config.query_timeout_seconds,
+                    pool="embed",
                 )
                 control_verdict = False
             except asyncio.CancelledError:
@@ -4173,6 +4193,7 @@ class SearchDaemon:
                     lambda: cache.refresh_if_stale(effective_zone_id),
                     remaining=_remaining,
                     exec_cap=self.config.query_timeout_seconds,
+                    pool="refresh",
                 )
             except Exception as exc:
                 self.stats.path_context_attach_failures += 1

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -2847,6 +2847,7 @@ class SearchDaemon:
                 fusion_method=req.fusion_method,
                 rrf_k=req.rrf_k,
                 zone_id=req.zone_id,
+                query_vector=req.query_vector,
             )
         else:
 
@@ -2860,6 +2861,7 @@ class SearchDaemon:
                     fusion_method=req.fusion_method,
                     rrf_k=req.rrf_k,
                     zone_id=req.zone_id,
+                    query_vector=req.query_vector,
                 )
 
             results = await self._run_on_owner_loop(_work)
@@ -2885,6 +2887,7 @@ class SearchDaemon:
         fusion_method: str = "rrf",
         zone_id: str | None = None,
         rrf_k: int = 60,
+        query_vector: list[float] | None = None,
     ) -> list[SearchResult]:
         """Execute a search query with pre-warmed indexes.
 
@@ -3051,6 +3054,7 @@ class SearchDaemon:
                     fusion_method=fusion_method,
                     rrf_k=rrf_k,
                     zone_id=effective_zone_id,
+                    query_vector=query_vector,
                 )
                 backend_ms = (time.perf_counter() - backend_start) * 1000
                 self.last_search_timing = _merge_backend_timing(backend_ms, self.last_search_timing)
@@ -3165,6 +3169,7 @@ class SearchDaemon:
         alpha: float = 0.5,
         fusion_method: str = "rrf",
         rrf_k: int = 60,
+        query_vector: list[float] | None = None,
     ) -> list[SearchResult]:
         """Run keyword / semantic / hybrid via the new search backends.
 
@@ -3209,7 +3214,11 @@ class SearchDaemon:
             return [self._coerce_to_search_result(r, search_type=search_type) for r in results]
 
         if search_type == "semantic":
-            qvec = await timed_leg("embed_ms", self._embed_query(query))
+            qvec = (
+                query_vector
+                if query_vector is not None
+                else await timed_leg("embed_ms", self._embed_query(query))
+            )
             if qvec is None:
                 record_total()
                 return []
@@ -3236,7 +3245,11 @@ class SearchDaemon:
         widen = min(self.config.chunks_per_page, _MAX_CAP_WIDEN) + 1
         leg_limit = limit * 2 * widen if pooled else limit * 2
 
-        qvec = await timed_leg("embed_ms", self._embed_query(query))
+        qvec = (
+            query_vector
+            if query_vector is not None
+            else await timed_leg("embed_ms", self._embed_query(query))
+        )
         if qvec is None:
             # Without an embedding we still want a useful result — fall back
             # to keyword-only and let the caller decide if that's enough.

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -96,6 +96,22 @@ MUTATION_CONSUMER_NAMES: tuple[str, ...] = ("fts", "embedding")
 _BATCH_FAILURE_MESSAGE = "Search query failed"
 _BATCH_TIMEOUT_MESSAGE = "Search timed out"
 _BATCH_EMBED_UNAVAILABLE_MESSAGE = "Query embedding unavailable"
+# Grace window for draining cancelled batch tasks. Cancellation is normally
+# immediate; this only bounds a backend that swallows CancelledError during
+# cleanup so it cannot hold the request open indefinitely.
+_BATCH_VECTOR_BACKEND_MESSAGE = "Vector backend unavailable"
+_BATCH_CANCEL_DRAIN_SECONDS = 5.0
+
+
+class VectorBackendUnavailableError(RuntimeError):
+    """The dense backend itself is absent or unusable for this search.
+
+    Distinct from :class:`EmbeddingUnavailableError` (which means the query
+    text could not be embedded). Missing-embedding is legitimate hybrid
+    degradation and stays fail-soft; a missing/failed vector BACKEND means
+    dense coverage is silently incomplete, so under the batch policy it is
+    a per-query failure rather than a keyword-only "success".
+    """
 
 
 class EmbeddingUnavailableError(RuntimeError):
@@ -3537,9 +3553,11 @@ class SearchDaemon:
         except Exception as exc:
             # Batch mode reports dense INFRASTRUCTURE failures per query
             # instead of silently serving keyword-only hits as a full
-            # success. A missing embedding is legitimate degradation (the
-            # hybrid contract serves keyword-only then) and stays fail-soft
-            # in both modes.
+            # success. ONLY a missing query embedding is legitimate
+            # degradation (the hybrid contract serves keyword-only then) and
+            # stays fail-soft in both modes — an absent/failed vector BACKEND
+            # raises VectorBackendUnavailableError and is NOT carved out,
+            # since it means dense coverage is silently incomplete.
             if propagate_failures and not isinstance(exc, EmbeddingUnavailableError):
                 raise
             logger.warning("hybrid dense leg failed; continuing keyword-only: %s", exc)
@@ -3697,6 +3715,16 @@ class SearchDaemon:
 
         effective_zone_id = zone_id or ROOT_ZONE_ID
 
+        # ONE monotonic deadline governs the whole request: pre-embed, the
+        # search fan-out, cancellation drain, and the path-context refresh
+        # each get only the REMAINING budget. Per-phase timeouts alone let a
+        # request accumulate pre-embed + fan-out + refresh windows.
+        batch_deadline = time.monotonic() + max(0.0, self.config.batch_search_timeout_seconds)
+
+        def _remaining(cap: float | None = None) -> float:
+            left = max(0.0, batch_deadline - time.monotonic())
+            return left if cap is None else min(left, cap)
+
         # Pre-embed unique texts once. When the ONE shared embed_batch call
         # fails (after the client's own retries), the whole batch treats the
         # embedding provider as down for this request: semantic-only queries
@@ -3720,7 +3748,7 @@ class SearchDaemon:
                 try:
                     vectors = await asyncio.wait_for(
                         self._embedding_client.embed_batch(unique_texts),
-                        timeout=self.config.query_timeout_seconds,
+                        timeout=_remaining(self.config.query_timeout_seconds),
                     )
                     vector_by_text = dict(zip(unique_texts, vectors, strict=True))
                 except Exception as exc:
@@ -3748,7 +3776,7 @@ class SearchDaemon:
                     # all completed siblings and never produce the advertised
                     # per-query timeout failure. wait_for cancels the hung
                     # inner search and the except below converts it.
-                    return await asyncio.wait_for(
+                    inner_result = await asyncio.wait_for(
                         self.search(
                             SearchRequest(
                                 query=query_text,
@@ -3768,10 +3796,20 @@ class SearchDaemon:
                                 embedding_unavailable=pre_embed_failed,
                             )
                         ),
-                        timeout=self.config.query_timeout_seconds,
+                        timeout=_remaining(self.config.query_timeout_seconds),
                     )
+                    # A search that suppresses its cancellation can return a
+                    # value AFTER the deadline (wait_for then yields that
+                    # value instead of raising). It was unfinished when the
+                    # budget ran out, so settle it as a timeout rather than
+                    # reporting a healthy late result.
+                    if time.monotonic() >= batch_deadline:
+                        return BatchQueryFailure(error=_BATCH_TIMEOUT_MESSAGE)
+                    return inner_result
                 except EmbeddingUnavailableError:
                     return BatchQueryFailure(error=_BATCH_EMBED_UNAVAILABLE_MESSAGE)
+                except VectorBackendUnavailableError:
+                    return BatchQueryFailure(error=_BATCH_VECTOR_BACKEND_MESSAGE)
                 except TimeoutError:
                     logger.warning("batch_search inner search timed out: %r", query_text)
                     return BatchQueryFailure(error=_BATCH_TIMEOUT_MESSAGE)
@@ -3790,14 +3828,17 @@ class SearchDaemon:
         # completed siblings keep their results.
         tasks = [asyncio.ensure_future(_run_one(q)) for q in queries]
         try:
-            _done_tasks, pending_tasks = await asyncio.wait(
-                tasks, timeout=max(0.0, self.config.batch_search_timeout_seconds)
-            )
+            _done_tasks, pending_tasks = await asyncio.wait(tasks, timeout=_remaining())
         except BaseException:
             for task in tasks:
                 task.cancel()
             await asyncio.gather(*tasks, return_exceptions=True)
             raise
+        # The set pending AT EXPIRY is authoritative for settlement: a task
+        # that finishes during cancellation cleanup (or suppresses the
+        # cancel) was still unfinished at the deadline and must not be
+        # reported as a healthy result.
+        timed_out_positions = {i for i, task in enumerate(tasks) if task in pending_tasks}
         if pending_tasks:
             logger.warning(
                 "batch_search deadline (%.1fs) expired with %d of %d queries unfinished",
@@ -3807,13 +3848,23 @@ class SearchDaemon:
             )
             for task in pending_tasks:
                 task.cancel()
-            await asyncio.gather(*pending_tasks, return_exceptions=True)
-        # After the cancel+drain every task is done; a task that slipped in a
-        # normal completion between the deadline and the cancel keeps its
-        # result rather than being misreported as timed out.
+            # Bounded drain: a backend that swallows cancellation must not
+            # hold the request open past its deadline. Un-drained tasks are
+            # abandoned (already settled as timeouts below).
+            drain = asyncio.gather(*pending_tasks, return_exceptions=True)
+            try:
+                await asyncio.wait_for(asyncio.shield(drain), timeout=_BATCH_CANCEL_DRAIN_SECONDS)
+            except (TimeoutError, asyncio.CancelledError):
+                logger.warning(
+                    "batch_search cancellation drain exceeded %.1fs; abandoning %d task(s)",
+                    _BATCH_CANCEL_DRAIN_SECONDS,
+                    len(pending_tasks),
+                )
         results: list[list[Any] | BatchQueryFailure] = [
-            BatchQueryFailure(error=_BATCH_TIMEOUT_MESSAGE) if task.cancelled() else task.result()
-            for task in tasks
+            BatchQueryFailure(error=_BATCH_TIMEOUT_MESSAGE)
+            if i in timed_out_positions
+            else task.result()
+            for i, task in enumerate(tasks)
         ]
         # Issue #3773: attach admin-configured path contexts. The whole batch
         # is single-zone by design (``zone_id=effective_zone_id`` above), so
@@ -3843,7 +3894,7 @@ class SearchDaemon:
                 # the stale-snapshot fail-soft path below.
                 await asyncio.wait_for(
                     cache.refresh_if_stale(effective_zone_id),
-                    timeout=self.config.query_timeout_seconds,
+                    timeout=_remaining(self.config.query_timeout_seconds),
                 )
             except Exception as exc:
                 self.stats.path_context_attach_failures += 1
@@ -4439,7 +4490,7 @@ class SearchDaemon:
         """
         if self._vector_backend is None:
             if propagate_failures:
-                raise EmbeddingUnavailableError(query)
+                raise VectorBackendUnavailableError(query)
             return []
 
         try:

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -105,6 +105,10 @@ _BATCH_CANCEL_DRAIN_SECONDS = 5.0
 # failure. Bounds the degenerate case (many independently-bad inputs) so a
 # batch can never turn into a per-text retry storm against the provider.
 _BATCH_EMBED_PROBE_LIMIT = 16
+# Consecutive probes with no success anywhere before the provider (rather
+# than the inputs) is blamed. Keeps a total outage to a handful of calls
+# while still letting independently-bad inputs in different halves isolate.
+_BATCH_EMBED_OUTAGE_PROBES = 4
 
 
 class VectorBackendUnavailableError(RuntimeError):
@@ -3746,6 +3750,33 @@ class SearchDaemon:
             tracked.add(task)
             task.add_done_callback(_done)
 
+    async def _run_bounded_batch_op(
+        self,
+        coro: Awaitable[T],
+        *,
+        timeout: float,
+    ) -> T:
+        """Run one batch-phase coroutine under a permit and a hard bound.
+
+        Wrapping with ``asyncio.wait_for`` alone is not enough: on timeout it
+        cancels the coroutine and then WAITS for that cancellation to finish,
+        so a provider that delays or swallows ``CancelledError`` keeps the
+        whole batch suspended. The work runs as its own task, is awaited
+        through ``shield``, and on timeout is cancelled and handed to
+        :meth:`_track_abandoned_batch_tasks` — which keeps it charged against
+        the daemon-scoped permit pool until it genuinely finishes.
+        """
+        semaphore = self._batch_semaphore()
+        await semaphore.acquire()
+        task: asyncio.Task[T] = asyncio.ensure_future(coro)
+        task.add_done_callback(lambda _task: semaphore.release())
+        try:
+            return await asyncio.wait_for(asyncio.shield(task), timeout=timeout)
+        except (TimeoutError, asyncio.CancelledError):
+            task.cancel()
+            self._track_abandoned_batch_tasks({task})
+            raise
+
     async def _embed_batch_texts(
         self,
         texts: list[str],
@@ -3756,29 +3787,37 @@ class SearchDaemon:
 
         Returns ``(vector_by_text, failed_texts, provider_down)``.
 
-        One shared ``embed_batch`` call covers the happy path. When it
-        fails, the cause is either ONE bad input (e.g. a text the provider
-        rejects) or a provider-wide outage — and the two need opposite
-        handling: a bad input must not fail its healthy siblings, while an
-        outage must not turn into a per-text retry storm. A bounded binary
-        search separates them: halves are probed until the offender is
-        isolated (O(log n) probes), and if BOTH halves fail at the first
-        split the provider is treated as down (2 extra probes, no storm).
-        ``_BATCH_EMBED_PROBE_LIMIT`` caps total probe calls.
+        One shared ``embed_batch`` call covers the happy path. When it fails
+        the cause is either specific bad input (texts the provider rejects)
+        or a provider-wide outage — and the two need opposite handling: bad
+        input must not fail its healthy siblings, while an outage must not
+        turn into a per-text retry storm. Bisection separates them: failing
+        halves keep splitting so that INDEPENDENT bad inputs in different
+        halves are each isolated, while an outage — recognised as
+        ``_BATCH_EMBED_OUTAGE_PROBES`` consecutive probes with no success
+        anywhere — stops the walk early. ``_BATCH_EMBED_PROBE_LIMIT`` caps
+        total probes either way; every vector obtained along the way is
+        kept.
         """
         probes_left = _BATCH_EMBED_PROBE_LIMIT
+        probes_done = 0
         vector_by_text: dict[str, list[float]] = {}
         failed_texts: set[str] = set()
 
-        async def _probe(chunk: list[str]) -> bool:
-            """Embed one chunk; True on success (vectors recorded)."""
-            nonlocal probes_left
-            budget = remaining(self.config.query_timeout_seconds)
-            vectors = await asyncio.wait_for(
-                self._embedding_client.embed_batch(chunk), timeout=budget
+        async def _probe(chunk: list[str]) -> None:
+            """Embed one chunk, recording its vectors. Raises on failure."""
+            nonlocal probes_done
+            probes_done += 1
+            vectors = await self._run_bounded_batch_op(
+                self._embedding_client.embed_batch(chunk),
+                timeout=remaining(self.config.query_timeout_seconds),
             )
             vector_by_text.update(dict(zip(chunk, vectors, strict=True)))
-            return True
+
+        def _looks_like_outage() -> bool:
+            # No probe has EVER succeeded after several attempts: the
+            # provider itself is the common factor, not the inputs.
+            return not vector_by_text and probes_done >= _BATCH_EMBED_OUTAGE_PROBES
 
         try:
             await _probe(texts)
@@ -3789,22 +3828,17 @@ class SearchDaemon:
             logger.warning("batch pre-embed failed (%d texts); isolating: %s", len(texts), exc)
 
         async def _isolate(chunk: list[str]) -> str:
-            """Bisect ``chunk``; returns "input" or "down".
-
-            "down" means the provider itself looks unavailable (both halves
-            of a split failed outright, or the probe budget ran out with no
-            success anywhere) — the caller degrades the whole batch once.
-            "input" means the failures were isolated to specific texts,
-            recorded in ``failed_texts``, leaving healthy siblings usable.
-            """
+            """Bisect ``chunk``; returns "input" or "down"."""
             nonlocal probes_left
+            if _looks_like_outage():
+                return "down"
             if len(chunk) == 1:
                 failed_texts.add(chunk[0])
                 return "input"
             mid = len(chunk) // 2
             halves = [chunk[:mid], chunk[mid:]]
-            # Probe BOTH halves before recursing: a provider-wide outage is
-            # then two probes deep, not a full descent.
+            # Probe BOTH halves before recursing so an outage surfaces from
+            # the shared no-success signal rather than a deep descent.
             outcomes: list[bool | None] = []
             for half in halves:
                 if probes_left <= 0 or remaining() <= 0:
@@ -3818,11 +3852,7 @@ class SearchDaemon:
                     raise
                 except Exception:
                     outcomes.append(False)
-            if all(o is False for o in outcomes):
-                return "down"
-            if all(o is None for o in outcomes):
-                # No budget left to learn anything — treat conservatively as
-                # a provider problem rather than blaming these texts.
+            if _looks_like_outage():
                 return "down"
             for half, outcome in zip(halves, outcomes, strict=True):
                 if outcome is True:
@@ -3832,6 +3862,9 @@ class SearchDaemon:
                     # rather than probing further.
                     failed_texts.update(half)
                     continue
+                # A FAILED half keeps splitting: independent bad inputs in
+                # both halves must each be isolated, not collapsed into a
+                # false "provider down".
                 if await _isolate(half) == "down":
                     return "down"
             return "input"

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -109,6 +109,9 @@ _BATCH_EMBED_PROBE_LIMIT = 16
 # than the inputs) is blamed. Keeps a total outage to a handful of calls
 # while still letting independently-bad inputs in different halves isolate.
 _BATCH_EMBED_OUTAGE_PROBES = 4
+# Known-valid text used to settle "is the provider down, or are these inputs
+# bad?" once several probes have failed with no success anywhere.
+_BATCH_EMBED_CONTROL_TEXT = "nexus embedding health probe"
 
 
 class VectorBackendUnavailableError(RuntimeError):
@@ -3752,26 +3755,39 @@ class SearchDaemon:
 
     async def _run_bounded_batch_op(
         self,
-        coro: Awaitable[T],
+        make_coro: Callable[[], Awaitable[T]],
         *,
         timeout: float,
     ) -> T:
-        """Run one batch-phase coroutine under a permit and a hard bound.
+        """Run one batch-phase operation under a permit and a hard bound.
 
-        Wrapping with ``asyncio.wait_for`` alone is not enough: on timeout it
-        cancels the coroutine and then WAITS for that cancellation to finish,
-        so a provider that delays or swallows ``CancelledError`` keeps the
-        whole batch suspended. The work runs as its own task, is awaited
-        through ``shield``, and on timeout is cancelled and handed to
+        The bound covers PERMIT ACQUISITION as well as the work itself:
+        abandoned cancellation-resistant work deliberately keeps its permits,
+        so an exhausted pool would otherwise park the next request here,
+        outside any deadline. The coroutine is created only after a permit is
+        held (a coroutine built up front and never awaited leaks).
+
+        ``asyncio.wait_for`` alone is also not enough for the work itself: on
+        timeout it cancels and then WAITS for that cancellation to finish, so
+        a provider that delays or swallows ``CancelledError`` keeps the batch
+        suspended. The work runs as its own task, is awaited through
+        ``shield``, and on timeout is cancelled and handed to
         :meth:`_track_abandoned_batch_tasks` — which keeps it charged against
         the daemon-scoped permit pool until it genuinely finishes.
         """
+        started = time.monotonic()
+        budget = max(0.0, timeout)
         semaphore = self._batch_semaphore()
-        await semaphore.acquire()
-        task: asyncio.Task[T] = asyncio.ensure_future(coro)
+        # No coroutine exists yet: a timeout here cannot leak one.
+        await asyncio.wait_for(semaphore.acquire(), timeout=budget)
+        remaining_budget = budget - (time.monotonic() - started)
+        if remaining_budget <= 0:
+            semaphore.release()
+            raise TimeoutError("batch operation budget exhausted while waiting for a permit")
+        task: asyncio.Task[T] = asyncio.ensure_future(make_coro())
         task.add_done_callback(lambda _task: semaphore.release())
         try:
-            return await asyncio.wait_for(asyncio.shield(task), timeout=timeout)
+            return await asyncio.wait_for(asyncio.shield(task), timeout=remaining_budget)
         except (TimeoutError, asyncio.CancelledError):
             task.cancel()
             self._track_abandoned_batch_tasks({task})
@@ -3809,15 +3825,40 @@ class SearchDaemon:
             nonlocal probes_done
             probes_done += 1
             vectors = await self._run_bounded_batch_op(
-                self._embedding_client.embed_batch(chunk),
+                lambda: self._embedding_client.embed_batch(chunk),
                 timeout=remaining(self.config.query_timeout_seconds),
             )
             vector_by_text.update(dict(zip(chunk, vectors, strict=True)))
 
-        def _looks_like_outage() -> bool:
-            # No probe has EVER succeeded after several attempts: the
-            # provider itself is the common factor, not the inputs.
-            return not vector_by_text and probes_done >= _BATCH_EMBED_OUTAGE_PROBES
+        control_verdict: bool | None = None
+
+        async def _looks_like_outage() -> bool:
+            """Is the PROVIDER down, or are these texts simply bad?
+
+            Probe count alone cannot answer that — bad inputs can contaminate
+            every early partition. When nothing has embedded after several
+            attempts, settle it with evidence: one probe of a known-valid
+            control text. Control succeeds -> the provider is healthy and the
+            failures belong to specific inputs; control fails -> outage. The
+            verdict is cached so it costs at most one extra call per batch.
+            """
+            nonlocal control_verdict
+            if vector_by_text or probes_done < _BATCH_EMBED_OUTAGE_PROBES:
+                return False
+            if control_verdict is not None:
+                return control_verdict
+            try:
+                await self._run_bounded_batch_op(
+                    lambda: self._embedding_client.embed_batch([_BATCH_EMBED_CONTROL_TEXT]),
+                    timeout=remaining(self.config.query_timeout_seconds),
+                )
+                control_verdict = False
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                logger.warning("batch pre-embed control probe failed; provider looks down: %s", exc)
+                control_verdict = True
+            return control_verdict
 
         try:
             await _probe(texts)
@@ -3830,7 +3871,7 @@ class SearchDaemon:
         async def _isolate(chunk: list[str]) -> str:
             """Bisect ``chunk``; returns "input" or "down"."""
             nonlocal probes_left
-            if _looks_like_outage():
+            if await _looks_like_outage():
                 return "down"
             if len(chunk) == 1:
                 failed_texts.add(chunk[0])
@@ -3852,7 +3893,7 @@ class SearchDaemon:
                     raise
                 except Exception:
                     outcomes.append(False)
-            if _looks_like_outage():
+            if await _looks_like_outage():
                 return "down"
             for half, outcome in zip(halves, outcomes, strict=True):
                 if outcome is True:
@@ -3936,8 +3977,6 @@ class SearchDaemon:
                     remaining=_remaining,
                 )
 
-        semaphore = self._batch_semaphore()
-
         async def _run_one(q: Any) -> list[Any] | BatchQueryFailure:
             if not isinstance(q, dict):
                 return BatchQueryFailure(error="invalid query spec: expected an object")
@@ -3948,42 +3987,32 @@ class SearchDaemon:
                 # No embedding for THIS text — don't burn a per-query retry
                 # cycle just to fail the same way.
                 return BatchQueryFailure(error=_BATCH_EMBED_UNAVAILABLE_MESSAGE)
-            # Permits follow REAL in-flight work: acquired here and released
-            # by the search task's own completion callback, so a search that
-            # outlives its timeout (cancellation-resistant backend) keeps
-            # consuming capacity instead of silently accumulating behind a
-            # released permit.
-            await semaphore.acquire()
-            search_task: asyncio.Task[list[SearchResult]] = asyncio.ensure_future(
-                self.search(
-                    SearchRequest(
-                        query=query_text,
-                        search_type=search_type,
-                        limit=int(q.get("limit", 10)),
-                        path_filter=q.get("path_filter"),
-                        alpha=float(q.get("alpha", 0.5)),
-                        fusion_method=q.get("fusion_method", "rrf"),
-                        rrf_k=int(q.get("rrf_k", 60)),
-                        expand=q.get("expand", "none"),
-                        recency=q.get("recency"),
-                        recency_weight=q.get("recency_weight"),
-                        recency_half_life_days=q.get("recency_half_life_days"),
-                        zone_id=effective_zone_id,
-                        query_vector=vector_by_text.get(query_text),
-                        propagate_failures=True,
-                        embedding_unavailable=text_embed_failed,
-                    )
-                )
+            request = SearchRequest(
+                query=query_text,
+                search_type=search_type,
+                limit=int(q.get("limit", 10)),
+                path_filter=q.get("path_filter"),
+                alpha=float(q.get("alpha", 0.5)),
+                fusion_method=q.get("fusion_method", "rrf"),
+                rrf_k=int(q.get("rrf_k", 60)),
+                expand=q.get("expand", "none"),
+                recency=q.get("recency"),
+                recency_weight=q.get("recency_weight"),
+                recency_half_life_days=q.get("recency_half_life_days"),
+                zone_id=effective_zone_id,
+                query_vector=vector_by_text.get(query_text),
+                propagate_failures=True,
+                embedding_unavailable=text_embed_failed,
             )
-            search_task.add_done_callback(lambda _task: semaphore.release())
             try:
-                # Bounded per query: asyncio.wait waits for EVERY entry, so a
-                # hung backend would otherwise withhold all completed siblings
-                # and never produce the advertised per-query timeout failure.
-                # shield keeps the timeout from silently detaching the task —
-                # it is cancelled and accounted for explicitly below.
-                inner_result = await asyncio.wait_for(
-                    asyncio.shield(search_task),
+                # Bounded end to end (permit wait + search): asyncio.wait waits
+                # for EVERY entry, so an unbounded query would withhold all
+                # completed siblings and never produce the advertised per-query
+                # timeout failure. Permits follow real in-flight work, so a
+                # search that outlives its timeout keeps consuming capacity
+                # instead of accumulating silently.
+                inner_result = await self._run_bounded_batch_op(
+                    lambda: self.search(request),
                     timeout=_remaining(self.config.query_timeout_seconds),
                 )
                 # A search that suppresses its cancellation can return a
@@ -3994,21 +4023,14 @@ class SearchDaemon:
                 if time.monotonic() >= batch_deadline:
                     return BatchQueryFailure(error=_BATCH_TIMEOUT_MESSAGE)
                 return inner_result
-            except asyncio.CancelledError:
-                search_task.cancel()
-                self._track_abandoned_batch_tasks({search_task})
-                raise
             except EmbeddingUnavailableError:
                 return BatchQueryFailure(error=_BATCH_EMBED_UNAVAILABLE_MESSAGE)
             except VectorBackendUnavailableError:
                 return BatchQueryFailure(error=_BATCH_VECTOR_BACKEND_MESSAGE)
             except TimeoutError:
+                # Cancellation + abandoned-task accounting already happened
+                # inside _run_bounded_batch_op.
                 logger.warning("batch_search inner search timed out: %r", query_text)
-                # The task is still running: cancel it and keep it charged
-                # (its permit is released by the done-callback only when it
-                # actually finishes).
-                search_task.cancel()
-                self._track_abandoned_batch_tasks({search_task})
                 return BatchQueryFailure(error=_BATCH_TIMEOUT_MESSAGE)
             except Exception:
                 # Full diagnostics stay server-side; the wire gets a stable

--- a/src/nexus/bricks/search/graph_search_service.py
+++ b/src/nexus/bricks/search/graph_search_service.py
@@ -34,12 +34,16 @@ class DaemonSemanticSearchWrapper:
         alpha: float = 0.5,  # noqa: ARG002
         **kwargs: Any,  # noqa: ARG002
     ) -> list[BaseSearchResult]:
+        from nexus.contracts.search_types import SearchRequest
+
         results = await self.daemon.search(
-            query=query,
-            search_type=search_mode,
-            limit=limit,
-            path_filter=path if path != "/" else None,
-            zone_id=self._zone_id,
+            SearchRequest(
+                query=query,
+                search_type=search_mode,
+                limit=limit,
+                path_filter=path if path != "/" else None,
+                zone_id=self._zone_id,
+            )
         )
         return [
             BaseSearchResult(

--- a/src/nexus/bricks/search/search_service.py
+++ b/src/nexus/bricks/search/search_service.py
@@ -37,6 +37,7 @@ from nexus.contracts.search_types import (
     GREP_ZOEKT_THRESHOLD,
     LAST_SEMANTIC_DEGRADED,
     GlobStrategy,
+    SearchRequest,
     SearchStrategy,
 )
 from nexus.contracts.types import Permission
@@ -4055,11 +4056,13 @@ class SearchService:
             if daemon is not None:
                 try:
                     rows = await daemon.search(
-                        query=query,
-                        search_type="keyword",
-                        limit=per_lane_limit,
-                        path_filter=db_path,
-                        zone_id=zone_id,
+                        SearchRequest(
+                            query=query,
+                            search_type="keyword",
+                            limit=per_lane_limit,
+                            path_filter=db_path,
+                            zone_id=zone_id,
+                        )
                     )
                 except Exception as exc:
                     logger.warning(
@@ -4358,11 +4361,13 @@ class SearchService:
 
                 db_path = _unscope(path) if path != "/" else None
                 daemon_results = await daemon.search(
-                    query=query,
-                    search_type="keyword",
-                    limit=fetch_limit,
-                    path_filter=db_path,
-                    zone_id=zone_id,
+                    SearchRequest(
+                        query=query,
+                        search_type="keyword",
+                        limit=fetch_limit,
+                        path_filter=db_path,
+                        zone_id=zone_id,
+                    )
                 )
                 hits: builtins.list[dict[str, Any]] = []
                 for r in daemon_results:
@@ -4561,11 +4566,13 @@ class SearchService:
 
             db_path = _unscope(path) if path != "/" else None
             daemon_results = await daemon.search(
-                query=query,
-                search_type=search_mode,
-                limit=fetch_limit,
-                path_filter=db_path,
-                zone_id=zone_id,
+                SearchRequest(
+                    query=query,
+                    search_type=search_mode,
+                    limit=fetch_limit,
+                    path_filter=db_path,
+                    zone_id=zone_id,
+                )
             )
             hits = []
             for r in daemon_results:

--- a/src/nexus/contracts/search_types.py
+++ b/src/nexus/contracts/search_types.py
@@ -41,6 +41,8 @@ __all__ = [
     "LAST_SEMANTIC_DEGRADED",
     # SearchBrickProtocol.search bundled request (#4553 follow-up B)
     "SearchRequest",
+    # Positional per-query failure marker for batch_search
+    "BatchQueryFailure",
 ]
 
 
@@ -85,6 +87,20 @@ class SearchRequest:
     # batch endpoint embeds all unique query texts in one embed_batch call
     # and hands each inner search its vector.
     query_vector: list[float] | None = None
+
+
+@dataclass(frozen=True, kw_only=True)
+class BatchQueryFailure:
+    """Positional per-query failure marker returned by ``batch_search``.
+
+    The batch endpoint historically collapsed inner exceptions to ``[]``,
+    making a backend failure indistinguishable from a genuine empty result.
+    Returning this marker instead lets callers with fail-closed coverage
+    contracts (e.g. cross-workspace fan-out) count the query as FAILED
+    rather than "searched, no matches".
+    """
+
+    error: str
 
 
 # Per-task flag recording whether the last SANDBOX semantic_search call

--- a/src/nexus/contracts/search_types.py
+++ b/src/nexus/contracts/search_types.py
@@ -80,6 +80,11 @@ class SearchRequest:
     recency: str | None = None
     recency_weight: float | None = None
     recency_half_life_days: float | None = None
+    # Pre-computed query embedding. When set, the daemon uses this vector
+    # for the dense leg instead of embedding the query text itself — the
+    # batch endpoint embeds all unique query texts in one embed_batch call
+    # and hands each inner search its vector.
+    query_vector: list[float] | None = None
 
 
 # Per-task flag recording whether the last SANDBOX semantic_search call

--- a/src/nexus/contracts/search_types.py
+++ b/src/nexus/contracts/search_types.py
@@ -87,6 +87,16 @@ class SearchRequest:
     # batch endpoint embeds all unique query texts in one embed_batch call
     # and hands each inner search its vector.
     query_vector: list[float] | None = None
+    # Batch-mode failure semantics. The interactive path degrades several
+    # backend failures to an empty result (query timeout, legacy semantic
+    # backend errors, missing query embedding on a semantic-only search).
+    # When True those failures raise to the caller instead, so the batch
+    # endpoint can report a per-query failure rather than a healthy empty.
+    propagate_failures: bool = False
+    # Set when a shared batch pre-embed already failed: dense legs skip
+    # their own embed attempt (hybrid degrades to keyword-only immediately)
+    # instead of re-hammering a degraded embedding provider once per query.
+    embedding_unavailable: bool = False
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/src/nexus/server/api/v2/routers/_search_batch.py
+++ b/src/nexus/server/api/v2/routers/_search_batch.py
@@ -75,12 +75,12 @@ def _as_float(
         out = float(value)
     except (TypeError, ValueError):
         return f"{name} must be a number"
-    if exclusive_lo and out <= lo:
-        return f"{name} must be greater than {lo} and at most {hi}"
-    if not exclusive_lo and not lo <= out <= hi:
-        return f"{name} must be between {lo} and {hi}"
-    if out > hi:
-        return f"{name} must be greater than {lo} and at most {hi}"
+    if exclusive_lo:
+        if not (out > lo and out <= hi):
+            return f"{name} must be greater than {lo} and at most {hi}"
+    else:
+        if not (lo <= out <= hi):
+            return f"{name} must be between {lo} and {hi}"
     return out
 
 

--- a/src/nexus/server/api/v2/routers/_search_batch.py
+++ b/src/nexus/server/api/v2/routers/_search_batch.py
@@ -93,6 +93,32 @@ def _check_choice(value: str, name: str, allowed: tuple[str, ...]) -> str | None
     return None
 
 
+def _enum_value(
+    raw: dict[str, Any],
+    name: str,
+    allowed: tuple[str, ...],
+    default: str,
+    *,
+    legacy: str | None = None,
+) -> tuple[str, str | None]:
+    """Resolve one enum param to ``(value, error)``.
+
+    The default applies ONLY when neither the public key nor its legacy
+    alias is present. A present-but-non-string value (including explicit
+    null) and a present-but-unknown string both error — ``"type": ""``
+    must not silently run a hybrid search.
+    """
+    if name in raw:
+        value = raw[name]
+    elif legacy is not None and legacy in raw:
+        value = raw[legacy]
+    else:
+        return default, None
+    if not isinstance(value, str):
+        return default, f"{name} must be a string"
+    return value, _check_choice(value, name, allowed)
+
+
 def _as_float(
     value: Any, name: str, lo: float, hi: float, *, exclusive_lo: bool = False
 ) -> float | str:
@@ -169,20 +195,29 @@ def parse_batch_query_spec(raw: Any) -> ParsedBatchSpec | str:
 
     # Enum validation runs after alias resolution; messages use the
     # canonical public name (so `search_type: "keywrod"` errors on "type").
-    search_type = str(_pick(raw, "type", "search_type") or "hybrid")
-    if (err := _check_choice(search_type, "type", _TYPE_CHOICES)) is not None:
+    # Defaults apply ONLY when the key (and its alias) is absent — an
+    # explicit empty string or null must error like the single route does,
+    # not silently coerce to the default semantics.
+    search_type, err = _enum_value(raw, "type", _TYPE_CHOICES, "hybrid", legacy="search_type")
+    if err is not None:
         return err
-    fusion_method = str(_pick(raw, "fusion", "fusion_method") or "rrf")
-    if (err := _check_choice(fusion_method, "fusion", _FUSION_CHOICES)) is not None:
+    fusion_method, err = _enum_value(raw, "fusion", _FUSION_CHOICES, "rrf", legacy="fusion_method")
+    if err is not None:
         return err
-    expand = str(raw.get("expand") or "none")
-    if (err := _check_choice(expand, "expand", _EXPAND_CHOICES)) is not None:
+    expand, err = _enum_value(raw, "expand", _EXPAND_CHOICES, "none")
+    if err is not None:
         return err
 
-    raw_recency = raw.get("recency")
-    recency = str(raw_recency) if raw_recency is not None else None
-    if recency is not None and (err := _check_choice(recency, "recency", _RECENCY_CHOICES)):
-        return err
+    # recency is the only optional enum: absent AND explicit null both mean
+    # "no recency directive"; any other non-string or unknown value errors.
+    recency: str | None = None
+    if raw.get("recency") is not None:
+        raw_recency = raw["recency"]
+        if not isinstance(raw_recency, str):
+            return "recency must be a string"
+        if (err := _check_choice(raw_recency, "recency", _RECENCY_CHOICES)) is not None:
+            return err
+        recency = raw_recency
 
     return ParsedBatchSpec(
         query=query,

--- a/src/nexus/server/api/v2/routers/_search_batch.py
+++ b/src/nexus/server/api/v2/routers/_search_batch.py
@@ -1,0 +1,150 @@
+"""Batch search request parsing (`POST /query/batch`).
+
+Extracted from ``routers/search.py`` the same way ``_search_serialize.py``
+was (the router sits near the repo's 2000-line file cap). This module owns
+the pure per-query spec contract; the route keeps auth, the read gate, and
+daemon wiring.
+
+Each spec mirrors the single ``/query`` route's public parameter names and
+keeps the legacy batch aliases (``query``/``search_type``/``path_filter``).
+The public name wins when both are present. Numeric bounds mirror the
+single route's FastAPI ``Query()`` validation exactly; string params pass
+through unvalidated (single-route parity — the daemon handles unknown
+values). Invalid specs return an error MESSAGE rather than raising: the
+route maps them to per-entry ``error`` fields so one bad query cannot fail
+a whole batch.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True, kw_only=True)
+class ParsedBatchSpec:
+    """One validated batch query, normalized to daemon spec key names."""
+
+    query: str
+    search_type: str = "hybrid"
+    limit: int = 10
+    path_filter: str | None = None
+    alpha: float = 0.5
+    fusion_method: str = "rrf"
+    rrf_k: int = 60
+    expand: str = "none"
+    recency: str | None = None
+    recency_weight: float | None = None
+    recency_half_life_days: float | None = None
+
+
+def spec_query_text(raw: Any) -> str:
+    """Best-effort query-text echo for error entries (public name wins)."""
+    if not isinstance(raw, dict):
+        return ""
+    return str(raw.get("q") or raw.get("query") or "")
+
+
+def _pick(raw: dict[str, Any], public: str, legacy: str) -> Any:
+    """Resolve a public-name/legacy-alias pair; public wins when present."""
+    if public in raw:
+        return raw[public]
+    return raw.get(legacy)
+
+
+def _as_int(value: Any, name: str, lo: int, hi: int) -> int | str:
+    try:
+        # bool is an int subclass; reject it explicitly so `limit: true`
+        # doesn't silently parse as 1.
+        if isinstance(value, bool):
+            raise ValueError
+        out = int(value)
+    except (TypeError, ValueError):
+        return f"{name} must be an integer"
+    if not lo <= out <= hi:
+        return f"{name} must be between {lo} and {hi}"
+    return out
+
+
+def _as_float(
+    value: Any, name: str, lo: float, hi: float, *, exclusive_lo: bool = False
+) -> float | str:
+    try:
+        if isinstance(value, bool):
+            raise ValueError
+        out = float(value)
+    except (TypeError, ValueError):
+        return f"{name} must be a number"
+    if exclusive_lo and out <= lo:
+        return f"{name} must be greater than {lo} and at most {hi}"
+    if not exclusive_lo and not lo <= out <= hi:
+        return f"{name} must be between {lo} and {hi}"
+    if out > hi:
+        return f"{name} must be greater than {lo} and at most {hi}"
+    return out
+
+
+def parse_batch_query_spec(raw: Any) -> ParsedBatchSpec | str:
+    """Parse one raw batch query spec.
+
+    Returns a :class:`ParsedBatchSpec` on success or an error message on
+    invalid input. Bounds mirror the single ``/query`` route: ``limit``
+    1..100, ``alpha`` 0.0..1.0, ``rrf_k`` 1..1000, ``recency_weight``
+    0.0..5.0, ``recency_half_life_days`` >0.0..3650.0.
+    """
+    if not isinstance(raw, dict):
+        return "invalid query spec: expected an object"
+
+    query = spec_query_text(raw)
+    if not query:
+        return "query text required (q)"
+
+    path = _pick(raw, "path", "path_filter")
+    if path is not None and not isinstance(path, str):
+        return "path must be a string"
+
+    limit = _as_int(raw.get("limit", 10), "limit", 1, 100)
+    if isinstance(limit, str):
+        return limit
+    alpha = _as_float(raw.get("alpha", 0.5), "alpha", 0.0, 1.0)
+    if isinstance(alpha, str):
+        return alpha
+    rrf_k = _as_int(raw.get("rrf_k", 60), "rrf_k", 1, 1000)
+    if isinstance(rrf_k, str):
+        return rrf_k
+
+    recency_weight: float | None = None
+    if raw.get("recency_weight") is not None:
+        parsed_weight = _as_float(raw["recency_weight"], "recency_weight", 0.0, 5.0)
+        if isinstance(parsed_weight, str):
+            return parsed_weight
+        recency_weight = parsed_weight
+
+    recency_half_life: float | None = None
+    if raw.get("recency_half_life_days") is not None:
+        parsed_half_life = _as_float(
+            raw["recency_half_life_days"],
+            "recency_half_life_days",
+            0.0,
+            3650.0,
+            exclusive_lo=True,
+        )
+        if isinstance(parsed_half_life, str):
+            return parsed_half_life
+        recency_half_life = parsed_half_life
+
+    recency = raw.get("recency")
+
+    return ParsedBatchSpec(
+        query=query,
+        search_type=str(_pick(raw, "type", "search_type") or "hybrid"),
+        limit=limit,
+        path_filter=path,
+        alpha=alpha,
+        fusion_method=str(_pick(raw, "fusion", "fusion_method") or "rrf"),
+        rrf_k=rrf_k,
+        expand=str(raw.get("expand") or "none"),
+        recency=str(recency) if recency is not None else None,
+        recency_weight=recency_weight,
+        recency_half_life_days=recency_half_life,
+    )

--- a/src/nexus/server/api/v2/routers/_search_batch.py
+++ b/src/nexus/server/api/v2/routers/_search_batch.py
@@ -48,10 +48,16 @@ class ParsedBatchSpec:
 
 
 def spec_query_text(raw: Any) -> str:
-    """Best-effort query-text echo for error entries (public name wins)."""
+    """Best-effort query-text echo for error entries.
+
+    Public name wins by KEY PRESENCE (an explicit ``"q": ""`` must not fall
+    through to the legacy alias), and non-string values echo as ``""``
+    rather than their Python ``str()`` representation.
+    """
     if not isinstance(raw, dict):
         return ""
-    return str(raw.get("q") or raw.get("query") or "")
+    value = raw["q"] if "q" in raw else raw.get("query")
+    return value if isinstance(value, str) else ""
 
 
 def _pick(raw: dict[str, Any], public: str, legacy: str) -> Any:
@@ -64,8 +70,12 @@ def _pick(raw: dict[str, Any], public: str, legacy: str) -> Any:
 def _as_int(value: Any, name: str, lo: int, hi: int) -> int | str:
     try:
         # bool is an int subclass; reject it explicitly so `limit: true`
-        # doesn't silently parse as 1.
+        # doesn't silently parse as 1. Fractional floats must not silently
+        # truncate (`limit: 1.9` -> 1) — the single route rejects them;
+        # integral floats (`limit: 5.0`) stay accepted for JSON parity.
         if isinstance(value, bool):
+            raise ValueError
+        if isinstance(value, float) and not value.is_integer():
             raise ValueError
         out = int(value)
     except (TypeError, ValueError):
@@ -115,9 +125,13 @@ def parse_batch_query_spec(raw: Any) -> ParsedBatchSpec | str:
     if not isinstance(raw, dict):
         return "invalid query spec: expected an object"
 
-    query = spec_query_text(raw)
-    if not query:
+    if "q" in raw or "query" in raw:
+        raw_query = raw["q"] if "q" in raw else raw["query"]
+    else:
         return "query text required (q)"
+    if not isinstance(raw_query, str) or not raw_query:
+        return "query text must be a non-empty string (q)"
+    query = raw_query
 
     path = _pick(raw, "path", "path_filter")
     if path is not None and not isinstance(path, str):

--- a/src/nexus/server/api/v2/routers/_search_batch.py
+++ b/src/nexus/server/api/v2/routers/_search_batch.py
@@ -8,17 +8,26 @@ daemon wiring.
 Each spec mirrors the single ``/query`` route's public parameter names and
 keeps the legacy batch aliases (``query``/``search_type``/``path_filter``).
 The public name wins when both are present. Numeric bounds mirror the
-single route's FastAPI ``Query()`` validation exactly; string params pass
-through unvalidated (single-route parity — the daemon handles unknown
-values). Invalid specs return an error MESSAGE rather than raising: the
-route maps them to per-entry ``error`` fields so one bad query cannot fail
-a whole batch.
+single route's FastAPI ``Query()`` validation exactly; the enum params
+(``type``/``fusion``/``expand``/``recency``) are validated against the
+same accepted sets the single route 400s on, surfaced here as per-query
+errors (validation runs AFTER alias resolution, and messages use the
+canonical public name — e.g. an invalid ``search_type`` reports ``type``).
+Invalid specs return an error MESSAGE rather than raising: the route maps
+them to per-entry ``error`` fields so one bad query cannot fail a whole
+batch.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Any
+
+# Accepted enum values, mirroring the single /query route's 400 validation.
+_TYPE_CHOICES = ("keyword", "semantic", "hybrid")
+_FUSION_CHOICES = ("rrf", "weighted", "rrf_weighted")
+_EXPAND_CHOICES = ("none", "macro")
+_RECENCY_CHOICES = ("off", "on", "auto")
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -66,6 +75,14 @@ def _as_int(value: Any, name: str, lo: int, hi: int) -> int | str:
     return out
 
 
+def _check_choice(value: str, name: str, allowed: tuple[str, ...]) -> str | None:
+    """Return an error message when ``value`` is not an accepted enum value."""
+    if value not in allowed:
+        choices = ", ".join(f"'{a}'" for a in allowed)
+        return f"{name} must be one of {choices}"
+    return None
+
+
 def _as_float(
     value: Any, name: str, lo: float, hi: float, *, exclusive_lo: bool = False
 ) -> float | str:
@@ -90,7 +107,10 @@ def parse_batch_query_spec(raw: Any) -> ParsedBatchSpec | str:
     Returns a :class:`ParsedBatchSpec` on success or an error message on
     invalid input. Bounds mirror the single ``/query`` route: ``limit``
     1..100, ``alpha`` 0.0..1.0, ``rrf_k`` 1..1000, ``recency_weight``
-    0.0..5.0, ``recency_half_life_days`` >0.0..3650.0.
+    0.0..5.0, ``recency_half_life_days`` >0.0..3650.0. Enum params mirror
+    it too: ``type`` in {keyword, semantic, hybrid}, ``fusion`` in
+    {rrf, weighted, rrf_weighted}, ``expand`` in {none, macro}, ``recency``
+    (when provided) in {off, on, auto}.
     """
     if not isinstance(raw, dict):
         return "invalid query spec: expected an object"
@@ -133,18 +153,33 @@ def parse_batch_query_spec(raw: Any) -> ParsedBatchSpec | str:
             return parsed_half_life
         recency_half_life = parsed_half_life
 
-    recency = raw.get("recency")
+    # Enum validation runs after alias resolution; messages use the
+    # canonical public name (so `search_type: "keywrod"` errors on "type").
+    search_type = str(_pick(raw, "type", "search_type") or "hybrid")
+    if (err := _check_choice(search_type, "type", _TYPE_CHOICES)) is not None:
+        return err
+    fusion_method = str(_pick(raw, "fusion", "fusion_method") or "rrf")
+    if (err := _check_choice(fusion_method, "fusion", _FUSION_CHOICES)) is not None:
+        return err
+    expand = str(raw.get("expand") or "none")
+    if (err := _check_choice(expand, "expand", _EXPAND_CHOICES)) is not None:
+        return err
+
+    raw_recency = raw.get("recency")
+    recency = str(raw_recency) if raw_recency is not None else None
+    if recency is not None and (err := _check_choice(recency, "recency", _RECENCY_CHOICES)):
+        return err
 
     return ParsedBatchSpec(
         query=query,
-        search_type=str(_pick(raw, "type", "search_type") or "hybrid"),
+        search_type=search_type,
         limit=limit,
         path_filter=path,
         alpha=alpha,
-        fusion_method=str(_pick(raw, "fusion", "fusion_method") or "rrf"),
+        fusion_method=fusion_method,
         rrf_k=rrf_k,
-        expand=str(raw.get("expand") or "none"),
-        recency=str(recency) if recency is not None else None,
+        expand=expand,
+        recency=recency,
         recency_weight=recency_weight,
         recency_half_life_days=recency_half_life,
     )

--- a/src/nexus/server/api/v2/routers/search.py
+++ b/src/nexus/server/api/v2/routers/search.py
@@ -832,7 +832,11 @@ async def search_query_batch(
     from nexus.contracts.constants import ROOT_ZONE_ID
 
     zone_id = auth_result.get("zone_id") or ROOT_ZONE_ID
-    body = await request.json()
+    try:
+        body = await request.json()
+    except Exception as exc:
+        # Empty/truncated/invalid JSON is a client error, not a 500.
+        raise HTTPException(status_code=400, detail="Invalid JSON body") from exc
     # A valid-JSON non-object root ([], null, "...", 42) must be the same
     # batch-level 400 as a missing/empty queries array — calling .get on it
     # would 500.

--- a/src/nexus/server/api/v2/routers/search.py
+++ b/src/nexus/server/api/v2/routers/search.py
@@ -848,6 +848,16 @@ async def search_query_batch(
     # in the parse comprehension below.
     if not isinstance(raw_queries, list) or not raw_queries:
         raise HTTPException(status_code=400, detail="No queries provided")
+    # Cardinality ceiling: every accepted query becomes a task before the
+    # daemon's concurrency semaphore applies, so an unbounded batch could
+    # exhaust the worker before any timeout could run.
+    raw_max = getattr(getattr(search_daemon, "config", None), "batch_search_max_queries", None)
+    max_queries = raw_max if isinstance(raw_max, int) and not isinstance(raw_max, bool) else 500
+    if len(raw_queries) > max_queries:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Too many queries: {len(raw_queries)} exceeds the limit of {max_queries}",
+        )
 
     # #4557 (gap 1): batch had no read gate at all -- a write-only token
     # could read via /query/batch even though /query fails it closed.

--- a/src/nexus/server/api/v2/routers/search.py
+++ b/src/nexus/server/api/v2/routers/search.py
@@ -38,12 +38,17 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel
 
 from nexus.bricks.search.daemon import _BACKEND_LEG_TIMING_KEYS
-from nexus.contracts.search_types import SearchRequest
+from nexus.contracts.search_types import BatchQueryFailure, SearchRequest
 from nexus.lib.pagination import build_paginated_list_response
 from nexus.lib.rebac_filter import apply_rebac_filter as _apply_rebac_filter
 from nexus.lib.rebac_filter import compute_rebac_fetch_limit as _compute_rebac_fetch_limit
 from nexus.lib.rebac_filter import rebac_denial_stats as _rebac_denial_stats
 from nexus.runtime.zone_resolution import target_zone_for_context
+from nexus.server.api.v2.routers._search_batch import (
+    ParsedBatchSpec,
+    parse_batch_query_spec,
+    spec_query_text,
+)
 from nexus.server.api.v2.routers._search_deps import _get_search_daemon
 from nexus.server.dependencies import get_operation_context, require_admin, require_auth
 from nexus.server.zone_execution import run_zone_scoped
@@ -801,26 +806,28 @@ async def search_query_batch(
     auth_result: dict[str, Any] = Depends(require_auth),
     search_daemon: Any = Depends(_get_search_daemon),
 ) -> dict[str, Any]:
-    """Batch search: run N queries through full hybrid pipeline.
+    """Batch search: run N queries through the full hybrid pipeline.
 
-    Body: {
-        "queries": [
-            {"q": "text", "limit": 10, "path": "/optional"},
-            ...
-        ]
-    }
+    Body: ``{"queries": [{...}]}`` where each entry mirrors the single
+    ``/query`` route's public parameter names (``q``, ``type``, ``limit``,
+    ``path``, ``alpha``, ``fusion``, ``rrf_k``, ``expand``, ``recency``,
+    ``recency_weight``, ``recency_half_life_days``); the legacy batch
+    aliases ``query``/``search_type``/``path_filter`` stay accepted (see
+    ``_search_batch.py`` for the exact contract).
 
-    Returns: {"queries": [{"query": str, "results": [...], "total": int}, ...]}
+    Returns ``{"queries": [{"query", "results", "total"[, "error"]}], ...}``.
+    Results use the same serialization as single ``/query``. A failed or
+    invalid query yields a per-entry additive ``error`` message instead of
+    failing the batch (absence of ``error`` means the result set is
+    genuine); batch-level auth/read-gate/daemon-init failures still fail
+    the whole request.
 
-    Applies the same ReBAC file-level permission filter as the single-query
-    ``/query`` endpoint (Decision #17). Each query is over-fetched 3x when
-    the permission enforcer is active and trimmed to its configured ``limit``
-    after filtering so authorized results are not starved by denied paths.
-
-    Optimized for benchmarks and bulk evaluations. txtai's batchsearch()
-    embeds all query texts in ONE OpenAI API call, then runs each through
-    the full hybrid pipeline (BM25 + vector + fusion). For 470 queries:
-    ~30s instead of ~16 min sequential.
+    Applies the same ReBAC file-level permission filter as ``/query``
+    (Decision #17), over-fetching via ``_compute_rebac_fetch_limit`` and
+    trimming to each query's requested ``limit`` after filtering. All
+    unique query texts are embedded in ONE ``embed_batch`` call and the
+    inner searches run concurrently (``NEXUS_SEARCH_BATCH_CONCURRENCY``,
+    default 8).
     """
     from nexus.contracts.constants import ROOT_ZONE_ID
 
@@ -849,71 +856,74 @@ async def search_query_batch(
     # Same ReBAC hook the single-query endpoint uses.
     permission_enforcer = getattr(request.app.state, "permission_enforcer", None)
     op_context = get_operation_context(auth_result)
-    overfetch_multiplier = 3 if permission_enforcer is not None else 1
 
-    # Over-fetch per-query so ReBAC filtering does not strip us below the
-    # caller's requested limit. Keep caller's original limit for trimming.
-    requested_limits: list[int] = []
-    fetch_queries: list[dict[str, Any]] = []
-    for q_spec in raw_queries:
-        orig_limit = max(1, int(q_spec.get("limit", 10)))
-        query_text = str(q_spec.get("query") or q_spec.get("q") or "")
-        path_filter = q_spec.get("path_filter", q_spec.get("path"))
-        requested_limits.append(orig_limit)
-        fetch_queries.append(
-            {
-                **q_spec,
-                "query": query_text,
-                "path_filter": path_filter,
-                "limit": orig_limit * overfetch_multiplier,
-            }
-        )
+    parsed = [parse_batch_query_spec(raw) for raw in raw_queries]
+    valid: list[tuple[int, ParsedBatchSpec]] = [
+        (i, p) for i, p in enumerate(parsed) if isinstance(p, ParsedBatchSpec)
+    ]
+    fetch_specs = [
+        {
+            "query": spec.query,
+            "search_type": spec.search_type,
+            "limit": _compute_rebac_fetch_limit(
+                spec.limit, has_enforcer=permission_enforcer is not None
+            ),
+            "path_filter": spec.path_filter,
+            "alpha": spec.alpha,
+            "fusion_method": spec.fusion_method,
+            "rrf_k": spec.rrf_k,
+            "expand": spec.expand,
+            "recency": spec.recency,
+            "recency_weight": spec.recency_weight,
+            "recency_half_life_days": spec.recency_half_life_days,
+        }
+        for _, spec in valid
+    ]
 
     t0 = time.perf_counter()
-    raw_results = await search_daemon.batch_search(fetch_queries, zone_id=zone_id)
+    raw_results = (
+        await search_daemon.batch_search(fetch_specs, zone_id=zone_id) if fetch_specs else []
+    )
     elapsed_ms = (time.perf_counter() - t0) * 1000
+
+    result_by_index: dict[int, Any] = {
+        i: result for (i, _), result in zip(valid, raw_results, strict=True)
+    }
 
     filter_ms_total = 0.0
     response_queries: list[dict[str, Any]] = []
-    for q_spec, results, orig_limit in zip(raw_queries, raw_results, requested_limits, strict=True):
+    for i, p in enumerate(parsed):
+        if isinstance(p, str):
+            response_queries.append(
+                {
+                    "query": spec_query_text(raw_queries[i]),
+                    "results": [],
+                    "total": 0,
+                    "error": p,
+                }
+            )
+            continue
+        inner = result_by_index[i]
+        if isinstance(inner, BatchQueryFailure):
+            response_queries.append(
+                {"query": p.query, "results": [], "total": 0, "error": inner.error}
+            )
+            continue
         # File-level ReBAC filtering (Decision #17) — same enforcement as /query.
         filtered, filter_ms = _apply_rebac_filter(
-            results,
+            inner,
             permission_enforcer,
             auth_result,
             zone_id,
             operation_context=op_context,
         )
         filter_ms_total += filter_ms
-        trimmed = filtered[:orig_limit]
-
-        formatted: list[dict[str, Any]] = []
-        for r in trimmed:
-            entry: dict[str, Any] = {
-                "path": r.path,
-                "chunk_text": r.chunk_text,
-                "score": round(r.score, 4),
-                "keyword_score": round(r.keyword_score, 4) if r.keyword_score is not None else None,
-                "vector_score": round(r.vector_score, 4) if r.vector_score is not None else None,
-            }
-            title = getattr(r, "title_score", None)
-            if title is not None:
-                entry["title_score"] = round(title, 4)
-            ctx = getattr(r, "context", None)
-            if ctx is not None:
-                entry["context"] = ctx
-            # Issue #4544 (Codex review R1): batch hits must carry the same
-            # omit-when-None tier_boost attribution as single-query results,
-            # or batch consumers see multiplied scores they cannot explain.
-            tier_boost = getattr(r, "tier_boost", None)
-            if tier_boost is not None:
-                entry["tier_boost"] = round(tier_boost, 4)
-            formatted.append(entry)
+        trimmed = filtered[: p.limit]
         response_queries.append(
             {
-                "query": q_spec.get("query") or q_spec.get("q", ""),
-                "results": formatted,
-                "total": len(formatted),
+                "query": p.query,
+                "results": [_serialize_search_result(r) for r in trimmed],
+                "total": len(trimmed),
             }
         )
 

--- a/src/nexus/server/api/v2/routers/search.py
+++ b/src/nexus/server/api/v2/routers/search.py
@@ -833,8 +833,11 @@ async def search_query_batch(
 
     zone_id = auth_result.get("zone_id") or ROOT_ZONE_ID
     body = await request.json()
-    raw_queries: list[dict[str, Any]] = body.get("queries", [])
-    if not raw_queries:
+    raw_queries = body.get("queries", [])
+    # Missing/empty/non-list ``queries`` is a batch-level 400: a string here
+    # used to iterate per-char into bogus per-entry errors and an int 500'd
+    # in the parse comprehension below.
+    if not isinstance(raw_queries, list) or not raw_queries:
         raise HTTPException(status_code=400, detail="No queries provided")
 
     # #4557 (gap 1): batch had no read gate at all -- a write-only token

--- a/src/nexus/server/api/v2/routers/search.py
+++ b/src/nexus/server/api/v2/routers/search.py
@@ -833,6 +833,11 @@ async def search_query_batch(
 
     zone_id = auth_result.get("zone_id") or ROOT_ZONE_ID
     body = await request.json()
+    # A valid-JSON non-object root ([], null, "...", 42) must be the same
+    # batch-level 400 as a missing/empty queries array — calling .get on it
+    # would 500.
+    if not isinstance(body, dict):
+        raise HTTPException(status_code=400, detail="No queries provided")
     raw_queries = body.get("queries", [])
     # Missing/empty/non-list ``queries`` is a batch-level 400: a string here
     # used to iterate per-char into bogus per-entry errors and an int 500'd

--- a/src/nexus/server/lifespan/search.py
+++ b/src/nexus/server/lifespan/search.py
@@ -206,6 +206,16 @@ async def startup_search(app: "FastAPI", svc: "LifespanServices") -> list[asynci
         # Skeleton title arm in hybrid fusion (Issue #4545). Default on.
         _title_arm_env = os.environ.get("NEXUS_SEARCH_TITLE_ARM", "true")
         _title_arm = _title_arm_env.strip().lower() not in ("false", "0", "no")
+        _batch_max_env = os.environ.get("NEXUS_SEARCH_BATCH_MAX_QUERIES", "")
+        _batch_max = 500
+        if _batch_max_env:
+            try:
+                _batch_max = max(1, int(_batch_max_env))
+            except ValueError:
+                logger.warning(
+                    "Invalid NEXUS_SEARCH_BATCH_MAX_QUERIES=%r — falling back to 500",
+                    _batch_max_env,
+                )
         _batch_timeout_env = os.environ.get("NEXUS_SEARCH_BATCH_TIMEOUT", "")
         _batch_timeout = 120.0
         if _batch_timeout_env:
@@ -250,6 +260,7 @@ async def startup_search(app: "FastAPI", svc: "LifespanServices") -> list[asynci
             index_preload_enabled=_index_preload,
             batch_search_concurrency=_batch_concurrency,
             batch_search_timeout_seconds=_batch_timeout,
+            batch_search_max_queries=_batch_max,
         )
 
         # Inject async_session_factory from RecordStoreABC when available

--- a/src/nexus/server/lifespan/search.py
+++ b/src/nexus/server/lifespan/search.py
@@ -206,6 +206,16 @@ async def startup_search(app: "FastAPI", svc: "LifespanServices") -> list[asynci
         # Skeleton title arm in hybrid fusion (Issue #4545). Default on.
         _title_arm_env = os.environ.get("NEXUS_SEARCH_TITLE_ARM", "true")
         _title_arm = _title_arm_env.strip().lower() not in ("false", "0", "no")
+        _batch_concurrency_env = os.environ.get("NEXUS_SEARCH_BATCH_CONCURRENCY", "")
+        _batch_concurrency = 8
+        if _batch_concurrency_env:
+            try:
+                _batch_concurrency = max(1, int(_batch_concurrency_env))
+            except ValueError:
+                logger.warning(
+                    "Invalid NEXUS_SEARCH_BATCH_CONCURRENCY=%r — falling back to 8",
+                    _batch_concurrency_env,
+                )
         config = DaemonConfig(
             database_url=svc.database_url,
             query_timeout_seconds=float(os.environ.get("NEXUS_QUERY_TIMEOUT", "10.0")),
@@ -228,6 +238,7 @@ async def startup_search(app: "FastAPI", svc: "LifespanServices") -> list[asynci
             page_bm25_rrf_k=_page_bm25_rrf_k,
             title_arm=_title_arm,
             index_preload_enabled=_index_preload,
+            batch_search_concurrency=_batch_concurrency,
         )
 
         # Inject async_session_factory from RecordStoreABC when available

--- a/src/nexus/server/lifespan/search.py
+++ b/src/nexus/server/lifespan/search.py
@@ -206,6 +206,16 @@ async def startup_search(app: "FastAPI", svc: "LifespanServices") -> list[asynci
         # Skeleton title arm in hybrid fusion (Issue #4545). Default on.
         _title_arm_env = os.environ.get("NEXUS_SEARCH_TITLE_ARM", "true")
         _title_arm = _title_arm_env.strip().lower() not in ("false", "0", "no")
+        _batch_timeout_env = os.environ.get("NEXUS_SEARCH_BATCH_TIMEOUT", "")
+        _batch_timeout = 120.0
+        if _batch_timeout_env:
+            try:
+                _batch_timeout = max(1.0, float(_batch_timeout_env))
+            except ValueError:
+                logger.warning(
+                    "Invalid NEXUS_SEARCH_BATCH_TIMEOUT=%r — falling back to 120",
+                    _batch_timeout_env,
+                )
         _batch_concurrency_env = os.environ.get("NEXUS_SEARCH_BATCH_CONCURRENCY", "")
         _batch_concurrency = 8
         if _batch_concurrency_env:
@@ -239,6 +249,7 @@ async def startup_search(app: "FastAPI", svc: "LifespanServices") -> list[asynci
             title_arm=_title_arm,
             index_preload_enabled=_index_preload,
             batch_search_concurrency=_batch_concurrency,
+            batch_search_timeout_seconds=_batch_timeout,
         )
 
         # Inject async_session_factory from RecordStoreABC when available

--- a/tests/e2e/self_contained/test_search_surface_live_e2e.py
+++ b/tests/e2e/self_contained/test_search_surface_live_e2e.py
@@ -251,6 +251,51 @@ def test_live_search_http_surface_correctness_and_latency(live_search_app: LiveS
     )
     _assert_endpoint_latency(batch_body)
 
+    # Hardened batch contract: single-/query serializer parity, tuning
+    # params accepted, healthy entries carry no error field.
+    parity_response, parity_body = _request(
+        live,
+        "post",
+        "/api/v2/search/query/batch",
+        json={
+            "queries": [
+                {"q": "needle", "type": "keyword", "limit": 5},
+                {"q": "needle", "type": "hybrid", "limit": 5, "alpha": 0.3, "fusion": "weighted"},
+                {"q": "needle", "type": "semantic", "limit": 5},
+            ]
+        },
+    )
+    assert parity_response.status_code == 200
+    assert parity_body["total_queries"] == 3
+    for entry in parity_body["queries"]:
+        assert "error" not in entry, entry
+    single_response, single_body = _request(
+        live,
+        "get",
+        "/api/v2/search/query",
+        params={"q": "needle", "type": "keyword", "limit": 5},
+    )
+    assert single_response.status_code == 200
+    batch_keyword_results = parity_body["queries"][0]["results"]
+    single_results = single_body["results"]
+    assert [r["path"] for r in batch_keyword_results] == [r["path"] for r in single_results]
+    # Field-shape parity: every key the single route emits appears in the
+    # batch entry with the same value (single may add response-envelope
+    # keys, so compare per-hit dicts directly).
+    for batch_hit, single_hit in zip(batch_keyword_results, single_results, strict=True):
+        assert batch_hit == single_hit
+
+    # Per-query error isolation: an invalid spec errors alone.
+    mixed_response, mixed_body = _request(
+        live,
+        "post",
+        "/api/v2/search/query/batch",
+        json={"queries": [{"q": "needle", "limit": 0}, {"q": "needle", "limit": 2}]},
+    )
+    assert mixed_response.status_code == 200
+    assert "limit" in mixed_body["queries"][0]["error"]
+    assert "error" not in mixed_body["queries"][1]
+
     refresh_response, refresh_body = _request(
         live,
         "post",

--- a/tests/integration/services/test_search_query_batch.py
+++ b/tests/integration/services/test_search_query_batch.py
@@ -397,3 +397,37 @@ class TestBatchRoute:
 
         assert resp.status_code == 400
         daemon.batch_search.assert_not_called()
+
+
+@pytest.mark.skipif(not _HAS_FASTAPI_TESTCLIENT, reason="fastapi test client not available")
+class TestBatchCardinality:
+    def test_batch_over_max_queries_400(self):
+        daemon = MagicMock()
+        daemon.batch_search = AsyncMock(return_value=[])
+        daemon.config = MagicMock()
+        daemon.config.batch_search_max_queries = 3
+        app = _build_batch_app(daemon)
+
+        resp = TestClient(app).post(
+            "/api/v2/search/query/batch",
+            json={"queries": [{"q": f"q{i}"} for i in range(4)]},
+        )
+
+        assert resp.status_code == 400, resp.text
+        assert "Too many queries" in resp.json()["detail"]
+        daemon.batch_search.assert_not_called()
+
+    def test_batch_at_max_queries_allowed(self):
+        daemon = MagicMock()
+        daemon.batch_search = AsyncMock(return_value=[[], [], []])
+        daemon.config = MagicMock()
+        daemon.config.batch_search_max_queries = 3
+        app = _build_batch_app(daemon)
+
+        resp = TestClient(app).post(
+            "/api/v2/search/query/batch",
+            json={"queries": [{"q": f"q{i}"} for i in range(3)]},
+        )
+
+        assert resp.status_code == 200, resp.text
+        daemon.batch_search.assert_called_once()

--- a/tests/integration/services/test_search_query_batch.py
+++ b/tests/integration/services/test_search_query_batch.py
@@ -114,9 +114,21 @@ class TestParseBatchQuerySpec:
             ("not a dict", "expected an object"),
             ({}, "query text"),
             ({"q": ""}, "query text"),
+            # Structured / null / non-string query text must error, never be
+            # stringified into a searchable Python repr.
+            ({"q": {"nested": "value"}}, "query text"),
+            ({"q": None}, "query text"),
+            ({"q": 42}, "query text"),
+            # Public name wins by KEY PRESENCE: an explicit empty "q" must
+            # error rather than silently executing the legacy alias.
+            ({"q": "", "query": "legacy"}, "query text"),
             ({"q": "x", "limit": 0}, "limit"),
             ({"q": "x", "limit": 101}, "limit"),
             ({"q": "x", "limit": "ten"}, "limit"),
+            # Fractional numerics must not silently truncate (single-route
+            # pydantic rejects them); integral floats stay accepted.
+            ({"q": "x", "limit": 1.9}, "limit"),
+            ({"q": "x", "rrf_k": 60.5}, "rrf_k"),
             ({"q": "x", "alpha": 1.5}, "alpha"),
             ({"q": "x", "alpha": -0.1}, "alpha"),
             ({"q": "x", "rrf_k": 0}, "rrf_k"),
@@ -157,6 +169,16 @@ class TestParseBatchQuerySpec:
         assert spec_query_text({"q": "a", "query": "b"}) == "a"
         assert spec_query_text("junk") == ""
         assert spec_query_text({}) == ""
+        # Presence beats truthiness: explicit "q" masks the legacy alias
+        # even when falsy, and non-string values echo as "".
+        assert spec_query_text({"q": "", "query": "b"}) == ""
+        assert spec_query_text({"q": {"nested": "v"}}) == ""
+        assert spec_query_text({"q": None, "query": "b"}) == ""
+
+    def test_integral_float_limit_accepted(self):
+        spec = parse_batch_query_spec({"q": "x", "limit": 5.0})
+        assert isinstance(spec, ParsedBatchSpec)
+        assert spec.limit == 5
 
 
 def _build_batch_app(mock_daemon):

--- a/tests/integration/services/test_search_query_batch.py
+++ b/tests/integration/services/test_search_query_batch.py
@@ -140,3 +140,167 @@ class TestParseBatchQuerySpec:
         assert spec_query_text({"q": "a", "query": "b"}) == "a"
         assert spec_query_text("junk") == ""
         assert spec_query_text({}) == ""
+
+
+def _build_batch_app(mock_daemon):
+    from fastapi import FastAPI
+
+    from nexus.server.api.v2.routers.search import router
+
+    app = FastAPI()
+    app.include_router(router)
+    mock_daemon.is_initialized = True
+    app.state.search_daemon = mock_daemon
+    app.state.search_daemon_enabled = True
+    app.state.record_store = MagicMock()
+    app.state.async_session_factory = MagicMock()
+    app.state.async_read_session_factory = MagicMock()
+
+    from nexus.server.dependencies import require_auth
+
+    app.dependency_overrides[require_auth] = lambda: {
+        "authenticated": True,
+        "user_id": "u",
+        "zone_id": "eng",
+        "zone_set": ["eng"],
+        "zone_perms": [["eng", "r"]],
+    }
+    return app
+
+
+@pytest.mark.skipif(not _HAS_FASTAPI_TESTCLIENT, reason="fastapi test client not available")
+class TestBatchRoute:
+    def test_params_forwarded_to_daemon(self):
+        daemon = MagicMock()
+        daemon.batch_search = AsyncMock(return_value=[[]])
+        app = _build_batch_app(daemon)
+
+        resp = TestClient(app).post(
+            "/api/v2/search/query/batch",
+            json={
+                "queries": [
+                    {
+                        "q": "tuned",
+                        "type": "hybrid",
+                        "limit": 7,
+                        "path": "/ws/",
+                        "alpha": 0.3,
+                        "fusion": "weighted",
+                        "rrf_k": 90,
+                        "expand": "macro",
+                        "recency": "on",
+                        "recency_weight": 1.5,
+                        "recency_half_life_days": 30,
+                    }
+                ]
+            },
+        )
+
+        assert resp.status_code == 200, resp.text
+        (specs,) = daemon.batch_search.call_args.args
+        assert daemon.batch_search.call_args.kwargs == {"zone_id": "eng"}
+        spec = specs[0]
+        assert spec["query"] == "tuned"
+        assert spec["search_type"] == "hybrid"
+        assert spec["path_filter"] == "/ws/"
+        assert (spec["alpha"], spec["fusion_method"], spec["rrf_k"]) == (0.3, "weighted", 90)
+        assert (spec["expand"], spec["recency"]) == ("macro", "on")
+        assert (spec["recency_weight"], spec["recency_half_life_days"]) == (1.5, 30.0)
+        # No enforcer on this app -> fetch limit == requested limit.
+        assert spec["limit"] == 7
+
+    def test_serializer_parity_with_single_query(self):
+        from nexus.server.api.v2.routers._search_serialize import _serialize_search_result
+
+        result = _MockResult(
+            path="/ws/doc.md",
+            chunk_text="hello",
+            score=0.9123456,
+            chunk_index=3,
+            line_start=10,
+            line_end=14,
+            keyword_score=1.25,
+            vector_score=0.75,
+        )
+        daemon = MagicMock()
+        daemon.batch_search = AsyncMock(return_value=[[result]])
+        app = _build_batch_app(daemon)
+
+        resp = TestClient(app).post(
+            "/api/v2/search/query/batch", json={"queries": [{"q": "hello"}]}
+        )
+
+        assert resp.status_code == 200, resp.text
+        entry = resp.json()["queries"][0]
+        assert "error" not in entry
+        assert entry["total"] == 1
+        assert entry["results"][0] == _serialize_search_result(result)
+        assert entry["results"][0]["chunk_index"] == 3
+        assert entry["results"][0]["line_start"] == 10
+
+    def test_daemon_failure_becomes_error_entry(self):
+        from nexus.contracts.search_types import BatchQueryFailure
+
+        daemon = MagicMock()
+        daemon.batch_search = AsyncMock(
+            return_value=[[], BatchQueryFailure(error="backend fell over")]
+        )
+        app = _build_batch_app(daemon)
+
+        resp = TestClient(app).post(
+            "/api/v2/search/query/batch",
+            json={"queries": [{"q": "ok"}, {"q": "doomed"}]},
+        )
+
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert "error" not in body["queries"][0]
+        assert body["queries"][1] == {
+            "query": "doomed",
+            "results": [],
+            "total": 0,
+            "error": "backend fell over",
+        }
+
+    def test_invalid_spec_gets_error_entry_and_is_not_sent_to_daemon(self):
+        daemon = MagicMock()
+        daemon.batch_search = AsyncMock(return_value=[[]])
+        app = _build_batch_app(daemon)
+
+        resp = TestClient(app).post(
+            "/api/v2/search/query/batch",
+            json={"queries": [{"q": "bad-limit", "limit": 0}, {"q": "fine"}]},
+        )
+
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["total_queries"] == 2
+        assert body["queries"][0]["query"] == "bad-limit"
+        assert "limit" in body["queries"][0]["error"]
+        assert body["queries"][0]["results"] == []
+        assert "error" not in body["queries"][1]
+        # Only the valid spec reached the daemon.
+        (specs,) = daemon.batch_search.call_args.args
+        assert [s["query"] for s in specs] == ["fine"]
+
+    def test_all_specs_invalid_skips_daemon_entirely(self):
+        daemon = MagicMock()
+        daemon.batch_search = AsyncMock(return_value=[])
+        app = _build_batch_app(daemon)
+
+        resp = TestClient(app).post(
+            "/api/v2/search/query/batch", json={"queries": [{"q": "x", "limit": 9999}]}
+        )
+
+        assert resp.status_code == 200, resp.text
+        assert "limit" in resp.json()["queries"][0]["error"]
+        daemon.batch_search.assert_not_called()
+
+    def test_empty_queries_still_400(self):
+        daemon = MagicMock()
+        daemon.batch_search = AsyncMock(return_value=[])
+        app = _build_batch_app(daemon)
+
+        resp = TestClient(app).post("/api/v2/search/query/batch", json={"queries": []})
+
+        assert resp.status_code == 400

--- a/tests/integration/services/test_search_query_batch.py
+++ b/tests/integration/services/test_search_query_batch.py
@@ -19,10 +19,12 @@ if "nexus_runtime" not in sys.modules:
     sys.modules["nexus_runtime"] = _nexus_runtime_stub
 
 from dataclasses import dataclass
+from unittest.mock import AsyncMock, MagicMock  # noqa: F401
 
 import pytest
 
 try:
+    from fastapi import FastAPI  # noqa: F401
     from fastapi.testclient import TestClient  # noqa: F401
 
     _HAS_FASTAPI_TESTCLIENT = True
@@ -123,6 +125,8 @@ class TestParseBatchQuerySpec:
             ({"q": "x", "recency_half_life_days": 0}, "recency_half_life_days"),
             ({"q": "x", "recency_half_life_days": 3651}, "recency_half_life_days"),
             ({"q": "x", "path": 42}, "path"),
+            ({"q": "x", "recency_half_life_days": "nan"}, "recency_half_life_days"),
+            ({"q": "x", "recency_half_life_days": float("nan")}, "recency_half_life_days"),
         ],
     )
     def test_invalid_specs_return_error_message(self, raw, fragment):

--- a/tests/integration/services/test_search_query_batch.py
+++ b/tests/integration/services/test_search_query_batch.py
@@ -304,3 +304,16 @@ class TestBatchRoute:
         resp = TestClient(app).post("/api/v2/search/query/batch", json={"queries": []})
 
         assert resp.status_code == 400
+
+    @pytest.mark.parametrize("queries", ["ab", 42])
+    def test_non_list_queries_400(self, queries):
+        # A string used to iterate per-char into per-entry errors (200) and
+        # an int 500'd in the comprehension; both are batch-level 400s.
+        daemon = MagicMock()
+        daemon.batch_search = AsyncMock(return_value=[])
+        app = _build_batch_app(daemon)
+
+        resp = TestClient(app).post("/api/v2/search/query/batch", json={"queries": queries})
+
+        assert resp.status_code == 400
+        daemon.batch_search.assert_not_called()

--- a/tests/integration/services/test_search_query_batch.py
+++ b/tests/integration/services/test_search_query_batch.py
@@ -361,6 +361,21 @@ class TestBatchRoute:
         assert resp.status_code == 400, resp.text
         daemon.batch_search.assert_not_called()
 
+    @pytest.mark.parametrize("content", ["", "{not json", '{"queries": [truncated'])
+    def test_malformed_json_body_400(self, content):
+        daemon = MagicMock()
+        daemon.batch_search = AsyncMock(return_value=[])
+        app = _build_batch_app(daemon)
+
+        resp = TestClient(app).post(
+            "/api/v2/search/query/batch",
+            content=content,
+            headers={"Content-Type": "application/json"},
+        )
+
+        assert resp.status_code == 400, resp.text
+        daemon.batch_search.assert_not_called()
+
     def test_empty_queries_still_400(self):
         daemon = MagicMock()
         daemon.batch_search = AsyncMock(return_value=[])

--- a/tests/integration/services/test_search_query_batch.py
+++ b/tests/integration/services/test_search_query_batch.py
@@ -127,12 +127,29 @@ class TestParseBatchQuerySpec:
             ({"q": "x", "path": 42}, "path"),
             ({"q": "x", "recency_half_life_days": "nan"}, "recency_half_life_days"),
             ({"q": "x", "recency_half_life_days": float("nan")}, "recency_half_life_days"),
+            ({"q": "x", "type": "keywrod"}, "type"),
+            # Legacy alias resolves first; the message reports the canonical
+            # public name.
+            ({"q": "x", "search_type": "keywrod"}, "type"),
+            ({"q": "x", "fusion": "bogus"}, "fusion"),
+            ({"q": "x", "expand": "huge"}, "expand"),
+            ({"q": "x", "recency": "always"}, "recency"),
         ],
     )
     def test_invalid_specs_return_error_message(self, raw, fragment):
         err = parse_batch_query_spec(raw)
         assert isinstance(err, str)
         assert fragment in err
+
+    def test_recency_none_or_absent_stays_valid(self):
+        # recency is the only optional enum: absent AND explicit null both
+        # mean "no recency directive" and must not trip enum validation.
+        absent = parse_batch_query_spec({"q": "x"})
+        assert isinstance(absent, ParsedBatchSpec)
+        assert absent.recency is None
+        explicit_null = parse_batch_query_spec({"q": "x", "recency": None})
+        assert isinstance(explicit_null, ParsedBatchSpec)
+        assert explicit_null.recency is None
 
     def test_spec_query_text_best_effort(self):
         assert spec_query_text({"q": "a"}) == "a"

--- a/tests/integration/services/test_search_query_batch.py
+++ b/tests/integration/services/test_search_query_batch.py
@@ -1,0 +1,138 @@
+"""Batch search query spec parser tests."""
+
+from __future__ import annotations
+
+import sys
+import types
+
+# nexus.bricks.search.__init__ imports SearchService → nexus_runtime (Rust
+# extension).  The Rust binary is not available in the test venv, so we
+# stub the module before any nexus.bricks.search import can trigger it.
+# Using a MagicMock stub so that any attribute access (import name from ...)
+# succeeds without enumerating every symbol the Rust extension exposes.
+if "nexus_runtime" not in sys.modules:
+    from unittest.mock import MagicMock as _MagicMock
+
+    _nexus_runtime_stub = _MagicMock()
+    _nexus_runtime_stub.__name__ = "nexus_runtime"
+    _nexus_runtime_stub.__spec__ = types.ModuleType("nexus_runtime")
+    sys.modules["nexus_runtime"] = _nexus_runtime_stub
+
+from dataclasses import dataclass
+
+import pytest
+
+try:
+    from fastapi.testclient import TestClient  # noqa: F401
+
+    _HAS_FASTAPI_TESTCLIENT = True
+except ImportError:
+    _HAS_FASTAPI_TESTCLIENT = False
+
+from nexus.server.api.v2.routers._search_batch import (
+    ParsedBatchSpec,
+    parse_batch_query_spec,
+    spec_query_text,
+)
+
+
+@dataclass
+class _MockResult:
+    path: str = "test.txt"
+    chunk_text: str = "hello"
+    score: float = 0.95
+    chunk_index: int = 0
+    line_start: int | None = None
+    line_end: int | None = None
+    keyword_score: float | None = None
+    vector_score: float | None = None
+    splade_score: float | None = None
+    reranker_score: float | None = None
+
+
+class TestParseBatchQuerySpec:
+    def test_defaults(self):
+        spec = parse_batch_query_spec({"q": "hello"})
+        assert spec == ParsedBatchSpec(query="hello")
+        assert (spec.search_type, spec.limit, spec.alpha) == ("hybrid", 10, 0.5)
+        assert (spec.fusion_method, spec.rrf_k, spec.expand) == ("rrf", 60, "none")
+        assert (spec.recency, spec.recency_weight, spec.recency_half_life_days) == (
+            None,
+            None,
+            None,
+        )
+
+    def test_public_names_win_over_legacy_aliases(self):
+        spec = parse_batch_query_spec(
+            {
+                "q": "public",
+                "query": "legacy",
+                "type": "semantic",
+                "search_type": "keyword",
+                "path": "/a/",
+                "path_filter": "/b/",
+                "fusion": "weighted",
+                "fusion_method": "rrf",
+            }
+        )
+        assert isinstance(spec, ParsedBatchSpec)
+        assert spec.query == "public"
+        assert spec.search_type == "semantic"
+        assert spec.path_filter == "/a/"
+        assert spec.fusion_method == "weighted"
+
+    def test_legacy_aliases_still_accepted(self):
+        spec = parse_batch_query_spec(
+            {"query": "legacy", "search_type": "keyword", "path_filter": "/b/"}
+        )
+        assert isinstance(spec, ParsedBatchSpec)
+        assert (spec.query, spec.search_type, spec.path_filter) == ("legacy", "keyword", "/b/")
+
+    def test_tuning_params_parsed(self):
+        spec = parse_batch_query_spec(
+            {
+                "q": "tuned",
+                "alpha": 0.3,
+                "fusion": "weighted",
+                "rrf_k": 90,
+                "expand": "macro",
+                "recency": "on",
+                "recency_weight": 1.5,
+                "recency_half_life_days": 30,
+            }
+        )
+        assert isinstance(spec, ParsedBatchSpec)
+        assert (spec.alpha, spec.fusion_method, spec.rrf_k) == (0.3, "weighted", 90)
+        assert (spec.expand, spec.recency) == ("macro", "on")
+        assert (spec.recency_weight, spec.recency_half_life_days) == (1.5, 30.0)
+
+    @pytest.mark.parametrize(
+        ("raw", "fragment"),
+        [
+            ("not a dict", "expected an object"),
+            ({}, "query text"),
+            ({"q": ""}, "query text"),
+            ({"q": "x", "limit": 0}, "limit"),
+            ({"q": "x", "limit": 101}, "limit"),
+            ({"q": "x", "limit": "ten"}, "limit"),
+            ({"q": "x", "alpha": 1.5}, "alpha"),
+            ({"q": "x", "alpha": -0.1}, "alpha"),
+            ({"q": "x", "rrf_k": 0}, "rrf_k"),
+            ({"q": "x", "rrf_k": 1001}, "rrf_k"),
+            ({"q": "x", "recency_weight": 5.1}, "recency_weight"),
+            ({"q": "x", "recency_half_life_days": 0}, "recency_half_life_days"),
+            ({"q": "x", "recency_half_life_days": 3651}, "recency_half_life_days"),
+            ({"q": "x", "path": 42}, "path"),
+        ],
+    )
+    def test_invalid_specs_return_error_message(self, raw, fragment):
+        err = parse_batch_query_spec(raw)
+        assert isinstance(err, str)
+        assert fragment in err
+
+    def test_spec_query_text_best_effort(self):
+        assert spec_query_text({"q": "a"}) == "a"
+        assert spec_query_text({"query": "b"}) == "b"
+        assert spec_query_text({"q": "a", "query": "b"}) == "a"
+        assert spec_query_text("junk") == ""
+        assert spec_query_text({}) == ""

--- a/tests/integration/services/test_search_query_batch.py
+++ b/tests/integration/services/test_search_query_batch.py
@@ -140,6 +140,13 @@ class TestParseBatchQuerySpec:
             ({"q": "x", "recency_half_life_days": "nan"}, "recency_half_life_days"),
             ({"q": "x", "recency_half_life_days": float("nan")}, "recency_half_life_days"),
             ({"q": "x", "type": "keywrod"}, "type"),
+            # Explicit falsy enum values must error, not silently coerce to
+            # the default semantics (the single route rejects them too).
+            ({"q": "x", "type": ""}, "type"),
+            ({"q": "x", "type": None}, "type"),
+            ({"q": "x", "fusion": ""}, "fusion"),
+            ({"q": "x", "expand": ""}, "expand"),
+            ({"q": "x", "recency": ""}, "recency"),
             # Legacy alias resolves first; the message reports the canonical
             # public name.
             ({"q": "x", "search_type": "keywrod"}, "type"),
@@ -333,6 +340,25 @@ class TestBatchRoute:
 
         assert resp.status_code == 200, resp.text
         assert "limit" in resp.json()["queries"][0]["error"]
+        daemon.batch_search.assert_not_called()
+
+    @pytest.mark.parametrize("body", [[], None, "abc", 42])
+    def test_non_object_json_root_400(self, body):
+        import json as json_module
+
+        daemon = MagicMock()
+        daemon.batch_search = AsyncMock(return_value=[])
+        app = _build_batch_app(daemon)
+
+        # Post raw content: httpx treats json=None as "no body", but the
+        # contract under test is a request whose JSON root is null/[]/str/int.
+        resp = TestClient(app).post(
+            "/api/v2/search/query/batch",
+            content=json_module.dumps(body),
+            headers={"Content-Type": "application/json"},
+        )
+
+        assert resp.status_code == 400, resp.text
         daemon.batch_search.assert_not_called()
 
     def test_empty_queries_still_400(self):

--- a/tests/unit/bricks/search/test_daemon_batch_search.py
+++ b/tests/unit/bricks/search/test_daemon_batch_search.py
@@ -885,7 +885,7 @@ async def test_abandoned_batch_tasks_keep_their_permits(monkeypatch) -> None:
     # The abandoned search is tracked and still holds the daemon-scoped
     # permit, so a follow-up batch cannot start fresh work behind its back.
     assert daemon._abandoned_batch_tasks
-    assert daemon._batch_semaphore().locked()
+    assert daemon._batch_semaphore("search").locked()
     started_before = started
     await daemon._batch_search_on_current_loop([{"query": "b"}], zone_id="root")
     assert started == started_before
@@ -1057,7 +1057,7 @@ async def test_exhausted_permit_pool_cannot_wedge_a_later_batch(monkeypatch) -> 
 
     daemon.search = MethodType(resistant, daemon)
     await daemon._batch_search_on_current_loop([{"query": "a"}], zone_id="root")
-    assert daemon._batch_semaphore().locked()
+    assert daemon._batch_semaphore("search").locked()
 
     # A follow-up batch must settle on its OWN deadline rather than parking
     # forever on the permit the abandoned work still holds.
@@ -1206,6 +1206,115 @@ async def test_resistant_path_context_refresh_cannot_hold_the_response(monkeypat
     # The fail-soft refresh must not hold the response open past the deadline.
     assert elapsed < 3.0, f"path-context refresh escaped the deadline ({elapsed:.2f}s)"
     assert out == [[]]
+
+    release.set()
+    await asyncio.sleep(0.1)
+
+
+@pytest.mark.asyncio
+async def test_resistant_pre_embed_does_not_block_keyword_fallback(monkeypatch) -> None:
+    import asyncio
+
+    from nexus.bricks.search import daemon as daemon_module
+
+    monkeypatch.setattr(daemon_module, "_BATCH_CANCEL_DRAIN_SECONDS", 0.05)
+
+    daemon = _make_batch_daemon()
+    # Concurrency 1: with a shared pool the stuck embed would hold the only
+    # permit and the hybrid keyword fallback could never run.
+    daemon.config = type(daemon.config)(
+        batch_search_concurrency=1,
+        query_timeout_seconds=0.05,
+        batch_search_timeout_seconds=1.0,
+    )
+    release = asyncio.Event()
+
+    class ResistantEmbeddingClient:
+        async def embed_batch(self, texts: Any) -> list[list[float]]:
+            inner = asyncio.ensure_future(release.wait())
+            while not inner.done():
+                try:
+                    await asyncio.shield(inner)
+                except asyncio.CancelledError:
+                    current = asyncio.current_task()
+                    if current is not None:
+                        current.uncancel()
+            return [[0.1, 0.2] for _ in texts]
+
+    daemon._embedding_client = ResistantEmbeddingClient()
+    captured: list[Any] = []
+
+    async def fake_search(self: Any, request: Any) -> list[Any]:
+        captured.append(request)
+        return []
+
+    daemon.search = MethodType(fake_search, daemon)
+
+    out = await daemon._batch_search_on_current_loop(
+        [{"query": "a", "search_type": "hybrid"}], zone_id="root"
+    )
+
+    assert out == [[]], out
+    assert len(captured) == 1
+    assert captured[0].embedding_unavailable is True
+    assert not daemon._batch_semaphore("search").locked()
+
+    release.set()
+    await asyncio.sleep(0.1)
+
+
+@pytest.mark.asyncio
+async def test_resistant_refresh_does_not_block_the_next_batch(monkeypatch) -> None:
+    import asyncio
+    from unittest.mock import MagicMock
+
+    from nexus.bricks.search import daemon as daemon_module
+    from nexus.bricks.search.daemon import DaemonStats
+
+    monkeypatch.setattr(daemon_module, "_BATCH_CANCEL_DRAIN_SECONDS", 0.05)
+
+    daemon = _make_batch_daemon()
+    daemon.config = type(daemon.config)(
+        batch_search_concurrency=1,
+        query_timeout_seconds=0.05,
+        batch_search_timeout_seconds=0.5,
+    )
+    daemon.stats = DaemonStats()
+    release = asyncio.Event()
+
+    class ResistantCache:
+        async def refresh_if_stale(self, zone_id: str) -> None:
+            inner = asyncio.ensure_future(release.wait())
+            while not inner.done():
+                try:
+                    await asyncio.shield(inner)
+                except asyncio.CancelledError:
+                    current = asyncio.current_task()
+                    if current is not None:
+                        current.uncancel()
+
+        def snapshot_zone(self, zone_id: str) -> None:
+            return None
+
+    daemon._resolve_path_context_cache = MagicMock(
+        side_effect=lambda: asyncio.sleep(0, result=ResistantCache())
+    )
+
+    async def fake_search(self: Any, request: Any) -> list[Any]:
+        return []
+
+    daemon.search = MethodType(fake_search, daemon)
+
+    await daemon._batch_search_on_current_loop(
+        [{"query": "a", "search_type": "keyword"}], zone_id="root"
+    )
+    # A stuck refresh lives in its own pool, so the NEXT keyword-only batch
+    # still executes instead of returning timeouts.
+    out = await daemon._batch_search_on_current_loop(
+        [{"query": "b", "search_type": "keyword"}], zone_id="root"
+    )
+
+    assert out == [[]], out
 
     release.set()
     await asyncio.sleep(0.1)

--- a/tests/unit/bricks/search/test_daemon_batch_search.py
+++ b/tests/unit/bricks/search/test_daemon_batch_search.py
@@ -835,7 +835,9 @@ async def test_provider_outage_is_bounded_and_degrades_hybrid() -> None:
     # A total outage is classified after the first split, not by descending
     # through every text — and hybrid queries still RUN (keyword-degraded)
     # rather than being timed out by an exhausted deadline.
-    assert len(client.calls) <= 3, client.calls
+    # Bounded by the no-success outage signal (initial probe + first split +
+    # a couple more), never a descent through all 64 texts.
+    assert len(client.calls) <= 6, client.calls
     assert len(captured) == 64
     assert all(r.embedding_unavailable is True for r in captured)
     assert out == [[] for _ in range(64)]
@@ -890,3 +892,98 @@ async def test_abandoned_batch_tasks_keep_their_permits(monkeypatch) -> None:
 
     release.set()
     await asyncio.sleep(0.15)
+
+
+@pytest.mark.asyncio
+async def test_multiple_bad_inputs_across_halves_are_isolated_individually() -> None:
+    from nexus.contracts.search_types import BatchQueryFailure
+
+    daemon = _make_batch_daemon()
+
+    class MultiPoisonClient:
+        def __init__(self) -> None:
+            self.calls: list[list[str]] = []
+
+        async def embed_batch(self, texts: Any) -> list[list[float]]:
+            chunk = list(texts)
+            self.calls.append(chunk)
+            if any(t in {"bad1", "bad2"} for t in chunk):
+                raise ValueError("input rejected")
+            return [[0.1, 0.2] for _ in chunk]
+
+    daemon._embedding_client = MultiPoisonClient()
+    captured: list[Any] = []
+
+    async def fake_search(self: Any, request: Any) -> list[Any]:
+        captured.append(request)
+        return []
+
+    daemon.search = MethodType(fake_search, daemon)
+
+    # sorted() puts one bad text in each bisection half.
+    specs = [
+        {"query": t, "search_type": "semantic"}
+        for t in ("aaa", "bad1", "ccc", "bad2", "eee", "fff")
+    ]
+    out = await daemon._batch_search_on_current_loop(specs, zone_id="root")
+
+    failures = {specs[i]["query"] for i, r in enumerate(out) if isinstance(r, BatchQueryFailure)}
+    # Independent bad inputs in DIFFERENT halves must not collapse into a
+    # false "provider down" that fails every healthy sibling.
+    assert failures == {"bad1", "bad2"}, out
+    assert {r.query for r in captured} == {"aaa", "ccc", "eee", "fff"}
+    assert all(r.query_vector == [0.1, 0.2] for r in captured)
+
+
+@pytest.mark.asyncio
+async def test_cancellation_resistant_pre_embed_cannot_outlive_deadline(monkeypatch) -> None:
+    import asyncio
+    import time
+
+    from nexus.bricks.search import daemon as daemon_module
+    from nexus.contracts.search_types import BatchQueryFailure
+
+    monkeypatch.setattr(daemon_module, "_BATCH_CANCEL_DRAIN_SECONDS", 0.05)
+
+    daemon = _make_batch_daemon()
+    daemon.config = type(daemon.config)(
+        batch_search_concurrency=4,
+        query_timeout_seconds=0.05,
+        batch_search_timeout_seconds=0.3,
+    )
+    release = asyncio.Event()
+
+    class ResistantEmbeddingClient:
+        async def embed_batch(self, texts: Any) -> list[list[float]]:
+            inner = asyncio.ensure_future(release.wait())
+            while not inner.done():
+                try:
+                    await asyncio.shield(inner)
+                except asyncio.CancelledError:
+                    current = asyncio.current_task()
+                    if current is not None:
+                        current.uncancel()
+            return [[0.1, 0.2] for _ in texts]
+
+    daemon._embedding_client = ResistantEmbeddingClient()
+
+    async def fake_search(self: Any, request: Any) -> list[Any]:
+        return []
+
+    daemon.search = MethodType(fake_search, daemon)
+
+    started = time.monotonic()
+    out = await daemon._batch_search_on_current_loop(
+        [{"query": "a", "search_type": "semantic"}], zone_id="root"
+    )
+    elapsed = time.monotonic() - started
+
+    # A provider that swallows cancellation must not suspend the batch: the
+    # pre-embed is cancelled, charged to the daemon-scoped pool, and the
+    # request settles within its own deadline.
+    assert elapsed < 3.0, f"pre-embed outlived the batch deadline ({elapsed:.2f}s)"
+    assert isinstance(out[0], BatchQueryFailure)
+    assert daemon._abandoned_batch_tasks
+
+    release.set()
+    await asyncio.sleep(0.1)

--- a/tests/unit/bricks/search/test_daemon_batch_search.py
+++ b/tests/unit/bricks/search/test_daemon_batch_search.py
@@ -800,3 +800,93 @@ async def test_caller_cancellation_propagates_and_does_not_strand() -> None:
     # converted into per-query failures or left pending forever.
     with pytest.raises(asyncio.CancelledError):
         await asyncio.wait_for(batch, timeout=10)
+
+
+@pytest.mark.asyncio
+async def test_provider_outage_is_bounded_and_degrades_hybrid() -> None:
+    daemon = _make_batch_daemon()
+    daemon.config = type(daemon.config)(
+        batch_search_concurrency=8,
+        query_timeout_seconds=30.0,
+        batch_search_timeout_seconds=30.0,
+    )
+
+    class DeadEmbeddingClient:
+        def __init__(self) -> None:
+            self.calls: list[list[str]] = []
+
+        async def embed_batch(self, texts: Any) -> list[list[float]]:
+            self.calls.append(list(texts))
+            raise RuntimeError("provider down")
+
+    client = DeadEmbeddingClient()
+    daemon._embedding_client = client
+    captured: list[Any] = []
+
+    async def fake_search(self: Any, request: Any) -> list[Any]:
+        captured.append(request)
+        return []
+
+    daemon.search = MethodType(fake_search, daemon)
+
+    specs = [{"query": f"q{i}", "search_type": "hybrid"} for i in range(64)]
+    out = await daemon._batch_search_on_current_loop(specs, zone_id="root")
+
+    # A total outage is classified after the first split, not by descending
+    # through every text — and hybrid queries still RUN (keyword-degraded)
+    # rather than being timed out by an exhausted deadline.
+    assert len(client.calls) <= 3, client.calls
+    assert len(captured) == 64
+    assert all(r.embedding_unavailable is True for r in captured)
+    assert out == [[] for _ in range(64)]
+
+
+@pytest.mark.asyncio
+async def test_abandoned_batch_tasks_keep_their_permits(monkeypatch) -> None:
+    import asyncio
+
+    from nexus.bricks.search import daemon as daemon_module
+
+    # Keep the drain short so the test does not sit on the production grace
+    # window; the behavior under test is what happens AFTER the drain gives up.
+    monkeypatch.setattr(daemon_module, "_BATCH_CANCEL_DRAIN_SECONDS", 0.05)
+
+    daemon = _make_batch_daemon()
+    daemon.config = type(daemon.config)(
+        batch_search_concurrency=1,
+        query_timeout_seconds=30.0,
+        batch_search_timeout_seconds=0.05,
+    )
+    release = asyncio.Event()
+    started = 0
+
+    async def fake_search(self: Any, request: Any) -> list[Any]:
+        nonlocal started
+        started += 1
+        # Cancellation-resistant backend: swallows the cancel and clears the
+        # request (uncancel) so it genuinely keeps running, the way a driver
+        # that shields its cleanup would.
+        inner = asyncio.ensure_future(release.wait())
+        while not inner.done():
+            try:
+                await asyncio.shield(inner)
+            except asyncio.CancelledError:
+                current = asyncio.current_task()
+                if current is not None:
+                    current.uncancel()
+        return []
+
+    daemon.search = MethodType(fake_search, daemon)
+
+    await daemon._batch_search_on_current_loop([{"query": "a"}], zone_id="root")
+
+    # The abandoned search is tracked and still holds the daemon-scoped
+    # permit, so a follow-up batch cannot start fresh work behind its back.
+    assert daemon._abandoned_batch_tasks
+    assert daemon._batch_semaphore().locked()
+    started_before = started
+    await daemon._batch_search_on_current_loop([{"query": "b"}], zone_id="root")
+    assert started == started_before
+
+    release.set()
+    await asyncio.sleep(0.15)

--- a/tests/unit/bricks/search/test_daemon_batch_search.py
+++ b/tests/unit/bricks/search/test_daemon_batch_search.py
@@ -509,3 +509,108 @@ async def test_hung_pre_embed_degrades_instead_of_blocking_batch() -> None:
     # pre-embed failure: hybrid runs keyword-only, no per-query embed retry.
     assert out == [[]]
     assert captured[0].embedding_unavailable is True
+
+
+@pytest.mark.asyncio
+async def test_batch_deadline_bounds_queued_hung_queries() -> None:
+    import asyncio
+    import time
+
+    from nexus.contracts.search_types import BatchQueryFailure
+
+    daemon = _make_batch_daemon()
+    # Per-query timeout generous; the ABSOLUTE batch deadline is the bound
+    # under test: with concurrency 1, three hung queries would otherwise
+    # consume three consecutive per-query windows.
+    daemon.config = type(daemon.config)(
+        batch_search_concurrency=1,
+        query_timeout_seconds=30.0,
+        batch_search_timeout_seconds=0.1,
+    )
+
+    async def fake_search(self: Any, request: Any) -> list[Any]:
+        if request.query.startswith("hung"):
+            await asyncio.sleep(60)
+        return []
+
+    daemon.search = MethodType(fake_search, daemon)
+
+    started = time.monotonic()
+    out = await daemon._batch_search_on_current_loop(
+        [{"query": "ok"}, {"query": "hung-1"}, {"query": "hung-2"}], zone_id="root"
+    )
+    elapsed = time.monotonic() - started
+
+    assert elapsed < 5, f"batch deadline did not bound the request ({elapsed:.1f}s)"
+    # Concurrency 1 runs the healthy query first; the queued hung queries are
+    # cancelled at the deadline and settled positionally as timeouts.
+    assert out[0] == []
+    assert isinstance(out[1], BatchQueryFailure)
+    assert out[1].error == "Search timed out"
+    assert isinstance(out[2], BatchQueryFailure)
+    assert out[2].error == "Search timed out"
+
+
+@pytest.mark.asyncio
+async def test_hybrid_dense_backend_failure_fails_batch_query() -> None:
+    daemon = _make_daemon()
+
+    class RaisingVectorBackend:
+        async def semantic_search(
+            self, qvec: list[float], path: str, limit: int, zone_id: str
+        ) -> list[Any]:
+            raise RuntimeError("vector backend down")
+
+    daemon._vector_backend = RaisingVectorBackend()
+
+    # Interactive contract: fail-soft to keyword-only.
+    out = await daemon._search_via_backends(
+        "q", search_type="hybrid", limit=5, path_filter=None, zone_id="root"
+    )
+    assert out  # keyword hits still served
+
+    # Batch contract: a dense INFRASTRUCTURE failure is a per-query failure,
+    # not a silently keyword-only "success".
+    with pytest.raises(RuntimeError, match="vector backend down"):
+        await daemon._search_via_backends(
+            "q",
+            search_type="hybrid",
+            limit=5,
+            path_filter=None,
+            zone_id="root",
+            propagate_failures=True,
+        )
+
+
+@pytest.mark.asyncio
+async def test_legacy_hybrid_missing_embedding_still_degrades_under_batch() -> None:
+    from nexus.bricks.search.daemon import SearchDaemon, SearchResult
+
+    daemon: Any = SearchDaemon.__new__(SearchDaemon)
+
+    async def _keyword_search(self: Any, *args: Any, **kwargs: Any) -> list[Any]:
+        return [
+            SearchResult(
+                path="/kw.md", chunk_text="kw", score=1.0, chunk_index=0, search_type="keyword"
+            )
+        ]
+
+    daemon._keyword_search = MethodType(_keyword_search, daemon)
+
+    class NoEmbedVectorBackend:
+        async def semantic_search(self, *args: Any, **kwargs: Any) -> list[Any]:
+            raise AssertionError("dense leg must not run without an embedding")
+
+    daemon._vector_backend = NoEmbedVectorBackend()
+
+    async def _no_embed(self: Any, query: str) -> None:
+        return None
+
+    daemon._embed_query = MethodType(_no_embed, daemon)
+
+    # Missing embedding is legitimate hybrid degradation even in batch mode:
+    # the EmbeddingUnavailableError carve-out keeps the keyword-only result.
+    out = await daemon._hybrid_search(
+        "q", 4, None, 0.5, "rrf", zone_id="root", propagate_failures=True
+    )
+    assert [r.path for r in out] == ["/kw.md"]

--- a/tests/unit/bricks/search/test_daemon_batch_search.py
+++ b/tests/unit/bricks/search/test_daemon_batch_search.py
@@ -719,3 +719,84 @@ async def test_missing_vector_backend_is_distinct_from_missing_embedding() -> No
         await daemon._hybrid_search(
             "q", 4, None, 0.5, "rrf", zone_id="root", propagate_failures=True
         )
+
+
+@pytest.mark.asyncio
+async def test_single_bad_embedding_input_does_not_poison_siblings() -> None:
+    from nexus.contracts.search_types import BatchQueryFailure
+
+    daemon = _make_batch_daemon()
+
+    class PoisonRejectingClient:
+        def __init__(self) -> None:
+            self.calls: list[list[str]] = []
+
+        async def embed_batch(self, texts: Any) -> list[list[float]]:
+            chunk = list(texts)
+            self.calls.append(chunk)
+            if any(t == "poison" for t in chunk):
+                raise ValueError("input rejected: poison")
+            return [[0.1, 0.2] for _ in chunk]
+
+    client = PoisonRejectingClient()
+    daemon._embedding_client = client
+    captured: list[Any] = []
+
+    async def fake_search(self: Any, request: Any) -> list[Any]:
+        captured.append(request)
+        return []
+
+    daemon.search = MethodType(fake_search, daemon)
+
+    out = await daemon._batch_search_on_current_loop(
+        [
+            {"query": "alpha", "search_type": "semantic"},
+            {"query": "poison", "search_type": "semantic"},
+            {"query": "beta", "search_type": "semantic"},
+        ],
+        zone_id="root",
+    )
+
+    # Only the offending text fails; healthy siblings still get vectors and
+    # run their searches.
+    assert isinstance(out[1], BatchQueryFailure)
+    assert out[1].error == "Query embedding unavailable"
+    assert out[0] == [] and out[2] == []
+    ran = {r.query: r for r in captured}
+    assert set(ran) == {"alpha", "beta"}
+    assert all(r.query_vector == [0.1, 0.2] for r in ran.values())
+    # Isolation is bounded (bisection), not one probe per text.
+    assert len(client.calls) <= 6
+
+
+@pytest.mark.asyncio
+async def test_caller_cancellation_propagates_and_does_not_strand() -> None:
+    import asyncio
+    import contextlib
+
+    daemon = _make_batch_daemon()
+    daemon.config = type(daemon.config)(
+        batch_search_concurrency=8,
+        query_timeout_seconds=30.0,
+        batch_search_timeout_seconds=30.0,
+    )
+
+    async def fake_search(self: Any, request: Any) -> list[Any]:
+        # Cancellation-resistant backend.
+        with contextlib.suppress(asyncio.CancelledError):
+            await asyncio.sleep(30)
+        await asyncio.sleep(30)
+        return []
+
+    daemon.search = MethodType(fake_search, daemon)
+
+    batch = asyncio.ensure_future(
+        daemon._batch_search_on_current_loop([{"query": "a"}, {"query": "b"}], zone_id="root")
+    )
+    await asyncio.sleep(0.05)
+    batch.cancel()
+
+    # Caller cancellation must propagate promptly (bounded cleanup), never be
+    # converted into per-query failures or left pending forever.
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(batch, timeout=10)

--- a/tests/unit/bricks/search/test_daemon_batch_search.py
+++ b/tests/unit/bricks/search/test_daemon_batch_search.py
@@ -116,3 +116,190 @@ async def test_no_query_vector_still_embeds() -> None:
     )
 
     assert counter.calls == ["hello"]
+
+
+def _make_batch_daemon(concurrency: int = 8) -> Any:
+    """Bare daemon for _batch_search_on_current_loop: search() is stubbed
+    per-test; only batch orchestration fields are real."""
+    from unittest.mock import AsyncMock
+
+    from nexus.bricks.search.daemon import DaemonConfig, SearchDaemon
+
+    daemon: Any = SearchDaemon.__new__(SearchDaemon)
+    daemon._initialized = True
+    daemon._embedding_client = None
+    daemon.config = DaemonConfig(batch_search_concurrency=concurrency)
+    # Path-context attach is exercised elsewhere; resolve to None (= skip).
+    daemon._resolve_path_context_cache = AsyncMock(return_value=None)
+    return daemon
+
+
+class _FakeEmbeddingClient:
+    def __init__(self, fail: bool = False) -> None:
+        self.calls: list[list[str]] = []
+        self.fail = fail
+
+    async def embed_batch(self, texts: Any) -> list[list[float]]:
+        self.calls.append(list(texts))
+        if self.fail:
+            raise RuntimeError("embed down")
+        return [[0.1, 0.2] for _ in texts]
+
+
+@pytest.mark.asyncio
+async def test_batch_pre_embeds_unique_texts_once() -> None:
+    daemon = _make_batch_daemon()
+    client = _FakeEmbeddingClient()
+    daemon._embedding_client = client
+    seen_vectors: list[Any] = []
+
+    async def fake_search(self: Any, request: Any) -> list[Any]:
+        seen_vectors.append(request.query_vector)
+        return []
+
+    daemon.search = MethodType(fake_search, daemon)
+    specs = [{"query": "same text", "search_type": "hybrid", "limit": 5} for _ in range(24)]
+
+    out = await daemon._batch_search_on_current_loop(specs, zone_id="root")
+
+    assert client.calls == [["same text"]]  # ONE embed_batch call, unique texts only
+    assert seen_vectors == [[0.1, 0.2]] * 24
+    assert out == [[] for _ in range(24)]
+
+
+@pytest.mark.asyncio
+async def test_batch_keyword_only_never_embeds() -> None:
+    daemon = _make_batch_daemon()
+    client = _FakeEmbeddingClient()
+    daemon._embedding_client = client
+
+    async def fake_search(self: Any, request: Any) -> list[Any]:
+        return []
+
+    daemon.search = MethodType(fake_search, daemon)
+
+    await daemon._batch_search_on_current_loop(
+        [{"query": "kw", "search_type": "keyword"}], zone_id="root"
+    )
+
+    assert client.calls == []
+
+
+@pytest.mark.asyncio
+async def test_batch_embed_failure_falls_back_to_per_query() -> None:
+    daemon = _make_batch_daemon()
+    daemon._embedding_client = _FakeEmbeddingClient(fail=True)
+    seen_vectors: list[Any] = []
+
+    async def fake_search(self: Any, request: Any) -> list[Any]:
+        seen_vectors.append(request.query_vector)
+        return []
+
+    daemon.search = MethodType(fake_search, daemon)
+
+    out = await daemon._batch_search_on_current_loop(
+        [{"query": "a", "search_type": "hybrid"}], zone_id="root"
+    )
+
+    assert out == [[]]  # fail-soft: search still ran
+    assert seen_vectors == [None]  # ...and embeds for itself downstream
+
+
+@pytest.mark.asyncio
+async def test_batch_failure_isolated_per_query() -> None:
+    from nexus.contracts.search_types import BatchQueryFailure
+
+    daemon = _make_batch_daemon()
+
+    async def fake_search(self: Any, request: Any) -> list[Any]:
+        if request.query == "poison":
+            raise RuntimeError("boom")
+        return []
+
+    daemon.search = MethodType(fake_search, daemon)
+
+    out = await daemon._batch_search_on_current_loop(
+        [{"query": "ok1"}, {"query": "poison"}, {"query": "ok2"}], zone_id="root"
+    )
+
+    assert out[0] == [] and out[2] == []
+    assert isinstance(out[1], BatchQueryFailure)
+    assert "boom" in out[1].error
+
+
+@pytest.mark.asyncio
+async def test_batch_respects_concurrency_bound() -> None:
+    import asyncio
+
+    daemon = _make_batch_daemon(concurrency=2)
+    peak = 0
+    active = 0
+
+    async def fake_search(self: Any, request: Any) -> list[Any]:
+        nonlocal peak, active
+        active += 1
+        peak = max(peak, active)
+        await asyncio.sleep(0.01)
+        active -= 1
+        return []
+
+    daemon.search = MethodType(fake_search, daemon)
+
+    await daemon._batch_search_on_current_loop(
+        [{"query": f"q{i}"} for i in range(10)], zone_id="root"
+    )
+
+    assert peak <= 2
+
+
+@pytest.mark.asyncio
+async def test_batch_forwards_tuning_params() -> None:
+    daemon = _make_batch_daemon()
+    captured: list[Any] = []
+
+    async def fake_search(self: Any, request: Any) -> list[Any]:
+        captured.append(request)
+        return []
+
+    daemon.search = MethodType(fake_search, daemon)
+
+    await daemon._batch_search_on_current_loop(
+        [
+            {
+                "query": "tuned",
+                "search_type": "hybrid",
+                "limit": 7,
+                "path_filter": "/ws/",
+                "alpha": 0.3,
+                "fusion_method": "weighted",
+                "rrf_k": 90,
+                "expand": "macro",
+                "recency": "on",
+                "recency_weight": 1.5,
+                "recency_half_life_days": 30.0,
+            }
+        ],
+        zone_id="root",
+    )
+
+    req = captured[0]
+    assert (req.alpha, req.fusion_method, req.rrf_k) == (0.3, "weighted", 90)
+    assert (req.expand, req.recency, req.recency_weight) == ("macro", "on", 1.5)
+    assert req.recency_half_life_days == 30.0
+    assert (req.limit, req.path_filter, req.zone_id) == (7, "/ws/", "root")
+
+
+@pytest.mark.asyncio
+async def test_batch_non_dict_spec_becomes_failure() -> None:
+    from nexus.contracts.search_types import BatchQueryFailure
+
+    daemon = _make_batch_daemon()
+
+    async def fake_search(self: Any, request: Any) -> list[Any]:
+        return []
+
+    daemon.search = MethodType(fake_search, daemon)
+
+    out = await daemon._batch_search_on_current_loop(["not a dict"], zone_id="root")
+
+    assert isinstance(out[0], BatchQueryFailure)

--- a/tests/unit/bricks/search/test_daemon_batch_search.py
+++ b/tests/unit/bricks/search/test_daemon_batch_search.py
@@ -445,3 +445,67 @@ async def test_legacy_semantic_search_uses_query_vector_and_propagates() -> None
     out = await daemon._semantic_search("q", 5, None, zone_id="root", embedding_unavailable=True)
     assert out == []
     assert counter.calls == []
+
+
+@pytest.mark.asyncio
+async def test_hung_inner_search_times_out_without_blocking_siblings() -> None:
+    import asyncio
+
+    from nexus.contracts.search_types import BatchQueryFailure
+
+    daemon = _make_batch_daemon()
+    daemon.config = type(daemon.config)(batch_search_concurrency=8, query_timeout_seconds=0.05)
+
+    async def fake_search(self: Any, request: Any) -> list[Any]:
+        if request.query == "hung":
+            await asyncio.sleep(30)
+        return []
+
+    daemon.search = MethodType(fake_search, daemon)
+
+    out = await asyncio.wait_for(
+        daemon._batch_search_on_current_loop(
+            [{"query": "hung"}, {"query": "healthy"}], zone_id="root"
+        ),
+        timeout=5,
+    )
+
+    # The hung query is bounded and converted; the healthy sibling's result
+    # is not withheld behind it.
+    assert isinstance(out[0], BatchQueryFailure)
+    assert out[0].error == "Search timed out"
+    assert out[1] == []
+
+
+@pytest.mark.asyncio
+async def test_hung_pre_embed_degrades_instead_of_blocking_batch() -> None:
+    import asyncio
+
+    daemon = _make_batch_daemon()
+    daemon.config = type(daemon.config)(batch_search_concurrency=8, query_timeout_seconds=0.05)
+
+    class HangingEmbeddingClient:
+        async def embed_batch(self, texts: Any) -> list[list[float]]:
+            await asyncio.sleep(30)
+            return []
+
+    daemon._embedding_client = HangingEmbeddingClient()
+    captured: list[Any] = []
+
+    async def fake_search(self: Any, request: Any) -> list[Any]:
+        captured.append(request)
+        return []
+
+    daemon.search = MethodType(fake_search, daemon)
+
+    out = await asyncio.wait_for(
+        daemon._batch_search_on_current_loop(
+            [{"query": "a", "search_type": "hybrid"}], zone_id="root"
+        ),
+        timeout=5,
+    )
+
+    # Shared pre-embed timeout takes the same degradation path as any other
+    # pre-embed failure: hybrid runs keyword-only, no per-query embed retry.
+    assert out == [[]]
+    assert captured[0].embedding_unavailable is True

--- a/tests/unit/bricks/search/test_daemon_batch_search.py
+++ b/tests/unit/bricks/search/test_daemon_batch_search.py
@@ -186,23 +186,72 @@ async def test_batch_keyword_only_never_embeds() -> None:
 
 
 @pytest.mark.asyncio
-async def test_batch_embed_failure_falls_back_to_per_query() -> None:
+async def test_batch_embed_failure_degrades_hybrid_without_per_query_retries() -> None:
+    from nexus.contracts.search_types import BatchQueryFailure
+
     daemon = _make_batch_daemon()
     daemon._embedding_client = _FakeEmbeddingClient(fail=True)
-    seen_vectors: list[Any] = []
+    captured: list[Any] = []
 
     async def fake_search(self: Any, request: Any) -> list[Any]:
-        seen_vectors.append(request.query_vector)
+        captured.append(request)
         return []
 
     daemon.search = MethodType(fake_search, daemon)
 
     out = await daemon._batch_search_on_current_loop(
-        [{"query": "a", "search_type": "hybrid"}], zone_id="root"
+        [
+            {"query": "a", "search_type": "hybrid"},
+            {"query": "a", "search_type": "semantic"},
+        ],
+        zone_id="root",
     )
 
-    assert out == [[]]  # fail-soft: search still ran
-    assert seen_vectors == [None]  # ...and embeds for itself downstream
+    # Hybrid still runs, but flagged so the dense leg skips its own embed
+    # retry (no N-way retry storm against a degraded provider).
+    assert out[0] == []
+    assert len(captured) == 1
+    assert captured[0].search_type == "hybrid"
+    assert captured[0].embedding_unavailable is True
+    assert captured[0].query_vector is None
+    # Semantic-only cannot be served without an embedding: typed failure,
+    # and search() is never invoked for it.
+    assert isinstance(out[1], BatchQueryFailure)
+    assert out[1].error == "Query embedding unavailable"
+
+
+@pytest.mark.asyncio
+async def test_batch_sets_propagate_failures() -> None:
+    daemon = _make_batch_daemon()
+    captured: list[Any] = []
+
+    async def fake_search(self: Any, request: Any) -> list[Any]:
+        captured.append(request)
+        return []
+
+    daemon.search = MethodType(fake_search, daemon)
+
+    await daemon._batch_search_on_current_loop([{"query": "q"}], zone_id="root")
+
+    assert captured[0].propagate_failures is True
+    assert captured[0].embedding_unavailable is False
+
+
+@pytest.mark.asyncio
+async def test_batch_timeout_becomes_sanitized_failure() -> None:
+    from nexus.contracts.search_types import BatchQueryFailure
+
+    daemon = _make_batch_daemon()
+
+    async def fake_search(self: Any, request: Any) -> list[Any]:
+        raise TimeoutError
+
+    daemon.search = MethodType(fake_search, daemon)
+
+    out = await daemon._batch_search_on_current_loop([{"query": "slow"}], zone_id="root")
+
+    assert isinstance(out[0], BatchQueryFailure)
+    assert out[0].error == "Search timed out"
 
 
 @pytest.mark.asyncio
@@ -224,7 +273,11 @@ async def test_batch_failure_isolated_per_query() -> None:
 
     assert out[0] == [] and out[2] == []
     assert isinstance(out[1], BatchQueryFailure)
-    assert "boom" in out[1].error
+    # Raw exception text must never cross the API boundary (it can carry
+    # SQL/hosts/provider internals) — the wire message is the stable
+    # sanitized constant; full detail goes to the server log.
+    assert "boom" not in out[1].error
+    assert out[1].error == "Search query failed"
 
 
 @pytest.mark.asyncio
@@ -303,3 +356,92 @@ async def test_batch_non_dict_spec_becomes_failure() -> None:
     out = await daemon._batch_search_on_current_loop(["not a dict"], zone_id="root")
 
     assert isinstance(out[0], BatchQueryFailure)
+
+
+@pytest.mark.asyncio
+async def test_semantic_backend_leg_propagates_missing_embedding() -> None:
+    from nexus.bricks.search.daemon import EmbeddingUnavailableError
+
+    daemon = _make_daemon()
+
+    async def _no_embed(self: Any, query: str) -> None:
+        return None
+
+    daemon._embed_query = MethodType(_no_embed, daemon)
+
+    # Interactive contract: degrade to empty.
+    out = await daemon._search_via_backends(
+        "q", search_type="semantic", limit=5, path_filter=None, zone_id="root"
+    )
+    assert out == []
+
+    # Batch contract: a semantic search served nothing because the embedding
+    # is missing — that is a failure, not a healthy empty.
+    with pytest.raises(EmbeddingUnavailableError):
+        await daemon._search_via_backends(
+            "q",
+            search_type="semantic",
+            limit=5,
+            path_filter=None,
+            zone_id="root",
+            propagate_failures=True,
+        )
+
+
+@pytest.mark.asyncio
+async def test_backend_legs_skip_embed_when_unavailable_flagged() -> None:
+    daemon = _make_daemon()
+    counter = _CountingEmbed()
+    daemon._embed_query = MethodType(counter.__call__, daemon)
+
+    # Hybrid with embedding_unavailable: no embed attempt, keyword-only result.
+    out = await daemon._search_via_backends(
+        "hello",
+        search_type="hybrid",
+        limit=5,
+        path_filter=None,
+        zone_id="root",
+        embedding_unavailable=True,
+    )
+    assert counter.calls == []
+    assert out  # keyword fallback still serves results
+
+
+@pytest.mark.asyncio
+async def test_legacy_semantic_search_uses_query_vector_and_propagates() -> None:
+    from nexus.bricks.search.daemon import EmbeddingUnavailableError, SearchDaemon
+
+    daemon: Any = SearchDaemon.__new__(SearchDaemon)
+    seen_vectors: list[Any] = []
+
+    class FakeVectorBackend:
+        async def semantic_search(
+            self, qvec: list[float], path: str, limit: int, zone_id: str
+        ) -> list[Any]:
+            seen_vectors.append(qvec)
+            return []
+
+    daemon._vector_backend = FakeVectorBackend()
+    counter = _CountingEmbed()
+    daemon._embed_query = MethodType(counter.__call__, daemon)
+
+    # Pre-computed vector: the legacy fallback must not re-embed (the batch
+    # empty-result fallthrough runs this path on every miss).
+    out = await daemon._semantic_search("q", 5, None, zone_id="root", query_vector=[0.9, 0.8])
+    assert out == []
+    assert counter.calls == []
+    assert seen_vectors == [[0.9, 0.8]]
+
+    # No vector + no embedding available + batch mode -> typed failure.
+    async def _no_embed(self: Any, query: str) -> None:
+        return None
+
+    daemon._embed_query = MethodType(_no_embed, daemon)
+    with pytest.raises(EmbeddingUnavailableError):
+        await daemon._semantic_search("q", 5, None, zone_id="root", propagate_failures=True)
+
+    # embedding_unavailable (hybrid degrade support): no embed attempt, empty.
+    daemon._embed_query = MethodType(counter.__call__, daemon)
+    out = await daemon._semantic_search("q", 5, None, zone_id="root", embedding_unavailable=True)
+    assert out == []
+    assert counter.calls == []

--- a/tests/unit/bricks/search/test_daemon_batch_search.py
+++ b/tests/unit/bricks/search/test_daemon_batch_search.py
@@ -987,3 +987,86 @@ async def test_cancellation_resistant_pre_embed_cannot_outlive_deadline(monkeypa
 
     release.set()
     await asyncio.sleep(0.1)
+
+
+@pytest.mark.asyncio
+async def test_bad_inputs_contaminating_every_early_partition_stay_isolated() -> None:
+    from nexus.contracts.search_types import BatchQueryFailure
+
+    daemon = _make_batch_daemon()
+    bad = {"bad1", "bad2", "bad3", "bad4"}
+
+    class SpreadPoisonClient:
+        async def embed_batch(self, texts: Any) -> list[list[float]]:
+            chunk = list(texts)
+            if any(t in bad for t in chunk):
+                raise ValueError("input rejected")
+            return [[0.1, 0.2] for _ in chunk]
+
+    daemon._embedding_client = SpreadPoisonClient()
+    captured: list[Any] = []
+
+    async def fake_search(self: Any, request: Any) -> list[Any]:
+        captured.append(request)
+        return []
+
+    daemon.search = MethodType(fake_search, daemon)
+
+    # Interleaved so a bad text lands in the initial batch, both halves, and
+    # the early quarters — the shape that used to read as a provider outage.
+    texts = ["bad1", "aaa", "bad2", "bbb", "bad3", "ccc", "bad4", "ddd"]
+    out = await daemon._batch_search_on_current_loop(
+        [{"query": t, "search_type": "semantic"} for t in texts], zone_id="root"
+    )
+
+    failed = {texts[i] for i, r in enumerate(out) if isinstance(r, BatchQueryFailure)}
+    # The control probe proves the provider is healthy, so only the offending
+    # texts fail — healthy siblings still run with their vectors.
+    assert failed == bad, out
+    assert {r.query for r in captured} == {"aaa", "bbb", "ccc", "ddd"}
+
+
+@pytest.mark.asyncio
+async def test_exhausted_permit_pool_cannot_wedge_a_later_batch(monkeypatch) -> None:
+    import asyncio
+    import time
+
+    from nexus.bricks.search import daemon as daemon_module
+    from nexus.contracts.search_types import BatchQueryFailure
+
+    monkeypatch.setattr(daemon_module, "_BATCH_CANCEL_DRAIN_SECONDS", 0.05)
+
+    daemon = _make_batch_daemon()
+    daemon.config = type(daemon.config)(
+        batch_search_concurrency=1,
+        query_timeout_seconds=0.05,
+        batch_search_timeout_seconds=0.2,
+    )
+    release = asyncio.Event()
+
+    async def resistant(self: Any, request: Any) -> list[Any]:
+        inner = asyncio.ensure_future(release.wait())
+        while not inner.done():
+            try:
+                await asyncio.shield(inner)
+            except asyncio.CancelledError:
+                current = asyncio.current_task()
+                if current is not None:
+                    current.uncancel()
+        return []
+
+    daemon.search = MethodType(resistant, daemon)
+    await daemon._batch_search_on_current_loop([{"query": "a"}], zone_id="root")
+    assert daemon._batch_semaphore().locked()
+
+    # A follow-up batch must settle on its OWN deadline rather than parking
+    # forever on the permit the abandoned work still holds.
+    started = time.monotonic()
+    out = await daemon._batch_search_on_current_loop([{"query": "b"}], zone_id="root")
+    elapsed = time.monotonic() - started
+
+    assert elapsed < 3.0, f"permit wait escaped the batch deadline ({elapsed:.2f}s)"
+    assert isinstance(out[0], BatchQueryFailure)
+
+    release.set()
+    await asyncio.sleep(0.1)

--- a/tests/unit/bricks/search/test_daemon_batch_search.py
+++ b/tests/unit/bricks/search/test_daemon_batch_search.py
@@ -1318,3 +1318,48 @@ async def test_resistant_refresh_does_not_block_the_next_batch(monkeypatch) -> N
 
     release.set()
     await asyncio.sleep(0.1)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("batch_size", [470, 500])
+async def test_single_bad_input_isolates_at_documented_cardinality(batch_size) -> None:
+    from nexus.contracts.search_types import BatchQueryFailure
+
+    daemon = _make_batch_daemon()
+    poison = "q001"
+
+    class OnePoisonClient:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def embed_batch(self, texts: Any) -> list[list[float]]:
+            self.calls += 1
+            chunk = list(texts)
+            if poison in chunk:
+                raise ValueError("input rejected")
+            return [[0.1, 0.2] for _ in chunk]
+
+    client = OnePoisonClient()
+    daemon._embedding_client = client
+    captured: list[Any] = []
+
+    async def fake_search(self: Any, request: Any) -> list[Any]:
+        captured.append(request)
+        return []
+
+    daemon.search = MethodType(fake_search, daemon)
+
+    texts = [f"q{i:03d}" for i in range(batch_size)]
+    out = await daemon._batch_search_on_current_loop(
+        [{"query": t, "search_type": "semantic"} for t in texts], zone_id="root"
+    )
+
+    failed = {texts[i] for i, r in enumerate(out) if isinstance(r, BatchQueryFailure)}
+    # The probe budget must be big enough to isolate ONE bad text at the
+    # documented 470-500 query workload; a too-small budget used to give up
+    # mid-walk and fail the whole unresolved half.
+    assert failed == {poison}, sorted(failed)[:10]
+    assert len(captured) == batch_size - 1
+    assert all(r.query_vector == [0.1, 0.2] for r in captured)
+    # Isolation stays logarithmic, not per-text.
+    assert client.calls <= 40, client.calls

--- a/tests/unit/bricks/search/test_daemon_batch_search.py
+++ b/tests/unit/bricks/search/test_daemon_batch_search.py
@@ -614,3 +614,108 @@ async def test_legacy_hybrid_missing_embedding_still_degrades_under_batch() -> N
         "q", 4, None, 0.5, "rrf", zone_id="root", propagate_failures=True
     )
     assert [r.path for r in out] == ["/kw.md"]
+
+
+@pytest.mark.asyncio
+async def test_batch_deadline_covers_pre_embed_phase() -> None:
+    import asyncio
+    import time
+
+    from nexus.contracts.search_types import BatchQueryFailure
+
+    daemon = _make_batch_daemon()
+    daemon.config = type(daemon.config)(
+        batch_search_concurrency=8,
+        query_timeout_seconds=30.0,
+        batch_search_timeout_seconds=0.2,
+    )
+
+    class SlowEmbeddingClient:
+        async def embed_batch(self, texts: Any) -> list[list[float]]:
+            await asyncio.sleep(0.3)
+            return [[0.1, 0.2] for _ in texts]
+
+    daemon._embedding_client = SlowEmbeddingClient()
+
+    async def fake_search(self: Any, request: Any) -> list[Any]:
+        await asyncio.sleep(5)
+        return []
+
+    daemon.search = MethodType(fake_search, daemon)
+
+    started = time.monotonic()
+    out = await daemon._batch_search_on_current_loop([{"query": "a"}], zone_id="root")
+    elapsed = time.monotonic() - started
+
+    # The ONE deadline spans pre-embed + fan-out: a pre-embed that eats the
+    # whole budget must not hand the fan-out a fresh window.
+    assert elapsed < 2.0, f"pre-embed escaped the batch deadline ({elapsed:.2f}s)"
+    assert isinstance(out[0], BatchQueryFailure)
+
+
+@pytest.mark.asyncio
+async def test_task_finishing_during_cancel_still_settles_as_timeout() -> None:
+    import asyncio
+    import contextlib
+
+    from nexus.contracts.search_types import BatchQueryFailure
+
+    daemon = _make_batch_daemon()
+    daemon.config = type(daemon.config)(
+        batch_search_concurrency=8,
+        query_timeout_seconds=30.0,
+        batch_search_timeout_seconds=0.05,
+    )
+
+    async def fake_search(self: Any, request: Any) -> list[Any]:
+        # Suppress the cancellation and complete anyway — the task was still
+        # unfinished AT THE DEADLINE, so it must settle as a timeout.
+        with contextlib.suppress(asyncio.CancelledError):
+            await asyncio.sleep(0.5)
+        return [{"path": "/late.md"}]
+
+    daemon.search = MethodType(fake_search, daemon)
+
+    out = await daemon._batch_search_on_current_loop([{"query": "late"}], zone_id="root")
+
+    assert isinstance(out[0], BatchQueryFailure)
+    assert out[0].error == "Search timed out"
+
+
+@pytest.mark.asyncio
+async def test_missing_vector_backend_is_distinct_from_missing_embedding() -> None:
+    from nexus.bricks.search.daemon import (
+        SearchDaemon,
+        SearchResult,
+        VectorBackendUnavailableError,
+    )
+
+    daemon: Any = SearchDaemon.__new__(SearchDaemon)
+    daemon._vector_backend = None
+
+    async def _keyword_search(self: Any, *args: Any, **kwargs: Any) -> list[Any]:
+        return [
+            SearchResult(
+                path="/kw.md", chunk_text="kw", score=1.0, chunk_index=0, search_type="keyword"
+            )
+        ]
+
+    daemon._keyword_search = MethodType(_keyword_search, daemon)
+
+    # Interactive contract: absent dense backend degrades to empty/keyword.
+    assert await daemon._semantic_search("q", 5, None, zone_id="root") == []
+
+    # Batch contract: an ABSENT backend is infrastructure, not a missing
+    # embedding — even with a valid precomputed vector in hand.
+    with pytest.raises(VectorBackendUnavailableError):
+        await daemon._semantic_search(
+            "q", 5, None, zone_id="root", query_vector=[0.1], propagate_failures=True
+        )
+
+    # ...and the hybrid gather helper must NOT suppress it (that carve-out is
+    # only for a genuinely missing embedding), so incomplete dense coverage
+    # cannot masquerade as a keyword-only success.
+    with pytest.raises(VectorBackendUnavailableError):
+        await daemon._hybrid_search(
+            "q", 4, None, 0.5, "rrf", zone_id="root", propagate_failures=True
+        )

--- a/tests/unit/bricks/search/test_daemon_batch_search.py
+++ b/tests/unit/bricks/search/test_daemon_batch_search.py
@@ -1,0 +1,118 @@
+"""Batch search plumbing: pre-computed query_vector threads through the daemon.
+
+SearchRequest.query_vector allows the batch endpoint to embed all unique queries
+once and hand each inner search its vector, bypassing redundant per-search embeds.
+Tests pin the thread and the embed-skip logic.
+"""
+
+from __future__ import annotations
+
+from types import MethodType
+from typing import Any
+
+import pytest
+
+
+def _make_daemon() -> Any:
+    """Bare SearchDaemon with fake (non-PG) fts + vector backends.
+
+    Fixture corpus is built so keyword and dense orderings disagree:
+      keyword (BM25):  /a.md (10.0) > /b.md (9.0) > /c.md (8.0)
+      dense  (cosine): /d.md (0.99) > /c.md (0.9) > /a.md (0.5)
+    so any change of fusion method / alpha / k is visible in the ordering.
+    """
+    from nexus.bricks.search.daemon import DaemonConfig, SearchDaemon, SearchResult
+
+    def _kw(path: str, score: float) -> SearchResult:
+        return SearchResult(
+            path=path, chunk_text=path, score=score, chunk_index=0, search_type="keyword"
+        )
+
+    def _dense(path: str, score: float) -> SearchResult:
+        return SearchResult(
+            path=path, chunk_text=path, score=score, chunk_index=0, search_type="semantic"
+        )
+
+    class FakeFtsBackend:
+        async def keyword_search(
+            self,
+            query: str,
+            path: str,
+            limit: int,
+            zone_id: str,
+            *,
+            timing: dict[str, float] | None = None,
+        ) -> list[Any]:
+            return [_kw("/a.md", 10.0), _kw("/b.md", 9.0), _kw("/c.md", 8.0)]
+
+    class FakeVectorBackend:
+        async def semantic_search(
+            self, qvec: list[float], path: str, limit: int, zone_id: str
+        ) -> list[Any]:
+            return [_dense("/d.md", 0.99), _dense("/c.md", 0.9), _dense("/a.md", 0.5)]
+
+    async def _embed_query(self: Any, query: str) -> list[float]:
+        return [0.1, 0.2]
+
+    daemon: Any = SearchDaemon.__new__(SearchDaemon)
+    daemon.last_search_timing = {}
+    daemon._fts_backend = FakeFtsBackend()
+    daemon._vector_backend = FakeVectorBackend()
+    # Title arm (#4545) is on by default; bare __new__ skips __init__, so
+    # give locate() an empty skeleton index (no hits → fusion unchanged).
+    daemon._skeleton_docs = {}
+    daemon._skeleton_title_index = {}
+    daemon._skeleton_path_index = {}
+    daemon._skeleton_exact_title_index = {}
+    daemon._embed_query = MethodType(_embed_query, daemon)
+    # Disable #4542 final-list page pooling: these tests assert chunk-grain
+    # fusion ordering, which pooling would re-group.
+    daemon.config = DaemonConfig(page_aggregation=False)
+    return daemon
+
+
+class _CountingEmbed:
+    """Records embed calls made through daemon._embed_query."""
+
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    async def __call__(self, daemon: Any, query: str) -> list[float]:
+        self.calls.append(query)
+        return [0.1, 0.2]
+
+
+@pytest.mark.asyncio
+async def test_query_vector_override_skips_embed() -> None:
+    daemon = _make_daemon()
+    counter = _CountingEmbed()
+    daemon._embed_query = MethodType(counter.__call__, daemon)
+
+    results = await daemon._search_via_backends(
+        "hello",
+        search_type="hybrid",
+        limit=5,
+        path_filter=None,
+        zone_id="root",
+        query_vector=[0.3, 0.4],
+    )
+
+    assert counter.calls == []
+    assert results  # fused hybrid results still produced
+
+
+@pytest.mark.asyncio
+async def test_no_query_vector_still_embeds() -> None:
+    daemon = _make_daemon()
+    counter = _CountingEmbed()
+    daemon._embed_query = MethodType(counter.__call__, daemon)
+
+    await daemon._search_via_backends(
+        "hello",
+        search_type="hybrid",
+        limit=5,
+        path_filter=None,
+        zone_id="root",
+    )
+
+    assert counter.calls == ["hello"]

--- a/tests/unit/bricks/search/test_daemon_batch_search.py
+++ b/tests/unit/bricks/search/test_daemon_batch_search.py
@@ -1070,3 +1070,142 @@ async def test_exhausted_permit_pool_cannot_wedge_a_later_batch(monkeypatch) -> 
 
     release.set()
     await asyncio.sleep(0.1)
+
+
+@pytest.mark.asyncio
+async def test_healthy_queued_waves_get_a_full_execution_budget() -> None:
+    import asyncio
+
+    daemon = _make_batch_daemon()
+    # Concurrency 1 forces three waves; each search takes longer than the
+    # queue wait it sits through.
+    daemon.config = type(daemon.config)(
+        batch_search_concurrency=1,
+        query_timeout_seconds=0.1,
+        batch_search_timeout_seconds=5.0,
+    )
+
+    async def fake_search(self: Any, request: Any) -> list[Any]:
+        await asyncio.sleep(0.06)
+        return []
+
+    daemon.search = MethodType(fake_search, daemon)
+
+    out = await daemon._batch_search_on_current_loop(
+        [{"query": "a"}, {"query": "b"}, {"query": "c"}], zone_id="root"
+    )
+
+    # Queue time is charged to the batch deadline, not to each query's own
+    # execution budget — every healthy wave must complete.
+    assert out == [[], [], []], out
+
+
+@pytest.mark.asyncio
+async def test_timed_out_pre_embed_probe_does_not_drain_the_permit_pool(monkeypatch) -> None:
+    import asyncio
+
+    from nexus.bricks.search import daemon as daemon_module
+
+    monkeypatch.setattr(daemon_module, "_BATCH_CANCEL_DRAIN_SECONDS", 0.05)
+
+    daemon = _make_batch_daemon()
+    daemon.config = type(daemon.config)(
+        batch_search_concurrency=8,
+        query_timeout_seconds=0.05,
+        batch_search_timeout_seconds=1.0,
+    )
+    release = asyncio.Event()
+
+    class ResistantEmbeddingClient:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def embed_batch(self, texts: Any) -> list[list[float]]:
+            self.calls += 1
+            inner = asyncio.ensure_future(release.wait())
+            while not inner.done():
+                try:
+                    await asyncio.shield(inner)
+                except asyncio.CancelledError:
+                    current = asyncio.current_task()
+                    if current is not None:
+                        current.uncancel()
+            return [[0.1, 0.2] for _ in texts]
+
+    client = ResistantEmbeddingClient()
+    daemon._embedding_client = client
+
+    async def fake_search(self: Any, request: Any) -> list[Any]:
+        return []
+
+    daemon.search = MethodType(fake_search, daemon)
+
+    await daemon._batch_search_on_current_loop(
+        [{"query": f"q{i}", "search_type": "hybrid"} for i in range(8)], zone_id="root"
+    )
+
+    # A timed-out probe stops isolation: exactly one provider task is left
+    # holding a permit, so later batches still have capacity.
+    assert client.calls == 1, client.calls
+    assert len(daemon._abandoned_batch_tasks) == 1
+
+    release.set()
+    await asyncio.sleep(0.1)
+
+
+@pytest.mark.asyncio
+async def test_resistant_path_context_refresh_cannot_hold_the_response(monkeypatch) -> None:
+    import asyncio
+    import time
+    from unittest.mock import MagicMock
+
+    from nexus.bricks.search import daemon as daemon_module
+
+    monkeypatch.setattr(daemon_module, "_BATCH_CANCEL_DRAIN_SECONDS", 0.05)
+
+    daemon = _make_batch_daemon()
+    daemon.config = type(daemon.config)(
+        batch_search_concurrency=4,
+        query_timeout_seconds=0.05,
+        batch_search_timeout_seconds=0.3,
+    )
+    release = asyncio.Event()
+
+    class ResistantCache:
+        async def refresh_if_stale(self, zone_id: str) -> None:
+            inner = asyncio.ensure_future(release.wait())
+            while not inner.done():
+                try:
+                    await asyncio.shield(inner)
+                except asyncio.CancelledError:
+                    current = asyncio.current_task()
+                    if current is not None:
+                        current.uncancel()
+
+        def snapshot_zone(self, zone_id: str) -> None:
+            return None
+
+    daemon._resolve_path_context_cache = MagicMock(
+        return_value=asyncio.sleep(0, result=ResistantCache())
+    )
+    # The attach block's fail-soft counters live on the daemon's stats object,
+    # which a bare __new__ daemon does not have.
+    from nexus.bricks.search.daemon import DaemonStats
+
+    daemon.stats = DaemonStats()
+
+    async def fake_search(self: Any, request: Any) -> list[Any]:
+        return []
+
+    daemon.search = MethodType(fake_search, daemon)
+
+    started = time.monotonic()
+    out = await daemon._batch_search_on_current_loop([{"query": "a"}], zone_id="root")
+    elapsed = time.monotonic() - started
+
+    # The fail-soft refresh must not hold the response open past the deadline.
+    assert elapsed < 3.0, f"path-context refresh escaped the deadline ({elapsed:.2f}s)"
+    assert out == [[]]
+
+    release.set()
+    await asyncio.sleep(0.1)

--- a/tests/unit/bricks/search/test_daemon_fusion_params.py
+++ b/tests/unit/bricks/search/test_daemon_fusion_params.py
@@ -234,7 +234,15 @@ def _make_fallback_daemon() -> Any:
         ]
 
     async def _semantic_search(
-        self: Any, query: str, limit: int, path_filter: Any, *, zone_id: Any = None
+        self: Any,
+        query: str,
+        limit: int,
+        path_filter: Any,
+        *,
+        zone_id: Any = None,
+        query_vector: list[float] | None = None,
+        propagate_failures: bool = False,
+        embedding_unavailable: bool = False,
     ) -> list[Any]:
         return [
             _res("/d.md", 0.99, "semantic"),
@@ -347,6 +355,8 @@ async def test_search_threads_fusion_params_to_fallback() -> None:
         rrf_k: int = 60,
         *,
         zone_id: Any = None,
+        query_vector: list[float] | None = None,
+        embedding_unavailable: bool = False,
     ) -> list[SearchResult]:
         seen.update({"alpha": alpha, "fusion_method": fusion_method, "rrf_k": rrf_k})
         return []
@@ -533,7 +543,15 @@ async def test_fallback_empty_semantic_leg_stamps_non_default_degraded() -> None
     daemon = _make_fallback_daemon()
 
     async def _semantic_search(
-        self: Any, query: str, limit: int, path_filter: Any, *, zone_id: Any = None
+        self: Any,
+        query: str,
+        limit: int,
+        path_filter: Any,
+        *,
+        zone_id: Any = None,
+        query_vector: list[float] | None = None,
+        propagate_failures: bool = False,
+        embedding_unavailable: bool = False,
     ) -> list[Any]:
         return []
 

--- a/tests/unit/bricks/search/test_daemon_fusion_params.py
+++ b/tests/unit/bricks/search/test_daemon_fusion_params.py
@@ -357,6 +357,7 @@ async def test_search_threads_fusion_params_to_fallback() -> None:
         zone_id: Any = None,
         query_vector: list[float] | None = None,
         embedding_unavailable: bool = False,
+        propagate_failures: bool = False,
     ) -> list[SearchResult]:
         seen.update({"alpha": alpha, "fusion_method": fusion_method, "rrf_k": rrf_k})
         return []

--- a/tests/unit/bricks/search/test_daemon_zone_runner.py
+++ b/tests/unit/bricks/search/test_daemon_zone_runner.py
@@ -73,6 +73,7 @@ async def test_search_with_zone_stays_on_daemon_owner_loop() -> None:
         fusion_method: str,
         rrf_k: int,
         zone_id: str | None,
+        query_vector: list[float] | None = None,
     ) -> list[str]:
         seen.append((asyncio.get_running_loop(), threading.get_ident(), zone_id))
         return [query, search_type, str(limit), str(path_filter), str(alpha), fusion_method]

--- a/tests/unit/bricks/search/test_daemon_zone_runner.py
+++ b/tests/unit/bricks/search/test_daemon_zone_runner.py
@@ -74,6 +74,8 @@ async def test_search_with_zone_stays_on_daemon_owner_loop() -> None:
         rrf_k: int,
         zone_id: str | None,
         query_vector: list[float] | None = None,
+        propagate_failures: bool = False,
+        embedding_unavailable: bool = False,
     ) -> list[str]:
         seen.append((asyncio.get_running_loop(), threading.get_ident(), zone_id))
         return [query, search_type, str(limit), str(path_filter), str(alpha), fusion_method]

--- a/tests/unit/bricks/search/test_final_list_page_pooling.py
+++ b/tests/unit/bricks/search/test_final_list_page_pooling.py
@@ -724,6 +724,9 @@ async def test_legacy_hybrid_fallback_caps_at_shared_boundary() -> None:
         rrf_k: int = 60,
         *,
         zone_id: str | None = None,
+        query_vector: list[float] | None = None,
+        embedding_unavailable: bool = False,
+        propagate_failures: bool = False,
     ) -> list[SearchResult]:
         legacy_limits.append(limit)
         rows = [_chunk("/long.md", i, 10.0 - i) for i in range(4)] + [

--- a/tests/unit/bricks/search/test_sandbox_hybrid_rrf.py
+++ b/tests/unit/bricks/search/test_sandbox_hybrid_rrf.py
@@ -75,22 +75,17 @@ class _FakeDaemon:
         self._rows = rows
         self.calls: list[dict[str, Any]] = []
 
-    async def search(
-        self,
-        *,
-        query: str,
-        search_type: str,
-        limit: int,
-        path_filter: str | None,
-        zone_id: str | None,
-    ) -> list[_DaemonRow]:
+    async def search(self, request: Any) -> list[_DaemonRow]:
+        # Mirrors the real contract: SearchDaemon.search() takes a single
+        # SearchRequest. A kwargs-shaped double silently diverged from
+        # production and hid a live TypeError in the keyword lane.
         self.calls.append(
             {
-                "query": query,
-                "search_type": search_type,
-                "limit": limit,
-                "path_filter": path_filter,
-                "zone_id": zone_id,
+                "query": request.query,
+                "search_type": request.search_type,
+                "limit": request.limit,
+                "path_filter": request.path_filter,
+                "zone_id": request.zone_id,
             }
         )
         if isinstance(self._rows, Exception):


### PR DESCRIPTION
Fixes #4582.

Restores `POST /api/v2/search/query/batch` to its documented contract and gives it single-`/query` parity. Design doc: `docs/superpowers/specs/2026-08-04-batch-search-hardening-design.md` (committed on this branch).

## What changed

**Contract restoration**

- **Concurrent inner searches.** `_batch_search_on_current_loop` replaces its sequential `for ... await` loop with a bounded fan-out — `DaemonConfig.batch_search_concurrency`, env `NEXUS_SEARCH_BATCH_CONCURRENCY` (default 8, `1` restores sequential execution as an ops fallback). Owner-loop safe: `_run_on_owner_loop` has a same-loop shortcut.
- **Embed once per batch.** Unique non-keyword query texts are embedded in ONE `embed_batch` call; each inner search receives its vector via a new optional `SearchRequest.query_vector` and skips its own embed step — including on the legacy `_semantic_search` / `_hybrid_search` fallbacks that run whenever an indexed lookup comes back empty.
- **Param parity.** Batch specs accept the single-`/query` public names (`q`, `type`, `limit`, `path`, `alpha`, `fusion`, `rrf_k`, `expand`, `recency`, `recency_weight`, `recency_half_life_days`) with legacy aliases (`query`/`search_type`/`path_filter`/`fusion_method`) preserved; public name wins by key presence. Numeric bounds and enum sets mirror the single route exactly. Parsing lives in a new `_search_batch.py` helper (the router sits near the 2000-line cap).
- **Serializer parity.** Batch hits go through the shared `_serialize_search_result`, so entries gain `chunk_index`, `line_start`/`line_end`, `splade_score`, `reranker_score`, and the conditional `title_score`/`context`/`tier_boost`/`recency_boost`/`semantic_degraded`/`macro_*` fields — pinned by a byte-equality test against the single route.
- **Per-query error surfacing.** An invalid spec or failed inner search yields `{"query": ..., "results": [], "total": 0, "error": "<msg>"}` instead of a silent `[]`. Absence of `error` means the result set is genuine. Messages are stable sanitized constants; full exception detail stays in server logs.
- **ReBAC parity.** Over-fetch uses the shared `compute_rebac_fetch_limit`; filtering and trim-to-requested-limit unchanged.

**Hardening (11 rounds of adversarial review, 22 findings)**

- **Failure fidelity.** `SearchRequest.propagate_failures` makes batch mode raise where the interactive path degrades to `[]` (query timeout, legacy semantic backend errors, missing embedding on a semantic-only search), so a failed search can never be reported as a healthy empty. `VectorBackendUnavailableError` distinguishes an absent/failed dense backend from a missing query embedding — only the latter is legitimate hybrid keyword-only degradation.
- **One deadline for the whole request.** A single monotonic deadline computed at method entry governs pre-embed, permit waits, the fan-out, cancellation drain, and the path-context refresh. Queue time is charged to that batch deadline while each admitted operation still gets a fresh `min(query_timeout, remaining)` execution window. The set pending at expiry is authoritative for settlement, so a search that finishes during cancellation cleanup — or swallows its cancellation and returns late — settles as a timeout rather than a healthy result. Env: `NEXUS_SEARCH_BATCH_TIMEOUT` (default 120s).
- **Embedding failure isolation.** A failed shared `embed_batch` is classified by bounded bisection (budget scales with batch size, so a single bad input is still isolated at the documented 470-500 query workload): independently-bad inputs in different halves are each isolated (healthy siblings keep their vectors), while a genuine outage is settled by one probe of a known-valid control text and degrades the batch once with no per-text retry storm. A timed-out probe stops isolation immediately.
- **Resource accounting.** Permits follow real in-flight work: each operation runs as its own task whose completion callback releases the permit, so a cancellation-resistant search that outlives its timeout keeps consuming capacity instead of letting the next request start work behind it. Pools are **separate per class** (search / embedding / path-context refresh) so stuck ancillary work can never starve query execution. Caller cancellation always propagates and is never converted into per-query failures.
- **Cardinality cap.** `DaemonConfig.batch_search_max_queries` (env `NEXUS_SEARCH_BATCH_MAX_QUERIES`, default 500 — preserves the documented 470-query benchmark workload) with a route-level 400, since every accepted query becomes a task before the concurrency limit applies.
- **Request validation.** Malformed JSON, non-object JSON roots, and oversized batches return 400 instead of 500.

**Adjacent pre-existing bug found by live testing (fixed here)**

Standing up a real stack (`nexus up --build`) and running
`scripts/test_build_perf_e2e.py` surfaced that four PRODUCTION callers still
invoke `SearchDaemon.search()` with keyword arguments after it was refactored
to take a single `SearchRequest`: the keyword lane, keyword search, and
semantic search in `search_service.py`, plus `graph_search_service.py`. Each
raises `SearchDaemon.search() got an unexpected keyword argument 'query'` at
runtime, so `nexus search query`, graph search, and the `semantic_search` RPC
are broken on `develop` today. Reproduced on `origin/develop`; this shares its
root cause with the pre-existing test failures disclosed below, but these are
live code paths rather than stale doubles. Fixed in this branch because the
requested e2e validation cannot pass without it — happy to split it into its
own PR if maintainers prefer. The `_FakeDaemon` double in
`test_sandbox_hybrid_rrf.py` is updated to the real contract too; being
kwargs-shaped is how it let the broken call sites reach `develop` unnoticed.

## Compatibility

- Response changes are additive only; request aliases keep working. In-repo consumers checked: `scripts/test_read_gate_e2e.py` (status-code assertions), the #4557 zone-set read-gate tests (pass unchanged). No MCP tool, SDK, or benchmark harness consumes `batch_search` directly.
- Behavior changes for degenerate inputs, intentionally aligned with `/query`: empty/absent query text, out-of-range numerics, and invalid enum values now yield per-query `error` entries where the old route silently searched (or silently ran hybrid on a typo'd `type`); a non-list `queries` value is now 400 (previously a string yielded per-char 200 entries and an int crashed with 500).
- No schema/alembic delta.

## Evidence

- **Unit/daemon** (`tests/unit/bricks/search/test_daemon_batch_search.py`, 37 tests): embed-once (24 same-text specs → exactly 1 `embed_batch` call), `query_vector` override skips `_embed_query`, keyword-only never embeds, concurrency bound respected, per-query failure isolation, sanitized error messages, timeout settlement (including a search that suppresses cancellation and returns late), deadline coverage of the pre-embed phase, single- and multi-bad-input isolation, bounded outage classification, permit accounting for abandoned work, healthy multi-wave batches under concurrency 1, and per-class pool isolation (a stuck embed still permits the hybrid keyword fallback; a stuck refresh does not block the next keyword-only batch).
- **Router** (`tests/integration/services/test_search_query_batch.py`, 56 tests): alias precedence by key presence, bounds + enum validation, serializer byte-parity, error entries for invalid specs and daemon failures, invalid specs never reaching the daemon, all-invalid batches skipping the daemon call, malformed/non-object bodies, and the cardinality cap.
- **Full `tests/unit/bricks/search` suite green**; pre-commit (ruff, mypy, file caps, boundary checks) green across the whole branch; `search.py` at 1782 lines.
- **Live e2e** (`test_search_surface_live_e2e.py`): mixed-type batch + single-`/query` parity + per-query error isolation added after the existing batch block. Honest caveat: the module carries a pre-existing non-strict `xfail` (documented glob fixture gap upstream of the batch block), so these assertions were validated via an isolated live probe against a booted self-contained server rather than gating in CI.
- **Live stack** (`nexus up --build` from this branch's source, demo preset):
  `scripts/test_build_perf_e2e.py` → **23 passed, 0 failed** (exit 0). Before the
  `daemon.search()` call-site fix it was 20 passed / 3 failed; the three failures
  were the CLI search path dying on the `TypeError` above.
- **Live batch-endpoint exercise** against that same stack — 24 checks, all
  passing: positional query mapping, healthy entries carrying no `error`, a
  genuine empty result returning `total: 0` with **no** `error` key, hit-dict
  byte-parity against single `/query` (including `chunk_index` and
  `line_start`/`line_end`), tuning params accepted, per-query validation errors
  isolated from valid siblings, batch-level 400s (empty / non-object root /
  malformed JSON / over-cap), a 500-query batch at the cap returning 500
  entries, and legacy-alias specs still working.
- **Bench** (self-contained live server, 24 hybrid specs sharing one query text, medians of 3): batch endpoint latency 40.8 ms → **33.4 ms**; batch vs 24 sequential single-`/query` GETs speedup 2.8× → **4.1×**. Two caveats, stated plainly: these were measured at commit `f485493`, i.e. **before** the hardening commits above, and the fixture has no embedding key so hybrid degrades to keyword server-side — the numbers reflect concurrency and request-count effects only. The embedding amortisation (24 → 1 provider calls for a same-text fan-out, the dominant win on real deployments) is evidenced by the embed-once unit test, not by this bench.

## Pre-existing failures (disclosure, not introduced here)

27 test failures + 1 collect error reproduce identically at `origin/develop` (verified in a scratch worktree): 6 in `test_search_zone_set.py` single-`/query` tests + 20 in federated-search tests (both from the pre-branch `search(SearchRequest)` positional-call refactor vs `mock_search(**kwargs)` stubs), 1 sqlite test, and a `test_brick_compliance` collect-time ImportError. This branch fixes the test doubles it broke itself (`test_daemon_zone_runner.py`, `test_daemon_fusion_params.py`, `test_final_list_page_pooling.py` — all now accept the new keyword-only params) and leaves the pre-existing ones untouched.

## Follow-ups (non-blocking)

- Extract the batch e2e block from the xfailed module once its fixture gap is fixed, so these assertions gate in CI.
- Re-measure the bench on the final branch state if the numbers are load-bearing for a decision.
- Downstream adoption (koodle cross-workspace fan-out) tracked in DeepBuildAI/koodle#2050.
