### PR TITLE
fix(search-plugin): read-side orphan guard — drop ANN hits without FTS rows

### DIFF
--- a/rust/services/search-plugin/src/service.rs
+++ b/rust/services/search-plugin/src/service.rs
@@ -786,8 +786,6 @@ fn do_semantic_query(
     // Materialise chunk_text + mtime via the FTS index — the ANN
     // stores only vectors + paths, but the RPC contract carries the
     // full QueryResult shape so callers don't need a follow-up read.
-    // A missing FTS row (drift scenario) leaves chunk_text empty;
-    // the path itself is still meaningful.
     let fts = manager.get_or_open(zone_id).ok();
 
     let mut out = Vec::with_capacity(limit);
@@ -795,27 +793,49 @@ fn do_semantic_query(
         if !path_filter.is_empty() && !hit.path.starts_with(path_filter) {
             continue;
         }
-        out.push(enrich_ann_hit(fts.as_deref(), hit, zone_id));
-        if out.len() >= limit {
-            break;
+        // Orphan guard (review residual, follow-up landed): an ANN
+        // hit whose path has NO FTS row is drift — a deleted or
+        // content-transitioned doc whose vectors outlived it (the
+        // write-side lifecycle closes the known paths; this closes
+        // the unknown ones at read time).  Dropped, not served.
+        // When FTS itself is unavailable the hit is UNVERIFIABLE and
+        // kept — availability over a drift-window false negative.
+        if let Some(result) = enrich_ann_hit(fts.as_deref(), hit, zone_id) {
+            out.push(result);
+            if out.len() >= limit {
+                break;
+            }
         }
     }
     Ok(out)
 }
 
+/// Enrich an ANN hit with FTS-side text/mtime.  Returns None when the
+/// FTS index is OPEN but has no row for the path — the orphan-vector
+/// read guard; see the caller comment.
 fn enrich_ann_hit(
     fts: Option<&crate::fts_index::FtsIndex>,
     hit: AnnHit,
     zone_id: &str,
-) -> QueryResult {
+) -> Option<QueryResult> {
     // Score = 1 - cosine distance so higher = closer, matching the
     // BM25 "higher is better" convention keyword callers already
     // rely on.  ANN returns distance in [0, 2]; score falls in [-1, 1].
     let score = 1.0 - hit.distance;
-    let (chunk_text, mtime_ms) = fts
-        .and_then(|f| lookup_fts_by_path(f, &hit.path))
-        .unwrap_or((String::new(), None));
-    QueryResult {
+    let (chunk_text, mtime_ms) = match fts {
+        Some(f) => match lookup_fts_by_path(f, &hit.path) {
+            Some(pair) => pair,
+            None => {
+                tracing::debug!(
+                    path = %hit.path,
+                    "semantic hit dropped: ANN vector has no FTS row (orphan guard)",
+                );
+                return None;
+            }
+        },
+        None => (String::new(), None),
+    };
+    Some(QueryResult {
         path: hit.path,
         chunk_index: hit.chunk_index,
         chunk_text,
@@ -824,7 +844,7 @@ fn enrich_ann_hit(
         mtime_ms,
         expanded_context: String::new(),
         title_score: None,
-    }
+    })
 }
 
 /// Look up an FTS row by exact path via the STRING-indexed `path`

--- a/rust/services/search-plugin/tests/index_visibility_e2e.rs
+++ b/rust/services/search-plugin/tests/index_visibility_e2e.rs
@@ -232,6 +232,55 @@ async fn stats_identity_fields_present_and_idle() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn semantic_query_drops_ann_hits_without_fts_rows() {
+    // Orphan guard: a vector whose FTS row is gone (drift — deleted /
+    // content-transitioned doc) must not surface in semantic results.
+    let dir = TempDir::new().unwrap();
+    let manager = Arc::new(IndexManager::with_root(dir.path().to_path_buf()));
+    let svc = SearchServiceImpl::builder(Arc::new(handle_for(leak_kernel())))
+        .manager(Arc::clone(&manager))
+        .embedder(Arc::new(MockEmbedder::with_dim(16)))
+        .build();
+
+    svc.index_documents(Request::new(IndexDocumentsRequest {
+        documents: vec![
+            doc("/ws/intact.md", "quantum widget assembly manual"),
+            doc("/ws/orphaned.md", "quantum widget assembly notes"),
+        ],
+        zone_id: String::new(),
+        auth_token: String::new(),
+    }))
+    .await
+    .expect("index rpc");
+
+    // Simulate drift: drop ONE doc's FTS rows while its vectors stay.
+    let fts = manager.get_or_open("root").expect("fts open");
+    fts.delete_all_chunks("/ws/orphaned.md");
+    fts.commit().expect("fts commit");
+
+    let resp = svc
+        .query(Request::new(QueryRequest {
+            q: "quantum widget assembly".to_string(),
+            limit: 10,
+            query_type: QueryType::Semantic as i32,
+            ..Default::default()
+        }))
+        .await
+        .expect("query rpc")
+        .into_inner();
+    assert!(resp.error.is_none(), "query error: {:?}", resp.error);
+    let paths: Vec<&str> = resp.results.iter().map(|r| r.path.as_str()).collect();
+    assert!(
+        paths.contains(&"/ws/intact.md"),
+        "intact doc must still surface: {paths:?}"
+    );
+    assert!(
+        !paths.contains(&"/ws/orphaned.md"),
+        "orphaned vector must be dropped by the read guard: {paths:?}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn prefix_boost_promotes_doc_from_below_the_requested_limit() {
     // Review R3: score adjustments must act on an OVER-FETCHED pool.
     // Pre-fix, a keyword query with limit=1 fetched exactly one hit,


### PR DESCRIPTION
## Summary

Read-side defense-in-depth for the ANN lane: `do_semantic_query` now drops ANN hits whose path has **no corresponding FTS row** when the FTS index is open and readable.

This was documented residual #3 from the PR #4622 adversarial review ("ANN-without-FTS read guard"). The write-side lifecycle work in #4622 (embedder-generation-aware `IndexState`, delete tombstones, content-transition purges, per-zone write locks) closes every *known* path that creates orphaned vectors — but any *unknown* or historical drift (crash between ANN insert and FTS commit, pre-#4622 indexes, manual index surgery) could still surface ANN hits pointing at documents that no longer exist in FTS. Those hits previously came back with empty `chunk_text` and no mtime — junk results the caller can't distinguish from real ones.

## Behavior

`enrich_ann_hit` returns `Option<QueryResult>`:

- **FTS open, no row for the hit's path** → hit dropped, `tracing::debug!` orphan-guard log. These are provably stale vectors.
- **FTS unavailable** (failed to open) → hit kept with empty text, as before. Absence of FTS is not evidence the document is gone; degrading semantic search to zero results on an FTS outage would be worse than returning unverifiable hits.

Cost is effectively zero: the FTS lookup per ANN hit was already being performed to materialize `chunk_text`/`mtime_ms` — this only changes what happens when that lookup misses.

## Testing

- New regression test `semantic_query_drops_ann_hits_without_fts_rows` in `tests/index_visibility_e2e.rs`: indexes docs, deletes one's FTS rows out from under the ANN index, asserts the orphaned path never appears in semantic results while live paths still do.
- Full plugin suites green locally: 137 lib tests + all e2e integration tests.

## Related

- Residual from #4622 review (round 10 documented residuals).
- Follow-up tracking issues filed alongside this: #4630 (CLI/legacy seeding split), #4631 (KeyLockMap/OpCounter migration), #4632 (embed-failure parking), #4633 (release manifest), #4634 (boost-inside-collection).
