### PR TITLE
feat(nexusd): co-host the real sudocode agent runtime (opt-in SpawnTask adapter)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,6 +13,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aead"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -45,6 +51,71 @@ dependencies = [
  "ctr",
  "ghash",
  "subtle",
+]
+
+[[package]]
+name = "agent-client-protocol"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af62fb84df2af0f933d8f5fd78b843fa5eb0ec5a48fa1b528c41951d0bbe36c"
+dependencies = [
+ "agent-client-protocol-derive",
+ "agent-client-protocol-schema",
+ "anyhow",
+ "futures",
+ "futures-concurrency",
+ "jsonrpcmsg",
+ "rmcp",
+ "rustc-hash 2.1.3",
+ "schemars 1.2.2",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "agent-client-protocol-derive"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cabdc9d845d08ec7ed2d0c9de1ae4a1b198301407d55855261572761be90ec9f"
+dependencies = [
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "agent-client-protocol-schema"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49bae57dad1c28a362fbdcf7bab0583316a02b45a70792109fced55780a3b63c"
+dependencies = [
+ "anyhow",
+ "derive_more",
+ "schemars 1.2.2",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "strum",
+ "tracing",
+]
+
+[[package]]
+name = "agent-client-protocol-tokio"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e1572b219f22c4b3be0f20f934c8b6f1d1457126ce72923c4f6608f96153b65"
+dependencies = [
+ "agent-client-protocol",
+ "futures",
+ "serde",
+ "serde_json",
+ "shell-words",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -160,6 +231,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
+name = "api"
+version = "0.1.18"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=bb2a0d3dcd10cd308b2b2ac0037f7bb6ae82de84#bb2a0d3dcd10cd308b2b2ac0037f7bb6ae82de84"
+dependencies = [
+ "base64 0.22.1",
+ "httpdate",
+ "reqwest 0.12.28",
+ "runtime",
+ "serde",
+ "serde_json",
+ "telemetry",
+ "tokio",
+ "uuid",
+]
+
+[[package]]
 name = "arc-swap"
 version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -250,7 +337,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.11.0",
- "tonic",
+ "tonic 0.14.6",
  "tracing",
  "transport",
 ]
@@ -291,6 +378,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
+ "base64 0.22.1",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -309,11 +397,14 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
+ "sha1",
  "sync_wrapper",
  "tokio",
+ "tokio-tungstenite",
  "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -332,6 +423,7 @@ dependencies = [
  "sync_wrapper",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -358,11 +450,11 @@ dependencies = [
  "memchr",
  "memmap2",
  "parking_lot",
- "prost",
+ "prost 0.14.4",
  "rayon",
  "redb",
  "regex",
- "reqwest",
+ "reqwest 0.13.4",
  "roaring",
  "serde",
  "serde_json",
@@ -370,7 +462,7 @@ dependencies = [
  "simdutf8",
  "tempfile",
  "tokio",
- "tonic",
+ "tonic 0.14.6",
  "tracing",
  "uuid",
 ]
@@ -501,6 +593,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "bstr"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -612,8 +713,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-traits",
+ "serde",
+ "wasm-bindgen",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "chrono-tz"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93698b29de5e97ad0ae26447b344c482a7284c737d9ddc5f9e52b74a336671bb"
+dependencies = [
+ "chrono",
+ "chrono-tz-build",
+ "phf",
+]
+
+[[package]]
+name = "chrono-tz-build"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c088aee841df9c3041febbb73934cfc39708749bf96dc827e3359cd39ef11b1"
+dependencies = [
+ "parse-zoneinfo",
+ "phf",
+ "phf_codegen",
 ]
 
 [[package]]
@@ -709,6 +835,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "command-group"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a68fa787550392a9d58f44c21a3022cfb3ea3e2458b7f85d3b399d0ceeccf409"
+dependencies = [
+ "nix 0.27.1",
+ "winapi",
+]
+
+[[package]]
+name = "commands"
+version = "0.1.18"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=bb2a0d3dcd10cd308b2b2ac0037f7bb6ae82de84#bb2a0d3dcd10cd308b2b2ac0037f7bb6ae82de84"
+dependencies = [
+ "plugins",
+ "runtime",
+ "serde_json",
+]
+
+[[package]]
 name = "compact_str"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -777,6 +923,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -827,6 +982,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "cron"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8c3e73077b4b4a6ab1ea5047c37c57aee77657bc8ecd6f29b0af082d0b0c07"
+dependencies = [
+ "chrono",
+ "nom",
+ "once_cell",
 ]
 
 [[package]]
@@ -950,8 +1116,18 @@ version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
 ]
 
 [[package]]
@@ -969,12 +1145,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
- "darling_core",
+ "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.119",
 ]
@@ -1087,7 +1287,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
 dependencies = [
- "darling",
+ "darling 0.20.11",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -1101,6 +1301,29 @@ checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.119",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1127,6 +1350,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1148,6 +1392,12 @@ name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "ed25519"
@@ -1300,6 +1550,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
 name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1342,6 +1601,16 @@ dependencies = [
  "lz4_flex 0.13.1",
  "tempfile",
  "xxhash-rust",
+]
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -1404,7 +1673,7 @@ dependencies = [
  "libc",
  "log",
  "memchr",
- "nix",
+ "nix 0.30.1",
  "num_enum",
  "page_size",
  "parking_lot",
@@ -1440,6 +1709,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-concurrency"
+version = "7.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175cd8cca9e1d45b87f18ffa75088f2099e3c4fe5e2f83e42de112560bea8ea6"
+dependencies = [
+ "fixedbitset",
+ "futures-core",
+ "futures-lite",
+ "pin-project",
+ "smallvec",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1461,6 +1743,19 @@ name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -1622,12 +1917,18 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
  "tracing",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -1683,6 +1984,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1713,7 +2020,7 @@ dependencies = [
  "cpu-time",
  "env_logger",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.14.0",
  "lazy_static",
  "log",
  "mmap-rs",
@@ -1820,6 +2127,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1852,7 +2160,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.5",
  "tokio",
  "tower-service",
  "tracing",
@@ -1992,6 +2300,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
+ "png",
+ "zune-core",
+ "zune-jpeg",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1999,6 +2333,8 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2076,10 +2412,12 @@ dependencies = [
  "defmt",
  "jiff-core",
  "jiff-static",
+ "jiff-tzdb-platform",
  "log",
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2101,6 +2439,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142bd39932ad231f10513df9ab62661fead8719872150b7ad02a2df79f4e141e"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
 ]
 
 [[package]]
@@ -2174,6 +2527,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonrpcmsg"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d833a15225c779251e13929203518c2ff26e2fe0f322d584b213f4f4dad37bd"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "kernel"
 version = "0.10.1"
 source = "git+https://github.com/nexi-lab/nexus-vfs?rev=c9ecc9da2b755039a1028bbb619ee7cbb86f5dad#c9ecc9da2b755039a1028bbb619ee7cbb86f5dad"
@@ -2200,7 +2563,7 @@ dependencies = [
  "memmap2",
  "nexus-plugin-abi",
  "parking_lot",
- "prost",
+ "prost 0.14.4",
  "protoc-bin-vendored",
  "rayon",
  "redb",
@@ -2212,11 +2575,21 @@ dependencies = [
  "string-interner",
  "tempfile",
  "tokio",
- "tonic",
+ "tonic 0.14.6",
  "tonic-prost",
  "tonic-prost-build",
  "tracing",
  "uuid",
+]
+
+[[package]]
+name = "keyring"
+version = "3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+dependencies = [
+ "log",
+ "zeroize",
 ]
 
 [[package]]
@@ -2259,7 +2632,7 @@ dependencies = [
  "thiserror 2.0.18",
  "time",
  "tokio",
- "tonic",
+ "tonic 0.14.6",
  "tracing",
  "x509-parser",
 ]
@@ -2295,6 +2668,15 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "libredox"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2026a5056764a10b2bf5d56488cba40da507f5493a6a429340e2004d9ed085fa"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -2487,6 +2869,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2507,7 +2899,7 @@ dependencies = [
  "combine",
  "libc",
  "mach2",
- "nix",
+ "nix 0.30.1",
  "sysctl",
  "thiserror 2.0.18",
  "widestring",
@@ -2534,6 +2926,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
 ]
 
 [[package]]
@@ -2579,7 +2981,7 @@ dependencies = [
  "raft 0.1.0",
  "rand 0.10.2",
  "tokio",
- "tonic",
+ "tonic 0.14.6",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
@@ -2634,17 +3036,17 @@ dependencies = [
  "nexus-plugin-abi",
  "ort",
  "parking_lot",
- "prost",
+ "prost 0.14.4",
  "protoc-bin-vendored",
  "regex",
- "reqwest",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "tantivy",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
- "tonic",
+ "tonic 0.14.6",
  "tonic-prost",
  "tonic-prost-build",
  "tracing",
@@ -2659,15 +3061,28 @@ dependencies = [
  "kernel",
  "libloading 0.8.9",
  "nexus-plugin-abi",
- "prost",
+ "prost 0.14.4",
  "services",
  "tempfile",
  "tokio",
  "tokio-stream",
- "tonic",
+ "tonic 0.14.6",
  "tonic-prost",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "nexus-vfs-client"
+version = "0.1.18"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=bb2a0d3dcd10cd308b2b2ac0037f7bb6ae82de84#bb2a0d3dcd10cd308b2b2ac0037f7bb6ae82de84"
+dependencies = [
+ "prost 0.13.5",
+ "protoc-bin-vendored",
+ "serde_json",
+ "tokio",
+ "tonic 0.13.1",
+ "tonic-build 0.13.1",
 ]
 
 [[package]]
@@ -2677,8 +3092,11 @@ dependencies = [
  "a2a",
  "anyhow",
  "backends",
+ "kernel",
  "nexus-cluster",
+ "runtime",
  "services",
+ "tools",
 ]
 
 [[package]]
@@ -2695,6 +3113,29 @@ dependencies = [
  "num-traits",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "nix"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+dependencies = [
+ "bitflags 2.13.1",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.13.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]
@@ -2878,6 +3319,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "ort"
 version = "2.0.0-rc.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2916,6 +3363,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2936,6 +3389,15 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "parse-zoneinfo"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f2a05b18d44e2957b88f96ba460715e295bc1d7510468a2f3d3b44535d26c24"
+dependencies = [
+ "regex",
 ]
 
 [[package]]
@@ -2968,13 +3430,61 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "petgraph"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
+dependencies = [
+ "fixedbitset",
+ "indexmap 2.14.0",
+]
+
+[[package]]
+name = "petgraph"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.14.0",
+]
+
+[[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand 0.8.7",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -3018,6 +3528,28 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "plugins"
+version = "0.1.18"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=bb2a0d3dcd10cd308b2b2ac0037f7bb6ae82de84#bb2a0d3dcd10cd308b2b2ac0037f7bb6ae82de84"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags 2.13.1",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "polyval"
@@ -3100,12 +3632,42 @@ dependencies = [
 
 [[package]]
 name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive 0.13.5",
+]
+
+[[package]]
+name = "prost"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.14.4",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
+dependencies = [
+ "heck",
+ "itertools 0.12.1",
+ "log",
+ "multimap",
+ "once_cell",
+ "petgraph 0.7.1",
+ "prettyplease",
+ "prost 0.13.5",
+ "prost-types 0.13.5",
+ "regex",
+ "syn 2.0.119",
+ "tempfile",
 ]
 
 [[package]]
@@ -3118,15 +3680,28 @@ dependencies = [
  "itertools 0.12.1",
  "log",
  "multimap",
- "petgraph",
+ "petgraph 0.8.3",
  "prettyplease",
- "prost",
- "prost-types",
+ "prost 0.14.4",
+ "prost-types 0.14.4",
  "pulldown-cmark",
  "pulldown-cmark-to-cmark",
  "regex",
  "syn 2.0.119",
  "tempfile",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools 0.12.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3144,11 +3719,20 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
+dependencies = [
+ "prost 0.13.5",
+]
+
+[[package]]
+name = "prost-types"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
 dependencies = [
- "prost",
+ "prost 0.14.4",
 ]
 
 [[package]]
@@ -3266,6 +3850,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pxfm"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
+
+[[package]]
 name = "quick_cache"
 version = "0.6.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3288,7 +3878,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.3",
  "rustls",
- "socket2",
+ "socket2 0.6.5",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3327,7 +3917,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.5",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -3368,7 +3958,7 @@ dependencies = [
  "lib",
  "parking_lot",
  "pem",
- "prost",
+ "prost 0.14.4",
  "protobuf",
  "protoc-bin-vendored",
  "raft 0.7.0",
@@ -3383,7 +3973,7 @@ dependencies = [
  "thiserror 2.0.18",
  "time",
  "tokio",
- "tonic",
+ "tonic 0.14.6",
  "tonic-prost",
  "tonic-prost-build",
  "tracing",
@@ -3583,6 +4173,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "ref-cast"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3633,6 +4234,47 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams 0.4.2",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
@@ -3668,7 +4310,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.5.0",
  "web-sys",
 ]
 
@@ -3687,6 +4329,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmcp"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1f571c72940a19d9532fe52dbea8bc9912bf1d766c2970bb824056b86f3f59"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "chrono",
+ "futures",
+ "pastey",
+ "pin-project-lite",
+ "rmcp-macros",
+ "schemars 1.2.2",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aad0035b69380782d78ea95b508327e6deaa2235909053e596eea8f27b5e1d5"
+dependencies = [
+ "darling 0.23.0",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "roaring"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3694,6 +4371,41 @@ checksum = "1dedc5658c6ecb3bdb5ef5f3295bb9253f42dcf3fd1402c03f6b1f7659c3c4a9"
 dependencies = [
  "bytemuck",
  "byteorder",
+]
+
+[[package]]
+name = "runtime"
+version = "0.1.18"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=bb2a0d3dcd10cd308b2b2ac0037f7bb6ae82de84#bb2a0d3dcd10cd308b2b2ac0037f7bb6ae82de84"
+dependencies = [
+ "agent-client-protocol",
+ "agent-client-protocol-schema",
+ "agent-client-protocol-tokio",
+ "async-trait",
+ "axum",
+ "base64 0.22.1",
+ "chrono",
+ "chrono-tz",
+ "cron",
+ "futures",
+ "getrandom 0.2.17",
+ "glob",
+ "image",
+ "kernel",
+ "keyring",
+ "nexus-vfs-client",
+ "nix 0.29.0",
+ "plugins",
+ "regex",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "telemetry",
+ "tokio",
+ "tokio-tungstenite",
+ "tower-http",
+ "walkdir",
 ]
 
 [[package]]
@@ -3883,6 +4595,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
+dependencies = [
+ "chrono",
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98c67716b46af2f0b8cf752abc930f6f9aecfbf671ecfb531db8a31dbe4e2ba"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3954,6 +4704,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_derive_internals"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f852137cce035d6a4df67ccce505ff6b3e9fd3a10e3e52b24dc71e650bb1a9bd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3990,6 +4751,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "3.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee78f1fbe43ac4a0e47aadb3dbd357b69eb0d3793e948624cd03dd2750ab1c0a"
+dependencies = [
+ "base64 0.22.1",
+ "bs58",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.14.0",
+ "jiff",
+ "schemars 0.9.0",
+ "schemars 1.2.2",
+ "serde_core",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8705578779c2b6bd90d84d66eb2e206b708b1a4d7b9f17641b293545bf1c7e46"
+dependencies = [
+ "darling 0.23.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "services"
 version = "0.1.0"
 dependencies = [
@@ -4008,8 +4802,8 @@ dependencies = [
  "kernel",
  "libc",
  "parking_lot",
- "prost",
- "prost-types",
+ "prost 0.14.4",
+ "prost-types 0.14.4",
  "protoc-bin-vendored",
  "serde",
  "serde_json",
@@ -4017,7 +4811,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
- "tonic",
+ "tonic 0.14.6",
  "tonic-prost",
  "tonic-prost-build",
  "tower",
@@ -4079,6 +4873,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4108,6 +4908,12 @@ checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "simd_cesu8"
@@ -4163,6 +4969,16 @@ name = "smallvec"
 version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
+name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "socket2"
@@ -4232,6 +5048,27 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "subtle"
@@ -4443,6 +5280,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "telemetry"
+version = "0.1.18"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=bb2a0d3dcd10cd308b2b2ac0037f7bb6ae82de84#bb2a0d3dcd10cd308b2b2ac0037f7bb6ae82de84"
+dependencies = [
+ "chrono",
+ "dirs",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4610,9 +5458,10 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.5",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -4650,6 +5499,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4657,6 +5522,7 @@ checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "pin-project-lite",
  "tokio",
@@ -4677,7 +5543,7 @@ version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "toml_datetime",
  "toml_parser",
  "winnow",
@@ -4690,6 +5556,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow",
+]
+
+[[package]]
+name = "tonic"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e581ba15a835f4d9ea06c55ab1bd4dce26fc53752c69a04aac00703bfb49ba9"
+dependencies = [
+ "async-trait",
+ "axum",
+ "base64 0.22.1",
+ "bytes",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "prost 0.13.5",
+ "socket2 0.5.10",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -4711,7 +5606,7 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "socket2",
+ "socket2 0.6.5",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
@@ -4720,6 +5615,20 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac6f67be712d12f0b41328db3137e0d0757645d8904b4cb7d51cd9c2279e847"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "prost-build 0.13.5",
+ "prost-types 0.13.5",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4741,8 +5650,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
 dependencies = [
  "bytes",
- "prost",
- "tonic",
+ "prost 0.14.4",
+ "tonic 0.14.6",
 ]
 
 [[package]]
@@ -4753,12 +5662,31 @@ checksum = "654e5643eff75d7f8c99197ce1440ed19a3474eada74c12bbac488b2cafdae27"
 dependencies = [
  "prettyplease",
  "proc-macro2",
- "prost-build",
- "prost-types",
+ "prost-build 0.14.4",
+ "prost-types 0.14.4",
  "quote",
  "syn 2.0.119",
  "tempfile",
- "tonic-build",
+ "tonic-build 0.14.6",
+]
+
+[[package]]
+name = "tools"
+version = "0.1.18"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=bb2a0d3dcd10cd308b2b2ac0037f7bb6ae82de84#bb2a0d3dcd10cd308b2b2ac0037f7bb6ae82de84"
+dependencies = [
+ "api",
+ "async-trait",
+ "command-group",
+ "commands",
+ "flate2",
+ "futures",
+ "plugins",
+ "reqwest 0.12.28",
+ "runtime",
+ "serde",
+ "serde_json",
+ "tokio",
 ]
 
 [[package]]
@@ -4769,7 +5697,7 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap",
+ "indexmap 2.14.0",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -4816,6 +5744,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -4904,14 +5833,14 @@ dependencies = [
  "lib",
  "parking_lot",
  "pem",
- "prost",
+ "prost 0.14.4",
  "raft 0.1.0",
  "serde",
  "serde_json",
  "sha2 0.11.0",
  "thiserror 2.0.18",
  "tokio",
- "tonic",
+ "tonic 0.14.6",
  "tower",
  "tracing",
  "uuid",
@@ -4923,6 +5852,24 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.5",
+ "rustls",
+ "rustls-pki-types",
+ "sha1",
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "twox-hash"
@@ -4962,6 +5909,12 @@ name = "unicode-segmentation"
 version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unicode_categories"
@@ -5136,6 +6089,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-streams"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
@@ -5172,6 +6138,15 @@ name = "webpki-root-certs"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -5328,6 +6303,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -5693,4 +6677,19 @@ checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
 dependencies = [
  "cc",
  "pkg-config",
+]
+
+[[package]]
+name = "zune-core"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56377fd46368984a170bc5aac5567e52ca5da874caa60bea39fcbca78fb658b"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -232,8 +232,8 @@ checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "api"
-version = "0.1.18"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=bb2a0d3dcd10cd308b2b2ac0037f7bb6ae82de84#bb2a0d3dcd10cd308b2b2ac0037f7bb6ae82de84"
+version = "0.1.19"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=d7f64b9898151553f517d0b4ba177658da5264a8#d7f64b9898151553f517d0b4ba177658da5264a8"
 dependencies = [
  "base64 0.22.1",
  "httpdate",
@@ -846,8 +846,8 @@ dependencies = [
 
 [[package]]
 name = "commands"
-version = "0.1.18"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=bb2a0d3dcd10cd308b2b2ac0037f7bb6ae82de84#bb2a0d3dcd10cd308b2b2ac0037f7bb6ae82de84"
+version = "0.1.19"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=d7f64b9898151553f517d0b4ba177658da5264a8#d7f64b9898151553f517d0b4ba177658da5264a8"
 dependencies = [
  "plugins",
  "runtime",
@@ -3074,8 +3074,8 @@ dependencies = [
 
 [[package]]
 name = "nexus-vfs-client"
-version = "0.1.18"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=bb2a0d3dcd10cd308b2b2ac0037f7bb6ae82de84#bb2a0d3dcd10cd308b2b2ac0037f7bb6ae82de84"
+version = "0.1.19"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=d7f64b9898151553f517d0b4ba177658da5264a8#d7f64b9898151553f517d0b4ba177658da5264a8"
 dependencies = [
  "prost 0.13.5",
  "protoc-bin-vendored",
@@ -3531,8 +3531,8 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plugins"
-version = "0.1.18"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=bb2a0d3dcd10cd308b2b2ac0037f7bb6ae82de84#bb2a0d3dcd10cd308b2b2ac0037f7bb6ae82de84"
+version = "0.1.19"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=d7f64b9898151553f517d0b4ba177658da5264a8#d7f64b9898151553f517d0b4ba177658da5264a8"
 dependencies = [
  "serde",
  "serde_json",
@@ -3657,7 +3657,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -3677,7 +3677,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph 0.8.3",
@@ -3698,7 +3698,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -3711,7 +3711,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -4375,8 +4375,8 @@ dependencies = [
 
 [[package]]
 name = "runtime"
-version = "0.1.18"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=bb2a0d3dcd10cd308b2b2ac0037f7bb6ae82de84#bb2a0d3dcd10cd308b2b2ac0037f7bb6ae82de84"
+version = "0.1.19"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=d7f64b9898151553f517d0b4ba177658da5264a8#d7f64b9898151553f517d0b4ba177658da5264a8"
 dependencies = [
  "agent-client-protocol",
  "agent-client-protocol-schema",
@@ -5281,8 +5281,8 @@ dependencies = [
 
 [[package]]
 name = "telemetry"
-version = "0.1.18"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=bb2a0d3dcd10cd308b2b2ac0037f7bb6ae82de84#bb2a0d3dcd10cd308b2b2ac0037f7bb6ae82de84"
+version = "0.1.19"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=d7f64b9898151553f517d0b4ba177658da5264a8#d7f64b9898151553f517d0b4ba177658da5264a8"
 dependencies = [
  "chrono",
  "dirs",
@@ -5672,8 +5672,8 @@ dependencies = [
 
 [[package]]
 name = "tools"
-version = "0.1.18"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=bb2a0d3dcd10cd308b2b2ac0037f7bb6ae82de84#bb2a0d3dcd10cd308b2b2ac0037f7bb6ae82de84"
+version = "0.1.19"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=d7f64b9898151553f517d0b4ba177658da5264a8#d7f64b9898151553f517d0b4ba177658da5264a8"
 dependencies = [
  "api",
  "async-trait",

--- a/rust/nexusd/Cargo.toml
+++ b/rust/nexusd/Cargo.toml
@@ -54,10 +54,10 @@ anyhow = "1"
 # the seam and `SpawnTask<Kernel>` is a single monomorphised type.
 # `sudocode-tools` carries the `spawn_managed_agent` factory (it composes
 # the api + runtime crates); `sudocode-runtime` names the `AgentLoopState`
-# / `SpawnHandle` types the adapter maps. Pinned to the #392 branch tip
-# until #392 merges to sudocode main (then bump to the merge commit).
-sudocode-runtime = { package = "runtime", git = "https://github.com/sudoprivacy/sudocode", rev = "bb2a0d3dcd10cd308b2b2ac0037f7bb6ae82de84", optional = true }
-sudocode-tools = { package = "tools", git = "https://github.com/sudoprivacy/sudocode", rev = "bb2a0d3dcd10cd308b2b2ac0037f7bb6ae82de84", optional = true }
+# / `SpawnHandle` types the adapter maps. Pinned to the sudocode main merge
+# commit of #392 (co-host readiness).
+sudocode-runtime = { package = "runtime", git = "https://github.com/sudoprivacy/sudocode", rev = "d7f64b9898151553f517d0b4ba177658da5264a8", optional = true }
+sudocode-tools = { package = "tools", git = "https://github.com/sudoprivacy/sudocode", rev = "d7f64b9898151553f517d0b4ba177658da5264a8", optional = true }
 # Named directly to spell `kernel::kernel::{ServiceDecl, Kernel}` — the
 # managed-agent boot decl's return type (both builds) and the co-host
 # adapter's `SpawnTask<Kernel>` (cohost build). Already present transitively

--- a/rust/nexusd/Cargo.toml
+++ b/rust/nexusd/Cargo.toml
@@ -18,6 +18,15 @@ default = []
 # so the shipped binary keeps the sudowork/edge size budget; only an
 # S3-serving tier builds `--features driver-s3`.
 driver-s3 = ["dep:backends", "backends/driver-s3"]
+# Co-host the real sudocode managed-agent runtime IN-PROCESS. Off by
+# default so the slim `cluster` binary stays sudocode-free (profile purity
+# — §7); a cohost-enabled build statically links `sudocode_runtime` +
+# `tools` and wires `SudoCodeSpawnAdapter` via
+# `install_managed_agent_with_spawn`, so a minted agent runs a real LLM
+# loop doing in-process `KernelSyscall` calls (no gRPC on its fs path).
+# The kernel rev MUST match the workspace pin (both at nexus-vfs
+# `c9ecc9da`) so `SpawnTask<Kernel>` is one type across the seam.
+cohost-sudocode = ["dep:sudocode-runtime", "dep:sudocode-tools"]
 
 [dependencies]
 # Cluster library entry — `nexus_cluster::run_with_services` owns clap
@@ -37,3 +46,21 @@ services = { workspace = true, features = ["service-managed-agent"] }
 # so it is not pulled at all in the default (slim cluster) build.
 backends = { workspace = true, default-features = false, optional = true }
 anyhow = "1"
+
+# ── Co-host (opt-in `cohost-sudocode`) ──────────────────────────────────
+# The real sudocode agent runtime, linked ONLY when co-hosting. Both crates
+# reach `kernel` at the SAME nexus-vfs rev the workspace pins (`c9ecc9da`),
+# so the `Kernel` / `AgentDescriptor` / `KernelSyscall` types unify across
+# the seam and `SpawnTask<Kernel>` is a single monomorphised type.
+# `sudocode-tools` carries the `spawn_managed_agent` factory (it composes
+# the api + runtime crates); `sudocode-runtime` names the `AgentLoopState`
+# / `SpawnHandle` types the adapter maps. Pinned to the #392 branch tip
+# until #392 merges to sudocode main (then bump to the merge commit).
+sudocode-runtime = { package = "runtime", git = "https://github.com/sudoprivacy/sudocode", rev = "bb2a0d3dcd10cd308b2b2ac0037f7bb6ae82de84", optional = true }
+sudocode-tools = { package = "tools", git = "https://github.com/sudoprivacy/sudocode", rev = "bb2a0d3dcd10cd308b2b2ac0037f7bb6ae82de84", optional = true }
+# Named directly to spell `kernel::kernel::{ServiceDecl, Kernel}` — the
+# managed-agent boot decl's return type (both builds) and the co-host
+# adapter's `SpawnTask<Kernel>` (cohost build). Already present transitively
+# via services / nexus-cluster at the same workspace pin, so this direct dep
+# adds no new compilation and keeps one `Kernel` type.
+kernel = { workspace = true, default-features = false }

--- a/rust/nexusd/src/cohost.rs
+++ b/rust/nexusd/src/cohost.rs
@@ -1,0 +1,83 @@
+//! Co-host adapter: bridge the nexus `SpawnTask` DI seam to the real
+//! `sudocode` managed-agent runtime.
+//!
+//! This is the ONLY `nexus → sudocode` edge, and it lives at a binary LEAF
+//! (`nexusd-cluster`, a `[[bin]]` nothing imports), so there is no crate
+//! cycle: `sudocode_runtime → kernel`; `nexusd → {sudocode_*, services,
+//! nexus-cluster}`; `kernel` / `services` stay sudocode-free (they know
+//! only the `SpawnTask` DI trait). Compiled only under the
+//! `cohost-sudocode` feature — the default slim cluster build never links
+//! sudocode.
+//!
+//! The adapter is deliberately THIN. All agent construction (the LLM
+//! `api_client`, the VFS-backed `tool_executor`, the system prompt, the
+//! permission policy) is the SSOT of `sudocode`'s
+//! `tools::managed_agent::spawn_managed_agent` factory; the adapter only
+//! (1) forwards the kernel + descriptor into that factory, (2) maps
+//! sudocode's `AgentLoopState` onto the services-tier enum on each
+//! transition, and (3) wraps the returned handle so the service's
+//! `on_terminate` observer can abort the loop. Evolving the agent means
+//! changing the sudocode factory internals; this adapter's shape never
+//! moves.
+
+use std::sync::Arc;
+
+use kernel::core::agents::registry::AgentDescriptor;
+use kernel::kernel::Kernel;
+use services::managed_agent::{
+    AgentLoopState as ServiceLoopState, SpawnHandle as ServiceSpawnHandle, SpawnTask,
+};
+use sudocode_runtime::spawn_task::{
+    AgentLoopState as SudoLoopState, SpawnHandle as SudoSpawnHandle,
+};
+
+/// The concrete `SpawnTask<Kernel>` provider wired at the `nexusd-cluster`
+/// binary edge via `install_managed_agent_with_spawn`. Monomorphises
+/// `spawn_managed_agent::<Kernel>` internally, so the per-`sys_read` path
+/// carries no vtable cost — only the once-per-`start_session` `spawn` call
+/// is `dyn`-dispatched.
+pub struct SudoCodeSpawnAdapter;
+
+impl SpawnTask<Kernel> for SudoCodeSpawnAdapter {
+    fn spawn(
+        &self,
+        kernel: Arc<Kernel>,
+        desc: AgentDescriptor,
+        state_observer: Arc<dyn Fn(ServiceLoopState) + Send + Sync>,
+    ) -> Box<dyn ServiceSpawnHandle> {
+        // The services-tier observer expects the services enum; sudocode's
+        // factory emits the runtime enum. Map on every transition.
+        let handle: SudoSpawnHandle =
+            sudocode_tools::managed_agent::spawn_managed_agent(kernel, desc, move |sc_state| {
+                state_observer(map_loop_state(sc_state));
+            });
+        Box::new(SudoCodeSpawnHandle { inner: handle })
+    }
+}
+
+/// Map sudocode's runtime loop-state onto the services-tier mirror. The
+/// two enums are intentionally identical (same variants) — services owns
+/// its copy to keep the DI trait runtime-agnostic; this is the single
+/// translation point.
+fn map_loop_state(state: SudoLoopState) -> ServiceLoopState {
+    match state {
+        SudoLoopState::WarmingUp => ServiceLoopState::WarmingUp,
+        SudoLoopState::Ready => ServiceLoopState::Ready,
+        SudoLoopState::Busy => ServiceLoopState::Busy,
+    }
+}
+
+/// Wraps the sudocode `SpawnHandle` so the services tier sees only the
+/// abort capability its `on_terminate` observer needs. `abort` signals the
+/// runtime loop's shared `HookAbortSignal`; the worker thread observes it
+/// and exits on its next poll (idempotent — the observer may fire
+/// concurrently with an in-flight `cancel(Session)`).
+struct SudoCodeSpawnHandle {
+    inner: SudoSpawnHandle,
+}
+
+impl ServiceSpawnHandle for SudoCodeSpawnHandle {
+    fn abort(&self) {
+        self.inner.abort_signal.abort();
+    }
+}

--- a/rust/nexusd/src/main.rs
+++ b/rust/nexusd/src/main.rs
@@ -19,6 +19,34 @@
 //! adds; supersets inherit it. `acp` (nexus-drives-ACP one-shot) is NOT a
 //! cluster service.
 
+#[cfg(feature = "cohost-sudocode")]
+mod cohost;
+
+/// The `managed_agent` boot declaration. In the default slim cluster build
+/// this is the procfs-only variant (`service_decl`) — no runtime body. In a
+/// `cohost-sudocode` build it becomes a custom decl whose `install` injects
+/// the real sudocode runtime via `install_managed_agent_with_spawn`, so a
+/// minted agent runs a live LLM loop in-process. Same service name either
+/// way; only the install closure differs.
+#[cfg(not(feature = "cohost-sudocode"))]
+fn managed_agent_decl() -> kernel::kernel::ServiceDecl {
+    services::managed_agent::service_decl()
+}
+
+#[cfg(feature = "cohost-sudocode")]
+fn managed_agent_decl() -> kernel::kernel::ServiceDecl {
+    use std::sync::Arc;
+    kernel::kernel::ServiceDecl {
+        name: "managed_agent".to_string(),
+        install: Box::new(|kernel| {
+            services::managed_agent::install_managed_agent_with_spawn(
+                kernel,
+                Arc::new(cohost::SudoCodeSpawnAdapter),
+            )
+        }),
+    }
+}
+
 fn main() -> anyhow::Result<()> {
     // The daemon's service set — the SSOT for "which services this daemon
     // runs", ordered. a2a is installed first (its from-stamp hook must be
@@ -26,9 +54,6 @@ fn main() -> anyhow::Result<()> {
     // `ctx.auth_armed` is boot-derived (true iff sk- auth is armed) and
     // sets a2a's fail-closed posture.
     nexus_cluster::run_with_services(|ctx| {
-        vec![
-            a2a::service_decl(ctx.auth_armed),
-            services::managed_agent::service_decl(),
-        ]
+        vec![a2a::service_decl(ctx.auth_armed), managed_agent_decl()]
     })
 }


### PR DESCRIPTION
Phase 2c of the sudocode in-process co-host: wire the nexus `SpawnTask` DI
seam (proven empty in #4640) to sudocode's real managed-agent runtime, so a
minted agent runs a live LLM loop **in-process** inside `nexusd-cluster` —
no gRPC on its fs path (the perf reason for co-hosting).

Depends on (and pins) sudocode **#392** (co-host readiness: kernel pin bump
+ FsBackend VFS-in-process switch + PascalCase tool-dispatch fix) — **MERGED**
to sudocode main; the git deps are pinned to that merge commit.

## Design (Model B — nexusd is the binary edge)
`nexusd-cluster` statically links `sudocode_runtime` + `tools` and wraps
them in a thin `SudoCodeSpawnAdapter: services::managed_agent::SpawnTask<Kernel>`.
The ONLY `nexus → sudocode` edge, at a binary LEAF (`[[bin]]`, nothing
imports it) → no crate cycle; `kernel` / `services` stay sudocode-free.

- **`cohost.rs`** — forwards kernel + descriptor into
  `tools::managed_agent::spawn_managed_agent` (SSOT for the LLM client,
  VFS-backed tool executor, prompt, policy), maps `AgentLoopState`, wraps
  the handle for abort.
- **`main.rs`** — `managed_agent_decl()` is procfs-only `service_decl` in
  slim builds; under `cohost-sudocode` it installs the adapter via
  `install_managed_agent_with_spawn`.

## Opt-in / profile purity
Gated behind `cohost-sudocode` — **off by default**, so the shipped slim
`cluster` binary stays sudocode-free (§7 size budget).

## Kernel-rev unification
Both sudocode and nexus pin nexus-vfs `kernel` at the same rev (`c9ecc9da`),
so `Kernel` / `AgentDescriptor` / `KernelSyscall` unify → `SpawnTask<Kernel>`
is one type; no `[patch]`.

## Verified
- `cargo check -p nexusd` (slim, default) — clean.
- `cargo check -p nexusd --features cohost-sudocode` — clean.
- **Full release `nexusd-cluster` binary built + boots** with the adapter (28.8 MB).
- clippy + fmt clean on both.
- **LIVE co-host proof green** (sudocode `tools/tests/cohost_live_llm.rs`):
  a real sudocode agent loop, co-hosted on a Kernel, WarmingUp→Ready→Busy→
  Ready, then a real LLM reply through `/proc/{pid}/chat-with-me`
  in-process (claude-haiku-4-5 via sudorouter).

Cross-machine Win↔Mac (Phase 3) follows.