### PR TITLE
fix(search): SearchDaemon proxy async contract + live-plugin CI test

### DIFF
--- a/.github/workflows/search-plugin-e2e.yml
+++ b/.github/workflows/search-plugin-e2e.yml
@@ -175,7 +175,11 @@ jobs:
         if: steps.changes.outputs.run == 'true'
         uses: actions/setup-python@v5
         with:
-          python-version: "3.14"
+          # 3.13 (not 3.14) because pdf-inspector's pyo3-ffi pin
+          # rejects 3.14 during workspace resolution.  The daemon
+          # proxy itself is version-agnostic — this only affects the
+          # test-side env.
+          python-version: "3.13"
 
       - name: Install uv
         if: steps.changes.outputs.run == 'true'

--- a/.github/workflows/search-plugin-e2e.yml
+++ b/.github/workflows/search-plugin-e2e.yml
@@ -26,6 +26,8 @@ on:
       - 'tests/e2e/docker/test_search_plugin.py'
       - 'tests/e2e/docker/search_helpers.py'
       - 'tests/e2e/docker/runbook_helpers.py'
+      - 'tests/integration/bricks/search/test_search_daemon_live_plugin.py'
+      - 'src/nexus/bricks/search/daemon.py'
       - '.github/workflows/search-plugin-e2e.yml'
   pull_request:
     branches: [main, develop]
@@ -62,7 +64,7 @@ jobs:
           cat /tmp/changed_files.txt
           # Workflow file itself is intentionally NOT in the regex — see
           # federation-e2e.yml's identical rationale.
-          if grep -Eq '^(dockerfiles/(Dockerfile\.(search-plugin-test|nexusd-cluster|federation-test)|docker-compose\.search-plugin-e2e\.yml)|rust/services/(search-plugin|proto/nexus/search)/|Cargo\.toml$|Cargo\.lock$|tests/e2e/docker/(test_search_plugin|search_helpers|runbook_helpers)\.py$)' /tmp/changed_files.txt; then
+          if grep -Eq '^(dockerfiles/(Dockerfile\.(search-plugin-test|nexusd-cluster|federation-test)|docker-compose\.search-plugin-e2e\.yml)|rust/services/(search-plugin|proto/nexus/search)/|Cargo\.toml$|Cargo\.lock$|tests/e2e/docker/(test_search_plugin|search_helpers|runbook_helpers)\.py$|tests/integration/bricks/search/test_search_daemon_live_plugin\.py$|src/nexus/bricks/search/daemon\.py$)' /tmp/changed_files.txt; then
             echo "run=true" >> "$GITHUB_OUTPUT"
           else
             echo "run=false" >> "$GITHUB_OUTPUT"
@@ -161,6 +163,35 @@ jobs:
         run: |
           docker compose -f dockerfiles/docker-compose.search-plugin-e2e.yml \
             run --rm test
+
+      # RustSearchDaemon proxy round-trip: exercises the exact
+      # `SearchDaemon.<method>` shapes the FastAPI router calls, so a
+      # regression in the async gRPC wrapper (like sync methods calling
+      # `run_until_complete` inside a live event loop) is caught here
+      # rather than at first request.  Runs on the runner rather than
+      # in-compose because the slim federation-test image doesn't ship
+      # `nexus.bricks`.
+      - name: Set up Python for daemon-proxy tests
+        if: steps.changes.outputs.run == 'true'
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+
+      - name: Install uv
+        if: steps.changes.outputs.run == 'true'
+        uses: astral-sh/setup-uv@v6
+
+      - name: Install nexus dependencies
+        if: steps.changes.outputs.run == 'true'
+        run: uv sync --frozen
+
+      - name: Run SearchDaemon live-plugin proxy tests
+        if: steps.changes.outputs.run == 'true'
+        env:
+          NEXUS_SEARCH_LIVE_PLUGIN: "1"
+          NEXUS_SEARCH_PLUGIN_TARGET: "127.0.0.1:2126"
+        run: |
+          uv run pytest tests/integration/bricks/search/test_search_daemon_live_plugin.py -v
 
       - name: Dump container logs on failure
         if: failure() && steps.changes.outputs.run == 'true'

