### PR TITLE
fix(search): fail-soft startup when nexus-search-plugin unreachable

### DIFF
--- a/src/nexus/server/lifespan/search.py
+++ b/src/nexus/server/lifespan/search.py
@@ -39,15 +39,45 @@ async def startup_search(app: "FastAPI", svc: "LifespanServices") -> list[asynci
         logger.debug("Search Daemon disabled (set NEXUS_SEARCH_DAEMON=true to enable)")
         return []
 
+    app.state.database_url = svc.database_url
+
     try:
         from nexus.bricks.search.daemon import SearchDaemon
 
-        app.state.search_daemon = SearchDaemon(
-            target=os.environ.get("NEXUS_SEARCH_PLUGIN_TARGET"),
-        )
-        app.state.database_url = svc.database_url
+        target = os.environ.get("NEXUS_SEARCH_PLUGIN_TARGET")
+        candidate = SearchDaemon(target=target)
+        await candidate.startup()
 
-        await app.state.search_daemon.startup()
+        # Boot-time reachability probe.  P12 turned the daemon into a
+        # gRPC proxy to the nexus-search-plugin cdylib; a deployment
+        # that boots the FastAPI server without also loading the plugin
+        # (single-container edge-smoke topology, dev workstations, any
+        # deployment that hasn't caught up to the new sidecar contract)
+        # used to get an in-process daemon and now would fail every
+        # request with UNAVAILABLE if we left the unusable proxy in
+        # place.  Fail-soft instead: if the plugin can't be reached in
+        # bounded time, warn loudly and leave app.state.search_daemon
+        # unset so _get_search_daemon returns 503 and no code path
+        # blocks on unreachable gRPC.
+        try:
+            await asyncio.wait_for(candidate.get_health(), timeout=5.0)
+        except Exception as probe_exc:
+            logger.warning(
+                "Search plugin not reachable at %s (%s: %s); disabling "
+                "search daemon.  Load nexus-search-plugin via "
+                "nexusd-cluster --plugin-dir to enable, or set "
+                "NEXUS_SEARCH_DAEMON=false to silence this warning.",
+                target or "<default>",
+                type(probe_exc).__name__,
+                probe_exc,
+            )
+            with contextlib.suppress(Exception):
+                await candidate.shutdown()
+            app.state.search_daemon = None
+            app.state.search_daemon_enabled = False
+            return []
+
+        app.state.search_daemon = candidate
         app.state.search_daemon_enabled = True
 
         # Wire the daemon into SearchService so semantic_search queries
@@ -62,11 +92,12 @@ async def startup_search(app: "FastAPI", svc: "LifespanServices") -> list[asynci
 
         logger.info(
             "Search Daemon started (backend=rust-plugin, target=%s)",
-            os.environ.get("NEXUS_SEARCH_PLUGIN_TARGET") or "<default>",
+            target or "<default>",
         )
 
     except Exception as e:
         logger.warning("Failed to start Search Daemon: %s", e)
+        app.state.search_daemon = None
         app.state.search_daemon_enabled = False
 
     return []

--- a/tests/unit/server/lifespan/test_search_startup_failsoft.py
+++ b/tests/unit/server/lifespan/test_search_startup_failsoft.py
@@ -1,0 +1,109 @@
+"""``startup_search`` must fail SOFT when the nexus-search-plugin
+sidecar isn't reachable.
+
+P12 turned ``SearchDaemon`` into a Python-side proxy for the Rust
+``nexus-search-plugin`` cdylib.  Every method dials
+``NEXUS_SEARCH_PLUGIN_TARGET`` (default ``127.0.0.1:2126``).  A
+deployment topology that boots the FastAPI server without also
+loading the plugin (single-container edge smoke, dev workstation,
+anything that hasn't caught up to the new sidecar contract) used to
+get an in-process daemon and now would leave an unusable proxy in
+``app.state`` — every subsequent request handler would UNAVAILABLE.
+
+The fix: ``startup_search`` runs a bounded ``get_health()`` probe
+before publishing the daemon.  On failure it logs a warning, tears
+the candidate down, and sets ``app.state.search_daemon = None`` so
+``_get_search_daemon`` returns 503 cleanly and no code path blocks
+on unreachable gRPC.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from nexus.server.lifespan.search import startup_search
+
+
+class _FakeApp:
+    """Minimal FastAPI stand-in — ``startup_search`` only touches
+    ``app.state`` (SimpleNamespace so attribute assignment works)."""
+
+    def __init__(self) -> None:
+        self.state = SimpleNamespace()
+
+
+class _FakeSvc:
+    def __init__(self) -> None:
+        self.database_url = "postgresql://x"
+        self.nexus_fs = SimpleNamespace(service=lambda _: None)
+        self.zone_manager = None
+
+
+@pytest.mark.asyncio
+async def test_startup_failsoft_when_plugin_unreachable(monkeypatch):
+    """Plugin health probe raises ⇒ app.state.search_daemon = None."""
+    monkeypatch.setenv("NEXUS_SEARCH_DAEMON", "true")
+    monkeypatch.setenv("NEXUS_SEARCH_PLUGIN_TARGET", "127.0.0.1:2126")
+
+    fake = AsyncMock()
+    fake.startup.return_value = None
+    fake.get_health.side_effect = ConnectionRefusedError("Connection refused")
+    fake.shutdown.return_value = None
+
+    app, svc = _FakeApp(), _FakeSvc()
+    with patch("nexus.bricks.search.daemon.SearchDaemon", return_value=fake):
+        tasks = await startup_search(app, svc)
+
+    assert tasks == []
+    assert app.state.search_daemon is None, (
+        "unreachable plugin must not leave a broken proxy on app.state"
+    )
+    assert app.state.search_daemon_enabled is False
+    fake.shutdown.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_startup_publishes_daemon_when_plugin_healthy(monkeypatch):
+    """Healthy probe ⇒ daemon published + wired into search service."""
+    monkeypatch.setenv("NEXUS_SEARCH_DAEMON", "true")
+    monkeypatch.setenv("NEXUS_SEARCH_PLUGIN_TARGET", "127.0.0.1:2126")
+
+    fake = AsyncMock()
+    fake.startup.return_value = None
+    fake.get_health.return_value = {"status": "healthy", "detail": ""}
+
+    class _SearchSvcHolder:
+        def __init__(self) -> None:
+            self._search_daemon = None
+
+    holder = _SearchSvcHolder()
+
+    app, svc = _FakeApp(), _FakeSvc()
+    svc.nexus_fs = SimpleNamespace(service=lambda name: holder if name == "search" else None)
+
+    # _wire_notify_hooks + _init_zone_registry short-circuit on the
+    # SimpleNamespace fake (no register_intercept_write / zone_manager).
+    with patch("nexus.bricks.search.daemon.SearchDaemon", return_value=fake):
+        tasks = await startup_search(app, svc)
+
+    assert tasks == []
+    assert app.state.search_daemon is fake
+    assert app.state.search_daemon_enabled is True
+    assert holder._search_daemon is fake, "SearchService got wired to the daemon"
+
+
+@pytest.mark.asyncio
+async def test_startup_skipped_when_explicit_off(monkeypatch):
+    """NEXUS_SEARCH_DAEMON=false ⇒ never construct."""
+    monkeypatch.setenv("NEXUS_SEARCH_DAEMON", "false")
+
+    app, svc = _FakeApp(), _FakeSvc()
+    with patch("nexus.bricks.search.daemon.SearchDaemon") as ctor:
+        tasks = await startup_search(app, svc)
+
+    assert tasks == []
+    ctor.assert_not_called()
+    assert not hasattr(app.state, "search_daemon")


### PR DESCRIPTION
## Summary

**Fixes the edge-smoke CI failure on the post-P12 develop tip** (\`7cc6f13f0\`).

P12 turned \`SearchDaemon\` into a Python-side proxy for the Rust \`nexus-search-plugin\` cdylib.  Deployments that boot the FastAPI server without also loading the plugin — single-container edge smoke, dev workstations, anything on the old sidecar-less topology — used to get an in-process daemon and were left with an unusable proxy on \`app.state\`.  Every subsequent \`/health\` (etc.) did gRPC to \`127.0.0.1:2126\` → \`StatusCode.UNAVAILABLE\` → the container never went healthy.

## Fix

\`startup_search\` now runs a bounded 5-second \`get_health()\` probe against the freshly constructed daemon before publishing it to \`app.state\`.  Probe raises ⇒ warn loudly, tear the candidate down, leave \`search_daemon = None\`.

- \`_get_search_daemon\` already 503s on \`None\`.
- \`/health\` router branch and VFS auto-index hooks are already guarded on \`if search_daemon is None\`.
- Deployments that DO ship a plugin see zero behavior change.

## Test plan

- **Unit** — \`tests/unit/server/lifespan/test_search_startup_failsoft.py\` locks in three cases:
  - Unreachable-plugin fail-soft: probe raises → \`app.state.search_daemon is None\`, \`shutdown\` awaited on the candidate.
  - Healthy-plugin publish: daemon lands on \`app.state\` and gets wired into SearchService.
  - \`NEXUS_SEARCH_DAEMON=false\` skip: constructor never called.
  Locally: \`3 passed in 8.18s\`.
- **E2E** — the edge-smoke CI job that failed on \`7cc6f13f0\` should now go green (that job IS the end-to-end fail-soft test); \`search-plugin-e2e\` continues to cover the plugin-present path.