### PR TITLE
docs(integration): correct binary edge — nexusd-cluster wraps sudocode_runtime (not the reverse)

### DIFF
--- a/docs/architecture/nexus-integration-architecture.html
+++ b/docs/architecture/nexus-integration-architecture.html
@@ -170,7 +170,7 @@ graph TD
 
     sw -->|"gRPC &lpar;VFS port&rpar;"| grpc
 
-    subgraph host["sudocode binary — one process per host (embeds the kernel)"]
+    subgraph host["nexusd-cluster — one process per host (kernel + agent control plane)"]
         grpc["gRPC server &lpar;VFS port&rpar;<br/>NexusVFSService.Call routes managed_agent<br/>+ ACP methods + sys_* for external clients"]
 
         subgraph kernel["Embedded Rust Kernel &lpar;one kernel::Kernel per host&rpar;"]
@@ -211,11 +211,11 @@ graph TD
 
 <h3>Constraints</h3>
 <ul>
-  <li><strong>One nexus per host.</strong> A host that runs sudocode agents runs one <strong>sudocode binary</strong> process &mdash; the sudocode binary already links the nexus <code>kernel</code> crate, so it embeds one <code>kernel::Kernel</code> in-process, and that kernel is the host's nexus. A host without sudocode agents runs the standalone <code>nexusd-cluster</code> binary. The <code>nexus-bootstrap</code> launcher protocol owns discover-or-launch, so both shapes converge on one kernel per host (&sect;8).</li>
-  <li><strong>Pure-infra nexus.</strong> The kernel and the service-tier crates (<code>services</code>, <code>raft</code>, <code>lib</code>, <code>contracts</code>) compile with zero knowledge of any agent runtime; the dependency edge runs <code>sudocode &rarr; nexus</code>. The <strong>sudocode binary</strong> (sudocode repo) is where both source trees link and <code>SpawnTask&lt;Kernel&gt;</code> monomorphises (&sect;2.3).</li>
+  <li><strong>One nexus per host.</strong> A host runs one <code>nexusd-cluster</code> process (the cluster profile + the agent control plane); its embedded <code>kernel::Kernel</code> is that host's nexus. Whether it hosts in-process sudocode agents is a build-time choice &mdash; the <code>SpawnTask</code> adapter compiled in &mdash; not a second binary. The <code>nexus-bootstrap</code> launcher protocol owns discover-or-launch, so there is one kernel per host (&sect;8).</li>
+  <li><strong>Pure-infra nexus.</strong> The kernel and the service-tier crates (<code>services</code>, <code>raft</code>, <code>lib</code>, <code>contracts</code>) compile with zero knowledge of any agent runtime &mdash; they know only the <code>SpawnTask</code> DI trait. The single <code>nexus &rarr; sudocode</code> edge is the binary edge <code>nexusd-cluster</code> (<code>rust/nexusd</code>), where both source trees link and <code>SpawnTask&lt;Kernel&gt;</code> monomorphises (&sect;2.3). Because that edge is a binary leaf (nothing imports a <code>[[bin]]</code>) and <code>sudocode_runtime</code> only depends downward on <code>kernel</code>, there is no dependency cycle.</li>
   <li><strong>State SSOT.</strong> Agent runtime state (<code>pid &rarr; AgentState</code>, condvar wakeup, signal semantics, parent/child links, transition validation) lives in <code>kernel::core::agents::registry::AgentRegistry</code>. In-process Rust callers reach it directly; external callers reach it through the gRPC surface.</li>
   <li><strong>gRPC is the external surface.</strong> External clients (sudowork UI, orchestrator) reach the kernel over the VFS gRPC port; the agent&harr;kernel hot path stays in-process Rust.</li>
-  <li><strong>Cluster profile.</strong> The <strong>sudocode binary</strong> and <code>nexusd-cluster</code> both run Nexus's cluster profile &mdash; bricks: IPC, FEDERATION.</li>
+  <li><strong>Cluster profile.</strong> <code>nexusd-cluster</code> runs Nexus's cluster profile &mdash; bricks: IPC, FEDERATION &mdash; whether or not the sudocode agent adapter is compiled in.</li>
   <li><strong>Zone = VFS path mount point.</strong> A zone's visibility boundary is its mount path. ReBAC governs sub-path access within a zone.</li>
 </ul>
 
