### PR TITLE
fix(ci/macos-nfs-e2e): bound the readiness mount probe (fixes the develop hang)

### DIFF
--- a/.github/workflows/fuse-plugin-macos-nfs-e2e.yml
+++ b/.github/workflows/fuse-plugin-macos-nfs-e2e.yml
@@ -20,6 +20,7 @@ on:
       - 'Cargo.toml'
       - 'Cargo.lock'
       - 'tests/e2e/macos/**'
+      - 'scripts/wedge_probe.py'
       - '.github/workflows/fuse-plugin-macos-nfs-e2e.yml'
   pull_request:
     branches: [main, develop]
@@ -63,7 +64,7 @@ jobs:
           git fetch --no-tags --prune origin "${{ github.base_ref }}"
           git diff --name-only "origin/${{ github.base_ref }}"...HEAD > /tmp/changed_files.txt
           cat /tmp/changed_files.txt
-          if grep -Eq '^(rust/services/fuse-plugin/|Cargo\.toml$|Cargo\.lock$|tests/e2e/macos/)' /tmp/changed_files.txt; then
+          if grep -Eq '^(rust/services/fuse-plugin/|Cargo\.toml$|Cargo\.lock$|tests/e2e/macos/|scripts/wedge_probe\.py$|\.github/workflows/fuse-plugin-macos-nfs-e2e\.yml$)' /tmp/changed_files.txt; then
             echo "run=true" >> "$GITHUB_OUTPUT"
           else
             echo "run=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/fuse-plugin-macos-nfs-e2e.yml
+++ b/.github/workflows/fuse-plugin-macos-nfs-e2e.yml
@@ -34,10 +34,13 @@ jobs:
     runs-on: macos-latest
     # 12-min budget is a safety net, not a gate.  Layers that catch
     # wedges BEFORE this triggers:
+    #   * readiness poll below — bounded mount probe (wedge_probe.py
+    #     --readonly) on a 180s wall-clock deadline, so a mounted-but-
+    #     not-yet-serving backend can never block the poll;
     #   * per-test pytest-timeout via `wedge_watchdog` marker
     #     (tests/e2e/macos/conftest.py — 60s per test);
-    #   * pre-pytest wedge probe below — stat+mkdir+rmdir on the mount
-    #     with hard subprocess timeouts.
+    #   * pre-pytest wedge probe below — stat+readdir+mkdir+rmdir on the
+    #     mount with hard subprocess timeouts.
     # In practice this workflow completes in <8min warm-cache and
     # <15min cold.  If we approach 12min it means something below the
     # test layer failed (build hung, cargo install hung, or the
@@ -194,23 +197,30 @@ jobs:
           DAEMON_PID=$!
           echo "nexusd-cluster started, pid=$DAEMON_PID"
 
-          # Wait for gRPC + NFS mount ready.
+          # Wait for gRPC + NFS mount ready, on a hard 180s wall-clock
+          # deadline — NOT an iteration count.  The mount probe can take
+          # up to its per-op timeout on a not-yet-serving mount, so a
+          # fixed `seq` loop would let slow probes overshoot the job
+          # budget; the deadline keeps total readiness wait bounded.
           READY=false
-          for i in $(seq 1 90); do
+          READY_DEADLINE=$(( $(date +%s) + 180 ))
+          i=0
+          while [ "$(date +%s)" -lt "$READY_DEADLINE" ]; do
+            i=$((i + 1))
             GRPC_OK=false
             if nc -z 127.0.0.1 2126 2>/dev/null; then
               GRPC_OK=true
             fi
+            # Mount liveness = it answers a *bounded* read (stat + readdir).
+            # A bare `ls` here blocks forever on macOS's hard NFS mount when
+            # the backend mounted but cannot yet serve, defeating the
+            # deadline; wedge_probe.py --readonly caps every syscall.
             MOUNT_OK=false
-            # Check if the mount point is live by testing for a
-            # directory that only exists when the VFS is mounted.
-            # `mount | grep` doesn't reliably show FUSE-T or NFS
-            # mounts in all mount output formats on macOS.
-            if [ -d "/tmp/nexus-nfs-e2e" ] && ls /tmp/nexus-nfs-e2e >/dev/null 2>&1; then
+            if python3 scripts/wedge_probe.py "$NEXUS_FUSE_MOUNT_POINT" --readonly --per-op-timeout 5 >/dev/null 2>&1; then
               MOUNT_OK=true
             fi
             if [ "$GRPC_OK" = "true" ] && [ "$MOUNT_OK" = "true" ]; then
