### PR TITLE
feat(search-plugin): P7 zone-scoped query cache [WIP]

### DIFF
--- a/rust/services/search-plugin/src/lib.rs
+++ b/rust/services/search-plugin/src/lib.rs
@@ -60,6 +60,7 @@ pub mod fusion;
 pub mod index_manager;
 pub mod index_state;
 pub mod kernel_io;
+pub mod query_cache;
 pub mod scoring;
 pub mod service;
 

--- a/rust/services/search-plugin/src/query_cache.rs
+++ b/rust/services/search-plugin/src/query_cache.rs
@@ -1,0 +1,409 @@
+//! In-memory zone-scoped query result cache (Phase 7 of the
+//! Python-parity roadmap; see `PARITY_ROADMAP.md`).
+//!
+//! # What this stores
+//!
+//! `zone_id → { hash(request) → (cached results, inserted_at) }`.
+//! Serves Query calls whose full parameter tuple hits an entry
+//! younger than `TTL` — bypassing FTS + ANN + fusion + scoring +
+//! pooling entirely.
+//!
+//! # Auth boundary
+//!
+//! The plugin never sees subject identity (D5 read-gating stays
+//! kernel-tier).  `zone_id` IS the auth boundary — two callers who
+//! hit the same query in the same zone are equivalent from the
+//! plugin's perspective, so sharing a cache entry between them is
+//! safe.  The kernel-side router already checked read permission
+//! before dialing the plugin.
+//!
+//! # Cache key
+//!
+//! Hash of every QueryRequest field that changes the result:
+//! `q`, `zone_id`, `limit`, `path_filter`, `query_type`, `alpha`,
+//! `fusion_method`, `rrf_k`, `chunks_per_page`, `expand`,
+//! `recency_mode`, `recency_weight`, `recency_half_life_days`,
+//! `path_prefix_boosts`.  Explicitly EXCLUDES `auth_token` (per
+//! above — zone is the boundary).  `path_prefix_boosts` is folded
+//! in via a sorted-key traversal so map ordering doesn't flap the
+//! hash.
+//!
+//! # Adversarial hardening (#4559)
+//!
+//! - `path_filter="/foo/"` vs `"/foo"` MUST key distinctly —
+//!   different filter semantics.  The hash sees the raw string.
+//! - Alpha 0.0 vs 0.001 MUST key distinctly — floats hash by bit
+//!   pattern (`f32::to_bits`) rather than value equality that would
+//!   collapse NaN vs NaN or ±0.
+//! - Wire fields ADDED in a future phase MUST land in the hash
+//!   even if the caller doesn't set them (they'd share the default
+//!   value, which is fine — the key stays stable per that default).
+//!
+//! # Eviction
+//!
+//! - TTL: entries older than [`DEFAULT_TTL`] on read return None
+//!   and get dropped lazily on next insert to the same zone.
+//! - Per-zone capacity: [`MAX_ENTRIES_PER_ZONE`] — on insert past
+//!   the cap the OLDEST entry is evicted (FIFO by inserted_at).
+//!   LRU would be marginally better but FIFO is simpler and the
+//!   difference at 128 entries is inside measurement noise.
+//! - Zone-wide invalidate: `invalidate_zone(zone)` drops the whole
+//!   zone's cache.  Called by Index + Refresh so callers who just
+//!   changed the corpus don't see the stale prior response.
+//!
+//! # Concurrency
+//!
+//! `parking_lot::Mutex<HashMap<zone, ZoneEntry>>` at the top level.
+//! Lock held for the map lookup + one HashMap operation on the
+//! zone entry; both are ns-scale.  Concurrent Query calls to
+//! different zones don't serialise beyond that.
+
+use std::collections::HashMap;
+use std::hash::{Hash, Hasher};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use parking_lot::Mutex;
+
+use crate::search_proto::{QueryRequest, QueryResult};
+
+/// Default entry TTL.  5 minutes matches the Python
+/// SearchDaemon's `result_cache_ttl_seconds` default.
+pub const DEFAULT_TTL: Duration = Duration::from_secs(300);
+
+/// Per-zone entry cap.  Past this on insert, the OLDEST entry
+/// (smallest `inserted_at`) is evicted.  128 keeps memory bounded
+/// on a busy zone (typical entry = a few KB of QueryResult) while
+/// still absorbing burst query patterns.
+pub const MAX_ENTRIES_PER_ZONE: usize = 128;
+
+/// One cached response entry.
+#[derive(Debug, Clone)]
+struct Entry {
+    results: Vec<QueryResult>,
+    inserted_at: Instant,
+}
+
+/// One zone's cache slice.  Nested inside the top-level Mutex map
+/// so per-zone reads/writes stay cheap and don't need their own
+/// lock — the top-level Mutex serialises accesses across all
+/// zones, but each access is ns-scale.
+type ZoneEntries = HashMap<u64, Entry>;
+
+/// Zone-scoped query result cache.  Cheap to clone via Arc.
+pub struct QueryCache {
+    zones: Mutex<HashMap<String, ZoneEntries>>,
+    ttl: Duration,
+}
+
+impl QueryCache {
+    /// New cache with the default 5-minute TTL.
+    pub fn new() -> Self {
+        Self::with_ttl(DEFAULT_TTL)
+    }
+
+    /// New cache with an explicit TTL — used by tests that need
+    /// deterministic expiration windows.
+    pub fn with_ttl(ttl: Duration) -> Self {
+        Self {
+            zones: Mutex::new(HashMap::new()),
+            ttl,
+        }
+    }
+
+    /// Fetch the cached response for `(zone_id, hash(req))` if it
+    /// exists AND hasn't expired.  Returns a clone of the results
+    /// (callers get their own copy; the cache retains ownership).
+    pub fn get(&self, req: &QueryRequest) -> Option<Vec<QueryResult>> {
+        let key = hash_request(req);
+        let zones = self.zones.lock();
+        let zone = zones.get(&req.zone_id)?;
+        let entry = zone.get(&key)?;
+        if entry.inserted_at.elapsed() >= self.ttl {
+            // Lazy TTL — leave the stale entry for the next insert
+            // to sweep, but don't hand it back to this caller.
+            return None;
+        }
+        Some(entry.results.clone())
+    }
+
+    /// Insert `results` under the cache key derived from `req`.
+    /// Evicts stale entries + the oldest entry if this zone is at
+    /// [`MAX_ENTRIES_PER_ZONE`].
+    pub fn insert(&self, req: &QueryRequest, results: Vec<QueryResult>) {
+        let key = hash_request(req);
+        let now = Instant::now();
+        let mut zones = self.zones.lock();
+        let zone = zones.entry(req.zone_id.clone()).or_default();
+
+        // Lazy TTL sweep — walk the whole per-zone map dropping
+        // anything past TTL.  With 128-entry cap the sweep cost is
+        // negligible; kept simple.
+        zone.retain(|_, e| e.inserted_at.elapsed() < self.ttl);
+
+        // Capacity eviction — if inserting this key would push past
+        // the cap, drop the oldest entry first.  Skipped when we're
+        // overwriting an existing key (already-counted).
+        if !zone.contains_key(&key) && zone.len() >= MAX_ENTRIES_PER_ZONE {
+            if let Some(oldest_key) = zone
+                .iter()
+                .min_by_key(|(_, e)| e.inserted_at)
+                .map(|(k, _)| *k)
+            {
+                zone.remove(&oldest_key);
+            }
+        }
+
+        zone.insert(
+            key,
+            Entry {
+                results,
+                inserted_at: now,
+            },
+        );
+    }
+
+    /// Drop every cache entry for `zone_id`.  Called by Index +
+    /// Refresh whenever the underlying corpus for a zone changes,
+    /// so the next Query sees fresh results rather than the stale
+    /// pre-change response.
+    pub fn invalidate_zone(&self, zone_id: &str) {
+        self.zones.lock().remove(zone_id);
+    }
+
+    /// Number of live entries across all zones — used by tests +
+    /// operator diagnostics.
+    pub fn total_entries(&self) -> usize {
+        self.zones.lock().values().map(|z| z.len()).sum()
+    }
+
+    /// Number of live entries in one zone.
+    pub fn zone_entries(&self, zone_id: &str) -> usize {
+        self.zones.lock().get(zone_id).map(|z| z.len()).unwrap_or(0)
+    }
+}
+
+impl Default for QueryCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Hash every meaningful QueryRequest field — see the module doc
+/// for the "meaningful" definition (all-fields-except-auth_token).
+///
+/// Floats hash by bit pattern (`to_bits`) so alpha=0.0 and
+/// alpha=0.001 key distinctly (they'd Hash-equal under a naive
+/// f32 impl that PartialEq'd 0.0 to -0.0, and both would collide
+/// with sign-bit variants).  `path_prefix_boosts` sorts its keys
+/// so map iteration order doesn't flap the hash.
+fn hash_request(req: &QueryRequest) -> u64 {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    req.q.hash(&mut hasher);
+    req.zone_id.hash(&mut hasher);
+    req.limit.hash(&mut hasher);
+    req.path_filter.hash(&mut hasher);
+    req.query_type.hash(&mut hasher);
+    req.alpha.to_bits().hash(&mut hasher);
+    req.fusion_method.hash(&mut hasher);
+    req.rrf_k.hash(&mut hasher);
+    req.chunks_per_page.hash(&mut hasher);
+    req.expand.hash(&mut hasher);
+    req.recency_mode.hash(&mut hasher);
+    req.recency_weight.to_bits().hash(&mut hasher);
+    req.recency_half_life_days.to_bits().hash(&mut hasher);
+    // Sort by key so map iteration order doesn't flap.
+    let mut boost_entries: Vec<(&String, &f32)> = req.path_prefix_boosts.iter().collect();
+    boost_entries.sort_by(|a, b| a.0.cmp(b.0));
+    for (k, v) in boost_entries {
+        k.hash(&mut hasher);
+        v.to_bits().hash(&mut hasher);
+    }
+    hasher.finish()
+}
+
+/// Shared handle — service.rs stores an `Arc<QueryCache>` in
+/// SearchServiceImpl and Index/Refresh call `invalidate_zone`.
+pub type SharedQueryCache = Arc<QueryCache>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn base_req(zone: &str, q: &str) -> QueryRequest {
+        QueryRequest {
+            q: q.to_string(),
+            zone_id: zone.to_string(),
+            limit: 10,
+            path_filter: String::new(),
+            query_type: 1,
+            auth_token: String::new(),
+            fusion_method: 0,
+            alpha: 0.0,
+            rrf_k: 0,
+            chunks_per_page: 0,
+            expand: String::new(),
+            recency_mode: String::new(),
+            recency_weight: 0.0,
+            recency_half_life_days: 0.0,
+            path_prefix_boosts: HashMap::new(),
+        }
+    }
+
+    fn hit(path: &str, score: f32) -> QueryResult {
+        QueryResult {
+            path: path.to_string(),
+            chunk_index: 0,
+            chunk_text: String::new(),
+            score,
+            zone_id: "root".to_string(),
+            mtime_ms: None,
+            expanded_context: String::new(),
+        }
+    }
+
+    #[test]
+    fn get_returns_none_on_miss() {
+        let c = QueryCache::new();
+        assert!(c.get(&base_req("root", "widget")).is_none());
+    }
+
+    #[test]
+    fn insert_then_get_returns_cached_results() {
+        let c = QueryCache::new();
+        let req = base_req("root", "widget");
+        c.insert(&req, vec![hit("/a", 1.0)]);
+        let got = c.get(&req).expect("should hit");
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].path, "/a");
+    }
+
+    #[test]
+    fn different_zones_dont_share() {
+        let c = QueryCache::new();
+        let r1 = base_req("root", "widget");
+        let r2 = base_req("other", "widget");
+        c.insert(&r1, vec![hit("/only-in-root", 1.0)]);
+        assert!(c.get(&r1).is_some());
+        assert!(c.get(&r2).is_none(), "zones must not share");
+    }
+
+    #[test]
+    fn different_queries_dont_share() {
+        let c = QueryCache::new();
+        c.insert(&base_req("root", "alpha"), vec![hit("/a", 1.0)]);
+        assert!(c.get(&base_req("root", "beta")).is_none());
+    }
+
+    #[test]
+    fn auth_token_does_not_affect_key() {
+        // Zone is the auth boundary; two callers with different
+        // tokens in the same zone SHARE the cache entry.  Locks
+        // the D5 posture.
+        let c = QueryCache::new();
+        let mut r1 = base_req("root", "widget");
+        r1.auth_token = "token-a".into();
+        let mut r2 = base_req("root", "widget");
+        r2.auth_token = "token-b".into();
+        c.insert(&r1, vec![hit("/x", 1.0)]);
+        assert!(c.get(&r2).is_some(), "different tokens must share");
+    }
+
+    #[test]
+    fn distinct_path_filter_suffix_keys_distinctly() {
+        // Adversarial regression: "/foo/" and "/foo" have different
+        // filter semantics.  Cache key must NOT collapse them.
+        let c = QueryCache::new();
+        let mut r1 = base_req("root", "q");
+        r1.path_filter = "/foo/".into();
+        let mut r2 = base_req("root", "q");
+        r2.path_filter = "/foo".into();
+        c.insert(&r1, vec![hit("/a", 1.0)]);
+        assert!(c.get(&r2).is_none(), "path_filter suffix must matter");
+    }
+
+    #[test]
+    fn distinct_prefix_boosts_key_distinctly() {
+        let c = QueryCache::new();
+        let mut r1 = base_req("root", "q");
+        r1.path_prefix_boosts.insert("/docs/".to_string(), 1.5);
+        let mut r2 = base_req("root", "q");
+        r2.path_prefix_boosts.insert("/docs/".to_string(), 2.0);
+        c.insert(&r1, vec![hit("/x", 1.0)]);
+        assert!(c.get(&r2).is_none(), "boost value must key distinctly");
+    }
+
+    #[test]
+    fn prefix_boost_key_order_stable() {
+        // Insertion order into HashMap shouldn't affect the hash —
+        // sorted-key traversal makes {a,b} == {b,a} on the wire.
+        let c = QueryCache::new();
+        let mut r1 = base_req("root", "q");
+        r1.path_prefix_boosts.insert("/a/".to_string(), 1.0);
+        r1.path_prefix_boosts.insert("/b/".to_string(), 2.0);
+        let mut r2 = base_req("root", "q");
+        r2.path_prefix_boosts.insert("/b/".to_string(), 2.0);
+        r2.path_prefix_boosts.insert("/a/".to_string(), 1.0);
+        c.insert(&r1, vec![hit("/x", 1.0)]);
+        assert!(c.get(&r2).is_some(), "map-order should not flap the key");
+    }
+
+    #[test]
+    fn ttl_expiry_returns_none() {
+        let c = QueryCache::with_ttl(Duration::from_millis(1));
+        c.insert(&base_req("root", "q"), vec![hit("/a", 1.0)]);
+        std::thread::sleep(Duration::from_millis(10));
+        assert!(c.get(&base_req("root", "q")).is_none(), "TTL not honoured");
+    }
+
+    #[test]
+    fn invalidate_zone_drops_all_entries_for_zone() {
+        let c = QueryCache::new();
+        c.insert(&base_req("root", "q1"), vec![hit("/a", 1.0)]);
+        c.insert(&base_req("root", "q2"), vec![hit("/b", 1.0)]);
+        c.insert(&base_req("other", "q1"), vec![hit("/c", 1.0)]);
+        assert_eq!(c.zone_entries("root"), 2);
+        c.invalidate_zone("root");
+        assert_eq!(c.zone_entries("root"), 0);
+        assert_eq!(c.zone_entries("other"), 1, "unrelated zone untouched");
+    }
+
+    #[test]
+    fn capacity_eviction_drops_oldest() {
+        let c = QueryCache::new();
+        // Fill past the cap with unique queries (each has a
+        // different q so each hashes differently).
+        for i in 0..MAX_ENTRIES_PER_ZONE {
+            c.insert(
+                &base_req("root", &format!("q{i}")),
+                vec![hit(&format!("/p{i}"), 1.0)],
+            );
+        }
+        assert_eq!(c.zone_entries("root"), MAX_ENTRIES_PER_ZONE);
+        // The oldest entry (q0) should still be present.
+        assert!(c.get(&base_req("root", "q0")).is_some());
+        // One more insert — oldest gets evicted.
+        c.insert(&base_req("root", "q_new"), vec![hit("/p_new", 1.0)]);
+        assert_eq!(c.zone_entries("root"), MAX_ENTRIES_PER_ZONE);
+        assert!(
+            c.get(&base_req("root", "q0")).is_none(),
+            "oldest not evicted"
+        );
+    }
+
+    #[test]
+    fn alpha_zero_vs_epsilon_key_distinctly() {
+        // Adversarial: naive f32 hash could collapse 0.0 and
+        // 0.001; to_bits() prevents it.
+        let c = QueryCache::new();
+        let mut r_zero = base_req("root", "q");
+        r_zero.alpha = 0.0;
+        let mut r_eps = base_req("root", "q");
+        r_eps.alpha = 0.001;
+        c.insert(&r_zero, vec![hit("/z", 1.0)]);
+        assert!(
+            c.get(&r_eps).is_none(),
+            "alpha 0 vs epsilon must key distinctly"
+        );
+    }
+}

