### PR TITLE
chore(deps): bump nexus-vfs pin to c9ecc9da (auth CLI = live-daemon client + control zone)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "a2a"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=27f076d60444a3ee6a6a324f575cf456ec2b21b9#27f076d60444a3ee6a6a324f575cf456ec2b21b9"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=c9ecc9da2b755039a1028bbb619ee7cbb86f5dad#c9ecc9da2b755039a1028bbb619ee7cbb86f5dad"
 dependencies = [
  "contracts",
  "kernel",
@@ -239,7 +239,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 [[package]]
 name = "auth"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=27f076d60444a3ee6a6a324f575cf456ec2b21b9#27f076d60444a3ee6a6a324f575cf456ec2b21b9"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=c9ecc9da2b755039a1028bbb619ee7cbb86f5dad#c9ecc9da2b755039a1028bbb619ee7cbb86f5dad"
 dependencies = [
  "contracts",
  "dashmap",
@@ -337,7 +337,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=27f076d60444a3ee6a6a324f575cf456ec2b21b9#27f076d60444a3ee6a6a324f575cf456ec2b21b9"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=c9ecc9da2b755039a1028bbb619ee7cbb86f5dad#c9ecc9da2b755039a1028bbb619ee7cbb86f5dad"
 dependencies = [
  "ahash",
  "base64 0.22.1",
@@ -770,7 +770,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=27f076d60444a3ee6a6a324f575cf456ec2b21b9#27f076d60444a3ee6a6a324f575cf456ec2b21b9"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=c9ecc9da2b755039a1028bbb619ee7cbb86f5dad#c9ecc9da2b755039a1028bbb619ee7cbb86f5dad"
 dependencies = [
  "parking_lot",
  "serde",
@@ -2176,7 +2176,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=27f076d60444a3ee6a6a324f575cf456ec2b21b9#27f076d60444a3ee6a6a324f575cf456ec2b21b9"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=c9ecc9da2b755039a1028bbb619ee7cbb86f5dad#c9ecc9da2b755039a1028bbb619ee7cbb86f5dad"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -2234,7 +2234,7 @@ checksum = "0c2cdeb66e45e9f36bfad5bbdb4d2384e70936afbee843c6f6543f0c551ebb25"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=27f076d60444a3ee6a6a324f575cf456ec2b21b9#27f076d60444a3ee6a6a324f575cf456ec2b21b9"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=c9ecc9da2b755039a1028bbb619ee7cbb86f5dad#c9ecc9da2b755039a1028bbb619ee7cbb86f5dad"
 dependencies = [
  "ahash",
  "base64 0.22.1",
@@ -2566,7 +2566,7 @@ dependencies = [
 [[package]]
 name = "nexus-cluster"
 version = "0.1.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=27f076d60444a3ee6a6a324f575cf456ec2b21b9#27f076d60444a3ee6a6a324f575cf456ec2b21b9"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=c9ecc9da2b755039a1028bbb619ee7cbb86f5dad#c9ecc9da2b755039a1028bbb619ee7cbb86f5dad"
 dependencies = [
  "a2a",
  "anyhow",
@@ -2618,7 +2618,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=27f076d60444a3ee6a6a324f575cf456ec2b21b9#27f076d60444a3ee6a6a324f575cf456ec2b21b9"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=c9ecc9da2b755039a1028bbb619ee7cbb86f5dad#c9ecc9da2b755039a1028bbb619ee7cbb86f5dad"
 
 [[package]]
 name = "nexus-search-plugin"
@@ -3113,7 +3113,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "petgraph",
@@ -3134,7 +3134,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -3354,7 +3354,7 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 [[package]]
 name = "raft"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=27f076d60444a3ee6a6a324f575cf456ec2b21b9#27f076d60444a3ee6a6a324f575cf456ec2b21b9"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=c9ecc9da2b755039a1028bbb619ee7cbb86f5dad#c9ecc9da2b755039a1028bbb619ee7cbb86f5dad"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -4884,7 +4884,7 @@ dependencies = [
 [[package]]
 name = "transport"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=27f076d60444a3ee6a6a324f575cf456ec2b21b9#27f076d60444a3ee6a6a324f575cf456ec2b21b9"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=c9ecc9da2b755039a1028bbb619ee7cbb86f5dad#c9ecc9da2b755039a1028bbb619ee7cbb86f5dad"
 dependencies = [
  "axum",
  "backends",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -224,24 +224,24 @@ exclude = ["nexus-fuse"]
 #
 # Bump alongside the rest of nexus-vfs updates when a downstream
 # change needs newer kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "27f076d60444a3ee6a6a324f575cf456ec2b21b9" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "27f076d60444a3ee6a6a324f575cf456ec2b21b9" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "27f076d60444a3ee6a6a324f575cf456ec2b21b9" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "27f076d60444a3ee6a6a324f575cf456ec2b21b9", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "27f076d60444a3ee6a6a324f575cf456ec2b21b9", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "27f076d60444a3ee6a6a324f575cf456ec2b21b9", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "27f076d60444a3ee6a6a324f575cf456ec2b21b9" }
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "c9ecc9da2b755039a1028bbb619ee7cbb86f5dad" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "c9ecc9da2b755039a1028bbb619ee7cbb86f5dad" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "c9ecc9da2b755039a1028bbb619ee7cbb86f5dad" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "c9ecc9da2b755039a1028bbb619ee7cbb86f5dad", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "c9ecc9da2b755039a1028bbb619ee7cbb86f5dad", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "c9ecc9da2b755039a1028bbb619ee7cbb86f5dad", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "c9ecc9da2b755039a1028bbb619ee7cbb86f5dad" }
 # The cluster daemon library entry (`nexus_cluster::run_with_services`),
 # consumed by the nexus-side assembly binary (`rust/nexusd`) that composes
 # the kernel/federation boot with the nexus service set via the
 # ServiceRegistry bring-up seam.
-nexus-cluster = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "27f076d60444a3ee6a6a324f575cf456ec2b21b9" }
+nexus-cluster = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "c9ecc9da2b755039a1028bbb619ee7cbb86f5dad" }
 # a2a messaging substrate. `default-features = false` leaves the
 # `install` feature (which pulls raft to arm the stream-wakeup observer)
 # OFF, so nexus-side consumers link only the stamp hook and stay
 # raft-free — they reach raft through kernel.sys_* (§6.1). The substrate
 # is armed in production at cluster boot in nexus-vfs, not here.
-a2a = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "27f076d60444a3ee6a6a324f575cf456ec2b21b9", default-features = false }
+a2a = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "c9ecc9da2b755039a1028bbb619ee7cbb86f5dad", default-features = false }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir --no-deps --prefix=/install .
 # enforces agreement) — an unpinned install tracks nexus-vfs HEAD and
 # ships an untested kernel (#4343). --locked honors the source tree's
 # Cargo.lock.
-ARG NEXUS_VFS_REV=27f076d60444a3ee6a6a324f575cf456ec2b21b9
+ARG NEXUS_VFS_REV=c9ecc9da2b755039a1028bbb619ee7cbb86f5dad
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-cluster nexus-cluster
 
 # -- Runtime stage --

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -25,7 +25,7 @@ WORKDIR /build
 # (CI preflight enforces agreement) — an unpinned install tracks HEAD
 # and can skew the raft contract against the cluster/witness images.
 # --locked honors the source tree's Cargo.lock.
-ARG NEXUS_VFS_REV=27f076d60444a3ee6a6a324f575cf456ec2b21b9
+ARG NEXUS_VFS_REV=c9ecc9da2b755039a1028bbb619ee7cbb86f5dad
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexus-raft-server raft
 
 # ---------- Production image ----------

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=27f076d60444a3ee6a6a324f575cf456ec2b21b9
+ARG NEXUS_VFS_REV=c9ecc9da2b755039a1028bbb619ee7cbb86f5dad
 RUN cargo install \
     --locked \
     --git https://github.com/nexi-lab/nexus-vfs \


### PR DESCRIPTION
Picks up **nexus-vfs #206** — unifies the auth CLI as a live-daemon client + a replicated control zone:

- `auth mint`/`revoke` (agent **and** sk-) route through the live daemon when one is up, so they just-work **without stopping the daemon** on any node (previously "stop the daemon first" on the founder). Offline is a founder cold-start fallback.
- Auth records now live in a **replicated control zone** (founder sole-voter, joiners learners) instead of per-node `root`, so a founder-minted credential **resolves cluster-wide** — fixing the old per-node binding that silently gave each node its own key space.
- Agent-name uniqueness enforced at raft **apply** (CAS), holding under concurrent minters.

Bumps the rev SSOT in `Cargo.toml` (+ `Cargo.lock`) and the three kernel-image Dockerfile `NEXUS_VFS_REV` ARGs together. No nexus-side source changes.

`27f076d6` → `c9ecc9da`