### PR TITLE
ci(fuse-windows-e2e): install WinFsp from cached vendor .msi, drop live Chocolatey

### DIFF
--- a/.github/workflows/fuse-plugin-windows-e2e.yml
+++ b/.github/workflows/fuse-plugin-windows-e2e.yml
@@ -73,16 +73,42 @@ jobs:
         run: |
           echo "No FUSE-plugin-relevant Windows changes; reporting required check without running suite."
 
-      # WinFsp is the Windows kernel-side userspace-filesystem driver
-      # the plugin depends on at runtime.  Chocolatey's `winfsp`
-      # package installs the .sys driver + the userspace DLL.  The
-      # /VERYSILENT switch skips the GUI installer's UAC dance — fine
-      # because the runner already runs as Administrator.
-      - name: Install WinFsp
+      # WinFsp is the Windows kernel-side userspace-filesystem driver the
+      # plugin depends on at runtime.  Pull the fixed-version .msi from the
+      # VENDOR GitHub release behind an actions/cache — NOT
+      # `choco install winfsp`.  community.chocolatey.org is a rate-limited
+      # free service that explicitly warns against CI use; a 503/rate-limit
+      # there failed this job even though our code is fine, and it recurs.
+      # Caching the pinned .msi keeps the hot path network-free on a cache
+      # hit and, on the one-time miss, fetches the release origin (not
+      # Chocolatey's re-host).  Mirrors the #4646 cache-then-download
+      # pattern used for the ORT dylib + fastembed model.
+      - name: Cache WinFsp installer (pinned .msi)
+        if: steps.changes.outputs.run == 'true'
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}\winfsp.msi
+          key: winfsp-msi-2.1.25156
+
+      - name: Install WinFsp (vendor .msi, no Chocolatey)
         if: steps.changes.outputs.run == 'true'
         shell: pwsh
         run: |
-          choco install winfsp -y --no-progress
+          $msi = "$env:RUNNER_TEMP\winfsp.msi"
+          if (-not (Test-Path $msi)) {
+            $url = 'https://github.com/winfsp/winfsp/releases/download/v2.1/winfsp-2.1.25156.msi'
+            Write-Host "WinFsp installer cache miss; downloading $url"
+            Invoke-WebRequest -Uri $url -OutFile $msi -UseBasicParsing
+          } else {
+            Write-Host "WinFsp installer restored from cache"
+          }
+          # Silent install (runner is Administrator); WinFsp lands the .sys
+          # driver + userspace DLL under C:\Program Files (x86)\WinFsp\.
+          $p = Start-Process msiexec.exe -ArgumentList "/i `"$msi`" /qn /norestart" -Wait -PassThru
+          if ($p.ExitCode -ne 0) {
+            Write-Error "msiexec returned $($p.ExitCode) installing WinFsp"
+            exit 1
+          }
           # Verify the driver landed.
           if (-not (Test-Path 'C:\Program Files (x86)\WinFsp\bin\winfsp-x64.dll')) {
             Write-Error "WinFsp install did not place winfsp-x64.dll"

--- a/.github/workflows/fuse-plugin-windows-e2e.yml
+++ b/.github/workflows/fuse-plugin-windows-e2e.yml
@@ -62,7 +62,7 @@ jobs:
           git fetch --no-tags --prune origin "${{ github.base_ref }}"
           git diff --name-only "origin/${{ github.base_ref }}"...HEAD > /tmp/changed_files.txt
           cat /tmp/changed_files.txt
-          if grep -Eq '^(rust/services/fuse-plugin/|Cargo\.toml$|Cargo\.lock$|tests/e2e/windows/)' /tmp/changed_files.txt; then
+          if grep -Eq '^(rust/services/fuse-plugin/|Cargo\.toml$|Cargo\.lock$|tests/e2e/windows/|\.github/workflows/fuse-plugin-windows-e2e\.yml$)' /tmp/changed_files.txt; then
             echo "run=true" >> "$GITHUB_OUTPUT"
           else
             echo "run=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Problem
`FUSE Plugin Windows E2E` → step **Install WinFsp** runs `choco install winfsp`
against `community.chocolatey.org` on every fuse-plugin Windows E2E run.
Chocolatey Community is a rate-limited free service that [explicitly warns
against CI use](https://docs.chocolatey.org/en-us/community-repository/community-packages-disclaimer/).
A 503/rate-limit there fails the job even when our code is fine — observed on
develop @ `98d18282` (`503 Service Unavailable` fetching `winfsp` 2.1.25156),
and it **recurs** for every PR touching `fuse-plugin` / `Cargo.*` / the
windows e2e tests. Pinning the winfsp version in the choco call does not help
because the FEED itself returns 503.

This is a genuine flake-mode (external outage surfacing as red CI), not a
one-off — surfaced during nexus #4650 (nexusd co-host adapter, entirely
unrelated to fuse-plugin) purely because that landed in a Chocolatey 503
window.

## Fix (systemic, not a retry band-aid)
WinFsp is a fixed-version binary (2.1.25156). Fetch its `.msi` from the
**vendor GitHub release** (the true origin) behind an `actions/cache`:
- **Cache hit** → hot path is network-free.
- **One-time miss** → download from `github.com/winfsp/winfsp/releases/.../winfsp-2.1.25156.msi`, then `msiexec /i … /qn` silent install.
- The `Test-Path …\winfsp-x64.dll` guard stays — it now fires only on a
  genuine install failure, not a third-party outage.

Mirrors the #4646 cache-then-download pattern already used for the ORT dylib
+ fastembed model. Eliminates the `community.chocolatey.org` dependency on
the hot path.

## Note (out of scope for this PR)
- The same workflow still has a `choco install protoc` **fallback** (only
  fires when protoc isn't already on PATH — rarely hit); same exposure, lower
  probability. Can follow up.
- Separate pre-existing develop red: `E2E edge smoke tests` HERB 0/8 — that is
  NOT an embedder-provisioning gap (the job already provisions + mounts the
  ORT dylib + model, docker-publish.yml:401-451); it's the edge-topology
  shared-FS gap (#4608 residual, per the edge-override compose comment).
  Search-plugin owner's fix.