### PR TITLE
search: keyword-only deployments must degrade, not fail, on the batch path

### DIFF
--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -4898,9 +4898,18 @@ class SearchDaemon:
                 # Raise real backend errors so the gather helper can apply
                 # the batch policy; missing-embedding degradation is carved
                 # out there (hybrid legitimately serves keyword-only then).
-                propagate_failures=propagate_failures,
+                #
+                # An ABSENT dense backend is different from a broken one: a
+                # deployment with no vector backend configured (SQLite without
+                # sqlite-vec, no embedding provider) is a valid keyword-only
+                # mode, and single /query degrades to keyword there. Turning
+                # that deployment property into a per-query batch failure would
+                # make batch and single disagree on the same healthy install,
+                # so the dense leg only propagates when a backend actually
+                # exists to fail.
+                propagate_failures=propagate_failures and self._vector_backend is not None,
             ),
-            propagate_failures=propagate_failures,
+            propagate_failures=propagate_failures and self._vector_backend is not None,
         )
 
         fusion_config = FusionConfig(

--- a/tests/e2e/self_contained/test_search_surface_live_e2e.py
+++ b/tests/e2e/self_contained/test_search_surface_live_e2e.py
@@ -251,51 +251,6 @@ def test_live_search_http_surface_correctness_and_latency(live_search_app: LiveS
     )
     _assert_endpoint_latency(batch_body)
 
-    # Hardened batch contract: single-/query serializer parity, tuning
-    # params accepted, healthy entries carry no error field.
-    parity_response, parity_body = _request(
-        live,
-        "post",
-        "/api/v2/search/query/batch",
-        json={
-            "queries": [
-                {"q": "needle", "type": "keyword", "limit": 5},
-                {"q": "needle", "type": "hybrid", "limit": 5, "alpha": 0.3, "fusion": "weighted"},
-                {"q": "needle", "type": "semantic", "limit": 5},
-            ]
-        },
-    )
-    assert parity_response.status_code == 200
-    assert parity_body["total_queries"] == 3
-    for entry in parity_body["queries"]:
-        assert "error" not in entry, entry
-    single_response, single_body = _request(
-        live,
-        "get",
-        "/api/v2/search/query",
-        params={"q": "needle", "type": "keyword", "limit": 5},
-    )
-    assert single_response.status_code == 200
-    batch_keyword_results = parity_body["queries"][0]["results"]
-    single_results = single_body["results"]
-    assert [r["path"] for r in batch_keyword_results] == [r["path"] for r in single_results]
-    # Field-shape parity: every key the single route emits appears in the
-    # batch entry with the same value (single may add response-envelope
-    # keys, so compare per-hit dicts directly).
-    for batch_hit, single_hit in zip(batch_keyword_results, single_results, strict=True):
-        assert batch_hit == single_hit
-
-    # Per-query error isolation: an invalid spec errors alone.
-    mixed_response, mixed_body = _request(
-        live,
-        "post",
-        "/api/v2/search/query/batch",
-        json={"queries": [{"q": "needle", "limit": 0}, {"q": "needle", "limit": 2}]},
-    )
-    assert mixed_response.status_code == 200
-    assert "limit" in mixed_body["queries"][0]["error"]
-    assert "error" not in mixed_body["queries"][1]
-
     refresh_response, refresh_body = _request(
         live,
         "post",
@@ -405,3 +360,110 @@ def test_live_search_http_surface_correctness_and_latency(live_search_app: LiveS
         time.sleep(0.1)
     assert any(c["path"] == "/workspace/src/main.py" for c in locate_body["candidates"])
     _assert_endpoint_latency(locate_body, key="elapsed_ms")
+
+
+def test_live_batch_search_contract(live_search_app: LiveSearchApp) -> None:
+    """The hardened `/query/batch` contract, gated in CI.
+
+    Deliberately NOT part of
+    ``test_live_search_http_surface_correctness_and_latency``: that test is
+    xfailed for an unrelated reason (its glob/grep assertions need a file
+    index the TestClient fixture never populates), which silently made these
+    batch assertions dormant. This test seeds its own corpus through the
+    explicit `/search/index` endpoint, so it depends on nothing the xfail
+    covers and actually fails CI when the batch contract regresses.
+    """
+    live = live_search_app
+
+    # The fixture starts empty and `/search/index` resolves path_id from the
+    # file_paths projection, so the file must exist before it is indexed —
+    # otherwise the call burns its full projection-wait budget and 409s.
+    live.nx.mkdir("/workspace", exist_ok=True)
+    live.nx.write(
+        "/workspace/batch-contract.md",
+        b"# Batch Contract\nhaystack marker for the batch contract test\n",
+    )
+
+    index_response, index_body = _request(
+        live,
+        "post",
+        "/api/v2/search/index",
+        max_wall_ms=15_000.0,
+        json={
+            "documents": [
+                {
+                    "id": "/workspace/batch-contract.md",
+                    "path": "/workspace/batch-contract.md",
+                    "text": "haystack marker for the batch contract test",
+                }
+            ]
+        },
+    )
+    assert index_response.status_code == 200
+    assert index_body["count"] == 1
+
+    single_response, single_body = _request(
+        live,
+        "get",
+        "/api/v2/search/query",
+        params={"q": "haystack", "type": "keyword", "limit": 5},
+    )
+    assert single_response.status_code == 200
+
+    batch_response, batch_body = _request(
+        live,
+        "post",
+        "/api/v2/search/query/batch",
+        json={
+            "queries": [
+                {"q": "haystack", "type": "keyword", "limit": 5},
+                {"q": "haystack", "type": "hybrid", "limit": 5, "alpha": 0.3, "fusion": "weighted"},
+                {"q": "haystack", "type": "semantic", "limit": 5},
+            ]
+        },
+    )
+    assert batch_response.status_code == 200
+    assert batch_body["total_queries"] == 3
+    # Lanes this deployment can serve report NO error — absence of the key is
+    # the signal that an empty result set is genuine. Hybrid is included: a
+    # fixture with no embedding provider must DEGRADE to keyword-only, exactly
+    # as single `/query` does, not fail the query.
+    for entry in batch_body["queries"][:2]:
+        assert "error" not in entry, entry
+    # A semantic-ONLY query is different: the caller asked for dense retrieval
+    # this deployment cannot serve, so it must report the typed failure rather
+    # than masquerading as a healthy empty result.
+    semantic_entry = batch_body["queries"][2]
+    assert semantic_entry["error"] == "Vector backend unavailable", semantic_entry
+    assert semantic_entry["results"] == []
+    # Serializer + result parity with single `/query`.
+    assert [r["path"] for r in batch_body["queries"][0]["results"]] == [
+        r["path"] for r in single_body["results"]
+    ]
+    for batch_hit, single_hit in zip(
+        batch_body["queries"][0]["results"], single_body["results"], strict=True
+    ):
+        assert batch_hit == single_hit
+    _assert_endpoint_latency(batch_body)
+
+    # A per-query problem stays isolated to its own entry.
+    mixed_response, mixed_body = _request(
+        live,
+        "post",
+        "/api/v2/search/query/batch",
+        json={"queries": [{"q": "haystack", "limit": 0}, {"q": "haystack", "limit": 2}]},
+    )
+    assert mixed_response.status_code == 200
+    assert "limit" in mixed_body["queries"][0]["error"]
+    assert "error" not in mixed_body["queries"][1]
+
+    # Batch-level failures stay whole-request.
+    empty_response, _ = _request(live, "post", "/api/v2/search/query/batch", json={"queries": []})
+    assert empty_response.status_code == 400
+    oversize_response, _ = _request(
+        live,
+        "post",
+        "/api/v2/search/query/batch",
+        json={"queries": [{"q": f"q{i}"} for i in range(501)]},
+    )
+    assert oversize_response.status_code == 400

--- a/tests/unit/bricks/search/test_daemon_batch_search.py
+++ b/tests/unit/bricks/search/test_daemon_batch_search.py
@@ -712,13 +712,15 @@ async def test_missing_vector_backend_is_distinct_from_missing_embedding() -> No
             "q", 5, None, zone_id="root", query_vector=[0.1], propagate_failures=True
         )
 
-    # ...and the hybrid gather helper must NOT suppress it (that carve-out is
-    # only for a genuinely missing embedding), so incomplete dense coverage
-    # cannot masquerade as a keyword-only success.
-    with pytest.raises(VectorBackendUnavailableError):
-        await daemon._hybrid_search(
-            "q", 4, None, 0.5, "rrf", zone_id="root", propagate_failures=True
-        )
+    # Hybrid is the exception, and only for an ABSENT backend: a deployment
+    # with no dense backend configured is a valid keyword-only mode that
+    # single `/query` also degrades for, so batch must not turn it into a
+    # per-query failure. (A backend that EXISTS and throws still propagates —
+    # see test_hybrid_dense_backend_failure_fails_batch_query.)
+    degraded = await daemon._hybrid_search(
+        "q", 4, None, 0.5, "rrf", zone_id="root", propagate_failures=True
+    )
+    assert [r.path for r in degraded] == ["/kw.md"]
 
 
 @pytest.mark.asyncio
@@ -1363,3 +1365,40 @@ async def test_single_bad_input_isolates_at_documented_cardinality(batch_size) -
     assert all(r.query_vector == [0.1, 0.2] for r in captured)
     # Isolation stays logarithmic, not per-text.
     assert client.calls <= 40, client.calls
+
+
+@pytest.mark.asyncio
+async def test_absent_dense_backend_degrades_hybrid_but_fails_semantic() -> None:
+    """A keyword-only DEPLOYMENT is not a per-query failure.
+
+    An absent vector backend (SQLite without sqlite-vec, no embedding provider)
+    is a valid deployment mode, and single `/query` degrades hybrid to
+    keyword-only there. Batch must agree, or the two surfaces disagree on the
+    same healthy install. A semantic-ONLY query still fails typed: the caller
+    asked for dense retrieval this deployment cannot serve.
+    """
+    from nexus.bricks.search.daemon import (
+        SearchDaemon,
+        SearchResult,
+        VectorBackendUnavailableError,
+    )
+
+    daemon: Any = SearchDaemon.__new__(SearchDaemon)
+    daemon._vector_backend = None
+
+    async def _keyword_search(self: Any, *args: Any, **kwargs: Any) -> list[Any]:
+        return [
+            SearchResult(
+                path="/kw.md", chunk_text="kw", score=1.0, chunk_index=0, search_type="keyword"
+            )
+        ]
+
+    daemon._keyword_search = MethodType(_keyword_search, daemon)
+
+    out = await daemon._hybrid_search(
+        "q", 4, None, 0.5, "rrf", zone_id="root", propagate_failures=True
+    )
+    assert [r.path for r in out] == ["/kw.md"]
+
+    with pytest.raises(VectorBackendUnavailableError):
+        await daemon._semantic_search("q", 5, None, zone_id="root", propagate_failures=True)


### PR DESCRIPTION
Follow-up to #4583, found by closing a gap that PR left open.

## The gap

#4583 added live e2e assertions for the batch contract, but put them inside `test_live_search_http_surface_correctness_and_latency` — which is `xfail`ed for an unrelated reason (its glob/grep assertions need a file index the TestClient fixture never populates). So those assertions never gated CI. This PR re-homes them into their own `test_live_batch_search_contract`, which seeds its own corpus through `/search/index` and depends on nothing the xfail covers.

## The bug that gap was hiding

Running them immediately failed — and the failure was real.

#4583 introduced `VectorBackendUnavailableError` so an absent/failed dense backend could not masquerade as a healthy empty result. But **absent** and **broken** are not the same thing:

- a deployment with **no dense backend configured** (SQLite without sqlite-vec, no embedding provider) is a valid keyword-only mode, and single `/query` degrades hybrid to keyword-only there;
- batch was failing those hybrid queries outright.

So the two surfaces disagreed on the same healthy install. The self-contained e2e fixture reproduces it exactly — it deletes `OPENAI_API_KEY`, so every hybrid batch query returned `error: "Vector backend unavailable"` where single `/query` happily returned keyword hits.

## Fix

The hybrid dense leg now propagates only when a backend actually **exists** to fail:

```python
propagate_failures=propagate_failures and self._vector_backend is not None
```

A backend that exists and throws still fails the query (that check is unchanged, and still covered by `test_hybrid_dense_backend_failure_fails_batch_query`). A semantic-**only** query on a backendless deployment still reports the typed failure — the caller asked for dense retrieval this deployment cannot serve.

## Tests

- New gating `test_live_batch_search_contract`: serializer/result parity vs single `/query`, healthy lanes carry no `error`, hybrid degrades on a backendless fixture, semantic-only reports the typed failure, per-query errors stay isolated, and batch-level 400s (empty / over-cap).
- New `test_absent_dense_backend_degrades_hybrid_but_fails_semantic` unit regression.
- `test_missing_vector_backend_is_distinct_from_missing_embedding` updated: its hybrid assertion encoded the behavior this PR corrects.
- Full `tests/unit/bricks/search` + the batch/router/read-gate suites green; `tests/surface_coverage` unchanged at its baseline.