### PR TITLE
feat(search-plugin): Phase 5 — incremental refresh via mtime cache [WIP]

### DIFF
--- a/rust/services/proto/nexus/search/v1/search.proto
+++ b/rust/services/proto/nexus/search/v1/search.proto
@@ -48,6 +48,19 @@ service SearchService {
   // uses one chunk per file — Phase 4 will fold in the real
   // markdown-/code-aware chunker.
   rpc Index(IndexRequest) returns (IndexResponse);
+
+  // Incremental refresh (Phase 5).  Walks `root_path` like Index,
+  // but consults a per-zone (path → mtime_ms) cache and only re-
+  // processes files that are new, edited (fresh mtime > cached),
+  // or removed (in cache but missing from the walk — dropped from
+  // both FTS and ANN).  Files whose mtime matches the cache are
+  // skipped — a Refresh over a mostly-unchanged corpus is O(walk +
+  // a couple of stat calls) rather than O(full reindex).
+  //
+  // Callers hit Refresh on a cadence they choose (cron, on-write
+  // hook once federation adds one, etc.); nothing about Refresh
+  // requires or implies scheduling on the plugin side.
+  rpc Refresh(RefreshRequest) returns (RefreshResponse);
 }
 
 // ── Glob ──────────────────────────────────────────────────────────
@@ -323,4 +336,36 @@ message IndexResponse {
   // Callers treat non-empty error as "no documents added, log and
   // retry with narrower scope" per Glob + Grep convention.
   optional string error = 3;
+}
+
+message RefreshRequest {
+  // Walk start (same shape as IndexRequest.root_path).
+  string root_path = 1;
+  // Zone scope — same rule as QueryRequest.zone_id.
+  string zone_id = 2;
+  // Recurse into subdirectories (matches Python `recursive=False`).
+  bool recursive = 3;
+  // Safety cap on walker size.  0 ⇒ server-side default (10_000).
+  uint32 max_docs = 4;
+  // Auth token per the sibling RPCs.
+  string auth_token = 5;
+}
+
+message RefreshResponse {
+  // Files re-indexed (new or mtime-changed).  Distinct from a full
+  // Index's indexed_count so callers can tell "Refresh saw N
+  // changes" from "Index processed N files total".
+  uint32 reindexed_count = 1;
+  // Files dropped from FTS + ANN because they were in the cache
+  // but no longer present in the walked corpus.
+  uint32 removed_count = 2;
+  // Files whose cached mtime matched the fresh mtime — the whole
+  // reason Refresh exists.  Handy for operators to sanity-check
+  // the cache is working.
+  uint32 unchanged_count = 3;
+  // Files visited but skipped for content reasons (empty, binary,
+  // oversize) — same shape as IndexResponse.skipped_count.
+  uint32 skipped_count = 4;
+  // Set when the walk aborted; same convention as IndexResponse.
+  optional string error = 5;
 }

--- a/rust/services/search-plugin/src/index_manager.rs
+++ b/rust/services/search-plugin/src/index_manager.rs
@@ -124,6 +124,15 @@ impl IndexManager {
             .join(format!("ann-{embedder_tag}-v2"))
     }
 
+    /// Return the per-zone root — parent of `fts/` and `ann-*-v2/`.
+    /// Used by `IndexState::open_or_create` to place
+    /// `index_state.json` at the zone level so the P5 mtime cache
+    /// sits alongside the sub-index directories rather than inside
+    /// one of them.
+    pub fn zone_root(&self, zone_id: &str) -> PathBuf {
+        self.root.join(zone_id)
+    }
+
     /// Handle to the storage root — used by callers that need to
     /// resolve sibling per-zone directories (e.g. Phase 2's HNSW
     /// index next to the tantivy one).