--- a/.github/workflows/search-plugin-e2e.yml
+++ b/.github/workflows/search-plugin-e2e.yml
@@ -175,11 +175,7 @@ jobs:
         if: steps.changes.outputs.run == 'true'
         uses: actions/setup-python@v5
         with:
-          # 3.13 (not 3.14) because pdf-inspector's pyo3-ffi pin
-          # rejects 3.14 during workspace resolution.  The daemon
-          # proxy itself is version-agnostic — this only affects the
-          # test-side env.
-          python-version: "3.13"
+          python-version: "3.14"
 
       - name: Install uv
         if: steps.changes.outputs.run == 'true'
@@ -187,6 +183,11 @@ jobs:
 
       - name: Install nexus dependencies
         if: steps.changes.outputs.run == 'true'
+        env:
+          # Third-party PyO3 sdists (pdf-inspector) reject 3.14 at
+          # build time without ABI3 forward-compat; mirrors the setting
+          # code-quality.yml already applies for the same reason.
+          PYO3_USE_ABI3_FORWARD_COMPATIBILITY: "1"
         run: uv sync --frozen
 
       - name: Run SearchDaemon live-plugin proxy tests

--- a/dockerfiles/docker-compose.search-plugin-e2e.yml
+++ b/dockerfiles/docker-compose.search-plugin-e2e.yml
@@ -61,6 +61,13 @@ services:
       # service armed" log lines the plan calls out as the E2E's
       # readiness signals.
       RUST_LOG: info,nexus_raft=info,kernel::plugins=debug,plugins=debug
+    # Host port exposure so the search-plugin CI job can drive
+    # tests/integration/bricks/search/test_search_daemon_live_plugin.py
+    # (needs nexus.bricks — not shippable inside the slim
+    # federation-test runner image, so it runs directly on the CI
+    # runner against the exposed host port).
+    ports:
+      - "2126:2126"
     volumes:
       - search_plugin_node_data:/app/data
     networks:

--- a/docs/surface-coverage/api-rpc-surface-coverage.yaml
+++ b/docs/surface-coverage/api-rpc-surface-coverage.yaml
@@ -290,7 +290,7 @@ operations:
   transports:
     http:
       name: POST /indexing-mode
-      source: src/nexus/server/api/v2/routers/_search_indexed_dirs.py:167
+      source: src/nexus/server/api/v2/routers/_search_indexed_dirs.py:168
   profiles:
     lite: supported
     sandbox: supported

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -179,58 +179,6 @@ class SearchDaemon:
         )
         await self._get_stub().NotifyFileChange(req)
 
