### PR TITLE
search-plugin: mirror title-arm hybrid fusion (#4552 / closes #4628)

### DIFF
--- a/rust/services/proto/nexus/search/v1/search.proto
+++ b/rust/services/proto/nexus/search/v1/search.proto
@@ -351,6 +351,26 @@ message QueryRequest {
   // ⇒ no boost (multiplier stays 1.0).  Matches Python's
   // per-prefix ranking weight via path_contexts (#4544).
   map<string, float> path_prefix_boosts = 15;
+
+  // ── Title arm (P7, #4552 mirror / #4628) ───────────────────────
+  //
+  // When true (default), the hybrid keyword sub-fusion adds a
+  // THIRD arm — BM25 over the per-doc skeleton index (path tokens +
+  // first-heading title, title weighted 2x) — so title-shaped
+  // queries ("<project> design doc", "Q3 report") rank their
+  // target even when body chunks are weak.  KEYWORD-only queries
+  // do NOT run the title arm (no fusion happens there); Hybrid /
+  // Semantic queries do.
+  //
+  // Set to false to A/B-ablate the ranking effect or as a rollback
+  // knob; the plugin also honours NEXUS_SEARCH_TITLE_ARM=false to
+  // disable server-side without a wire flag change.
+  //
+  // Wire default is false (proto3), but the plugin treats the
+  // "unset" state as "on" — mirrors Python's default-on config so
+  // callers that don't set the field get the ranking-quality
+  // improvement automatically.
+  bool title_arm_disabled = 16;
 }
 
 message QueryResult {
@@ -388,6 +408,14 @@ message QueryResult {
   // string) for `expand="none"` or when the source file has only
   // this one chunk.
   string expanded_context = 7;
+
+  // Per-arm score attribution for the hybrid keyword sub-fusion
+  // (#4552 title arm mirror / #4628).  Populated only when the
+  // corresponding arm scored this hit; absent when the hit came
+  // from the other arms alone.  Present values are float scores
+  // in the same range the sub-fusion consumes (rank-derived for
+  // RRF; raw for weighted).
+  optional float title_score = 8;
 }
 
 message QueryResponse {

--- a/rust/services/search-plugin/src/chunker.rs
+++ b/rust/services/search-plugin/src/chunker.rs
@@ -139,6 +139,34 @@ pub fn chunk_document(text: &str) -> Vec<Chunk> {
     emitter.into_chunks()
 }
 
+/// Extract the FIRST markdown ATX heading text from a document, or
+/// `None` if none exists.  Skips fenced code blocks so a `#` inside
+/// a triple-backtick block isn't mistaken for a heading.
+///
+/// Used by [`crate::skeleton_index`] to seed the title arm's `title`
+/// field at index time — the first heading of a document is the
+/// closest cheap approximation to "the document's title" for the
+/// markdown corpus this plugin targets.
+pub fn extract_first_heading(text: &str) -> Option<String> {
+    let mut in_code_fence = false;
+    for raw_line in text.split_inclusive('\n') {
+        let trimmed_start = raw_line.trim_start();
+        if trimmed_start.starts_with("```") {
+            in_code_fence = !in_code_fence;
+            continue;
+        }
+        if in_code_fence {
+            continue;
+        }
+        if let Some((_, title)) = parse_heading(raw_line) {
+            if !title.is_empty() {
+                return Some(title);
+            }
+        }
+    }
+    None
+}
+
 /// Parse a markdown-style ATX heading (`#` through `######` +
 /// whitespace + title).  Setext (underline) headings not handled
 /// yet — deferred; rare enough that Python's chunker treats them

--- a/rust/services/search-plugin/src/fusion.rs
+++ b/rust/services/search-plugin/src/fusion.rs
@@ -66,6 +66,50 @@ pub fn rrf(keyword: &[QueryResult], semantic: &[QueryResult], k: u32) -> Vec<Que
     finalise(merged)
 }
 
+/// Multi-source RRF — takes N labelled result lists and fuses them
+/// under the same 1/(k + rank) contribution rule as [`rrf`].  Adds
+/// per-source score ATTRIBUTION on the output when the source label
+/// matches a known attribution slot: the `"title"` label stamps
+/// each hit's `title_score` with the RRF contribution the title arm
+/// added.  Other labels contribute to the fused score but produce
+/// no attribution field.
+///
+/// Mirrors Python `rrf_multi_fusion([("chunk", …), ("page", …),
+/// ("title", …)])` — used by [`crate::service`]'s hybrid path to
+/// fold the skeleton index's title-arm hits into the keyword
+/// sub-fusion alongside chunk-BM25 and page-pooling arms (#4552
+/// mirror / #4628).
+///
+/// The dedup key is `(path, chunk_index)` — the same key `rrf` uses.
+/// Sources listed EARLIER win the "first-seen template" (richer
+/// chunk_text / mtime_ms fields), so callers pass the arms with
+/// the richest QueryResult templates first — typically page_kw
+/// then chunk_kw then title (title's `QueryResult` carries an empty
+/// or synthetic chunk_text; the caller hydrates it post-fusion).
+pub fn rrf_multi_fusion(sources: &[(&str, &[QueryResult])], k: u32) -> Vec<QueryResult> {
+    let mut merged: HashMap<DocKey, MergedHit> = HashMap::new();
+    let k_f = k.max(1) as f32;
+    for (label, list) in sources {
+        for (idx, r) in list.iter().enumerate() {
+            let contribution = 1.0 / (k_f + (idx + 1) as f32);
+            let key = DocKey::of(r);
+            let entry = merged.entry(key).or_insert_with(|| MergedHit {
+                score: 0.0,
+                template: r.clone(),
+            });
+            entry.score += contribution;
+            // Per-arm attribution — a doc scored by the title arm
+            // carries its title contribution as `title_score` so
+            // callers observe which arm surfaced it.
+            if *label == "title" {
+                let prior = entry.template.title_score.unwrap_or(0.0);
+                entry.template.title_score = Some(prior + contribution);
+            }
+        }
+    }
+    finalise(merged)
+}
+
 pub fn rrf_weighted(
     keyword: &[QueryResult],
     semantic: &[QueryResult],
@@ -233,6 +277,7 @@ mod tests {
             zone_id: "root".to_string(),
             mtime_ms: Some(1),
             expanded_context: String::new(),
+            title_score: None,
         }
     }
 
@@ -340,6 +385,7 @@ mod tests {
             zone_id: "root".into(),
             mtime_ms: Some(100),
             expanded_context: String::new(),
+            title_score: None,
         }];
         let sem = vec![QueryResult {
             path: "/a".into(),
@@ -349,6 +395,7 @@ mod tests {
             zone_id: "root".into(),
             mtime_ms: Some(200),
             expanded_context: String::new(),
+            title_score: None,
         }];
         let fused = rrf(&kw, &sem, 60);
         assert_eq!(fused.len(), 1);
@@ -380,6 +427,80 @@ mod tests {
         assert_eq!(paths, ["/a", "/a", "/b", "/c"]);
     }
 
+    // ── rrf_multi_fusion (#4552 mirror / #4628) ──────────────────
+
+    #[test]
+    fn rrf_multi_fusion_empty_title_arm_ranks_like_two_arm_rrf() {
+        // Fusion parity guard: adding an empty title arm to the
+        // sub-fusion must not change the rank order or scores of the
+        // pre-existing chunk+page arms.  Locks in the "opt-in
+        // ranking-neutral when the title arm has no hits" property
+        // called out by the design doc.
+        let chunk = vec![hit("/a", 0, 5.0), hit("/b", 0, 4.0)];
+        let page = vec![hit("/b", 0, 3.0), hit("/c", 0, 2.0)];
+        let two_arm = rrf(&chunk, &page, DEFAULT_RRF_K);
+        let three_arm =
+            rrf_multi_fusion(&[("chunk", &chunk), ("page", &page), ("title", &[])], DEFAULT_RRF_K);
+        assert_eq!(three_arm.len(), two_arm.len());
+        for (a, b) in three_arm.iter().zip(two_arm.iter()) {
+            assert_eq!(a.path, b.path, "rank order must match: {three_arm:?} vs {two_arm:?}");
+            assert!(
+                (a.score - b.score).abs() < 1e-5,
+                "scores must match: {} vs {}",
+                a.score,
+                b.score,
+            );
+            assert!(a.title_score.is_none(), "empty title arm produces no attribution");
+        }
+    }
+
+    #[test]
+    fn rrf_multi_fusion_title_score_attributed_when_arm_hits() {
+        // A doc scored only by the title arm gets `title_score`
+        // populated; a doc scored by chunk alone does not.
+        let chunk = vec![hit("/a", 0, 5.0)];
+        let title = vec![hit("/z", 0, 9.0)];
+        let fused =
+            rrf_multi_fusion(&[("chunk", &chunk), ("page", &[]), ("title", &title)], DEFAULT_RRF_K);
+        let a = fused.iter().find(|r| r.path == "/a").expect("/a");
+        let z = fused.iter().find(|r| r.path == "/z").expect("/z");
+        assert!(a.title_score.is_none(), "/a scored only by chunk arm");
+        assert!(z.title_score.is_some(), "/z scored by title arm: {z:?}");
+        assert!(z.title_score.unwrap() > 0.0);
+    }
+
+    #[test]
+    fn rrf_multi_fusion_title_and_chunk_share_a_doc_accumulate() {
+        // A doc that appears in both the chunk arm AND the title arm
+        // accumulates its fused score AND still carries the
+        // title-arm attribution.
+        let doc = hit("/shared", 0, 5.0);
+        let fused = rrf_multi_fusion(
+            &[
+                ("chunk", &[doc.clone()]),
+                ("page", &[]),
+                ("title", &[doc.clone()]),
+            ],
+            DEFAULT_RRF_K,
+        );
+        assert_eq!(fused.len(), 1);
+        assert!(fused[0].title_score.is_some());
+        // Fused score = chunk contribution (1/61) + title contribution (1/61)
+        // = 2/61 ≈ 0.032787
+        let expected = 2.0 / 61.0;
+        assert!(
+            (fused[0].score - expected).abs() < 1e-5,
+            "expected {expected}, got {}",
+            fused[0].score,
+        );
+    }
+
+    #[test]
+    fn rrf_multi_fusion_empty_sources_returns_empty() {
+        let fused = rrf_multi_fusion(&[], DEFAULT_RRF_K);
+        assert!(fused.is_empty());
+    }
+
     #[test]
     fn pool_by_document_preserves_input_order_among_kept_hits() {
         // Regression: a naive impl that groups-then-emits would break
@@ -409,6 +530,7 @@ mod tests {
                 zone_id: "root".into(),
                 mtime_ms: None,
                 expanded_context: String::new(),
+                title_score: None,
             },
             QueryResult {
                 path: "/a".into(),
@@ -418,6 +540,7 @@ mod tests {
                 zone_id: "root".into(),
                 mtime_ms: None,
                 expanded_context: String::new(),
+                title_score: None,
             },
         ];
         // rrf here: rank-1 and rank-2 have different scores; equalise

--- a/rust/services/search-plugin/src/fusion.rs
+++ b/rust/services/search-plugin/src/fusion.rs
@@ -477,9 +477,9 @@ mod tests {
         let doc = hit("/shared", 0, 5.0);
         let fused = rrf_multi_fusion(
             &[
-                ("chunk", &[doc.clone()]),
+                ("chunk", std::slice::from_ref(&doc)),
                 ("page", &[]),
-                ("title", &[doc.clone()]),
+                ("title", std::slice::from_ref(&doc)),
             ],
             DEFAULT_RRF_K,
         );

--- a/rust/services/search-plugin/src/index_manager.rs
+++ b/rust/services/search-plugin/src/index_manager.rs
@@ -45,6 +45,7 @@ use parking_lot::Mutex;
 
 use crate::ann_index::{AnnError, AnnIndex};
 use crate::fts_index::{FtsIndex, IndexError};
+use crate::skeleton_index::SkeletonIndex;
 
 /// Directory name inside a per-zone index root for the FTS store.
 /// Sibling directories (Phase 2's `ann/` for HNSW, etc.) land next
@@ -57,6 +58,12 @@ use crate::fts_index::{FtsIndex, IndexError};
 /// `index_state` version bump forces exactly that on the next
 /// Refresh).
 const FTS_SUBDIR: &str = "fts-v2";
+
+/// Directory name for the per-zone skeleton index (title arm — #4552
+/// mirror).  Lives alongside `fts-v2/` and `ann-*-v2/` under the
+/// zone root; `v1` because it's a fresh schema with no prior on-disk
+/// history to preserve.
+const SKELETON_SUBDIR: &str = "skeleton-v1";
 
 /// Environment variable that names the per-node state root.  Same
 /// SSOT the sibling `nexus-vault` plugin honours — one variable
@@ -84,6 +91,10 @@ pub struct IndexManager {
     root: PathBuf,
     zones: Mutex<HashMap<String, Arc<FtsIndex>>>,
     ann_zones: Mutex<HashMap<AnnKey, Arc<AnnIndex>>>,
+    /// Per-zone skeleton index cache (title arm — #4552 mirror).
+    /// Shape parallels `zones` / `ann_zones` — one Arc per zone,
+    /// lazily opened on first Index or Query call.
+    skeleton_zones: Mutex<HashMap<String, Arc<SkeletonIndex>>>,
     /// Per-zone WRITE locks (review R1).  Index / IndexDocuments /
     /// Refresh / NotifyFileChange each open an independent
     /// `IndexState` and save the whole snapshot at the end, so two
@@ -117,6 +128,7 @@ impl IndexManager {
             root,
             zones: Mutex::new(HashMap::new()),
             ann_zones: Mutex::new(HashMap::new()),
+            skeleton_zones: Mutex::new(HashMap::new()),
             zone_write_locks: Mutex::new(HashMap::new()),
         }
     }
@@ -152,6 +164,12 @@ impl IndexManager {
         self.root
             .join(zone_id)
             .join(format!("ann-{embedder_tag}-v2"))
+    }
+
+    /// Return the on-disk directory the given zone's skeleton index
+    /// lives in.  Same shape as [`index_dir`] but under `skeleton-v1/`.
+    pub fn skeleton_dir(&self, zone_id: &str) -> PathBuf {
+        self.root.join(zone_id).join(SKELETON_SUBDIR)
     }
 
     /// Return the per-zone root — parent of `fts/` and `ann-*-v2/`.
@@ -208,6 +226,20 @@ impl IndexManager {
         }
         let idx = AnnIndex::open_or_create(self.ann_dir(zone_id, embedder_tag), dim)?;
         zones.insert(key, Arc::clone(&idx));
+        Ok(idx)
+    }
+
+    /// Fetch (or lazily open) the skeleton index for `zone_id`.  Same
+    /// caching contract as [`get_or_open`]: repeat calls return the
+    /// same `Arc<SkeletonIndex>` so writer state (buffered adds)
+    /// survives across RPCs.
+    pub fn get_or_open_skeleton(&self, zone_id: &str) -> Result<Arc<SkeletonIndex>, IndexError> {
+        let mut zones = self.skeleton_zones.lock();
+        if let Some(idx) = zones.get(zone_id) {
+            return Ok(Arc::clone(idx));
+        }
+        let idx = SkeletonIndex::open_or_create(self.skeleton_dir(zone_id))?;
+        zones.insert(zone_id.to_string(), Arc::clone(&idx));
         Ok(idx)
     }
 }

--- a/rust/services/search-plugin/src/lib.rs
+++ b/rust/services/search-plugin/src/lib.rs
@@ -66,6 +66,7 @@ pub mod parked_state;
 pub mod query_cache;
 pub mod scoring;
 pub mod service;
+pub mod skeleton_index;
 pub mod zone_modes_state;
 
 use search_proto::search_service_server::SearchService as SearchServiceTrait;

--- a/rust/services/search-plugin/src/query_cache.rs
+++ b/rust/services/search-plugin/src/query_cache.rs
@@ -219,6 +219,12 @@ fn hash_request(req: &QueryRequest) -> u64 {
         k.hash(&mut hasher);
         v.to_bits().hash(&mut hasher);
     }
+    // Title arm (#4552 mirror / #4628) — MUST land in the hash even
+    // for its default value per the module's "adversarial hardening"
+    // clause: two requests differing only in title_arm_disabled
+    // produce different ranked outputs and MUST NOT share a cache
+    // entry.
+    req.title_arm_disabled.hash(&mut hasher);
     hasher.finish()
 }
 
@@ -229,6 +235,22 @@ pub type SharedQueryCache = Arc<QueryCache>;
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn title_arm_flag_distinguishes_cache_entries() {
+        // Adversarial hardening: two requests differing ONLY in
+        // title_arm_disabled produce different fused rankings and
+        // MUST NOT share a cache entry.  Regression pin for the
+        // #4552 mirror / #4628 hash-key addition.
+        let a = base_req("root", "widget");
+        let mut b = a.clone();
+        b.title_arm_disabled = true;
+        assert_ne!(
+            hash_request(&a),
+            hash_request(&b),
+            "title_arm_disabled must land in the cache key",
+        );
+    }
 
     fn base_req(zone: &str, q: &str) -> QueryRequest {
         QueryRequest {

--- a/rust/services/search-plugin/src/query_cache.rs
+++ b/rust/services/search-plugin/src/query_cache.rs
@@ -247,6 +247,7 @@ mod tests {
             recency_weight: 0.0,
             recency_half_life_days: 0.0,
             path_prefix_boosts: HashMap::new(),
+            title_arm_disabled: false,
         }
     }
 
@@ -259,6 +260,7 @@ mod tests {
             zone_id: "root".to_string(),
             mtime_ms: None,
             expanded_context: String::new(),
+            title_score: None,
         }
     }
 

--- a/rust/services/search-plugin/src/scoring.rs
+++ b/rust/services/search-plugin/src/scoring.rs
@@ -225,6 +225,7 @@ mod tests {
             zone_id: "root".to_string(),
             mtime_ms,
             expanded_context: String::new(),
+            title_score: None,
         }
     }
 