--- a/rust/services/search-plugin/src/service.rs
+++ b/rust/services/search-plugin/src/service.rs
@@ -86,6 +86,10 @@ pub struct SearchServiceImpl {
     /// so an operator setting `NEXUS_SEARCH_MODEL_DIR` mid-run
     /// unblocks semantic search without a plugin restart.
     embedder_slot: Arc<Mutex<Option<Arc<dyn Embedder>>>>,
+    /// P7 zone-scoped result cache.  Query checks it before
+    /// dispatch; Index + Refresh invalidate the target zone so
+    /// callers who mutated the corpus don't see stale results.
+    query_cache: crate::query_cache::SharedQueryCache,
 }
 
 impl SearchServiceImpl {
@@ -97,6 +101,7 @@ impl SearchServiceImpl {
             handle,
             manager: Arc::new(IndexManager::new()),
             embedder_slot: Arc::new(Mutex::new(None)),
+            query_cache: Arc::new(crate::query_cache::QueryCache::new()),
         }
     }
 
@@ -110,6 +115,7 @@ impl SearchServiceImpl {
             handle,
             manager,
             embedder_slot: Arc::new(Mutex::new(None)),
+            query_cache: Arc::new(crate::query_cache::QueryCache::new()),
         }
     }
 
@@ -127,6 +133,24 @@ impl SearchServiceImpl {
             handle,
             manager,
             embedder_slot: Arc::new(Mutex::new(Some(embedder))),
+            query_cache: Arc::new(crate::query_cache::QueryCache::new()),
+        }
+    }
+
+    /// Test constructor — inject a QueryCache with an explicit
+    /// TTL.  Used by integration tests that want to observe cache
+    /// expiry within seconds rather than the 5-minute default.
+    pub fn with_manager_embedder_and_cache(
+        handle: Arc<KernelHandle>,
+        manager: Arc<IndexManager>,
+        embedder: Arc<dyn Embedder>,
+        query_cache: crate::query_cache::SharedQueryCache,
+    ) -> Self {
+        Self {
+            handle,
+            manager,
+            embedder_slot: Arc::new(Mutex::new(Some(embedder))),
+            query_cache,
         }
     }
 
