### PR TITLE
fix(search): two more sync daemon.get_stats() call sites — P12 async audit

### DIFF
--- a/src/nexus/bricks/search/federated_search.py
+++ b/src/nexus/bricks/search/federated_search.py
@@ -333,54 +333,26 @@ class FederatedSearchDispatcher:
 
         Phase 3: Skips semantic queries to keyword-only zones.
 
+        Post-P12 the sole daemon shape is the Rust ``nexus-search-plugin``
+        proxy, which routes keyword through a zone-filtered tantivy index
+        — there's no cross-zone leak like the Python daemon's BM25S /
+        Zoekt in-memory indexes had.  So decision 13B (force keyword →
+        hybrid to avoid leak) no longer applies; return the requested
+        type unless the registry says the zone can't do semantic.
+
         Returns:
             (effective_search_type, alpha_override_or_None)
         """
-        # Decision 13B rationale: BM25S and Zoekt in-memory indexes don't
-        # filter by zone_id, so keyword search through them leaks cross-zone
-        # results. When they're active, we force the semantic path which
-        # uses pgvector (zone-filtered).
-        #
-        # However, when BM25S/Zoekt are NOT available (bm25_documents=0,
-        # zoekt_available=False), keyword search falls through to PostgreSQL
-        # FTS which IS zone-filtered. In that case, forcing semantic would
-        # break search on DBs without embeddings. So we only force semantic
-        # when the leaky backends are actually active.
-        # Check if the daemon has leaky (non-zone-filtered) keyword backends.
-        # BM25S and Zoekt don't filter by zone_id, so keyword through them
-        # leaks cross-zone results. When they have data, we force semantic.
-        # When they're empty or absent, FTS (zone-filtered) handles keyword.
-        try:
-            daemon = self._get_daemon_for_zone(zone_id)
-            _stats = (
-                daemon.get_stats()
-                if hasattr(daemon, "get_stats") and callable(getattr(daemon, "get_stats", None))
-                else {}
-            )
-            has_bm25s = _stats.get("bm25_documents", 0) > 0 if isinstance(_stats, dict) else False
-            has_zoekt = _stats.get("zoekt_available", False) if isinstance(_stats, dict) else False
-        except Exception:
-            has_bm25s = False
-            has_zoekt = False
-        has_leaky_keyword = has_bm25s or has_zoekt
-
         if self._registry is None:
-            if search_type == "keyword" and has_leaky_keyword:
-                return ("hybrid", 1.0)  # 13B: force semantic to avoid zone leak
             return (search_type, None)
 
         caps = self._registry.get_capabilities(zone_id)
         if caps is None:
-            if search_type == "keyword" and has_leaky_keyword:
-                return ("hybrid", 1.0)
             return (search_type, None)
 
         # Phase 3: Route based on zone capabilities
         if search_type in ("semantic", "hybrid") and not caps.supports_semantic:
             return ("keyword", None)
-
-        if search_type == "keyword" and has_leaky_keyword:
-            return ("hybrid", 1.0)
 
         return (search_type, None)
 

--- a/src/nexus/bricks/search/zone_registry.py
+++ b/src/nexus/bricks/search/zone_registry.py
@@ -44,26 +44,23 @@ class ZoneSearchCapabilities:
 
     @classmethod
     def from_daemon_stats(cls, zone_id: str, daemon: Any) -> "ZoneSearchCapabilities":
-        """Derive capabilities from a SearchDaemon's runtime state.
+        """Derive capabilities for a SearchDaemon (Rust plugin proxy).
 
-        Inspects the daemon to determine what search backends are available.
+        Post-P12 the sole daemon shape is the ``SearchDaemon`` proxy that
+        forwards to the Rust ``nexus-search-plugin`` cdylib.  The plugin
+        always supports keyword + semantic + hybrid; there's no graph
+        store and no SPLADE lane.  A per-zone gRPC round-trip to
+        ``get_stats()`` would only confirm what we already know, and
+        keeping this classmethod SYNC lets the sync ``register()``
+        caller stay unchanged.
         """
-        stats = daemon.get_stats() if hasattr(daemon, "get_stats") else {}
-        modes = ["keyword"]  # BM25S/FTS always available
-
-        has_db = stats.get("db_pool_size", 0) > 0
-        if has_db:
-            modes.append("semantic")
-            modes.append("hybrid")
-
-        has_graph = hasattr(daemon, "_graph_store")
-
+        del daemon  # capability set is fixed for the Rust plugin
         return cls(
             zone_id=zone_id,
-            search_modes=tuple(modes),
-            has_graph=has_graph,
-            has_splade=False,  # Detected at startup, not from stats
-            embedding_dimensions=stats.get("embedding_dimensions", 0),
+            search_modes=("keyword", "semantic", "hybrid"),
+            has_graph=False,
+            has_splade=False,
+            embedding_dimensions=0,
         )
 
 


### PR DESCRIPTION
## Summary

Wider audit after #4606 caught only one of the missing awaits.  \`grep -rE 'daemon\.(get_stats|get_health|list_indexed_directories|get_zone_indexing_modes)' src/\` turned up two more:

1. **\`zone_registry.ZoneSearchCapabilities.from_daemon_stats\`** — invoked from sync \`register()\`.  Post-P12 the daemon shape is fixed (Rust plugin proxy = keyword+semantic+hybrid, no graph, no SPLADE), so drop the \`get_stats()\` probe entirely and return the known caps.  Previously the failing probe silently degraded to \`modes=(\"keyword\",)\` which UNDER-reported plugin capabilities to federation routing.
2. **\`federated_search._get_effective_search_type\`** — the \`has_bm25s\` / \`has_zoekt\` gates were Python-daemon-specific (BM25S in-memory + Zoekt didn't zone-filter, hence decision 13B \"force to hybrid\").  Rust plugin's tantivy index IS zone-filtered, so 13B doesn't apply.  Delete the get_stats-driven branch; keep the registry-driven \"skip semantic on keyword-only zones\" gate.

Both call sites now compile down to synchronous, deterministic behavior with no coroutine leak.  Correctness improves: federation routing now knows the plugin can do all three modes.

## Test plan

- Ruff / unit / lint CI runs.
- Once merged, docker-publish edge-smoke runs — the two removed sites lived in edge-smoke's code path.