### PR TITLE
feat(nexusd): A2A co-host — bind the co-host loop to a replicated /agents inbox

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -232,8 +232,8 @@ checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "api"
-version = "0.1.19"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=d7f64b9898151553f517d0b4ba177658da5264a8#d7f64b9898151553f517d0b4ba177658da5264a8"
+version = "0.1.20"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=fc59c5ffbf5c4ae7ccd4629e4810882973eb01f6#fc59c5ffbf5c4ae7ccd4629e4810882973eb01f6"
 dependencies = [
  "base64 0.22.1",
  "httpdate",
@@ -846,8 +846,8 @@ dependencies = [
 
 [[package]]
 name = "commands"
-version = "0.1.19"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=d7f64b9898151553f517d0b4ba177658da5264a8#d7f64b9898151553f517d0b4ba177658da5264a8"
+version = "0.1.20"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=fc59c5ffbf5c4ae7ccd4629e4810882973eb01f6#fc59c5ffbf5c4ae7ccd4629e4810882973eb01f6"
 dependencies = [
  "plugins",
  "runtime",
@@ -3074,8 +3074,8 @@ dependencies = [
 
 [[package]]
 name = "nexus-vfs-client"
-version = "0.1.19"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=d7f64b9898151553f517d0b4ba177658da5264a8#d7f64b9898151553f517d0b4ba177658da5264a8"
+version = "0.1.20"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=fc59c5ffbf5c4ae7ccd4629e4810882973eb01f6#fc59c5ffbf5c4ae7ccd4629e4810882973eb01f6"
 dependencies = [
  "prost 0.13.5",
  "protoc-bin-vendored",
@@ -3531,8 +3531,8 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plugins"
-version = "0.1.19"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=d7f64b9898151553f517d0b4ba177658da5264a8#d7f64b9898151553f517d0b4ba177658da5264a8"
+version = "0.1.20"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=fc59c5ffbf5c4ae7ccd4629e4810882973eb01f6#fc59c5ffbf5c4ae7ccd4629e4810882973eb01f6"
 dependencies = [
  "serde",
  "serde_json",
@@ -3657,7 +3657,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "once_cell",
@@ -3677,7 +3677,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "petgraph 0.8.3",
@@ -3698,7 +3698,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -3711,7 +3711,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -4375,8 +4375,8 @@ dependencies = [
 
 [[package]]
 name = "runtime"
-version = "0.1.19"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=d7f64b9898151553f517d0b4ba177658da5264a8#d7f64b9898151553f517d0b4ba177658da5264a8"
+version = "0.1.20"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=fc59c5ffbf5c4ae7ccd4629e4810882973eb01f6#fc59c5ffbf5c4ae7ccd4629e4810882973eb01f6"
 dependencies = [
  "agent-client-protocol",
  "agent-client-protocol-schema",
@@ -5281,8 +5281,8 @@ dependencies = [
 
 [[package]]
 name = "telemetry"
-version = "0.1.19"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=d7f64b9898151553f517d0b4ba177658da5264a8#d7f64b9898151553f517d0b4ba177658da5264a8"
+version = "0.1.20"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=fc59c5ffbf5c4ae7ccd4629e4810882973eb01f6#fc59c5ffbf5c4ae7ccd4629e4810882973eb01f6"
 dependencies = [
  "chrono",
  "dirs",
@@ -5672,8 +5672,8 @@ dependencies = [
 
 [[package]]
 name = "tools"
-version = "0.1.19"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=d7f64b9898151553f517d0b4ba177658da5264a8#d7f64b9898151553f517d0b4ba177658da5264a8"
+version = "0.1.20"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=fc59c5ffbf5c4ae7ccd4629e4810882973eb01f6#fc59c5ffbf5c4ae7ccd4629e4810882973eb01f6"
 dependencies = [
  "api",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -233,7 +233,7 @@ checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 [[package]]
 name = "api"
 version = "0.1.20"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=fc59c5ffbf5c4ae7ccd4629e4810882973eb01f6#fc59c5ffbf5c4ae7ccd4629e4810882973eb01f6"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=b1d3e887f65f1917d9ec6a10e6c870c9e7b0bd03#b1d3e887f65f1917d9ec6a10e6c870c9e7b0bd03"
 dependencies = [
  "base64 0.22.1",
  "httpdate",
@@ -847,7 +847,7 @@ dependencies = [
 [[package]]
 name = "commands"
 version = "0.1.20"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=fc59c5ffbf5c4ae7ccd4629e4810882973eb01f6#fc59c5ffbf5c4ae7ccd4629e4810882973eb01f6"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=b1d3e887f65f1917d9ec6a10e6c870c9e7b0bd03#b1d3e887f65f1917d9ec6a10e6c870c9e7b0bd03"
 dependencies = [
  "plugins",
  "runtime",
@@ -3075,7 +3075,7 @@ dependencies = [
 [[package]]
 name = "nexus-vfs-client"
 version = "0.1.20"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=fc59c5ffbf5c4ae7ccd4629e4810882973eb01f6#fc59c5ffbf5c4ae7ccd4629e4810882973eb01f6"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=b1d3e887f65f1917d9ec6a10e6c870c9e7b0bd03#b1d3e887f65f1917d9ec6a10e6c870c9e7b0bd03"
 dependencies = [
  "prost 0.13.5",
  "protoc-bin-vendored",
@@ -3532,7 +3532,7 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 [[package]]
 name = "plugins"
 version = "0.1.20"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=fc59c5ffbf5c4ae7ccd4629e4810882973eb01f6#fc59c5ffbf5c4ae7ccd4629e4810882973eb01f6"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=b1d3e887f65f1917d9ec6a10e6c870c9e7b0bd03#b1d3e887f65f1917d9ec6a10e6c870c9e7b0bd03"
 dependencies = [
  "serde",
  "serde_json",
@@ -4376,7 +4376,7 @@ dependencies = [
 [[package]]
 name = "runtime"
 version = "0.1.20"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=fc59c5ffbf5c4ae7ccd4629e4810882973eb01f6#fc59c5ffbf5c4ae7ccd4629e4810882973eb01f6"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=b1d3e887f65f1917d9ec6a10e6c870c9e7b0bd03#b1d3e887f65f1917d9ec6a10e6c870c9e7b0bd03"
 dependencies = [
  "agent-client-protocol",
  "agent-client-protocol-schema",
@@ -5282,7 +5282,7 @@ dependencies = [
 [[package]]
 name = "telemetry"
 version = "0.1.20"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=fc59c5ffbf5c4ae7ccd4629e4810882973eb01f6#fc59c5ffbf5c4ae7ccd4629e4810882973eb01f6"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=b1d3e887f65f1917d9ec6a10e6c870c9e7b0bd03#b1d3e887f65f1917d9ec6a10e6c870c9e7b0bd03"
 dependencies = [
  "chrono",
  "dirs",
@@ -5673,7 +5673,7 @@ dependencies = [
 [[package]]
 name = "tools"
 version = "0.1.20"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=fc59c5ffbf5c4ae7ccd4629e4810882973eb01f6#fc59c5ffbf5c4ae7ccd4629e4810882973eb01f6"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=b1d3e887f65f1917d9ec6a10e6c870c9e7b0bd03#b1d3e887f65f1917d9ec6a10e6c870c9e7b0bd03"
 dependencies = [
  "api",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "a2a"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=c9ecc9da2b755039a1028bbb619ee7cbb86f5dad#c9ecc9da2b755039a1028bbb619ee7cbb86f5dad"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=0bdb6f64f9f1e81536f3bc7b68c216a0db089cd5#0bdb6f64f9f1e81536f3bc7b68c216a0db089cd5"
 dependencies = [
  "contracts",
  "kernel",
@@ -233,7 +233,7 @@ checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 [[package]]
 name = "api"
 version = "0.1.20"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=b1d3e887f65f1917d9ec6a10e6c870c9e7b0bd03#b1d3e887f65f1917d9ec6a10e6c870c9e7b0bd03"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=bf0ba2e4d171d5fdf459a61f0fe4642dfbd29324#bf0ba2e4d171d5fdf459a61f0fe4642dfbd29324"
 dependencies = [
  "base64 0.22.1",
  "httpdate",
@@ -326,7 +326,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 [[package]]
 name = "auth"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=c9ecc9da2b755039a1028bbb619ee7cbb86f5dad#c9ecc9da2b755039a1028bbb619ee7cbb86f5dad"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=0bdb6f64f9f1e81536f3bc7b68c216a0db089cd5#0bdb6f64f9f1e81536f3bc7b68c216a0db089cd5"
 dependencies = [
  "contracts",
  "dashmap",
@@ -429,7 +429,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=c9ecc9da2b755039a1028bbb619ee7cbb86f5dad#c9ecc9da2b755039a1028bbb619ee7cbb86f5dad"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=0bdb6f64f9f1e81536f3bc7b68c216a0db089cd5#0bdb6f64f9f1e81536f3bc7b68c216a0db089cd5"
 dependencies = [
  "ahash",
  "base64 0.22.1",
@@ -847,7 +847,7 @@ dependencies = [
 [[package]]
 name = "commands"
 version = "0.1.20"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=b1d3e887f65f1917d9ec6a10e6c870c9e7b0bd03#b1d3e887f65f1917d9ec6a10e6c870c9e7b0bd03"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=bf0ba2e4d171d5fdf459a61f0fe4642dfbd29324#bf0ba2e4d171d5fdf459a61f0fe4642dfbd29324"
 dependencies = [
  "plugins",
  "runtime",
@@ -916,7 +916,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=c9ecc9da2b755039a1028bbb619ee7cbb86f5dad#c9ecc9da2b755039a1028bbb619ee7cbb86f5dad"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=0bdb6f64f9f1e81536f3bc7b68c216a0db089cd5#0bdb6f64f9f1e81536f3bc7b68c216a0db089cd5"
 dependencies = [
  "parking_lot",
  "serde",
@@ -2539,7 +2539,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=c9ecc9da2b755039a1028bbb619ee7cbb86f5dad#c9ecc9da2b755039a1028bbb619ee7cbb86f5dad"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=0bdb6f64f9f1e81536f3bc7b68c216a0db089cd5#0bdb6f64f9f1e81536f3bc7b68c216a0db089cd5"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -2607,7 +2607,7 @@ checksum = "0c2cdeb66e45e9f36bfad5bbdb4d2384e70936afbee843c6f6543f0c551ebb25"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=c9ecc9da2b755039a1028bbb619ee7cbb86f5dad#c9ecc9da2b755039a1028bbb619ee7cbb86f5dad"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=0bdb6f64f9f1e81536f3bc7b68c216a0db089cd5#0bdb6f64f9f1e81536f3bc7b68c216a0db089cd5"
 dependencies = [
  "ahash",
  "base64 0.22.1",
@@ -2968,7 +2968,7 @@ dependencies = [
 [[package]]
 name = "nexus-cluster"
 version = "0.1.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=c9ecc9da2b755039a1028bbb619ee7cbb86f5dad#c9ecc9da2b755039a1028bbb619ee7cbb86f5dad"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=0bdb6f64f9f1e81536f3bc7b68c216a0db089cd5#0bdb6f64f9f1e81536f3bc7b68c216a0db089cd5"
 dependencies = [
  "a2a",
  "anyhow",
@@ -3020,7 +3020,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=c9ecc9da2b755039a1028bbb619ee7cbb86f5dad#c9ecc9da2b755039a1028bbb619ee7cbb86f5dad"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=0bdb6f64f9f1e81536f3bc7b68c216a0db089cd5#0bdb6f64f9f1e81536f3bc7b68c216a0db089cd5"
 
 [[package]]
 name = "nexus-search-plugin"
@@ -3075,7 +3075,7 @@ dependencies = [
 [[package]]
 name = "nexus-vfs-client"
 version = "0.1.20"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=b1d3e887f65f1917d9ec6a10e6c870c9e7b0bd03#b1d3e887f65f1917d9ec6a10e6c870c9e7b0bd03"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=bf0ba2e4d171d5fdf459a61f0fe4642dfbd29324#bf0ba2e4d171d5fdf459a61f0fe4642dfbd29324"
 dependencies = [
  "prost 0.13.5",
  "protoc-bin-vendored",
@@ -3532,7 +3532,7 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 [[package]]
 name = "plugins"
 version = "0.1.20"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=b1d3e887f65f1917d9ec6a10e6c870c9e7b0bd03#b1d3e887f65f1917d9ec6a10e6c870c9e7b0bd03"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=bf0ba2e4d171d5fdf459a61f0fe4642dfbd29324#bf0ba2e4d171d5fdf459a61f0fe4642dfbd29324"
 dependencies = [
  "serde",
  "serde_json",
@@ -3946,7 +3946,7 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 [[package]]
 name = "raft"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=c9ecc9da2b755039a1028bbb619ee7cbb86f5dad#c9ecc9da2b755039a1028bbb619ee7cbb86f5dad"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=0bdb6f64f9f1e81536f3bc7b68c216a0db089cd5#0bdb6f64f9f1e81536f3bc7b68c216a0db089cd5"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -4376,7 +4376,7 @@ dependencies = [
 [[package]]
 name = "runtime"
 version = "0.1.20"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=b1d3e887f65f1917d9ec6a10e6c870c9e7b0bd03#b1d3e887f65f1917d9ec6a10e6c870c9e7b0bd03"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=bf0ba2e4d171d5fdf459a61f0fe4642dfbd29324#bf0ba2e4d171d5fdf459a61f0fe4642dfbd29324"
 dependencies = [
  "agent-client-protocol",
  "agent-client-protocol-schema",
@@ -5282,7 +5282,7 @@ dependencies = [
 [[package]]
 name = "telemetry"
 version = "0.1.20"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=b1d3e887f65f1917d9ec6a10e6c870c9e7b0bd03#b1d3e887f65f1917d9ec6a10e6c870c9e7b0bd03"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=bf0ba2e4d171d5fdf459a61f0fe4642dfbd29324#bf0ba2e4d171d5fdf459a61f0fe4642dfbd29324"
 dependencies = [
  "chrono",
  "dirs",
@@ -5673,7 +5673,7 @@ dependencies = [
 [[package]]
 name = "tools"
 version = "0.1.20"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=b1d3e887f65f1917d9ec6a10e6c870c9e7b0bd03#b1d3e887f65f1917d9ec6a10e6c870c9e7b0bd03"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=bf0ba2e4d171d5fdf459a61f0fe4642dfbd29324#bf0ba2e4d171d5fdf459a61f0fe4642dfbd29324"
 dependencies = [
  "api",
  "async-trait",
@@ -5816,7 +5816,7 @@ dependencies = [
 [[package]]
 name = "transport"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=c9ecc9da2b755039a1028bbb619ee7cbb86f5dad#c9ecc9da2b755039a1028bbb619ee7cbb86f5dad"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=0bdb6f64f9f1e81536f3bc7b68c216a0db089cd5#0bdb6f64f9f1e81536f3bc7b68c216a0db089cd5"
 dependencies = [
  "axum",
  "backends",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -224,24 +224,24 @@ exclude = ["nexus-fuse"]
 #
 # Bump alongside the rest of nexus-vfs updates when a downstream
 # change needs newer kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "c9ecc9da2b755039a1028bbb619ee7cbb86f5dad" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "c9ecc9da2b755039a1028bbb619ee7cbb86f5dad" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "c9ecc9da2b755039a1028bbb619ee7cbb86f5dad" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "c9ecc9da2b755039a1028bbb619ee7cbb86f5dad", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "c9ecc9da2b755039a1028bbb619ee7cbb86f5dad", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "c9ecc9da2b755039a1028bbb619ee7cbb86f5dad", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "c9ecc9da2b755039a1028bbb619ee7cbb86f5dad" }
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "0bdb6f64f9f1e81536f3bc7b68c216a0db089cd5" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "0bdb6f64f9f1e81536f3bc7b68c216a0db089cd5" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "0bdb6f64f9f1e81536f3bc7b68c216a0db089cd5" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "0bdb6f64f9f1e81536f3bc7b68c216a0db089cd5", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "0bdb6f64f9f1e81536f3bc7b68c216a0db089cd5", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "0bdb6f64f9f1e81536f3bc7b68c216a0db089cd5", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "0bdb6f64f9f1e81536f3bc7b68c216a0db089cd5" }
 # The cluster daemon library entry (`nexus_cluster::run_with_services`),
 # consumed by the nexus-side assembly binary (`rust/nexusd`) that composes
 # the kernel/federation boot with the nexus service set via the
 # ServiceRegistry bring-up seam.
-nexus-cluster = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "c9ecc9da2b755039a1028bbb619ee7cbb86f5dad" }
+nexus-cluster = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "0bdb6f64f9f1e81536f3bc7b68c216a0db089cd5" }
 # a2a messaging substrate. `default-features = false` leaves the
 # `install` feature (which pulls raft to arm the stream-wakeup observer)
 # OFF, so nexus-side consumers link only the stamp hook and stay
 # raft-free — they reach raft through kernel.sys_* (§6.1). The substrate
 # is armed in production at cluster boot in nexus-vfs, not here.
-a2a = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "c9ecc9da2b755039a1028bbb619ee7cbb86f5dad", default-features = false }
+a2a = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "0bdb6f64f9f1e81536f3bc7b68c216a0db089cd5", default-features = false }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/rust/nexusd/Cargo.toml
+++ b/rust/nexusd/Cargo.toml
@@ -49,7 +49,7 @@ anyhow = "1"
 
 # ── Co-host (opt-in `cohost-sudocode`) ──────────────────────────────────
 # The real sudocode agent runtime, linked ONLY when co-hosting. Both crates
-# reach `kernel` at the SAME nexus-vfs rev the workspace pins (`c9ecc9da`),
+# reach `kernel` at the SAME nexus-vfs rev the workspace pins (`0bdb6f64f` = c9ecc9da + federation A+D),
 # so the `Kernel` / `AgentDescriptor` / `KernelSyscall` types unify across
 # the seam and `SpawnTask<Kernel>` is a single monomorphised type.
 # `sudocode-tools` carries the `spawn_managed_agent` factory (it composes
@@ -57,8 +57,8 @@ anyhow = "1"
 # / `SpawnHandle` types the adapter maps. Pinned to the `feat/cohost-a2a-mailbox`
 # tip: #401 per-recipient A2A mailbox + the transient-inbox-read survival fix
 # (the co-host boot loop must not die on a cold/pre-mint read).
-sudocode-runtime = { package = "runtime", git = "https://github.com/sudoprivacy/sudocode", rev = "b1d3e887f65f1917d9ec6a10e6c870c9e7b0bd03", optional = true }
-sudocode-tools = { package = "tools", git = "https://github.com/sudoprivacy/sudocode", rev = "b1d3e887f65f1917d9ec6a10e6c870c9e7b0bd03", optional = true }
+sudocode-runtime = { package = "runtime", git = "https://github.com/sudoprivacy/sudocode", rev = "bf0ba2e4d171d5fdf459a61f0fe4642dfbd29324", optional = true }
+sudocode-tools = { package = "tools", git = "https://github.com/sudoprivacy/sudocode", rev = "bf0ba2e4d171d5fdf459a61f0fe4642dfbd29324", optional = true }
 # Named directly to spell `kernel::kernel::{ServiceDecl, Kernel}` — the
 # managed-agent boot decl's return type (both builds) and the co-host
 # adapter's `SpawnTask<Kernel>` (cohost build). Already present transitively

--- a/rust/nexusd/Cargo.toml
+++ b/rust/nexusd/Cargo.toml
@@ -54,10 +54,11 @@ anyhow = "1"
 # the seam and `SpawnTask<Kernel>` is a single monomorphised type.
 # `sudocode-tools` carries the `spawn_managed_agent` factory (it composes
 # the api + runtime crates); `sudocode-runtime` names the `AgentLoopState`
-# / `SpawnHandle` types the adapter maps. Pinned to the sudocode main merge
-# commit of #392 (co-host readiness).
-sudocode-runtime = { package = "runtime", git = "https://github.com/sudoprivacy/sudocode", rev = "fc59c5ffbf5c4ae7ccd4629e4810882973eb01f6", optional = true }
-sudocode-tools = { package = "tools", git = "https://github.com/sudoprivacy/sudocode", rev = "fc59c5ffbf5c4ae7ccd4629e4810882973eb01f6", optional = true }
+# / `SpawnHandle` types the adapter maps. Pinned to the `feat/cohost-a2a-mailbox`
+# tip: #401 per-recipient A2A mailbox + the transient-inbox-read survival fix
+# (the co-host boot loop must not die on a cold/pre-mint read).
+sudocode-runtime = { package = "runtime", git = "https://github.com/sudoprivacy/sudocode", rev = "b1d3e887f65f1917d9ec6a10e6c870c9e7b0bd03", optional = true }
+sudocode-tools = { package = "tools", git = "https://github.com/sudoprivacy/sudocode", rev = "b1d3e887f65f1917d9ec6a10e6c870c9e7b0bd03", optional = true }
 # Named directly to spell `kernel::kernel::{ServiceDecl, Kernel}` — the
 # managed-agent boot decl's return type (both builds) and the co-host
 # adapter's `SpawnTask<Kernel>` (cohost build). Already present transitively

--- a/rust/nexusd/Cargo.toml
+++ b/rust/nexusd/Cargo.toml
@@ -56,8 +56,8 @@ anyhow = "1"
 # the api + runtime crates); `sudocode-runtime` names the `AgentLoopState`
 # / `SpawnHandle` types the adapter maps. Pinned to the sudocode main merge
 # commit of #392 (co-host readiness).
-sudocode-runtime = { package = "runtime", git = "https://github.com/sudoprivacy/sudocode", rev = "d7f64b9898151553f517d0b4ba177658da5264a8", optional = true }
-sudocode-tools = { package = "tools", git = "https://github.com/sudoprivacy/sudocode", rev = "d7f64b9898151553f517d0b4ba177658da5264a8", optional = true }
+sudocode-runtime = { package = "runtime", git = "https://github.com/sudoprivacy/sudocode", rev = "fc59c5ffbf5c4ae7ccd4629e4810882973eb01f6", optional = true }
+sudocode-tools = { package = "tools", git = "https://github.com/sudoprivacy/sudocode", rev = "fc59c5ffbf5c4ae7ccd4629e4810882973eb01f6", optional = true }
 # Named directly to spell `kernel::kernel::{ServiceDecl, Kernel}` — the
 # managed-agent boot decl's return type (both builds) and the co-host
 # adapter's `SpawnTask<Kernel>` (cohost build). Already present transitively

--- a/rust/nexusd/src/cohost.rs
+++ b/rust/nexusd/src/cohost.rs
@@ -22,13 +22,13 @@
 
 use std::sync::Arc;
 
-use kernel::core::agents::registry::AgentDescriptor;
+use kernel::core::agents::registry::{AgentDescriptor, AgentKind};
 use kernel::kernel::Kernel;
 use services::managed_agent::{
     AgentLoopState as ServiceLoopState, SpawnHandle as ServiceSpawnHandle, SpawnTask,
 };
 use sudocode_runtime::spawn_task::{
-    AgentLoopState as SudoLoopState, SpawnHandle as SudoSpawnHandle,
+    AgentLoopState as SudoLoopState, Mailbox, SpawnHandle as SudoSpawnHandle,
 };
 
 /// The concrete `SpawnTask<Kernel>` provider wired at the `nexusd-cluster`
@@ -45,12 +45,22 @@ impl SpawnTask<Kernel> for SudoCodeSpawnAdapter {
         desc: AgentDescriptor,
         state_observer: Arc<dyn Fn(ServiceLoopState) + Send + Sync>,
     ) -> Box<dyn ServiceSpawnHandle> {
+        // The managed-agent `StartSession` path is the node-local procfs
+        // model: the loop reads + replies on `/proc/{pid}/chat-with-me`.
+        let mailbox = Mailbox::LocalStream {
+            path: format!("/proc/{}/chat-with-me", desc.pid),
+            self_id: desc.name.clone(),
+        };
         // The services-tier observer expects the services enum; sudocode's
         // factory emits the runtime enum. Map on every transition.
-        let handle: SudoSpawnHandle =
-            sudocode_tools::managed_agent::spawn_managed_agent(kernel, desc, move |sc_state| {
+        let handle: SudoSpawnHandle = sudocode_tools::managed_agent::spawn_managed_agent(
+            kernel,
+            desc,
+            mailbox,
+            move |sc_state| {
                 state_observer(map_loop_state(sc_state));
-            });
+            },
+        );
         Box::new(SudoCodeSpawnHandle { inner: handle })
     }
 }
@@ -79,5 +89,76 @@ struct SudoCodeSpawnHandle {
 impl ServiceSpawnHandle for SudoCodeSpawnHandle {
     fn abort(&self) {
         self.inner.abort_signal.abort();
+    }
+}
+
+// ── A2A co-host boot spawn ──────────────────────────────────────────────
+//
+// The production path for the Win↔Mac duet: co-host a sudocode agent bound
+// to its REPLICATED A2A inbox `/agents/<name>/chat-with-me` (not the
+// node-local `/proc` stream), so two co-hosted agents on different nodes
+// converse over A2A with no bridge/relay. Config-driven at boot via env:
+//
+//   NEXUS_COHOST_AGENT=win-ai            # the A2A agent to co-host here
+//   NEXUS_COHOST_MODEL=claude-haiku-4-5  # optional (defaults to haiku)
+//
+// The agent MUST already be minted (its replicated `/agents/<name>/`
+// mailbox present) before this fires — mint once, then boot.
+
+/// Install a boot-time A2A co-host loop from env config. No-op when
+/// `NEXUS_COHOST_AGENT` is unset (e.g. a founder that only relays). Wired as
+/// a `ServiceDecl` so it gets the booted `Arc<Kernel>`.
+pub fn install_a2a_cohost(kernel: &Arc<Kernel>) -> Result<(), String> {
+    let Ok(agent) = std::env::var("NEXUS_COHOST_AGENT") else {
+        return Ok(());
+    };
+    let agent = agent.trim().to_string();
+    if agent.is_empty() {
+        return Ok(());
+    }
+    let model = std::env::var("NEXUS_COHOST_MODEL")
+        .ok()
+        .filter(|m| !m.trim().is_empty())
+        .unwrap_or_else(|| "claude-haiku-4-5".to_string());
+
+    let mut desc = AgentDescriptor {
+        pid: format!("cohost-{agent}"),
+        name: agent.clone(),
+        kind: AgentKind::Managed,
+        owner_id: "root".to_string(),
+        zone_id: "root".to_string(),
+        ..Default::default()
+    };
+    desc.labels.insert("model".to_string(), model.clone());
+
+    // Read its OWN replicated inbox; reply to each SENDER's inbox — raft
+    // replication carries the reply to the peer's node.
+    let mailbox = Mailbox::A2aInbox {
+        base: "/agents".to_string(),
+        self_name: agent.clone(),
+    };
+    eprintln!(
+        "[cohost] co-hosting A2A agent {agent} (model {model}) on /agents/{agent}/chat-with-me"
+    );
+
+    let agent_for_cb = agent.clone();
+    let _handle = sudocode_tools::managed_agent::spawn_managed_agent(
+        Arc::clone(kernel),
+        desc,
+        mailbox,
+        move |state| eprintln!("[cohost] agent {agent_for_cb} loop state: {state:?}"),
+    );
+    // `_handle` is intentionally dropped: dropping detaches the worker
+    // thread (its `JoinHandle`) and does NOT signal abort, so the co-host
+    // loop runs for the daemon's lifetime.
+    Ok(())
+}
+
+/// `ServiceDecl` for the boot-time A2A co-host spawn (no-op unless
+/// `NEXUS_COHOST_AGENT` is set).
+pub fn service_decl() -> kernel::kernel::ServiceDecl {
+    kernel::kernel::ServiceDecl {
+        name: "cohost_a2a".to_string(),
+        install: Box::new(install_a2a_cohost),
     }
 }

--- a/rust/nexusd/src/main.rs
+++ b/rust/nexusd/src/main.rs
@@ -47,6 +47,19 @@ fn managed_agent_decl() -> kernel::kernel::ServiceDecl {
     }
 }
 
+/// Extra boot decls only a cohost build adds: the A2A co-host loop
+/// (`NEXUS_COHOST_AGENT`), spawned after a2a + managed_agent so the
+/// replicated `/agents/<name>` mailbox it binds to is already armed.
+#[cfg(not(feature = "cohost-sudocode"))]
+fn cohost_a2a_decls() -> Vec<kernel::kernel::ServiceDecl> {
+    Vec::new()
+}
+
+#[cfg(feature = "cohost-sudocode")]
+fn cohost_a2a_decls() -> Vec<kernel::kernel::ServiceDecl> {
+    vec![cohost::service_decl()]
+}
+
 fn main() -> anyhow::Result<()> {
     // The daemon's service set — the SSOT for "which services this daemon
     // runs", ordered. a2a is installed first (its from-stamp hook must be
@@ -54,6 +67,8 @@ fn main() -> anyhow::Result<()> {
     // `ctx.auth_armed` is boot-derived (true iff sk- auth is armed) and
     // sets a2a's fail-closed posture.
     nexus_cluster::run_with_services(|ctx| {
-        vec![a2a::service_decl(ctx.auth_armed), managed_agent_decl()]
+        let mut decls = vec![a2a::service_decl(ctx.auth_armed), managed_agent_decl()];
+        decls.extend(cohost_a2a_decls());
+        decls
     })
 }


### PR DESCRIPTION
Pairs with sudocode #401 (per-recipient A2A Mailbox). Bumps the sudocode dep to that merge (fc59c5ff) and threads a Mailbox into spawn_managed_agent.

- **SudoCodeSpawnAdapter** (managed-agent StartSession path) → Mailbox::LocalStream on /proc/{pid}/chat-with-me — node-local, unchanged.
- **install_a2a_cohost + cohost_a2a ServiceDecl** — boot-config (NEXUS_COHOST_AGENT / NEXUS_COHOST_MODEL) spawns a co-host loop bound to the agent's REPLICATED A2A inbox (Mailbox::A2aInbox /agents/<name>): reads its own inbox, replies to the sender's inbox. Two co-hosted agents on different nodes converse over A2A with no bridge/relay. Agent must be minted first; no-op unless the env is set; slim build unaffected.

Verified: slim + cohost cargo check clean, clippy + fmt clean. Local + Win<->Mac live proof to follow (haiku via sudorouter).