@@ -293,13 +293,13 @@ sequenceDiagram
     Registry->>Registry: reap /proc/{pid}/
 </pre>
 
-<p>A managed agent runs as one in-process agent loop inside the <strong>sudocode binary</strong>, reaching the kernel through direct Rust syscalls (<code>kernel.sys_read</code>, <code>sys_write</code>, <code>sys_watch</code>) and the dispatch hooks through the same in-process channel every kernel observer uses. External ACP agents (claude / codex / codebuddy / nanobot) run as subprocesses over stdio, because JSON-RPC over stdio is the only protocol those binaries speak; that path lives in <code>AcpService</code> (&sect;1).</p>
+<p>A managed agent runs as one in-process agent loop inside <code>nexusd-cluster</code>, reaching the kernel through direct Rust syscalls (<code>kernel.sys_read</code>, <code>sys_write</code>, <code>sys_watch</code>) and the dispatch hooks through the same in-process channel every kernel observer uses. External ACP agents (claude / codex / codebuddy / nanobot) run as subprocesses over stdio, because JSON-RPC over stdio is the only protocol those binaries speak; that path lives in <code>AcpService</code> (&sect;1).</p>
 
 <p>Three identity layers, durable vs ephemeral: <code>agent-name</code> (durable principal), <code>session-id</code> (durable UUID &mdash; the transcript key you <code>--resume</code>, spanning many pids), and <code>pid</code> (ephemeral &mdash; one boot/run of a worker, the AgentRegistry handle). <strong>session-id &ne; pid</strong>: a session outlives any single process, so the two cannot be the same value. On <code>start_session</code>, <code>ManagedAgentService</code> mints a new session-id (or echoes the resumed one), registers a pid, plants the per-pid <code>AgentDescriptor</code> &mdash; the spawn-time SSOT (<code>agent_id</code> &rarr; <code>desc.name</code>, <code>model</code> &rarr; <code>desc.labels["model"]</code>, workspace list &rarr; <code>desc.repos</code>) &mdash; stamps the <code>/proc/{pid}/</code> entries (&sect;2.2), and returns <code>{session_id, pid, workspace_path}</code> to the caller.</p>
 
-<p><code>ManagedAgentService</code> hands off to the runtime through the <code>SpawnTask&lt;K: KernelAbi&gt;</code> DI seam &mdash; one indirect call per session start. The binary edge is the <strong>sudocode binary</strong> itself (sudocode repo): it constructs a concrete <code>SpawnTask&lt;Kernel&gt;</code> adapter wrapping <code>sudocode_runtime::spawn_task</code> and registers it via <code>install_managed_agent_with_spawn(kernel, adapter)</code>. <code>start_session</code> calls <code>provider.spawn(kernel, desc, observer)</code> through <code>Arc&lt;dyn SpawnTask&lt;K&gt;&gt;</code>: exactly one vtable dispatch per session, and the returned <code>Box&lt;dyn SpawnHandle&gt;</code> lands in the service's <code>spawn_handles</code> sidecar. Inside the spawn body the surface is plain monomorphic Rust: <code>spawn_task::&lt;Kernel&gt;</code> and its inner <code>run_loop</code> are generic over <code>K: KernelAbi</code>, specialised against the concrete <code>Kernel</code> at the binary edge, so every <code>sys_read</code> / <code>sys_write</code> / <code>sys_watch</code> in the mailbox loop is an inline direct call. The services rlib depends on the <code>SpawnTask</code> trait only; pure-Rust slim builds call <code>install_managed_agent</code> (no spawn provider, no per-pid task).</p>
+<p><code>ManagedAgentService</code> hands off to the runtime through the <code>SpawnTask&lt;K: KernelSyscall&gt;</code> DI seam &mdash; one indirect call per session start. The binary edge is <code>nexusd-cluster</code> (<code>rust/nexusd</code>, nexus repo): it constructs a concrete <code>SpawnTask&lt;Kernel&gt;</code> adapter wrapping <code>sudocode_runtime::spawn_task</code> and registers it via <code>install_managed_agent_with_spawn(kernel, adapter)</code>. <code>start_session</code> calls <code>provider.spawn(kernel, desc, observer)</code> through <code>Arc&lt;dyn SpawnTask&lt;K&gt;&gt;</code>: exactly one vtable dispatch per session, and the returned <code>Box&lt;dyn SpawnHandle&gt;</code> lands in the service's <code>spawn_handles</code> sidecar. Inside the spawn body the surface is plain monomorphic Rust: <code>spawn_task::&lt;Kernel&gt;</code> and its inner <code>run_loop</code> are generic over <code>K: KernelSyscall</code>, specialised against the concrete <code>Kernel</code> at the binary edge, so every <code>sys_read</code> / <code>sys_write</code> / <code>sys_watch</code> in the mailbox loop is an inline direct call. The services rlib depends on the <code>SpawnTask</code> trait only; pure-Rust slim builds call <code>install_managed_agent</code> (no spawn provider, no per-pid task).</p>
 