--- a/rust/services/search-plugin/src/service.rs
+++ b/rust/services/search-plugin/src/service.rs
@@ -769,6 +769,7 @@ fn enrich_ann_hit(
         zone_id: zone_id.to_string(),
         mtime_ms,
         expanded_context: String::new(),
+        title_score: None,
     }
 }
 
@@ -796,6 +797,7 @@ fn fts_hit_to_result(hit: FtsHit, zone_id: &str) -> QueryResult {
         zone_id: zone_id.to_string(),
         mtime_ms: hit.mtime_ms,
         expanded_context: String::new(),
+        title_score: None,
     }
 }
 

--- a/rust/services/search-plugin/src/service.rs
+++ b/rust/services/search-plugin/src/service.rs
@@ -953,6 +953,7 @@ fn fuse_hybrid(
 struct IndexSinks<'a> {
     fts: &'a Arc<crate::fts_index::FtsIndex>,
     ann: Option<&'a Arc<crate::ann_index::AnnIndex>>,
+    skeleton: &'a Arc<crate::skeleton_index::SkeletonIndex>,
     embedder: Option<&'a Arc<dyn Embedder>>,
     state: &'a crate::index_state::IndexState,
     /// True when an embedder IS configured but failed to initialise
@@ -1030,9 +1031,14 @@ fn do_index(
         }
     }
 
+    let skeleton = manager
+        .get_or_open_skeleton(zone_id)
+        .map_err(|e| format!("open skeleton for zone {zone_id:?}: {e}"))?;
+
     let sinks = IndexSinks {
         fts: &fts,
         ann: ann.as_ref(),
+        skeleton: &skeleton,
         embedder,
         state: &state,
         embed_broken,
@@ -1093,6 +1099,12 @@ fn do_index(
             return Err(format!("ann commit: {e}"));
         }
     }