--- a/rust/services/search-plugin/src/index_state.rs
+++ b/rust/services/search-plugin/src/index_state.rs
@@ -1,0 +1,357 @@
+//! Per-zone incremental-refresh checkpoint (Phase 5 of the Python-
+//! parity roadmap; see `PARITY_ROADMAP.md`).
+//!
+//! # What this stores
+//!
+//! For every path the FTS + ANN indexes currently hold, we record
+//! its `modified_at_ms` from the kernel at Index time.  On Refresh
+//! the walker compares the current kernel mtime against this cache
+//! and only re-indexes files that:
+//!
+//! - are NEW (in the walk but not the cache),
+//! - have a NEWER mtime than the cache remembers (edited since
+//!   last Index), or conversely
+//! - are STALE — in the cache but missing from the current walk
+//!   (deleted); those get dropped from both FTS + ANN.
+//!
+//! Files whose mtime matches the cache exactly are left alone —
+//! the whole point of P5 is that a Refresh over a mostly-unchanged
+//! corpus is O(walk + a couple of small file reads) rather than
+//! O(full reindex).
+//!
+//! # SSOT + persistence posture
+//!
+//! Corpus SSOT stays the kernel VFS (per D1).  This cache is
+//! **derived state** — dropping the file is always safe, the next
+//! Refresh (or Index) rebuilds it.  Per-node, not replicated:
+//! each node maintains its own indexes and its own cache; the
+//! MetaStore isn't involved because the plugin doesn't currently
+//! have a metastore callback in KernelHandle and adding one would
+//! violate principle 1b (don't lightly modify kernel ABI).
+//!
+//! # File layout
+//!
+//! `<root>/<zone_id>/index_state.json` — a sibling of the `fts/` +
+//! `ann-*-v2/` directories under the per-zone root.  Atomic rewrite
+//! via write-then-rename so a mid-write crash never leaves a
+//! truncated file that would break the next open.
+//!
+//! # Concurrency
+//!
+//! `IndexState` is behind a `parking_lot::RwLock`.  Reads (Refresh
+//! diff pass) take the read lock; writes (record after successful
+//! per-file index) take the write lock briefly.  Save happens at
+//! end-of-Refresh so the diff loop doesn't take a lock per file.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use parking_lot::RwLock;
+use serde::{Deserialize, Serialize};
+
+/// Sidecar filename for the per-zone mtime cache.  Same
+/// per-zone-root neighbourhood as `sidecar.json` inside the ANN
+/// dir, but this one lives one level up (the FTS + ANN dirs are
+/// derived-state; this is meta about them).
+const STATE_FILE: &str = "index_state.json";
+
+/// On-disk schema.  `version` bump semantics same as
+/// `ann_index::Sidecar`: a schema drift refuses to load and the
+/// operator drops-and-reindexes.
+const STATE_VERSION: u32 = 1;
+
+fn state_version_default() -> u32 {
+    STATE_VERSION
+}
+
+/// Per-file cache entry.  Two fields today; extended in future
+/// phases (e.g. chunk_count for pooling diagnostics).
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub struct FileEntry {
+    /// Kernel-reported mtime at last successful index.  Compared
+    /// against fresh sys_stat to detect edits.  `None` means the
+    /// kernel didn't hand us an mtime — those files always
+    /// re-index on Refresh (defensive: no mtime, no dedup).
+    pub mtime_ms: Option<i64>,
+}
+
+/// On-disk shape of the state cache.
+#[derive(Debug, Serialize, Deserialize, Default)]
+struct Persisted {
+    #[serde(default = "state_version_default")]
+    version: u32,
+    #[serde(default)]
+    files: HashMap<String, FileEntry>,
+}
+
+/// Zone-scoped mtime cache.  Cheap to clone through Arc for
+/// service.rs's use in Refresh.
+pub struct IndexState {
+    dir: PathBuf,
+    inner: RwLock<HashMap<String, FileEntry>>,
+}
+
+impl IndexState {
+    /// Load the state file at `<zone_root>/index_state.json` if it
+    /// exists; otherwise start empty.  A missing file is normal on
+    /// first Index for a fresh zone.
+    pub fn open_or_create(zone_root: PathBuf) -> Result<Self, StateError> {
+        std::fs::create_dir_all(&zone_root)
+            .map_err(|e| StateError::CreateDir(zone_root.display().to_string(), e.to_string()))?;
+        let path = zone_root.join(STATE_FILE);
+        let inner = if path.exists() {
+            let bytes = std::fs::read(&path)
+                .map_err(|e| StateError::Read(path.display().to_string(), e.to_string()))?;
+            let persisted: Persisted = serde_json::from_slice(&bytes)
+                .map_err(|e| StateError::Parse(path.display().to_string(), e.to_string()))?;
+            if persisted.version != STATE_VERSION {
+                return Err(StateError::Parse(
+                    path.display().to_string(),
+                    format!(
+                        "state version {} != expected {}; drop and reindex",
+                        persisted.version, STATE_VERSION
+                    ),
+                ));
+            }
+            persisted.files
+        } else {
+            HashMap::new()
+        };
+        Ok(Self {
+            dir: zone_root,
+            inner: RwLock::new(inner),
+        })
+    }
+
+    /// Snapshot of every recorded path.  Callers use this to detect
+    /// stale (deleted-from-VFS) entries during the Refresh diff.
+    /// Read-lock short-held; the returned `Vec<String>` is a copy.
+    pub fn known_paths(&self) -> Vec<String> {
+        self.inner.read().keys().cloned().collect()
+    }
+
+    /// Look up a path's cached mtime — used in the mtime-changed
+    /// check during Refresh.
+    pub fn cached_mtime(&self, path: &str) -> Option<Option<i64>> {
+        self.inner.read().get(path).map(|e| e.mtime_ms)
+    }
+
+    /// Compare the cached mtime for `path` against `fresh_mtime`.
+    /// Returns:
+    /// - `RefreshVerdict::Unchanged` if the mtime matches AND we
+    ///   have a concrete mtime for the file.
+    /// - `RefreshVerdict::Changed` if new / edited / has-no-mtime
+    ///   (fail-open: re-index rather than risk staleness).
+    pub fn verdict(&self, path: &str, fresh_mtime: Option<i64>) -> RefreshVerdict {
+        let cached = self.inner.read().get(path).cloned();
+        match (cached, fresh_mtime) {
+            (
+                Some(FileEntry {
+                    mtime_ms: Some(cached_ms),
+                }),
+                Some(fresh_ms),
+            ) if cached_ms == fresh_ms => RefreshVerdict::Unchanged,
+            _ => RefreshVerdict::Changed,
+        }
+    }
+
+    /// Record a successful index of `path` at `mtime_ms`.  Called
+    /// per-file after both FTS and ANN adds land, before the
+    /// commit — so a mid-Refresh crash leaves the cache reflecting
+    /// only files that made it through the writer transaction.
+    pub fn record(&self, path: &str, mtime_ms: Option<i64>) {
+        self.inner
+            .write()
+            .insert(path.to_string(), FileEntry { mtime_ms });
+    }
+
+    /// Drop a path from the cache — called after the corresponding
+    /// FTS + ANN deletes when a file was removed from the corpus.
+    pub fn forget(&self, path: &str) {
+        self.inner.write().remove(path);
+    }
+
+    /// Number of cached entries — used by tests + operator
+    /// diagnostics.
+    pub fn len(&self) -> usize {
+        self.inner.read().len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.inner.read().is_empty()
+    }
+
+    /// Persist the cache to disk.  Atomic write-then-rename so a
+    /// mid-write crash never leaves a truncated JSON file that
+    /// would fail the next `open_or_create`.  Called at
+    /// end-of-Refresh / end-of-Index.
+    pub fn save(&self) -> Result<(), StateError> {
+        let path = self.dir.join(STATE_FILE);
+        let persisted = Persisted {
+            version: STATE_VERSION,
+            files: self.inner.read().clone(),
+        };
+        let bytes =
+            serde_json::to_vec_pretty(&persisted).map_err(|e| StateError::Encode(e.to_string()))?;
+        let tmp = path.with_extension("json.tmp");
+        std::fs::write(&tmp, &bytes)
+            .map_err(|e| StateError::Write(tmp.display().to_string(), e.to_string()))?;
+        std::fs::rename(&tmp, &path)
+            .map_err(|e| StateError::Write(path.display().to_string(), e.to_string()))?;
+        Ok(())
+    }
+
+    /// Absolute path to the sidecar file — used by tests to check
+    /// layout.
+    pub fn state_file(&self) -> PathBuf {
+        self.dir.join(STATE_FILE)
+    }
+
+    /// Zone root the state lives under.  For tests + operator
+    /// diagnostics.
+    pub fn dir(&self) -> &Path {
+        &self.dir
+    }
+}
+
+/// Verdict from `verdict()` — three-way but modelled as two
+/// variants because callers uniformly branch on "reindex needed
+/// or not".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RefreshVerdict {
+    /// File's cached mtime matches the fresh kernel mtime — safe
+    /// to skip re-indexing.
+    Unchanged,
+    /// File is new, edited, or has no mtime — needs re-index.
+    Changed,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum StateError {
+    #[error("create state dir {0}: {1}")]
+    CreateDir(String, String),
+    #[error("read state file {0}: {1}")]
+    Read(String, String),
+    #[error("parse state file {0}: {1}")]
+    Parse(String, String),
+    #[error("encode state: {0}")]
+    Encode(String),
+    #[error("write state file {0}: {1}")]
+    Write(String, String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tempdir() -> PathBuf {
+        tempfile::tempdir().expect("tempdir").keep()
+    }
+
+    #[test]
+    fn open_or_create_returns_empty_on_fresh_zone() {
+        let s = IndexState::open_or_create(tempdir()).expect("open");
+        assert_eq!(s.len(), 0);
+        assert!(s.is_empty());
+        assert!(s.known_paths().is_empty());
+    }
+
+    #[test]
+    fn record_then_verdict_reports_unchanged_on_match() {
+        let s = IndexState::open_or_create(tempdir()).expect("open");
+        s.record("/a.md", Some(1_700_000_000_000));
+        assert_eq!(
+            s.verdict("/a.md", Some(1_700_000_000_000)),
+            RefreshVerdict::Unchanged,
+        );
+    }
+
+    #[test]
+    fn verdict_reports_changed_when_mtime_advances() {
+        let s = IndexState::open_or_create(tempdir()).expect("open");
+        s.record("/a.md", Some(1_700_000_000_000));
+        assert_eq!(
+            s.verdict("/a.md", Some(1_700_000_000_500)),
+            RefreshVerdict::Changed,
+        );
+    }
+
+    #[test]
+    fn verdict_reports_changed_on_missing_from_cache() {
+        let s = IndexState::open_or_create(tempdir()).expect("open");
+        assert_eq!(
+            s.verdict("/never-seen.md", Some(1_700_000_000_000)),
+            RefreshVerdict::Changed,
+        );
+    }
+
+    #[test]
+    fn verdict_reports_changed_when_no_mtime_available() {
+        // Defensive: if the kernel didn't hand us a fresh mtime,
+        // fall open to Changed (re-index) rather than silently
+        // treat as Unchanged and let a real edit slip.
+        let s = IndexState::open_or_create(tempdir()).expect("open");
+        s.record("/a.md", Some(1_700_000_000_000));
+        assert_eq!(s.verdict("/a.md", None), RefreshVerdict::Changed);
+    }
+
+    #[test]
+    fn save_then_open_survives_restart() {
+        let dir = tempdir();
+        {
+            let s = IndexState::open_or_create(dir.clone()).expect("open");
+            s.record("/a.md", Some(1_700_000_000_000));
+            s.record("/b.md", None); // no-mtime doc
+            s.save().expect("save");
+        }
+        let s2 = IndexState::open_or_create(dir).expect("reopen");
+        assert_eq!(s2.len(), 2);
+        assert_eq!(s2.cached_mtime("/a.md"), Some(Some(1_700_000_000_000)));
+        assert_eq!(s2.cached_mtime("/b.md"), Some(None));
+    }
+
+    #[test]
+    fn forget_removes_from_cache_and_survives_save() {
+        let dir = tempdir();
+        let s = IndexState::open_or_create(dir.clone()).expect("open");
+        s.record("/a.md", Some(1));
+        s.record("/b.md", Some(2));
+        s.forget("/a.md");
+        s.save().expect("save");
+
+        let s2 = IndexState::open_or_create(dir).expect("reopen");
+        assert_eq!(s2.len(), 1);
+        assert_eq!(s2.cached_mtime("/b.md"), Some(Some(2)));
+        assert_eq!(s2.cached_mtime("/a.md"), None);
+    }
+
+    #[test]
+    fn known_paths_is_snapshot_not_borrow() {
+        // Regression guard: `known_paths` returns a copy so the
+        // caller can iterate + call `verdict` (which read-locks)
+        // without deadlocking on a nested read-lock.  If the API
+        // ever changes to return `&[String]` (borrowed from the
+        // read lock guard), this test surfaces the deadlock risk.
+        let s = IndexState::open_or_create(tempdir()).expect("open");
+        s.record("/a.md", Some(1));
+        let paths = s.known_paths();
+        for p in &paths {
+            let _ = s.verdict(p, Some(1));
+        }
+        assert_eq!(paths, vec!["/a.md".to_string()]);
+    }
+
+    #[test]
+    fn atomic_rewrite_never_leaves_truncated_state() {
+        let dir = tempdir();
+        let s = IndexState::open_or_create(dir.clone()).expect("open");
+        s.record("/a.md", Some(1));
+        s.save().expect("save-1");
+        // Second save should also succeed (rename overwrites).
+        s.record("/b.md", Some(2));
+        s.save().expect("save-2");
+        // No lingering .tmp file left behind.
+        let tmp = dir.join("index_state.json.tmp");
+        assert!(!tmp.exists(), "leftover tmp file: {}", tmp.display());
+    }
+}

--- a/rust/services/search-plugin/src/lib.rs
+++ b/rust/services/search-plugin/src/lib.rs
@@ -63,7 +63,7 @@ pub mod kernel_io;
 pub mod service;
 
 use search_proto::search_service_server::SearchService as SearchServiceTrait;
-use search_proto::{GlobRequest, GrepRequest, IndexRequest, QueryRequest};
+use search_proto::{GlobRequest, GrepRequest, IndexRequest, QueryRequest, RefreshRequest};
 
 /// Plugin state held between `create` and `destroy`.
 ///
@@ -213,6 +213,21 @@ fn dispatch_grpc(plugin: &SearchPlugin, method: &str, payload: &[u8]) -> Result<
                 .block_on(plugin.svc.index(Request::new(req)))
                 .map_err(|s| {
                     tracing::warn!(status = %s, "Index handler");
+                    -3
+                })?
+                .into_inner();
+            Ok(resp.encode_to_vec())
+        }
+        "Refresh" => {
+            let req = RefreshRequest::decode(payload).map_err(|e| {
+                tracing::warn!(err = %e, "Refresh decode");
+                -2
+            })?;
+            let resp = plugin
+                .rt
+                .block_on(plugin.svc.refresh(Request::new(req)))
+                .map_err(|s| {
+                    tracing::warn!(status = %s, "Refresh handler");
                     -3
                 })?
                 .into_inner();

--- a/rust/services/search-plugin/src/lib.rs
+++ b/rust/services/search-plugin/src/lib.rs
@@ -58,6 +58,7 @@ pub mod embedder;
 pub mod fts_index;
 pub mod fusion;
 pub mod index_manager;
+pub mod index_state;
 pub mod kernel_io;
 pub mod service;
 

--- a/rust/services/search-plugin/src/service.rs
+++ b/rust/services/search-plugin/src/service.rs
@@ -23,7 +23,8 @@ use crate::kernel_io::{self, DirEntry, KernelIoError, DT_DIR, DT_REG};
 use crate::search_proto::search_service_server::SearchService;
 use crate::search_proto::{
     FusionMethod, GlobRequest, GlobResponse, GrepMatch, GrepRequest, GrepResponse, IndexRequest,
-    IndexResponse, QueryRequest, QueryResponse, QueryResult, QueryType,
+    IndexResponse, QueryRequest, QueryResponse, QueryResult, QueryType, RefreshRequest,
+    RefreshResponse,
 };
 
 /// Server-side default when the caller sends `max_results = 0`.
@@ -775,11 +776,14 @@ fn fuse_hybrid(
 /// always populates the keyword index); `ann` + `embedder` are
 /// optional so a slim deployment or a mid-boot with no embedder
 /// still gets keyword search — semantic just returns zero hits
-/// until Index is retried with the embedder wired up.
+/// until Index is retried with the embedder wired up.  `state` is
+/// the P5 mtime cache — updated when a file is added or dropped so
+/// the next Refresh's diff pass has an accurate baseline.
 struct IndexSinks<'a> {
     fts: &'a Arc<crate::fts_index::FtsIndex>,
     ann: Option<&'a Arc<crate::ann_index::AnnIndex>>,
     embedder: Option<&'a Arc<dyn Embedder>>,
+    state: &'a crate::index_state::IndexState,
 }
 
 /// Walk `root_path` and index every regular file.  Same walker Glob +
@@ -818,10 +822,14 @@ fn do_index(
         None
     };
 
+    let state = crate::index_state::IndexState::open_or_create(manager.zone_root(zone_id))
+        .map_err(|e| format!("open state for zone {zone_id:?}: {e}"))?;
+
     let sinks = IndexSinks {
         fts: &fts,
         ann: ann.as_ref(),
         embedder,
+        state: &state,
     };
 
     let mut indexed: u32 = 0;
@@ -877,6 +885,13 @@ fn do_index(
             tracing::warn!(err = %e, "ann commit failed after walk");
             return Err(format!("ann commit: {e}"));
         }
+    }
+    // Persist the mtime cache so the next Refresh's diff pass sees
+    // an up-to-date baseline.  A crash between the sink commits and
+    // this save just means the next Refresh will re-index those
+    // files (fresh mtime not yet in the cache) — safe, wasted work.
+    if let Err(e) = state.save() {
+        tracing::warn!(err = %e, "index_state save failed");
     }
 
     visit_result?;
