### PR TITLE
fix(search): edge-smoke reachable — get_stats await + shared workspace volume

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -239,7 +239,18 @@ jobs:
           fi
           docker compose -f dockerfiles/docker-compose.search-plugin-e2e.yml build node
 
+      - name: Prepare shared workspace volume
+        run: |
+          # Both containers see the same /workspace bytes.  Post-P12
+          # the plugin has to read a file by absolute path when
+          # NotifyFileChange fires, so nexus-e2e's writes must land
+          # somewhere the plugin container can also read.
+          docker volume create nexus-shared-workspace
+          sudo chmod 777 "$(docker volume inspect nexus-shared-workspace --format '{{.Mountpoint}}')"
+
       - name: Start search-plugin sidecar on 127.0.0.1:2126
+        env:
+          NEXUS_SHARED_WORKSPACE: nexus-shared-workspace
         run: |
           docker compose -f dockerfiles/docker-compose.search-plugin-e2e.yml up -d node
           # Wait for the plugin's gRPC bind to be reachable from the host
@@ -283,6 +294,7 @@ jobs:
             -e NEXUS_SEARCH_POOL_MAX=8 \
             -e NEXUS_SEARCH_PLUGIN_TARGET=127.0.0.1:2126 \
             -v /tmp/nexus-data:/app/data \
+            -v nexus-shared-workspace:/workspace \
             ghcr.io/nexi-lab/nexus:edge
 
           # Wait for server to be ready
@@ -515,3 +527,4 @@ jobs:
         run: |
           docker rm -f nexus-e2e 2>/dev/null || true
           docker compose -f dockerfiles/docker-compose.search-plugin-e2e.yml down -v --remove-orphans 2>/dev/null || true
+          docker volume rm -f nexus-shared-workspace 2>/dev/null || true

--- a/dockerfiles/docker-compose.search-plugin-e2e.yml
+++ b/dockerfiles/docker-compose.search-plugin-e2e.yml
@@ -70,6 +70,12 @@ services:
       - "2126:2126"
     volumes:
       - search_plugin_node_data:/app/data
+      # Optional host-shared workspace so a co-tenant container (edge
+      # smoke's nexus-e2e) that writes to /workspace can have those
+      # writes seen by the plugin when NotifyFileChange fires with an
+      # absolute path.  The mount is a bind if $NEXUS_SHARED_WORKSPACE
+      # is set, otherwise falls back to a plugin-owned empty dir.
+      - ${NEXUS_SHARED_WORKSPACE:-search_plugin_workspace}:/workspace
     networks:
       - nexus-search-plugin-net
     healthcheck:
@@ -130,3 +136,5 @@ secrets:
 volumes:
   search_plugin_node_data:
     name: nexus-search-plugin-node-data
+  search_plugin_workspace:
+    name: nexus-search-plugin-workspace

--- a/src/nexus/bricks/search/search_service.py
+++ b/src/nexus/bricks/search/search_service.py
@@ -4802,7 +4802,7 @@ class SearchService:
         """Get semantic search indexing statistics."""
         daemon = getattr(self, "_search_daemon", None)
         if daemon is not None:
-            stats = dict(daemon.get_stats())
+            stats = dict(await daemon.get_stats())
             stats.setdefault("engine", stats.get("backend", "txtai"))
             return stats
 


### PR DESCRIPTION
## Summary

Two independent bugs still surface as edge-smoke auto-index failures on develop tip \`f7f45118a\` (after #4605 wired the plugin sidecar):

1. **\`search_service.py:4805\`** called \`daemon.get_stats()\` without an await.  Post-P12 that method is async; the coroutine was never awaited, so \`nexus search stats\` returned nothing and callers couldn't tell whether search worked.  The container log surfaced \`RuntimeWarning: coroutine 'SearchDaemon.get_stats' was never awaited\`.  Fixed inline.
2. **Plugin sidecar can't open the file** \`NotifyFileChange\` references.  nexus-e2e's writes land on its own ephemeral FS, not the sidecar's FS.  Even when the RPC arrived, the plugin couldn't read \`/workspace/demo/...\` and skipped indexing.
   - Fix: workflow creates a shared workspace docker volume (\`nexus-shared-workspace\`) and mounts it into BOTH nexus-e2e (\`-v nexus-shared-workspace:/workspace\`) and the plugin sidecar (via a new \`NEXUS_SHARED_WORKSPACE\` env override in the compose file — falls back to a plugin-owned empty dir when the env is unset, so \`search-plugin-e2e.yml\` keeps working unchanged).  Both containers now see the same bytes.

## Test plan

- The docker-publish workflow doesn't fire on PRs — validation happens post-merge on the develop tip.
- Fail-soft from #4604 still guards accidental no-plugin topologies (a rebuild without sidecar drops search cleanly rather than 500-ing every request).