-<p>The <strong>sudocode binary</strong> is the single binary-edge where the nexus and sudocode source trees link: it builds on <code>sudocode_runtime</code> and pulls the nexus <code>kernel</code> / <code>services</code> crates as git deps pinned to one nexus rev (so <code>SpawnTask&lt;Kernel&gt;</code> monomorphises), and the dependency edge stays <code>sudocode &rarr; nexus</code> (&sect;8). No separate host binary is needed &mdash; sudocode already links the kernel in-process.</p>
+<p><code>nexusd-cluster</code> (<code>rust/nexusd</code>) is the single binary-edge where the nexus and sudocode source trees link: it composes the nexus-vfs cluster boot (<code>nexus_cluster::run_with_services</code>) + the nexus service crates, and pulls <code>sudocode_runtime</code> as a library &mdash; all resolving to one <code>kernel</code> rev so <code>SpawnTask&lt;Kernel&gt;</code> monomorphises to a single type. The reusable crates (<code>kernel</code>, <code>services</code>, <code>cluster</code>) stay agent-runtime-free &mdash; they know only the <code>SpawnTask</code> DI trait, never <code>sudocode</code> &mdash; so the only <code>nexus &rarr; sudocode</code> edge is this binary leaf (nothing imports a <code>[[bin]]</code>), and there is no dependency cycle: <code>sudocode_runtime &rarr; kernel</code>; <code>nexusd &rarr; {sudocode_runtime, services, cluster}</code>; <code>kernel</code> depends on neither. <code>scode</code> stays a standalone CLI; there is no separate host binary.</p>
 
 <p>A worker boots by reading its profile from <code>/agents/{name}/</code> and the requested <code>--session-id</code> transcript from <code>/sessions/&lt;session-id&gt;/</code> (&sect;2.1), works (appending to the transcript and the mailbox), and exits; the <code>/proc/{pid}/</code> subtree is reaped. Resuming re-reads the same session-id under a fresh pid &mdash; persistent state lives in <code>/agents/{name}/</code> and <code>/sessions/</code>, not in a long-running process. Out-of-band termination (SIGTERM / SIGKILL / orphan reap) flows through <code>AgentRegistry::on_terminate</code>, which reaps <code>/proc/{pid}/</code> and aborts the worker via its <code>SpawnHandle</code>; <code>cancel(pid)</code> calls <code>AgentRegistry::kill(pid, 0)</code> for the same outcome.</p>
 
@@ -323,13 +323,13 @@ sequenceDiagram
 <table>
   <thead><tr><th>Backend</th><th>Used by</th><th>Reaches files via</th></tr></thead>
   <tbody>
-    <tr><td><code>KernelFsBackend&lt;Kernel&gt;</code></td><td>the sudocode binary (production)</td><td>in-process kernel syscalls</td></tr>
+    <tr><td><code>KernelFsBackend&lt;Kernel&gt;</code></td><td><code>nexusd-cluster</code> (production)</td><td>in-process kernel syscalls</td></tr>
     <tr><td><code>StdFsBackend</code></td><td>standalone CLI</td><td>host <code>std::fs</code></td></tr>
     <tr><td><code>NexusVfsFsBackend</code></td><td>edge / dev CLI</td><td>gRPC to a remote kernel</td></tr>
   </tbody>
 </table>
 
