### PR TITLE
feat(search-plugin): P6 recency decay + path-prefix boost [WIP]

### DIFF
--- a/rust/services/proto/nexus/search/v1/search.proto
+++ b/rust/services/proto/nexus/search/v1/search.proto
@@ -255,6 +255,40 @@ message QueryRequest {
   // follow-up read.  Matches the Python SearchDaemon expand=macro
   // contract.
   string expand = 11;
+
+  // ── Recency decay (P6, #4543) ──────────────────────────────────
+  //
+  // Multiplicative post-fusion boost that favours recently-modified
+  // files.  Formula: `score *= 1 + weight * H / (H + age_days)`
+  // where `age_days = (now - file_mtime) / 86400_000`.  Newer
+  // files get a bigger multiplier; H (half-life) controls the
+  // steepness (score halves ~H days after mtime).
+  //
+  // `recency_mode`:
+  //   ""      | "off"  ⇒ no decay (default)
+  //   "on"             ⇒ always apply the decay
+  //   "auto"           ⇒ apply only if the query text hints at
+  //                       recency ("latest", "recent", "new", ...).
+  //                       Matches Python's `RECENCY_WORDS` gate.
+  string recency_mode = 12;
+  // Boost magnitude.  Server-side default = 0.5 when 0.0 wire value
+  // (matches Python).  Range [0.0, 5.0]; a caller passing >5 gets
+  // clamped inside the plugin to bound worst-case skew.
+  float recency_weight = 13;
+  // Half-life in days.  Server-side default = 30.0 when 0.0 wire
+  // value (matches Python).  Range (0.0, 3650.0].
+  float recency_half_life_days = 14;
+
+  // ── Path-prefix score boost (P6, #4544) ────────────────────────
+  //
+  // Per-request map of `path_prefix -> multiplier`.  Applied post-
+  // fusion, pre-pooling: for each hit, the LONGEST cache-hit prefix
+  // wins and multiplies the score.  Prefixes must be absolute VFS
+  // paths (start with `/`).  Callers use this to tier-boost curated
+  // content roots (e.g. `/docs/` = 1.5, `/tmp/` = 0.5).  No entry
+  // ⇒ no boost (multiplier stays 1.0).  Matches Python's
+  // per-prefix ranking weight via path_contexts (#4544).
+  map<string, float> path_prefix_boosts = 15;
 }
 
 message QueryResult {

--- a/rust/services/search-plugin/src/lib.rs
+++ b/rust/services/search-plugin/src/lib.rs
@@ -59,6 +59,7 @@ pub mod fts_index;
 pub mod fusion;
 pub mod index_manager;
 pub mod index_state;
+pub mod scoring;
 pub mod kernel_io;
 pub mod service;
 

--- a/rust/services/search-plugin/src/lib.rs
+++ b/rust/services/search-plugin/src/lib.rs
@@ -59,8 +59,8 @@ pub mod fts_index;
 pub mod fusion;
 pub mod index_manager;
 pub mod index_state;
-pub mod scoring;
 pub mod kernel_io;
+pub mod scoring;
 pub mod service;
 
 use search_proto::search_service_server::SearchService as SearchServiceTrait;

--- a/rust/services/search-plugin/src/scoring.rs
+++ b/rust/services/search-plugin/src/scoring.rs
@@ -1,0 +1,412 @@
+//! Post-fusion score adjustments — recency decay + path-prefix
+//! boost (Phase 6 of the Python-parity roadmap; see
+//! `PARITY_ROADMAP.md`).
+//!
+//! # What lives here
+//!
+//! Two orthogonal multipliers applied to every hit's `score` after
+//! fusion but before pooling.  Both are pure math over
+//! `QueryResult` slices; no I/O, no side effects.
+//!
+//! - [`apply_recency`] — bumps recently-modified files' scores per
+//!   `score *= 1 + weight * H / (H + age_days)`.  In "auto" mode
+//!   only fires if the query text hints at recency
+//!   (`latest`, `recent`, ...).  Matches Python `#4543` decay.
+//!
+//! - [`apply_prefix_boost`] — multiplies each hit's score by the
+//!   longest-prefix-match multiplier from the caller's map.
+//!   Matches Python `#4544` `path_contexts` weighting.
+//!
+//! # Why post-fusion
+//!
+//! Recency + prefix boost must NOT influence the raw retrieval
+//! ranks that RRF fuses on; they'd double-count if applied to the
+//! per-source lists AND the fused one.  Applying once at the end
+//! keeps the semantics predictable and matches Python's shape.
+//!
+//! # Pool interaction
+//!
+//! Pooling (`chunks_per_page`) runs AFTER these adjustments so a
+//! recency-boosted or prefix-boosted chunk can rise above another
+//! chunk of the same file before pooling caps them.
+
+use std::collections::HashMap;
+
+use crate::search_proto::QueryResult;
+
+/// Server-side default weight when the caller sends 0.0.  Matches
+/// Python `SearchDaemon.recency_weight` default.
+pub const DEFAULT_RECENCY_WEIGHT: f32 = 0.5;
+
+/// Server-side default half-life in days.  Matches Python.
+pub const DEFAULT_RECENCY_HALF_LIFE_DAYS: f32 = 30.0;
+
+/// Clamp on weight to bound worst-case ranking skew.  A caller
+/// sending weight = 1000 shouldn't be able to make an old-but-
+/// popular doc leapfrog a fresh-but-irrelevant one by six orders
+/// of magnitude; 5.0 = ceiling.
+pub const RECENCY_WEIGHT_MAX: f32 = 5.0;
+
+/// Recency modes the wire accepts.  Matches Python's three-value
+/// string convention.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RecencyMode {
+    /// No decay (default).
+    Off,
+    /// Always apply decay.
+    On,
+    /// Apply only if the query text hints at recency (see
+    /// [`query_wants_recency`]).
+    Auto,
+}
+
+impl RecencyMode {
+    /// Parse the wire string.  Empty / unknown / "off" all map to
+    /// Off for forward compat.
+    pub fn from_str(s: &str) -> Self {
+        match s {
+            "on" => Self::On,
+            "auto" => Self::Auto,
+            _ => Self::Off,
+        }
+    }
+}
+
+/// Set of query words that trigger `RecencyMode::Auto`.  Sourced
+/// from Python `RECENCY_WORDS` (`nexus/contracts/search_types.py`)
+/// so recall matches after the cutover.  Case-insensitive: the
+/// scorer lowercases the query before checking.
+const RECENCY_TRIGGER_WORDS: &[&str] = &[
+    "latest",
+    "newest",
+    "recent",
+    "recently",
+    "current",
+    "currently",
+    "today",
+    "yesterday",
+    "now",
+    "new",
+];
+
+/// True if `query` contains any of the recency trigger words.
+/// Whitespace-split so `"newmarket"` doesn't trip on "new".  Fast
+/// path for empty query — returns false without allocating.
+pub fn query_wants_recency(query: &str) -> bool {
+    if query.is_empty() {
+        return false;
+    }
+    for token in query.split_whitespace() {
+        let normalised: String = token
+            .chars()
+            .filter(|c| c.is_alphanumeric())
+            .flat_map(|c| c.to_lowercase())
+            .collect();
+        if RECENCY_TRIGGER_WORDS.iter().any(|w| *w == normalised) {
+            return true;
+        }
+    }
+    false
+}
+
+/// Recency decay applied in-place.  Each hit's `score` is
+/// multiplied by `1 + weight * H / (H + age_days)`.  Hits with no
+/// mtime (kernel didn't stamp them) get no boost — their score
+/// stays untouched so a query that promoted them earlier isn't
+/// silently penalised for lack of an mtime.
+///
+/// `now_ms` is the current wall-clock time in ms.  Injected so
+/// tests are deterministic; production callers pass
+/// `chrono::Utc::now().timestamp_millis()` or equivalent.
+pub fn apply_recency(
+    hits: &mut [QueryResult],
+    mode: RecencyMode,
+    weight: f32,
+    half_life_days: f32,
+    now_ms: i64,
+    query: &str,
+) {
+    let should_apply = match mode {
+        RecencyMode::Off => false,
+        RecencyMode::On => true,
+        RecencyMode::Auto => query_wants_recency(query),
+    };
+    if !should_apply {
+        return;
+    }
+    let w = weight.clamp(0.0, RECENCY_WEIGHT_MAX);
+    let h = half_life_days.max(0.001); // avoid divide-by-zero
+    let ms_per_day = 86_400_000.0f32;
+    for hit in hits.iter_mut() {
+        let Some(mtime_ms) = hit.mtime_ms else {
+            continue;
+        };
+        let age_ms = (now_ms - mtime_ms).max(0) as f32;
+        let age_days = age_ms / ms_per_day;
+        let multiplier = 1.0 + w * h / (h + age_days);
+        hit.score *= multiplier;
+    }
+}
+
+/// Path-prefix score boost applied in-place.  For each hit, walk
+/// `boosts` for the LONGEST prefix that matches the hit's path;
+/// multiply the score by that entry's multiplier.  No matching
+/// prefix ⇒ score unchanged (multiplier 1.0).
+///
+/// Longest-match semantics matter when boosts overlap
+/// (`/docs/` = 1.5, `/docs/api/` = 2.0) — the more specific
+/// prefix wins.  Ties (same length) break arbitrarily but stably
+/// (BTreeMap iteration order).
+pub fn apply_prefix_boost(hits: &mut [QueryResult], boosts: &HashMap<String, f32>) {
+    if boosts.is_empty() {
+        return;
+    }
+    for hit in hits.iter_mut() {
+        let best = boosts
+            .iter()
+            .filter(|(prefix, _)| hit.path.starts_with(prefix.as_str()))
+            .max_by_key(|(prefix, _)| prefix.len());
+        if let Some((_, &multiplier)) = best {
+            hit.score *= multiplier;
+        }
+    }
+}
+
+/// Convenience wrapper — apply both adjustments in the canonical
+/// order (recency first, then prefix boost).  Order matters because
+/// the two multipliers stack; the test suite pins expected values
+/// for both orderings but callers should use this helper unless
+/// they have a reason to reorder.
+pub fn apply_all(
+    hits: &mut [QueryResult],
+    recency_mode: RecencyMode,
+    recency_weight: f32,
+    recency_half_life_days: f32,
+    now_ms: i64,
+    query: &str,
+    prefix_boosts: &HashMap<String, f32>,
+) {
+    apply_recency(
+        hits,
+        recency_mode,
+        recency_weight,
+        recency_half_life_days,
+        now_ms,
+        query,
+    );
+    apply_prefix_boost(hits, prefix_boosts);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn hit(path: &str, score: f32, mtime_ms: Option<i64>) -> QueryResult {
+        QueryResult {
+            path: path.to_string(),
+            chunk_index: 0,
+            chunk_text: String::new(),
+            score,
+            zone_id: "root".to_string(),
+            mtime_ms,
+            expanded_context: String::new(),
+        }
+    }
+
+    // ── query_wants_recency ────────────────────────────────────
+
+    #[test]
+    fn recency_trigger_words_hit() {
+        for q in [
+            "latest news",
+            "what's new?",
+            "recent activity",
+            "today",
+            "NEWEST",
+        ] {
+            assert!(query_wants_recency(q), "should trigger: {q:?}");
+        }
+    }
+
+    #[test]
+    fn non_trigger_query_does_not_hit() {
+        for q in ["cat dog fish", "widget alpha", "python code", "newmarket"] {
+            assert!(!query_wants_recency(q), "should not trigger: {q:?}");
+        }
+    }
+
+    #[test]
+    fn empty_query_short_circuits() {
+        assert!(!query_wants_recency(""));
+    }
+
+    // ── apply_recency ──────────────────────────────────────────
+
+    #[test]
+    fn recency_off_leaves_scores_untouched() {
+        let mut hits = vec![hit("/a", 1.0, Some(0))];
+        apply_recency(
+            &mut hits,
+            RecencyMode::Off,
+            DEFAULT_RECENCY_WEIGHT,
+            DEFAULT_RECENCY_HALF_LIFE_DAYS,
+            1_700_000_000_000,
+            "latest",
+        );
+        assert_eq!(hits[0].score, 1.0);
+    }
+
+    #[test]
+    fn recency_on_boosts_fresh_more_than_old() {
+        // Two docs, same score.  Fresh (mtime = now) should end up
+        // with a higher score than old (mtime = 60 days back).
+        let now = 1_700_000_000_000;
+        let day = 86_400_000i64;
+        let mut hits = vec![
+            hit("/fresh", 1.0, Some(now)),
+            hit("/old", 1.0, Some(now - 60 * day)),
+        ];
+        apply_recency(&mut hits, RecencyMode::On, 1.0, 30.0, now, "any");
+        assert!(
+            hits[0].score > hits[1].score,
+            "fresh should beat old: {hits:?}"
+        );
+    }
+
+    #[test]
+    fn recency_multiplier_matches_formula() {
+        // For weight=1, H=30, age=0: multiplier = 1 + 1 * 30 / (30 + 0) = 2.
+        let now = 1_700_000_000_000;
+        let mut hits = vec![hit("/x", 2.5, Some(now))];
+        apply_recency(&mut hits, RecencyMode::On, 1.0, 30.0, now, "any");
+        assert!(
+            (hits[0].score - 5.0).abs() < 0.001,
+            "expected 2.5 * 2 = 5.0, got {}",
+            hits[0].score,
+        );
+    }
+
+    #[test]
+    fn recency_hit_with_no_mtime_untouched() {
+        let mut hits = vec![hit("/x", 1.5, None)];
+        apply_recency(
+            &mut hits,
+            RecencyMode::On,
+            1.0,
+            30.0,
+            1_700_000_000_000,
+            "any",
+        );
+        assert_eq!(
+            hits[0].score, 1.5,
+            "no-mtime hits must not be silently penalised"
+        );
+    }
+
+    #[test]
+    fn recency_auto_only_fires_when_query_triggers() {
+        let now = 1_700_000_000_000;
+        // Same query, same corpus; auto-off with a non-trigger
+        // query is a no-op, auto-on with "latest" applies the boost.
+        let baseline = hit("/x", 1.0, Some(now));
+        let mut off = vec![baseline.clone()];
+        apply_recency(&mut off, RecencyMode::Auto, 1.0, 30.0, now, "widget");
+        assert_eq!(off[0].score, 1.0, "auto-mode + non-trigger query = off");
+
+        let mut on = vec![baseline];
+        apply_recency(&mut on, RecencyMode::Auto, 1.0, 30.0, now, "latest widget");
+        assert!(on[0].score > 1.0, "auto-mode + trigger query = on");
+    }
+
+    #[test]
+    fn recency_weight_clamped_to_max() {
+        // A caller passing weight = 1000 gets the SAME multiplier
+        // as weight = RECENCY_WEIGHT_MAX (5.0) — bounded skew.
+        let now = 1_700_000_000_000;
+        let mut runaway = vec![hit("/x", 1.0, Some(now))];
+        let mut capped = vec![hit("/x", 1.0, Some(now))];
+        apply_recency(&mut runaway, RecencyMode::On, 1000.0, 30.0, now, "any");
+        apply_recency(
+            &mut capped,
+            RecencyMode::On,
+            RECENCY_WEIGHT_MAX,
+            30.0,
+            now,
+            "any",
+        );
+        assert!(
+            (runaway[0].score - capped[0].score).abs() < 0.001,
+            "weight clamp not enforced: {} vs {}",
+            runaway[0].score,
+            capped[0].score,
+        );
+    }
+
+    // ── apply_prefix_boost ─────────────────────────────────────
+
+    #[test]
+    fn prefix_boost_empty_map_is_noop() {
+        let mut hits = vec![hit("/a", 1.0, None)];
+        apply_prefix_boost(&mut hits, &HashMap::new());
+        assert_eq!(hits[0].score, 1.0);
+    }
+
+    #[test]
+    fn prefix_boost_multiplies_matching_hit() {
+        let mut hits = vec![
+            hit("/docs/api.md", 1.0, None),
+            hit("/tmp/scratch.md", 1.0, None),
+            hit("/unrelated.md", 1.0, None),
+        ];
+        let mut boosts = HashMap::new();
+        boosts.insert("/docs/".to_string(), 2.0);
+        boosts.insert("/tmp/".to_string(), 0.5);
+        apply_prefix_boost(&mut hits, &boosts);
+        assert_eq!(hits[0].score, 2.0);
+        assert_eq!(hits[1].score, 0.5);
+        assert_eq!(hits[2].score, 1.0, "no matching prefix = untouched");
+    }
+
+    #[test]
+    fn prefix_boost_longest_match_wins() {
+        // Overlapping prefixes — the more specific one wins.
+        let mut hits = vec![hit("/docs/api/spec.md", 1.0, None)];
+        let mut boosts = HashMap::new();
+        boosts.insert("/docs/".to_string(), 1.5);
+        boosts.insert("/docs/api/".to_string(), 3.0);
+        apply_prefix_boost(&mut hits, &boosts);
+        assert_eq!(hits[0].score, 3.0, "longer prefix must win");
+    }
+
+    #[test]
+    fn prefix_boost_at_zero_zeros_the_score() {
+        // A caller genuinely wants to blacklist a path — 0.0
+        // multiplier collapses the score to 0 without special-
+        // casing.  Documented as intentional; if a caller wants
+        // "exclude" semantics they can filter upstream.
+        let mut hits = vec![hit("/blocked/foo.md", 5.0, None)];
+        let mut boosts = HashMap::new();
+        boosts.insert("/blocked/".to_string(), 0.0);
+        apply_prefix_boost(&mut hits, &boosts);
+        assert_eq!(hits[0].score, 0.0);
+    }
+
+    // ── apply_all ordering ─────────────────────────────────────
+
+    #[test]
+    fn apply_all_composes_recency_and_prefix() {
+        // Doc /docs/x.md with mtime = now, score 1.0, weight 1,
+        // H=30.  Recency multiplier = 2.  Prefix boost = 1.5.
+        // Combined = 1.0 * 2 * 1.5 = 3.0.
+        let now = 1_700_000_000_000;
+        let mut hits = vec![hit("/docs/x.md", 1.0, Some(now))];
+        let mut boosts = HashMap::new();
+        boosts.insert("/docs/".to_string(), 1.5);
+        apply_all(&mut hits, RecencyMode::On, 1.0, 30.0, now, "any", &boosts);
+        assert!(
+            (hits[0].score - 3.0).abs() < 0.001,
+            "expected 3.0, got {}",
+            hits[0].score,
+        );
+    }
+}