+    // Skeleton is best-effort: a commit failure logs but does not
+    // fail the pass — FTS is the SSOT for retrievability, skeleton
+    // is a query-time booster that a follow-up Refresh rebuilds.
+    if let Err(e) = skeleton.commit() {
+        tracing::warn!(err = %e, "skeleton commit failed after walk");
+    }
     // Persist the mtime cache so the next Refresh's diff pass sees
     // an up-to-date baseline.  A crash between the sink commits and
     // this save just means the next Refresh will re-index those
@@ -1134,6 +1146,10 @@ enum IndexOne {
 /// the real mtime finalizes the skip.
 fn record_content_skip(handle: &KernelHandle, sinks: &IndexSinks<'_>, vfs_path: &str) -> IndexOne {
     sinks.fts.delete_all_chunks(vfs_path);
+    // Skeleton parity: a content transition that purges FTS chunks
+    // must also drop the doc's title-arm entry, or a query naming
+    // the old title would keep hitting the now-empty file.
+    sinks.skeleton.delete(vfs_path);
     match sinks.ann {
         Some(ann) => {
             ann.delete_all_chunks(vfs_path);
@@ -1215,6 +1231,21 @@ fn index_one(handle: &KernelHandle, sinks: &IndexSinks<'_>, vfs_path: &str) -> I
             );
             return IndexOne::Skipped;
         }
+    }
+
+    // Skeleton (title arm — #4552 mirror): upsert the file's title
+    // alongside the FTS chunks so hybrid fusion can rank
+    // title-shaped queries against the same doc set FTS sees.
+    // Best-effort — a skeleton write failure logs but does not fail
+    // the whole indexing pass; skeleton is a query-time booster,
+    // FTS is the SSOT for retrievability.
+    let title = crate::chunker::extract_first_heading(text).unwrap_or_default();
+    if let Err(e) = sinks.skeleton.upsert(vfs_path, &title) {
+        tracing::warn!(
+            path = %vfs_path,
+            err = %e,
+            "index: skeleton upsert failed — title arm will miss this doc until next refresh",
+        );
     }
 
     // ANN side — keyword-degradation per query is fine, but a
@@ -1303,6 +1334,9 @@ fn index_one(handle: &KernelHandle, sinks: &IndexSinks<'_>, vfs_path: &str) -> I
 /// working ANN sink completes the removal.
 fn remove_one(sinks: &IndexSinks<'_>, vfs_path: &str, zone_has_ann: bool) -> bool {
     sinks.fts.delete_all_chunks(vfs_path);
+    // Skeleton parity: the title-arm entry is small + orthogonal to
+    // ANN reachability, so drop it unconditionally alongside FTS.
+    sinks.skeleton.delete(vfs_path);
     match sinks.ann {
         Some(ann) => {
             ann.delete_all_chunks(vfs_path);
@@ -1428,9 +1462,14 @@ fn do_refresh(
         }
     }
 
+    let skeleton = manager
+        .get_or_open_skeleton(zone_id)
+        .map_err(|e| format!("open skeleton for zone {zone_id:?}: {e}"))?;
+
     let sinks = IndexSinks {
         fts: &fts,
         ann: ann.as_ref(),
+        skeleton: &skeleton,
         embedder,
         state: &state,
         embed_broken,
@@ -1552,6 +1591,10 @@ fn do_refresh(
             return Err(format!("ann commit: {e}"));
         }
     }
+    // Skeleton is best-effort — see do_index for the rationale.
+    if let Err(e) = skeleton.commit() {
+        tracing::warn!(err = %e, "skeleton commit failed after refresh");
+    }
     if let Err(e) = state.save() {
         tracing::warn!(err = %e, "index_state save failed");
     }
@@ -1609,6 +1652,9 @@ fn do_index_documents(
         } else {
             None
         };
+        let skeleton = manager
+            .get_or_open_skeleton(&zone_id)
+            .map_err(|e| format!("open skeleton for zone {zone_id:?}: {e}"))?;
         let state = crate::index_state::IndexState::open_or_create(manager.zone_root(&zone_id))
             .map_err(|e| format!("open state for zone {zone_id:?}: {e}"))?;
 
@@ -1641,6 +1687,9 @@ fn do_index_documents(
         // chunks, not leave stale text searchable behind a skip.
         let content_skip = |path: &str| {
             fts.delete_all_chunks(path);
+            // Skeleton parity: content transition drops the title-arm
+            // entry so a query on the old title stops matching.
+            skeleton.delete(path);
             match ann.as_ref() {
                 Some(a) => {
                     a.delete_all_chunks(path);
@@ -1683,6 +1732,17 @@ fn do_index_documents(
             if !fts_ok {
                 total_skipped += 1;
                 continue;
+            }
+
+            // Skeleton: upsert the doc's title alongside FTS chunks so
+            // hybrid fusion's title arm ranks it consistently.
+            let title = crate::chunker::extract_first_heading(&doc.text).unwrap_or_default();
+            if let Err(e) = skeleton.upsert(&doc.path, &title) {
+                tracing::warn!(
+                    path = %doc.path,
+                    err = %e,
+                    "index_documents: skeleton upsert failed — title arm will miss until next refresh",
+                );
             }
 
             // ANN: keyword-degradation is fine per query, but a
@@ -1750,6 +1810,11 @@ fn do_index_documents(
                 if let Err(e) = fts.commit() {
                     return Err(format!("fts incremental commit for zone {zone_id:?}: {e}"));
                 }
+                // Match FTS visibility on the incremental step so the
+                // title arm doesn't lag behind a keyword-visible doc.
+                if let Err(e) = skeleton.commit() {
+                    tracing::warn!(err = %e, zone = %zone_id, "skeleton incremental commit failed");
+                }
                 // Cached results captured before this commit would
                 // mask the fresh docs for the cache TTL — drop them
                 // with every visibility step, not just at the end.
@@ -1765,6 +1830,9 @@ fn do_index_documents(
             if let Err(e) = a.commit() {
                 return Err(format!("ann commit for zone {zone_id:?}: {e}"));
             }
+        }
+        if let Err(e) = skeleton.commit() {
+            tracing::warn!(err = %e, zone = %zone_id, "skeleton commit failed");
         }
         if let Err(e) = state.save() {
             tracing::warn!(err = %e, zone = %zone_id, "index_state save failed");
@@ -1795,12 +1863,18 @@ fn do_notify_file_change(
     let fts = manager
         .get_or_open(zone_id)
         .map_err(|e| format!("open fts for zone {zone_id:?}: {e}"))?;
+    let skeleton = manager
+        .get_or_open_skeleton(zone_id)
+        .map_err(|e| format!("open skeleton for zone {zone_id:?}: {e}"))?;
     let state = crate::index_state::IndexState::open_or_create(manager.zone_root(zone_id))
         .map_err(|e| format!("open state for zone {zone_id:?}: {e}"))?;
 
     match change_type {
         "delete" => {
             fts.delete_all_chunks(path);
+            // Skeleton drop mirrors the FTS delete — a deleted file
+            // must stop matching title-arm queries immediately.
+            skeleton.delete(path);
             // Only open ANN if it happens to already be there —
             // creating an empty ANN dir on a delete is
             // counterproductive.  We'd need the embedder tag to
@@ -1815,6 +1889,9 @@ fn do_notify_file_change(
             state.record(path, None);
             if let Err(e) = fts.commit() {
                 return Err(format!("fts commit: {e}"));
+            }
+            if let Err(e) = skeleton.commit() {
+                tracing::warn!(err = %e, "skeleton commit failed on delete notify");
             }
             // The tombstone IS the deferred-ANN-cleanup record — if it
             // cannot be persisted the delete must FAIL so the caller

--- a/rust/services/search-plugin/src/service.rs
+++ b/rust/services/search-plugin/src/service.rs
@@ -695,6 +695,85 @@ fn do_keyword_query(
         .collect())
 }
 
+/// Title-arm ranked search over the per-zone skeleton index
+/// (#4552 mirror / #4628).  Returns hits shaped as `QueryResult`
+/// with chunk_text hydrated from the sibling FTS: covered paths
+/// borrow the first chunk (FtsIndex::get_chunks_by_path[0]) so a
+/// title-only hit still carries a snippet callers can render.
+/// A hit whose FTS row is absent (drift or chunkless doc) still
+/// enters the fusion with an empty `chunk_text` — the doc stays
+/// retrievable per the design doc.
+fn do_title_query(
+    manager: &IndexManager,
+    q: &str,
+    zone_id: &str,
+    limit: usize,
+    path_filter: &str,
+) -> Result<Vec<QueryResult>, String> {
+    if q.trim().is_empty() {
+        return Ok(Vec::new());
+    }
+    let skeleton = manager
+        .get_or_open_skeleton(zone_id)
+        .map_err(|e| format!("open skeleton for zone {zone_id:?}: {e}"))?;
+
+    let prefix = if path_filter.is_empty() {
+        None
+    } else {
+        Some(path_filter)
+    };
+
+    let hits = skeleton
+        .search(q, limit, prefix)
+        .map_err(|e| format!("title search: {e}"))?;
+
+    // Best-effort FTS side to hydrate chunk_text + mtime — a missing
+    // FTS row (drift or chunkless doc) still ships the title hit
+    // through with empty chunk_text.
+    let fts = manager.get_or_open(zone_id).ok();
+
+    Ok(hits
+        .into_iter()
+        .map(|h| title_hit_to_result(fts.as_deref(), h, zone_id))
+        .collect())
+}
+
+/// Hydrate a [`crate::skeleton_index::SkeletonHit`] into a full
+/// `QueryResult` by borrowing the first FTS chunk for the same
+/// path.  Chunkless docs (no FTS row) come through with empty
+/// `chunk_text` — the doc is still retrievable through the fused
+/// result envelope per the design doc.  The skeleton hit's raw
+/// BM25 score is preserved as the sub-fusion input; the title-arm
+/// attribution stamped later by [`fusion::rrf_multi_fusion`] is a
+/// separate rank-derived value.
+fn title_hit_to_result(
+    fts: Option<&crate::fts_index::FtsIndex>,
+    hit: crate::skeleton_index::SkeletonHit,
+    zone_id: &str,
+) -> QueryResult {
+    let (chunk_text, chunk_index, mtime_ms) = fts
+        .and_then(|f| f.get_chunks_by_path(&hit.path).ok())
+        .and_then(|mut chunks| {
+            if chunks.is_empty() {
+                None
+            } else {
+                let first = chunks.remove(0);
+                Some((first.chunk_text, first.chunk_index, first.mtime_ms))
+            }
+        })
+        .unwrap_or((String::new(), 0, None));
+    QueryResult {
+        path: hit.path,
+        chunk_index,
+        chunk_text,
+        score: hit.score,
+        zone_id: zone_id.to_string(),
+        mtime_ms,
+        expanded_context: String::new(),
+        title_score: None,
+    }
+}
+
 /// Vector-similarity search over the per-zone HNSW index (Phase 2).
 /// Embeds `q` via the caller-supplied embedder, opens the ANN index
 /// tagged with the embedder's `tag()`, runs top-k, and materialises
@@ -922,10 +1001,36 @@ const HYBRID_OVER_FETCH_MULT: usize = 2;
 const ADJUSTMENT_OVER_FETCH_MULT: usize = 10;
 const ADJUSTMENT_FETCH_CEILING: usize = 500;
 
-/// Fuse two source result lists per the caller's chosen method,
-/// pool per-doc, and truncate to `limit`.  Pure math — the two
-/// source lists come in already fetched.  The RPC handler runs
-/// the fetches in parallel then hands them here.
+/// Env kill-switch for the title arm — matches Python's
+/// `NEXUS_SEARCH_TITLE_ARM` config knob.  Absent or truthy ⇒ arm on;
+/// any of `false/0/off/no` (case-insensitive) ⇒ arm off.  Combined
+/// with the wire flag `QueryRequest.title_arm_disabled` via
+/// [`title_arm_effective`].  Read fresh per query — env access is
+/// cheap and this lets ops flip the switch without a plugin restart.
+fn title_arm_env_enabled() -> bool {
+    match std::env::var("NEXUS_SEARCH_TITLE_ARM").ok() {
+        None => true,
+        Some(v) => !matches!(v.trim().to_ascii_lowercase().as_str(), "false" | "0" | "off" | "no"),
+    }
+}
+
+/// Effective title-arm state for a single hybrid query.  ON when
+/// BOTH the env allows it AND the wire request has not disabled it.
+/// The wire flag exists so callers can ablate per-query; the env
+/// flag exists so ops can rollback fleet-wide without a redeploy.
+fn title_arm_effective(req: &QueryRequest) -> bool {
+    title_arm_env_enabled() && !req.title_arm_disabled
+}
+
+/// Fuse the keyword + semantic legs per the caller's chosen method,
+/// pool per-doc, and truncate to `limit`.  Pure math — the source
+/// lists come in already fetched.  The RPC handler runs the fetches
+/// in parallel then hands them here.
+///
+/// The title-arm variant [`fuse_hybrid_with_title`] adds a third
+/// keyword-side arm to the sub-fusion; the plain [`fuse_hybrid`]
+/// preserves the pre-title-arm two-source shape for callers that
+/// disabled the arm.
 fn fuse_hybrid(
     keyword: Vec<QueryResult>,
     semantic: Vec<QueryResult>,
@@ -943,6 +1048,34 @@ fn fuse_hybrid(
     };
     let pooled = fusion::pool_by_document(fused, opts.chunks_per_page);
     pooled.into_iter().take(limit).collect()
+}
+
+/// Three-arm sub-fusion variant (#4552 mirror / #4628).  Runs
+/// `rrf_multi_fusion(chunk, title)` first (page arm empty in the
+/// Rust plugin since FTS already stores chunks, not pages), then
+/// feeds the fused keyword lane into the caller's chosen final
+/// method against the semantic lane.
+///
+/// The title arm can PROMOTE a title-shaped hit ranked below the
+/// requested limit in chunk BM25 alone into the top-N — which is
+/// exactly the point.  Fusion parity for non-title queries is
+/// covered by `fusion::rrf_multi_fusion_empty_title_arm_ranks_like_two_arm_rrf`.
+fn fuse_hybrid_with_title(
+    chunk_kw: Vec<QueryResult>,
+    title_kw: Vec<QueryResult>,
+    semantic: Vec<QueryResult>,
+    limit: usize,
+    opts: FusionOpts,
+) -> Vec<QueryResult> {
+    let kw_fused = fusion::rrf_multi_fusion(
+        &[("chunk", &chunk_kw), ("title", &title_kw)],
+        opts.rrf_k,
+    );
+    // Feed the sub-fused keyword lane into the final method against
+    // the semantic lane. RRF-family methods work naturally; weighted
+    // will renormalise its inputs so the intermediate score scale is
+    // fine.
+    fuse_hybrid(kw_fused, semantic, limit, opts)
 }
 
 /// Sinks the Index walker writes into.  `fts` is required (Index
@@ -2080,6 +2213,11 @@ impl SearchService for SearchServiceImpl {
             req.recency_half_life_days
         };
         let prefix_boosts = req.path_prefix_boosts.clone();
+        // Grab the title-arm flag before any downstream move — the
+        // Hybrid arm below moves several req fields for its parallel
+        // spawns, so we resolve title_arm_effective here while &req
+        // is still fully alive.
+        let title_arm_on = title_arm_effective(&req);
         let limit = if req.limit == 0 {
             DEFAULT_QUERY_LIMIT
         } else {
@@ -2173,21 +2311,43 @@ impl SearchService for SearchServiceImpl {
                 // on the blocking pool + joining brings wall-clock to
                 // max(kw, sem) ≈ 300 ms — no free lunch on total CPU
                 // but user-visible p95 halves in the worst-case ratio.
+                //
+                // Title arm (#4552 mirror / #4628): runs as a THIRD
+                // parallel leg when enabled.  Skeleton search is
+                // sub-millisecond (per-doc index, ~one BM25 term
+                // query) so its cost is dominated by the ~300 ms
+                // semantic leg — free ranking-quality lift.
                 let over_fetch = limit
                     .saturating_mul(HYBRID_OVER_FETCH_MULT)
                     .max(limit)
                     .max(fetch_limit);
-                let (kw_task, sem_task) = {
+                let title_enabled = title_arm_on;
+                let (kw_task, sem_task, title_task) = {
                     let mgr_kw = Arc::clone(&manager);
                     let mgr_sem = Arc::clone(&manager);
+                    let mgr_title = Arc::clone(&manager);
                     let embedder = Arc::clone(&embedder);
                     let embed_cache = Arc::clone(&self.embed_cache);
                     let q_kw = q.clone();
-                    let q_sem = q;
+                    let q_sem = q.clone();
+                    let q_title = q;
                     let zone_kw = zone_id.clone();
-                    let zone_sem = zone_id;
+                    let zone_sem = zone_id.clone();
+                    let zone_title = zone_id;
                     let path_kw = path_filter.clone();
-                    let path_sem = path_filter;
+                    let path_sem = path_filter.clone();
+                    let path_title = path_filter;
+                    let title_fut: tokio::task::JoinHandle<Result<Vec<QueryResult>, String>> =
+                        if title_enabled {
+                            tokio::task::spawn_blocking(move || {
+                                do_title_query(&mgr_title, &q_title, &zone_title, over_fetch, &path_title)
+                            })
+                        } else {
+                            // Match the type: an already-resolved
+                            // future returning an empty list keeps
+                            // downstream code branch-free.
+                            tokio::task::spawn_blocking(|| Ok(Vec::new()))
+                        };
                     (
                         tokio::task::spawn_blocking(move || {
                             do_keyword_query(&mgr_kw, &q_kw, &zone_kw, over_fetch, &path_kw)
@@ -2203,20 +2363,42 @@ impl SearchService for SearchServiceImpl {
                                 &path_sem,
                             )
                         }),
+                        title_fut,
                     )
                 };
-                let (kw_join, sem_join) = tokio::join!(kw_task, sem_task);
+                let (kw_join, sem_join, title_join) =
+                    tokio::join!(kw_task, sem_task, title_task);
                 let kw = kw_join
                     .map_err(|e| Status::internal(format!("spawn_blocking joined error: {e}")))?;
                 let sem = sem_join
                     .map_err(|e| Status::internal(format!("spawn_blocking joined error: {e}")))?;
+                // A title-arm error MUST NOT fail the whole hybrid
+                // query — title is a booster, not a required lane.
+                // Log and treat as empty, mirroring the "hydration
+                // failure is best-effort" clause in the design doc.
+                let title = match title_join {
+                    Ok(Ok(hits)) => hits,
+                    Ok(Err(e)) => {
+                        tracing::warn!(err = %e, "title arm failed — falling back to two-arm hybrid");
+                        Vec::new()
+                    }
+                    Err(e) => {
+                        tracing::warn!(err = %e, "title arm spawn joined error — falling back");
+                        Vec::new()
+                    }
+                };
                 match (kw, sem) {
                     (Ok(keyword), Ok(semantic)) => {
                         // Keep the over-fetched pool through fusion
                         // when adjustments still need to reorder it;
                         // the final truncate-to-limit happens post-
                         // adjustment below.
-                        Ok(fuse_hybrid(keyword, semantic, fetch_limit, fusion_opts))
+                        let fused = if title_enabled && !title.is_empty() {
+                            fuse_hybrid_with_title(keyword, title, semantic, fetch_limit, fusion_opts)
+                        } else {
+                            fuse_hybrid(keyword, semantic, fetch_limit, fusion_opts)
+                        };
+                        Ok(fused)
                     }
                     // A source-side error on either leg — surface it
                     // as the response's `error` field rather than a

--- a/rust/services/search-plugin/src/skeleton_index.rs
+++ b/rust/services/search-plugin/src/skeleton_index.rs
@@ -1,0 +1,513 @@
+//! Per-zone tantivy skeleton index — BM25 over path tokens + title,
+//! with title weighted 2× at query time (Rust mirror of the Python
+//! `_skeleton_docs` + `SearchDaemon.locate()` pair — #4552).
+//!
+//! # Why a separate index
+//!
+//! Titles are not searchable text in [`crate::fts_index`] because the
+//! FTS schema stores CHUNK text, not document metadata.  A query
+//! naming a document by its title only ("Q3 design doc",
+//! "<project> spec") under-ranks its target when the title text does
+//! not recur in body chunks.  The skeleton index gives titles their
+//! own BM25 field so the hybrid fusion pipeline can enter a third
+//! keyword-side arm ranking title matches on their own merits, then
+//! RRF-fuse that with the chunk-BM25 and semantic-vector arms.
+//!
+//! # Storage layout
+//!
+//! Same pattern as [`crate::fts_index`]:
+//! `~/.nexus/plugins/search/<zone_id>/skeleton-v1/`.  Plugin-owned,
+//! per-node, NOT replicated — the SSOT is the kernel VFS and the
+//! sibling FtsIndex/AnnIndex which hold the raw doc content.
+//! Dropping the directory is always safe: the next Index or Refresh
+//! rebuilds it from the same doc bytes the FTS index sees.
+//!
+//! # Schema
+//!
+//! ```text
+//! path         STRING | STORED       exact match + retrievable (dedup key)
+//! path_tokens  TEXT(en_stem)         BM25-analysed, English-stemmed
+//! title        TEXT(en_stem) | STORED  BM25-analysed, English-stemmed
+//! ```
+//!
+//! Both text fields use the same `en_stem` chain as FtsIndex so
+//! morphological query variants match consistently across the three
+//! keyword arms (chunk / page / title) — a query "authorization"
+//! matches a title "authorized guide" the same way it matches a
+//! body chunk containing "authorized".  Title-2× is applied at
+//! QUERY time (per-field boost), keeping the schema symmetric with
+//! FtsIndex's single-analyser convention.
+//!
+//! # Idempotency
+//!
+//! One document per `path`.  [`upsert`](SkeletonIndex::upsert) deletes
+//! any prior doc under the same path before adding the new one, so
+//! the writer's uncommitted transaction is (drop-all, add-new) —
+//! commit lands atomically, readers never see a partial state.
+//!
+//! # Concurrency
+//!
+//! Same shape as FtsIndex — one writer per index behind a
+//! `parking_lot::Mutex`; the reader is `Send + Sync` and searches
+//! take no locks.  The mutex is not held across `.await`.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+use tantivy::collector::TopDocs;
+use tantivy::directory::MmapDirectory;
+use tantivy::query::{BooleanQuery, Occur, Query, QueryParser};
+use tantivy::query::{BoostQuery, TermQuery};
+use tantivy::schema::{
+    Field, IndexRecordOption, Schema, TextFieldIndexing, TextOptions, Value, STORED, STRING,
+};
+use tantivy::{doc, Index, IndexReader, IndexWriter, ReloadPolicy, TantivyDocument, Term};
+
+use crate::fts_index::IndexError;
+
+/// Same 50 MiB budget FtsIndex uses.  The skeleton index has far
+/// fewer documents (one per file, not per chunk), so this is
+/// generous — kept identical to make sizing predictable.
+const WRITER_HEAP_BYTES: usize = 50 * 1024 * 1024;
+
+/// Weight applied to the title field at query time — Python's
+/// `SearchDaemon.locate()` weights title 2× vs path tokens; mirror
+/// exactly so cross-cutover ranking stays comparable.
+const TITLE_BOOST: f32 = 2.0;
+
+/// Result row returned by [`SkeletonIndex::search`].
+#[derive(Debug, Clone)]
+pub struct SkeletonHit {
+    pub path: String,
+    pub title: String,
+    pub score: f32,
+}
+
+/// Skeleton schema field handles.
+#[derive(Debug, Clone)]
+struct Fields {
+    path: Field,
+    path_tokens: Field,
+    title: Field,
+}
+
+impl Fields {
+    fn from_schema(schema: &Schema) -> Self {
+        Self {
+            path: schema.get_field("path").expect("schema field: path"),
+            path_tokens: schema
+                .get_field("path_tokens")
+                .expect("schema field: path_tokens"),
+            title: schema.get_field("title").expect("schema field: title"),
+        }
+    }
+}
+
+/// Build the skeleton schema.  Broken out so tests can construct a
+/// schema without opening a directory.
+pub fn build_schema() -> Schema {
+    let mut sb = Schema::builder();
+    // path — exact-match STRING, primary dedupe key.  Also stored so
+    // hits can round-trip the retrievable path without a sibling
+    // lookup.
+    sb.add_text_field("path", STRING | STORED);
+    // path_tokens — path split into whitespace-separated segments and
+    // BM25-analysed through `en_stem`.  Callers pass the tokenized
+    // form; the schema keeps the transform explicit at insert time so
+    // storage cost is minimal.
+    let text_opts = TextOptions::default().set_indexing_options(
+        TextFieldIndexing::default()
+            .set_tokenizer("en_stem")
+            .set_index_option(IndexRecordOption::WithFreqsAndPositions),
+    );
+    sb.add_text_field("path_tokens", text_opts.clone());
+    // title — BM25-analysed AND stored so hits carry the display
+    // string.  Applies the query-time boost via [`TITLE_BOOST`].
+    let title_opts = TextOptions::default()
+        .set_indexing_options(
+            TextFieldIndexing::default()
+                .set_tokenizer("en_stem")
+                .set_index_option(IndexRecordOption::WithFreqsAndPositions),
+        )
+        .set_stored();
+    sb.add_text_field("title", title_opts);
+    sb.build()
+}
+
+/// One per-zone skeleton index.  Cheap to clone (`Arc` inside).
+pub struct SkeletonIndex {
+    index: Index,
+    fields: Fields,
+    writer: Mutex<IndexWriter>,
+    reader: IndexReader,
+}
+
+impl SkeletonIndex {
+    /// Open the index at `dir`, creating it (with the skeleton schema)
+    /// if nothing lives there yet.  Same open-or-create contract as
+    /// [`crate::fts_index::FtsIndex::open_or_create`].
+    pub fn open_or_create(dir: PathBuf) -> Result<Arc<Self>, IndexError> {
+        std::fs::create_dir_all(&dir)
+            .map_err(|e| IndexError::CreateDir(dir.display().to_string(), e.to_string()))?;
+
+        let mmap = MmapDirectory::open(&dir)
+            .map_err(|e| IndexError::Open(dir.display().to_string(), e.to_string()))?;
+
+        let schema = build_schema();
+        let index = Index::open_or_create(mmap, schema.clone())
+            .map_err(|e| IndexError::Open(dir.display().to_string(), e.to_string()))?;
+
+        let fields = Fields::from_schema(&schema);
+
+        let writer = index
+            .writer::<TantivyDocument>(WRITER_HEAP_BYTES)
+            .map_err(|e| IndexError::WriterInit(e.to_string()))?;
+
+        let reader = index
+            .reader_builder()
+            .reload_policy(ReloadPolicy::OnCommitWithDelay)
+            .try_into()
+            .map_err(|e| IndexError::ReaderInit(e.to_string()))?;
+
+        Ok(Arc::new(Self {
+            index,
+            fields,
+            writer: Mutex::new(writer),
+            reader,
+        }))
+    }
+
+    /// Idempotent write: drops any prior doc under `path`, then adds
+    /// the new (path, title) pair.  Both operations queue on the same
+    /// writer transaction so [`commit`](Self::commit) lands them
+    /// atomically — a reader never sees the file present under the
+    /// wrong title.
+    ///
+    /// `title` may be empty when a doc has no heading and no
+    /// meaningful basename; skeleton entries with empty title still
+    /// match on `path_tokens`, keeping the "path-search" leg working.
+    pub fn upsert(&self, path: &str, title: &str) -> Result<(), IndexError> {
+        let path_tokens = tokenize_path(path);
+        let writer = self.writer.lock();
+        writer.delete_term(Term::from_field_text(self.fields.path, path));
+        writer
+            .add_document(doc!(
+                self.fields.path => path,
+                self.fields.path_tokens => path_tokens,
+                self.fields.title => title,
+            ))
+            .map_err(|e| IndexError::AddDoc(path.to_string(), e.to_string()))?;
+        Ok(())
+    }
+
+    /// Drop the skeleton entry for `path`.  No-op if none exists.
+    /// The caller commits with the next [`commit`](Self::commit).
+    pub fn delete(&self, path: &str) {
+        let writer = self.writer.lock();
+        writer.delete_term(Term::from_field_text(self.fields.path, path));
+    }
+
+    /// Flush buffered writes to disk and force-reload the reader so a
+    /// subsequent [`search`](Self::search) sees the commit — mirrors
+    /// FtsIndex's commit contract.
+    pub fn commit(&self) -> Result<(), IndexError> {
+        let mut writer = self.writer.lock();
+        writer
+            .commit()
+            .map_err(|e| IndexError::Commit(e.to_string()))?;
+        self.reader
+            .reload()
+            .map_err(|e| IndexError::Commit(e.to_string()))?;
+        Ok(())
+    }
+
+    /// Title-2× ranked search over path tokens + title.  Returns up to
+    /// `limit` hits ordered by BM25 score descending.  `path_prefix`
+    /// filters on `stored_path.starts_with(prefix)` after scoring
+    /// (same pattern FtsIndex uses).
+    pub fn search(
+        &self,
+        query: &str,
+        limit: usize,
+        path_prefix: Option<&str>,
+    ) -> Result<Vec<SkeletonHit>, IndexError> {
+        if query.trim().is_empty() {
+            return Ok(Vec::new());
+        }
+        let searcher = self.reader.searcher();
+
+        // Two per-field queries; the title arm is boosted 2×.  Wrapped
+        // in a SHOULD boolean so a doc matching either field scores,
+        // and a doc matching both accumulates.  Both branches use the
+        // same tokenized query text because the two fields share the
+        // `en_stem` analyser.
+        let path_parser = QueryParser::for_index(&self.index, vec![self.fields.path_tokens]);
+        let path_q = path_parser
+            .parse_query(query)
+            .map_err(|e| IndexError::ParseQuery(query.to_string(), e.to_string()))?;
+
+        let title_parser = QueryParser::for_index(&self.index, vec![self.fields.title]);
+        let title_q = title_parser
+            .parse_query(query)
+            .map_err(|e| IndexError::ParseQuery(query.to_string(), e.to_string()))?;
+
+        let boosted_title: Box<dyn Query> = Box::new(BoostQuery::new(title_q, TITLE_BOOST));
+        let combined = BooleanQuery::new(vec![
+            (Occur::Should, path_q),
+            (Occur::Should, boosted_title),
+        ]);
+
+        let fetch = if path_prefix.is_some() {
+            (limit * 4).min(1_000)
+        } else {
+            limit
+        };
+
+        let top = searcher
+            .search(&combined, &TopDocs::with_limit(fetch))
+            .map_err(|e| IndexError::Search(e.to_string()))?;
+
+        let mut hits = Vec::with_capacity(limit);
+        for (score, addr) in top {
+            let stored: TantivyDocument = searcher
+                .doc(addr)
+                .map_err(|e| IndexError::Search(e.to_string()))?;
+            let hit = self.decode(stored, score);
+            if let Some(prefix) = path_prefix {
+                if !hit.path.starts_with(prefix) {
+                    continue;
+                }
+            }
+            hits.push(hit);
+            if hits.len() >= limit {
+                break;
+            }
+        }
+        Ok(hits)
+    }
+
+    /// Exact-path lookup — resolves a single skeleton row by its
+    /// `path` field.  Used by tests and by the hydration path in
+    /// `do_hybrid_query` to fetch a doc's title after fusion.
+    pub fn get_by_path(&self, path: &str) -> Result<Option<SkeletonHit>, IndexError> {
+        let searcher = self.reader.searcher();
+        let term = Term::from_field_text(self.fields.path, path);
+        let query = TermQuery::new(term, IndexRecordOption::Basic);
+        let top = searcher
+            .search(&query, &TopDocs::with_limit(1))
+            .map_err(|e| IndexError::Search(e.to_string()))?;
+        let Some((score, addr)) = top.into_iter().next() else {
+            return Ok(None);
+        };
+        let stored: TantivyDocument = searcher
+            .doc(addr)
+            .map_err(|e| IndexError::Search(e.to_string()))?;
+        Ok(Some(self.decode(stored, score)))
+    }
+
+    fn decode(&self, stored: TantivyDocument, score: f32) -> SkeletonHit {
+        let path = stored
+            .get_first(self.fields.path)
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string();
+        let title = stored
+            .get_first(self.fields.title)
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string();
+        SkeletonHit { path, title, score }
+    }
+}
+
+/// Split a path into whitespace-separated segments the BM25 analyser
+/// can tokenize normally.  Non-alphanumeric separators (`/`, `-`,
+/// `_`, `.`) all become spaces so `/notes/q3-plan.md` becomes
+/// `notes q3 plan md` and matches a query "q3 plan".
+///
+/// Deliberately preserves `md` / `txt` / etc. as tokens — the query
+/// stemmer treats them like any other word, and callers who want to
+/// exclude them can filter at the caller.  Not a public API; the
+/// caller passes a `path`, not tokens.
+fn tokenize_path(path: &str) -> String {
+    let mut out = String::with_capacity(path.len());
+    for ch in path.chars() {
+        if ch.is_alphanumeric() {
+            out.push(ch);
+        } else {
+            out.push(' ');
+        }
+    }
+    // Collapse runs of whitespace so the token stream stays clean.
+    out.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tempdir() -> PathBuf {
+        tempfile::tempdir().expect("tempdir").keep()
+    }
+
+    #[test]
+    fn open_creates_empty_index() {
+        let dir = tempdir().join("skeleton");
+        let idx = SkeletonIndex::open_or_create(dir.clone()).expect("open");
+        assert!(dir.exists());
+        let hits = idx.search("anything", 10, None).expect("search");
+        assert!(hits.is_empty());
+    }
+
+    #[test]
+    fn upsert_then_search_finds_by_path_token() {
+        let dir = tempdir().join("skeleton");
+        let idx = SkeletonIndex::open_or_create(dir).expect("open");
+        idx.upsert("/notes/q3-plan.md", "Q3 Roadmap").expect("upsert");
+        idx.commit().expect("commit");
+
+        // Query matches on the path tokenization.
+        let hits = idx.search("q3 plan", 10, None).expect("search");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].path, "/notes/q3-plan.md");
+        assert!(hits[0].score > 0.0);
+    }
+
+    #[test]
+    fn title_matches_score_higher_than_path_only_matches() {
+        // Two docs, one has the query word ONLY in path tokens, the
+        // other has it ONLY in the title.  Title 2× must rank the
+        // title-match ahead of the path-match.
+        let dir = tempdir().join("skeleton");
+        let idx = SkeletonIndex::open_or_create(dir).expect("open");
+        idx.upsert("/reports/rocket-launch.md", "Weekly Digest")
+            .expect("upsert-path");
+        idx.upsert("/misc/other.md", "Rocket Launch Retrospective")
+            .expect("upsert-title");
+        idx.commit().expect("commit");
+
+        let hits = idx.search("rocket", 10, None).expect("search");
+        assert_eq!(hits.len(), 2, "both docs match on 'rocket': {hits:?}");
+        assert_eq!(
+            hits[0].path, "/misc/other.md",
+            "title-match must lead path-only match: {hits:?}"
+        );
+        assert!(
+            hits[0].score > hits[1].score,
+            "title 2× boost should widen the score gap: {hits:?}"
+        );
+    }
+
+    #[test]
+    fn upsert_is_idempotent_and_replaces_title() {
+        let dir = tempdir().join("skeleton");
+        let idx = SkeletonIndex::open_or_create(dir).expect("open");
+        idx.upsert("/doc.md", "Old Title").expect("first");
+        idx.commit().expect("commit-1");
+        idx.upsert("/doc.md", "New Title").expect("second");
+        idx.commit().expect("commit-2");
+
+        // Only ONE hit — no duplicate row.
+        let hits = idx.search("title", 10, None).expect("search");
+        assert_eq!(hits.len(), 1, "upsert must dedupe: {hits:?}");
+        assert_eq!(hits[0].title, "New Title");
+        // Old title no longer scores.
+        let old = idx.search("old", 10, None).expect("search-old");
+        assert!(old.is_empty(), "old title text must be gone: {old:?}");
+    }
+
+    #[test]
+    fn delete_removes_the_entry() {
+        let dir = tempdir().join("skeleton");
+        let idx = SkeletonIndex::open_or_create(dir).expect("open");
+        idx.upsert("/gone.md", "Doomed").expect("upsert");
+        idx.commit().expect("commit-1");
+        idx.delete("/gone.md");
+        idx.commit().expect("commit-2");
+        let hits = idx.search("doomed", 10, None).expect("search");
+        assert!(hits.is_empty(), "delete must remove the doc: {hits:?}");
+    }
+
+    #[test]
+    fn empty_query_returns_empty() {
+        let dir = tempdir().join("skeleton");
+        let idx = SkeletonIndex::open_or_create(dir).expect("open");
+        idx.upsert("/x.md", "Widget").expect("upsert");
+        idx.commit().expect("commit");
+        assert!(idx.search("", 10, None).expect("search").is_empty());
+        assert!(idx.search("   ", 10, None).expect("search").is_empty());
+    }
+
+    #[test]
+    fn morphological_variants_match_stemmed_titles() {
+        // Same en_stem chain FtsIndex uses — title "authorized"
+        // must match query "authorization".
+        let dir = tempdir().join("skeleton");
+        let idx = SkeletonIndex::open_or_create(dir).expect("open");
+        idx.upsert("/a.md", "authorized access guide")
+            .expect("upsert");
+        idx.commit().expect("commit");
+        let hits = idx.search("authorization", 10, None).expect("search");
+        assert_eq!(hits.len(), 1, "stemmer must bridge the variants");
+    }
+
+    #[test]
+    fn path_prefix_filters_out_off_prefix_hits() {
+        let dir = tempdir().join("skeleton");
+        let idx = SkeletonIndex::open_or_create(dir).expect("open");
+        idx.upsert("/notes/hello.md", "Hello Notes")
+            .expect("upsert-a");
+        idx.upsert("/logs/hello.md", "Hello Log").expect("upsert-b");
+        idx.commit().expect("commit");
+        let hits = idx.search("hello", 10, Some("/notes/")).expect("search");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].path, "/notes/hello.md");
+    }
+
+    #[test]
+    fn get_by_path_returns_the_stored_row() {
+        let dir = tempdir().join("skeleton");
+        let idx = SkeletonIndex::open_or_create(dir).expect("open");
+        idx.upsert("/z.md", "Zeta Doc").expect("upsert");
+        idx.commit().expect("commit");
+        let hit = idx
+            .get_by_path("/z.md")
+            .expect("get")
+            .expect("must be present");
+        assert_eq!(hit.title, "Zeta Doc");
+    }
+
+    #[test]
+    fn get_by_path_missing_is_none() {
+        let dir = tempdir().join("skeleton");
+        let idx = SkeletonIndex::open_or_create(dir).expect("open");
+        assert!(idx.get_by_path("/nope.md").expect("get").is_none());
+    }
+
+    #[test]
+    fn empty_title_still_matches_on_path_tokens() {
+        // Chunkless / heading-less files still enter the index so the
+        // path-search leg keeps working.  Zero-body files stay
+        // retrievable per the design doc.
+        let dir = tempdir().join("skeleton");
+        let idx = SkeletonIndex::open_or_create(dir).expect("open");
+        idx.upsert("/notes/rocket.md", "").expect("upsert");
+        idx.commit().expect("commit");
+        let hits = idx.search("rocket", 10, None).expect("search");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].path, "/notes/rocket.md");
+        assert_eq!(hits[0].title, "");
+    }
+
+    #[test]
+    fn tokenize_path_splits_on_non_alphanumeric() {
+        assert_eq!(tokenize_path("/notes/q3-plan.md"), "notes q3 plan md");
+        assert_eq!(
+            tokenize_path("/a/b_c/d.e.f"),
+            "a b c d e f",
+            "underscores and dots split too"
+        );
+        assert_eq!(tokenize_path("/"), "");
+    }
+}

--- a/rust/services/search-plugin/tests/title_arm_e2e.rs
+++ b/rust/services/search-plugin/tests/title_arm_e2e.rs
@@ -1,0 +1,454 @@
+//! End-to-end test for the hybrid title arm (#4552 mirror / #4628).
+//!
+//! Exercises the full RPC handler → parallel legs (chunk_kw +
+//! semantic + title) → `fuse_hybrid_with_title` → `QueryResult`
+//! roundtrip against an injected [`MockEmbedder`] so the test never
+//! downloads a real model or links ONNX Runtime.
+//!
+//! Acceptance mapping (issue #4628):
+//! - `title_match_doc_enters_top_n_with_title_score` — a doc whose
+//!   title matches the query but whose body chunks are weak enters
+//!   the hybrid top-N carrying `title_score = Some(_)`.
+//! - `disabling_via_wire_flag_reverts_pre_arm_ranking` — set
+//!   `QueryRequest.title_arm_disabled = true` and the title-only
+//!   match drops out (parity gate for the wire kill-switch).
+//! - `chunkless_doc_still_returned_via_title` — a doc whose body
+//!   text is empty (heading-only) still surfaces via the title arm
+//!   with `chunk_text = ""`.
+//!
+//! The MockKernel scaffold is duplicated inline rather than
+//! extracted to `tests/common` — same rationale the sibling
+//! `semantic_query_e2e.rs` and `index_e2e.rs` cite: Cargo's shared
+//! test-module story requires a `mod common;` at each caller, and
+//! the extra plumbing costs more than the duplication does at this
+//! size.
+
+use std::collections::HashMap;
+use std::ffi::{c_void, CStr};
+use std::os::raw::c_char;
+use std::sync::Arc;
+
+use nexus_plugin_abi::KernelHandle;
+use nexus_search_plugin::embedder::MockEmbedder;
+use nexus_search_plugin::index_manager::IndexManager;
+use nexus_search_plugin::search_proto::search_service_server::SearchService;
+use nexus_search_plugin::search_proto::{IndexRequest, QueryRequest, QueryType};
+use nexus_search_plugin::service::SearchServiceImpl;
+use tempfile::TempDir;
+use tonic::Request;
+
+// ── Mock kernel (same shape as semantic_query_e2e.rs) ───────────
+
+struct FileEntry {
+    bytes: Vec<u8>,
+    mtime_ms: i64,
+}
+
+pub struct MockKernel {
+    files: HashMap<String, FileEntry>,
+    dirs: HashMap<String, Vec<(String, u8)>>,
+}
+
+impl MockKernel {
+    fn new() -> Self {
+        Self {
+            files: HashMap::new(),
+            dirs: HashMap::new(),
+        }
+    }
+    fn add_file(&mut self, path: &str, bytes: &[u8], mtime_ms: i64) {
+        self.files.insert(
+            path.to_string(),
+            FileEntry {
+                bytes: bytes.to_vec(),
+                mtime_ms,
+            },
+        );
+        let (parent, name) = split_parent(path);
+        self.dirs
+            .entry(parent)
+            .or_default()
+            .push((name, 0 /* DT_REG */));
+    }
+    fn add_dir(&mut self, path: &str) {
+        if !self.dirs.contains_key(path) {
+            self.dirs.insert(path.to_string(), Vec::new());
+        }
+        if path == "/" {
+            return;
+        }
+        let (parent, name) = split_parent(path);
+        let entries = self.dirs.entry(parent).or_default();
+        if !entries.iter().any(|(n, _)| n == &name) {
+            entries.push((name, 1 /* DT_DIR */));
+        }
+    }
+}
+
+fn split_parent(path: &str) -> (String, String) {
+    match path.rsplit_once('/') {
+        Some(("", name)) => ("/".to_string(), name.to_string()),
+        Some((parent, name)) => (parent.to_string(), name.to_string()),
+        None => ("/".to_string(), path.to_string()),
+    }
+}
+
+fn into_out_buf(mut v: Vec<u8>, out_buf: *mut *mut u8, out_len: *mut usize) {
+    v.shrink_to_fit();
+    let len = v.len();
+    let ptr = v.as_mut_ptr();
+    std::mem::forget(v);
+    unsafe {
+        *out_buf = ptr;
+        *out_len = len;
+    }
+}
+
+unsafe extern "C" fn mock_sys_read(
+    k: *const c_void,
+    path: *const c_char,
+    out_buf: *mut *mut u8,
+    out_len: *mut usize,
+) -> i32 {
+    let kernel = &*(k as *const MockKernel);
+    let p = match CStr::from_ptr(path).to_str() {
+        Ok(s) => s,
+        Err(_) => return -2,
+    };
+    match kernel.files.get(p) {
+        Some(entry) => {
+            into_out_buf(entry.bytes.clone(), out_buf, out_len);
+            0
+        }
+        None => -404,
+    }
+}
+
+unsafe extern "C" fn mock_sys_readdir(
+    k: *const c_void,
+    parent_path: *const c_char,
+    out_json: *mut *mut u8,
+    out_len: *mut usize,
+) -> i32 {
+    let kernel = &*(k as *const MockKernel);
+    let p = match CStr::from_ptr(parent_path).to_str() {
+        Ok(s) => s,
+        Err(_) => return -2,
+    };
+    match kernel.dirs.get(p) {
+        Some(entries) => {
+            let payload: Vec<serde_json::Value> = entries
+                .iter()
+                .map(|(name, et)| serde_json::json!({ "name": name, "entry_type": et }))
+                .collect();
+            let json = serde_json::to_vec(&payload).expect("mock readdir json");
+            into_out_buf(json, out_json, out_len);
+            0
+        }
+        None => -404,
+    }
+}
+
+unsafe extern "C" fn mock_sys_stat(
+    k: *const c_void,
+    path: *const c_char,
+    out_json: *mut *mut u8,
+    out_len: *mut usize,
+) -> i32 {
+    let kernel = &*(k as *const MockKernel);
+    let p = match CStr::from_ptr(path).to_str() {
+        Ok(s) => s,
+        Err(_) => return -2,
+    };
+    if let Some(entry) = kernel.files.get(p) {
+        let payload = serde_json::json!({
+            "path": p,
+            "entry_type": 0,
+            "size": entry.bytes.len(),
+            "zone_id": "root",
+            "modified_at_ms": entry.mtime_ms,
+        });
+        into_out_buf(serde_json::to_vec(&payload).unwrap(), out_json, out_len);
+        0
+    } else if kernel.dirs.contains_key(p) {
+        let payload = serde_json::json!({
+            "path": p,
+            "entry_type": 1,
+            "size": 0,
+            "zone_id": "root",
+            "modified_at_ms": null,
+        });
+        into_out_buf(serde_json::to_vec(&payload).unwrap(), out_json, out_len);
+        0
+    } else {
+        -404
+    }
+}
+
+unsafe extern "C" fn unused_write(
+    _: *const c_void,
+    _: *const c_char,
+    _: *const u8,
+    _: usize,
+) -> i32 {
+    -1
+}
+unsafe extern "C" fn unused_unlink(_: *const c_void, _: *const c_char) -> i32 {
+    -1
+}
+unsafe extern "C" fn unused_mkdir(_: *const c_void, _: *const c_char) -> i32 {
+    -1
+}
+unsafe extern "C" fn unused_rmdir(_: *const c_void, _: *const c_char) -> i32 {
+    -1
+}
+unsafe extern "C" fn unused_rename(
+    _: *const c_void,
+    _: *const c_char,
+    _: *const c_char,
+) -> i32 {
+    -1
+}
+unsafe extern "C" fn unused_stat_batch(
+    _: *const c_void,
+    _: *const c_char,
+    _: *mut *mut u8,
+    _: *mut usize,
+) -> i32 {
+    -1
+}
+
+fn handle_for(kernel: *const MockKernel) -> KernelHandle {
+    KernelHandle {
+        sys_read: mock_sys_read,
+        sys_write: unused_write,
+        sys_stat: mock_sys_stat,
+        sys_readdir: mock_sys_readdir,
+        sys_unlink: unused_unlink,
+        sys_mkdir: unused_mkdir,
+        sys_rmdir: unused_rmdir,
+        sys_rename: unused_rename,
+        sys_stat_batch: unused_stat_batch,
+        kernel_ptr: kernel as *const c_void,
+    }
+}
+
+// ── Harness ─────────────────────────────────────────────────────
+
+struct Harness {
+    _dir: TempDir,
+    mock: *mut MockKernel,
+    svc: SearchServiceImpl,
+}
+
+impl Harness {
+    fn start() -> Self {
+        let dir = TempDir::new().expect("tempdir");
+        let mock = Box::into_raw(Box::new(MockKernel::new()));
+        let handle = handle_for(mock);
+        let manager = Arc::new(IndexManager::with_root(dir.path().to_path_buf()));
+        let embedder = Arc::new(MockEmbedder::with_dim(16));
+        let svc = SearchServiceImpl::builder(Arc::new(handle))
+            .manager(manager)
+            .embedder(embedder)
+            .build();
+        Self {
+            _dir: dir,
+            mock,
+            svc,
+        }
+    }
+
+    fn mock_mut(&self) -> &mut MockKernel {
+        unsafe { &mut *self.mock }
+    }
+}
+
+impl Drop for Harness {
+    fn drop(&mut self) {
+        unsafe {
+            drop(Box::from_raw(self.mock));
+        }
+    }
+}
+
+async fn index_root(svc: &SearchServiceImpl) {
+    let resp = svc
+        .index(Request::new(IndexRequest {
+            root_path: "/".into(),
+            zone_id: "root".into(),
+            recursive: true,
+            max_docs: 0,
+            auth_token: String::new(),
+        }))
+        .await
+        .expect("index")
+        .into_inner();
+    assert!(resp.error.is_none(), "index error: {:?}", resp.error);
+}
+
+async fn hybrid_query(
+    svc: &SearchServiceImpl,
+    q: &str,
+    disable_title: bool,
+) -> nexus_search_plugin::search_proto::QueryResponse {
+    svc.query(Request::new(QueryRequest {
+        q: q.into(),
+        zone_id: "root".into(),
+        limit: 10,
+        query_type: QueryType::Hybrid as i32,
+        title_arm_disabled: disable_title,
+        ..Default::default()
+    }))
+    .await
+    .expect("query")
+    .into_inner()
+}
+
+// ── Tests ───────────────────────────────────────────────────────
+
+/// Acceptance criterion 1 (issue #4628): a doc whose title matches
+/// the query but whose body text is weak enters the hybrid top-N
+/// carrying `title_score = Some(_)`.  Locks in the ranking-quality
+/// improvement the title arm exists to deliver.
+#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+async fn title_match_doc_enters_top_n_with_title_score() {
+    let h = Harness::start();
+    let mock = h.mock_mut();
+    mock.add_dir("/");
+    mock.add_dir("/misc");
+    mock.add_dir("/reports");
+    // Doc A: body mentions "rocket" but title is unrelated.
+    mock.add_file(
+        "/reports/weekly.md",
+        b"# Weekly Digest\n\nvarious rocket updates below\n",
+        1,
+    );
+    // Doc B: body has NO "rocket" text; title is "Rocket Launch
+    // Retrospective" — only the title arm can surface this on a
+    // "rocket" query.
+    mock.add_file(
+        "/misc/target.md",
+        b"# Rocket Launch Retrospective\n\ngeneric content with no matching body tokens\n",
+        2,
+    );
+
+    index_root(&h.svc).await;
+
+    let resp = hybrid_query(&h.svc, "rocket", false).await;
+    assert!(resp.error.is_none(), "query error: {:?}", resp.error);
+    assert!(!resp.results.is_empty(), "expected hits: {resp:?}");
+
+    let paths: Vec<&str> = resp.results.iter().map(|r| r.path.as_str()).collect();
+    assert!(
+        paths.contains(&"/misc/target.md"),
+        "title-arm target must enter top-N; got {paths:?}",
+    );
+
+    // The title-only doc carries title_score attribution.
+    let target = resp
+        .results
+        .iter()
+        .find(|r| r.path == "/misc/target.md")
+        .expect("target present");
+    assert!(
+        target.title_score.is_some(),
+        "target must carry title_score: {target:?}",
+    );
+    assert!(
+        target.title_score.unwrap() > 0.0,
+        "title_score must be positive: {target:?}",
+    );
+}
+
+/// Acceptance criterion 2 (issue #4628): setting
+/// `QueryRequest.title_arm_disabled = true` reverts to the pre-arm
+/// two-source hybrid.  Non-title queries stay ranking-neutral (that
+/// property is covered by `fusion::rrf_multi_fusion_empty_title_arm_
+/// ranks_like_two_arm_rrf`).  This test covers the wire kill-switch:
+/// the title-only doc must drop below the arm-on doc when the arm
+/// is off, and lose its `title_score` attribution.
+#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+async fn disabling_via_wire_flag_reverts_pre_arm_ranking() {
+    let h = Harness::start();
+    let mock = h.mock_mut();
+    mock.add_dir("/");
+    mock.add_dir("/misc");
+    mock.add_file(
+        "/misc/title_only.md",
+        b"# Rocket Launch Retrospective\n\nno body match for the query\n",
+        1,
+    );
+    // Body-only doc so the arm-off case still has at least one hit.
+    mock.add_file(
+        "/misc/body_only.md",
+        b"# Weekly Digest\n\nlots of rocket updates and rocket news\n",
+        2,
+    );
+
+    index_root(&h.svc).await;
+
+    let with_arm = hybrid_query(&h.svc, "rocket", false).await;
+    let without_arm = hybrid_query(&h.svc, "rocket", true).await;
+
+    // Title-only doc: present + attributed with arm on; absent OR
+    // sans attribution with arm off.
+    let with_target = with_arm
+        .results
+        .iter()
+        .find(|r| r.path == "/misc/title_only.md");
+    assert!(
+        with_target.is_some() && with_target.unwrap().title_score.is_some(),
+        "arm-on: title-only doc must be present with title_score: {with_arm:?}",
+    );
+
+    let without_target = without_arm
+        .results
+        .iter()
+        .find(|r| r.path == "/misc/title_only.md");
+    match without_target {
+        Some(h) => assert!(
+            h.title_score.is_none(),
+            "arm-off: title_score must not be stamped: {h:?}",
+        ),
+        None => {
+            // Ranking dropped it entirely — also valid: the title-only
+            // doc's only pathway to top-N was the title arm.
+        }
+    }
+}
+
+/// Acceptance criterion 3 (issue #4628): a heading-only doc with no
+/// meaningful body text is still retrievable via the title arm.
+/// Chunkless docs come through with an empty `chunk_text` — the
+/// hydration path preserves the "doc still discoverable" contract.
+#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+async fn chunkless_doc_still_returned_via_title() {
+    let h = Harness::start();
+    let mock = h.mock_mut();
+    mock.add_dir("/");
+    mock.add_dir("/lonely");
+    // Title-only file: just the heading, no body paragraph.
+    mock.add_file("/lonely/pure_title.md", b"# Nova Prime Overview\n", 1);
+
+    index_root(&h.svc).await;
+
+    let resp = hybrid_query(&h.svc, "nova prime", false).await;
+    assert!(resp.error.is_none(), "query error: {:?}", resp.error);
+    let hit = resp
+        .results
+        .iter()
+        .find(|r| r.path == "/lonely/pure_title.md");
+    assert!(
+        hit.is_some(),
+        "title-only doc must surface via title arm: {resp:?}",
+    );
+    let hit = hit.unwrap();
+    assert!(
+        hit.title_score.is_some(),
+        "title-only surfacing must carry title_score: {hit:?}",
+    );
+    // chunk_text may be empty or hold the single heading chunk —
+    // either shape satisfies "doc still discoverable"; we assert on
+    // the retrievability contract, not the exact snippet.
+}


### PR DESCRIPTION
## Summary

Mirrors Python's #4552 title-arm hybrid fusion into the Rust \`nexus-search-plugin\`, closing the last unmirrored windoliver search feature (issue #4628).  Title-shaped queries (\"<project> design doc\", \"Q3 report\") now rank their target even when body chunks are weak.

## What's new

**SkeletonIndex primitive** — per-zone tantivy BM25 over path tokens + first-heading title, title weighted 2× at query time.  Same disk-layout / open-or-create / commit contract as \`FtsIndex\` and \`AnnIndex\`; storage lives at \`<root>/<zone>/skeleton-v1/\`, dropping the directory is safe.

**Population** — every indexing path (\`do_index\` walk, \`do_index_documents\` batch, \`do_refresh\` diff, \`do_notify_file_change\` delete) now keeps skeleton in sync with FTS.  Title text comes from \`chunker::extract_first_heading\`; empty title still enters the index so the path-search leg keeps working for heading-less files.

**rrf_multi_fusion** — new fusion primitive that folds N labelled result lists under the same \`1/(k + rank)\` rule as \`rrf\`.  Per-arm score attribution: hits scored by the \"title\" arm carry their contribution on \`QueryResult.title_score\` so downstream observers see which arm surfaced them.  Fusion-parity guard: \`rrf_multi_fusion([chunk, page])\` rank-equals \`rrf(chunk, page)\` — the swap is ranking-neutral for non-title queries.

**Hybrid wiring** — \`do_hybrid_query\` gains a third parallel leg.  \`do_title_query\` searches the skeleton and hydrates each hit's \`chunk_text\` from the sibling FTS's first chunk (chunkless docs come through with \`chunk_text=\"\"\` — retrievability preserved).  \`fuse_hybrid_with_title\` runs \`rrf_multi_fusion([chunk, title])\` then feeds the fused keyword lane into the existing final stage.  Semantic leg (~300 ms) dominates wall-clock so the title arm's <1 ms cost is free.

**Kill-switches (both must be permissive)**:
- \`QueryRequest.title_arm_disabled\` — per-query wire flag for ablation.
- \`NEXUS_SEARCH_TITLE_ARM=false\` — fleet-wide rollback for ops without a redeploy.

**Query cache** — \`hash_request\` gains \`title_arm_disabled\` per the module's \"adversarial hardening\" clause: two requests differing only in that flag produce different rankings and must not share a cache entry.  Found by the E2E test below; regression pin added.

## Acceptance mapping (issue #4628)

| Acceptance criterion | Covered by |
|---|---|
| Title-match doc with weak body chunks enters hybrid top-N | \`title_arm_e2e::title_match_doc_enters_top_n_with_title_score\` |
| Non-title queries unchanged within tolerance | \`fusion::rrf_multi_fusion_empty_title_arm_ranks_like_two_arm_rrf\` |
| Attribution field marking title-arm participation | \`QueryResult.title_score\` |
| Kill-switch reverts to pre-arm ranking | \`title_arm_e2e::disabling_via_wire_flag_reverts_pre_arm_ranking\` |
| Chunkless / title-only doc still retrievable | \`title_arm_e2e::chunkless_doc_still_returned_via_title\` |

## Test plan

- [x] \`cargo build -p nexus-search-plugin\` — green (local, MSVC + Windows SDK)
- [x] \`cargo test -p nexus-search-plugin --lib -- --test-threads=1\` — 154/154 passed
- [x] \`cargo test -p nexus-search-plugin --test title_arm_e2e -- --test-threads=1\` — 3/3 passed
- [x] SkeletonIndex primitive covers title-2× boost, upsert dedupe, stemmer parity with FtsIndex, empty-title path-search leg, delete tombstone, path_prefix filter, exact get_by_path, empty-query short-circuit (12 tests)
- [x] fusion parity guard: rrf_multi_fusion with empty title arm rank-equals two-arm rrf (4 new tests)
- [ ] Full CI on develop base

## Non-goals

- No reindex — skeleton is derived from the same doc bytes FTS consumes; existing zones populate on the next Refresh.
- No Docker-topology Python live test — the Rust integration test exercises the full RPC handler + real tantivy indices, covering the acceptance criteria one layer deeper than the docker-compose smoke would.