-<p>Inside the <strong>sudocode binary</strong> the agent loop runs on <code>KernelFsBackend&lt;Kernel&gt;</code>, so <code>SessionStore</code>, <code>ConfigLoader</code>, and the workspace-bounded <code>file_ops</code> helpers all issue kernel syscalls against nexus VFS paths:</p>
+<p>Inside <code>nexusd-cluster</code> the agent loop runs on <code>KernelFsBackend&lt;Kernel&gt;</code>, so <code>SessionStore</code>, <code>ConfigLoader</code>, and the workspace-bounded <code>file_ops</code> helpers all issue kernel syscalls against nexus VFS paths:</p>
 
 <p>Sessions are <strong>not</strong> partitioned by a workspace hash: a session lives flat at <code>/sessions/&lt;session-id&gt;/</code> and records the repos it touched as DT_LINKs under <code>repos/</code> (&sect;2.1), so one profile talking to multiple repos needs no per-repo path partition. Static prompt sections embed as <code>&amp;'static str</code> and need no IO.</p>
 
@@ -602,7 +602,7 @@ graph TB
 
 <h3>8.2 Isolation</h3>
 
-<p>Agent loops share the <strong>sudocode binary</strong>'s address space as in-process loops. Isolation floor is <code>catch_unwind</code> per loop plus <code>SpawnHandle::abort</code> on reap. Workers are cattle: persistent state lives in <code>/agents/{name}/</code>, so a host that dies is restarted and each worker resumes from its <code>--session-id</code> transcript.</p>
+<p>Agent loops share <code>nexusd-cluster</code>'s address space as in-process loops. Isolation floor is <code>catch_unwind</code> per loop plus <code>SpawnHandle::abort</code> on reap. Workers are cattle: persistent state lives in <code>/agents/{name}/</code>, so a host that dies is restarted and each worker resumes from its <code>--session-id</code> transcript.</p>
 
 <h3>8.3 One nexus per host</h3>
 
@@ -610,7 +610,7 @@ graph TB
 
 <h3>8.4 Binary-edge placement</h3>
 
-<p>The binary that links the nexus <code>kernel</code> / <code>services</code> crates in-process lives in the sudocode repo &mdash; it <em>is</em> the sudocode binary, which already depends on the nexus <code>kernel</code> crate. Keeping the link on the sudocode side holds the dependency edge at <code>sudocode &rarr; nexus</code>: nexus infra never depends on any agent runtime.</p>
+<p>The binary that links both source trees is <code>nexusd-cluster</code> (<code>rust/nexusd</code>, nexus repo): it composes the nexus-vfs cluster boot + the nexus service crates and pulls <code>sudocode_runtime</code> as a library. Placing the link at this binary edge keeps the reusable crates (<code>kernel</code>, <code>services</code>, <code>cluster</code>) agent-runtime-free &mdash; they know only the <code>SpawnTask</code> DI trait &mdash; so the single <code>nexus &rarr; sudocode</code> edge is a binary leaf and never forms a cycle (<code>sudocode_runtime</code> depends only downward on <code>kernel</code>). <code>scode</code> stays a standalone CLI; the daemon (<code>nexusd-cluster</code>) is the host.</p>
 
 <hr>
 


### PR DESCRIPTION
Corrects the previous reframe (#4636), which got the **dependency direction backwards**.

The actual code (`rust/nexusd/src/main.rs`) is unambiguous: **`nexusd-cluster` (`rust/nexusd`) is the binary edge** — it composes the nexus-vfs cluster boot (`nexus_cluster::run_with_services`) + the nexus service crates (`a2a`, `managed_agent`), and to host agents it wraps `sudocode_runtime` via the `SpawnTask<K: KernelSyscall>` DI adapter.

- The single `nexus → sudocode` edge is **this binary leaf only** (nothing imports a `[[bin]]`).
- The reusable crates (`kernel`, `services`, `cluster`) stay **agent-runtime-free** — they know only the `SpawnTask` trait, never sudocode. **No dependency cycle** (sudocode_runtime → kernel; nexusd → {sudocode_runtime, services, cluster}; kernel depends on neither).
- `scode` stays a standalone CLI; `nexusd-cluster` is the host.

Also fixes the stale `KernelAbi` → `KernelSyscall` trait name. Auto-publishes to ShareOne on merge.