### PR TITLE
search-plugin: stem chunk_text with en_stem + fts-v2 index bump (#4618)

### DIFF
--- a/rust/services/search-plugin/src/fts_index.rs
+++ b/rust/services/search-plugin/src/fts_index.rs
@@ -4,7 +4,7 @@
 //! # Storage layout
 //!
 //! Each zone has its own tantivy directory rooted at
-//! `~/.nexus/plugins/search/<zone_id>/fts/`.  The directory is
+//! `~/.nexus/plugins/search/<zone_id>/fts-v2/`.  The directory is
 //! plugin-owned, per-node, and NOT replicated — the SSOT for
 //! "what belongs in the index" is the kernel VFS itself, and the
 //! MetaStore `search.indexed_gen` sidecar (added in Phase 5)
@@ -18,9 +18,19 @@
 //! ```text
 //! path         STRING | STORED   exact match + retrievable
 //! chunk_index  I64    | STORED   integer, 0 in P1 (one chunk per file)
-//! chunk_text   TEXT   | STORED   BM25-analysed
+//! chunk_text   TEXT(en_stem) | STORED   BM25-analysed, English-stemmed
 //! mtime_ms     I64    | STORED   millisecond-resolution mtime
 //! ```
+//!
+//! `chunk_text` runs through tantivy's built-in `en_stem` analyzer
+//! (simple tokenizer + lowercase + English Porter stemmer) so
+//! morphological query variants match — `authorization` finds
+//! "authorized", matching the pre-P12 Postgres FTS behaviour that
+//! stemmed both sides (#4618).  The query parser resolves the same
+//! analyzer from the field config, so index and query time agree.
+//! This is an index-schema property: indices built with the
+//! pre-stemmer schema live under the old `fts/` directory and the
+//! manager opens `fts-v2/` instead — rebuild to populate.
 //!
 //! `mtime_ms` is STORED only in P1 (no INDEXED).  P6 flips it to
 //! `STORED | INDEXED` when recency queries land; INDEXED today would
@@ -57,7 +67,9 @@ use tantivy::collector::TopDocs;
 use tantivy::directory::MmapDirectory;
 use tantivy::query::QueryParser;
 use tantivy::query::TermQuery;
-use tantivy::schema::{Field, IndexRecordOption, Schema, Value, STORED, STRING, TEXT};
+use tantivy::schema::{
+    Field, IndexRecordOption, Schema, TextFieldIndexing, TextOptions, Value, STORED, STRING,
+};
 use tantivy::{doc, Index, IndexReader, IndexWriter, ReloadPolicy, TantivyDocument, Term};
 
 /// tantivy writer heap — 50 MiB is the conventional per-index budget
@@ -119,9 +131,20 @@ pub fn build_schema() -> Schema {
     // P4's chunker flips to `STORED | INDEXED` when composite-key
     // dedupe by (path, chunk_index) lands.
     sb.add_i64_field("chunk_index", STORED);
-    // chunk_text — BM25-analysed.  Default TEXT = lowercase + simple
-    // tokeniser; P4 replaces this with a language-aware chain.
-    sb.add_text_field("chunk_text", TEXT | STORED);
+    // chunk_text — BM25-analysed through `en_stem` (simple tokenizer
+    // + lowercase + English Porter stemmer; pre-registered in
+    // tantivy's default TokenizerManager).  The default TEXT chain
+    // has no stemmer, which cost the keyword lane every
+    // morphological-variant query vs the pre-P12 Postgres stack
+    // (#4618: `authorization` vs "authorized" → 0 hits).
+    let chunk_text_opts = TextOptions::default()
+        .set_indexing_options(
+            TextFieldIndexing::default()
+                .set_tokenizer("en_stem")
+                .set_index_option(IndexRecordOption::WithFreqsAndPositions),
+        )
+        .set_stored();
+    sb.add_text_field("chunk_text", chunk_text_opts);
     // mtime_ms — STORED only in P1.  P6 lifts to `STORED | INDEXED`
     // when recency range queries land; indexing today would build a
     // range structure nothing queries.
@@ -452,6 +475,43 @@ mod tests {
         assert_eq!(hits[0].chunk_index, 0);
         assert_eq!(hits[0].mtime_ms, Some(1_700_000_000_000));
         assert!(hits[0].score > 0.0);
+    }
+
+    #[test]
+    fn morphological_query_variants_match_stemmed_corpus_terms() {
+        // #4618: the pre-P12 Postgres FTS stack stems both sides
+        // (`authorization` → `authoriz` → matches "authorized"); the
+        // tantivy default tokenizer does not, so natural-language
+        // morphological variants of corpus terms returned 0 hits.
+        // `chunk_text` uses the `en_stem` analyzer — same lowercase +
+        // simple-tokenize chain plus an English stemmer, applied at
+        // index AND query time via the field's tokenizer config.
+        let dir = tempdir().join("fts");
+        let idx = FtsIndex::open_or_create(dir).expect("open");
+        idx.add_document("/d09.md", 0, "access was authorized by the admin", Some(1))
+            .expect("add");
+        idx.add_document("/d05.md", 0, "the engineering team shipped it", Some(2))
+            .expect("add");
+        idx.add_document("/d13.md", 0, "swap the battery pack first", Some(3))
+            .expect("add");
+        idx.commit().expect("commit");
+
+        for (query, want_path) in [
+            ("authorization", "/d09.md"),
+            ("engineers", "/d05.md"),
+            ("batteries", "/d13.md"),
+            // Exact-form controls — must keep matching post-stemmer.
+            ("authorized", "/d09.md"),
+            ("engineering", "/d05.md"),
+        ] {
+            let hits = idx.search(query, 10, None).expect("search");
+            assert_eq!(
+                hits.len(),
+                1,
+                "query {query:?}: expected 1 hit, got {hits:?}"
+            );
+            assert_eq!(hits[0].path, want_path, "query {query:?}");
+        }
     }
 
     #[test]

--- a/rust/services/search-plugin/src/index_manager.rs
+++ b/rust/services/search-plugin/src/index_manager.rs
@@ -23,7 +23,7 @@
 //!
 //! # Storage roots
 //!
-//! The directory layout is `<root>/<zone_id>/fts/`.  Root resolves
+//! The directory layout is `<root>/<zone_id>/fts-v2/`.  Root resolves
 //! from the `NEXUS_DATA_DIR` env var (same convention as
 //! [`nexus-vault`]'s per-node state), falling back to `./nexus-data`
 //! when unset — one SSOT lets operators relocate ALL plugins by
@@ -49,7 +49,14 @@ use crate::fts_index::{FtsIndex, IndexError};
 /// Directory name inside a per-zone index root for the FTS store.
 /// Sibling directories (Phase 2's `ann/` for HNSW, etc.) land next
 /// to this one under the same zone root.
-const FTS_SUBDIR: &str = "fts";
+///
+/// The `v2` bump marks the #4618 schema change (`chunk_text` moved
+/// from the default tokenizer to `en_stem`) — same convention as
+/// `ann-<tag>-v2`: pre-stemmer `fts/` dirs stay on disk untouched
+/// while callers converge on v2.  Reindex to populate (the
+/// `index_state` version bump forces exactly that on the next
+/// Refresh).
+const FTS_SUBDIR: &str = "fts-v2";
 
 /// Environment variable that names the per-node state root.  Same
 /// SSOT the sibling `nexus-vault` plugin honours — one variable
@@ -213,8 +220,8 @@ mod tests {
         let _ = mgr.get_or_open("zone-a").expect("open a");
         let _ = mgr.get_or_open("zone-b").expect("open b");
 
-        assert!(root.join("zone-a/fts").exists(), "za dir not created");
-        assert!(root.join("zone-b/fts").exists(), "zb dir not created");
+        assert!(root.join("zone-a/fts-v2").exists(), "za dir not created");
+        assert!(root.join("zone-b/fts-v2").exists(), "zb dir not created");
     }
 
     // NEXUS_DATA_DIR resolution regression tests.  Use `unsafe { set_var }`
@@ -252,6 +259,17 @@ mod tests {
             Some(v) => unsafe { std::env::set_var(DATA_DIR_ENV, v) },
             None => unsafe { std::env::remove_var(DATA_DIR_ENV) },
         }
+    }
+
+    #[test]
+    fn fts_dir_versioned_v2() {
+        // #4618's en_stem tokenizer is an index-schema change — same
+        // convention as ann-<tag>-v2: new dir alongside the old one,
+        // pre-stemmer `fts/` dirs stay on disk untouched, a reindex
+        // populates v2.
+        let root = tempdir();
+        let mgr = IndexManager::with_root(root.clone());
+        assert_eq!(mgr.index_dir("za"), root.join("za/fts-v2"));
     }
 
     #[test]

--- a/rust/services/search-plugin/src/index_state.rs
+++ b/rust/services/search-plugin/src/index_state.rs
@@ -31,7 +31,7 @@
 //!
 //! # File layout
 //!
-//! `<root>/<zone_id>/index_state.json` — a sibling of the `fts/` +
+//! `<root>/<zone_id>/index_state.json` — a sibling of the `fts-v2/` +
 //! `ann-*-v2/` directories under the per-zone root.  Atomic rewrite
 //! via write-then-rename so a mid-write crash never leaves a
 //! truncated file that would break the next open.
@@ -55,10 +55,16 @@ use serde::{Deserialize, Serialize};
 /// derived-state; this is meta about them).
 const STATE_FILE: &str = "index_state.json";
 
-/// On-disk schema.  `version` bump semantics same as
-/// `ann_index::Sidecar`: a schema drift refuses to load and the
-/// operator drops-and-reindexes.
-const STATE_VERSION: u32 = 1;
+/// On-disk schema version.  A mismatched on-disk version loads as
+/// EMPTY (not an error): the cache is derived state, and a version
+/// bump signals the indices it describes were invalidated — an empty
+/// cache makes the next Refresh re-index everything into the new
+/// layout.  Preserving the old cache instead would report Unchanged
+/// for every file and leave the fresh index silently empty.
+///
+/// v1 → v2: #4618 `en_stem` schema change moved the FTS store from
+/// `fts/` to `fts-v2/`; v1 caches describe the abandoned v1 dir.
+const STATE_VERSION: u32 = 2;
 
 fn state_version_default() -> u32 {
     STATE_VERSION
@@ -105,15 +111,20 @@ impl IndexState {
             let persisted: Persisted = serde_json::from_slice(&bytes)
                 .map_err(|e| StateError::Parse(path.display().to_string(), e.to_string()))?;
             if persisted.version != STATE_VERSION {
-                return Err(StateError::Parse(
-                    path.display().to_string(),
-                    format!(
-                        "state version {} != expected {}; drop and reindex",
-                        persisted.version, STATE_VERSION
-                    ),
-                ));
+                // Stale layout generation (see STATE_VERSION doc):
+                // start empty so the next Refresh re-indexes the
+                // whole corpus into the current index layout.  The
+                // next save() rewrites the file at the new version.
+                tracing::warn!(
+                    on_disk = persisted.version,
+                    expected = STATE_VERSION,
+                    path = %path.display(),
+                    "index_state version mismatch — resetting mtime cache; next refresh reindexes",
+                );
+                HashMap::new()
+            } else {
+                persisted.files
             }
-            persisted.files
         } else {
             HashMap::new()
         };
@@ -339,6 +350,24 @@ mod tests {
             let _ = s.verdict(p, Some(1));
         }
         assert_eq!(paths, vec!["/a.md".to_string()]);
+    }
+
+    #[test]
+    fn stale_on_disk_version_loads_as_empty_not_error() {
+        // Index-layout bumps (fts → fts-v2, #4618) must invalidate
+        // this cache: a preserved v1 cache reports Unchanged for
+        // every file and the fresh (empty) index never repopulates.
+        // The cache is derived state — an old version loads as EMPTY
+        // (full reindex on next Refresh) rather than erroring.
+        let dir = tempdir();
+        std::fs::write(
+            dir.join(STATE_FILE),
+            r#"{"version":1,"files":{"/a.md":{"mtime_ms":123}}}"#,
+        )
+        .expect("write stale-version state");
+        let s = IndexState::open_or_create(dir).expect("open must not error");
+        assert!(s.is_empty(), "stale-version cache must reset to empty");
+        assert_eq!(s.cached_mtime("/a.md"), None);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

#4618: keyword-lane hit@1 dropped 0.733 → 0.400 vs the pre-P12 Postgres stack. Root cause (isolated in the issue): the plugin's tantivy index tokenizes `chunk_text` with the default chain — lowercase + split, **no stemmer** — so morphological query variants return zero hits (`authorization` misses "authorized", `engineers` misses "engineering", `batteries` misses "battery"). Postgres FTS stemmed both sides.

## Fix

- **`fts_index.rs`** — `chunk_text` now indexes through tantivy's built-in `en_stem` analyzer (simple tokenizer + lowercase + English Porter stemmer, pre-registered in the default `TokenizerManager`). `QueryParser` resolves the analyzer from the field config, so index and query time agree; `IndexRecordOption::WithFreqsAndPositions` kept (same as the old default TEXT), so phrase queries still work.
- **`index_manager.rs`** — index-schema change ⇒ FTS dir bumped `fts/` → `fts-v2/`, same convention as `ann-<tag>-v2`. Pre-stemmer dirs stay on disk untouched; opening the old dir with the new schema would error anyway.
- **`index_state.rs`** — `STATE_VERSION` 1 → 2, and a mismatched on-disk version now loads as **empty** instead of erroring. Without this, the preserved mtime cache reports `Unchanged` for every file and the fresh `fts-v2` index stays silently empty forever. Empty cache ⇒ next Refresh re-indexes the whole corpus into the new layout — the rebuild the issue calls for, with no operator action.

## Tests (TDD — all three watched fail first)

- `morphological_query_variants_match_stemmed_corpus_terms` — the issue's probe table verbatim (`authorization`/`engineers`/`batteries` + exact-form controls). Failed pre-fix with `query "authorization": expected 1 hit, got []`.
- `fts_dir_versioned_v2` — layout contract.
- `stale_on_disk_version_loads_as_empty_not_error` — the cache-invalidation coupling.

`cargo test -p nexus-search-plugin`: 123 lib + 32 e2e tests pass. `cargo fmt --check` clean. Clippy findings in `ann_index.rs`/e2e mocks are pre-existing and untouched.

## Operational note

First Refresh after deploy re-indexes each zone's full corpus (FTS + ANN re-embed) — one-time cost, same as any drop-and-rebuild. Old `fts/` dirs are left on disk and can be GC'd manually.

Closes #4618