-              echo "Cluster healthy (gRPC + NFS mount) after ${i}s"
+              echo "Cluster healthy (gRPC + NFS mount) after ${i} probes"
               READY=true
               break
             fi

--- a/scripts/wedge_probe.py
+++ b/scripts/wedge_probe.py
@@ -1,11 +1,22 @@
 #!/usr/bin/env python3
 """Wedge probe for a live filesystem mount point.
 
-Exercises the syscalls that fs-vulnerable tests will fire (stat +
-mkdir + rmdir) via ``subprocess.run(timeout=...)`` so a wedged
-kernel-fs backend surfaces as a Python-bounded timeout, not an
-indefinite kernel-level block.  Used by CI workflows as a pre-pytest
-gate — see ``.github/workflows/fuse-plugin-macos-nfs-e2e.yml``.
+Exercises the syscalls that fs-vulnerable tests will fire — read
+(stat + readdir) and, unless ``--readonly``, write (mkdir + rmdir) —
+via ``subprocess.run(timeout=...)`` so a wedged kernel-fs backend
+surfaces as a Python-bounded timeout, not an indefinite kernel-level
+block.  Two callers, one bounded probe:
+
+  * ``--readonly`` — read-only and idempotent, safe to call every
+    couple of seconds from a readiness poll: the mount answers a
+    bounded stat+readdir or it does not.  A readiness poll must never
+    mutate the mount nor block unbounded on it (a bare ``ls`` blocks
+    forever on macOS's hard NFS mount when the backend mounted but
+    cannot yet serve).
+  * default — full read+write gate run once before pytest, so a
+    backend that reads but wedges on the first write surfaces early.
+
+Used by CI workflows — see ``.github/workflows/fuse-plugin-macos-nfs-e2e.yml``.
 
 Why a standalone script (not inline in the workflow):
   * GNU ``timeout`` isn't on macOS runners by default; ``coreutils``
@@ -19,7 +30,7 @@ Why a standalone script (not inline in the workflow):
   * Sharable by Docker E2E workflows — same failure class, same fix.
 
 Usage:
-    python3 scripts/wedge_probe.py <mount-point> [--per-op-timeout SECS]
+    python3 scripts/wedge_probe.py <mount-point> [--readonly] [--per-op-timeout SECS]
 
 Exit code:
     0 — all syscalls responded within their timeout, mount is healthy.
@@ -61,14 +72,31 @@ def main() -> int:
         default=5.0,
         help="Per-syscall timeout in seconds (default 5).",
     )
+    parser.add_argument(
+        "--readonly",
+        action="store_true",
+        help=(
+            "Probe with read-only, idempotent syscalls (stat + readdir) only, "
+            "skipping the mutating mkdir/rmdir. Use from a readiness poll loop, "
+            "which must never mutate the mount."
+        ),
+    )
     args = parser.parse_args()
 
-    probe_dir = f"{args.mount}/.wedge-probe-{uuid.uuid4().hex[:8]}"
-    checks: list[list[str]] = [
+    # Read checks exercise attr + readdir — the round-trips that reveal a
+    # backend that mounted but cannot yet serve. Write checks additionally
+    # exercise the mutating syscalls a live test will fire; readonly mode is
+    # exactly the read prefix, so the two callers share one code path.
+    read_checks: list[list[str]] = [
         ["stat", args.mount],
+        ["ls", args.mount],
+    ]
+    probe_dir = f"{args.mount}/.wedge-probe-{uuid.uuid4().hex[:8]}"
+    write_checks: list[list[str]] = [
         ["mkdir", "-p", probe_dir],
         ["rmdir", probe_dir],
     ]
+    checks = read_checks if args.readonly else read_checks + write_checks
     ok = all(_bounded(cmd, timeout=args.per_op_timeout) for cmd in checks)
     return 0 if ok else 1
 

--- a/tests/unit/scripts/test_wedge_probe.py
+++ b/tests/unit/scripts/test_wedge_probe.py
@@ -1,0 +1,58 @@
+"""Unit coverage for ``scripts/wedge_probe.py`` — the bounded mount probe.
+
+The probe shells out to POSIX ``stat``/``ls``/``mkdir``/``rmdir``, so it is a
+macOS/Linux-only tool (the Windows FUSE E2E uses a separate PowerShell probe).
+These tests exercise it against a real, always-serving directory (the happy
+path) and a missing path (the failure path) for both modes.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="wedge_probe uses POSIX stat/ls/mkdir/rmdir; macOS/Linux-only tool",
+)
+
+WEDGE_PROBE = Path(__file__).resolve().parents[3] / "scripts" / "wedge_probe.py"
+
+
+def _run(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(WEDGE_PROBE), *args],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def test_full_probe_healthy_dir(tmp_path: Path) -> None:
+    # A real directory answers stat + readdir + mkdir + rmdir within timeout.
+    assert _run(str(tmp_path)).returncode == 0
+
+
+def test_readonly_probe_healthy_dir(tmp_path: Path) -> None:
+    assert _run(str(tmp_path), "--readonly").returncode == 0
+
+
+def test_readonly_probe_is_side_effect_free(tmp_path: Path) -> None:
+    # A readiness poll runs this every couple of seconds; it must not mutate
+    # the mount (no leftover probe dir).
+    before = set(tmp_path.iterdir())
+    assert _run(str(tmp_path), "--readonly").returncode == 0
+    assert set(tmp_path.iterdir()) == before
+
+
+def test_readonly_probe_missing_path_fails(tmp_path: Path) -> None:
+    result = _run(str(tmp_path / "does-not-exist"), "--readonly")
+    assert result.returncode == 1
+    assert "::error::" in result.stdout
+
+
+def test_full_probe_missing_path_fails(tmp_path: Path) -> None:
+    assert _run(str(tmp_path / "does-not-exist")).returncode == 1


