### PR TITLE
Add Trustabl Agent Scanner to CI

### DIFF
--- a/.github/workflows/trustabl.yml
+++ b/.github/workflows/trustabl.yml
@@ -1,0 +1,17 @@
+name: Trustabl
+on:
+  push:
+    branches: [develop]
+  pull_request:
+
+permissions:
+  contents: read
+  security-events: write
+  pull-requests: write
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: trustabl/trustabl-action@v0


### PR DESCRIPTION
We came across your repo and we like how it provides a robust foundation for building multi-agent systems by addressing crucial aspects such as storage, communication, and permissions. 

1. [MEDIUM] Project uses default OpenAI tracing
   What it means: The project uses the OpenAI Agents SDK with default tracing enabled.
2. [MEDIUM] Tool parameters are not type-annotated
   File: examples/claude_agent_sdk/claude_agent_react_demo.py
   What it means: Without parameter type annotations, the SDK cannot generate an input schema to validate model output. 

Recommendations are based on our understanding of agent runtime reliability, some findings may be intentional. Please let us know if this was intentional or if our findings are helpful so we can improve the accuracy of the scanner.

Best,
Trustabl.ai
Open-source AI agent reliability scanner (runs locally, GitHub Action)