### PR TITLE
fix(search): batch_search proxy — typed per-query failures + full param forwarding (#4612)

### DIFF
--- a/docs/surface-coverage/api-rpc-surface-coverage.yaml
+++ b/docs/surface-coverage/api-rpc-surface-coverage.yaml
@@ -7692,7 +7692,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/expand
-      source: src/nexus/server/api/v2/routers/search.py:1611
+      source: src/nexus/server/api/v2/routers/search.py:1615
   profiles:
     lite: supported
     sandbox: supported
@@ -7716,7 +7716,7 @@ operations:
       source: src/nexus/bricks/search/search_service.py:1792
     http:
       name: POST /api/v2/search/glob
-      source: src/nexus/server/api/v2/routers/search.py:1469
+      source: src/nexus/server/api/v2/routers/search.py:1473
     mcp:
       name: nexus_glob
       source: src/nexus/config/tool_profiles.yaml:1
@@ -7743,7 +7743,7 @@ operations:
       source: src/nexus/bricks/search/search_service.py:2102
     http:
       name: POST /api/v2/search/grep
-      source: src/nexus/server/api/v2/routers/search.py:1346
+      source: src/nexus/server/api/v2/routers/search.py:1350
     mcp:
       name: nexus_grep
       source: src/nexus/config/tool_profiles.yaml:1
@@ -7796,7 +7796,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/index
-      source: src/nexus/server/api/v2/routers/search.py:1531
+      source: src/nexus/server/api/v2/routers/search.py:1535
   profiles:
     lite: supported
     sandbox: supported
@@ -7848,7 +7848,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/refresh
-      source: src/nexus/server/api/v2/routers/search.py:1590
+      source: src/nexus/server/api/v2/routers/search.py:1594
   profiles:
     lite: supported
     sandbox: supported

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING, Any
 import grpc
 
 from nexus.bricks.search.results import BaseSearchResult
+from nexus.contracts.search_types import BatchQueryFailure
 from nexus.grpc.search.v1 import search_pb2, search_pb2_grpc
 
 if TYPE_CHECKING:
@@ -84,23 +85,7 @@ class SearchDaemon:
 
     async def search(self, request: "SearchRequest") -> list[BaseSearchResult]:
         """Forward a SearchRequest to the Rust plugin's Query RPC."""
-        req = search_pb2.QueryRequest(
-            q=request.query,
-            zone_id=request.zone_id or "",
-            limit=request.limit,
-            path_filter=request.path_filter or "",
-            query_type=_QUERY_TYPE_MAP.get(request.search_type, search_pb2.QUERY_TYPE_UNSPECIFIED),
-            alpha=request.alpha,
-            fusion_method=_FUSION_METHOD_MAP.get(
-                request.fusion_method, search_pb2.FUSION_METHOD_UNSPECIFIED
-            ),
-            rrf_k=request.rrf_k,
-            expand=request.expand or "",
-            recency_mode=request.recency or "",
-            recency_weight=request.recency_weight or 0.0,
-            recency_half_life_days=request.recency_half_life_days or 0.0,
-        )
-        resp = await self._get_stub().Query(req)
+        resp = await self._get_stub().Query(_request_to_pb(request))
         if resp.HasField("error"):
             logger.warning("rust search returned error: %s", resp.error)
             return []
@@ -109,21 +94,25 @@ class SearchDaemon:
     async def batch_search(
         self,
         requests: list["SearchRequest"],
-    ) -> list[list[BaseSearchResult]]:
-        """Forward a batch of queries to the Rust plugin."""
-        pb_queries = [
-            search_pb2.QueryRequest(
-                q=r.query,
-                zone_id=r.zone_id or "",
-                limit=r.limit,
-                path_filter=r.path_filter or "",
-                query_type=_QUERY_TYPE_MAP.get(r.search_type, search_pb2.QUERY_TYPE_UNSPECIFIED),
-            )
-            for r in requests
-        ]
-        req = search_pb2.BatchQueryRequest(queries=pb_queries)
+    ) -> list[list[BaseSearchResult] | BatchQueryFailure]:
+        """Forward a batch of queries to the Rust plugin.
+
+        Positional with ``requests``.  An inner query the plugin failed
+        (embedder unavailable, per-query timeout, backend error) comes
+        back as :class:`BatchQueryFailure` — NOT an empty list — so the
+        batch endpoint can emit its per-entry additive ``error`` field
+        and fail-closed consumers can tell "searched, no matches" from
+        "search failed" (#4612).
+        """
+        req = search_pb2.BatchQueryRequest(queries=[_request_to_pb(r) for r in requests])
         resp = await self._get_stub().BatchQuery(req)