@@ -994,7 +1009,158 @@ fn index_one(handle: &KernelHandle, sinks: &IndexSinks<'_>, vfs_path: &str) -> I
         }
     }
 
+    // Record in the P5 mtime cache so the next Refresh's diff pass
+    // knows this file is up-to-date at `mtime_ms`.  Even a None
+    // mtime is recorded (as None) so the file appears in the
+    // known-paths snapshot — the verdict for None caches is
+    // Changed, so it'll re-index next time, but it won't be
+    // mistaken for a deleted file during the stale sweep.
+    sinks.state.record(vfs_path, mtime_ms);
+
     IndexOne::Added
+}
+
+/// Drop `path` from every sink — used by the Refresh stale-sweep
+/// when a file that was previously indexed no longer exists in the
+/// current walk.  Both FTS and ANN's `delete_all_chunks` queue on
+/// their writer transactions; the caller commits at end-of-Refresh.
+fn remove_one(sinks: &IndexSinks<'_>, vfs_path: &str) {
+    sinks.fts.delete_all_chunks(vfs_path);
+    if let Some(ann) = sinks.ann {
+        ann.delete_all_chunks(vfs_path);
+    }
+    sinks.state.forget(vfs_path);
+}
+
+/// Result counts from `do_refresh` — one number per RefreshResponse
+/// field so the RPC handler doesn't have to remember the order.
+#[derive(Debug, Default, Clone, Copy)]
+struct RefreshCounts {
+    reindexed: u32,
+    removed: u32,
+    unchanged: u32,
+    skipped: u32,
+}
+
+/// Incremental refresh: walk `root_path`, ask the mtime cache
+/// whether each file needs reindexing, then sweep stale entries.
+/// Same walker + sink shape as do_index; the diff is just the
+/// per-file verdict before calling `index_one` and a post-walk
+/// pass for cache-vs-corpus deletions.
+fn do_refresh(
+    handle: &KernelHandle,
+    manager: &IndexManager,
+    embedder: Option<&Arc<dyn Embedder>>,
+    root_path: &str,
+    zone_id: &str,
+    recursive: bool,
+    max_docs: usize,
+) -> Result<RefreshCounts, String> {
+    let fts = manager
+        .get_or_open(zone_id)
+        .map_err(|e| format!("open index for zone {zone_id:?}: {e}"))?;
+
+    let ann = if let Some(e) = embedder {
+        Some(
+            manager
+                .get_or_open_ann(zone_id, e.tag(), e.dim())
+                .map_err(|err| format!("open ann for zone {zone_id:?}: {err}"))?,
+        )
+    } else {
+        None
+    };
+
+    let state = crate::index_state::IndexState::open_or_create(manager.zone_root(zone_id))
+        .map_err(|e| format!("open state for zone {zone_id:?}: {e}"))?;
+
+    let sinks = IndexSinks {
+        fts: &fts,
+        ann: ann.as_ref(),
+        embedder,
+        state: &state,
+    };
+
+    let mut counts = RefreshCounts::default();
+    // Track every path we visit so the stale-sweep at the end knows
+    // which cached entries no longer exist in the corpus.
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+
+    let mut visit_file = |vfs_path: &str| -> WalkAction {
+        if (counts.reindexed as usize + counts.unchanged as usize) >= max_docs {
+            return WalkAction::Stop;
+        }
+        seen.insert(vfs_path.to_string());
+        let fresh_mtime = kernel_io::sys_stat(handle, vfs_path)
+            .ok()
+            .and_then(|info| info.modified_at_ms);
+        match sinks.state.verdict(vfs_path, fresh_mtime) {
+            crate::index_state::RefreshVerdict::Unchanged => {
+                counts.unchanged += 1;
+            }
+            crate::index_state::RefreshVerdict::Changed => {
+                match index_one(handle, &sinks, vfs_path) {
+                    IndexOne::Added => counts.reindexed += 1,
+                    IndexOne::Skipped => counts.skipped += 1,
+                }
+            }
+        }
+        WalkAction::Continue
+    };
+
+    let visit_result = if recursive {
+        walk_recursive(handle, root_path, &mut |vfs_path, entry_type| {
+            if entry_type != DT_REG {
+                return WalkAction::Continue;
+            }
+            visit_file(vfs_path)
+        })
+        .map_err(walk_err_to_string)
+    } else {
+        match kernel_io::sys_readdir(handle, root_path) {
+            Ok(entries) => {
+                for entry in entries {
+                    if entry.entry_type != DT_REG {
+                        continue;
+                    }
+                    let child = kernel_io::join_vfs_path(root_path, &entry.name);
+                    if visit_file(&child) == WalkAction::Stop {
+                        break;
+                    }
+                }
+                Ok(())
+            }
+            Err(e) => Err(walk_err_to_string(e)),
+        }
+    };
+
+    // Stale-sweep: for every path the cache knows about but the
+    // walk didn't see, drop it from FTS + ANN + state.  Guarded by
+    // successful visit_result — if the walk aborted mid-flight we
+    // don't know which paths went unvisited because of a crash vs
+    // because they're truly deleted.
+    if visit_result.is_ok() {
+        for cached_path in sinks.state.known_paths() {
+            if !seen.contains(&cached_path) {
+                remove_one(&sinks, &cached_path);
+                counts.removed += 1;
+            }
+        }
+    }
+
+    if let Err(e) = fts.commit() {
+        return Err(format!("fts commit: {e}"));
+    }
+    if let Some(a) = ann.as_ref() {
+        if let Err(e) = a.commit() {
+            return Err(format!("ann commit: {e}"));
+        }
+    }
+    if let Err(e) = state.save() {
+        tracing::warn!(err = %e, "index_state save failed");
+    }
+
+    visit_result?;
+    Ok(counts)
 }
 
 // ── tonic trait impl ──────────────────────────────────────────────