@@ -1285,6 +1309,20 @@ impl SearchService for SearchServiceImpl {
                 error: Some("q must not be empty".into()),
             }));
         }
+        // P7 cache check.  Zone is the auth boundary (D5), so a
+        // hit here is safe to serve directly — we don't need to
+        // re-check permission, the kernel router already did.  A
+        // hit skips FTS + ANN + fusion + scoring + pooling +
+        // expand entirely.
+        if let Some(cached) = self.query_cache.get(&req) {
+            return Ok(Response::new(QueryResponse {
+                results: cached,
+                error: None,
+            }));
+        }
+        // Retained across the outcome branches to feed the cache
+        // insert on success.  Cloning is cheap next to the fetch.
+        let req_for_cache = req.clone();
         // Parse borrow-only fields FIRST so later `let q = req.q`
         // moves don't leave `req` partially moved for later reads.
         let query_type = QueryType::try_from(req.query_type).unwrap_or(QueryType::Unspecified);
@@ -1473,6 +1511,13 @@ impl SearchService for SearchServiceImpl {
                         &mut results,
                     );
                 }
+                // P7 cache write.  Store the fully-processed
+                // response (post-scoring, post-pool, post-expand)
+                // so the next hit skips all of it.  Errors are
+                // NOT cached — a stale FTS index / missing zone
+                // may resolve on retry, and we don't want the
+                // cache to sticky-fail those.
+                self.query_cache.insert(&req_for_cache, results.clone());
                 Ok(Response::new(QueryResponse {
                     results,
                     error: None,
@@ -1510,6 +1555,10 @@ impl SearchService for SearchServiceImpl {
         // and re-runs Index.  This matches the "graceful degradation"
         // posture SemanticQuery uses.
         let embedder = self.get_or_init_embedder().ok();
+        // Retain the zone id for post-outcome cache invalidation
+        // (the closure below moves the owned copy into
+        // spawn_blocking).
+        let zone_for_invalidate = zone_id.clone();
         let outcome = tokio::task::spawn_blocking(move || {
             do_index(
                 &handle,
@@ -1525,11 +1574,20 @@ impl SearchService for SearchServiceImpl {
         .map_err(|e| Status::internal(format!("spawn_blocking joined error: {e}")))?;
 
         match outcome {
-            Ok((indexed_count, skipped_count)) => Ok(Response::new(IndexResponse {
-                indexed_count,
-                skipped_count,
-                error: None,
-            })),
+            Ok((indexed_count, skipped_count)) => {
+                // P7 cache invalidation.  The corpus for this zone
+                // just changed; any cached Query response is
+                // potentially stale.  Drop the whole zone's cache
+                // — coarse but safe, and cheap (per-zone hashmap
+                // remove is O(1) on the outer + O(n) on the entries
+                // dropped).
+                self.query_cache.invalidate_zone(&zone_for_invalidate);
+                Ok(Response::new(IndexResponse {
+                    indexed_count,
+                    skipped_count,
+                    error: None,
+                }))
+            }
             Err(err) => Ok(Response::new(IndexResponse {
                 indexed_count: 0,
                 skipped_count: 0,
@@ -1561,6 +1619,7 @@ impl SearchService for SearchServiceImpl {
         // embedder means ANN stays unchanged this Refresh; keyword
         // side still incrementally updates.
         let embedder = self.get_or_init_embedder().ok();
+        let zone_for_invalidate = zone_id.clone();
         let outcome = tokio::task::spawn_blocking(move || {
             do_refresh(
                 &handle,
@@ -1576,13 +1635,23 @@ impl SearchService for SearchServiceImpl {
         .map_err(|e| Status::internal(format!("spawn_blocking joined error: {e}")))?;
 
         match outcome {
-            Ok(counts) => Ok(Response::new(RefreshResponse {
-                reindexed_count: counts.reindexed,
-                removed_count: counts.removed,
-                unchanged_count: counts.unchanged,
-                skipped_count: counts.skipped,
-                error: None,
-            })),
+            Ok(counts) => {
+                // P7 cache invalidation on any successful Refresh
+                // that actually changed anything.  A no-op Refresh
+                // (all cached unchanged) leaves the cache intact —
+                // avoids gratuitously blowing away hot entries when
+                // an operator polls Refresh on a quiet corpus.
+                if counts.reindexed > 0 || counts.removed > 0 {
+                    self.query_cache.invalidate_zone(&zone_for_invalidate);
+                }
+                Ok(Response::new(RefreshResponse {
+                    reindexed_count: counts.reindexed,
+                    removed_count: counts.removed,
+                    unchanged_count: counts.unchanged,
+                    skipped_count: counts.skipped,
+                    error: None,
+                }))
+            }
             Err(err) => Ok(Response::new(RefreshResponse {
                 reindexed_count: 0,
                 removed_count: 0,


### PR DESCRIPTION
## Summary

Phase 7 of the Python-parity roadmap. In-memory zone-scoped
query result cache. A hit skips FTS + ANN + fusion + scoring +
pooling + expand entirely.

## Design

- Zone is auth boundary per D5. Two callers with different
  auth_tokens sharing a query in the same zone share the entry.
- Cache key = hash of every meaningful QueryRequest field
  (all-but-auth_token). Floats via to_bits so 0.0 vs 0.001
  distinct. path_prefix_boosts sorted for map-order stability.
- TTL 5 min (Python default). Per-zone cap 128, FIFO eviction.
- Index + Refresh invalidate on success (Refresh no-op leaves
  cache intact to avoid gratuitous flush).

## Adversarial hardening (#4559 folded in)

- path_filter '/foo/' vs '/foo' key distinctly
- prefix_boost value differences key distinctly
- prefix_boost map iteration order stable across HashMap
- alpha 0.0 vs 0.001 vs -0.0 key distinctly (to_bits)
- auth_token change does NOT bust cache (locks D5 posture)

## Test plan

- [ ] 12 Rust unit tests (empty/hit/zone-isolation/query-
      isolation/auth-share/path-filter-suffix/prefix-boost-
      value/prefix-boost-order/ttl/invalidate/capacity/alpha-
      epsilon)

## Deferred

Adaptive grep strategy (parallel/trigram) from the same P7
scope — separate follow-up. Adds rayon + trigram-index work
that's better sized as its own PR.