### PR TITLE
release: publish nexusd-cluster plugin-host image + deployment contract docs (#4613)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -20,6 +20,12 @@ permissions:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository_owner }}/nexus
+  # Plugin-host image (#4613): nexusd-cluster + signed search plugin.
+  # Post-P12 the Rust plugin is the sole search backend, so a published
+  # server image without a published plugin-host image cannot serve
+  # search — the two are tagged from the same commit so deployments can
+  # pin the pairing by digest.
+  CLUSTER_IMAGE_NAME: ${{ github.repository_owner }}/nexusd-cluster
 
 jobs:
   # Fan out amd64 and arm64 onto native GitHub-hosted runners; emit one
@@ -147,6 +153,161 @@ jobs:
           docker buildx imagetools inspect "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}"
 
   # ---------------------------------------------------------------------------
+  # Plugin-host image (#4613): nexusd-cluster + signed nexus-search-plugin
+  # baked into /plugins.  Built from dockerfiles/Dockerfile.nexusd-cluster-plugins
+  # (self-contained — cluster binary from the pinned nexus-vfs rev, plugin
+  # cdylib from this repo, Ed25519 signing in-build) and published with the
+  # SAME tag set as the server image so every server tag has a matching
+  # plugin-host tag from the same commit.
+  # ---------------------------------------------------------------------------
+  build-cluster-platform:
+    name: Build cluster ${{ matrix.platform }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check plugin signing key availability
+        env:
+          PLUGIN_SIGNING_PRIVKEY: ${{ secrets.PLUGIN_SIGNING_PRIVKEY }}
+        run: |
+          if [ -z "$PLUGIN_SIGNING_PRIVKEY" ]; then
+            echo "::error::PLUGIN_SIGNING_PRIVKEY secret is not available — cannot sign the plugin, and an unsigned plugin would only defer the failure to daemon boot."
+            exit 1
+          fi
+
+      - name: Read NEXUS_VFS_REV from Cargo.toml
+        id: vfs_rev
+        run: |
+          sha=$(grep -oP '(?<=rev = ")[a-f0-9]{40}' Cargo.toml | sort -u | head -1)
+          if [ -z "$sha" ]; then
+            echo "::error::Could not parse nexus-vfs SHA from Cargo.toml"
+            exit 1
+          fi
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout nexus-vfs source at pinned SHA
+        uses: actions/checkout@v4
+        with:
+          repository: nexi-lab/nexus-vfs
+          ref: ${{ steps.vfs_rev.outputs.sha }}
+          path: nexus-vfs-src
+          fetch-depth: 1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Normalize platform pair (for artifact name)
+        id: pair
+        run: |
+          pair="${{ matrix.platform }}"
+          echo "value=${pair//\//-}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: dockerfiles/Dockerfile.nexusd-cluster-plugins
+          build-contexts: |
+            nexus-vfs-src=nexus-vfs-src
+          secrets: |
+            plugin_signing_key=${{ secrets.PLUGIN_SIGNING_PRIVKEY }}
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.CLUSTER_IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true,oci-mediatypes=true
+          cache-from: type=gha,scope=cluster-publish-${{ steps.pair.outputs.value }}
+          cache-to: type=gha,mode=max,scope=cluster-publish-${{ steps.pair.outputs.value }},ignore-error=true
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-cluster-publish-${{ steps.pair.outputs.value }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  push-cluster-manifest:
+    name: Push multi-arch cluster image
+    needs: [build-cluster-platform]
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.meta.outputs.version }}
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-cluster-publish-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Determine image tags
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.CLUSTER_IMAGE_NAME }}
+          # Same tag rules as the server image — every server tag must
+          # have a matching plugin-host tag from the same commit.
+          tags: |
+            type=semver,pattern={{version}}
+            type=raw,value=stable,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=raw,value=edge,enable=${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/tags/v') }}
+            type=raw,value=${{ github.event.inputs.tag }},enable=${{ github.event.inputs.tag != '' }}
+            type=sha,prefix=,enable=${{ github.event.inputs.tag == '' }}
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          mapfile -t image_tags < <(jq -r '.tags[]' <<< "$DOCKER_METADATA_OUTPUT_JSON")
+          tag_args=()
+          for tag in "${image_tags[@]}"; do
+            tag_args+=("-t" "$tag")
+          done
+          digest_args=()
+          for digest in *; do
+            digest_args+=("${{ env.REGISTRY }}/${{ env.CLUSTER_IMAGE_NAME }}@sha256:${digest}")
+          done
+          docker buildx imagetools create \
+            "${tag_args[@]}" \
+            "${digest_args[@]}"
+
+      - name: Inspect
+        run: |
+          docker buildx imagetools inspect "${{ env.REGISTRY }}/${{ env.CLUSTER_IMAGE_NAME }}:${{ steps.meta.outputs.version }}"
+
+  # ---------------------------------------------------------------------------
   # E2E smoke tests against the edge image (develop + tagged releases)
   # Starts a Nexus container, runs init, then exercises the permissions demo
   # and build-perf e2e scripts.  Failures block the workflow so issues are
@@ -154,7 +315,7 @@ jobs:
   # ---------------------------------------------------------------------------
   e2e-edge:
     name: E2E edge smoke tests
-    needs: build-and-push
+    needs: [build-and-push, push-cluster-manifest]
     if: github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     timeout-minutes: 45
@@ -190,55 +351,14 @@ jobs:
       # The edge image is Python-server-only (no plugin baked in), so
       # the smoke tests that assert auto-index-on-write (sections 9+10
       # of test_build_perf_e2e.py) need a plugin process reachable at
-      # NEXUS_SEARCH_PLUGIN_TARGET.  Reuse the search-plugin-e2e
-      # compose so the plugin build + signing pipeline stays SSOT.
+      # NEXUS_SEARCH_PLUGIN_TARGET.
+      #
+      # #4613: the sidecar now runs the PUBLISHED plugin-host image
+      # (pushed by push-cluster-manifest earlier in this workflow)
+      # instead of an in-workflow build — the smoke validates the
+      # exact artifact the public pulls, so a tag can no longer pass
+      # e2e using an image that doesn't exist outside CI.
       # ---------------------------------------------------------------
-      - name: Set up Docker Buildx (for cluster image)
-        uses: docker/setup-buildx-action@v3
-
-      - name: Read NEXUS_VFS_REV from Cargo.toml
-        id: vfs_rev
-        run: |
-          sha=$(grep -oP '(?<=rev = ")[a-f0-9]{40}' Cargo.toml | sort -u | head -1)
-          if [ -z "$sha" ]; then
-            echo "::error::Could not parse nexus-vfs SHA from Cargo.toml"
-            exit 1
-          fi
-          echo "sha=$sha" >> "$GITHUB_OUTPUT"
-
-      - name: Checkout nexus-vfs source at pinned SHA
-        uses: actions/checkout@v4
-        with:
-          repository: nexi-lab/nexus-vfs
-          ref: ${{ steps.vfs_rev.outputs.sha }}
-          path: nexus-vfs-src
-          fetch-depth: 1
-
-      - name: Build nexusd-cluster image (for plugin sidecar)
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: dockerfiles/Dockerfile.nexusd-cluster
-          build-contexts: |
-            nexus-vfs-src=nexus-vfs-src
-          load: true
-          tags: nexusd-cluster:latest
-          # Share cache scope with search-plugin-e2e so this stage
-          # comes up warm on most runs (cold build is ~10 min).
-          cache-from: type=gha,scope=search-plugin-cluster
-          cache-to: type=gha,scope=search-plugin-cluster,mode=max
-
-      - name: Build search-plugin-test image
-        env:
-          BUILDX_BUILDER: default
-          PLUGIN_SIGNING_PRIVKEY: ${{ secrets.PLUGIN_SIGNING_PRIVKEY }}
-        run: |
-          if [ -z "$PLUGIN_SIGNING_PRIVKEY" ]; then
-            echo "::error::PLUGIN_SIGNING_PRIVKEY secret is not available."
-            exit 1
-          fi
-          docker compose -f dockerfiles/docker-compose.search-plugin-e2e.yml build node
-
       - name: Prepare shared workspace volume
         run: |
           # Both containers see the same /workspace bytes.  Post-P12
@@ -250,16 +370,26 @@ jobs:
 
       - name: Start search-plugin sidecar on 127.0.0.1:2126
         run: |
-          # Compose with the edge-override so both the plugin sidecar
-          # and nexus-e2e see the same bytes at /workspace (see
-          # dockerfiles/docker-compose.search-plugin-e2e.edge-override.yml).
-          docker compose \
-            -f dockerfiles/docker-compose.search-plugin-e2e.yml \
-            -f dockerfiles/docker-compose.search-plugin-e2e.edge-override.yml \
-            up -d node
-          # Wait for the plugin's gRPC bind to be reachable from the host
-          # (compose maps 2126:2126 so --network host of nexus-e2e sees
-          # the same port).
+          # Same single-node topology + flags as the search-plugin-e2e
+          # compose's bootstrap entrypoint, but running the published
+          # image.  Reachable 0.0.0.0 bind + --no-tls trips the
+          # loopback auth invariant; this is a trusted CI smoke, so
+          # take the sanctioned escape.
+          docker run -d --name nexus-search-plugin-node \
+            -p 2126:2126 \
+            -e NEXUS_HOSTNAME=node \
+            -e NEXUS_ADVERTISE_ADDR=127.0.0.1:2126 \
+            -e RUST_LOG=info,nexus_raft=info,kernel::plugins=debug,plugins=debug \
+            -v nexus-shared-workspace:/workspace \
+            "${{ env.REGISTRY }}/${{ env.CLUSTER_IMAGE_NAME }}:${{ needs.push-cluster-manifest.outputs.version }}" \
+            --bind-addr 0.0.0.0:2126 \
+            --data-dir /app/data \
+            --no-tls \
+            --insecure-no-auth \
+            --plugin-dir /plugins
+          # Wait for the plugin's gRPC bind to be reachable from the
+          # host (2126:2126 mapping so --network host of nexus-e2e
+          # sees the same port).
           deadline=$((SECONDS + 120))
           while [ $SECONDS -lt $deadline ]; do
             if timeout 1 bash -c '</dev/tcp/127.0.0.1/2126' 2>/dev/null; then
@@ -269,10 +399,7 @@ jobs:
             sleep 2
           done
           echo "::error::Search plugin sidecar failed to bind 127.0.0.1:2126 within 120s"
-          docker compose \
-            -f dockerfiles/docker-compose.search-plugin-e2e.yml \
-            -f dockerfiles/docker-compose.search-plugin-e2e.edge-override.yml \
-            logs --tail=200 node
+          docker logs --tail=200 nexus-search-plugin-node || true
           exit 1
 
       - name: Start Nexus edge container
@@ -529,12 +656,15 @@ jobs:
           echo "Last 200 container log lines:"
           docker logs nexus-e2e 2>&1 | tail -200 || true
 
+      - name: Collect sidecar logs on failure
+        if: failure() || cancelled()
+        run: |
+          echo "Search-plugin sidecar (published image) last 200 log lines:"
+          docker logs --tail=200 nexus-search-plugin-node 2>&1 || true
+
       - name: Cleanup
         if: always()
         run: |
           docker rm -f nexus-e2e 2>/dev/null || true
-          docker compose \
-            -f dockerfiles/docker-compose.search-plugin-e2e.yml \
-            -f dockerfiles/docker-compose.search-plugin-e2e.edge-override.yml \
-            down -v --remove-orphans 2>/dev/null || true
+          docker rm -f nexus-search-plugin-node 2>/dev/null || true
           docker volume rm -f nexus-shared-workspace 2>/dev/null || true

--- a/dockerfiles/Dockerfile.nexusd-cluster
+++ b/dockerfiles/Dockerfile.nexusd-cluster
@@ -19,6 +19,10 @@
 # Pinning is single-sourced in `Cargo.toml` — the plugin dylibs and
 # the cluster binary must compile against the same nexus-vfs commit
 # for ABI parity, so there is one SHA, one place to bump.
+#
+# KEEP IN SYNC: `Dockerfile.nexusd-cluster-plugins` (the published
+# plugin-host image, #4613) mirrors this file's builder + runtime
+# stages — a change here almost certainly belongs there too.
 
 FROM rust:1-slim-bookworm AS builder
 

--- a/dockerfiles/Dockerfile.nexusd-cluster-plugins
+++ b/dockerfiles/Dockerfile.nexusd-cluster-plugins
@@ -1,0 +1,119 @@
+# Nexus Cluster + Search Plugin — the published plugin-host image
+#
+# Post-P12 (#4598) the Rust `nexus-search-plugin` cdylib, hosted by
+# `nexusd-cluster` over gRPC loopback, is the SOLE search backend for
+# the Python server image.  This Dockerfile produces the deployable
+# pairing's second half: the cluster daemon with the signed search
+# plugin baked into `/plugins/`, published to GHCR as
+# `ghcr.io/nexi-lab/nexusd-cluster` alongside the server image from
+# the same commit (#4613) so a deployment can pin both by digest.
+#
+# Self-contained by design: unlike the CI-only
+# `Dockerfile.search-plugin-test` (which layers the plugin on top of a
+# locally pre-built `nexusd-cluster:latest`), every stage lives in this
+# one file so a single `docker build` reproduces the published artifact
+# with any buildx driver — no local base image, no ordering contract:
+#
+#   docker build \
+#     -f dockerfiles/Dockerfile.nexusd-cluster-plugins \
+#     --build-context nexus-vfs-src=../nexus-vfs \
+#     --secret id=plugin_signing_key,env=PLUGIN_SIGNING_PRIVKEY \
+#     -t nexusd-cluster:latest .
+#
+# KEEP IN SYNC: the `cluster-builder` + runtime stages mirror
+# `Dockerfile.nexusd-cluster`, and the `plugin-builder` stage mirrors
+# `Dockerfile.search-plugin-test` — a change to either sibling almost
+# certainly belongs here too.
+#
+# Pinning is single-sourced in `Cargo.toml` — the plugin cdylib and the
+# cluster binary must compile against the same nexus-vfs commit for ABI
+# parity.  CI parses the SHA from Cargo.toml and checks out
+# nexi-lab/nexus-vfs at that rev as the `nexus-vfs-src` build context.
+
+# ---------- Cluster binary ----------
+FROM rust:1-slim-bookworm AS cluster-builder
+
+# protobuf-compiler: raft proto codegen shells out to system protoc.
+# python3{,-dev}: pyo3-build-config probes for an interpreter at
+# compile time.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        protobuf-compiler \
+        python3 \
+        python3-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=nexus-vfs-src . /build/nexus-vfs
+
+# `--locked` respects the source tree's `Cargo.lock` — the substrate's
+# own SSOT for dependency versions (see Dockerfile.nexusd-cluster for
+# the full rationale).
+RUN cargo install \
+    --locked \
+    --path /build/nexus-vfs/rust/profiles/cluster \
+    --bin nexusd-cluster
+
+# ---------- Search plugin cdylib ----------
+FROM rust:1-slim-bookworm AS plugin-builder
+
+# python3-cryptography: sign_plugin.py imports Ed25519PrivateKey.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        protobuf-compiler \
+        python3 \
+        python3-dev \
+        python3-cryptography \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+
+COPY Cargo.toml Cargo.lock ./
+COPY rust ./rust
+
+RUN cargo build --release -p nexus-search-plugin
+
+# Ed25519-sign the dylib (kernel refuses unsigned plugins; PluginLoader
+# verifies against compile-time trusted keys).  The private key arrives
+# as a BuildKit secret, never a layer.
+COPY scripts/sign_plugin.py ./scripts/sign_plugin.py
+RUN --mount=type=secret,id=plugin_signing_key \
+    PLUGIN_SIGNING_PRIVKEY="$(cat /run/secrets/plugin_signing_key)" \
+    python3 scripts/sign_plugin.py target/release/libnexus_search_plugin.so
+
+# ---------- Production image ----------
+FROM debian:bookworm-slim
+
+# bash: healthchecks use `bash -c '</dev/tcp/localhost/2126'`
+# ca-certificates: outbound TLS for remote backend drivers AND the
+# plugin's remote embedding endpoint (NEXUS_SEARCH_EMBED_API_URL).
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends bash ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY --from=cluster-builder /usr/local/cargo/bin/nexusd-cluster /usr/local/bin/
+
+# Non-root runtime user.  Pre-creates `/app/data` (raft state cache),
+# `/app/identity` (node-bound peer address book), and `/plugins` so
+# named volumes mounted at any of them inherit `nexus:nexus` ownership.
+RUN useradd -r -m -u 1000 -s /bin/bash nexus && \
+    mkdir -p /app/data /app/identity /plugins && \
+    chown -R nexus:nexus /app /plugins
+
+# Signed dylib + detached signature — PluginLoader reads `<plugin>.sig`
+# next to `<plugin>` at --plugin-dir scan time.
+COPY --from=plugin-builder --chown=nexus:nexus \
+    /build/target/release/libnexus_search_plugin.so \
+    /plugins/libnexus_search_plugin.so
+COPY --from=plugin-builder --chown=nexus:nexus \
+    /build/target/release/libnexus_search_plugin.so.sig \
+    /plugins/libnexus_search_plugin.so.sig
+
+USER nexus
+WORKDIR /app
+
+ENV NEXUS_BIND_ADDR=0.0.0.0:2126 \
+    NEXUS_DATA_DIR=/app/data \
+    NEXUS_PLUGIN_DIR=/plugins \
+    RUST_LOG=info,nexus_raft=info
+
+EXPOSE 2126
+
+ENTRYPOINT ["nexusd-cluster"]

--- a/dockerfiles/Dockerfile.search-plugin-test
+++ b/dockerfiles/Dockerfile.search-plugin-test
@@ -19,6 +19,10 @@
 # image so the operator gets a single image with the daemon and the
 # signed plugin in lockstep — exactly the shape the production
 # `--plugin-dir` load path exercises.
+#
+# KEEP IN SYNC: `Dockerfile.nexusd-cluster-plugins` (the published
+# plugin-host image, #4613) mirrors this builder stage — a change
+# here almost certainly belongs there too.
 
 # ---------- Builder ----------
 FROM rust:1-slim-bookworm AS builder

--- a/docs/deployment/search-plugin.md
+++ b/docs/deployment/search-plugin.md
@@ -1,0 +1,168 @@
+# Search plugin deployment (post-P12)
+
+Since the P12 pivot (#4598), the Python in-process search daemon is
+gone. The **Rust `nexus-search-plugin` cdylib**, hosted by
+`nexusd-cluster` and reached over gRPC, is the **sole search backend**
+for the Nexus server. A server deployment that does not run the plugin
+host boots with search disabled — the boot probe fail-softs (logs a
+warning, `/api/v2/search/*` returns 503) rather than failing the boot.
+
+This page is the deployment contract: which processes you run, how
+they are wired, and what changed for corpora indexed under the
+pre-P12 stack.
+
+## Required processes
+
+| Process | Image | Role |
+|---|---|---|
+| Nexus server | `ghcr.io/nexi-lab/nexus` | FastAPI/gRPC server; proxies search calls to the plugin |
+| Plugin host | `ghcr.io/nexi-lab/nexusd-cluster` | `nexusd-cluster` with the signed `nexus-search-plugin` cdylib in `/plugins`; owns FTS + ANN indices and embeddings |
+
+Both images are published from the **same commit** with the **same
+tag set** (`edge` on develop/main, `stable`/`latest`/semver on version
+tags, plus the commit SHA), so a deployable pairing is pinnable by
+digest. Publishing is done by `.github/workflows/docker-publish.yml`
+(#4613); the `e2e-edge` smoke job runs the exact published plugin-host
+image, not an in-CI build.
+
+The plugin-host image is reproducible locally from a nexus + nexus-vfs
+checkout (the nexus-vfs rev is pinned in the workspace `Cargo.toml`):
+
+```bash
+docker build \
+  -f dockerfiles/Dockerfile.nexusd-cluster-plugins \
+  --build-context nexus-vfs-src=../nexus-vfs \
+  --secret id=plugin_signing_key,env=PLUGIN_SIGNING_PRIVKEY \
+  -t nexusd-cluster:latest .
+```
+
+## Wiring
+
+1. Start the plugin host with the plugin dir enabled:
+
+   ```bash
+   docker run -d --name nexus-cluster \
+     -p 2126:2126 \
+     -v nexus-workspace:/workspace \
+     ghcr.io/nexi-lab/nexusd-cluster:stable \
+     --bind-addr 0.0.0.0:2126 \
+     --data-dir /app/data \
+     --plugin-dir /plugins
+   ```
+
+   (`--no-tls --insecure-no-auth` are available for trusted loopback
+   / compose topologies; production should keep TLS + auth on.)
+
+2. Point the server at it:
+
+   ```bash
+   -e NEXUS_SEARCH_PLUGIN_TARGET=<cluster-host>:2126
+   ```
+
+   The server's boot probe (`server/lifespan/search.py`) health-checks
+   the target with a 5 s timeout. Unreachable ⇒ search disabled for
+   the whole server lifetime with a loud warning; fix the wiring and
+   restart the server.
+
+3. **Shared filesystem**: on `NotifyFileChange` / `Index` the plugin
+   reads files **by absolute path through its own VFS/filesystem** —
+   the server and the plugin host must see the same bytes at the same
+   paths (shared volume in Docker, same host mount, or the kernel VFS
+   in federated topologies).
+
+## Environment reference (plugin host)
+
+Set these on the `nexusd-cluster` process — the plugin reads process
+env directly.
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `NEXUS_PLUGIN_DIR` | `/plugins` (in image) | `--plugin-dir` scan target |
+| `NEXUS_SEARCH_MODEL_DIR` | `<data>/plugins/search/models` | Local embedding model directory (see below) |
+| `ORT_DYLIB_PATH` | *(unset)* | Absolute path to `onnxruntime.{so,dylib,dll}`; **required** for local semantic search |
+| `NEXUS_SEARCH_BATCH_CONCURRENCY` | `4` (clamp 1..=16) | BatchQuery inner-query concurrency (#4610) |
+| `NEXUS_SEARCH_EMBED_API_URL` | *(unset)* | OpenAI-compatible `/v1/embeddings` endpoint; presence selects the remote embedder (#4614) |
+| `NEXUS_SEARCH_EMBED_MODEL` | — | Remote model name (required with URL) |
+| `NEXUS_SEARCH_EMBED_DIM` | — | Remote embedding dim (required with URL) |
+| `NEXUS_SEARCH_EMBED_API_KEY` | *(unset)* | Bearer token for the endpoint |
+| `NEXUS_SEARCH_EMBED_TIMEOUT_SECONDS` | `30` | Per-request timeout |
+
+And on the **server**:
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `NEXUS_SEARCH_PLUGIN_TARGET` | `127.0.0.1:2126` | gRPC dial target for the plugin |
+| `NEXUS_SEARCH_DAEMON` | auto (on when a DB URL is present) | `true`/`false` force search proxy on/off |
+
+## Plugin signing
+
+The kernel **refuses unsigned plugins** — `PluginLoader` verifies an
+Ed25519 detached signature (`<plugin>.so.sig` next to the dylib)
+against compile-time trusted keys. The published image ships the
+signed pair; if you build your own, sign with
+`scripts/sign_plugin.py` and a key the kernel trusts (CI uses the
+`PLUGIN_SIGNING_PRIVKEY` secret). An unsigned or foreign-signed
+plugin is skipped at `--plugin-dir` scan time and search stays down.
+
+## Embedding backends and model provisioning
+
+Keyword (BM25/tantivy) search works out of the box. The **semantic /
+hybrid lane needs an embedder**, one of:
+
+### Local ONNX (default)
+
+The plugin loads `multilingual-e5-small` (384-dim) from
+`NEXUS_SEARCH_MODEL_DIR`. Provision the directory with the layout a
+`huggingface-cli download intfloat/multilingual-e5-small` produces:
+
+```text
+<model-dir>/
+  model.onnx
+  tokenizer.json
+  config.json
+  special_tokens_map.json
+  tokenizer_config.json
+```
+
+and set `ORT_DYLIB_PATH` to a matching ONNX Runtime library (1.19+
+for the pinned ort 2.0 rc). Neither the model nor the ORT dylib is
+baked into the published image (size + licensing); mount them and set
+the two env vars. Missing model/dylib degrades gracefully: semantic
+queries return a typed "unavailable" error, keyword search keeps
+working.
+
+### Remote / API (#4614)
+
+Set `NEXUS_SEARCH_EMBED_API_URL` + `_MODEL` + `_DIM` (+ `_API_KEY`)
+and the plugin embeds via any OpenAI-compatible endpoint instead of
+local ONNX — no model files or ORT dylib needed. This is the
+migration path for deployments whose corpus quality was tuned on API
+embeddings (e.g. 1536-dim models) under the pre-P12 stack. A
+configured remote endpoint wins over the local model; a partially
+configured one (URL without model/dim) fails loudly rather than
+silently falling back.
+
+## Migrating a pre-P12 corpus
+
+The pre-P12 stack embedded via API models into pgvector; the post-P12
+plugin owns its own tantivy (FTS) + HNSW (ANN) indices under
+`<data>/plugins/search/<zone>/`. There is **no index migration** — a
+corpus indexed under the previous stack must be **fully reindexed**
+after the upgrade (`nexus reindex --target search`, then
+`nexus search index <path>` or your indexing pipeline).
+
+Choose the embedding backend **before** reindexing:
+
+- **Local mE5-small (384-dim)**: zero external dependencies, but a
+  different (generally weaker) vector space than 1536-dim API models —
+  re-validate retrieval quality and fusion tuning (`alpha`, etc.) on
+  your own eval set.
+- **Remote/API embedder pointed at your previous model**: preserves
+  the vector space your tuning was measured on. The ANN index is
+  still rebuilt (different storage engine), but embedding quality is
+  unchanged.
+
+The ANN directory tag encodes the embedder (`ann-<tag>-v<n>`, e.g.
+`ann-mE5-small-v1-v2` or `ann-api-text-embedding-3-small-1536-v2`), so
+switching embedders later re-tags and rebuilds alongside the old
+directory instead of corrupting it.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -211,5 +211,6 @@ nav:
     - SANDBOX Profile: deployment/sandbox-profile.md
     - MCP Hub Mode: deployment/mcp-hub-mode.md
     - S3 / R2 Payload Backend: deployment/s3-r2-payload-backend.md
+    - Search Plugin (post-P12): deployment/search-plugin.md
     - Hub Deploy: hub-deploy.md
     - Hub Deploy on Kubernetes: hub-deploy-k8s.md


### PR DESCRIPTION
Closes #4613.

## Problem

Post-P12 (#4598) the Rust `nexus-search-plugin` cdylib hosted by `nexusd-cluster` is the **sole** search backend, but `docker-publish.yml` only published the Python-server image. The plugin-host image existed solely as an in-workflow build for the e2e smoke — so **every published tag shipped with no working search out of the box** (the boot probe fail-softs and disables search), and the smoke passed using an artifact the public can't pull.

## Changes

### 1. Publish the plugin-host image (issue ask 1)

New self-contained `dockerfiles/Dockerfile.nexusd-cluster-plugins`:
- cluster binary built from the `Cargo.toml`-pinned nexus-vfs rev (`nexus-vfs-src` build context, same convention as the existing files),
- plugin cdylib built from this repo and Ed25519-signed in-build (BuildKit secret, never a layer),
- one runtime image with the signed pair in `/plugins` and `NEXUS_PLUGIN_DIR` preset.

Self-contained (vs the CI-only `Dockerfile.search-plugin-test` which layers on a locally pre-built base) so one `docker build` reproduces the published artifact with any buildx driver — that's what makes push-by-digest multi-arch publishing possible. Reciprocal KEEP-IN-SYNC notes added to the two siblings.

New `build-cluster-platform` (amd64 + arm64, native runners, push-by-digest — same pattern as the server image jobs) and `push-cluster-manifest` jobs publish `ghcr.io/nexi-lab/nexusd-cluster` with the **same tag rules** as the server image (`edge`, `stable`/`latest`/semver on tags, commit SHA) — every server tag gets a matching plugin-host tag from the same commit, pinnable by digest.

### 2. e2e-edge validates the published artifact (issue ask 3)

The sidecar steps drop the in-workflow `nexusd-cluster` + `search-plugin-test` builds (and the nexus-vfs checkout) and `docker run` the just-pushed image with the same single-node flags the compose bootstrap used (`--bind-addr 0.0.0.0:2126 --no-tls --insecure-no-auth --plugin-dir /plugins`, shared `/workspace` volume). The smoke now exercises the exact bytes the public pulls. (Full gating — pushing `stable`/`latest` only *after* the smoke — would need the tag push restructured to a post-e2e job; left as a follow-up, noted in the issue.)

### 3. Deployment contract docs (issue ask 2)

`docs/deployment/search-plugin.md` (+ mkdocs nav): required processes and the image pairing, `NEXUS_SEARCH_PLUGIN_TARGET` wiring + the 5s fail-soft boot probe, the shared-filesystem requirement, plugin signing expectations, env reference for plugin host + server, model provisioning (`NEXUS_SEARCH_MODEL_DIR` layout, `ORT_DYLIB_PATH`), the remote/API embedder alternative (#4614 / PR #4619), and the migration story for pre-P12 corpora (full reindex either way; remote embedder preserves the tuned vector space).

## Validation

- `actionlint` clean on the workflow; YAML parses.
- `docker build --check` clean on the new Dockerfile.
- The new Dockerfile's stages are line-for-line mirrors of `Dockerfile.nexusd-cluster` + `Dockerfile.search-plugin-test`, which PR CI (search-plugin-e2e) builds continuously — the publish workflow itself only runs on develop/tag pushes, so the first develop push after merge is the live validation; the cluster-image jobs are additive and can't break the existing server-image publish path (`e2e-edge` now needs `push-cluster-manifest`, which is the point).

⚠️ Reviewer note: first run publishes a new GHCR package `nexusd-cluster` — it may need package visibility set to public in org settings (GHCR defaults inherit from repo; if the first pull 403s, that's why).