### PR TITLE
fix(ci): edge-smoke shared /workspace via compose override

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -249,10 +249,14 @@ jobs:
           sudo chmod 777 "$(docker volume inspect nexus-shared-workspace --format '{{.Mountpoint}}')"
 
       - name: Start search-plugin sidecar on 127.0.0.1:2126
-        env:
-          NEXUS_SHARED_WORKSPACE: nexus-shared-workspace
         run: |
-          docker compose -f dockerfiles/docker-compose.search-plugin-e2e.yml up -d node
+          # Compose with the edge-override so both the plugin sidecar
+          # and nexus-e2e see the same bytes at /workspace (see
+          # dockerfiles/docker-compose.search-plugin-e2e.edge-override.yml).
+          docker compose \
+            -f dockerfiles/docker-compose.search-plugin-e2e.yml \
+            -f dockerfiles/docker-compose.search-plugin-e2e.edge-override.yml \
+            up -d node
           # Wait for the plugin's gRPC bind to be reachable from the host
           # (compose maps 2126:2126 so --network host of nexus-e2e sees
           # the same port).
@@ -265,7 +269,10 @@ jobs:
             sleep 2
           done
           echo "::error::Search plugin sidecar failed to bind 127.0.0.1:2126 within 120s"
-          docker compose -f dockerfiles/docker-compose.search-plugin-e2e.yml logs --tail=200 node
+          docker compose \
+            -f dockerfiles/docker-compose.search-plugin-e2e.yml \
+            -f dockerfiles/docker-compose.search-plugin-e2e.edge-override.yml \
+            logs --tail=200 node
           exit 1
 
       - name: Start Nexus edge container
@@ -526,5 +533,8 @@ jobs:
         if: always()
         run: |
           docker rm -f nexus-e2e 2>/dev/null || true
-          docker compose -f dockerfiles/docker-compose.search-plugin-e2e.yml down -v --remove-orphans 2>/dev/null || true
+          docker compose \
+            -f dockerfiles/docker-compose.search-plugin-e2e.yml \
+            -f dockerfiles/docker-compose.search-plugin-e2e.edge-override.yml \
+            down -v --remove-orphans 2>/dev/null || true
           docker volume rm -f nexus-shared-workspace 2>/dev/null || true

--- a/dockerfiles/docker-compose.search-plugin-e2e.edge-override.yml
+++ b/dockerfiles/docker-compose.search-plugin-e2e.edge-override.yml
@@ -1,0 +1,16 @@
+# Compose override used by .github/workflows/docker-publish.yml's
+# e2e-edge job.  Adds a bind mount so the plugin sidecar and the
+# nexus-e2e edge container see the SAME bytes at /workspace — the
+# plugin has to open the file NotifyFileChange references, so a
+# nexus-e2e write is only index-able when the plugin's FS agrees.
+#
+# Standalone search-plugin-e2e.yml stays unchanged; this override is
+# only merged in via `docker compose -f base.yml -f edge-override.yml`.
+services:
+  node:
+    volumes:
+      - nexus-shared-workspace:/workspace
+
+volumes:
+  nexus-shared-workspace:
+    external: true

--- a/dockerfiles/docker-compose.search-plugin-e2e.yml
+++ b/dockerfiles/docker-compose.search-plugin-e2e.yml
@@ -70,12 +70,6 @@ services:
       - "2126:2126"
     volumes:
       - search_plugin_node_data:/app/data
-      # Optional host-shared workspace so a co-tenant container (edge
-      # smoke's nexus-e2e) that writes to /workspace can have those
-      # writes seen by the plugin when NotifyFileChange fires with an
-      # absolute path.  The mount is a bind if $NEXUS_SHARED_WORKSPACE
-      # is set, otherwise falls back to a plugin-owned empty dir.
-      - ${NEXUS_SHARED_WORKSPACE:-search_plugin_workspace}:/workspace
     networks:
       - nexus-search-plugin-net
     healthcheck:
@@ -136,5 +130,3 @@ secrets:
 volumes:
   search_plugin_node_data:
     name: nexus-search-plugin-node-data
-  search_plugin_workspace:
-    name: nexus-search-plugin-workspace


### PR DESCRIPTION
## Summary

#4606's env-substituted volume name (\`\${NEXUS_SHARED_WORKSPACE:-search_plugin_workspace}:/workspace\`) fails compose parsing at edge-smoke run time with \`service \"node\" refers to undefined volume nexus-shared-workspace: invalid compose project\` — the substituted name isn't declared in the base compose's \`volumes:\` block, and adding it as \`external: true\` would break \`search-plugin-e2e.yml\`'s standalone path which doesn't create that volume.

## Fix

Keep the base compose free of \`/workspace\`.  Add the mount via a compose override file (\`dockerfiles/docker-compose.search-plugin-e2e.edge-override.yml\`) that only the edge-smoke workflow imports.  Standalone \`search-plugin-e2e.yml\` stays unchanged; the workflow merges both files, so its plugin container picks up the shared volume created earlier in the job.

## Test plan

- Workflow only fires on push to develop/main/tags; validation happens on merge.
- Falls back cleanly for the plugin sidecar workflow: same base compose, no override → no /workspace mount, no behavior change.