### PR TITLE
search-plugin: parallel BatchQuery + query-embedding cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2627,6 +2627,7 @@ dependencies = [
  "anndists",
  "bytes",
  "fastembed",
+ "futures-util",
  "globset",
  "hnsw_rs",
  "libloading 0.8.9",

--- a/rust/services/search-plugin/Cargo.toml
+++ b/rust/services/search-plugin/Cargo.toml
@@ -62,6 +62,12 @@ tokio = { version = "1", features = ["rt", "rt-multi-thread", "sync", "macros"] 
 # Bytes for tonic Request/Response body types.
 bytes = "1"
 
+# Stream combinators for BatchQuery's bounded, order-preserving
+# concurrent dispatch (#4610 — `stream::iter(..).buffered(n)`).
+# Already in the tree transitively via tonic; this only makes the
+# dependency direct.
+futures-util = "0.3"
+
 # Full-text search backend for the Query RPC (Phase 1 of the
 # Python-parity roadmap; see PARITY_ROADMAP.md D1).  Pure Rust, no
 # native deps — links into this plugin's cdylib only, cluster core

--- a/rust/services/search-plugin/src/embed_cache.rs
+++ b/rust/services/search-plugin/src/embed_cache.rs
@@ -1,0 +1,270 @@
+//! Bounded query-embedding cache (Issue #4610).
+//!
+//! # Why
+//!
+//! Path-scoped fan-out callers (Koodle's cross-workspace search,
+//! DeepBuildAI/koodle#2176) send the SAME query text across many
+//! `path_filter` variants — ~3 sub-paths × ~60 workspaces per
+//! keystroke.  Every one of those used to pay a full query embed, and
+//! `FastEmbedder` serialises embeds on a single ort-session mutex, so
+//! repeated embeds of identical text were not just wasted CPU — they
+//! were wasted time on the plugin's ONE embedding lane.  A hit here
+//! skips both.
+//!
+//! The P7 result cache (`query_cache`) cannot absorb this: its key
+//! includes `path_filter`, so the fan-out's queries are all distinct
+//! entries there even though their embedding is identical.
+//!
+//! # Semantics
+//!
+//! - Keyed by `(embedder tag, dim, query text)` — a model swap changes
+//!   the tag (see `Embedder::tag`), so stale vectors from a previous
+//!   model can never be served.  Dim is in the key for the same reason
+//!   the AnnIndex pins it at open time: belt-and-suspenders against a
+//!   tag collision across dims.
+//! - Embeddings are pure functions of (model, text) — there is no
+//!   corpus dependency, so Index / Refresh do NOT need to invalidate
+//!   this cache (unlike the result cache).
+//! - Failures are never cached; the caller retries on the next miss.
+//! - FIFO eviction, deliberately not LRU: the dominant pattern is a
+//!   burst of identical texts inside one fan-out window, where FIFO
+//!   and LRU behave identically, and FIFO keeps every operation O(1)
+//!   without an extra recency structure.
+//!
+//! # Sizing
+//!
+//! `NEXUS_SEARCH_QUERY_EMBED_CACHE_SIZE` overrides the default 512
+//! entries; `0` disables caching entirely (kill switch).  At the
+//! mE5-small 384-dim default an entry is ~1.5 KB, so the default cap
+//! is under a megabyte.
+
+use std::collections::{HashMap, VecDeque};
+
+use parking_lot::Mutex;
+
+use crate::embedder::Embedder;
+
+/// Env var overriding the cache capacity.  `0` disables the cache.
+pub const CACHE_SIZE_ENV: &str = "NEXUS_SEARCH_QUERY_EMBED_CACHE_SIZE";
+
+/// Default capacity when the env var is unset or unparseable.
+pub const DEFAULT_CACHE_SIZE: usize = 512;
+
+type CacheKey = (String, usize, String);
+
+#[derive(Default)]
+struct Inner {
+    map: HashMap<CacheKey, Vec<f32>>,
+    order: VecDeque<CacheKey>,
+}
+
+/// Bounded FIFO cache of query-text embeddings.  Thread-safe; the
+/// lock is only held for map operations, never across an embed call.
+pub struct QueryEmbedCache {
+    inner: Mutex<Inner>,
+    capacity: usize,
+}
+
+impl QueryEmbedCache {
+    /// Cache with an explicit capacity.  `0` = disabled (every `get`
+    /// misses, every `put` is a no-op).
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            inner: Mutex::new(Inner::default()),
+            capacity,
+        }
+    }
+
+    /// Production constructor — capacity from
+    /// [`CACHE_SIZE_ENV`], falling back to [`DEFAULT_CACHE_SIZE`].
+    pub fn from_env() -> Self {
+        let capacity = std::env::var(CACHE_SIZE_ENV)
+            .ok()
+            .and_then(|v| v.trim().parse::<usize>().ok())
+            .unwrap_or(DEFAULT_CACHE_SIZE);
+        Self::with_capacity(capacity)
+    }
+
+    pub fn get(&self, tag: &str, dim: usize, q: &str) -> Option<Vec<f32>> {
+        if self.capacity == 0 {
+            return None;
+        }
+        let inner = self.inner.lock();
+        inner
+            .map
+            .get(&(tag.to_string(), dim, q.to_string()))
+            .cloned()
+    }
+
+    pub fn put(&self, tag: &str, dim: usize, q: &str, vec: Vec<f32>) {
+        if self.capacity == 0 {
+            return;
+        }
+        let key: CacheKey = (tag.to_string(), dim, q.to_string());
+        let mut inner = self.inner.lock();
+        if inner.map.insert(key.clone(), vec).is_none() {
+            inner.order.push_back(key);
+            while inner.order.len() > self.capacity {
+                if let Some(evict) = inner.order.pop_front() {
+                    inner.map.remove(&evict);
+                }
+            }
+        }
+    }
+
+    /// Entry count — test + stats visibility.
+    pub fn len(&self) -> usize {
+        self.inner.lock().map.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+/// Embed `q` through `cache`: serve a hit without touching the
+/// embedder (and its session mutex), populate on miss.  Error text
+/// matches the previous inline `do_semantic_query` embed so callers'
+/// error surfaces are unchanged.
+pub fn embed_query_cached(
+    embedder: &dyn Embedder,
+    cache: &QueryEmbedCache,
+    q: &str,
+) -> Result<Vec<f32>, String> {
+    if let Some(v) = cache.get(embedder.tag(), embedder.dim(), q) {
+        return Ok(v);
+    }
+    let vec = embedder
+        .embed_batch(&[q])
+        .map_err(|e| format!("embed query: {e}"))?
+        .into_iter()
+        .next()
+        .ok_or_else(|| "embed query: empty result".to_string())?;
+    cache.put(embedder.tag(), embedder.dim(), q, vec.clone());
+    Ok(vec)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::embedder::MockEmbedder;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// MockEmbedder wrapper that counts embed_batch calls.
+    struct Counting {
+        inner: MockEmbedder,
+        calls: AtomicUsize,
+    }
+
+    impl Counting {
+        fn new() -> Self {
+            Self {
+                inner: MockEmbedder::with_dim(8),
+                calls: AtomicUsize::new(0),
+            }
+        }
+    }
+
+    impl Embedder for Counting {
+        fn embed_batch(
+            &self,
+            texts: &[&str],
+        ) -> Result<Vec<Vec<f32>>, crate::embedder::EmbedError> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            self.inner.embed_batch(texts)
+        }
+        fn dim(&self) -> usize {
+            self.inner.dim()
+        }
+        fn tag(&self) -> &str {
+            "counting"
+        }
+    }
+
+    #[test]
+    fn hit_skips_embedder() {
+        let e = Counting::new();
+        let cache = QueryEmbedCache::with_capacity(4);
+        let v1 = embed_query_cached(&e, &cache, "hello").unwrap();
+        let v2 = embed_query_cached(&e, &cache, "hello").unwrap();
+        assert_eq!(v1, v2);
+        assert_eq!(e.calls.load(Ordering::SeqCst), 1, "second call must hit");
+    }
+
+    #[test]
+    fn distinct_texts_miss_independently() {
+        let e = Counting::new();
+        let cache = QueryEmbedCache::with_capacity(4);
+        let _ = embed_query_cached(&e, &cache, "a").unwrap();
+        let _ = embed_query_cached(&e, &cache, "b").unwrap();
+        assert_eq!(e.calls.load(Ordering::SeqCst), 2);
+        assert_eq!(cache.len(), 2);
+    }
+
+    #[test]
+    fn tag_and_dim_isolate_entries() {
+        let cache = QueryEmbedCache::with_capacity(4);
+        cache.put("model-a", 8, "q", vec![1.0]);
+        assert!(cache.get("model-b", 8, "q").is_none(), "tag must isolate");
+        assert!(cache.get("model-a", 16, "q").is_none(), "dim must isolate");
+        assert_eq!(cache.get("model-a", 8, "q"), Some(vec![1.0]));
+    }
+
+    #[test]
+    fn capacity_bound_evicts_oldest() {
+        let cache = QueryEmbedCache::with_capacity(2);
+        cache.put("t", 8, "one", vec![1.0]);
+        cache.put("t", 8, "two", vec![2.0]);
+        cache.put("t", 8, "three", vec![3.0]);
+        assert_eq!(cache.len(), 2);
+        assert!(cache.get("t", 8, "one").is_none(), "oldest must evict");
+        assert_eq!(cache.get("t", 8, "three"), Some(vec![3.0]));
+    }
+
+    #[test]
+    fn re_put_same_key_does_not_grow_order() {
+        let cache = QueryEmbedCache::with_capacity(2);
+        for _ in 0..10 {
+            cache.put("t", 8, "same", vec![1.0]);
+        }
+        cache.put("t", 8, "other", vec![2.0]);
+        assert_eq!(
+            cache.len(),
+            2,
+            "duplicate puts must not evict via order growth"
+        );
+        assert!(cache.get("t", 8, "same").is_some());
+    }
+
+    #[test]
+    fn zero_capacity_disables() {
+        let e = Counting::new();
+        let cache = QueryEmbedCache::with_capacity(0);
+        let _ = embed_query_cached(&e, &cache, "hello").unwrap();
+        let _ = embed_query_cached(&e, &cache, "hello").unwrap();
+        assert_eq!(e.calls.load(Ordering::SeqCst), 2, "capacity 0 must bypass");
+        assert!(cache.is_empty());
+    }
+
+    #[test]
+    fn failures_are_not_cached() {
+        struct Failing;
+        impl Embedder for Failing {
+            fn embed_batch(
+                &self,
+                _texts: &[&str],
+            ) -> Result<Vec<Vec<f32>>, crate::embedder::EmbedError> {
+                Err(crate::embedder::EmbedError::Runtime("boom".into()))
+            }
+            fn dim(&self) -> usize {
+                8
+            }
+            fn tag(&self) -> &str {
+                "failing"
+            }
+        }
+        let cache = QueryEmbedCache::with_capacity(4);
+        assert!(embed_query_cached(&Failing, &cache, "q").is_err());
+        assert!(cache.is_empty(), "a failed embed must not be cached");
+    }
+}

--- a/rust/services/search-plugin/src/lib.rs
+++ b/rust/services/search-plugin/src/lib.rs
@@ -54,6 +54,7 @@ pub mod search_proto {
 
 pub mod ann_index;
 pub mod chunker;
+pub mod embed_cache;
 pub mod embedder;
 pub mod fts_index;
 pub mod fusion;

--- a/rust/services/search-plugin/src/service.rs
+++ b/rust/services/search-plugin/src/service.rs
@@ -10,11 +10,13 @@
 
 use std::sync::Arc;
 
+use futures_util::StreamExt;
 use nexus_plugin_abi::KernelHandle;
 use parking_lot::Mutex;
 use tonic::{async_trait, Request, Response, Status};
 
 use crate::ann_index::AnnHit;
+use crate::embed_cache::{embed_query_cached, QueryEmbedCache};
 use crate::embedder::{build_default_embedder, EmbedError, Embedder};
 use crate::fts_index::FtsHit;
 use crate::fusion::{self, DEFAULT_ALPHA, DEFAULT_RRF_K};
@@ -41,6 +43,22 @@ const DEFAULT_GLOB_MAX: usize = 10_000;
 const DEFAULT_GREP_MAX: usize = 1_000;
 const DEFAULT_QUERY_LIMIT: usize = 10;
 const DEFAULT_INDEX_MAX_DOCS: usize = 10_000;
+
+/// BatchQuery inner-query concurrency (#4610).  Each in-flight query
+/// spawns up to two blocking tasks (hybrid's keyword + semantic legs),
+/// so the ceiling stays small; `1` restores the pre-#4610 serial
+/// behaviour.  Env override: `NEXUS_SEARCH_BATCH_CONCURRENCY`.
+const BATCH_QUERY_CONCURRENCY_ENV: &str = "NEXUS_SEARCH_BATCH_CONCURRENCY";
+const DEFAULT_BATCH_QUERY_CONCURRENCY: usize = 4;
+const MAX_BATCH_QUERY_CONCURRENCY: usize = 16;
+
+fn batch_query_concurrency() -> usize {
+    std::env::var(BATCH_QUERY_CONCURRENCY_ENV)
+        .ok()
+        .and_then(|v| v.trim().parse::<usize>().ok())
+        .map(|n| n.clamp(1, MAX_BATCH_QUERY_CONCURRENCY))
+        .unwrap_or(DEFAULT_BATCH_QUERY_CONCURRENCY)
+}
 
 /// Belt-and-suspenders per-file size cap for grep — a 100 MB
 /// binary blob would otherwise stall a single request for seconds.
@@ -97,6 +115,14 @@ pub struct SearchServiceImpl {
     /// dispatch; Index + Refresh invalidate the target zone so
     /// callers who mutated the corpus don't see stale results.
     query_cache: crate::query_cache::SharedQueryCache,
+    /// Query-embedding cache (#4610).  Distinct from `query_cache`:
+    /// that one keys on the FULL request (including `path_filter`),
+    /// so a path-scoped fan-out sending the same q across N prefixes
+    /// misses it N times — but all N share one embedding, and
+    /// `FastEmbedder` serialises embeds on a single session mutex.
+    /// Embeddings have no corpus dependency, so Index / Refresh do
+    /// not invalidate this cache.
+    embed_cache: Arc<QueryEmbedCache>,
 }
 
 impl SearchServiceImpl {
@@ -119,6 +145,7 @@ impl SearchServiceImpl {
             manager: None,
             embedder: None,
             query_cache: None,
+            embed_cache: None,
         }
     }
 
@@ -157,6 +184,7 @@ pub struct SearchServiceBuilder {
     manager: Option<Arc<IndexManager>>,
     embedder: Option<Arc<dyn Embedder>>,
     query_cache: Option<crate::query_cache::SharedQueryCache>,
+    embed_cache: Option<Arc<QueryEmbedCache>>,
 }
 
 impl SearchServiceBuilder {
@@ -186,6 +214,13 @@ impl SearchServiceBuilder {
         self
     }
 
+    /// Inject a query-embedding cache (#4610) — tests use a tiny or
+    /// zero capacity to make hit / bypass behaviour observable.
+    pub fn embed_cache(mut self, cache: Arc<QueryEmbedCache>) -> Self {
+        self.embed_cache = Some(cache);
+        self
+    }
+
     pub fn build(self) -> SearchServiceImpl {
         SearchServiceImpl {
             handle: self.handle,
@@ -196,6 +231,9 @@ impl SearchServiceBuilder {
             query_cache: self
                 .query_cache
                 .unwrap_or_else(|| Arc::new(crate::query_cache::QueryCache::new())),
+            embed_cache: self
+                .embed_cache
+                .unwrap_or_else(|| Arc::new(QueryEmbedCache::from_env())),
         }
     }
 }
@@ -604,6 +642,7 @@ fn do_keyword_query(
 fn do_semantic_query(
     manager: &IndexManager,
     embedder: &Arc<dyn Embedder>,
+    embed_cache: &QueryEmbedCache,
     q: &str,
     zone_id: &str,
     limit: usize,
@@ -613,12 +652,10 @@ fn do_semantic_query(
         .get_or_open_ann(zone_id, embedder.tag(), embedder.dim())
         .map_err(|e| format!("open ann for zone {zone_id:?}: {e}"))?;
 
-    let query_vec = embedder
-        .embed_batch(&[q])
-        .map_err(|e| format!("embed query: {e}"))?
-        .into_iter()
-        .next()
-        .ok_or_else(|| "embed query: empty result".to_string())?;
+    // #4610: cached — a fan-out repeating the same q across path
+    // filters embeds once instead of serialising N times on the
+    // embedder's session mutex.
+    let query_vec = embed_query_cached(embedder.as_ref(), embed_cache, q)?;
 
     // Over-fetch when a path prefix is set — the post-scoring
     // filter would otherwise underfill the response.
@@ -1606,8 +1643,17 @@ impl SearchService for SearchServiceImpl {
                         }));
                     }
                 };
+                let embed_cache = Arc::clone(&self.embed_cache);
                 tokio::task::spawn_blocking(move || {
-                    do_semantic_query(&manager, &embedder, &q, &zone_id, limit, &path_filter)
+                    do_semantic_query(
+                        &manager,
+                        &embedder,
+                        &embed_cache,
+                        &q,
+                        &zone_id,
+                        limit,
+                        &path_filter,
+                    )
                 })
                 .await
                 .map_err(|e| Status::internal(format!("spawn_blocking joined error: {e}")))?
@@ -1637,6 +1683,7 @@ impl SearchService for SearchServiceImpl {
                     let mgr_kw = Arc::clone(&manager);
                     let mgr_sem = Arc::clone(&manager);
                     let embedder = Arc::clone(&embedder);
+                    let embed_cache = Arc::clone(&self.embed_cache);
                     let q_kw = q.clone();
                     let q_sem = q;
                     let zone_kw = zone_id.clone();
@@ -1649,7 +1696,13 @@ impl SearchService for SearchServiceImpl {
                         }),
                         tokio::task::spawn_blocking(move || {
                             do_semantic_query(
-                                &mgr_sem, &embedder, &q_sem, &zone_sem, over_fetch, &path_sem,
+                                &mgr_sem,
+                                &embedder,
+                                &embed_cache,
+                                &q_sem,
+                                &zone_sem,
+                                over_fetch,
+                                &path_sem,
                             )
                         }),
                     )
@@ -1896,15 +1949,70 @@ impl SearchService for SearchServiceImpl {
         request: Request<BatchQueryRequest>,
     ) -> Result<Response<BatchQueryResponse>, Status> {
         let req = request.into_inner();
-        // Serialise the batch: each Query has its own scoring +
-        // caching pass and reusing the existing `query` handler
-        // keeps the cache + scoring pipeline consistent.  A future
-        // optimisation could dedupe zone / caching lookups across
-        // the batch; not worth it until Python parity is proven.
-        let mut responses = Vec::with_capacity(req.queries.len());
-        for q_req in req.queries {
-            let resp = self.query(Request::new(q_req)).await?;
-            responses.push(resp.into_inner());
+        // #4610: the batch used to run strictly serially, so a caller
+        // batching N queries paid N × full query latency — measured
+        // live as the throughput ceiling on Koodle's cross-workspace
+        // fan-out (DeepBuildAI/koodle#2176: ~30% workspace coverage,
+        // client-side width increases only made it worse).  Each
+        // query still runs the full cache + scoring pipeline via the
+        // `query` handler, so per-query behaviour (result cache,
+        // fusion, recency, error surfaces) is identical to singles.
+        //
+        // Two changes:
+        //
+        // 1. Pre-warm the query-embedding cache once per DUPLICATE
+        //    embedding-needing text.  The fan-out pattern sends the
+        //    same q across many path filters; without this, the
+        //    parallel dispatch below would thundering-herd N
+        //    identical embeds into the embedder's serialising
+        //    session mutex on a cold cache.  Singleton texts skip
+        //    pre-warm — they embed inside their own query, in
+        //    parallel.  Pre-warm failures are ignored: each inner
+        //    query retries and surfaces its own error exactly as
+        //    before.
+        //
+        // 2. Bounded, order-preserving concurrent dispatch
+        //    (`buffered`).  The bound keeps one giant benchmark
+        //    batch from flooding the blocking pool; 1 restores the
+        //    serial behaviour.
+        let mut dupe_counts: std::collections::HashMap<&str, usize> =
+            std::collections::HashMap::new();
+        for q_req in &req.queries {
+            let qt = QueryType::try_from(q_req.query_type).unwrap_or(QueryType::Unspecified);
+            if matches!(qt, QueryType::Semantic | QueryType::Hybrid) && !q_req.q.is_empty() {
+                *dupe_counts.entry(q_req.q.as_str()).or_default() += 1;
+            }
+        }
+        let dupe_texts: Vec<String> = dupe_counts
+            .into_iter()
+            .filter(|(_, n)| *n > 1)
+            .map(|(t, _)| t.to_string())
+            .collect();
+        if !dupe_texts.is_empty() {
+            // Embedder init failure is fine here — the inner queries
+            // will produce their per-query "unavailable" errors.
+            if let Ok(embedder) = self.get_or_init_embedder() {
+                let cache = Arc::clone(&self.embed_cache);
+                let _ = tokio::task::spawn_blocking(move || {
+                    for text in dupe_texts {
+                        let _ = embed_query_cached(embedder.as_ref(), &cache, &text);
+                    }
+                })
+                .await;
+            }
+        }
+
+        let results: Vec<Result<Response<QueryResponse>, Status>> = futures_util::stream::iter(
+            req.queries
+                .into_iter()
+                .map(|q_req| self.query(Request::new(q_req))),
+        )
+        .buffered(batch_query_concurrency())
+        .collect()
+        .await;
+        let mut responses = Vec::with_capacity(results.len());
+        for resp in results {
+            responses.push(resp?.into_inner());
         }
         Ok(Response::new(BatchQueryResponse { responses }))
     }
@@ -2487,5 +2595,31 @@ mod tests {
         );
         assert_eq!(out.len(), 2);
         assert!(truncated);
+    }
+
+    #[test]
+    fn batch_query_concurrency_defaults_and_clamps() {
+        // SAFETY: no other test in this binary reads
+        // NEXUS_SEARCH_BATCH_CONCURRENCY (same convention as the
+        // embedder.rs env tests).
+        let saved = std::env::var(BATCH_QUERY_CONCURRENCY_ENV).ok();
+        unsafe { std::env::remove_var(BATCH_QUERY_CONCURRENCY_ENV) };
+        assert_eq!(batch_query_concurrency(), DEFAULT_BATCH_QUERY_CONCURRENCY);
+        unsafe { std::env::set_var(BATCH_QUERY_CONCURRENCY_ENV, "8") };
+        assert_eq!(batch_query_concurrency(), 8);
+        unsafe { std::env::set_var(BATCH_QUERY_CONCURRENCY_ENV, "0") };
+        assert_eq!(
+            batch_query_concurrency(),
+            1,
+            "0 clamps to serial, not panic"
+        );
+        unsafe { std::env::set_var(BATCH_QUERY_CONCURRENCY_ENV, "9999") };
+        assert_eq!(batch_query_concurrency(), MAX_BATCH_QUERY_CONCURRENCY);
+        unsafe { std::env::set_var(BATCH_QUERY_CONCURRENCY_ENV, "not-a-number") };
+        assert_eq!(batch_query_concurrency(), DEFAULT_BATCH_QUERY_CONCURRENCY);
+        match saved {
+            Some(v) => unsafe { std::env::set_var(BATCH_QUERY_CONCURRENCY_ENV, v) },
+            None => unsafe { std::env::remove_var(BATCH_QUERY_CONCURRENCY_ENV) },
+        }
     }
 }

