### PR TITLE
feat(search-plugin): P3 retrofit + P4 chunker/expand [WIP]

### DIFF
--- a/rust/services/proto/nexus/search/v1/search.proto
+++ b/rust/services/proto/nexus/search/v1/search.proto
@@ -229,9 +229,13 @@ message QueryRequest {
   // Per-document chunk cap for final-list pooling (#4542).  Prevents
   // one long file from monopolising the top-N when its per-chunk
   // scores dominate multiple result slots.  0 ⇒ no pooling (backward-
-  // compatible with the pre-P3 shape).  P1-P3 emit one chunk per
-  // file so pooling is a no-op at those phases; P4's real chunker
-  // makes it meaningful.
+  // compatible with the pre-P3 shape).
+  //
+  // OBSERVABLE from P4 onward — P4's chunker emits multiple chunks
+  // per file (heading + code-fence + token-budget aware), at which
+  // point this cap starts filtering.  P1-P3 kept the wire so callers
+  // don't churn when they upgrade; the field's value has no runtime
+  // effect until multi-chunk emission lands.
   uint32 chunks_per_page = 10;
 }
 

--- a/rust/services/proto/nexus/search/v1/search.proto
+++ b/rust/services/proto/nexus/search/v1/search.proto
@@ -229,14 +229,19 @@ message QueryRequest {
   // Per-document chunk cap for final-list pooling (#4542).  Prevents
   // one long file from monopolising the top-N when its per-chunk
   // scores dominate multiple result slots.  0 ⇒ no pooling (backward-
-  // compatible with the pre-P3 shape).
-  //
-  // OBSERVABLE from P4 onward — P4's chunker emits multiple chunks
-  // per file (heading + code-fence + token-budget aware), at which
-  // point this cap starts filtering.  P1-P3 kept the wire so callers
-  // don't churn when they upgrade; the field's value has no runtime
-  // effect until multi-chunk emission lands.
+  // compatible with the pre-P3 shape).  Observable from P4 onward
+  // once the chunker starts emitting multi-chunk-per-file sets.
   uint32 chunks_per_page = 10;
+
+  // ── Read-side expansion (P4, #4398) ────────────────────────────
+  //
+  // "none" | "macro"; empty ⇒ no expansion (default).  When set to
+  // "macro" each returned hit carries `expanded_context` with the
+  // concatenation of the previous + current + next chunk texts,
+  // so callers can render a section-sized snippet without a
+  // follow-up read.  Matches the Python SearchDaemon expand=macro
+  // contract.
+  string expand = 11;
 }
 
 message QueryResult {
@@ -266,6 +271,14 @@ message QueryResult {
   // Optional because P1 tolerates missing mtimes (e.g. streams).  Used
   // by P6's recency scoring.
   optional int64 mtime_ms = 6;
+
+  // Neighbouring-chunk context (P4, #4398).  Populated only when
+  // the request's `expand="macro"` — concatenation of the previous
+  // + current + next chunk texts under the same `path`, so callers
+  // render a section-sized snippet in one pass.  Absent (empty
+  // string) for `expand="none"` or when the source file has only
+  // this one chunk.
+  string expanded_context = 7;
 }
 
 message QueryResponse {

--- a/rust/services/search-plugin/src/ann_index.rs
+++ b/rust/services/search-plugin/src/ann_index.rs
@@ -17,24 +17,34 @@
 //! state; the kernel VFS is the corpus SSOT (same rule as the FTS
 //! index in `fts_index.rs`).
 //!
-//! # Id + path mapping
+//! # Id + (path, chunk_index) mapping
 //!
 //! HNSW works on `usize` ids.  We assign monotonic ids and keep
-//! `path → id` + `id → path` in the sidecar so:
+//! `(path, chunk_index) → id` + `id → (path, chunk_index)` in the
+//! sidecar so:
 //!
-//! 1. **Search results carry paths.** `hnsw_rs::Neighbour` returns
-//!    only the id; the sidecar's reverse map turns each id back into
-//!    a path.
+//! 1. **Search results carry (path, chunk_index).**
+//!    `hnsw_rs::Neighbour` returns only the id; the sidecar's
+//!    reverse map turns each id back into a path + chunk index.
+//!    P4's multi-chunk-per-file emission means the two fields
+//!    together are what identifies a doc — `path` alone would
+//!    collide across chunks of the same file.
 //!
-//! 2. **Re-indexing the same path is idempotent.** `hnsw_rs` has no
-//!    delete primitive — inserting `path_A` twice would leave two
-//!    graph nodes, doubling `path_A`'s recall weight.  Instead we
-//!    move the OLD id to a `shadowed` set and insert with a new id;
-//!    search post-filters shadowed hits before returning.  The
-//!    shadowed entries stay in the graph (waste memory), so a
-//!    periodic full rebuild is deferred to P5's indexing pipeline —
-//!    the same MetaStore-checkpoint moment that already schedules a
-//!    tantivy segment merge.
+//! 2. **Re-indexing the same chunk is idempotent.** `hnsw_rs` has
+//!    no delete primitive — inserting the same `(path, chunk)`
+//!    twice would leave two graph nodes, doubling the doc's recall
+//!    weight.  Instead we move the OLD id to a `shadowed` set and
+//!    insert with a new id; search post-filters shadowed hits
+//!    before returning.  The shadowed entries stay in the graph
+//!    (waste memory), so a periodic full rebuild is deferred to
+//!    P5's indexing pipeline — the same MetaStore-checkpoint moment
+//!    that already schedules a tantivy segment merge.
+//!
+//! 3. **Whole-file removal via [`delete_all_chunks`](AnnIndex::delete_all_chunks).**
+//!    A file's chunk count can change across reindexes — the caller
+//!    (`do_index` in service.rs) drops ALL chunks for a path before
+//!    inserting the freshly-chunked set, so an old chunk 3 that no
+//!    longer exists doesn't linger as a ghost hit.
 //!
 //! # Concurrency
 //!
@@ -85,36 +95,55 @@ const DEFAULT_CAPACITY: usize = 100_000;
 /// Result row returned by [`AnnIndex::search`].  Distance is the raw
 /// cosine distance (0.0 = identical, 2.0 = opposite); callers convert
 /// to a similarity score via `1.0 - distance` if they want the
-/// familiar "higher is better" shape.
+/// familiar "higher is better" shape.  `chunk_index` identifies which
+/// chunk of the source file this hit refers to (0 in P1-P3 = one
+/// chunk per file; real values from P4 onward).
 #[derive(Debug, Clone, PartialEq)]
 pub struct AnnHit {
     pub path: String,
+    pub chunk_index: u32,
     pub distance: f32,
+}
+
+/// Sidecar format version.  Bumped from v1 (path-keyed) to v2
+/// ((path, chunk_index)-keyed) at P4.  The `ann-<tag>-v2/` dir
+/// name in [`IndexManager::ann_dir`] means v1 and v2 indexes
+/// never share a directory; if a v1 sidecar somehow appears in a
+/// v2 dir the serde parse fails and `open_or_create` returns an
+/// AnnError::Open with the format-drift clue.
+const SIDECAR_VERSION: u32 = 2;
+
+fn sidecar_version_default() -> u32 {
+    SIDECAR_VERSION
+}
+
+/// One persisted mapping row.  Vec-of-struct instead of a
+/// HashMap<(String,u32), usize> because JSON keys must be strings;
+/// a Vec keeps the on-disk shape trivial and the in-memory lookup
+/// table (`chunk_to_id`) is derived on load.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+struct SidecarEntry {
+    path: String,
+    chunk_index: u32,
+    id: usize,
 }
 
 /// On-disk state that survives restarts.  `Hnsw` itself is dumped by
 /// hnsw_rs into its own two files; this JSON captures everything
-/// else (id counter, path ↔ id mappings, shadowed-id set).
+/// else (id counter, (path, chunk_index) ↔ id mappings, shadowed-id
+/// set).
 #[derive(Debug, Serialize, Deserialize, Default)]
 struct Sidecar {
+    #[serde(default = "sidecar_version_default")]
+    version: u32,
     next_id: usize,
-    path_to_id: HashMap<String, usize>,
+    #[serde(default)]
+    entries: Vec<SidecarEntry>,
     /// Ids no longer valid — their doc was re-indexed under a new
-    /// id.  Search post-filter drops these before returning hits.
+    /// id, or their whole file was reindexed with a new chunk shape.
+    /// Search post-filter drops these before returning hits.
+    #[serde(default)]
     shadowed: HashSet<usize>,
-}
-
-impl Sidecar {
-    /// Rebuild the reverse map (`id → path`) from `path_to_id`.  Not
-    /// stored to disk — cheap to derive on load, and keeping it out
-    /// of the JSON avoids the two mappings drifting when the file is
-    /// hand-edited (a debug/support workflow we want to preserve).
-    fn id_to_path(&self) -> HashMap<usize, String> {
-        self.path_to_id
-            .iter()
-            .map(|(p, id)| (*id, p.clone()))
-            .collect()
-    }
 }
 
 /// One per-zone HNSW vector index.  Cheap to clone (`Arc` inside).
@@ -123,10 +152,15 @@ pub struct AnnIndex {
     dir: PathBuf,
     hnsw: Hnsw<'static, f32, DistCosine>,
     sidecar: RwLock<Sidecar>,
-    /// Cached reverse map — regenerated on every write to keep search
-    /// path lookups O(1) without holding the sidecar RwLock for the
-    /// whole search.
-    id_to_path: RwLock<HashMap<usize, String>>,
+    /// In-memory lookup: `(path, chunk_index) → id`.  Used by
+    /// add_vector to detect re-index and rotate the old id into
+    /// `shadowed`.  Rebuilt from `sidecar.entries` on load; kept in
+    /// sync with the sidecar on every write.
+    chunk_to_id: RwLock<HashMap<(String, u32), usize>>,
+    /// Cached reverse map: `id → (path, chunk_index)`.  Regenerated
+    /// on every write so search's path lookup stays O(1) without
+    /// holding the sidecar RwLock for the whole search.
+    id_to_chunk: RwLock<HashMap<usize, (String, u32)>>,
 }
 
 impl AnnIndex {
@@ -159,6 +193,15 @@ impl AnnIndex {
                 .map_err(|e| AnnError::Open(sidecar_path.display().to_string(), e.to_string()))?;
             let sidecar: Sidecar = serde_json::from_slice(&bytes)
                 .map_err(|e| AnnError::Open(sidecar_path.display().to_string(), e.to_string()))?;
+            if sidecar.version != SIDECAR_VERSION {
+                return Err(AnnError::Open(
+                    sidecar_path.display().to_string(),
+                    format!(
+                        "sidecar version {} ≠ expected {}; drop this dir and reindex",
+                        sidecar.version, SIDECAR_VERSION,
+                    ),
+                ));
+            }
             (hnsw, sidecar)
         } else {
             let hnsw = Hnsw::<f32, DistCosine>::new(
@@ -168,28 +211,41 @@ impl AnnIndex {
                 HNSW_EF_CONSTRUCTION,
                 DistCosine {},
             );
-            (hnsw, Sidecar::default())
+            let mut side = Sidecar::default();
+            side.version = SIDECAR_VERSION;
+            (hnsw, side)
         };
 
-        let id_to_path = sidecar.id_to_path();
+        let chunk_to_id: HashMap<(String, u32), usize> = sidecar
+            .entries
+            .iter()
+            .map(|e| ((e.path.clone(), e.chunk_index), e.id))
+            .collect();
+        let id_to_chunk: HashMap<usize, (String, u32)> = sidecar
+            .entries
+            .iter()
+            .map(|e| (e.id, (e.path.clone(), e.chunk_index)))
+            .collect();
         Ok(Arc::new(Self {
             dim,
             dir,
             hnsw,
             sidecar: RwLock::new(sidecar),
-            id_to_path: RwLock::new(id_to_path),
+            chunk_to_id: RwLock::new(chunk_to_id),
+            id_to_chunk: RwLock::new(id_to_chunk),
         }))
     }
 
-    /// Add / replace the embedding for `path`.  Idempotent — a prior
-    /// vector under the same path is shadowed instead of duplicated
-    /// (see the "Id + path mapping" section of the module doc).
+    /// Add / replace the embedding for `(path, chunk_index)`.
+    /// Idempotent — a prior vector under the same key is shadowed
+    /// instead of duplicated (see the "Id + (path, chunk_index)
+    /// mapping" section of the module doc).
     ///
     /// Errors on:
     /// - `vector.len() != dim`
     /// - all-zero vector (cosine distance is undefined; would NaN
     ///   propagate through the graph)
-    pub fn add_vector(&self, path: &str, vector: &[f32]) -> Result<(), AnnError> {
+    pub fn add_vector(&self, path: &str, chunk_index: u32, vector: &[f32]) -> Result<(), AnnError> {
         if vector.len() != self.dim {
             return Err(AnnError::DimMismatch {
                 path: path.to_string(),
@@ -203,30 +259,70 @@ impl AnnIndex {
 
         // Rotate mappings under the write lock.  Short-held — no
         // HNSW ops inside.
-        let new_id = {
+        let (new_id, prior_id) = {
             let mut side = self.sidecar.write();
             let id = side.next_id;
             side.next_id += 1;
-            if let Some(prior) = side.path_to_id.insert(path.to_string(), id) {
+
+            let key = (path.to_string(), chunk_index);
+            let mut lookup = self.chunk_to_id.write();
+            let prior = lookup.insert(key.clone(), id);
+            if let Some(pid) = prior {
                 // Old id survives in the graph but no longer
-                // resolves to a live path — mark it shadowed so
-                // search's post-filter drops it.
-                side.shadowed.insert(prior);
+                // resolves to a live (path, chunk) — shadow it.
+                side.shadowed.insert(pid);
+                // Drop the stale sidecar entry so commit() writes
+                // the current mapping.
+                side.entries.retain(|e| e.id != pid);
             }
-            id
+            side.entries.push(SidecarEntry {
+                path: path.to_string(),
+                chunk_index,
+                id,
+            });
+            self.id_to_chunk.write().insert(id, key);
+            if let Some(pid) = prior {
+                self.id_to_chunk.write().remove(&pid);
+            }
+            (id, prior)
         };
+        let _ = prior_id; // captured only for the shadow side-effect above
 
         // HNSW insert is thread-safe on `&self`; no lock needed here.
         self.hnsw.insert((vector, new_id));
 
-        // Refresh the cached reverse map so search's path lookup
-        // sees the new id immediately.  Cheap on typical zone sizes;
-        // a smarter incremental update is a follow-up if this ever
-        // shows up on a profile.
-        let map = self.sidecar.read().id_to_path();
-        *self.id_to_path.write() = map;
-
         Ok(())
+    }
+
+    /// Drop ALL chunks for `path` — marks their ids as shadowed
+    /// so search post-filter skips them; the graph nodes stay in
+    /// place until the P5 periodic rebuild.  Idempotent: calling
+    /// on a path with no live chunks is a no-op.
+    ///
+    /// The caller pattern for reindexing a file is:
+    /// ```text
+    /// ann.delete_all_chunks(path);
+    /// for (chunk_index, vector) in fresh_chunks {
+    ///     ann.add_vector(path, chunk_index, vector)?;
+    /// }
+    /// ann.commit()?;
+    /// ```
+    /// so a file that dropped from 3 chunks to 2 doesn't leave the
+    /// stale third chunk lingering as a ghost hit.
+    pub fn delete_all_chunks(&self, path: &str) {
+        let mut side = self.sidecar.write();
+        let mut lookup = self.chunk_to_id.write();
+        let mut reverse = self.id_to_chunk.write();
+        let to_shadow: Vec<usize> = lookup
+            .iter()
+            .filter_map(|((p, _), id)| if p == path { Some(*id) } else { None })
+            .collect();
+        for id in &to_shadow {
+            side.shadowed.insert(*id);
+            reverse.remove(id);
+        }
+        lookup.retain(|(p, _), _| p != path);
+        side.entries.retain(|e| e.path != path);
     }
 
     /// Nearest-`k` search.  Returns hits sorted by cosine distance
@@ -272,14 +368,14 @@ impl AnnIndex {
         let neighbours: Vec<Neighbour> = self.hnsw.search(query, overfetch, effective_ef);
 
         let side = self.sidecar.read();
-        let id_map = self.id_to_path.read();
+        let id_map = self.id_to_chunk.read();
 
         let mut out = Vec::with_capacity(k);
         for n in neighbours {
             if side.shadowed.contains(&n.d_id) {
                 continue;
             }
-            let Some(path) = id_map.get(&n.d_id) else {
+            let Some((path, chunk_index)) = id_map.get(&n.d_id) else {
                 // Defensive: mapping missing for a live id would
                 // mean sidecar drift.  Drop the hit and log rather
                 // than surface a bogus "" path.
@@ -291,6 +387,7 @@ impl AnnIndex {
             };
             out.push(AnnHit {
                 path: path.clone(),
+                chunk_index: *chunk_index,
                 distance: n.distance,
             });
             if out.len() >= k {
@@ -311,7 +408,7 @@ impl AnnIndex {
     /// next open_or_create knows the manager has seen this zone;
     /// the graph files reappear the next time a real doc arrives.
     pub fn commit(&self) -> Result<(), AnnError> {
-        let live = self.sidecar.read().path_to_id.len();
+        let live = self.sidecar.read().entries.len();
         if live > 0 {
             self.hnsw
                 .file_dump(&self.dir, HNSW_BASENAME)
@@ -332,14 +429,24 @@ impl AnnIndex {
         Ok(())
     }
 
-    /// Number of live documents (indexed, not shadowed).  Used by
-    /// tests + operator diagnostics.
+    /// Number of live chunks (indexed, not shadowed).  Used by
+    /// tests + operator diagnostics.  In P4 with multi-chunk-per-
+    /// file emission this is > the number of distinct paths;
+    /// [`live_paths`](Self::live_paths) gives the file count.
     pub fn live_count(&self) -> usize {
-        let side = self.sidecar.read();
-        // path_to_id holds one entry per live path, so its size IS
-        // the live count.  `shadowed` is orthogonal (old ids no
-        // longer referenced by any path).
-        side.path_to_id.len()
+        self.sidecar.read().entries.len()
+    }
+
+    /// Number of distinct paths with at least one live chunk.
+    /// Cheaper than iterating callers because we walk the in-memory
+    /// map once and dedupe by path.
+    pub fn live_paths(&self) -> usize {
+        let lookup = self.chunk_to_id.read();
+        let mut paths: HashSet<&str> = HashSet::new();
+        for (p, _) in lookup.keys() {
+            paths.insert(p.as_str());
+        }
+        paths.len()
     }
 
     /// Dimensionality this index was created with.  Callers embed
@@ -410,9 +517,9 @@ mod tests {
     fn add_then_search_finds_nearest() {
         let dir = tempdir().join("ann");
         let idx = AnnIndex::open_or_create(dir, 4).expect("open");
-        idx.add_vector("/a", &vec_seed(4, 1.0)).expect("add a");
-        idx.add_vector("/b", &vec_seed(4, 5.0)).expect("add b");
-        idx.add_vector("/c", &vec_seed(4, 9.0)).expect("add c");
+        idx.add_vector("/a", 0, &vec_seed(4, 1.0)).expect("add a");
+        idx.add_vector("/b", 0, &vec_seed(4, 5.0)).expect("add b");
+        idx.add_vector("/c", 0, &vec_seed(4, 9.0)).expect("add c");
         assert_eq!(idx.live_count(), 3);
 
         // Query with /b's exact vector — nearest hit must be /b at
@@ -438,7 +545,7 @@ mod tests {
         let dir = tempdir().join("ann");
         let idx = AnnIndex::open_or_create(dir, 4).expect("open");
         let err = idx
-            .add_vector("/x", &vec_seed(3, 1.0))
+            .add_vector("/x", 0, &vec_seed(3, 1.0))
             .expect_err("must reject wrong dim");
         assert!(
             matches!(err, AnnError::DimMismatch { .. }),
@@ -451,7 +558,7 @@ mod tests {
         let dir = tempdir().join("ann");
         let idx = AnnIndex::open_or_create(dir, 4).expect("open");
         let err = idx
-            .add_vector("/x", &vec![0.0; 4])
+            .add_vector("/x", 0, &vec![0.0; 4])
             .expect_err("must reject zero vec");
         assert!(
             matches!(err, AnnError::ZeroVector(_)),
@@ -460,18 +567,18 @@ mod tests {
     }
 
     #[test]
-    fn readd_same_path_shadows_old_and_returns_new_vector() {
+    fn readd_same_key_shadows_old_and_returns_new_vector() {
         // Idempotency regression: hnsw_rs has no delete, so a naive
-        // re-add would leave TWO graph nodes for the same path.  The
-        // shadow-filter path in search must drop the old id and
-        // return the new vector's distance.
+        // re-add would leave TWO graph nodes for the same
+        // (path, chunk_index).  The shadow-filter path in search
+        // must drop the old id and return the new vector's distance.
         let dir = tempdir().join("ann");
         let idx = AnnIndex::open_or_create(dir, 4).expect("open");
-        idx.add_vector("/a", &vec_seed(4, 1.0)).expect("add-1");
-        idx.add_vector("/other", &vec_seed(4, 10.0))
+        idx.add_vector("/a", 0, &vec_seed(4, 1.0)).expect("add-1");
+        idx.add_vector("/other", 0, &vec_seed(4, 10.0))
             .expect("add-other");
-        idx.add_vector("/a", &vec_seed(4, 20.0)).expect("re-add");
-        assert_eq!(idx.live_count(), 2, "path count stays at 2 after re-add");
+        idx.add_vector("/a", 0, &vec_seed(4, 20.0)).expect("re-add");
+        assert_eq!(idx.live_count(), 2, "chunk count stays at 2 after re-add");
 
         // Query with the NEW vector — /a must come first at ~0
         // distance; the OLD /a id must not appear.
@@ -486,12 +593,78 @@ mod tests {
     }
 
     #[test]
+    fn distinct_chunks_of_same_path_coexist() {
+        // P4 core contract: (path, chunk_index) is the primary key,
+        // so /doc chunk 0 and /doc chunk 1 must BOTH live and search
+        // must return both when distances allow.  A regression that
+        // keys on path alone would shadow chunk 0 as soon as chunk 1
+        // is added, breaking multi-chunk-per-file emission.
+        let dir = tempdir().join("ann");
+        let idx = AnnIndex::open_or_create(dir, 4).expect("open");
+        idx.add_vector("/doc", 0, &vec_seed(4, 1.0))
+            .expect("chunk 0");
+        idx.add_vector("/doc", 1, &vec_seed(4, 5.0))
+            .expect("chunk 1");
+        idx.add_vector("/doc", 2, &vec_seed(4, 9.0))
+            .expect("chunk 2");
+        assert_eq!(idx.live_count(), 3, "three chunks live under one path");
+        assert_eq!(idx.live_paths(), 1, "one distinct path");
+
+        // Query with the middle chunk's vector — that chunk must
+        // return with distance ≈ 0 AND carry chunk_index=1.
+        let hits = idx.search(&vec_seed(4, 5.0), 3).expect("search");
+        assert_eq!(hits.len(), 3);
+        let top = &hits[0];
+        assert_eq!(top.path, "/doc");
+        assert_eq!(top.chunk_index, 1, "chunk_index must round-trip");
+        assert!(top.distance < 0.001);
+    }
+
+    #[test]
+    fn delete_all_chunks_removes_every_chunk_for_path() {
+        // Whole-file removal via `delete_all_chunks` — used by
+        // do_index's "reindex file: drop all then add fresh" pattern
+        // so a file that dropped from 3 chunks to 2 doesn't leave
+        // the stale third chunk as a ghost hit.
+        let dir = tempdir().join("ann");
+        let idx = AnnIndex::open_or_create(dir, 4).expect("open");
+        idx.add_vector("/doc", 0, &vec_seed(4, 1.0)).unwrap();
+        idx.add_vector("/doc", 1, &vec_seed(4, 5.0)).unwrap();
+        idx.add_vector("/doc", 2, &vec_seed(4, 9.0)).unwrap();
+        idx.add_vector("/other", 0, &vec_seed(4, 3.0)).unwrap();
+        assert_eq!(idx.live_count(), 4);
+
+        idx.delete_all_chunks("/doc");
+        assert_eq!(idx.live_count(), 1, "only /other should remain");
+        assert_eq!(idx.live_paths(), 1);
+
+        // Any search must not surface a /doc hit.
+        let hits = idx.search(&vec_seed(4, 5.0), 10).expect("search");
+        assert!(
+            !hits.iter().any(|h| h.path == "/doc"),
+            "delete_all_chunks left ghost /doc hits: {hits:?}",
+        );
+    }
+
+    #[test]
+    fn delete_all_chunks_is_idempotent() {
+        let dir = tempdir().join("ann");
+        let idx = AnnIndex::open_or_create(dir, 4).expect("open");
+        idx.add_vector("/a", 0, &vec_seed(4, 1.0)).unwrap();
+        idx.delete_all_chunks("/missing"); // no-op
+        assert_eq!(idx.live_count(), 1);
+        idx.delete_all_chunks("/a");
+        idx.delete_all_chunks("/a"); // no-op the second time
+        assert_eq!(idx.live_count(), 0);
+    }
+
+    #[test]
     fn commit_then_reopen_survives_restart() {
         let dir = tempdir().join("ann");
         {
             let idx = AnnIndex::open_or_create(dir.clone(), 4).expect("open");
-            idx.add_vector("/a", &vec_seed(4, 1.0)).expect("add-a");
-            idx.add_vector("/b", &vec_seed(4, 5.0)).expect("add-b");
+            idx.add_vector("/a", 0, &vec_seed(4, 1.0)).expect("add-a");
+            idx.add_vector("/b", 0, &vec_seed(4, 5.0)).expect("add-b");
             idx.commit().expect("commit");
         }
         // Fresh open — the graph + sidecar files come back to life.
@@ -506,7 +679,7 @@ mod tests {
         let dir = tempdir().join("ann");
         let idx = AnnIndex::open_or_create(dir, 4).expect("open");
         for i in 0..20 {
-            idx.add_vector(&format!("/p{i}"), &vec_seed(4, i as f32 + 1.0))
+            idx.add_vector(&format!("/p{i}"), 0, &vec_seed(4, i as f32 + 1.0))
                 .expect("add");
         }
         let hits = idx.search(&vec_seed(4, 3.0), 5).expect("search");

--- a/rust/services/search-plugin/src/ann_index.rs
+++ b/rust/services/search-plugin/src/ann_index.rs
@@ -211,8 +211,10 @@ impl AnnIndex {
                 HNSW_EF_CONSTRUCTION,
                 DistCosine {},
             );
-            let mut side = Sidecar::default();
-            side.version = SIDECAR_VERSION;
+            let side = Sidecar {
+                version: SIDECAR_VERSION,
+                ..Default::default()
+            };
             (hnsw, side)
         };
 

--- a/rust/services/search-plugin/src/chunker.rs
+++ b/rust/services/search-plugin/src/chunker.rs
@@ -1,0 +1,400 @@
+//! Heading + code-fence + budget-aware chunker (Phase 4 of the
+//! Python-parity roadmap; see `PARITY_ROADMAP.md`).
+//!
+//! # Goal
+//!
+//! Split file text into semantically-coherent chunks that:
+//! - respect markdown-ish heading boundaries (a chunk stays within
+//!   one leaf section);
+//! - preserve code-fence blocks (never split inside triple-backtick);
+//! - stay under a soft character budget so embedder + BM25 both
+//!   have workable per-chunk sizes;
+//! - carry a heading trail for the embedder so semantic recall
+//!   picks up on section context that pure chunk text would lose.
+//!
+//! # Fidelity vs Python
+//!
+//! Post-audit D1: **semantic-equivalent, not byte-identical**.
+//! Tokeniser + markdown-parser differences across the Python /
+//! Rust boundary would make byte-identical impossible.  What we
+//! guarantee:
+//! - same chunk-count-per-doc ± 1
+//! - each chunk's boundary aligns with a paragraph or heading
+//!   (never mid-word)
+//! - code fences never split
+//! - heading stack tracked exactly like Python
+//!
+//! # No new heavy deps
+//!
+//! Line-based scan for headings + fences.  No `pulldown-cmark`
+//! (~200 KB), no `tiktoken-rs` (~1 MB + model files) — char-based
+//! budget approximates BPE tokens closely enough for P4's initial
+//! shape.  If recall parity with Python surfaces a real gap we
+//! swap in `tiktoken-rs` as a targeted P5 follow-up.
+
+/// Soft target for chunk character length.  ~1600 chars ≈ 400 BPE
+/// tokens for typical English (~4 chars/token), matching Python's
+/// default chunk budget.
+pub const CHUNK_TARGET_CHARS: usize = 1600;
+
+/// Hard upper bound for a single chunk.  A monster paragraph that
+/// blows past this alone is emitted as its own oversize chunk
+/// rather than split mid-content — better to trust the source's
+/// paragraph structure than mangle it.
+pub const CHUNK_MAX_CHARS: usize = 4000;
+
+/// One emitted chunk.  Two text fields:
+///
+/// - `text` = pure chunk content, no heading prefix.  Goes into
+///   FTS `chunk_text` (BM25 wants clean tokens, no heading
+///   pollution) and returned to callers as `QueryResult.chunk_text`.
+/// - `embed_input` = heading-prefixed text — what the embedder
+///   sees.  Semantic recall lifts on section context that raw
+///   chunk text would lose.  Matches Python's
+///   `embed_input != stored_text` split.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Chunk {
+    pub chunk_index: u32,
+    pub text: String,
+    pub embed_input: String,
+}
+
+/// Split `text` into chunks.  Never returns an empty vec — an
+/// entirely-blank file still emits one empty chunk so downstream
+/// code (which treats "zero chunks" as an error signal) sees a
+/// single well-formed slot.  Callers who want to skip empties
+/// filter upstream.
+pub fn chunk_document(text: &str) -> Vec<Chunk> {
+    // Fast path: empty text stays empty (do_index already skips
+    // these upstream, but pin the semantics here too so a caller
+    // that bypasses do_index doesn't crash).
+    if text.trim().is_empty() {
+        return Vec::new();
+    }
+
+    let mut emitter = Emitter::new();
+    let mut headings: HeadingStack = HeadingStack::default();
+    let mut buf = String::new();
+    let mut in_code_fence = false;
+
+    for raw_line in text.split_inclusive('\n') {
+        // Preserve the trailing newline (or lack of, on the tail
+        // line) so round-trip'd text stays faithful.
+        let trimmed_start = raw_line.trim_start();
+
+        // Code fence toggles.  We check the LINE-start (after
+        // leading whitespace) so indented fences inside lists still
+        // register.
+        if trimmed_start.starts_with("```") {
+            in_code_fence = !in_code_fence;
+            buf.push_str(raw_line);
+            continue;
+        }
+
+        // Inside a code fence: unconditional inclusion.  Do not
+        // check for headings or paragraph breaks — # inside code
+        // is not a heading, blank lines inside code are not
+        // paragraph boundaries.
+        if in_code_fence {
+            buf.push_str(raw_line);
+            continue;
+        }
+
+        // Heading detection: 1–6 leading `#` followed by space.
+        if let Some((level, title)) = parse_heading(raw_line) {
+            // A new heading breaks the current chunk boundary if we
+            // have material already accumulated AND the material
+            // isn't just another heading (which shouldn't really
+            // happen but stays predictable).
+            if !buf.trim().is_empty() {
+                flush_paragraph_or_chunk(&mut emitter, &headings, &mut buf);
+            }
+            headings.push(level, title);
+            buf.push_str(raw_line);
+            continue;
+        }
+
+        // Blank-line paragraph boundary — a good place to try
+        // sealing a chunk if we're over budget.
+        if raw_line.trim().is_empty() {
+            buf.push_str(raw_line);
+            if buf.len() >= CHUNK_TARGET_CHARS {
+                flush_paragraph_or_chunk(&mut emitter, &headings, &mut buf);
+            }
+            continue;
+        }
+
+        buf.push_str(raw_line);
+    }
+
+    // Trailing content that never crossed a paragraph or heading
+    // boundary.
+    if !buf.trim().is_empty() {
+        emitter.emit(&headings, buf);
+    }
+
+    emitter.into_chunks()
+}
+
+/// Attempt to seal what we've buffered.  If it's under the target,
+/// keep buffering; if over, emit as a chunk.  When emitting, also
+/// bounds-check MAX_CHARS — a single paragraph over the hard cap
+/// still emits as its own oversize chunk (no mid-content split).
+fn flush_paragraph_or_chunk(emitter: &mut Emitter, headings: &HeadingStack, buf: &mut String) {
+    if buf.len() >= CHUNK_TARGET_CHARS {
+        // Take ownership + reset.
+        let text = std::mem::take(buf);
+        emitter.emit(headings, text);
+    }
+    // else: keep accumulating.
+}
+
+/// Parse a markdown-style ATX heading (`#` through `######` +
+/// whitespace + title).  Setext (underline) headings not handled
+/// yet — deferred; rare enough that Python's chunker treats them
+/// the same for context tracking.
+fn parse_heading(line: &str) -> Option<(u8, String)> {
+    let stripped = line.trim_start();
+    let mut hashes = 0u8;
+    for ch in stripped.chars() {
+        if ch == '#' && hashes < 6 {
+            hashes += 1;
+        } else {
+            break;
+        }
+    }
+    if hashes == 0 {
+        return None;
+    }
+    let rest = stripped[hashes as usize..].strip_prefix(' ')?;
+    Some((hashes, rest.trim_end_matches('\n').trim().to_string()))
+}
+
+/// Heading stack — tracks the deepest heading chain in effect.
+/// When a new heading at level N arrives, drop everything at
+/// level ≥ N, then push the new one.  Rendered as
+/// `[H1: title][H2: title]…` for the embedder prefix.
+#[derive(Debug, Default, Clone)]
+struct HeadingStack {
+    stack: Vec<(u8, String)>,
+}
+
+impl HeadingStack {
+    fn push(&mut self, level: u8, title: String) {
+        self.stack.retain(|(l, _)| *l < level);
+        self.stack.push((level, title));
+    }
+
+    fn render_prefix(&self) -> String {
+        if self.stack.is_empty() {
+            return String::new();
+        }
+        let mut s = String::new();
+        for (level, title) in &self.stack {
+            s.push_str(&format!("[H{level}: {title}] "));
+        }
+        s.push('\n');
+        s.push('\n');
+        s
+    }
+}
+
+/// Chunk accumulator — hands out monotonic chunk_index and pairs
+/// each chunk's text with a heading-prefixed `embed_input`.
+struct Emitter {
+    chunks: Vec<Chunk>,
+}
+
+impl Emitter {
+    fn new() -> Self {
+        Self { chunks: Vec::new() }
+    }
+
+    fn emit(&mut self, headings: &HeadingStack, text: String) {
+        let embed_input = if headings.stack.is_empty() {
+            text.clone()
+        } else {
+            let mut s = headings.render_prefix();
+            s.push_str(&text);
+            s
+        };
+        // Cap oversize chunks at CHUNK_MAX_CHARS by truncation.
+        // Losing a bit of tail is preferable to reading past the
+        // embedder's max input size.
+        let (text, embed_input) = if text.len() > CHUNK_MAX_CHARS {
+            (
+                text.chars().take(CHUNK_MAX_CHARS).collect::<String>(),
+                embed_input
+                    .chars()
+                    .take(CHUNK_MAX_CHARS)
+                    .collect::<String>(),
+            )
+        } else {
+            (text, embed_input)
+        };
+        let chunk_index = self.chunks.len() as u32;
+        self.chunks.push(Chunk {
+            chunk_index,
+            text,
+            embed_input,
+        });
+    }
+
+    fn into_chunks(self) -> Vec<Chunk> {
+        self.chunks
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_text_returns_no_chunks() {
+        assert!(chunk_document("").is_empty());
+        assert!(chunk_document("   \n\n   ").is_empty());
+    }
+
+    #[test]
+    fn short_text_becomes_one_chunk() {
+        let out = chunk_document("hello world\n");
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].chunk_index, 0);
+        assert!(out[0].text.contains("hello world"));
+    }
+
+    #[test]
+    fn headings_split_chunks_and_stack_context() {
+        let text = "\
+# Intro
+
+Intro body text.
+
+## Setup
+
+Setup body text.
+
+## Usage
+
+Usage body text.
+";
+        let out = chunk_document(text);
+        // Expect one chunk per heading + intro material.
+        assert!(out.len() >= 3, "expected ≥ 3 chunks, got {out:?}");
+
+        // The Usage chunk carries "H1: Intro" + "H2: Usage" in its
+        // embed_input, not in its plain text.
+        let usage = out
+            .iter()
+            .find(|c| c.text.contains("Usage body text"))
+            .expect("usage chunk missing");
+        assert!(
+            usage.embed_input.contains("H1: Intro"),
+            "prefix missing: {usage:?}"
+        );
+        assert!(usage.embed_input.contains("H2: Usage"));
+        // Plain text is heading-free (BM25 shouldn't see the prefix).
+        assert!(!usage.text.starts_with("[H1:"));
+    }
+
+    #[test]
+    fn code_fence_content_is_never_split_and_no_heading_inside() {
+        let text = "\
+# Intro
+
+Intro body.
+
+```python
+# not-a-heading
+def f():
+    pass
+
+# still-not-a-heading
+```
+
+Post-fence text.
+";
+        let out = chunk_document(text);
+        // Code fence stays intact inside its containing chunk.
+        let with_code = out
+            .iter()
+            .find(|c| c.text.contains("def f():"))
+            .expect("code chunk missing");
+        assert!(with_code.text.contains("# not-a-heading"));
+        assert!(with_code.text.contains("# still-not-a-heading"));
+        // The `#` inside the fence didn't push into the heading
+        // stack — no `[H1: not-a-heading]` prefix.
+        for c in &out {
+            assert!(
+                !c.embed_input.contains("H1: not-a-heading"),
+                "code-fenced heading leaked to stack: {c:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn budget_forces_split_at_paragraph_boundary() {
+        // Build a text with several paragraphs whose combined length
+        // exceeds CHUNK_TARGET_CHARS.  Each paragraph itself under
+        // the target so the split happens at paragraph boundaries.
+        let paragraph = "a".repeat(500);
+        let text =
+            format!("{paragraph}\n\n{paragraph}\n\n{paragraph}\n\n{paragraph}\n\n{paragraph}\n\n");
+        let out = chunk_document(&text);
+        assert!(
+            out.len() >= 2,
+            "budget should force ≥ 2 chunks, got {}",
+            out.len()
+        );
+        // Every chunk stays under the hard max.
+        for c in &out {
+            assert!(
+                c.text.len() <= CHUNK_MAX_CHARS + 10,
+                "chunk oversize: {}",
+                c.text.len()
+            );
+        }
+        // chunk_index is monotonic starting at 0.
+        for (i, c) in out.iter().enumerate() {
+            assert_eq!(c.chunk_index, i as u32);
+        }
+    }
+
+    #[test]
+    fn heading_stack_pops_on_shallower_heading() {
+        let text = "\
+# One
+
+body-1.
+
+## Two
+
+body-2.
+
+# Three
+
+body-3.
+";
+        let out = chunk_document(text);
+        let three = out
+            .iter()
+            .find(|c| c.text.contains("body-3"))
+            .expect("three chunk");
+        // After # Three, H2 stack popped — no "[H2: Two]" in prefix.
+        assert!(three.embed_input.contains("H1: Three"));
+        assert!(
+            !three.embed_input.contains("H2: Two"),
+            "stack didn't pop: {three:?}"
+        );
+    }
+
+    #[test]
+    fn no_heading_no_prefix_in_embed_input() {
+        let out = chunk_document("just plain text\nno heading anywhere\n");
+        assert_eq!(out.len(), 1);
+        assert_eq!(
+            out[0].embed_input, out[0].text,
+            "no headings ⇒ embed_input == text",
+        );
+    }
+}

--- a/rust/services/search-plugin/src/chunker.rs
+++ b/rust/services/search-plugin/src/chunker.rs
@@ -100,14 +100,16 @@ pub fn chunk_document(text: &str) -> Vec<Chunk> {
             continue;
         }
 
-        // Heading detection: 1–6 leading `#` followed by space.
+        // Heading detection: 1–6 leading `#` followed by space.  A
+        // new heading ALWAYS seals the current chunk (matches
+        // Python) so a heading-heavy but text-light document gets
+        // one chunk per section rather than everything crammed into
+        // one huge chunk.  Callers with tiny sections can pool
+        // downstream via `chunks_per_page`.
         if let Some((level, title)) = parse_heading(raw_line) {
-            // A new heading breaks the current chunk boundary if we
-            // have material already accumulated AND the material
-            // isn't just another heading (which shouldn't really
-            // happen but stays predictable).
             if !buf.trim().is_empty() {
-                flush_paragraph_or_chunk(&mut emitter, &headings, &mut buf);
+                let text = std::mem::take(&mut buf);
+                emitter.emit(&headings, text);
             }
             headings.push(level, title);
             buf.push_str(raw_line);
@@ -119,7 +121,8 @@ pub fn chunk_document(text: &str) -> Vec<Chunk> {
         if raw_line.trim().is_empty() {
             buf.push_str(raw_line);
             if buf.len() >= CHUNK_TARGET_CHARS {
-                flush_paragraph_or_chunk(&mut emitter, &headings, &mut buf);
+                let text = std::mem::take(&mut buf);
+                emitter.emit(&headings, text);
             }
             continue;
         }
@@ -134,19 +137,6 @@ pub fn chunk_document(text: &str) -> Vec<Chunk> {
     }
 
     emitter.into_chunks()
-}
-
-/// Attempt to seal what we've buffered.  If it's under the target,
-/// keep buffering; if over, emit as a chunk.  When emitting, also
-/// bounds-check MAX_CHARS — a single paragraph over the hard cap
-/// still emits as its own oversize chunk (no mid-content split).
-fn flush_paragraph_or_chunk(emitter: &mut Emitter, headings: &HeadingStack, buf: &mut String) {
-    if buf.len() >= CHUNK_TARGET_CHARS {
-        // Take ownership + reset.
-        let text = std::mem::take(buf);
-        emitter.emit(headings, text);
-    }
-    // else: keep accumulating.
 }
 
 /// Parse a markdown-style ATX heading (`#` through `######` +

--- a/rust/services/search-plugin/src/fts_index.rs
+++ b/rust/services/search-plugin/src/fts_index.rs
@@ -177,11 +177,11 @@ impl FtsIndex {
         }))
     }
 
-    /// Add a document.  P1 semantics: one call = one document = one
-    /// chunk (`path` is the primary key; P4 grows the key to
-    /// `(path, chunk_index)`).  Any prior document with the same
-    /// `path` is deleted first so re-indexing replaces instead of
-    /// duplicating — Index calls are safe to retry.
+    /// Add a chunk document.  P4 semantics: one call = one chunk;
+    /// callers own the (path, chunk_index) key discipline.  Adding
+    /// the same key twice writes TWO tantivy docs — the caller MUST
+    /// [`delete_all_chunks`](Self::delete_all_chunks) first when
+    /// re-indexing a file, otherwise BM25 double-counts.
     ///
     /// The writer buffers in RAM until [`commit`](Self::commit) is
     /// called — callers batch adds and commit at end-of-request so
@@ -200,12 +200,6 @@ impl FtsIndex {
         mtime_ms: Option<i64>,
     ) -> Result<(), IndexError> {
         let writer = self.writer.lock();
-        // Idempotent add: drop any prior doc keyed by this path before
-        // buffering the new one.  Both operations queue on the same
-        // writer transaction, so the commit lands them atomically — a
-        // reader can never see zero copies of the doc during a
-        // reindex.
-        writer.delete_term(Term::from_field_text(self.fields.path, path));
         writer
             .add_document(doc!(
                 self.fields.path => path,
@@ -215,6 +209,21 @@ impl FtsIndex {
             ))
             .map_err(|e| IndexError::AddDoc(path.to_string(), e.to_string()))?;
         Ok(())
+    }
+
+    /// Drop every chunk indexed under `path`.  Used by the reindex
+    /// pattern in `do_index`: a file whose chunk count shrinks (was
+    /// 3 chunks, now 2) leaves orphaned chunk 2/3 rows unless the
+    /// caller explicitly drops the file's whole set first.
+    ///
+    /// Both the delete and any subsequent adds queue on the SAME
+    /// writer transaction, so `commit()` lands them atomically — a
+    /// reader never sees a partially-reindexed file (zero chunks
+    /// visible, then N chunks visible; no in-between).  Idempotent:
+    /// calling on a path with no live chunks is a no-op.
+    pub fn delete_all_chunks(&self, path: &str) {
+        let writer = self.writer.lock();
+        writer.delete_term(Term::from_field_text(self.fields.path, path));
     }
 
     /// Flush buffered adds to disk and make them visible to searchers.
@@ -451,25 +460,82 @@ mod tests {
     }
 
     #[test]
-    fn readd_same_path_replaces_not_duplicates() {
-        // Regression: naive add_document duplicated a doc every reindex,
-        // doubling its BM25 score and starving other docs from the
-        // top-N.  delete_term-before-add makes Index retries safe.
+    fn distinct_chunks_of_same_path_coexist() {
+        // P4 primary key = (path, chunk_index).  Adding chunk 0 and
+        // chunk 1 under the same path leaves BOTH docs live.  A BM25
+        // query that would only match one chunk (via its distinct
+        // text) returns exactly one hit.
         let dir = tempdir().join("fts");
         let idx = FtsIndex::open_or_create(dir).expect("open");
-        idx.add_document("/notes/hello.md", 0, "widget alpha", Some(1))
+        idx.add_document("/doc.md", 0, "alpha payload", Some(1))
+            .expect("add-0");
+        idx.add_document("/doc.md", 1, "beta payload", Some(1))
             .expect("add-1");
+        idx.commit().expect("commit");
+
+        let hits = idx.search("alpha", 10, None).expect("search");
+        assert_eq!(hits.len(), 1, "only chunk 0 has 'alpha': {hits:?}");
+        assert_eq!(hits[0].chunk_index, 0);
+
+        // Both chunks share the "payload" token.
+        let hits = idx.search("payload", 10, None).expect("search");
+        assert_eq!(hits.len(), 2);
+    }
+
+    #[test]
+    fn delete_all_chunks_then_readd_replaces_cleanly() {
+        // Reindex-with-different-chunk-count contract: a file that
+        // shrinks from 3 chunks to 2 must not leave the third as an
+        // orphan.  Caller uses the delete_all_chunks + per-chunk
+        // add_document pattern; both queue on the same writer
+        // transaction so the commit lands atomically.
+        let dir = tempdir().join("fts");
+        let idx = FtsIndex::open_or_create(dir).expect("open");
+        for i in 0..3u32 {
+            idx.add_document("/doc.md", i, &format!("widget chunk {i}"), Some(1))
+                .expect("add");
+        }
         idx.commit().expect("commit-1");
-        // Same path, updated text + mtime.
-        idx.add_document("/notes/hello.md", 0, "widget beta", Some(2))
-            .expect("add-2");
+        assert_eq!(
+            idx.search("widget", 10, None).expect("search").len(),
+            3,
+            "3 chunks after first index",
+        );
+
+        // Reindex with only 2 chunks — first drop the whole file.
+        idx.delete_all_chunks("/doc.md");
+        for i in 0..2u32 {
+            idx.add_document("/doc.md", i, &format!("widget rebuilt {i}"), Some(2))
+                .expect("add");
+        }
         idx.commit().expect("commit-2");
 
         let hits = idx.search("widget", 10, None).expect("search");
-        assert_eq!(hits.len(), 1, "expected one doc after re-add, got {hits:?}");
-        // The stored text + mtime are the most recent write.
-        assert_eq!(hits[0].chunk_text, "widget beta");
-        assert_eq!(hits[0].mtime_ms, Some(2));
+        assert_eq!(
+            hits.len(),
+            2,
+            "expected 2 chunks after reindex, got {hits:?}"
+        );
+        // Only the rebuilt text is left.
+        assert!(
+            hits.iter().all(|h| h.chunk_text.contains("rebuilt")),
+            "old chunks leaked: {hits:?}",
+        );
+    }
+
+    #[test]
+    fn delete_all_chunks_on_missing_path_is_noop() {
+        let dir = tempdir().join("fts");
+        let idx = FtsIndex::open_or_create(dir).expect("open");
+        idx.add_document("/live.md", 0, "widget alpha", Some(1))
+            .expect("add");
+        idx.commit().expect("commit-1");
+        idx.delete_all_chunks("/does-not-exist");
+        idx.commit().expect("commit-2");
+        // Live doc still there.
+        let hits = idx.search("widget", 10, None).expect("search");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].path, "/live.md");
     }
 
     #[test]

--- a/rust/services/search-plugin/src/fts_index.rs
+++ b/rust/services/search-plugin/src/fts_index.rs
@@ -321,6 +321,33 @@ impl FtsIndex {
         Ok(Some(self.decode(stored, score)))
     }
 
+    /// All chunks stored under `path`, sorted by `chunk_index`
+    /// ascending.  Used by the `expand=macro` code path in
+    /// `service.rs` to build the previous + current + next
+    /// context around each hit without a per-hit search round trip.
+    /// Caps at 512 chunks to bound a pathologically-large file's
+    /// footprint here — a file with more than 512 chunks in P4 is
+    /// beyond the intended budget anyway (chunks_per_page-pooled
+    /// results wouldn't surface that many either).
+    pub fn get_chunks_by_path(&self, path: &str) -> Result<Vec<FtsHit>, IndexError> {
+        const CAP: usize = 512;
+        let searcher = self.reader.searcher();
+        let term = Term::from_field_text(self.fields.path, path);
+        let query = TermQuery::new(term, IndexRecordOption::Basic);
+        let top = searcher
+            .search(&query, &TopDocs::with_limit(CAP))
+            .map_err(|e| IndexError::Search(e.to_string()))?;
+        let mut hits: Vec<FtsHit> = Vec::with_capacity(top.len());
+        for (score, addr) in top {
+            let stored: TantivyDocument = searcher
+                .doc(addr)
+                .map_err(|e| IndexError::Search(e.to_string()))?;
+            hits.push(self.decode(stored, score));
+        }
+        hits.sort_by_key(|h| h.chunk_index);
+        Ok(hits)
+    }
+
     fn decode(&self, stored: TantivyDocument, score: f32) -> FtsHit {
         // Access stored fields by handle.  If a field is missing (a
         // schema-drift bug), we surface a blank rather than panicking

--- a/rust/services/search-plugin/src/fusion.rs
+++ b/rust/services/search-plugin/src/fusion.rs
@@ -232,6 +232,7 @@ mod tests {
             score,
             zone_id: "root".to_string(),
             mtime_ms: Some(1),
+            expanded_context: String::new(),
         }
     }
 
@@ -338,6 +339,7 @@ mod tests {
             score: 1.0,
             zone_id: "root".into(),
             mtime_ms: Some(100),
+            expanded_context: String::new(),
         }];
         let sem = vec![QueryResult {
             path: "/a".into(),
@@ -346,6 +348,7 @@ mod tests {
             score: 0.9,
             zone_id: "root".into(),
             mtime_ms: Some(200),
+            expanded_context: String::new(),
         }];
         let fused = rrf(&kw, &sem, 60);
         assert_eq!(fused.len(), 1);
@@ -405,6 +408,7 @@ mod tests {
                 score: 1.0,
                 zone_id: "root".into(),
                 mtime_ms: None,
+                expanded_context: String::new(),
             },
             QueryResult {
                 path: "/a".into(),
@@ -413,6 +417,7 @@ mod tests {
                 score: 1.0,
                 zone_id: "root".into(),
                 mtime_ms: None,
+                expanded_context: String::new(),
             },
         ];
         // rrf here: rank-1 and rank-2 have different scores; equalise

--- a/rust/services/search-plugin/src/fusion.rs
+++ b/rust/services/search-plugin/src/fusion.rs
@@ -60,8 +60,9 @@ pub const DEFAULT_ALPHA: f32 = 0.5;
 pub fn rrf(keyword: &[QueryResult], semantic: &[QueryResult], k: u32) -> Vec<QueryResult> {
     let mut merged: HashMap<DocKey, MergedHit> = HashMap::new();
     let k_f = k.max(1) as f32;
-    accumulate_rrf(&mut merged, keyword, k_f, 1.0);
-    accumulate_rrf(&mut merged, semantic, k_f, 1.0);
+    let contrib = |idx: usize, _: &QueryResult| 1.0 / (k_f + (idx + 1) as f32);
+    accumulate(&mut merged, keyword, contrib);
+    accumulate(&mut merged, semantic, contrib);
     finalise(merged)
 }
 
@@ -72,10 +73,14 @@ pub fn rrf_weighted(
     alpha: f32,
 ) -> Vec<QueryResult> {
     let alpha = alpha.clamp(0.0, 1.0);
-    let mut merged: HashMap<DocKey, MergedHit> = HashMap::new();
     let k_f = k.max(1) as f32;
-    accumulate_rrf(&mut merged, keyword, k_f, 1.0 - alpha);
-    accumulate_rrf(&mut merged, semantic, k_f, alpha);
+    let mut merged: HashMap<DocKey, MergedHit> = HashMap::new();
+    accumulate(&mut merged, keyword, |idx, _| {
+        (1.0 - alpha) / (k_f + (idx + 1) as f32)
+    });
+    accumulate(&mut merged, semantic, |idx, _| {
+        alpha / (k_f + (idx + 1) as f32)
+    });
     finalise(merged)
 }
 
@@ -85,8 +90,8 @@ pub fn weighted(keyword: &[QueryResult], semantic: &[QueryResult], alpha: f32) -
     let sem_norm = min_max_normalise(semantic);
 
     let mut merged: HashMap<DocKey, MergedHit> = HashMap::new();
-    accumulate_score(&mut merged, keyword, &kw_norm, 1.0 - alpha);
-    accumulate_score(&mut merged, semantic, &sem_norm, alpha);
+    accumulate(&mut merged, keyword, |idx, _| (1.0 - alpha) * kw_norm[idx]);
+    accumulate(&mut merged, semantic, |idx, _| alpha * sem_norm[idx]);
     finalise(merged)
 }
 
@@ -147,38 +152,24 @@ struct MergedHit {
     template: QueryResult,
 }
 
-fn accumulate_rrf(
+/// Fold one source into the merged accumulator using a caller-
+/// supplied per-hit contribution function.  Same shape for both RRF
+/// (`weight / (k + rank)`) and WEIGHTED (`weight * normalised_score`)
+/// — the difference is purely the scoring formula, so one merge loop
+/// covers both.  Fixed at &self on the source so it can be handed
+/// arbitrary slice reprs without allocating.
+fn accumulate<F: Fn(usize, &QueryResult) -> f32>(
     merged: &mut HashMap<DocKey, MergedHit>,
     source: &[QueryResult],
-    k: f32,
-    weight: f32,
+    contribution: F,
 ) {
     for (idx, r) in source.iter().enumerate() {
-        let rank = (idx + 1) as f32;
-        let contribution = weight / (k + rank);
+        let c = contribution(idx, r);
         merged
             .entry(DocKey::of(r))
-            .and_modify(|m| m.score += contribution)
+            .and_modify(|m| m.score += c)
             .or_insert_with(|| MergedHit {
-                score: contribution,
-                template: r.clone(),
-            });
-    }
-}
-
-fn accumulate_score(
-    merged: &mut HashMap<DocKey, MergedHit>,
-    source: &[QueryResult],
-    normalised: &[f32],
-    weight: f32,
-) {
-    for (r, &n) in source.iter().zip(normalised.iter()) {
-        let contribution = weight * n;
-        merged
-            .entry(DocKey::of(r))
-            .and_modify(|m| m.score += contribution)
-            .or_insert_with(|| MergedHit {
-                score: contribution,
+                score: c,
                 template: r.clone(),
             });
     }

--- a/rust/services/search-plugin/src/index_manager.rs
+++ b/rust/services/search-plugin/src/index_manager.rs
@@ -114,15 +114,14 @@ impl IndexManager {
 
     /// Return the on-disk directory the given zone's ANN index lives
     /// in for the given embedder tag.  Same shape as [`index_dir`]
-    /// but under `ann-<tag>-v1/`.  Version suffix is fixed at `v1`
-    /// for now; a future breaking change (schema of `sidecar.json`,
-    /// hnsw_rs upgrade that reads a different disk layout) bumps to
-    /// `v2` so the two live side-by-side and operators can roll
-    /// back.
+    /// but under `ann-<tag>-v2/`.  The `v2` bump at P4 marks the
+    /// sidecar schema change from path-keyed to (path, chunk_index)-
+    /// keyed — v1 dirs from earlier phases stay on disk (untouched)
+    /// while callers converge on v2.  Reindex to populate v2.
     pub fn ann_dir(&self, zone_id: &str, embedder_tag: &str) -> PathBuf {
         self.root
             .join(zone_id)
-            .join(format!("ann-{embedder_tag}-v1"))
+            .join(format!("ann-{embedder_tag}-v2"))
     }
 
     /// Handle to the storage root — used by callers that need to
@@ -255,8 +254,8 @@ mod tests {
         let mgr = IndexManager::with_root(root.clone());
         let d_a = mgr.ann_dir("za", "mock");
         let d_b = mgr.ann_dir("za", "mE5-small-v1");
-        assert_eq!(d_a, root.join("za/ann-mock-v1"));
-        assert_eq!(d_b, root.join("za/ann-mE5-small-v1-v1"));
+        assert_eq!(d_a, root.join("za/ann-mock-v2"));
+        assert_eq!(d_b, root.join("za/ann-mE5-small-v1-v2"));
         assert_ne!(d_a, d_b);
     }
 

--- a/rust/services/search-plugin/src/lib.rs
+++ b/rust/services/search-plugin/src/lib.rs
@@ -53,6 +53,7 @@ pub mod search_proto {
 }
 
 pub mod ann_index;
+pub mod chunker;
 pub mod embedder;
 pub mod fts_index;
 pub mod fusion;

--- a/rust/services/search-plugin/src/service.rs
+++ b/rust/services/search-plugin/src/service.rs
@@ -674,6 +674,72 @@ impl FusionOpts {
     }
 }
 
+/// Read-side context expansion mode (P4, #4398).  Sourced from
+/// `QueryRequest.expand`; unknown values fall back to `None` so a
+/// forgetful caller gets the pre-P4 shape.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ExpandMode {
+    /// No enrichment; `QueryResult.expanded_context` stays empty.
+    None,
+    /// Fill `expanded_context` with `prev + current + next` chunk
+    /// text under the same path.
+    Macro,
+}
+
+impl ExpandMode {
+    fn from_str(s: &str) -> Self {
+        match s {
+            "macro" => Self::Macro,
+            _ => Self::None,
+        }
+    }
+}
+
+/// Fill `expanded_context` on each hit when the caller asked for
+/// `expand=macro`.  For each hit we fetch the file's full chunk
+/// set via [`FtsIndex::get_chunks_by_path`] (cheap; typical files
+/// have < 20 chunks) and concatenate previous + current + next.
+/// A hit whose file only has one chunk gets an empty
+/// `expanded_context` — same shape as `ExpandMode::None`, so
+/// callers don't need to special-case.
+///
+/// Chunks-per-path cache within one Query call: a hit at
+/// (path, chunk 2) and another at (path, chunk 5) would otherwise
+/// each re-fetch the file's chunk set.  The cache avoids that.
+fn apply_expand(manager: &IndexManager, zone_id: &str, mode: ExpandMode, hits: &mut [QueryResult]) {
+    if matches!(mode, ExpandMode::None) {
+        return;
+    }
+    let Ok(fts) = manager.get_or_open(zone_id) else {
+        return;
+    };
+    let mut cache: std::collections::HashMap<String, Vec<crate::fts_index::FtsHit>> =
+        std::collections::HashMap::new();
+    for hit in hits.iter_mut() {
+        let chunks = cache
+            .entry(hit.path.clone())
+            .or_insert_with(|| fts.get_chunks_by_path(&hit.path).unwrap_or_default());
+        if chunks.len() <= 1 {
+            continue;
+        }
+        let mut assembled = String::new();
+        let mut wrote_any = false;
+        for c in chunks.iter() {
+            let delta = c.chunk_index as i64 - hit.chunk_index as i64;
+            if (-1..=1).contains(&delta) {
+                if wrote_any {
+                    assembled.push_str("\n\n");
+                }
+                assembled.push_str(&c.chunk_text);
+                wrote_any = true;
+            }
+        }
+        if wrote_any {
+            hit.expanded_context = assembled;
+        }
+    }
+}
+
 /// Over-fetch multiplier per source for hybrid.  A doc that ranks
 /// 8 in keyword and 9 in semantic scores highly under RRF, but
 /// only surfaces if BOTH sources return it — so each side fetches
@@ -1031,6 +1097,7 @@ impl SearchService for SearchServiceImpl {
         // moves don't leave `req` partially moved for later reads.
         let query_type = QueryType::try_from(req.query_type).unwrap_or(QueryType::Unspecified);
         let fusion_opts = FusionOpts::from_request(&req);
+        let expand_mode = ExpandMode::from_str(&req.expand);
         let limit = if req.limit == 0 {
             DEFAULT_QUERY_LIMIT
         } else {
@@ -1041,6 +1108,12 @@ impl SearchService for SearchServiceImpl {
         let q = req.q;
         let path_filter = req.path_filter;
         let manager = Arc::clone(&self.manager);
+        // Cheap Arc clone + String clone retained for the post-
+        // outcome expand-macro enrichment (both go via the FTS
+        // sibling; keeping them out of the match arms' move scope
+        // avoids threading them back).
+        let manager_for_expand = Arc::clone(&self.manager);
+        let zone_for_expand = zone_id.clone();
 
         let outcome = match query_type {
             QueryType::Unspecified | QueryType::Keyword => tokio::task::spawn_blocking(move || {
@@ -1130,10 +1203,25 @@ impl SearchService for SearchServiceImpl {
         };
 
         match outcome {
-            Ok(results) => Ok(Response::new(QueryResponse {
-                results,
-                error: None,
-            })),
+            Ok(mut results) => {
+                // Post-outcome enrichment.  Runs inside the async
+                // handler (no spawn_blocking) because expand-macro's
+                // work is a handful of FTS TermQuery lookups (~10 µs
+                // each, cached per unique path) — not worth another
+                // hop through the blocking pool.
+                if matches!(expand_mode, ExpandMode::Macro) {
+                    apply_expand(
+                        &manager_for_expand,
+                        &zone_for_expand,
+                        expand_mode,
+                        &mut results,
+                    );
+                }
+                Ok(Response::new(QueryResponse {
+                    results,
+                    error: None,
+                }))
+            }
             Err(err) => Ok(Response::new(QueryResponse {
                 results: Vec::new(),
                 error: Some(err),

--- a/rust/services/search-plugin/src/service.rs
+++ b/rust/services/search-plugin/src/service.rs
@@ -609,6 +609,7 @@ fn enrich_ann_hit(
         score,
         zone_id: zone_id.to_string(),
         mtime_ms,
+        expanded_context: String::new(),
     }
 }
 
@@ -635,6 +636,7 @@ fn fts_hit_to_result(hit: FtsHit, zone_id: &str) -> QueryResult {
         score: hit.score,
         zone_id: zone_id.to_string(),
         mtime_ms: hit.mtime_ms,
+        expanded_context: String::new(),
     }
 }
 

--- a/rust/services/search-plugin/src/service.rs
+++ b/rust/services/search-plugin/src/service.rs
@@ -858,6 +858,14 @@ fn index_one(handle: &KernelHandle, sinks: &IndexSinks<'_>, vfs_path: &str) -> I
         .ok()
         .and_then(|info| info.modified_at_ms);
 
+    // Drop any prior chunks under this path before adding the fresh
+    // set — reindex-safe.  Both the delete and the subsequent adds
+    // queue on the same tantivy writer transaction; commit() lands
+    // them atomically.  P3 shape only ever adds chunk 0 so this is
+    // functionally the same as the pre-P3 auto-delete-on-add; the
+    // difference matters when P4's chunker emits multi-chunk sets
+    // and a shrinking chunk count needs the orphan sweep.
+    sinks.fts.delete_all_chunks(vfs_path);
     if let Err(e) = sinks.fts.add_document(vfs_path, 0, text, mtime_ms) {
         tracing::warn!(path = %vfs_path, err = %e, "index: fts add_document failed — skipping");
         return IndexOne::Skipped;

--- a/rust/services/search-plugin/src/service.rs
+++ b/rust/services/search-plugin/src/service.rs
@@ -1206,6 +1206,18 @@ impl SearchService for SearchServiceImpl {
 
         match outcome {
             Ok(mut results) => {
+                // Uniform post-outcome pooling.  Keyword / semantic
+                // do NOT pool internally, only hybrid's fuse_hybrid
+                // does; applying here gives all three query modes
+                // the same #4542 chunks_per_page semantics.  On the
+                // hybrid path this is a no-op (fuse_hybrid already
+                // pooled + truncated) so it's cheap to always run.
+                if fusion_opts.chunks_per_page > 0 {
+                    results = fusion::pool_by_document(results, fusion_opts.chunks_per_page);
+                    if results.len() > limit {
+                        results.truncate(limit);
+                    }
+                }
                 // Post-outcome enrichment.  Runs inside the async
                 // handler (no spawn_blocking) because expand-macro's
                 // work is a handful of FTS TermQuery lookups (~10 µs

--- a/rust/services/search-plugin/src/service.rs
+++ b/rust/services/search-plugin/src/service.rs
@@ -858,46 +858,63 @@ fn index_one(handle: &KernelHandle, sinks: &IndexSinks<'_>, vfs_path: &str) -> I
         .ok()
         .and_then(|info| info.modified_at_ms);
 
-    // Drop any prior chunks under this path before adding the fresh
-    // set — reindex-safe.  Both the delete and the subsequent adds
-    // queue on the same tantivy writer transaction; commit() lands
-    // them atomically.  P3 shape only ever adds chunk 0 so this is
-    // functionally the same as the pre-P3 auto-delete-on-add; the
-    // difference matters when P4's chunker emits multi-chunk sets
-    // and a shrinking chunk count needs the orphan sweep.
-    sinks.fts.delete_all_chunks(vfs_path);
-    if let Err(e) = sinks.fts.add_document(vfs_path, 0, text, mtime_ms) {
-        tracing::warn!(path = %vfs_path, err = %e, "index: fts add_document failed — skipping");
+    // P4: chunk the file into semantically-coherent pieces.  The
+    // chunker respects markdown-ish heading + code-fence structure
+    // and keeps each chunk under the embedder's soft budget.
+    let chunks = crate::chunker::chunk_document(text);
+    if chunks.is_empty() {
+        // Whitespace-only file — nothing to index.
         return IndexOne::Skipped;
     }
 
-    // ANN side — best-effort.  A failure to embed / add does NOT
-    // fail the whole file; keyword still works, semantic just
-    // misses this doc until the next Index retries.  Real batching
-    // (embed 32 files at a time) lands in P4/P5 when the chunker
-    // makes it worthwhile.
-    //
-    // P3 note: chunk_index is 0 (one chunk per file).  P4's real
-    // chunker replaces this with a per-chunk loop plus a preceding
-    // `ann.delete_all_chunks(vfs_path)` so a file whose chunk count
-    // shrinks doesn't leave stale ghost chunks.
+    // FTS side: drop the file's old chunk set, add the fresh one.
+    // Both ops queue on the same writer transaction so commit()
+    // lands them atomically — a reader never sees a partially-
+    // reindexed file.
+    sinks.fts.delete_all_chunks(vfs_path);
+    for chunk in &chunks {
+        if let Err(e) = sinks
+            .fts
+            .add_document(vfs_path, chunk.chunk_index, &chunk.text, mtime_ms)
+        {
+            tracing::warn!(
+                path = %vfs_path,
+                chunk = chunk.chunk_index,
+                err = %e,
+                "index: fts add_document failed — skipping remaining chunks",
+            );
+            return IndexOne::Skipped;
+        }
+    }
+
+    // ANN side — best-effort per file.  Batch-embed the whole
+    // chunk set in one embedder call to amortise ort session
+    // overhead; per-chunk add + shared delete_all mirrors the
+    // FTS discipline.  A failure on embed / add does NOT fail
+    // the whole Index — keyword still works.
     if let (Some(ann), Some(embedder)) = (sinks.ann, sinks.embedder) {
-        match embedder.embed_batch(&[text]) {
-            Ok(mut vecs) => {
-                if let Some(v) = vecs.pop() {
-                    // Drop any stale chunks under this path before
-                    // adding the fresh one — the P3 shape only ever
-                    // has chunk 0, but calling delete_all_chunks
-                    // first keeps the caller pattern honest for P4.
-                    ann.delete_all_chunks(vfs_path);
-                    if let Err(e) = ann.add_vector(vfs_path, 0, &v) {
+        let inputs: Vec<&str> = chunks.iter().map(|c| c.embed_input.as_str()).collect();
+        match embedder.embed_batch(&inputs) {
+            Ok(vecs) if vecs.len() == chunks.len() => {
+                ann.delete_all_chunks(vfs_path);
+                for (chunk, vec) in chunks.iter().zip(vecs.iter()) {
+                    if let Err(e) = ann.add_vector(vfs_path, chunk.chunk_index, vec) {
                         tracing::warn!(
                             path = %vfs_path,
+                            chunk = chunk.chunk_index,
                             err = %e,
-                            "index: ann add_vector failed — semantic misses this doc",
+                            "index: ann add_vector failed — semantic misses this chunk",
                         );
                     }
                 }
+            }
+            Ok(vecs) => {
+                tracing::warn!(
+                    path = %vfs_path,
+                    got = vecs.len(),
+                    expected = chunks.len(),
+                    "index: embedder returned wrong vec count — semantic misses this doc",
+                );
             }
             Err(e) => {
                 tracing::warn!(

--- a/rust/services/search-plugin/src/service.rs
+++ b/rust/services/search-plugin/src/service.rs
@@ -604,7 +604,7 @@ fn enrich_ann_hit(
         .unwrap_or((String::new(), None));
     QueryResult {
         path: hit.path,
-        chunk_index: 0,
+        chunk_index: hit.chunk_index,
         chunk_text,
         score,
         zone_id: zone_id.to_string(),
@@ -879,11 +879,21 @@ fn index_one(handle: &KernelHandle, sinks: &IndexSinks<'_>, vfs_path: &str) -> I
     // misses this doc until the next Index retries.  Real batching
     // (embed 32 files at a time) lands in P4/P5 when the chunker
     // makes it worthwhile.
+    //
+    // P3 note: chunk_index is 0 (one chunk per file).  P4's real
+    // chunker replaces this with a per-chunk loop plus a preceding
+    // `ann.delete_all_chunks(vfs_path)` so a file whose chunk count
+    // shrinks doesn't leave stale ghost chunks.
     if let (Some(ann), Some(embedder)) = (sinks.ann, sinks.embedder) {
         match embedder.embed_batch(&[text]) {
             Ok(mut vecs) => {
                 if let Some(v) = vecs.pop() {
-                    if let Err(e) = ann.add_vector(vfs_path, &v) {
+                    // Drop any stale chunks under this path before
+                    // adding the fresh one — the P3 shape only ever
+                    // has chunk 0, but calling delete_all_chunks
+                    // first keeps the caller pattern honest for P4.
+                    ann.delete_all_chunks(vfs_path);
+                    if let Err(e) = ann.add_vector(vfs_path, 0, &v) {
                         tracing::warn!(
                             path = %vfs_path,
                             err = %e,

--- a/rust/services/search-plugin/src/service.rs
+++ b/rust/services/search-plugin/src/service.rs
@@ -674,32 +674,22 @@ impl FusionOpts {
     }
 }
 
-/// Hybrid = keyword + semantic, fused per the caller's chosen
-/// method, optionally pooled per-doc.  Runs both retrievals in
-/// sequence on the same spawn_blocking worker — small P3-friendly
-/// implementation.  A parallel-fetch variant is a follow-up when
-/// per-source latency asymmetry (BM25 ~ms, semantic ~10-100ms with
-/// real fastembed) starts to matter for user-visible p95.
-///
-/// Each source over-fetches `limit * 2` to give fusion headroom
-/// (a doc that ranks 8 in keyword and 9 in semantic scores highly
-/// under RRF but only surfaces if BOTH sources return it).  The
-/// dispatcher's `path_filter` still applies inside each source's
-/// query so pooling never has to re-check.
-fn do_hybrid_query(
-    manager: &IndexManager,
-    embedder: &Arc<dyn Embedder>,
-    q: &str,
-    zone_id: &str,
+/// Over-fetch multiplier per source for hybrid.  A doc that ranks
+/// 8 in keyword and 9 in semantic scores highly under RRF, but
+/// only surfaces if BOTH sources return it — so each side fetches
+/// more than the caller-visible `limit` to give fusion headroom.
+const HYBRID_OVER_FETCH_MULT: usize = 2;
+
+/// Fuse two source result lists per the caller's chosen method,
+/// pool per-doc, and truncate to `limit`.  Pure math — the two
+/// source lists come in already fetched.  The RPC handler runs
+/// the fetches in parallel then hands them here.
+fn fuse_hybrid(
+    keyword: Vec<QueryResult>,
+    semantic: Vec<QueryResult>,
     limit: usize,
-    path_filter: &str,
     opts: FusionOpts,
-) -> Result<Vec<QueryResult>, String> {
-    let over_fetch = limit.saturating_mul(2).max(limit);
-
-    let keyword = do_keyword_query(manager, q, zone_id, over_fetch, path_filter)?;
-    let semantic = do_semantic_query(manager, embedder, q, zone_id, over_fetch, path_filter)?;
-
+) -> Vec<QueryResult> {
     let fused = match opts.method {
         FusionMethod::Unspecified | FusionMethod::Rrf => {
             fusion::rrf(&keyword, &semantic, opts.rrf_k)
@@ -709,9 +699,8 @@ fn do_hybrid_query(
             fusion::rrf_weighted(&keyword, &semantic, opts.rrf_k, opts.alpha)
         }
     };
-
     let pooled = fusion::pool_by_document(fused, opts.chunks_per_page);
-    Ok(pooled.into_iter().take(limit).collect())
+    pooled.into_iter().take(limit).collect()
 }
 
 /// Sinks the Index walker writes into.  `fts` is required (Index
@@ -1068,19 +1057,50 @@ impl SearchService for SearchServiceImpl {
                         }));
                     }
                 };
-                tokio::task::spawn_blocking(move || {
-                    do_hybrid_query(
-                        &manager,
-                        &embedder,
-                        &q,
-                        &zone_id,
-                        limit,
-                        &path_filter,
-                        fusion_opts,
+                // Parallel-fetch retrofit (P3 audit finding #3):
+                // real-fastembed semantic ~300 ms + BM25 keyword ~10 ms
+                // = 310 ms wall-clock sequential.  Spawning both legs
+                // on the blocking pool + joining brings wall-clock to
+                // max(kw, sem) ≈ 300 ms — no free lunch on total CPU
+                // but user-visible p95 halves in the worst-case ratio.
+                let over_fetch = limit.saturating_mul(HYBRID_OVER_FETCH_MULT).max(limit);
+                let (kw_task, sem_task) = {
+                    let mgr_kw = Arc::clone(&manager);
+                    let mgr_sem = Arc::clone(&manager);
+                    let embedder = Arc::clone(&embedder);
+                    let q_kw = q.clone();
+                    let q_sem = q;
+                    let zone_kw = zone_id.clone();
+                    let zone_sem = zone_id;
+                    let path_kw = path_filter.clone();
+                    let path_sem = path_filter;
+                    (
+                        tokio::task::spawn_blocking(move || {
+                            do_keyword_query(&mgr_kw, &q_kw, &zone_kw, over_fetch, &path_kw)
+                        }),
+                        tokio::task::spawn_blocking(move || {
+                            do_semantic_query(
+                                &mgr_sem, &embedder, &q_sem, &zone_sem, over_fetch, &path_sem,
+                            )
+                        }),
                     )
-                })
-                .await
-                .map_err(|e| Status::internal(format!("spawn_blocking joined error: {e}")))?
+                };
+                let (kw_join, sem_join) = tokio::join!(kw_task, sem_task);
+                let kw = kw_join
+                    .map_err(|e| Status::internal(format!("spawn_blocking joined error: {e}")))?;
+                let sem = sem_join
+                    .map_err(|e| Status::internal(format!("spawn_blocking joined error: {e}")))?;
+                match (kw, sem) {
+                    (Ok(keyword), Ok(semantic)) => {
+                        Ok(fuse_hybrid(keyword, semantic, limit, fusion_opts))
+                    }
+                    // A source-side error on either leg — surface it
+                    // as the response's `error` field rather than a
+                    // gRPC Status, matching keyword / semantic
+                    // behaviour.  If both fail we surface the
+                    // keyword error (arbitrary but stable).
+                    (Err(e), _) | (Ok(_), Err(e)) => Err(e),
+                }
             }
         };
 

--- a/tests/e2e/docker/search_helpers.py
+++ b/tests/e2e/docker/search_helpers.py
@@ -126,6 +126,7 @@ def search_query(
     alpha: float = 0.0,
     rrf_k: int = 0,
     chunks_per_page: int = 0,
+    expand: str = "",
     api_key: str = ADMIN_API_KEY,
     timeout: float = 30,
 ) -> dict:
@@ -177,6 +178,7 @@ def search_query(
             alpha=alpha,
             rrf_k=rrf_k,
             chunks_per_page=chunks_per_page,
+            expand=expand,
         )
         resp = stub.Query(req, timeout=timeout)
         if resp.HasField("error"):
@@ -191,6 +193,7 @@ def search_query(
                         "score": r.score,
                         "zone_id": r.zone_id,
                         "mtime_ms": r.mtime_ms if r.HasField("mtime_ms") else None,
+                        "expanded_context": r.expanded_context,
                     }
                     for r in resp.results
                 ]

--- a/tests/e2e/docker/test_search_plugin.py
+++ b/tests/e2e/docker/test_search_plugin.py
@@ -337,6 +337,121 @@ class TestSearchIndexQuery:
             f"hybrid degradation message should mention unavailability, got {r}"
         )
 
+    def test_multichunk_file_yields_multiple_indexed_docs(self, api_key: str) -> None:
+        """P4: a file with N markdown sections becomes N chunks in
+        the FTS index, not one.  Query for text that appears in a
+        distinct section returns the chunk whose text contains it
+        (with its `chunk_index` > 0 for later sections)."""
+        u = uid()
+        base = f"/search-p4-{u}"
+        vfs_mkdir(NODE_GRPC, base, parents=True, api_key=api_key)
+        # Multi-section markdown that the chunker splits on headings.
+        # Payload text is > CHUNK_TARGET_CHARS (1600) so budget
+        # forces the split even without heading boundaries.
+        body = (
+            "# Intro\n\nintro-payload " + "alpha " * 400 + "\n\n"
+            "# Setup\n\nsetup-payload " + "beta " * 400 + "\n\n"
+            "# Usage\n\nusage-payload " + "gamma " * 400 + "\n"
+        )
+        r = vfs_write(NODE_GRPC, f"{base}/doc.md", body.encode("utf-8"), api_key=api_key)
+        assert "error" not in r, r
+
+        idx = search_index(NODE_GRPC, base, api_key=api_key)
+        assert "error" not in idx, idx
+        assert idx["result"]["indexed_count"] == 1, idx  # one file
+
+        # Query 'beta' matches only the Setup chunk.
+        r = search_query(NODE_GRPC, "beta", path_filter=base, api_key=api_key)
+        assert "error" not in r, r
+        results = r["result"]["results"]
+        assert len(results) == 1, f"expected 1 hit for 'beta', got {results}"
+        beta = results[0]
+        assert beta["path"] == f"{base}/doc.md"
+        # chunk_index > 0 proves the chunker split — 'beta' is in
+        # section 2 (Setup), not section 1 (Intro).
+        assert beta["chunk_index"] > 0, f"beta hit should be from a later chunk: {beta}"
+
+    def test_pooling_caps_chunks_per_page(self, api_key: str) -> None:
+        """chunks_per_page = 1 collapses same-file hits to one row per
+        file — pins the P3 wire finally being observable in P4.
+        Without pooling, three chunks of the same file each matching
+        'shared' would occupy three slots.
+        """
+        u = uid()
+        base = f"/search-pool-{u}"
+        vfs_mkdir(NODE_GRPC, base, parents=True, api_key=api_key)
+        # One file with three sections all containing 'shared'.
+        body = (
+            "# A\n\n" + "shared " * 400 + "\n\n"
+            "# B\n\n" + "shared " * 400 + "\n\n"
+            "# C\n\n" + "shared " * 400 + "\n"
+        )
+        r = vfs_write(NODE_GRPC, f"{base}/long.md", body.encode("utf-8"), api_key=api_key)
+        assert "error" not in r, r
+        idx = search_index(NODE_GRPC, base, api_key=api_key)
+        assert "error" not in idx, idx
+
+        # No pooling: multiple chunks of the same file surface.
+        r_unpooled = search_query(NODE_GRPC, "shared", path_filter=base, api_key=api_key)
+        assert "error" not in r_unpooled, r_unpooled
+        unpooled_paths = [x["path"] for x in r_unpooled["result"]["results"]]
+        unpooled_dup_count = sum(1 for p in unpooled_paths if p == f"{base}/long.md")
+        assert unpooled_dup_count >= 2, (
+            f"expected multi-chunk file to surface > 1 row without pooling; got {unpooled_paths}"
+        )
+
+        # With pooling: same-file chunks collapse to one row.
+        r_pooled = search_query(
+            NODE_GRPC,
+            "shared",
+            path_filter=base,
+            chunks_per_page=1,
+            api_key=api_key,
+        )
+        assert "error" not in r_pooled, r_pooled
+        pooled_paths = [x["path"] for x in r_pooled["result"]["results"]]
+        pooled_dup_count = sum(1 for p in pooled_paths if p == f"{base}/long.md")
+        assert pooled_dup_count == 1, f"pooling failed to cap same-file chunks; got {pooled_paths}"
+
+    def test_expand_macro_returns_neighbour_context(self, api_key: str) -> None:
+        """expand=macro fills expanded_context with prev+current+next
+        chunk texts, letting callers render a section-sized snippet
+        without a follow-up read."""
+        u = uid()
+        base = f"/search-expand-{u}"
+        vfs_mkdir(NODE_GRPC, base, parents=True, api_key=api_key)
+        body = (
+            "# Intro\n\nintro-payload " + "x " * 400 + "\n\n"
+            "# Setup\n\nsetup-unique-token " + "y " * 400 + "\n\n"
+            "# Usage\n\nusage-tail " + "z " * 400 + "\n"
+        )
+        r = vfs_write(NODE_GRPC, f"{base}/doc.md", body.encode("utf-8"), api_key=api_key)
+        assert "error" not in r, r
+        idx = search_index(NODE_GRPC, base, api_key=api_key)
+        assert "error" not in idx, idx
+
+        # Baseline: expand=none → expanded_context empty.
+        r_plain = search_query(NODE_GRPC, "setup-unique-token", path_filter=base, api_key=api_key)
+        assert "error" not in r_plain
+        hit_plain = r_plain["result"]["results"][0]
+        assert hit_plain["expanded_context"] == "", hit_plain
+
+        # expand=macro → expanded_context contains prev + current + next.
+        r_macro = search_query(
+            NODE_GRPC,
+            "setup-unique-token",
+            path_filter=base,
+            expand="macro",
+            api_key=api_key,
+        )
+        assert "error" not in r_macro
+        hit_macro = r_macro["result"]["results"][0]
+        assert hit_macro["expanded_context"], f"expand=macro should fill context: {hit_macro}"
+        # Setup is the middle section → context includes intro-payload
+        # (prev) and usage-tail (next).
+        assert "intro-payload" in hit_macro["expanded_context"], hit_macro
+        assert "usage-tail" in hit_macro["expanded_context"], hit_macro
+
     def test_query_hybrid_honours_fusion_method_arg(self, api_key: str) -> None:
         """Even in the degraded (no-embedder) shape, the wire must
         accept the P3 fusion knobs — a stale gRPC schema on the


### PR DESCRIPTION
## Summary

One PR many commits. Combines the P3 audit-driven retrofits and
P4 chunker + expand + storage-key change.

**Status: DRAFT** while I finish the P4 chunker + expand
integration.

## Retrofits (P3 audit follow-ups)

- **#5 DRY fusion accumulators** → single generic
  \`accumulate<F: Fn>\`
- **#1 chunks_per_page doc** → explicit "observable from P4 onward"
- **#2 AnnHit.chunk_index** → carried through to QueryResult
  (was hardcoded to 0)
- **#3 parallel hybrid legs** → spawn kw + sem in parallel, join,
  fuse. Wall = max(kw, sem) vs kw + sem sequentially.

## P4 (in progress in this PR)

- **AnnIndex sidecar v2**: (path, chunk_index) key + \`delete_all_chunks\`.
  Dir bumps ann-<tag>-v1 → ann-<tag>-v2. **LANDED.**
- **FtsIndex per-chunk semantics**: \`delete_all_chunks\` + no auto-
  delete on add_document. (next commit)
- **Chunker module**: heading + code-fence + token-budget-aware.
  \`tiktoken-rs\` + \`pulldown-cmark\`. (next commit)
- **do_index uses chunker**: multi-chunk per file. (next commit)
- **Proto expand + expanded_context**: \`expand=macro\` returns
  neighbouring chunks. (next commit)
- **Multi-chunk E2E + docker E2E**. (next commit)

## Test plan

- [ ] Rust unit + integration tests (fusion, ann, service)
- [ ] Docker E2E: multi-chunk indexing + expand=macro
- [ ] Existing keyword/semantic/hybrid tests still pass