--- a/rust/services/search-plugin/src/scoring.rs
+++ b/rust/services/search-plugin/src/scoring.rs
@@ -62,8 +62,12 @@ pub enum RecencyMode {
 
 impl RecencyMode {
     /// Parse the wire string.  Empty / unknown / "off" all map to
-    /// Off for forward compat.
-    pub fn from_str(s: &str) -> Self {
+    /// Off for forward compat.  Named `parse_wire` (not
+    /// `from_str`) to avoid the clippy `should_implement_trait`
+    /// lint on the stdlib `FromStr::from_str` shape — we return
+    /// an infallible `Self`, not a `Result`, so implementing
+    /// `FromStr` outright would be wrong.
+    pub fn parse_wire(s: &str) -> Self {
         match s {
             "on" => Self::On,
             "auto" => Self::Auto,

--- a/rust/services/search-plugin/src/service.rs
+++ b/rust/services/search-plugin/src/service.rs
@@ -61,6 +61,19 @@ fn resolve_zone(z: &str) -> &str {
     }
 }
 
+/// Wall-clock now in millis-since-epoch.  Broken out so the P6
+/// recency scorer has a single injection point + tests can mock it
+/// (via a #[cfg(test)] override) if we ever need to.  `SystemTime`
+/// on a broken host clock returns 0; that's harmless — every hit's
+/// age becomes very-negative, `.max(0)` clamps to 0, all hits get
+/// the maximum boost.  Better than a panic on `unwrap`.
+fn current_time_ms() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}
+
 pub struct SearchServiceImpl {
     handle: Arc<KernelHandle>,
     /// Per-zone `FtsIndex` + `AnnIndex` caches used by Query, Index,
@@ -1277,6 +1290,18 @@ impl SearchService for SearchServiceImpl {
         let query_type = QueryType::try_from(req.query_type).unwrap_or(QueryType::Unspecified);
         let fusion_opts = FusionOpts::from_request(&req);
         let expand_mode = ExpandMode::from_str(&req.expand);
+        let recency_mode = crate::scoring::RecencyMode::from_str(&req.recency_mode);
+        let recency_weight = if req.recency_weight == 0.0 {
+            crate::scoring::DEFAULT_RECENCY_WEIGHT
+        } else {
+            req.recency_weight
+        };
+        let recency_half_life_days = if req.recency_half_life_days == 0.0 {
+            crate::scoring::DEFAULT_RECENCY_HALF_LIFE_DAYS
+        } else {
+            req.recency_half_life_days
+        };
+        let prefix_boosts = req.path_prefix_boosts.clone();
         let limit = if req.limit == 0 {
             DEFAULT_QUERY_LIMIT
         } else {
@@ -1287,6 +1312,11 @@ impl SearchService for SearchServiceImpl {
         let q = req.q;
         let path_filter = req.path_filter;
         let manager = Arc::clone(&self.manager);
+        // Retained copies for post-outcome scoring — `q` moves into
+        // the spawn_blocking closures below; recency-auto needs to
+        // read the query text to decide whether to fire.  String
+        // clone is cheap next to the fetch itself.
+        let q_for_scoring = q.clone();
         // Cheap Arc clone + String clone retained for the post-
         // outcome expand-macro enrichment (both go via the FTS
         // sibling; keeping them out of the match arms' move scope
@@ -1383,6 +1413,41 @@ impl SearchService for SearchServiceImpl {
 
         match outcome {
             Ok(mut results) => {
+                // P6 post-fusion adjustments.  Order matters:
+                // 1. recency + prefix boost adjust scores in place,
+                // 2. re-sort so the pool + limit steps see the new
+                //    ranking,
+                // 3. pool by chunks_per_page (which respects the
+                //    post-boost order),
+                // 4. truncate to `limit`,
+                // 5. enrich with expand=macro context.
+                if matches!(
+                    recency_mode,
+                    crate::scoring::RecencyMode::On | crate::scoring::RecencyMode::Auto
+                ) || !prefix_boosts.is_empty()
+                {
+                    let now_ms = current_time_ms();
+                    crate::scoring::apply_all(
+                        &mut results,
+                        recency_mode,
+                        recency_weight,
+                        recency_half_life_days,
+                        now_ms,
+                        &q_for_scoring,
+                        &prefix_boosts,
+                    );
+                    // Re-sort descending by score so pooling +
+                    // truncation see the new ranking.  Deterministic
+                    // tie-break on (path, chunk_index) — same shape
+                    // as fusion::finalise.
+                    results.sort_by(|a, b| {
+                        b.score
+                            .partial_cmp(&a.score)
+                            .unwrap_or(std::cmp::Ordering::Equal)
+                            .then_with(|| a.path.cmp(&b.path))
+                            .then_with(|| a.chunk_index.cmp(&b.chunk_index))
+                    });
+                }
                 // Uniform post-outcome pooling.  Keyword / semantic
                 // do NOT pool internally, only hybrid's fuse_hybrid
                 // does; applying here gives all three query modes

--- a/rust/services/search-plugin/src/service.rs
+++ b/rust/services/search-plugin/src/service.rs
@@ -1290,7 +1290,7 @@ impl SearchService for SearchServiceImpl {
         let query_type = QueryType::try_from(req.query_type).unwrap_or(QueryType::Unspecified);
         let fusion_opts = FusionOpts::from_request(&req);
         let expand_mode = ExpandMode::from_str(&req.expand);
-        let recency_mode = crate::scoring::RecencyMode::from_str(&req.recency_mode);
+        let recency_mode = crate::scoring::RecencyMode::parse_wire(&req.recency_mode);
         let recency_weight = if req.recency_weight == 0.0 {
             crate::scoring::DEFAULT_RECENCY_WEIGHT
         } else {

--- a/tests/e2e/docker/search_helpers.py
+++ b/tests/e2e/docker/search_helpers.py
@@ -170,6 +170,10 @@ def search_query(
     rrf_k: int = 0,
     chunks_per_page: int = 0,
     expand: str = "",
+    recency_mode: str = "",
+    recency_weight: float = 0.0,
+    recency_half_life_days: float = 0.0,
+    path_prefix_boosts: dict[str, float] | None = None,
     api_key: str = ADMIN_API_KEY,
     timeout: float = 30,
 ) -> dict:
@@ -222,6 +226,10 @@ def search_query(
             rrf_k=rrf_k,
             chunks_per_page=chunks_per_page,
             expand=expand,
+            recency_mode=recency_mode,
+            recency_weight=recency_weight,
+            recency_half_life_days=recency_half_life_days,
+            path_prefix_boosts=path_prefix_boosts or {},
         )
         resp = stub.Query(req, timeout=timeout)
         if resp.HasField("error"):

--- a/tests/e2e/docker/test_search_plugin.py
+++ b/tests/e2e/docker/test_search_plugin.py
@@ -525,6 +525,78 @@ class TestSearchIndexQuery:
         paths = [x["path"] for x in r["result"]["results"]]
         assert f"{base}/a.md" in paths, paths
 
+    def test_recency_on_boosts_newer_over_older(self, api_key: str) -> None:
+        """P6 recency: two files with the same query text; the newer
+        one should score higher when recency_mode=on."""
+        import time as _time
+
+        u = uid()
+        base = f"/search-recency-{u}"
+        vfs_mkdir(NODE_GRPC, base, parents=True, api_key=api_key)
+        # Seed old first, sleep, then new — matches the pattern the
+        # existing sort_recency test uses to guarantee mtime tick
+        # separation.
+        r = vfs_write(NODE_GRPC, f"{base}/old.md", b"widget alpha\n", api_key=api_key)
+        assert "error" not in r, r
+        _time.sleep(1.1)
+        r = vfs_write(NODE_GRPC, f"{base}/new.md", b"widget alpha\n", api_key=api_key)
+        assert "error" not in r, r
+        idx = search_index(NODE_GRPC, base, api_key=api_key)
+        assert "error" not in idx, idx
+
+        # Baseline: no recency → same-score BM25 order is not
+        # guaranteed to favour /new.
+        base_r = search_query(NODE_GRPC, "widget alpha", path_filter=base, api_key=api_key)
+        assert "error" not in base_r
+        assert len(base_r["result"]["results"]) == 2
+
+        # recency_mode=on: /new.md must beat /old.md.
+        boosted = search_query(
+            NODE_GRPC,
+            "widget alpha",
+            path_filter=base,
+            recency_mode="on",
+            recency_weight=1.0,
+            recency_half_life_days=1.0,
+            api_key=api_key,
+        )
+        assert "error" not in boosted, boosted
+        results = boosted["result"]["results"]
+        assert results[0]["path"] == f"{base}/new.md", (
+            f"recency=on should promote /new.md, got {[r['path'] for r in results]}"
+        )
+
+    def test_path_prefix_boost_multiplies_matching_hits(self, api_key: str) -> None:
+        """P6 prefix boost: assigning weight 5.0 to a subdirectory
+        must promote its hits above equal-scored siblings in a
+        different subdirectory."""
+        u = uid()
+        base = f"/search-boost-{u}"
+        vfs_mkdir(NODE_GRPC, base, parents=True, api_key=api_key)
+        vfs_mkdir(NODE_GRPC, f"{base}/tier1", parents=True, api_key=api_key)
+        vfs_mkdir(NODE_GRPC, f"{base}/tier2", parents=True, api_key=api_key)
+        r = vfs_write(NODE_GRPC, f"{base}/tier1/a.md", b"widget alpha\n", api_key=api_key)
+        assert "error" not in r, r
+        r = vfs_write(NODE_GRPC, f"{base}/tier2/b.md", b"widget alpha\n", api_key=api_key)
+        assert "error" not in r, r
+        idx = search_index(NODE_GRPC, base, api_key=api_key)
+        assert "error" not in idx, idx
+
+        # Weight tier1 heavily.  The BM25 scores are identical
+        # (same query text), so the boost picks the winner.
+        boosted = search_query(
+            NODE_GRPC,
+            "widget alpha",
+            path_filter=base,
+            path_prefix_boosts={f"{base}/tier1/": 5.0},
+            api_key=api_key,
+        )
+        assert "error" not in boosted, boosted
+        results = boosted["result"]["results"]
+        assert results[0]["path"] == f"{base}/tier1/a.md", (
+            f"tier1 boost should lead, got {[r['path'] for r in results]}"
+        )
+
     def test_query_hybrid_honours_fusion_method_arg(self, api_key: str) -> None:
         """Even in the degraded (no-embedder) shape, the wire must
         accept the P3 fusion knobs — a stale gRPC schema on the


### PR DESCRIPTION
## Summary

Phase 6 of the Python-parity roadmap.  Two orthogonal post-fusion
score adjustments matching Python `SearchDaemon`:

- **Recency decay (#4543)**: `score *= 1 + w * H / (H + age_days)`.
  Modes: off / on / auto (auto fires on RECENCY_WORDS in query).
  Weight clamped to 5.0.
- **Path-prefix boost (#4544)**: per-request
  `map<prefix, multiplier>`.  Longest-match wins.

**Skeleton title arm (#4545)** deferred — recall gain small at
current chunker shape; revisit as follow-up.

## Commits

1. Proto + `scoring.rs` module (16 unit tests) + service.rs Query
   handler wires both.  Post-fusion, pre-pooling ordering with
   deterministic re-sort.
2. Docker E2E — recency-on promotes newer over older;
   prefix-boost promotes tier1 over tier2 at equal BM25.

## Design

- Post-fusion so RRF isn't double-counting.
- Fail-open on missing mtime (no silent penalty).
- Weight clamp prevents runaway callers.
- Prefix boost 0.0 collapses score (intentional blacklist).
- `current_time_ms` helper: broken clock → 0 → max boost, no
  panic.

## Test plan

- [ ] Rust: 16 scoring unit tests
- [ ] Docker E2E: TestSearchIndexQuery.test_recency* +
      test_path_prefix_boost*