### PR DESCRIPTION
## Root cause

The `FUSE Plugin macOS NFS E2E` job on develop went red (`cancelled`, 8 min of silence → 12-min job timeout) at the #4585 merge commit. Two layers:

- **Trigger (why *this* commit):** #4585 bumped `Cargo.lock`, which matches the workflow's path filter, so the normally-skipped heavy NFS-E2E body actually ran. The nexus-vfs #205 changes are **inert under this `NEXUS_NO_TLS` single-node config** (agent-minter slot empty, `mint_agent` RPC never invoked + requires mTLS, arm-minter gated on an absent `ca-key.pem`). The daemon boot is byte-identical to the old pin here — **not a code regression.**
- **The actual bug:** the readiness poll checked mount liveness with a bare `ls` — the *only* unbounded mount I/O left in the harness. On macOS's **hard** NFS mount, a mounted-but-not-yet-serving backend makes that `ls` block forever, defeating the loop's own designed 180s fail-fast and hanging to the job timeout. Evidence: daemon log ends healthy at `Root '/' created`; readiness prints `iter=1 grpcOK=false mountOK=true` then goes silent; teardown kills an orphan `ls`.

## Fix (systematic — one bounded probe everywhere)

1. **`scripts/wedge_probe.py`** (the repo's existing bounded mount probe) gains a `--readonly` mode: read-only, idempotent `stat`+`readdir`, skipping the mutating `mkdir`/`rmdir`, so a readiness poll reuses the same `subprocess.run(timeout=)` machinery without side effects. The full gate also gains a `readdir` check. First unit coverage added (both modes, POSIX-only, skipped on Windows).
2. **macOS NFS E2E readiness loop**: the bare `ls` → `wedge_probe.py --readonly`; the `seq 1 90` iteration count → a **180s wall-clock deadline** (a bounded probe can take up to its per-op timeout, so a count loop would let slow probes overshoot the job budget).
3. **Triggers**: the push paths and PR detect-changes filter now include this workflow and `scripts/wedge_probe.py`, so a harness change re-runs the E2E that covers it — **this PR self-validates** (it edits the workflow, so the body runs here).

Result: the harness has **zero unbounded mount I/O**. A transient wedge now retries to green within the 180s budget; a permanent one fails fast with diagnostics instead of a silent 12-min hang. No product / daemon / raft / ABI change.

## Quality audit (per the 10 principles)
Simplest-robust (reuse `_bounded`, delete the one unbounded call) · no infra/ABI change (daemon-side readiness-gate deliberately *not* taken) · right files (probe logic in `wedge_probe.py`, test in `tests/unit/scripts/`) · SRP/orthogonal (`--readonly` = read prefix of the full gate) · SSOT (mount point via `$NEXUS_FUSE_MOUNT_POINT`; one probe authority) · DRY (3 probe styles → 1) · systematic not patch (fixes the *unbounded-probe-defeats-poll* class + restores the harness's own claimed 180s/​wedge-gate protection) · e2e depth (readiness now verifies a real readdir; new unit test) · no tombstones (old `ls` deleted, not memorialized). Persistent-store / raft / critical-path perf: N/A (test harness only).