### PR TITLE
services: extract OpCounter + KeyLockMap as cross-service helpers

### DIFF
--- a/rust/services/src/lib.rs
+++ b/rust/services/src/lib.rs
@@ -39,6 +39,11 @@
 //!                          +--- backends     (peer; never crosses to services)
 //! ```
 
+// Cross-service helpers — small feature-free primitives usable by
+// any service impl (in-tree or downstream cdylib plugin) without
+// pulling a per-service feature gate.
+pub mod ops;
+
 // Generic hosted-subprocess primitive: launch an argv + surface its
 // stdio as VFS DT_PIPEs. Shared by `acp` (config-driven ACP one-shot)
 // and `managed_agent` (raw control-plane tunnel); knows nothing about

--- a/rust/services/src/lib.rs
+++ b/rust/services/src/lib.rs
@@ -42,6 +42,7 @@
 // Cross-service helpers — small feature-free primitives usable by
 // any service impl (in-tree or downstream cdylib plugin) without
 // pulling a per-service feature gate.
+pub mod locks;
 pub mod ops;
 
 // Generic hosted-subprocess primitive: launch an argv + surface its

--- a/rust/services/src/locks.rs
+++ b/rust/services/src/locks.rs
@@ -1,0 +1,160 @@
+//! Per-key writer-serialization locks.
+//!
+//! [`KeyLockMap`] hands out an `Arc<Mutex<()>>` per key so concurrent
+//! writers to the SAME key serialize while writers to DIFFERENT keys
+//! proceed in parallel. Readers do not touch the map.
+//!
+//! **When to reach for this.** Any writer whose shape is
+//! "open → mutate in-memory copy → save whole snapshot" against a
+//! per-key on-disk sidecar. Atomic-rename alone does NOT prevent
+//! lost writes there: two racing writers each open their own copy,
+//! each mutate it, each save — one's save silently overwrites the
+//! other's changes. Wrap the entire open→mutate→save transaction
+//! under `let _write = map.get(&key).lock();`.
+//!
+//! The inner [`parking_lot::Mutex`] must be held on blocking-pool
+//! threads only. Never hold it across `.await`.
+//!
+//! The map itself has no eviction: it grows with the number of
+//! distinct keys ever locked. Acceptable for bounded key sets
+//! (zones, mailboxes, tenants). If a caller needs eviction, layer
+//! it on top rather than teaching this type about lifecycle.
+//!
+//! # Example
+//!
+//! ```
+//! use services::locks::KeyLockMap;
+//! use std::sync::Arc;
+//!
+//! let map: KeyLockMap<String> = KeyLockMap::new();
+//! let lock = map.get(&"zone-a".to_string());
+//! let _guard = lock.lock();
+//! // ... open sidecar, mutate, save ...
+//! ```
+
+use parking_lot::Mutex;
+use std::collections::HashMap;
+use std::hash::Hash;
+use std::sync::Arc;
+
+/// Map from key → per-key writer lock.
+pub struct KeyLockMap<K: Eq + Hash + Clone> {
+    inner: Mutex<HashMap<K, Arc<Mutex<()>>>>,
+}
+
+impl<K: Eq + Hash + Clone> Default for KeyLockMap<K> {
+    fn default() -> Self {
+        Self {
+            inner: Mutex::new(HashMap::new()),
+        }
+    }
+}
+
+impl<K: Eq + Hash + Clone> KeyLockMap<K> {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Return the writer lock for `key`, creating it on first access.
+    ///
+    /// Calls with the same `key` return `Arc`s to the same `Mutex`.
+    pub fn get(&self, key: &K) -> Arc<Mutex<()>> {
+        Arc::clone(self.inner.lock().entry(key.clone()).or_default())
+    }
+
+    /// How many distinct keys have ever been locked (map cardinality).
+    /// Diagnostic helper — the map has no eviction.
+    pub fn tracked_keys(&self) -> usize {
+        self.inner.lock().len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::sync::Barrier;
+    use std::thread;
+    use std::time::{Duration, Instant};
+
+    #[test]
+    fn get_same_key_returns_same_lock() {
+        let map: KeyLockMap<String> = KeyLockMap::new();
+        let a = map.get(&"z".to_string());
+        let b = map.get(&"z".to_string());
+        assert!(Arc::ptr_eq(&a, &b));
+        assert_eq!(map.tracked_keys(), 1);
+    }
+
+    #[test]
+    fn distinct_keys_get_distinct_locks() {
+        let map: KeyLockMap<String> = KeyLockMap::new();
+        let a = map.get(&"z1".to_string());
+        let b = map.get(&"z2".to_string());
+        assert!(!Arc::ptr_eq(&a, &b));
+        assert_eq!(map.tracked_keys(), 2);
+    }
+
+    #[test]
+    fn writers_on_same_key_serialize() {
+        let map: Arc<KeyLockMap<String>> = Arc::new(KeyLockMap::new());
+        let counter = Arc::new(AtomicU32::new(0));
+        let max_concurrent = Arc::new(AtomicU32::new(0));
+        let barrier = Arc::new(Barrier::new(4));
+
+        let mut handles = vec![];
+        for _ in 0..4 {
+            let map = Arc::clone(&map);
+            let counter = Arc::clone(&counter);
+            let max_concurrent = Arc::clone(&max_concurrent);
+            let barrier = Arc::clone(&barrier);
+            handles.push(thread::spawn(move || {
+                barrier.wait();
+                let lock = map.get(&"same".to_string());
+                let _g = lock.lock();
+                let now = counter.fetch_add(1, Ordering::SeqCst) + 1;
+                max_concurrent.fetch_max(now, Ordering::SeqCst);
+                thread::sleep(Duration::from_millis(20));
+                counter.fetch_sub(1, Ordering::SeqCst);
+            }));
+        }
+        for h in handles {
+            h.join().unwrap();
+        }
+        assert_eq!(
+            max_concurrent.load(Ordering::SeqCst),
+            1,
+            "same-key writers must serialize"
+        );
+    }
+
+    #[test]
+    fn writers_on_distinct_keys_run_concurrently() {
+        let map: Arc<KeyLockMap<String>> = Arc::new(KeyLockMap::new());
+        let barrier = Arc::new(Barrier::new(4));
+
+        let start = Instant::now();
+        let mut handles = vec![];
+        for i in 0..4 {
+            let map = Arc::clone(&map);
+            let barrier = Arc::clone(&barrier);
+            handles.push(thread::spawn(move || {
+                let key = format!("k{i}");
+                let lock = map.get(&key);
+                barrier.wait();
+                let _g = lock.lock();
+                thread::sleep(Duration::from_millis(50));
+            }));
+        }
+        for h in handles {
+            h.join().unwrap();
+        }
+        let elapsed = start.elapsed();
+        // Four 50ms sleeps in parallel finish well under the serial
+        // 200ms; give a wide margin for CI jitter.
+        assert!(
+            elapsed < Duration::from_millis(180),
+            "distinct-key writers should run concurrently (took {elapsed:?})"
+        );
+    }
+}

--- a/rust/services/src/ops.rs
+++ b/rust/services/src/ops.rs
@@ -1,0 +1,182 @@
+//! In-flight operation counter with RAII drop-decrement.
+//!
+//! [`OpCounter`] tracks how many long-running background operations
+//! are currently in progress. Callers acquire an [`OpGuard`] via
+//! [`OpCounter::enter`]; the guard's `Drop` impl decrements the
+//! counter, so an observer reads a truthful "N operations in flight"
+//! at any instant.
+//!
+//! **Guard placement invariant.** The guard MUST be moved INTO the
+//! `spawn_blocking` closure that runs the actual work — never left
+//! owned by the outer async future. A `tonic` RPC future can be
+//! dropped by client cancellation while the `spawn_blocking` task it
+//! launched keeps running; a guard on the future runs its `Drop` at
+//! cancellation and zeroes the counter mid-work, during exactly the
+//! partial-build window the counter exists to expose. The contract
+//! test `spawn_blocking_holds_count_past_future_drop` locks in this
+//! invariant.
+//!
+//! # Example
+//!
+//! ```
+//! use services::ops::OpCounter;
+//!
+//! # async fn build_index() {}
+//! # let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
+//! # rt.block_on(async {
+//! let ops = OpCounter::new();
+//! let guard = ops.enter();
+//! tokio::task::spawn_blocking(move || {
+//!     let _guard = guard; // decrement fires when the WORK ends, not the RPC future
+//!     // ... long-running work ...
+//! })
+//! .await
+//! .unwrap();
+//! assert_eq!(ops.count(), 0);
+//! # });
+//! ```
+
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::Arc;
+
+/// Counter of currently in-flight operations.
+///
+/// Cheap to `clone` — the counter itself is `Arc<AtomicU32>` inside,
+/// so every clone points at the same underlying count.
+#[derive(Clone, Default)]
+pub struct OpCounter(Arc<AtomicU32>);
+
+impl OpCounter {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Snapshot of the current in-flight count.
+    pub fn count(&self) -> u32 {
+        self.0.load(Ordering::SeqCst)
+    }
+
+    /// Increment the counter and return a guard that decrements on drop.
+    ///
+    /// See the module docstring for the guard placement invariant.
+    pub fn enter(&self) -> OpGuard {
+        OpGuard::enter(&self.0)
+    }
+}
+
+/// RAII handle: increments the counter on [`OpCounter::enter`],
+/// decrements it when dropped.
+///
+/// Move this INTO the `spawn_blocking` closure that runs the work.
+pub struct OpGuard(Arc<AtomicU32>);
+
+impl OpGuard {
+    fn enter(counter: &Arc<AtomicU32>) -> Self {
+        counter.fetch_add(1, Ordering::SeqCst);
+        Self(Arc::clone(counter))
+    }
+}
+
+impl Drop for OpGuard {
+    fn drop(&mut self) {
+        self.0.fetch_sub(1, Ordering::SeqCst);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn enter_increments_drop_decrements() {
+        let ops = OpCounter::new();
+        assert_eq!(ops.count(), 0);
+        {
+            let _g = ops.enter();
+            assert_eq!(ops.count(), 1);
+        }
+        assert_eq!(ops.count(), 0);
+    }
+
+    #[test]
+    fn count_is_max_of_concurrent_guards() {
+        let ops = OpCounter::new();
+        let g1 = ops.enter();
+        let g2 = ops.enter();
+        let g3 = ops.enter();
+        assert_eq!(ops.count(), 3);
+        drop(g2);
+        assert_eq!(ops.count(), 2);
+        drop(g1);
+        drop(g3);
+        assert_eq!(ops.count(), 0);
+    }
+
+    #[test]
+    fn clone_shares_counter() {
+        let a = OpCounter::new();
+        let b = a.clone();
+        let _g = a.enter();
+        assert_eq!(b.count(), 1);
+    }
+
+    // Contract test for the module invariant: dropping the RPC future
+    // that spawn_blocking'd the work MUST NOT zero the counter while
+    // the work is still running. The guard has to live inside the
+    // blocking closure.
+    #[test]
+    fn spawn_blocking_holds_count_past_future_drop() {
+        use std::sync::mpsc::channel;
+        use std::time::Duration;
+
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(2)
+            .enable_all()
+            .build()
+            .unwrap();
+
+        let ops = OpCounter::new();
+        let (release_tx, release_rx) = channel::<()>();
+        let (started_tx, started_rx) = channel::<()>();
+
+        // Enter the counter, hand the guard to spawn_blocking, then
+        // DROP the outer future by dropping the JoinHandle.
+        {
+            let ops_clone = ops.clone();
+            let handle = rt.spawn(async move {
+                let guard = ops_clone.enter();
+                let started_tx = started_tx.clone();
+                let _blocking = tokio::task::spawn_blocking(move || {
+                    let _guard = guard; // MOVED into the blocking closure
+                    started_tx.send(()).unwrap();
+                    // Simulate long-running work: block until released.
+                    release_rx.recv().unwrap();
+                });
+                // Drop `_blocking` (and this future) here so cancellation
+                // of the RPC future is simulated.
+            });
+            drop(handle);
+        }
+
+        // Wait for the blocking task to have entered the counter.
+        started_rx.recv_timeout(Duration::from_secs(2)).unwrap();
+
+        // At this point the outer future is gone but the blocking task
+        // is still running with the guard.
+        assert_eq!(
+            ops.count(),
+            1,
+            "counter must reflect the still-running blocking task"
+        );
+
+        // Release the blocking task and let it drain.
+        release_tx.send(()).unwrap();
+        for _ in 0..200 {
+            if ops.count() == 0 {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        assert_eq!(ops.count(), 0, "counter should decrement after work ends");
+    }
+}


### PR DESCRIPTION
## Summary

Extracts two small feature-free primitives into the \`services\` rlib so any service impl (in-tree or downstream cdylib plugin) can reuse them without a per-service feature gate:

- **\`services::ops::OpCounter\` + \`OpGuard\`** — RAII in-flight operation counter. The load-bearing invariant (guard MUST be moved INTO the \`spawn_blocking\` closure, not owned by the RPC future) is documented in the module docstring and locked in by the \`spawn_blocking_holds_count_past_future_drop\` contract test.
- **\`services::locks::KeyLockMap<K>\`** — per-key writer-serialization map. Serializes concurrent writers to the SAME key while writers to DIFFERENT keys proceed in parallel. Correct choice for open→mutate→save-whole-snapshot flows against per-key sidecars where atomic-rename alone loses writes.

Both patterns exist today in nexus PR #4622 (\`IndexingGuard\` at \`search-plugin/src/service.rs\` and \`zone_write_locks\` at \`search-plugin/src/index_manager.rs\`). This PR lands the shared crates first; a follow-up branch (\`refactor/search-plugin-adopt-shared-helpers\`) will delete the local copies and adopt \`services::ops\` + \`services::locks\` once #4622 merges.

**Scope note:** the plan also considered refactoring \`tasks/store.rs\`'s 5 \`AtomicU64\` status-snapshot counters to use \`OpCounter\`. Audit rejected: those counters are persistent-status (initialized from a startup scan, mutated across function boundaries, some monotonic) — a different primitive from \`OpCounter\`'s in-flight+RAII shape. Forcing reuse would require polluting \`OpCounter\` with \`new_with_initial\`/\`bulk_add\`/\`forget\`, breaking SRP. tasks/store keeps its \`AtomicU64\` fields.

## Test plan

- [x] \`cargo build -p services\` — green (local, MSVC + Windows SDK)
- [x] \`cargo test -p services --lib\` — 8/8 passed (ops: 4 tests including the spawn_blocking contract test; locks: 4 tests including concurrent-writers-serialize + distinct-keys-parallel)
- [x] \`cargo clippy -p services --all-targets -- -D warnings\` — green
- [x] \`cargo fmt -p services --check\` — green
- [ ] CI on develop base