### PR TITLE
search: wire path_contexts weights into QueryRequest.path_prefix_boosts (#4620)

### DIFF
--- a/rust/services/search-plugin/src/scoring.rs
+++ b/rust/services/search-plugin/src/scoring.rs
@@ -157,6 +157,14 @@ pub fn apply_recency(
 /// multiply the score by that entry's multiplier.  No matching
 /// prefix ⇒ score unchanged (multiplier 1.0).
 ///
+/// A key ending in `/` also matches the path that EQUALS the key
+/// minus that trailing slash (#4620): the server wraps stored
+/// path-context prefixes as `/{p}/` for slash-boundary safety, and a
+/// row whose prefix names an exact file (`/notes/hello.md/` after
+/// wrapping) must still boost that file — the pre-P12 stack matched
+/// it via `path == prefix` equality.  Plain `starts_with` keys keep
+/// their raw semantics.
+///
 /// Longest-match semantics matter when boosts overlap
 /// (`/docs/` = 1.5, `/docs/api/` = 2.0) — the more specific
 /// prefix wins.  Ties (same length) break arbitrarily but stably
@@ -168,7 +176,10 @@ pub fn apply_prefix_boost(hits: &mut [QueryResult], boosts: &HashMap<String, f32
     for hit in hits.iter_mut() {
         let best = boosts
             .iter()
-            .filter(|(prefix, _)| hit.path.starts_with(prefix.as_str()))
+            .filter(|(prefix, _)| {
+                hit.path.starts_with(prefix.as_str())
+                    || (prefix.ends_with('/') && hit.path == prefix[..prefix.len() - 1])
+            })
             .max_by_key(|(prefix, _)| prefix.len());
         if let Some((_, &multiplier)) = best {
             hit.score *= multiplier;
@@ -347,6 +358,39 @@ mod tests {
     }
 
     // ── apply_prefix_boost ─────────────────────────────────────
+
+    #[test]
+    fn prefix_boost_trailing_slash_key_matches_exact_file_path() {
+        // #4620 parity: the server wraps stored path_contexts prefixes
+        // as "/{p}/" for slash-boundary safety.  A row whose prefix
+        // names an exact FILE ("/notes/hello.md/" after wrapping) must
+        // still boost that file — pre-P12 matched it via
+        // `path == prefix` equality.
+        let mut hits = vec![hit("/notes/hello.md", 1.0, None)];
+        let mut boosts = HashMap::new();
+        boosts.insert("/notes/hello.md/".to_string(), 3.0);
+        apply_prefix_boost(&mut hits, &boosts);
+        assert!(
+            (hits[0].score - 3.0).abs() < 1e-6,
+            "exact-file trailing-slash key must boost, got {}",
+            hits[0].score
+        );
+    }
+
+    #[test]
+    fn prefix_boost_trailing_slash_key_does_not_leak_to_siblings() {
+        // The boundary guarantee that motivated the "/{p}/" wrapping:
+        // "/docs/" must not touch "/docs-v2/…" or "/docsfile.md".
+        let mut hits = vec![
+            hit("/docs-v2/x.md", 1.0, None),
+            hit("/docsfile.md", 1.0, None),
+        ];
+        let mut boosts = HashMap::new();
+        boosts.insert("/docs/".to_string(), 5.0);
+        apply_prefix_boost(&mut hits, &boosts);
+        assert!((hits[0].score - 1.0).abs() < 1e-6, "sibling dir leaked");
+        assert!((hits[1].score - 1.0).abs() < 1e-6, "sibling file leaked");
+    }
 
     #[test]
     fn prefix_boost_empty_map_is_noop() {

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -99,6 +99,7 @@ class SearchDaemon:
             recency_mode=request.recency or "",
             recency_weight=request.recency_weight or 0.0,
             recency_half_life_days=request.recency_half_life_days or 0.0,
+            path_prefix_boosts=request.path_prefix_boosts or {},
         )
         resp = await self._get_stub().Query(req)
         if resp.HasField("error"):
@@ -118,6 +119,7 @@ class SearchDaemon:
                 limit=r.limit,
                 path_filter=r.path_filter or "",
                 query_type=_QUERY_TYPE_MAP.get(r.search_type, search_pb2.QUERY_TYPE_UNSPECIFIED),
+                path_prefix_boosts=r.path_prefix_boosts or {},
             )
             for r in requests
         ]

--- a/src/nexus/bricks/search/federated_search.py
+++ b/src/nexus/bricks/search/federated_search.py
@@ -284,12 +284,18 @@ class FederatedSearchDispatcher:
         *,
         registry: Any | None = None,
         enable_per_file_rebac: bool = False,
+        path_prefix_boosts_resolver: Any | None = None,
     ):
         self._daemon = daemon  # Default/fallback daemon
         self._rebac = rebac
         self._config = config or FederatedSearchConfig()
         self._registry = registry  # Phase 2: ZoneSearchRegistry
         self._enable_per_file_rebac = enable_per_file_rebac  # Phase 2: per-file filtering
+        # #4620: async callable ``zone_id -> dict[prefix_key, weight]``
+        # supplying each LOCAL leg's path-context tier weights (the
+        # caller owns store access; the router passes
+        # ``_resolve_path_prefix_boosts``). None = legs run unboosted.
+        self._path_prefix_boosts_resolver = path_prefix_boosts_resolver
         # Zone discovery cache: subject_key -> (zones, expiry_time)
         self._zone_cache: dict[str, tuple[list[str], float]] = {}
         # Phase 3: Result cache: cache_key -> (response, expiry_time)
@@ -437,7 +443,23 @@ class FederatedSearchDispatcher:
                 subject=subject,
             )
 
-        # Local zone: call daemon.search() directly
+        # Local zone: call daemon.search() directly.
+        # #4620: each local leg carries ITS zone's path-context tier
+        # weights. Remote legs stay unboosted — the remote RPC surface
+        # drops every search param today (#4556 above), and the remote
+        # node's own rows belong to the remote deployment anyway.
+        # Fail-open: a resolver error costs the boost, never the leg.
+        path_prefix_boosts: dict[str, float] | None = None
+        if self._path_prefix_boosts_resolver is not None:
+            try:
+                path_prefix_boosts = await self._path_prefix_boosts_resolver(zone_id) or None
+            except Exception:
+                logger.warning(
+                    "path-prefix boost resolution failed for zone %r; leg runs unboosted",
+                    zone_id,
+                    exc_info=True,
+                )
+
         daemon = self._get_daemon_for_zone(zone_id)
         results = await daemon.search(
             SearchRequest(
@@ -452,6 +474,7 @@ class FederatedSearchDispatcher:
                 recency_weight=recency_weight,
                 recency_half_life_days=recency_half_life_days,
                 zone_id=zone_id,
+                path_prefix_boosts=path_prefix_boosts,
             )
         )
 

--- a/src/nexus/bricks/search/path_context.py
+++ b/src/nexus/bricks/search/path_context.py
@@ -258,10 +258,12 @@ def prefix_boosts_from_records(
       child subtree keeps exempting itself from a weighted parent. A zone
       with no effective weights returns ``{}`` so the plugin skips its
       boost-and-resort pass entirely.
-    - Known gap: a row whose prefix names an exact FILE path used to boost
-      that file via ``path == prefix`` equality; ``/{p}/`` cannot express
-      that without un-bounded ``starts_with`` leaks, so file-exact rows do
-      not boost under P12.
+    - File-exact rows: a row whose prefix names an exact FILE path boosts
+      it via the plugin's trailing-slash rule (#4620) — a key ending in
+      ``/`` also matches the path equal to the key minus that slash, so
+      ``/{p}/`` covers both the subtree and the exact-path case without
+      un-bounded ``starts_with`` leaks. (Plugins older than that rule
+      simply miss exact-file boosts — same as before the fix.)
     """
     if not any(r.weight is not None and r.weight != 1.0 for r in records):
         return {}

--- a/src/nexus/bricks/search/path_context.py
+++ b/src/nexus/bricks/search/path_context.py
@@ -237,6 +237,41 @@ def lookup_in_records(records: builtins.list[PathContextRecord], path: str) -> s
     return record.description if record is not None else None
 
 
+def prefix_boosts_from_records(
+    records: builtins.list[PathContextRecord],
+) -> dict[str, float]:
+    """Map a zone's path_contexts rows onto ``QueryRequest.path_prefix_boosts`` (#4620).
+
+    The P12 plugin applies the longest plain-``starts_with``-matching key's
+    multiplier post-fusion (``scoring.rs``). Stored prefixes are slash-free
+    canonical (``_normalize_prefix``) while plugin hit paths arrive
+    slash-prefixed, so keys are rewrapped as ``/{prefix}/`` to keep matches
+    on directory boundaries (``docs`` must not boost ``/docs-v2/…``). The
+    empty prefix stays ``""`` — it matches every path, the zone-wide row.
+
+    Pre-P12 parity notes:
+
+    - The longest matching RECORD won even when it carried no weight (the
+      multiplier defaulted to 1.0), shadowing shorter weighted prefixes.
+      When any row carries an effective weight != 1.0 the whole zone's rows
+      are emitted (weightless rows as explicit 1.0) so a description-only
+      child subtree keeps exempting itself from a weighted parent. A zone
+      with no effective weights returns ``{}`` so the plugin skips its
+      boost-and-resort pass entirely.
+    - Known gap: a row whose prefix names an exact FILE path used to boost
+      that file via ``path == prefix`` equality; ``/{p}/`` cannot express
+      that without un-bounded ``starts_with`` leaks, so file-exact rows do
+      not boost under P12.
+    """
+    if not any(r.weight is not None and r.weight != 1.0 for r in records):
+        return {}
+    boosts: dict[str, float] = {}
+    for record in records:
+        key = "" if record.path_prefix == "" else f"/{record.path_prefix}/"
+        boosts[key] = float(record.weight) if record.weight is not None else 1.0
+    return boosts
+
+
 def _coerce_datetime(value: Any) -> datetime:
     """SQLite + aiosqlite can return datetimes as ISO strings; normalize to datetime."""
     if isinstance(value, datetime):

--- a/src/nexus/contracts/search_types.py
+++ b/src/nexus/contracts/search_types.py
@@ -97,6 +97,13 @@ class SearchRequest:
     # their own embed attempt (hybrid degrades to keyword-only immediately)
     # instead of re-hammering a degraded embedding provider once per query.
     embedding_unavailable: bool = False
+    # Path-prefix score multipliers applied post-fusion by the plugin
+    # (#4544 tier boost, rewired for P12 in #4620). Keys are in the
+    # plugin's wire shape — slash-wrapped directory prefixes ("/docs/")
+    # or "" for zone-wide — longest starts_with match wins. None/{} skips
+    # the plugin's boost pass entirely. Built from the zone's
+    # path_contexts rows by ``prefix_boosts_from_records``.
+    path_prefix_boosts: dict[str, float] | None = None
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/src/nexus/server/api/v2/routers/search.py
+++ b/src/nexus/server/api/v2/routers/search.py
@@ -674,11 +674,18 @@ async def _handle_federated_search(
 
     registry = getattr(request.app.state, "zone_search_registry", None)
     per_file_rebac = getattr(request.app.state, "federated_per_file_rebac", True)
+
+    # #4620: each local federated leg gets its zone's path-context tier
+    # weights, resolved through the same cache the single-zone path uses.
+    async def _boosts_for_zone(zone_id: str) -> dict[str, float]:
+        return await _resolve_path_prefix_boosts(request, zone_id)
+
     dispatcher = FederatedSearchDispatcher(
         daemon=search_daemon,
         rebac=rebac,
         registry=registry,
         enable_per_file_rebac=per_file_rebac,
+        path_prefix_boosts_resolver=_boosts_for_zone,
     )
     fed_response = await dispatcher.search(
         query=q,

--- a/src/nexus/server/api/v2/routers/search.py
+++ b/src/nexus/server/api/v2/routers/search.py
@@ -341,6 +341,73 @@ async def search_query(
     return await run_zone_scoped(_get_zone_registry(request), target_zone, _work)
 
 
+async def _resolve_path_prefix_boosts(request: Request, zone_id: str | None) -> dict[str, float]:
+    """Load the zone's path_contexts weight rows into the plugin's boost map (#4620).
+
+    Pre-P12 the daemon applied tier weights itself post-fusion (#4544);
+    post-P12 the plugin owns that pass but only sees what the server stamps
+    into ``QueryRequest.path_prefix_boosts`` — without this resolver the
+    weight rows are dead config (CRUD works, ranking silently ignores them).
+
+    Rows are served through a per-event-loop :class:`PathContextCache`
+    (fingerprint-checked, so an upsert is visible on the next query without
+    a per-request full table scan). Fail-open: any store or lookup error
+    logs once and returns ``{}`` — search must keep working unboosted.
+    """
+    import asyncio
+
+    from nexus.bricks.search.path_context import PathContextCache, prefix_boosts_from_records
+    from nexus.contracts.constants import ROOT_ZONE_ID
+
+    try:
+        from nexus.server.api.v2.routers.path_contexts import _get_store
+
+        store = await _get_store(request)
+    except HTTPException:
+        # No DB URL and no injected store — this deployment has no
+        # path-context storage at all, so there are no rows to apply.
+        return {}
+    except Exception:
+        logger.warning(
+            "path-context store unavailable; searching without tier boosts",
+            exc_info=True,
+        )
+        return {}
+
+    try:
+        # One cache per event loop, mirroring _get_store's per-loop store
+        # discipline (same loop ⇒ same store ⇒ the cache never mixes
+        # engines across loops).
+        loop = asyncio.get_running_loop()
+        caches: dict[Any, PathContextCache] | None = getattr(
+            request.app.state, "_search_prefix_boost_caches", None
+        )
+        if caches is None:
+            caches = {}
+            request.app.state._search_prefix_boost_caches = caches
+        for stale in [lk for lk in caches if not hasattr(lk, "is_closed") or lk.is_closed()]:
+            caches.pop(stale, None)
+        cache = caches.get(loop)
+        if cache is None:
+            cache = PathContextCache(store=store)
+            caches[loop] = cache
+
+        effective_zone = zone_id or ROOT_ZONE_ID
+        await cache.refresh_if_stale(effective_zone)
+        return prefix_boosts_from_records(cache.snapshot_zone(effective_zone) or [])
+    except Exception:
+        # Warn once per process, not per query — a deployment whose DB
+        # lacks the path_contexts table would otherwise log on every
+        # search. Once is enough to surface the dead-config risk.
+        if not getattr(request.app.state, "_prefix_boost_resolution_warned", False):
+            request.app.state._prefix_boost_resolution_warned = True
+            logger.warning(
+                "path-context boost resolution failed; searching without tier boosts",
+                exc_info=True,
+            )
+        return {}
+
+
 async def _handle_single_zone_search(
     *,
     request: Request,
@@ -467,6 +534,11 @@ async def _handle_single_zone_search(
                 response["routing"] = routing_info
             return response
 
+        # #4620: stamp the zone's path_contexts weight rows onto the
+        # request — the plugin applies them post-fusion (longest-prefix
+        # multiplier) and keys its query cache on them.
+        path_prefix_boosts = await _resolve_path_prefix_boosts(request, zone_id)
+
         results = await search_daemon.search(
             SearchRequest(
                 query=q,
@@ -481,6 +553,7 @@ async def _handle_single_zone_search(
                 recency=recency,
                 recency_weight=recency_weight,
                 recency_half_life_days=recency_half_life_days,
+                path_prefix_boosts=path_prefix_boosts or None,
             )
         )
 

--- a/tests/e2e/self_contained/test_search_surface_live_e2e.py
+++ b/tests/e2e/self_contained/test_search_surface_live_e2e.py
@@ -40,11 +40,38 @@ def _resolve_cluster_binary() -> Path | None:
     return None
 
 
+def _resolve_search_plugin_dylib() -> Path | None:
+    """Worktree build of the Rust search plugin, if present.
+
+    When found, the fixture loads it into the spawned kernel via
+    ``NEXUS_PLUGIN_DIR`` and points the app's SearchDaemon at the
+    kernel's gRPC listener — the /search surface then runs against the
+    REAL plugin instead of 503ing. Build with
+    ``cargo build -p nexus-search-plugin``.
+    """
+    root = _repo_root()
+    for directory in (
+        root / "rust" / "target" / "release",
+        root / "rust" / "target" / "debug",
+        root / "target" / "release",
+        root / "target" / "debug",
+    ):
+        for name in ("libnexus_search_plugin.dylib", "libnexus_search_plugin.so"):
+            candidate = directory / name
+            if candidate.exists():
+                return candidate
+    return None
+
+
 @dataclass
 class LiveSearchApp:
     client: TestClient
     nx: Any
     headers: dict[str, str]
+    # True when the worktree search-plugin dylib was loaded into the
+    # spawned kernel — tests that need real plugin-backed /search
+    # endpoints skip when False instead of asserting into 503s.
+    plugin_loaded: bool = False
 
 
 @pytest.fixture()
@@ -62,6 +89,37 @@ def live_search_app(
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
     (bin_dir / "nexus-cluster").symlink_to(cluster)
+
+    # Load the worktree search-plugin dylib into the spawned kernel when
+    # available (#4620). Must be set BEFORE nexus.connect — the kernel
+    # scans NEXUS_PLUGIN_DIR at boot. The kernel refuses unsigned
+    # plugins, so detach-sign the dylib with an ephemeral test-local
+    # Ed25519 key and trust it via NEXUS_LOCAL_TRUSTED_KEYS_DIR (the
+    # loader's documented local-trust extension point; format contract
+    # matches scripts/sign_plugin.py).
+    plugin_dylib = _resolve_search_plugin_dylib()
+    if plugin_dylib is not None:
+        import base64
+
+        from cryptography.hazmat.primitives import serialization
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+        plugins_dir = tmp_path / "plugins"
+        plugins_dir.mkdir()
+        (plugins_dir / plugin_dylib.name).symlink_to(plugin_dylib)
+        signing_key = Ed25519PrivateKey.generate()
+        (plugins_dir / (plugin_dylib.name + ".sig")).write_bytes(
+            signing_key.sign(plugin_dylib.read_bytes())
+        )
+        trust_dir = tmp_path / "trusted_keys"
+        trust_dir.mkdir()
+        pub_raw = signing_key.public_key().public_bytes(
+            encoding=serialization.Encoding.Raw,
+            format=serialization.PublicFormat.Raw,
+        )
+        (trust_dir / "live-e2e.pub").write_text(base64.b64encode(pub_raw).decode() + "\n")
+        monkeypatch.setenv("NEXUS_PLUGIN_DIR", str(plugins_dir))
+        monkeypatch.setenv("NEXUS_LOCAL_TRUSTED_KEYS_DIR", str(trust_dir))
 
     monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}")
     monkeypatch.setenv("NEXUS_ENFORCE_PERMISSIONS", "false")
@@ -85,6 +143,18 @@ def live_search_app(
             "enforce_permissions": False,
         }
     )
+
+    # The plugin's SearchService rides the kernel's own gRPC listener
+    # (Phase P routing), which binds a RANDOM free port locally — not the
+    # 2126 the SearchDaemon dials by default. Point the daemon at the
+    # spawned kernel before create_app's lifespan probes it.
+    plugin_loaded = False
+    if plugin_dylib is not None:
+        kernel_addr = getattr(getattr(nx, "_kernel", None), "_server_address", None)
+        if kernel_addr:
+            monkeypatch.setenv("NEXUS_SEARCH_PLUGIN_TARGET", str(kernel_addr))
+            plugin_loaded = True
+
     app = create_app(
         nexus_fs=nx,
         api_key="live-search-secret",
@@ -95,7 +165,13 @@ def live_search_app(
 
     try:
         with TestClient(app, raise_server_exceptions=False) as client:
-            yield LiveSearchApp(client=client, nx=nx, headers=headers)
+            # Decision #17 file-level ReBAC would deny every search hit for
+            # the test API key (no permission tuples are seeded), silently
+            # emptying /search/query responses. NEXUS_ENFORCE_PERMISSIONS
+            # only governs VFS ops, so null the search-path enforcer — this
+            # suite tests the search surface, not ReBAC.
+            app.state.permission_enforcer = None
+            yield LiveSearchApp(client=client, nx=nx, headers=headers, plugin_loaded=plugin_loaded)
     finally:
         close = getattr(nx, "close", None)
         if callable(close):
@@ -458,3 +534,122 @@ def test_live_batch_search_contract(live_search_app: LiveSearchApp) -> None:
         json={"queries": [{"q": f"q{i}"} for i in range(501)]},
     )
     assert oversize_response.status_code == 400
+
+
+def test_live_path_context_weight_moves_ranking(live_search_app: LiveSearchApp) -> None:
+    """A weighted path-context row must move ranking through the HTTP surface (#4620).
+
+    The exact differential-probe shape that caught the regression: two docs
+    matching the same rare term under different prefixes (one keyword-stronger
+    via repetition), then a ``weight: 10.0`` row upserted on the LOSER's
+    prefix must flip the order on the next query. Pre-fix the rows persisted
+    via CRUD but never reached ``QueryRequest.path_prefix_boosts``, so the
+    order (and scores) stayed identical.
+    """
+    live = live_search_app
+    if not live.plugin_loaded:
+        pytest.skip(
+            "requires the worktree search-plugin dylib; build it with "
+            "`cargo build -p nexus-search-plugin`"
+        )
+
+    live.nx.mkdir("/workspace", exist_ok=True)
+    live.nx.mkdir("/workspace/win", exist_ok=True)
+    live.nx.mkdir("/workspace/lose", exist_ok=True)
+    live.nx.write(
+        "/workspace/win/win.md",
+        b"zebrafly zebrafly zebrafly zebrafly keyword-strong doc\n",
+    )
+    live.nx.write("/workspace/lose/lose.md", b"zebrafly keyword-weak doc\n")
+
+    index_response, index_body = _request(
+        live,
+        "post",
+        "/api/v2/search/index",
+        max_wall_ms=15_000.0,
+        json={
+            "documents": [
+                {
+                    "id": "/workspace/win/win.md",
+                    "path": "/workspace/win/win.md",
+                    "text": "zebrafly zebrafly zebrafly zebrafly keyword-strong doc",
+                },
+                {
+                    "id": "/workspace/lose/lose.md",
+                    "path": "/workspace/lose/lose.md",
+                    "text": "zebrafly keyword-weak doc",
+                },
+            ]
+        },
+    )
+    assert index_response.status_code == 200
+    # Tolerate the count-shape drift tracked in #4617 (int pre-P12,
+    # {"indexed": …, "skipped": …} from the P12 proxy) — this test is
+    # about ranking, not the index response contract.
+    raw_count = index_body["count"]
+    indexed = raw_count["indexed"] if isinstance(raw_count, dict) else raw_count
+    assert indexed == 2, index_body
+
+    # Index visibility is eventually-consistent (#4623) — poll until both
+    # docs are queryable before asserting on order.
+    deadline = time.monotonic() + 5.0
+    before_paths: list[str] = []
+    while time.monotonic() < deadline:
+        before_response, before_body = _request(
+            live,
+            "get",
+            "/api/v2/search/query",
+            params={"q": "zebrafly", "type": "keyword", "limit": 5},
+        )
+        assert before_response.status_code == 200
+        before_paths = [r["path"] for r in before_body["results"]]
+        if len(before_paths) >= 2:
+            break
+        time.sleep(0.1)
+    assert before_paths[:2] == ["/workspace/win/win.md", "/workspace/lose/lose.md"], before_paths
+
+    put_response, _ = _request(
+        live,
+        "put",
+        "/api/v2/path-contexts/",
+        json={
+            "zone_id": "root",
+            "path_prefix": "workspace/lose",
+            "description": "tier-boosted loser prefix",
+            "weight": 10.0,
+        },
+    )
+    assert put_response.status_code == 200
+
+    after_response, after_body = _request(
+        live,
+        "get",
+        "/api/v2/search/query",
+        params={"q": "zebrafly", "type": "keyword", "limit": 5},
+    )
+    assert after_response.status_code == 200
+    after_paths = [r["path"] for r in after_body["results"]]
+    assert after_paths[:2] == ["/workspace/lose/lose.md", "/workspace/win/win.md"], (
+        f"weight 10.0 on the loser prefix must flip the order: "
+        f"before={before_paths} after={after_paths}"
+    )
+
+    # And deleting the row must restore the raw BM25 order — the boost is
+    # config, not index state.
+    delete_response, _ = _request(
+        live,
+        "delete",
+        "/api/v2/path-contexts/",
+        params={"zone_id": "root", "path_prefix": "workspace/lose"},
+    )
+    assert delete_response.status_code == 200
+
+    reset_response, reset_body = _request(
+        live,
+        "get",
+        "/api/v2/search/query",
+        params={"q": "zebrafly", "type": "keyword", "limit": 5},
+    )
+    assert reset_response.status_code == 200
+    reset_paths = [r["path"] for r in reset_body["results"]]
+    assert reset_paths[:2] == ["/workspace/win/win.md", "/workspace/lose/lose.md"], reset_paths

--- a/tests/integration/bricks/search/test_federated_search.py
+++ b/tests/integration/bricks/search/test_federated_search.py
@@ -69,6 +69,70 @@ def _make_rebac(zones: list[str]) -> AsyncMock:
 
 
 # =============================================================================
+# Per-zone path-prefix boosts (#4620)
+# =============================================================================
+
+
+def _make_capturing_daemon(captured: dict[str, Any]) -> AsyncMock:
+    daemon = AsyncMock()
+    daemon.is_initialized = True
+
+    async def capture_search(request: Any) -> list[MockSearchResult]:
+        captured[request.zone_id] = request
+        return []
+
+    daemon.search = capture_search
+    return daemon
+
+
+class TestPerZoneBoosts:
+    @pytest.mark.asyncio
+    async def test_resolver_boosts_stamped_per_zone(self) -> None:
+        captured: dict[str, Any] = {}
+        daemon = _make_capturing_daemon(captured)
+        rebac = _make_rebac(["zone_a", "zone_b"])
+
+        async def resolver(zone_id: str) -> dict[str, float]:
+            return {"/docs/": 5.0} if zone_id == "zone_a" else {}
+
+        dispatcher = FederatedSearchDispatcher(
+            daemon=daemon, rebac=rebac, path_prefix_boosts_resolver=resolver
+        )
+        await dispatcher.search("q", subject=("user", "alice"))
+
+        assert captured["zone_a"].path_prefix_boosts == {"/docs/": 5.0}
+        assert not captured["zone_b"].path_prefix_boosts
+
+    @pytest.mark.asyncio
+    async def test_no_resolver_leaves_legs_unboosted(self) -> None:
+        captured: dict[str, Any] = {}
+        daemon = _make_capturing_daemon(captured)
+        rebac = _make_rebac(["zone_a"])
+
+        dispatcher = FederatedSearchDispatcher(daemon=daemon, rebac=rebac)
+        await dispatcher.search("q", subject=("user", "alice"))
+
+        assert not captured["zone_a"].path_prefix_boosts
+
+    @pytest.mark.asyncio
+    async def test_resolver_error_fails_open_to_unboosted_leg(self) -> None:
+        captured: dict[str, Any] = {}
+        daemon = _make_capturing_daemon(captured)
+        rebac = _make_rebac(["zone_a"])
+
+        async def broken_resolver(zone_id: str) -> dict[str, float]:
+            raise RuntimeError("store down")
+
+        dispatcher = FederatedSearchDispatcher(
+            daemon=daemon, rebac=rebac, path_prefix_boosts_resolver=broken_resolver
+        )
+        resp = await dispatcher.search("q", subject=("user", "alice"))
+
+        assert "zone_a" in resp.zones_searched
+        assert not captured["zone_a"].path_prefix_boosts
+
+
+# =============================================================================
 # Zone discovery
 # =============================================================================
 

--- a/tests/unit/bricks/search/test_daemon_prefix_boosts.py
+++ b/tests/unit/bricks/search/test_daemon_prefix_boosts.py
@@ -1,0 +1,49 @@
+"""SearchDaemon must map SearchRequest.path_prefix_boosts onto the proto (#4620).
+
+The gRPC proxy is the last hop before the plugin — if it drops the
+field, the router wiring upstream is dead config all over again.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from nexus.bricks.search.daemon import SearchDaemon
+from nexus.contracts.search_types import SearchRequest
+from nexus.grpc.search.v1 import search_pb2
+
+
+class _CapturingStub:
+    def __init__(self) -> None:
+        self.query_requests: list[search_pb2.QueryRequest] = []
+
+    async def Query(self, req: search_pb2.QueryRequest) -> search_pb2.QueryResponse:  # noqa: N802
+        self.query_requests.append(req)
+        return search_pb2.QueryResponse(results=[])
+
+
+@pytest.fixture
+def stub(monkeypatch: pytest.MonkeyPatch) -> _CapturingStub:
+    captured = _CapturingStub()
+    monkeypatch.setattr(SearchDaemon, "_get_stub", lambda self: captured)
+    return captured
+
+
+@pytest.mark.asyncio
+async def test_search_forwards_path_prefix_boosts_to_proto(stub: _CapturingStub) -> None:
+    daemon = SearchDaemon(target="127.0.0.1:1")
+
+    await daemon.search(SearchRequest(query="needle", path_prefix_boosts={"/docs/": 5.0, "": 1.5}))
+
+    assert len(stub.query_requests) == 1
+    assert dict(stub.query_requests[0].path_prefix_boosts) == {"/docs/": 5.0, "": 1.5}
+
+
+@pytest.mark.asyncio
+async def test_search_without_boosts_sends_empty_map(stub: _CapturingStub) -> None:
+    daemon = SearchDaemon(target="127.0.0.1:1")
+
+    await daemon.search(SearchRequest(query="needle"))
+
+    assert len(stub.query_requests) == 1
+    assert dict(stub.query_requests[0].path_prefix_boosts) == {}

--- a/tests/unit/bricks/search/test_path_context_boosts.py
+++ b/tests/unit/bricks/search/test_path_context_boosts.py
@@ -1,0 +1,71 @@
+"""Unit tests for ``prefix_boosts_from_records`` (#4620).
+
+The P12 plugin applies ``QueryRequest.path_prefix_boosts`` post-fusion
+(longest ``starts_with``-matching key wins). These tests pin the
+translation from stored ``path_contexts`` rows (slash-free canonical
+prefixes, optional weights) onto that wire map.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from nexus.bricks.search.path_context import PathContextRecord, prefix_boosts_from_records
+
+_NOW = datetime.now(UTC).replace(tzinfo=None)
+
+
+def _record(prefix: str, weight: float | None) -> PathContextRecord:
+    return PathContextRecord(
+        zone_id="root",
+        path_prefix=prefix,
+        description="d",
+        created_at=_NOW,
+        updated_at=_NOW,
+        weight=weight,
+    )
+
+
+def test_no_rows_returns_empty() -> None:
+    assert prefix_boosts_from_records([]) == {}
+
+
+def test_description_only_rows_return_empty() -> None:
+    # Zones that only use path contexts for descriptions must keep the
+    # plugin's no-boost fast path (empty map skips the scoring pass).
+    records = [_record("docs", None), _record("src/nexus", None)]
+    assert prefix_boosts_from_records(records) == {}
+
+
+def test_all_explicit_neutral_weights_return_empty() -> None:
+    # weight=1.0 is a no-op multiplier; a zone with only neutral weights
+    # must not trigger the plugin's boost pass either.
+    records = [_record("docs", 1.0)]
+    assert prefix_boosts_from_records(records) == {}
+
+
+def test_weighted_row_wrapped_to_slash_boundary_key() -> None:
+    # Stored prefixes are slash-free canonical; plugin hit paths are
+    # slash-prefixed and matched with plain starts_with, so the key must
+    # be /-wrapped to stay on directory boundaries (no /docs-v2 leak).
+    records = [_record("docs", 5.0)]
+    assert prefix_boosts_from_records(records) == {"/docs/": 5.0}
+
+
+def test_empty_prefix_is_zone_wide_key() -> None:
+    # "" matches every path via starts_with — the zone-wide boost row.
+    records = [_record("", 2.0)]
+    assert prefix_boosts_from_records(records) == {"": 2.0}
+
+
+def test_weightless_rows_included_as_neutral_when_any_weight_exists() -> None:
+    # Pre-P12 parity: the longest matching RECORD won even when it had no
+    # weight (multiplier defaulted to 1.0), shadowing shorter weighted
+    # prefixes. A description-only child row must therefore ride along as
+    # an explicit 1.0 so it keeps exempting its subtree from the parent's
+    # boost.
+    records = [_record("docs", 5.0), _record("docs/archive", None)]
+    assert prefix_boosts_from_records(records) == {
+        "/docs/": 5.0,
+        "/docs/archive/": 1.0,
+    }

--- a/tests/unit/server/api/v2/test_search_prefix_boosts_wiring.py
+++ b/tests/unit/server/api/v2/test_search_prefix_boosts_wiring.py
@@ -1,0 +1,168 @@
+"""GET /api/v2/search/query must thread path_contexts weights to the daemon (#4620).
+
+Post-P12 the plugin honours ``QueryRequest.path_prefix_boosts`` but the
+server never populated it — path-context weight rows persisted via CRUD
+and then silently never reached ranking. These tests pin the wiring:
+rows with weights land on ``SearchRequest.path_prefix_boosts`` in the
+plugin's expected key shape, and deployments without a store keep
+searching unboosted.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from nexus.bricks.search.path_context import PathContextStore
+
+try:
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    _HAS_FASTAPI = True
+except ImportError:
+    _HAS_FASTAPI = False
+
+pytestmark = pytest.mark.skipif(not _HAS_FASTAPI, reason="fastapi test client unavailable")
+
+_AUTH = {
+    "authenticated": True,
+    "subject_type": "user",
+    "subject_id": "alice",
+    "zone_id": "eng",
+    "zone_perms": [["eng", "r"]],
+    "is_admin": False,
+}
+
+_CREATE_TABLE_SQL = """
+CREATE TABLE path_contexts (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    zone_id TEXT NOT NULL DEFAULT 'root',
+    path_prefix TEXT NOT NULL,
+    description TEXT NOT NULL,
+    weight FLOAT,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(zone_id, path_prefix)
+)
+"""
+
+
+class _Runner:
+    async def call(self, work: Any) -> Any:
+        return await work()
+
+
+class _Registry:
+    def runner_for(self, zone_id: str) -> _Runner:
+        return _Runner()
+
+
+def _make_daemon() -> MagicMock:
+    daemon = MagicMock()
+    daemon.is_initialized = True
+    daemon.config = MagicMock()
+    daemon.config.txtai_graph = False
+
+    async def fake_search(*args: Any, **kwargs: Any) -> list[Any]:
+        return []
+
+    daemon.search = AsyncMock(side_effect=fake_search)
+    return daemon
+
+
+def _build_app(daemon: Any, store: PathContextStore | None) -> "FastAPI":
+    from nexus.server.api.v2.routers.search import router
+    from nexus.server.dependencies import require_auth
+
+    app = FastAPI()
+    app.state.search_daemon = daemon
+    app.state.record_store = object()
+    app.state.async_read_session_factory = object()
+    app.state.permission_enforcer = None
+    app.state.zone_registry = _Registry()
+    if store is not None:
+        app.state.path_context_store = store
+    app.dependency_overrides[require_auth] = lambda: _AUTH
+    app.include_router(router)
+    return app
+
+
+@pytest_asyncio.fixture
+async def store():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:", future=True)
+    async with engine.begin() as conn:
+        await conn.exec_driver_sql(_CREATE_TABLE_SQL)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    yield PathContextStore(async_session_factory=factory, db_type="sqlite")
+    await engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def _no_db_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Force _get_store's app.state.path_context_store fallback — a DB URL
+    # in the environment would spin up a real engine instead.
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("NEXUS_DATABASE_URL", raising=False)
+
+
+@pytest.mark.asyncio
+async def test_weighted_row_reaches_daemon_request(store: PathContextStore) -> None:
+    await store.upsert("eng", "docs", "tier-1 docs", weight=5.0)
+    daemon = _make_daemon()
+    with TestClient(_build_app(daemon, store)) as client:
+        response = client.get("/api/v2/search/query", params={"q": "needle"})
+    assert response.status_code == 200, response.text
+    req = daemon.search.call_args.args[0]
+    assert req.path_prefix_boosts == {"/docs/": 5.0}
+
+
+@pytest.mark.asyncio
+async def test_description_only_rows_leave_request_unboosted(store: PathContextStore) -> None:
+    await store.upsert("eng", "docs", "just a description")
+    daemon = _make_daemon()
+    with TestClient(_build_app(daemon, store)) as client:
+        response = client.get("/api/v2/search/query", params={"q": "needle"})
+    assert response.status_code == 200, response.text
+    req = daemon.search.call_args.args[0]
+    assert not req.path_prefix_boosts
+
+
+@pytest.mark.asyncio
+async def test_other_zone_rows_do_not_bleed(store: PathContextStore) -> None:
+    await store.upsert("other-zone", "docs", "tier-1 docs", weight=5.0)
+    daemon = _make_daemon()
+    with TestClient(_build_app(daemon, store)) as client:
+        response = client.get("/api/v2/search/query", params={"q": "needle"})
+    assert response.status_code == 200, response.text
+    req = daemon.search.call_args.args[0]
+    assert not req.path_prefix_boosts
+
+
+def test_missing_store_fails_open_to_unboosted_search() -> None:
+    # No env DB URL, no app.state store: boost resolution must not take
+    # down /search/query — the request goes through without boosts.
+    daemon = _make_daemon()
+    with TestClient(_build_app(daemon, store=None)) as client:
+        response = client.get("/api/v2/search/query", params={"q": "needle"})
+    assert response.status_code == 200, response.text
+    req = daemon.search.call_args.args[0]
+    assert not req.path_prefix_boosts
+
+
+@pytest.mark.asyncio
+async def test_weight_update_visible_on_next_query(store: PathContextStore) -> None:
+    # The resolver caches per zone with a DB fingerprint check — an
+    # upsert between queries must be reflected, not served stale.
+    await store.upsert("eng", "docs", "tier-1", weight=2.0)
+    daemon = _make_daemon()
+    with TestClient(_build_app(daemon, store)) as client:
+        client.get("/api/v2/search/query", params={"q": "needle"})
+        await store.upsert("eng", "docs", "tier-1", weight=9.0)
+        client.get("/api/v2/search/query", params={"q": "needle"})
+    req = daemon.search.call_args.args[0]
+    assert req.path_prefix_boosts == {"/docs/": 9.0}

--- a/tests/unit/server/api/v2/test_search_prefix_boosts_wiring.py
+++ b/tests/unit/server/api/v2/test_search_prefix_boosts_wiring.py
@@ -155,6 +155,42 @@ def test_missing_store_fails_open_to_unboosted_search() -> None:
 
 
 @pytest.mark.asyncio
+async def test_federated_legs_carry_per_zone_boosts(store: PathContextStore) -> None:
+    # Multi-zone token auto-promotes to federated; each local leg must
+    # carry ITS zone's weight rows — and only its own.
+    await store.upsert("eng", "docs", "tier-1 docs", weight=5.0)
+    daemon = _make_daemon()
+    captured: dict[str, Any] = {}
+
+    async def capture_search(request: Any) -> list[Any]:
+        captured[request.zone_id] = request
+        return []
+
+    daemon.search = capture_search
+
+    app = _build_app(daemon, store)
+    rebac = MagicMock()
+    rebac.list_accessible_zones = AsyncMock(return_value=["eng", "ops"])
+    app.state.rebac_service = rebac
+    app.state.federated_per_file_rebac = False
+
+    from nexus.server.dependencies import require_auth
+
+    app.dependency_overrides[require_auth] = lambda: {
+        **_AUTH,
+        "zone_set": ["eng", "ops"],
+        "zone_perms": [["eng", "r"], ["ops", "r"]],
+    }
+
+    with TestClient(app) as client:
+        response = client.get("/api/v2/search/query", params={"q": "needle"})
+
+    assert response.status_code == 200, response.text
+    assert captured["eng"].path_prefix_boosts == {"/docs/": 5.0}
+    assert not captured["ops"].path_prefix_boosts
+
+
+@pytest.mark.asyncio
 async def test_weight_update_visible_on_next_query(store: PathContextStore) -> None:
     # The resolver caches per zone with a DB fingerprint check — an
     # upsert between queries must be reflected, not served stale.


### PR DESCRIPTION
## Problem

#4620: `path_contexts` ranking weights (#4544 tier boost) are dead config post-P12. The plugin fully honours `QueryRequest.path_prefix_boosts` (applies the longest `starts_with`-matching multiplier post-fusion, keys its query cache on the map) — but the server never loaded the zone's rows into the request. CRUD persisted rows; ranking silently ignored them.

## Fix (commit 1 — single-zone lane)

- **`contracts/search_types.py`** — `SearchRequest.path_prefix_boosts: dict[str, float] | None`, keys already in the plugin's wire shape.
- **`bricks/search/path_context.py`** — `prefix_boosts_from_records`: stored prefixes are slash-free canonical, plugin hit paths are slash-prefixed and matched with plain `starts_with`, so keys are rewrapped as `/{prefix}/` (directory-boundary safe — `docs` can't boost `/docs-v2/…`; `""` stays the zone-wide key). Pre-P12 parity: the longest matching *record* won even weightless (multiplier defaulted 1.0), shadowing shorter weighted prefixes — so when any row has an effective weight ≠ 1.0, all rows ride along (weightless as explicit 1.0); weight-free zones return `{}` to keep the plugin's no-boost fast path.
- **`routers/search.py`** — `_resolve_path_prefix_boosts`: per-event-loop `PathContextCache` over the path-contexts store (fingerprint-checked → an upsert is visible on the next query, no full table scan per request). Fail-open to unboosted search; warns once per process. Stamped onto the single-zone `SearchRequest`.
- **`bricks/search/daemon.py`** — the proxy stamps the field onto `QueryRequest` for both `Query` and `BatchQuery`.

## Fix (commit 2 — the flagged gaps)

- **Federated lane**: `FederatedSearchDispatcher` takes an optional async `path_prefix_boosts_resolver(zone_id)`; each **local** leg now carries its own zone's weight rows, resolved through the same per-loop cache. Fail-open per leg (a resolver error costs the boost, never the leg). Remote legs stay unboosted — the remote RPC surface drops every search param today (#4556) and remote rows belong to the remote deployment. Dispatcher is per-request, so its result cache can't serve stale boosts.
- **File-exact prefix parity (Rust)**: `scoring.rs::apply_prefix_boost` — a key ending in `/` now also matches the path equal to the key minus that slash. `/{p}/` therefore covers both the subtree and the exact-file case (pre-P12 matched via `path == prefix`), still with zero boundary leak (`/docs/` cannot touch `/docs-v2/…`, pinned by test).

## Tests (TDD — every RED watched first)

- Unit: `prefix_boosts_from_records` translation rules (5).
- Wiring: `/api/v2/search/query` against a real sqlite store + capturing daemon — weighted row reaches the daemon as `{"/docs/": 5.0}`, zone isolation, staleness refresh, fail-open without a store, **federated legs carry per-zone boosts** (6).
- Daemon proto mapping (2). Dispatcher resolver behavior incl. fail-open (3). Rust: exact-file match + boundary-leak pin (2; 122/122 plugin lib tests green).
- **Live e2e — the test the issue asked for**: `test_live_path_context_weight_moves_ranking` runs the issue's differential probe through the real HTTP surface (real kernel + real Rust plugin): `weight: 10.0` on the loser's prefix flips the order; deleting the row restores raw BM25 order. Verified RED against develop's router — `before=[win,lose] after=[win,lose]`, the exact signature from the issue — and GREEN with this fix.

## Live-e2e fixture upgrade (what made the HTTP-surface test possible)

The `live_search_app` fixture previously always 503'd on `/search/*`: the SearchDaemon dials `127.0.0.1:2126` but the locally spawned kernel binds a random port, and no plugin was ever loaded. The fixture now (all opt-in, only when a worktree `libnexus_search_plugin.dylib/.so` exists):
- detach-signs the dylib with an ephemeral Ed25519 key and trusts it via the loader's `NEXUS_LOCAL_TRUSTED_KEYS_DIR` extension point (kernel refuses unsigned plugins; format matches `scripts/sign_plugin.py`),
- loads it via `NEXUS_PLUGIN_DIR` before `nexus.connect`,
- points `NEXUS_SEARCH_PLUGIN_TARGET` at the spawned kernel's listener (the plugin's SearchService rides the kernel's own gRPC server via Phase-P routing),
- nulls `app.state.permission_enforcer` — Decision-#17 ReBAC denied 100% of hits for the unseeded test API key, silently emptying every `/search/query` response (`NEXUS_ENFORCE_PERMISSIONS` only governs VFS ops).

CI behavior unchanged: no worktree binary → suite skips exactly as before. `plugin_loaded=False` → the new test skips with a build hint.

## Remaining scope notes

- **Batch endpoint**: the daemon proxy forwards boosts for `BatchQuery`; the batch *route* stamping lands on PR #4622 (which owns the batch-route rework and is now stacked on this PR).
- Pre-existing test rot surfaced, not fixed here: `tests/integration/services/test_search_router.py::TestSearchQueryEndpoint` and most of `tests/integration/bricks/search/test_federated_search.py` fail identically on develop (mocks predate the P12 positional-`SearchRequest` daemon call — verified by running both suites against pristine develop).
- Merge-conflict heads-up: touches `daemon.py` + `search.py`, same files as PR #4622 — #4622 is now rebased onto this branch, so land this first.

Closes #4620