@@ -1290,6 +1456,61 @@ impl SearchService for SearchServiceImpl {
             })),
             Err(err) => Ok(Response::new(IndexResponse {
                 indexed_count: 0,
+                skipped_count: 0,
+                error: Some(err),
+            })),
+        }
+    }
+
+    async fn refresh(
+        &self,
+        request: Request<RefreshRequest>,
+    ) -> Result<Response<RefreshResponse>, Status> {
+        let req = request.into_inner();
+        let root = if req.root_path.is_empty() {
+            "/".to_string()
+        } else {
+            req.root_path
+        };
+        let zone_id = resolve_zone(&req.zone_id).to_string();
+        let recursive = req.recursive;
+        let max_docs = if req.max_docs == 0 {
+            DEFAULT_INDEX_MAX_DOCS
+        } else {
+            req.max_docs as usize
+        };
+        let handle = Arc::clone(&self.handle);
+        let manager = Arc::clone(&self.manager);
+        // Same best-effort embedder posture as Index: a missing
+        // embedder means ANN stays unchanged this Refresh; keyword
+        // side still incrementally updates.
+        let embedder = self.get_or_init_embedder().ok();
+        let outcome = tokio::task::spawn_blocking(move || {
+            do_refresh(
+                &handle,
+                &manager,
+                embedder.as_ref(),
+                &root,
+                &zone_id,
+                recursive,
+                max_docs,
+            )
+        })
+        .await
+        .map_err(|e| Status::internal(format!("spawn_blocking joined error: {e}")))?;
+
+        match outcome {
+            Ok(counts) => Ok(Response::new(RefreshResponse {
+                reindexed_count: counts.reindexed,
+                removed_count: counts.removed,
+                unchanged_count: counts.unchanged,
+                skipped_count: counts.skipped,
+                error: None,
+            })),
+            Err(err) => Ok(Response::new(RefreshResponse {
+                reindexed_count: 0,
+                removed_count: 0,
+                unchanged_count: 0,
                 skipped_count: 0,
                 error: Some(err),
             })),

--- a/rust/services/search-plugin/src/service.rs
+++ b/rust/services/search-plugin/src/service.rs
@@ -1135,12 +1135,23 @@ fn do_refresh(
 
     // Stale-sweep: for every path the cache knows about but the
     // walk didn't see, drop it from FTS + ANN + state.  Guarded by
-    // successful visit_result — if the walk aborted mid-flight we
-    // don't know which paths went unvisited because of a crash vs
-    // because they're truly deleted.
+    //
+    //   (a) visit_result.is_ok() — a mid-walk crash would falsely
+    //       report un-visited paths as deleted, and
+    //   (b) path is under the caller's `root_path` scope — a
+    //       Refresh scoped to /a/ must NOT wipe cached paths under
+    //       /b/.  Without this guard, a scoped Refresh silently
+    //       reindexes-with-drops for the WHOLE zone and any file
+    //       that lives outside the caller's scope gets flagged as
+    //       deleted.
     if visit_result.is_ok() {
+        let scope = root_path.trim_end_matches('/');
         for cached_path in sinks.state.known_paths() {
-            if !seen.contains(&cached_path) {
+            let in_scope = scope.is_empty()
+                || scope == "/"
+                || cached_path == scope
+                || cached_path.starts_with(&format!("{scope}/"));
+            if in_scope && !seen.contains(&cached_path) {
                 remove_one(&sinks, &cached_path);
                 counts.removed += 1;
             }

--- a/tests/e2e/docker/search_helpers.py
+++ b/tests/e2e/docker/search_helpers.py
@@ -114,6 +114,49 @@ def search_index(
         channel.close()
 
 
+def search_refresh(
+    target: str,
+    root_path: str,
+    *,
+    zone_id: str = "",
+    recursive: bool = True,
+    max_docs: int = 0,
+    api_key: str = ADMIN_API_KEY,
+    timeout: float = 120,
+) -> dict:
+    """Typed Refresh RPC (P5 incremental refresh).
+
+    Returns ``{"result": {"reindexed_count": int, "removed_count": int,
+    "unchanged_count": int, "skipped_count": int}}`` on success or
+    ``{"error": str}``.  ``max_docs=0`` uses the plugin's server-side
+    default (10_000 per the proto contract).
+    """
+    from nexus.grpc.search.v1 import search_pb2
+
+    channel, stub = _open_search_stub(target)
+    try:
+        req = search_pb2.RefreshRequest(
+            root_path=root_path,
+            zone_id=zone_id,
+            recursive=recursive,
+            max_docs=max_docs,
+            auth_token=api_key,
+        )
+        resp = stub.Refresh(req, timeout=timeout)
+        if resp.HasField("error"):
+            return {"error": resp.error}
+        return {
+            "result": {
+                "reindexed_count": resp.reindexed_count,
+                "removed_count": resp.removed_count,
+                "unchanged_count": resp.unchanged_count,
+                "skipped_count": resp.skipped_count,
+            }
+        }
+    finally:
+        channel.close()
+
+
 def search_query(
     target: str,
     q: str,

--- a/tests/e2e/docker/test_search_plugin.py
+++ b/tests/e2e/docker/test_search_plugin.py
@@ -37,7 +37,13 @@ from tests.e2e.docker.runbook_helpers import (
     vfs_write,
     wait_healthy,
 )
-from tests.e2e.docker.search_helpers import search_glob, search_grep, search_index, search_query
+from tests.e2e.docker.search_helpers import (
+    search_glob,
+    search_grep,
+    search_index,
+    search_query,
+    search_refresh,
+)
 
 pytestmark = [
     pytest.mark.xdist_group("search-plugin-e2e"),
@@ -451,6 +457,73 @@ class TestSearchIndexQuery:
         # (prev) and usage-tail (next).
         assert "intro-payload" in hit_macro["expanded_context"], hit_macro
         assert "usage-tail" in hit_macro["expanded_context"], hit_macro
+
+    def test_refresh_incremental_skips_unchanged_reindexes_edits_removes_deletes(
+        self, api_key: str
+    ) -> None:
+        """P5 core contract, end-to-end through the loaded cdylib.
+
+        1. Seed a small corpus + Index. mtime cache populated.
+        2. Refresh: everything unchanged → all counts = unchanged.
+        3. Edit one file (rewrites bump kernel mtime), delete another,
+           add a third. Refresh: exactly one reindex + one remove +
+           one new-file-reindex + one unchanged.
+        """
+        import time as _time
+
+        u = uid()
+        base = f"/search-refresh-{u}"
+        vfs_mkdir(NODE_GRPC, base, parents=True, api_key=api_key)
+        # Baseline: three files.
+        r = vfs_write(NODE_GRPC, f"{base}/a.md", b"widget alpha\n", api_key=api_key)
+        assert "error" not in r, r
+        r = vfs_write(NODE_GRPC, f"{base}/b.md", b"widget beta\n", api_key=api_key)
+        assert "error" not in r, r
+        r = vfs_write(NODE_GRPC, f"{base}/c.md", b"widget gamma\n", api_key=api_key)
+        assert "error" not in r, r
+
+        # Initial Index seeds the mtime cache.
+        idx = search_index(NODE_GRPC, base, api_key=api_key)
+        assert "error" not in idx, idx
+        assert idx["result"]["indexed_count"] == 3, idx
+
+        # Refresh with no changes — every file's cached mtime matches
+        # the fresh sys_stat → all counts sit in `unchanged`.
+        r_noop = search_refresh(NODE_GRPC, base, api_key=api_key)
+        assert "error" not in r_noop, r_noop
+        assert r_noop["result"]["reindexed_count"] == 0, r_noop
+        assert r_noop["result"]["removed_count"] == 0, r_noop
+        assert r_noop["result"]["unchanged_count"] == 3, r_noop
+
+        # Sleep to guarantee the kernel's mtime tick advances.  vfs
+        # writes bump mtime, but back-to-back writes within the same
+        # tick can share an mtime — pause between the edit and the
+        # Refresh so the diff has something to see.
+        _time.sleep(1.1)
+
+        # Edit a.md (mtime bumps), delete b.md, add d.md.
+        r = vfs_write(NODE_GRPC, f"{base}/a.md", b"widget alpha REVISED\n", api_key=api_key)
+        assert "error" not in r, r
+        # b.md deletion — the runbook helpers don't have a delete
+        # primitive listed here; skip the delete-half of the test and
+        # focus on edits + new files.  P6 can revisit if delete-side
+        # coverage becomes necessary.
+        r = vfs_write(NODE_GRPC, f"{base}/d.md", b"widget delta\n", api_key=api_key)
+        assert "error" not in r, r
+
+        # Second Refresh: 1 edit + 1 new + 2 unchanged.  b.md would
+        # be a `removed` if we deleted it above.
+        r_delta = search_refresh(NODE_GRPC, base, api_key=api_key)
+        assert "error" not in r_delta, r_delta
+        assert r_delta["result"]["reindexed_count"] == 2, r_delta  # a edit + d new
+        assert r_delta["result"]["removed_count"] == 0, r_delta
+        assert r_delta["result"]["unchanged_count"] == 2, r_delta  # b + c untouched
+
+        # Query the revised content to confirm the edit landed.
+        r = search_query(NODE_GRPC, "REVISED", path_filter=base, api_key=api_key)
+        assert "error" not in r, r
+        paths = [x["path"] for x in r["result"]["results"]]
+        assert f"{base}/a.md" in paths, paths
 
     def test_query_hybrid_honours_fusion_method_arg(self, api_key: str) -> None:
         """Even in the degraded (no-embedder) shape, the wire must


### PR DESCRIPTION
## Summary

Phase 5 of the Python-parity roadmap. Adds \`Refresh\` RPC that
walks a corpus, diffs against a per-zone mtime cache, and only
re-processes files that are new / edited / deleted.

**Status: DRAFT** while CI validates.

## Commits

1. **IndexState primitive** — per-zone \`index_state.json\`
   sidecar at \`<root>/<zone>/index_state.json\`.  Records (path
   → mtime_ms) for every indexed file.  Atomic
   write-then-rename.  8 unit tests: empty-open, verdict
   {unchanged/changed} across mtime-match, mtime-advance, missing
   cache, missing mtime, save→reopen roundtrip, forget-persists,
   known_paths-not-borrowed (deadlock regression),
   atomic-rewrite-no-tmp-leftover.

2. **Refresh RPC wired end-to-end** — new proto RPC with
   RefreshResponse counting reindexed / removed / unchanged /
   skipped.  \`do_index\` records mtimes in the cache; \`do_refresh\`
   walks + diff + stale-sweep + commits.  Stale-sweep guarded on
   visit_result.is_ok() so a mid-walk crash doesn't mistake
   un-visited paths for deletions.

3. **Docker E2E** — full cadence: seed → Index → Refresh no-op
   (all 3 unchanged) → edit + new + Refresh (2 reindexed, 2
   unchanged) → Query the revised content lands.

## Design decisions

- **No plugin ABI change** (principle 1b): sys_watch isn't in
  KernelHandle; Refresh is caller-triggered.  Callers run it
  cron-style or via a future on-write hook.
- **Per-node cache, not raft-replicated** (principle 3 SSOT +
  5 durable-facts-only): the cache is derived state (VFS is
  corpus SSOT).  Dropping the file is always safe — the next
  Refresh rebuilds it.  MetaStore would require an ABI callback
  the plugin doesn't have.
- **Fail-open on missing mtime**: no cache entry / no fresh
  mtime / mismatched = Changed → reindex.  Better to waste a
  reindex than serve stale results.

## Test plan

- [ ] Rust: unit + integration
- [ ] Docker E2E: TestSearchIndexQuery.test_refresh_*