-    # ── Parked queue ───────────────────────────────────────────
-
-    def list_parked(self) -> dict[str, list[dict[str, Any]]]:
-        # Python's list_parked is sync + returns {zone: entries}.
-        # SearchDaemon runs single-zone at a time; return a
-        # single-key dict keyed by the default zone for parity.  A
-        # zone-scoped variant is a follow-up if callers need it.
-        import asyncio
-
-        async def _call() -> list[dict[str, Any]]:
-            req = search_pb2.ParkedListRequest(zone_id="")
-            resp = await self._get_stub().ParkedList(req)
-            return [
-                {
-                    "path": e.path,
-                    "zone_id": e.zone_id,
-                    "parked_at_ms": e.parked_at_ms,
-                    "reason": e.reason,
-                }
-                for e in resp.entries
-            ]
-
-        entries = asyncio.get_event_loop().run_until_complete(_call())
-        # Group by zone.
-        by_zone: dict[str, list[dict[str, Any]]] = {}
-        for entry in entries:
-            by_zone.setdefault(entry["zone_id"], []).append(entry)
-        return by_zone
-
-    async def retry_parked(
-        self,
-        paths: list[str] | None = None,
-        *,
-        zone_id: str | None = None,
-    ) -> dict[str, int]:
-        req = search_pb2.ParkedRetryRequest(paths=paths or [], zone_id=zone_id or "")
-        resp = await self._get_stub().ParkedRetry(req)
-        return {
-            "retried": resp.retried_count,
-            "still_parked": resp.still_parked_count,
-        }
-
-    async def discard_parked(
-        self,
-        paths: list[str] | None = None,
-        *,
-        zone_id: str | None = None,
-    ) -> dict[str, int]:
-        req = search_pb2.ParkedDiscardRequest(paths=paths or [], zone_id=zone_id or "")
-        resp = await self._get_stub().ParkedDiscard(req)
-        return {"discarded": resp.discarded_count}
-
     # ── Indexed-directories registry ──────────────────────────
 
     async def add_indexed_directory(
@@ -251,15 +199,10 @@ class SearchDaemon:
         resp = await self._get_stub().RemoveIndexedDirectory(req)
         return "removed" if resp.removed else "not_found"
 
-    def list_indexed_directories(self, zone_id: str) -> list[str]:
-        import asyncio
-
-        async def _call() -> list[str]:
-            req = search_pb2.ListIndexedDirectoriesRequest(zone_id=zone_id)
-            resp = await self._get_stub().ListIndexedDirectories(req)
-            return [d.path for d in resp.directories]
-
-        return asyncio.get_event_loop().run_until_complete(_call())
+    async def list_indexed_directories(self, zone_id: str) -> list[str]:
+        req = search_pb2.ListIndexedDirectoriesRequest(zone_id=zone_id)
+        resp = await self._get_stub().ListIndexedDirectories(req)
+        return [d.path for d in resp.directories]
 
     # ── Zone indexing modes ────────────────────────────────────
 
@@ -270,45 +213,26 @@ class SearchDaemon:
             raise ValueError(resp.error)
         return {"zone_id": zone_id, "mode": mode}
 
-    @property
-    def _zone_indexing_modes(self) -> dict[str, str]:
-        # Python router touches this as a mapping; we make it a
-        # property that fetches on read.  A caller iterating in a
-        # tight loop pays one gRPC per read — acceptable for the
-        # operator UI which polls infrequently.
-        import asyncio
-
-        async def _call() -> dict[str, str]:
-            req = search_pb2.ListZoneIndexingModesRequest()
-            resp = await self._get_stub().ListZoneIndexingModes(req)
-            return {m.zone_id: m.mode for m in resp.modes}
-
-        return asyncio.get_event_loop().run_until_complete(_call())
+    async def get_zone_indexing_modes(self) -> dict[str, str]:
+        """Snapshot per-zone indexing modes from the plugin."""
+        req = search_pb2.ListZoneIndexingModesRequest()
+        resp = await self._get_stub().ListZoneIndexingModes(req)
+        return {m.zone_id: m.mode for m in resp.modes}
 
     # ── Health + stats ────────────────────────────────────────
 
-    def get_health(self) -> dict[str, Any]:
-        import asyncio
+    async def get_health(self) -> dict[str, Any]:
+        resp = await self._get_stub().Health(search_pb2.HealthRequest())
+        return {"status": resp.status, "detail": resp.detail}
 
-        async def _call() -> dict[str, Any]:
-            resp = await self._get_stub().Health(search_pb2.HealthRequest())
-            return {"status": resp.status, "detail": resp.detail}
-
-        return asyncio.get_event_loop().run_until_complete(_call())
-
-    def get_stats(self) -> dict[str, Any]:
-        import asyncio
-
-        async def _call() -> dict[str, Any]:
-            resp = await self._get_stub().Stats(search_pb2.StatsRequest())
-            return {
-                "fts_doc_count": resp.fts_doc_count,
-                "fts_path_count": resp.fts_path_count,
-                "ann_chunk_count": resp.ann_chunk_count,
-                "parked_count": resp.parked_count,
-            }
-
-        return asyncio.get_event_loop().run_until_complete(_call())
+    async def get_stats(self) -> dict[str, Any]:
+        resp = await self._get_stub().Stats(search_pb2.StatsRequest())
+        return {
+            "fts_doc_count": resp.fts_doc_count,
+            "fts_path_count": resp.fts_path_count,
+            "ann_chunk_count": resp.ann_chunk_count,
+            "parked_count": resp.parked_count,
+        }
 
 
 def _result_to_base(pb: search_pb2.QueryResult) -> BaseSearchResult:

--- a/src/nexus/server/api/core/health.py
+++ b/src/nexus/server/api/core/health.py
@@ -88,7 +88,7 @@ async def health_check_detailed(request: Request) -> dict[str, Any]:
 
     # Check search daemon (Issue #951)
     if state.search_daemon:
-        daemon_health = state.search_daemon.get_health()
+        daemon_health = await state.search_daemon.get_health()
         health["components"]["search_daemon"] = daemon_health
     else:
         health["components"]["search_daemon"] = {

--- a/src/nexus/server/api/v2/routers/_search_indexed_dirs.py
+++ b/src/nexus/server/api/v2/routers/_search_indexed_dirs.py
@@ -155,8 +155,9 @@ async def list_indexed_dirs(
         )
 
     zone_id = auth_result.get("zone_id") or ROOT_ZONE_ID
-    mode = search_daemon._zone_indexing_modes.get(zone_id, "on")
-    directories = search_daemon.list_indexed_directories(zone_id)
+    modes = await search_daemon.get_zone_indexing_modes()
+    mode = modes.get(zone_id, "on")
+    directories = await search_daemon.list_indexed_directories(zone_id)
     return {
         "zone_id": zone_id,
         "indexing_mode": mode,

--- a/src/nexus/server/api/v2/routers/search.py
+++ b/src/nexus/server/api/v2/routers/search.py
@@ -167,7 +167,7 @@ async def search_daemon_health(
             "daemon_enabled": False,
             "message": "Search daemon unavailable (set NEXUS_SEARCH_DAEMON=false to disable)",
         }
-    health: dict[str, Any] = search_daemon.get_health()
+    health: dict[str, Any] = await search_daemon.get_health()
     return health
 
 
@@ -176,7 +176,7 @@ async def search_daemon_stats(
     search_daemon: Any = Depends(_get_search_daemon),
 ) -> dict[str, Any]:
     """Get search daemon statistics."""
-    stats: dict[str, Any] = search_daemon.get_stats()
+    stats: dict[str, Any] = await search_daemon.get_stats()
     return stats
 
 

--- a/tests/integration/bricks/search/test_search_daemon_live_plugin.py
+++ b/tests/integration/bricks/search/test_search_daemon_live_plugin.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import uuid
 
 import pytest
 
@@ -81,59 +82,68 @@ class _MinimalSearchRequest:
 
 
 @pytest.fixture(scope="module")
-def daemon():
+def _event_loop():
+    """One loop shared across every test in the module.
+
+    ``grpc.aio.insecure_channel`` binds the channel to the loop it
+    first runs on; a per-test fresh loop would strand the channel
+    from prior tests.  Keeping a module-scoped loop matches the
+    daemon fixture's scope so every call reaches the same
+    stub+channel pair.
+    """
+    loop = asyncio.new_event_loop()
+    try:
+        yield loop
+    finally:
+        loop.close()
+
+
+@pytest.fixture(scope="module")
+def daemon(_event_loop):
     """SearchDaemon pointing at the docker compose node."""
     from nexus.bricks.search.daemon import SearchDaemon
 
     d = SearchDaemon(target=NODE_GRPC)
     yield d
-    # Shutdown is best-effort — the module fixture teardown runs
-    # after pytest closes its event loop, so a proper close needs
-    # its own loop.
     try:
-        asyncio.new_event_loop().run_until_complete(d.shutdown())
+        _event_loop.run_until_complete(d.shutdown())
     except Exception:
         pass
 
 
 class TestSearchDaemonRoundtrip:
-    """Every method the FastAPI router touches — verify it round-
-    trips through the plugin.  Same shape as the direct-gRPC E2E
-    suite, but the caller is the production ``SearchDaemon``
-    Python proxy."""
+    """Every method the FastAPI router touches — verify it round-trips
+    through the plugin.  Same shape as the direct-gRPC E2E suite, but
+    the caller is the production ``SearchDaemon`` Python proxy."""
 
-    def test_health_returns_status(self, daemon) -> None:
-        h = daemon.get_health()
-        # 'healthy' when the embedder is loaded, 'degraded' when
-        # not.  The docker image doesn't ship a model in the P8
-        # scope so degraded is the expected happy path.
+    def test_health_returns_status(self, daemon, _event_loop) -> None:
+        h = _event_loop.run_until_complete(daemon.get_health())
+        # 'healthy' when the embedder is loaded, 'degraded' when not.
+        # The docker image doesn't ship a model in the P8 scope so
+        # degraded is the expected happy path.
         assert h["status"] in ("healthy", "degraded"), h
 
-    def test_stats_returns_counts(self, daemon) -> None:
-        s = daemon.get_stats()
+    def test_stats_returns_counts(self, daemon, _event_loop) -> None:
+        s = _event_loop.run_until_complete(daemon.get_stats())
         for key in ("fts_doc_count", "fts_path_count", "ann_chunk_count", "parked_count"):
             assert key in s, f"stats missing {key}: {s}"
             assert isinstance(s[key], int), s
 
-    def test_index_documents_then_locate_and_search(self, daemon) -> None:
-        # Seed 3 docs via IndexDocuments.
+    def test_index_documents_then_locate_and_search(self, daemon, _event_loop) -> None:
         docs = [
             {"path": "/rust-daemon-e2e/a.md", "text": "widget alpha content"},
             {"path": "/rust-daemon-e2e/b.md", "text": "widget beta content"},
             {"path": "/rust-daemon-e2e/c.md", "text": "unrelated payload"},
         ]
 
-        async def _run():
+        async def journey():
             r = await daemon.index_documents(docs, zone_id="root")
             assert r["indexed"] == 3, r
-            # Locate — path exists.
             loc = await daemon.locate("/rust-daemon-e2e/a.md", zone_id="root")
             assert loc["indexed"] is True, loc
             assert loc["chunk_count"] >= 1
-            # Locate — missing path.
             miss = await daemon.locate("/rust-daemon-e2e/nope.md", zone_id="root")
             assert miss["indexed"] is False, miss
-            # Search — 2 hits for 'widget'.
             hits = await daemon.search(
                 _MinimalSearchRequest("widget", zone_id="root", path_filter="/rust-daemon-e2e/")
             )
@@ -142,68 +152,53 @@ class TestSearchDaemonRoundtrip:
             assert "/rust-daemon-e2e/b.md" in paths, paths
             assert "/rust-daemon-e2e/c.md" not in paths, paths
 
-        asyncio.new_event_loop().run_until_complete(_run())
+        _event_loop.run_until_complete(journey())
 
-    def test_notify_file_change_delete_removes_from_search(self, daemon) -> None:
-        async def _run():
-            docs = [
-                {"path": "/rust-daemon-notify/x.md", "text": "widget only"},
-            ]
+    def test_notify_file_change_delete_removes_from_search(self, daemon, _event_loop) -> None:
+        async def journey():
+            docs = [{"path": "/rust-daemon-notify/x.md", "text": "widget only"}]
             r = await daemon.index_documents(docs, zone_id="root")
             assert r["indexed"] == 1, r
 
-            # Delete via NotifyFileChange.
             await daemon.notify_file_change("/rust-daemon-notify/x.md", "delete", zone_id="root")
 
-            # Search must not surface it.
             hits = await daemon.search(
                 _MinimalSearchRequest("widget", zone_id="root", path_filter="/rust-daemon-notify/")
             )
             paths = {h.path for h in hits}
             assert "/rust-daemon-notify/x.md" not in paths, f"deleted doc leaked: {paths}"
 
-        asyncio.new_event_loop().run_until_complete(_run())
+        _event_loop.run_until_complete(journey())
 
-    def test_indexed_directories_add_list_remove(self, daemon) -> None:
-        async def _run():
-            r_add = await daemon.add_indexed_directory("root", "/some/registered/dir")
+    def test_indexed_directories_add_list_remove(self, daemon, _event_loop) -> None:
+        # Fresh path per test invocation so a rerun against a persisted
+        # plugin data volume doesn't see stale entries from prior runs
+        # (the plugin's indexed_dirs.json is durable across container
+        # restarts by design).
+        path = f"/some/registered/dir-{uuid.uuid4().hex[:8]}"
+
+        async def journey():
+            r_add = await daemon.add_indexed_directory("root", path)
             assert r_add["added"] is True, r_add
-            # List surfaces it.
-            dirs = daemon.list_indexed_directories("root")
-            assert "/some/registered/dir" in dirs, dirs
-            # Second add is idempotent.
-            r_add_dup = await daemon.add_indexed_directory("root", "/some/registered/dir")
+            dirs = await daemon.list_indexed_directories("root")
+            assert path in dirs, dirs
+            r_add_dup = await daemon.add_indexed_directory("root", path)
             assert r_add_dup["added"] is False, r_add_dup
-            # Remove.
-            r_rm = await daemon.remove_indexed_directory("root", "/some/registered/dir")
+            r_rm = await daemon.remove_indexed_directory("root", path)
             assert r_rm == "removed", r_rm
-            # Not found after remove.
-            r_rm2 = await daemon.remove_indexed_directory("root", "/some/registered/dir")
+            r_rm2 = await daemon.remove_indexed_directory("root", path)
             assert r_rm2 == "not_found", r_rm2
 
-        asyncio.new_event_loop().run_until_complete(_run())
+        _event_loop.run_until_complete(journey())
 
-    def test_set_zone_indexing_mode_roundtrip(self, daemon) -> None:
-        async def _run():
+    def test_set_zone_indexing_mode_roundtrip(self, daemon, _event_loop) -> None:
+        async def journey():
             await daemon.set_zone_indexing_mode("root", "sandbox")
-            modes = daemon._zone_indexing_modes
+            modes = await daemon.get_zone_indexing_modes()
             assert modes.get("root") == "sandbox", modes
-            # Reset.
             await daemon.set_zone_indexing_mode("root", "on")
-            modes = daemon._zone_indexing_modes
-            # After reset the key may be 'on' or absent (default);
-            # accept both.
+            modes = await daemon.get_zone_indexing_modes()
+            # After reset the key may be 'on' or absent (default); accept both.
             assert modes.get("root", "on") == "on", modes
 
-        asyncio.new_event_loop().run_until_complete(_run())
-
-    def test_parked_queue_list_shape(self, daemon) -> None:
-        # Rust plugin doesn't currently populate the parked queue
-        # (do_index_documents doesn't park on failure yet — see the
-        # step 4 commit body).  Just verify the list surface is
-        # dial-able and returns the expected dict shape.
-        parked = daemon.list_parked()
-        assert isinstance(parked, dict), parked
-        for zone, entries in parked.items():
-            assert isinstance(zone, str)
-            assert isinstance(entries, list)
+        _event_loop.run_until_complete(journey())


### PR DESCRIPTION
## Summary

**Live-run of `test_search_daemon_live_plugin.py` against a real compose-built plugin caught a real bug** — five `SearchDaemon` proxy methods (`get_health`, `get_stats`, `list_indexed_directories`, `_zone_indexing_modes`, `list_parked`) were calling `asyncio.get_event_loop().run_until_complete(...)` inside sync bodies.  Under FastAPI (or pytest-asyncio) the caller already owns the loop, so the first sync call throws `RuntimeError: This event loop is already running`.

## Fix

- Methods become `async def`; callers `await` them.
- `list_parked` / `retry_parked` / `discard_parked` deleted — the `/parked/*` endpoints they backed went with #4598 and nothing else called them.
- The `@property` on `_zone_indexing_modes` becomes `async def get_zone_indexing_modes()` (async properties are awkward; a plain method reads better at the call site).

## New live-test CI protection

`search-plugin-e2e.yml` now runs `tests/integration/bricks/search/test_search_daemon_live_plugin.py` on the runner (post-`test` step) against the compose stack's exposed `2126` port.  The slim `federation-test` image doesn't ship `nexus.bricks`, so this stage uses `actions/setup-python` + `uv sync` directly.  Compose gets a `ports: - "2126:2126"` on the `node` service to bridge.

## Test plan

Local run against docker-compose plugin build:

```
docker compose -f dockerfiles/docker-compose.search-plugin-e2e.yml up -d node
NEXUS_SEARCH_LIVE_PLUGIN=1 pytest tests/integration/bricks/search/test_search_daemon_live_plugin.py -v
# ...... [100%]  6 passed
```

- [x] All 6 live tests pass locally
- [x] Ruff clean
- [x] CI wired to keep regression cover