-        return [[_result_to_base(hit) for hit in sub.results] for sub in resp.responses]
+        out: list[list[BaseSearchResult] | BatchQueryFailure] = []
+        for sub in resp.responses:
+            if sub.HasField("error"):
+                out.append(BatchQueryFailure(error=sub.error))
+            else:
+                out.append([_result_to_base(hit) for hit in sub.results])
+        return out
 
     async def locate(
         self,
@@ -233,6 +222,30 @@ class SearchDaemon:
             "ann_chunk_count": resp.ann_chunk_count,
             "parked_count": resp.parked_count,
         }
+
+
+def _request_to_pb(request: "SearchRequest") -> search_pb2.QueryRequest:
+    """Map a SearchRequest onto the plugin's QueryRequest proto.
+
+    Shared by ``search`` and ``batch_search`` so the batch path can
+    never silently drop a tuning knob the single path forwards.
+    """
+    return search_pb2.QueryRequest(
+        q=request.query,
+        zone_id=request.zone_id or "",
+        limit=request.limit,
+        path_filter=request.path_filter or "",
+        query_type=_QUERY_TYPE_MAP.get(request.search_type, search_pb2.QUERY_TYPE_UNSPECIFIED),
+        alpha=request.alpha,
+        fusion_method=_FUSION_METHOD_MAP.get(
+            request.fusion_method, search_pb2.FUSION_METHOD_UNSPECIFIED
+        ),
+        rrf_k=request.rrf_k,
+        expand=request.expand or "",
+        recency_mode=request.recency or "",
+        recency_weight=request.recency_weight or 0.0,
+        recency_half_life_days=request.recency_half_life_days or 0.0,
+    )
 
 
 def _result_to_base(pb: search_pb2.QueryResult) -> BaseSearchResult:

--- a/src/nexus/server/api/v2/routers/search.py
+++ b/src/nexus/server/api/v2/routers/search.py
@@ -748,10 +748,11 @@ async def search_query_batch(
 
     Applies the same ReBAC file-level permission filter as ``/query``
     (Decision #17), over-fetching via ``_compute_rebac_fetch_limit`` and
-    trimming to each query's requested ``limit`` after filtering. All
-    unique query texts are embedded in ONE ``embed_batch`` call and the
-    inner searches run concurrently (``NEXUS_SEARCH_BATCH_CONCURRENCY``,
-    default 8).
+    trimming to each query's requested ``limit`` after filtering. The
+    Rust plugin runs the inner searches concurrently
+    (``NEXUS_SEARCH_BATCH_CONCURRENCY``, default 4, clamped 1..=16) and
+    pre-warms its query-embedding cache for duplicate embedding-needing
+    query texts, so a fan-out batch embeds each unique text once (#4611).
     """
     from nexus.contracts.constants import ROOT_ZONE_ID
 
@@ -807,29 +808,32 @@ async def search_query_batch(
     valid: list[tuple[int, ParsedBatchSpec]] = [
         (i, p) for i, p in enumerate(parsed) if isinstance(p, ParsedBatchSpec)
     ]
-    fetch_specs = [
-        {
-            "query": spec.query,
-            "search_type": spec.search_type,
-            "limit": _compute_rebac_fetch_limit(
+    # Same typed request shape as the single-query path — the P12 proxy's
+    # batch_search takes SearchRequest objects (zone_id rides inside each
+    # request, exactly like single ``search()``), so every tuning knob the
+    # single route forwards reaches the plugin here too (#4612).
+    fetch_requests = [
+        SearchRequest(
+            query=spec.query,
+            search_type=spec.search_type,
+            limit=_compute_rebac_fetch_limit(
                 spec.limit, has_enforcer=permission_enforcer is not None
             ),
-            "path_filter": spec.path_filter,
-            "alpha": spec.alpha,
-            "fusion_method": spec.fusion_method,
-            "rrf_k": spec.rrf_k,
-            "expand": spec.expand,
-            "recency": spec.recency,
-            "recency_weight": spec.recency_weight,
-            "recency_half_life_days": spec.recency_half_life_days,
-        }
+            path_filter=spec.path_filter,
+            alpha=spec.alpha,
+            fusion_method=spec.fusion_method,
+            rrf_k=spec.rrf_k,
+            zone_id=zone_id,
+            expand=spec.expand,
+            recency=spec.recency,
+            recency_weight=spec.recency_weight,
+            recency_half_life_days=spec.recency_half_life_days,
+        )
         for _, spec in valid
     ]
 
     t0 = time.perf_counter()
-    raw_results = (
-        await search_daemon.batch_search(fetch_specs, zone_id=zone_id) if fetch_specs else []
-    )
+    raw_results = await search_daemon.batch_search(fetch_requests) if fetch_requests else []
     elapsed_ms = (time.perf_counter() - t0) * 1000
 
     result_by_index: dict[int, Any] = {

--- a/tests/integration/services/test_search_query_batch.py
+++ b/tests/integration/services/test_search_query_batch.py
@@ -195,7 +195,11 @@ def _build_batch_app(mock_daemon):
 
     app = FastAPI()
     app.include_router(router)
-    mock_daemon.is_initialized = True
+    try:
+        mock_daemon.is_initialized = True
+    except AttributeError:
+        # Real SearchDaemon proxy: read-only property, already True.
+        pass
     app.state.search_daemon = mock_daemon
     app.state.search_daemon_enabled = True
     app.state.record_store = MagicMock()
@@ -243,17 +247,24 @@ class TestBatchRoute:
         )
 
         assert resp.status_code == 200, resp.text
+        # #4612: the route hands the daemon typed SearchRequest objects —
+        # the same shape single /query uses — with zone_id inside each
+        # request rather than a separate kwarg.
+        from nexus.contracts.search_types import SearchRequest
+
         (specs,) = daemon.batch_search.call_args.args
-        assert daemon.batch_search.call_args.kwargs == {"zone_id": "eng"}
+        assert daemon.batch_search.call_args.kwargs == {}
         spec = specs[0]
-        assert spec["query"] == "tuned"
-        assert spec["search_type"] == "hybrid"
-        assert spec["path_filter"] == "/ws/"
-        assert (spec["alpha"], spec["fusion_method"], spec["rrf_k"]) == (0.3, "weighted", 90)
-        assert (spec["expand"], spec["recency"]) == ("macro", "on")
-        assert (spec["recency_weight"], spec["recency_half_life_days"]) == (1.5, 30.0)
+        assert isinstance(spec, SearchRequest)
+        assert spec.query == "tuned"
+        assert spec.search_type == "hybrid"
+        assert spec.path_filter == "/ws/"
+        assert spec.zone_id == "eng"
+        assert (spec.alpha, spec.fusion_method, spec.rrf_k) == (0.3, "weighted", 90)
+        assert (spec.expand, spec.recency) == ("macro", "on")
+        assert (spec.recency_weight, spec.recency_half_life_days) == (1.5, 30.0)
         # No enforcer on this app -> fetch limit == requested limit.
-        assert spec["limit"] == 7
+        assert spec.limit == 7
 
     def test_serializer_parity_with_single_query(self):
         from nexus.server.api.v2.routers._search_serialize import _serialize_search_result
@@ -327,7 +338,7 @@ class TestBatchRoute:
         assert "error" not in body["queries"][1]
         # Only the valid spec reached the daemon.
         (specs,) = daemon.batch_search.call_args.args
-        assert [s["query"] for s in specs] == ["fine"]
+        assert [s.query for s in specs] == ["fine"]
 
     def test_all_specs_invalid_skips_daemon_entirely(self):
         daemon = MagicMock()
@@ -431,3 +442,117 @@ class TestBatchCardinality:
 
         assert resp.status_code == 200, resp.text
         daemon.batch_search.assert_called_once()
+
+
+@pytest.mark.skipif(not _HAS_FASTAPI_TESTCLIENT, reason="fastapi test client not available")
+class TestBatchRealProxyRoundtrip:
+    """Route → REAL SearchDaemon gRPC proxy → fake stub → route response.
+
+    The mock-daemon tests above pin the route's behaviour against
+    whatever ``batch_search`` they stub — which is how the P12 proxy
+    shipped with a signature the route couldn't even call (dict specs +
+    ``zone_id`` kwarg vs typed requests) and with the per-query typed
+    failure dropped on the floor (#4612).  This class runs the real
+    proxy with only the gRPC stub faked, so route↔proxy contract drift
+    fails a test instead of 500ing (or silently lying) in production.
+    """
+
+    def _daemon_with_stub(self, response):
+        from nexus.bricks.search.daemon import SearchDaemon
+
+        class _FakeStub:
+            def __init__(self, resp):
+                self._resp = resp
+                self.requests = []
+
+            async def BatchQuery(self, req):  # noqa: N802 — gRPC stub surface
+                self.requests.append(req)
+                return self._resp
+
+        daemon = SearchDaemon(target="127.0.0.1:1")  # never dialed
+        stub = _FakeStub(response)
+        daemon._stub = stub
+        return daemon, stub
+
+    def test_failed_inner_query_serializes_error_field(self):
+        from nexus.grpc.search.v1 import search_pb2
+
+        response = search_pb2.BatchQueryResponse(
+            responses=[
+                search_pb2.QueryResponse(
+                    results=[
+                        search_pb2.QueryResult(
+                            path="/ws/doc.md",
+                            chunk_text="hello",
+                            score=0.9,
+                            chunk_index=0,
+                            zone_id="eng",
+                        )
+                    ]
+                ),
+                search_pb2.QueryResponse(error="embedder unavailable"),
+            ]
+        )
+        daemon, _ = self._daemon_with_stub(response)
+        app = _build_batch_app(daemon)
+
+        resp = TestClient(app).post(
+            "/api/v2/search/query/batch",
+            json={"queries": [{"q": "ok"}, {"q": "doomed", "type": "semantic"}]},
+        )
+
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        ok, doomed = body["queries"]
+        assert "error" not in ok
+        assert ok["total"] == 1
+        assert ok["results"][0]["path"] == "/ws/doc.md"
+        # The 2026-08-04 contract: a failed inner query carries an additive
+        # per-entry error — absence of ``error`` means genuinely empty.
+        assert doomed == {
+            "query": "doomed",
+            "results": [],
+            "total": 0,
+            "error": "embedder unavailable",
+        }
+
+    def test_tuning_params_reach_the_wire(self):
+        from nexus.grpc.search.v1 import search_pb2
+
+        response = search_pb2.BatchQueryResponse(responses=[search_pb2.QueryResponse()])
+        daemon, stub = self._daemon_with_stub(response)
+        app = _build_batch_app(daemon)
+
+        resp = TestClient(app).post(
+            "/api/v2/search/query/batch",
+            json={
+                "queries": [
+                    {
+                        "q": "tuned",
+                        "type": "hybrid",
+                        "limit": 7,
+                        "path": "/ws/",
+                        "alpha": 0.3,
+                        "fusion": "weighted",
+                        "rrf_k": 90,
+                        "expand": "macro",
+                        "recency": "on",
+                        "recency_weight": 1.5,
+                        "recency_half_life_days": 30,
+                    }
+                ]
+            },
+        )
+
+        assert resp.status_code == 200, resp.text
+        (req,) = stub.requests
+        (q,) = req.queries
+        assert q.q == "tuned"
+        assert q.zone_id == "eng"
+        assert q.limit == 7
+        assert q.path_filter == "/ws/"
+        assert q.query_type == search_pb2.QUERY_TYPE_HYBRID
+        assert q.fusion_method == search_pb2.FUSION_METHOD_WEIGHTED
+        assert (round(q.alpha, 6), q.rrf_k) == (0.3, 90)
+        assert (q.expand, q.recency_mode) == ("macro", "on")
+        assert (q.recency_weight, q.recency_half_life_days) == (1.5, 30.0)


### PR DESCRIPTION
Closes #4612.

## What broke

The P12 proxy's `batch_search` shipped with three defects the mock-daemon tests couldn't see (they `AsyncMock` the daemon, so the route↔proxy call contract was never exercised):

1. **Signature drift — live `/query/batch` 500s.** The route called `batch_search(fetch_specs, zone_id=...)` (dict specs + kwarg, the deleted Python daemon's shape) while the P12 proxy takes a bare positional list of typed requests and reads attributes off each. Every live call raised `TypeError` before reaching the plugin.
2. **Dropped tuning knobs.** The batch pb mapping only forwarded `q`/`zone`/`limit`/`path`/`type` — `alpha`, `fusion_method`, `rrf_k`, `expand`, and the recency params were silently discarded on the batch path while the single path forwards them all.
3. **Dropped typed failures (the issue as filed).** `sub.error` from the plugin was discarded, so a failed inner query (embedder unavailable, per-query timeout, backend error) serialized as `{"results": [], "total": 0}` with no `error` key — regressing the 2026-08-04 contract (*absence of `error` means the result set is genuine*) that fail-closed consumers (Koodle's cross-workspace batch fold) rely on for coverage accounting. The route's `isinstance(inner, BatchQueryFailure)` branch was dead code.

## Fix

- Route builds `SearchRequest` objects (zone_id inside each request — exactly the single `/query` shape) and calls `batch_search(requests)`.
- Proxy maps requests through a shared `_request_to_pb` helper used by both `search` and `batch_search`, so batch can never again silently drop a knob the single path forwards.
- Proxy maps a non-empty `sub.error` to `BatchQueryFailure`, lighting the route's existing typed-failure path back up — the additive per-entry `error` field is on the wire again.
- Stale route docstring fixed: it advertised the pre-#4611 story (one `embed_batch` call, concurrency default 8); it now describes the shipped behaviour (duplicate-text embed-cache pre-warm, `NEXUS_SEARCH_BATCH_CONCURRENCY` default 4, clamp 1..=16). Kept the plugin default at 4 — that was a deliberate #4611 choice (each in-flight query can spawn two blocking tasks).

## Tests

- Mock-daemon forwarding assertions updated to the typed shape.
- New `TestBatchRealProxyRoundtrip` class: route → **real** `SearchDaemon` proxy → fake gRPC stub → route response. Pins (a) the route↔proxy call contract (would have caught the 500), (b) per-entry `error` serialization for a failed inner query, (c) the full knob set reaching the wire. `tests/integration/services/test_search_query_batch.py`: 58 passed.
- Related suites green: `tests/unit/bricks/search`, `tests/unit/server/api/v2`, search-startup failsoft. Surface-coverage validation passes.