--- a/rust/services/search-plugin/tests/batch_query_e2e.rs
+++ b/rust/services/search-plugin/tests/batch_query_e2e.rs
@@ -1,0 +1,605 @@
+//! End-to-end integration tests for the BatchQuery path (#4610).
+//!
+//! Sibling of `query_e2e.rs` / `semantic_query_e2e.rs` / `index_e2e.rs`.
+//! Pins the two #4610 behaviours:
+//!
+//! - a batch repeating the SAME query text across different
+//!   `path_filter`s embeds that text exactly once (pre-warm +
+//!   query-embedding cache), instead of once per query — the Koodle
+//!   cross-workspace fan-out shape (DeepBuildAI/koodle#2176);
+//! - the batch dispatches its queries concurrently (bounded), not
+//!   serially, while preserving response order and per-query error
+//!   isolation exactly as the serial loop did.
+//!
+//! Scaffold duplicated from `semantic_query_e2e.rs` per that file's
+//! note (Cargo shared-test-module plumbing costs more than the
+//! duplication at this size).
+
+use std::collections::HashMap;
+use std::ffi::{c_void, CStr};
+use std::os::raw::c_char;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use nexus_plugin_abi::KernelHandle;
+use nexus_search_plugin::embedder::{EmbedError, Embedder, MockEmbedder};
+use nexus_search_plugin::index_manager::IndexManager;
+use nexus_search_plugin::search_proto::search_service_server::SearchService;
+use nexus_search_plugin::search_proto::{BatchQueryRequest, IndexRequest, QueryRequest, QueryType};
+use nexus_search_plugin::service::SearchServiceImpl;
+use tempfile::TempDir;
+use tonic::Request;
+
+// ── Mock kernel (same shape as semantic_query_e2e.rs) ───────────
+
+struct FileEntry {
+    bytes: Vec<u8>,
+    mtime_ms: i64,
+}
+
+pub struct MockKernel {
+    files: HashMap<String, FileEntry>,
+    dirs: HashMap<String, Vec<(String, u8)>>,
+}
+
+impl MockKernel {
+    fn new() -> Self {
+        Self {
+            files: HashMap::new(),
+            dirs: HashMap::new(),
+        }
+    }
+    fn add_file(&mut self, path: &str, bytes: &[u8], mtime_ms: i64) {
+        self.files.insert(
+            path.to_string(),
+            FileEntry {
+                bytes: bytes.to_vec(),
+                mtime_ms,
+            },
+        );
+        let (parent, name) = split_parent(path);
+        self.dirs
+            .entry(parent)
+            .or_default()
+            .push((name, 0 /* DT_REG */));
+    }
+    fn add_dir(&mut self, path: &str) {
+        if !self.dirs.contains_key(path) {
+            self.dirs.insert(path.to_string(), Vec::new());
+        }
+        if path == "/" {
+            return;
+        }
+        let (parent, name) = split_parent(path);
+        let entries = self.dirs.entry(parent).or_default();
+        if !entries.iter().any(|(n, _)| n == &name) {
+            entries.push((name, 1 /* DT_DIR */));
+        }
+    }
+}
+
+fn split_parent(path: &str) -> (String, String) {
+    match path.rsplit_once('/') {
+        Some(("", name)) => ("/".to_string(), name.to_string()),
+        Some((parent, name)) => (parent.to_string(), name.to_string()),
+        None => ("/".to_string(), path.to_string()),
+    }
+}
+
+fn into_out_buf(mut v: Vec<u8>, out_buf: *mut *mut u8, out_len: *mut usize) {
+    v.shrink_to_fit();
+    let len = v.len();
+    let ptr = v.as_mut_ptr();
+    std::mem::forget(v);
+    unsafe {
+        *out_buf = ptr;
+        *out_len = len;
+    }
+}
+
+unsafe extern "C" fn mock_sys_read(
+    k: *const c_void,
+    path: *const c_char,
+    out_buf: *mut *mut u8,
+    out_len: *mut usize,
+) -> i32 {
+    let kernel = &*(k as *const MockKernel);
+    let p = match CStr::from_ptr(path).to_str() {
+        Ok(s) => s,
+        Err(_) => return -2,
+    };
+    match kernel.files.get(p) {
+        Some(entry) => {
+            into_out_buf(entry.bytes.clone(), out_buf, out_len);
+            0
+        }
+        None => -404,
+    }
+}
+
+unsafe extern "C" fn mock_sys_readdir(
+    k: *const c_void,
+    parent_path: *const c_char,
+    out_json: *mut *mut u8,
+    out_len: *mut usize,
+) -> i32 {
+    let kernel = &*(k as *const MockKernel);
+    let p = match CStr::from_ptr(parent_path).to_str() {
+        Ok(s) => s,
+        Err(_) => return -2,
+    };
+    match kernel.dirs.get(p) {
+        Some(entries) => {
+            let payload: Vec<serde_json::Value> = entries
+                .iter()
+                .map(|(name, et)| serde_json::json!({ "name": name, "entry_type": et }))
+                .collect();
+            let json = serde_json::to_vec(&payload).expect("mock readdir json");
+            into_out_buf(json, out_json, out_len);
+            0
+        }
+        None => -404,
+    }
+}
+
+unsafe extern "C" fn mock_sys_stat(
+    k: *const c_void,
+    path: *const c_char,
+    out_json: *mut *mut u8,
+    out_len: *mut usize,
+) -> i32 {
+    let kernel = &*(k as *const MockKernel);
+    let p = match CStr::from_ptr(path).to_str() {
+        Ok(s) => s,
+        Err(_) => return -2,
+    };
+    if let Some(entry) = kernel.files.get(p) {
+        let payload = serde_json::json!({
+            "path": p,
+            "entry_type": 0,
+            "size": entry.bytes.len(),
+            "zone_id": "root",
+            "modified_at_ms": entry.mtime_ms,
+        });
+        into_out_buf(serde_json::to_vec(&payload).unwrap(), out_json, out_len);
+        0
+    } else if kernel.dirs.contains_key(p) {
+        let payload = serde_json::json!({
+            "path": p,
+            "entry_type": 1,
+            "size": 0,
+            "zone_id": "root",
+            "modified_at_ms": null,
+        });
+        into_out_buf(serde_json::to_vec(&payload).unwrap(), out_json, out_len);
+        0
+    } else {
+        -404
+    }
+}
+
+unsafe extern "C" fn unused_sys_write(
+    _: *const c_void,
+    _: *const c_char,
+    _: *const u8,
+    _: usize,
+) -> i32 {
+    -1
+}
+unsafe extern "C" fn unused_sys_unlink(_: *const c_void, _: *const c_char) -> i32 {
+    -1
+}
+unsafe extern "C" fn unused_sys_mkdir(_: *const c_void, _: *const c_char) -> i32 {
+    -1
+}
+unsafe extern "C" fn unused_sys_rmdir(_: *const c_void, _: *const c_char) -> i32 {
+    -1
+}
+unsafe extern "C" fn unused_sys_rename(
+    _: *const c_void,
+    _: *const c_char,
+    _: *const c_char,
+) -> i32 {
+    -1
+}
+unsafe extern "C" fn unused_sys_stat_batch(
+    _: *const c_void,
+    _: *const c_char,
+    _: *mut *mut u8,
+    _: *mut usize,
+) -> i32 {
+    -1
+}
+
+fn handle_for(kernel: *const MockKernel) -> KernelHandle {
+    KernelHandle {
+        sys_read: mock_sys_read,
+        sys_write: unused_sys_write,
+        sys_stat: mock_sys_stat,
+        sys_readdir: mock_sys_readdir,
+        sys_unlink: unused_sys_unlink,
+        sys_mkdir: unused_sys_mkdir,
+        sys_rmdir: unused_sys_rmdir,
+        sys_rename: unused_sys_rename,
+        sys_stat_batch: unused_sys_stat_batch,
+        kernel_ptr: kernel as *const c_void,
+    }
+}
+
+// ── Instrumented embedders ──────────────────────────────────────
+
+/// MockEmbedder wrapper counting embed_batch calls, so tests can
+/// assert how many embeds a batch actually performed.
+struct CountingEmbedder {
+    inner: MockEmbedder,
+    calls: AtomicUsize,
+}
+
+impl CountingEmbedder {
+    fn new() -> Self {
+        Self {
+            inner: MockEmbedder::with_dim(16),
+            calls: AtomicUsize::new(0),
+        }
+    }
+}
+
+impl Embedder for CountingEmbedder {
+    fn embed_batch(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>, EmbedError> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        self.inner.embed_batch(texts)
+    }
+    fn dim(&self) -> usize {
+        self.inner.dim()
+    }
+    fn tag(&self) -> &str {
+        "mock"
+    }
+}
+
+/// MockEmbedder wrapper that records the PEAK number of concurrent
+/// embed_batch calls.  Each call parks (bounded spin) until it has
+/// observed a sibling in flight or a 2s deadline passes, so genuine
+/// concurrency is observed deterministically: a serial BatchQuery
+/// can never reach `max_in_flight >= 2`, it just times each call out.
+/// Runs on the blocking pool, so sleeping in place is safe.
+struct RendezvousEmbedder {
+    inner: MockEmbedder,
+    in_flight: AtomicUsize,
+    max_in_flight: AtomicUsize,
+}
+
+impl RendezvousEmbedder {
+    fn new() -> Self {
+        Self {
+            inner: MockEmbedder::with_dim(16),
+            in_flight: AtomicUsize::new(0),
+            max_in_flight: AtomicUsize::new(0),
+        }
+    }
+}
+
+impl Embedder for RendezvousEmbedder {
+    fn embed_batch(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>, EmbedError> {
+        let cur = self.in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+        self.max_in_flight.fetch_max(cur, Ordering::SeqCst);
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while self.in_flight.load(Ordering::SeqCst) < 2 && Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(1));
+        }
+        let cur = self.in_flight.load(Ordering::SeqCst);
+        self.max_in_flight.fetch_max(cur, Ordering::SeqCst);
+        let out = self.inner.embed_batch(texts);
+        self.in_flight.fetch_sub(1, Ordering::SeqCst);
+        out
+    }
+    fn dim(&self) -> usize {
+        self.inner.dim()
+    }
+    fn tag(&self) -> &str {
+        "mock"
+    }
+}
+
+// ── Harness ─────────────────────────────────────────────────────
+
+struct Harness<E: Embedder + 'static> {
+    _dir: TempDir,
+    mock: *mut MockKernel,
+    svc: SearchServiceImpl,
+    embedder: Arc<E>,
+}
+
+impl<E: Embedder + 'static> Harness<E> {
+    fn start(embedder: E) -> Self {
+        let dir = TempDir::new().expect("tempdir");
+        let mock = Box::into_raw(Box::new(MockKernel::new()));
+        let handle = handle_for(mock);
+        let manager = Arc::new(IndexManager::with_root(dir.path().to_path_buf()));
+        let embedder = Arc::new(embedder);
+        let svc = SearchServiceImpl::builder(Arc::new(handle))
+            .manager(manager)
+            .embedder(Arc::clone(&embedder) as Arc<dyn Embedder>)
+            .build();
+        Self {
+            _dir: dir,
+            mock,
+            svc,
+            embedder,
+        }
+    }
+
+    fn mock_mut(&self) -> &mut MockKernel {
+        unsafe { &mut *self.mock }
+    }
+}
+
+impl<E: Embedder + 'static> Drop for Harness<E> {
+    fn drop(&mut self) {
+        unsafe {
+            drop(Box::from_raw(self.mock));
+        }
+    }
+}
+
+async fn index_root(svc: &SearchServiceImpl) -> nexus_search_plugin::search_proto::IndexResponse {
+    svc.index(Request::new(IndexRequest {
+        root_path: "/".into(),
+        zone_id: "root".into(),
+        recursive: true,
+        max_docs: 0,
+        auth_token: String::new(),
+    }))
+    .await
+    .expect("index")
+    .into_inner()
+}
+
+fn query_req(q: &str, query_type: QueryType, path_filter: &str) -> QueryRequest {
+    QueryRequest {
+        q: q.into(),
+        zone_id: "root".into(),
+        limit: 10,
+        path_filter: path_filter.into(),
+        query_type: query_type as i32,
+        auth_token: String::new(),
+        ..Default::default()
+    }
+}
+
+// ── Tests ───────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn batch_same_q_across_path_filters_embeds_once() {
+    // The koodle#2176 fan-out shape: SAME query text, one semantic
+    // query per path prefix.  The dupe pre-warm must collapse all
+    // three embeds into one, and every sub-response must still
+    // honour its own path filter.
+    let h = Harness::start(CountingEmbedder::new());
+    let mock = h.mock_mut();
+    mock.add_dir("/");
+    mock.add_dir("/a");
+    mock.add_dir("/b");
+    mock.add_dir("/c");
+    mock.add_file("/a/doc.md", b"widget alpha payload", 1);
+    mock.add_file("/b/doc.md", b"widget alpha payload", 2);
+    mock.add_file("/c/doc.md", b"orange banana grape", 3);
+
+    let idx = index_root(&h.svc).await;
+    assert!(idx.error.is_none(), "{idx:?}");
+    assert_eq!(idx.indexed_count, 3);
+
+    // Indexing embeds documents through the same embedder — count
+    // only what the batch adds on top.
+    let baseline = h.embedder.calls.load(Ordering::SeqCst);
+
+    let resp = h
+        .svc
+        .batch_query(Request::new(BatchQueryRequest {
+            auth_token: String::new(),
+            queries: vec![
+                query_req("widget alpha payload", QueryType::Semantic, "/a/"),
+                query_req("widget alpha payload", QueryType::Semantic, "/b/"),
+                query_req("widget alpha payload", QueryType::Semantic, "/c/"),
+            ],
+        }))
+        .await
+        .expect("batch_query")
+        .into_inner();
+
+    assert_eq!(resp.responses.len(), 3);
+    for (i, sub) in resp.responses.iter().enumerate() {
+        assert!(sub.error.is_none(), "sub {i} errored: {sub:?}");
+    }
+    // Order preservation + per-query path filters: sub 0 sees only
+    // /a/, sub 1 only /b/, sub 2 only /c/.
+    for (i, prefix) in ["/a/", "/b/", "/c/"].iter().enumerate() {
+        for r in &resp.responses[i].results {
+            assert!(
+                r.path.starts_with(prefix),
+                "sub {i} leaked path {} outside {prefix}",
+                r.path,
+            );
+        }
+    }
+    assert!(
+        !resp.responses[0].results.is_empty(),
+        "expected /a/ hits: {:?}",
+        resp.responses[0],
+    );
+
+    let batch_embeds = h.embedder.calls.load(Ordering::SeqCst) - baseline;
+    assert_eq!(
+        batch_embeds, 1,
+        "identical query text across path filters must embed exactly once",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn batch_preserves_order_and_isolates_errors() {
+    let h = Harness::start(CountingEmbedder::new());
+    let mock = h.mock_mut();
+    mock.add_dir("/");
+    mock.add_file("/alpha.md", b"widget alpha payload", 1);
+    mock.add_file("/beta.md", b"orange banana grape", 2);
+
+    let idx = index_root(&h.svc).await;
+    assert!(idx.error.is_none(), "{idx:?}");
+
+    let resp = h
+        .svc
+        .batch_query(Request::new(BatchQueryRequest {
+            auth_token: String::new(),
+            queries: vec![
+                query_req("widget alpha", QueryType::Keyword, ""),
+                // Empty q → per-query error, must not fail the batch.
+                query_req("", QueryType::Keyword, ""),
+                query_req("orange banana", QueryType::Keyword, ""),
+            ],
+        }))
+        .await
+        .expect("batch_query")
+        .into_inner();
+
+    assert_eq!(resp.responses.len(), 3);
+    assert!(resp.responses[0].error.is_none(), "{:?}", resp.responses[0]);
+    assert!(
+        resp.responses[1].error.is_some(),
+        "empty q must surface its own error: {:?}",
+        resp.responses[1],
+    );
+    assert!(resp.responses[1].results.is_empty());
+    assert!(resp.responses[2].error.is_none(), "{:?}", resp.responses[2]);
+    // Order: sub 0 is the alpha query, sub 2 the orange query.
+    assert_eq!(resp.responses[0].results[0].path, "/alpha.md");
+    assert_eq!(resp.responses[2].results[0].path, "/beta.md");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn batch_dispatches_queries_concurrently() {
+    // Two DISTINCT semantic texts (no dupe pre-warm) — under the
+    // bounded concurrent dispatch both embeds must be in flight at
+    // once.  The rendezvous embedder parks each call until it sees a
+    // sibling (or 2s passes), so a serial regression fails the
+    // max_in_flight assertion instead of hanging.
+    let h = Harness::start(RendezvousEmbedder::new());
+    let mock = h.mock_mut();
+    mock.add_dir("/");
+    mock.add_file("/x.md", b"widget alpha payload", 1);
+
+    let idx = index_root(&h.svc).await;
+    assert!(idx.error.is_none(), "{idx:?}");
+
+    let resp = h
+        .svc
+        .batch_query(Request::new(BatchQueryRequest {
+            auth_token: String::new(),
+            queries: vec![
+                query_req("widget alpha payload", QueryType::Semantic, ""),
+                query_req("orange banana grape", QueryType::Semantic, ""),
+            ],
+        }))
+        .await
+        .expect("batch_query")
+        .into_inner();
+
+    assert_eq!(resp.responses.len(), 2);
+    for (i, sub) in resp.responses.iter().enumerate() {
+        assert!(sub.error.is_none(), "sub {i} errored: {sub:?}");
+    }
+    assert!(
+        h.embedder.max_in_flight.load(Ordering::SeqCst) >= 2,
+        "batch ran its queries serially — expected >= 2 concurrent embeds",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn batch_keyword_only_needs_no_embedder() {
+    // A keyword-only batch (with duplicate texts!) must not require
+    // an embedder: the dupe pre-warm only considers semantic/hybrid
+    // queries.  Built WITHOUT an injected embedder, so an errant
+    // get_or_init_embedder() would surface as a per-query error.
+    let dir = TempDir::new().expect("tempdir");
+    let mock = Box::into_raw(Box::new(MockKernel::new()));
+    let handle = handle_for(mock);
+    unsafe {
+        (*mock).add_dir("/");
+        (*mock).add_file("/x.md", b"widget alpha payload", 1);
+    }
+    let manager = Arc::new(IndexManager::with_root(dir.path().to_path_buf()));
+    let svc = SearchServiceImpl::builder(Arc::new(handle))
+        .manager(manager)
+        .build();
+
+    let idx = index_root(&svc).await;
+    assert!(idx.error.is_none(), "{idx:?}");
+
+    let resp = svc
+        .batch_query(Request::new(BatchQueryRequest {
+            auth_token: String::new(),
+            queries: vec![
+                query_req("widget alpha", QueryType::Keyword, ""),
+                query_req("widget alpha", QueryType::Keyword, ""),
+            ],
+        }))
+        .await
+        .expect("batch_query")
+        .into_inner();
+
+    assert_eq!(resp.responses.len(), 2);
+    for (i, sub) in resp.responses.iter().enumerate() {
+        assert!(sub.error.is_none(), "sub {i} errored: {sub:?}");
+        assert_eq!(sub.results[0].path, "/x.md");
+    }
+
+    unsafe {
+        drop(Box::from_raw(mock));
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn batch_matches_individual_query_responses() {
+    // Per-query behaviour must be identical to singles — same
+    // handler, same caches, same scoring.
+    let h = Harness::start(CountingEmbedder::new());
+    let mock = h.mock_mut();
+    mock.add_dir("/");
+    mock.add_file("/alpha.md", b"widget alpha payload", 1);
+    mock.add_file("/beta.md", b"orange banana grape", 2);
+
+    let idx = index_root(&h.svc).await;
+    assert!(idx.error.is_none(), "{idx:?}");
+
+    let singles = [
+        query_req("widget alpha payload", QueryType::Hybrid, ""),
+        query_req("orange banana grape", QueryType::Hybrid, ""),
+    ];
+    let mut single_responses = Vec::new();
+    for q in singles.clone() {
+        single_responses.push(
+            h.svc
+                .query(Request::new(q))
+                .await
+                .expect("query")
+                .into_inner(),
+        );
+    }
+
+    let batch = h
+        .svc
+        .batch_query(Request::new(BatchQueryRequest {
+            auth_token: String::new(),
+            queries: singles.to_vec(),
+        }))
+        .await
+        .expect("batch_query")
+        .into_inner();
+
+    assert_eq!(batch.responses.len(), single_responses.len());
+    for (i, (b, s)) in batch.responses.iter().zip(&single_responses).enumerate() {
+        let b_paths: Vec<&str> = b.results.iter().map(|r| r.path.as_str()).collect();
+        let s_paths: Vec<&str> = s.results.iter().map(|r| r.path.as_str()).collect();
+        assert_eq!(b_paths, s_paths, "sub {i} diverged from its single");
+    }
+}


### PR DESCRIPTION
Closes #4610.

## Problem

Measured live through Koodle's cross-workspace search fan-out (DeepBuildAI/koodle#2176): coverage pins at ~30% of a user's workspaces inside its 7s budget, and raising client-side concurrency makes it *worse* (16 → 19% coverage, 24 → 2%). The fan-out is throughput-bound at the search service. Two compounding causes in the plugin:

1. **`BatchQuery` ran its queries strictly serially** (`for q_req in req.queries { self.query(..).await? }`) — a batch of N queries paid N × full query latency. The deferral comment said "not worth it until Python parity is proven"; the live numbers say it is now the ceiling.
2. **Query embeddings were never cached**, and `FastEmbedder` serialises every embed on a single ort-session mutex. The fan-out shape sends the SAME query text across ~3 sub-paths × ~60 workspaces per keystroke — ~180 identical embeds through the plugin's one embedding lane. The P7 result cache can't absorb this: its key includes `path_filter`, so all of those are distinct entries there even though the embedding is identical.

## Changes

- **New `embed_cache` module** — bounded FIFO cache of query-text embeddings keyed by `(embedder tag, dim, text)`. A hit skips both the embed CPU and the session mutex. Embeddings have no corpus dependency → Index/Refresh need no invalidation; a model swap changes the tag → stale vectors can never serve; failures are never cached. `NEXUS_SEARCH_QUERY_EMBED_CACHE_SIZE` (default 512, `0` disables). ~1.5 KB/entry at mE5-small 384-dim → <1 MB default footprint.
- **`do_semantic_query` embeds through the cache** (semantic + hybrid arms).
- **`BatchQuery`: pre-warm + bounded concurrent dispatch.** Duplicate embedding-needing texts are pre-warmed once (avoids a cold-cache thundering herd into the session mutex), then queries dispatch via `futures_util .buffered(n)` — order-preserving, per-query error isolation unchanged, each query still runs the full `query` handler (result cache, scoring, recency identical to singles). `NEXUS_SEARCH_BATCH_CONCURRENCY` (default 4, clamp 1..=16; `1` restores serial).

`futures-util` becomes a direct dep — it is already in the tree transitively via tonic.

## Tests

- `embed_cache` unit suite: hit/miss, tag+dim isolation, FIFO bound, duplicate-put order integrity, capacity-0 bypass, failures-not-cached.
- New `tests/batch_query_e2e.rs`: same-q-across-path-filters embeds **exactly once** (counting embedder, baseline-adjusted for index-time embeds); order preservation + per-query error isolation (empty-q mid-batch); genuine concurrency (rendezvous embedder — a serial regression fails the assertion rather than hanging); keyword-only batch touches no embedder; batch responses byte-match singles.
- Env clamp unit test for `NEXUS_SEARCH_BATCH_CONCURRENCY`.

`cargo test -p nexus-search-plugin`: 120 lib + 5 batch e2e + 7 query e2e + 9 semantic e2e + 10 index e2e, all passing. `cargo clippy -p nexus-search-plugin -- -D warnings` and `cargo fmt --check` clean. (Pre-existing `clippy::mut_from_ref` in the sibling e2e scaffolds is outside CI's lint scope and untouched.)

## Expected effect for the koodle#2176 fan-out

Per batch call (3 sub-path queries, same q): 3 serial embeds + 3 serial query pipelines → 1 embed (cached across ALL subsequent calls of the keystroke, not just the batch) + up to 3 concurrent query pipelines. The residual bound becomes ANN/BM25 capacity rather than the embed mutex.