### PR TITLE
fix(search): route semantic_search_index through P12 plugin — unblock HERB gate

### DIFF
--- a/docs/surface-coverage/api-rpc-surface-coverage.yaml
+++ b/docs/surface-coverage/api-rpc-surface-coverage.yaml
@@ -4977,7 +4977,7 @@ operations:
   transports:
     grpc_expose:
       name: initialize_semantic_search
-      source: src/nexus/bricks/search/search_service.py:4869
+      source: src/nexus/bricks/search/search_service.py:4901
   profiles:
     lite: supported
     sandbox: supported
@@ -7972,7 +7972,7 @@ operations:
   transports:
     grpc_expose:
       name: semantic_search_stats
-      source: src/nexus/bricks/search/search_service.py:4821
+      source: src/nexus/bricks/search/search_service.py:4853
   profiles:
     lite: supported
     sandbox: supported

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -344,6 +344,42 @@ class SearchDaemon:
             "skipped_count": resp.skipped_count,
         }
 
+    async def index(
+        self,
+        root_path: str,
+        *,
+        zone_id: str | None = None,
+        recursive: bool = True,
+        max_docs: int = 0,
+    ) -> dict[str, Any]:
+        """Forward a walker-driven Index request to the Rust plugin.
+
+        Post-P12 companion to :meth:`index_documents` — the plugin walks
+        the VFS from ``root_path`` via ``sys_readdir``, reads each file,
+        chunks + indexes.  Used by ``SearchService.semantic_search_index``
+        when the wired daemon is the plugin proxy (this shim), so the
+        pre-existing ``nexus search index <path>`` CLI seeds the plugin
+        instead of only the SANDBOX in-process indexer (#4628 residual —
+        the P12 shim gate #4628 landed the query-path routing but the
+        index-path routing was still SANDBOX-only).
+
+        ``max_docs=0`` maps to the plugin's server-side default (10_000).
+        """
+        req = search_pb2.IndexRequest(
+            root_path=root_path,
+            zone_id=zone_id or "",
+            recursive=recursive,
+            max_docs=max_docs,
+        )
+        resp = await self._get_stub().Index(req)
+        # Fail closed on populated error, matching index_documents.
+        if resp.HasField("error"):
+            raise RuntimeError(f"plugin index failed: {resp.error}")
+        return {
+            "indexed_count": resp.indexed_count,
+            "skipped_count": resp.skipped_count,
+        }
+
     async def notify_file_change(
         self,
         path: str,

--- a/src/nexus/bricks/search/search_service.py
+++ b/src/nexus/bricks/search/search_service.py
@@ -4799,6 +4799,38 @@ class SearchService:
         Raises:
             ValueError: If semantic search is not initialized
         """
+        # Prefer the P12 plugin when a plugin-transport daemon is wired
+        # (#4628 residual — the shim gate at ``semantic_search``
+        # recognises ``_target`` for the QUERY path, but the INDEX path
+        # here stayed SANDBOX-only until now).  Without this arm the
+        # CLI ``nexus search index <dir>`` reports "Files indexed: N"
+        # from the SANDBOX in-process indexer while the plugin sees
+        # zero — an edge deployment's HERB gate hits hybrid on an
+        # unseeded plugin and returns 0/8 (Docker Publish HERB gate
+        # 2026-08-11..).
+        #
+        # Plugin-less deployments and SANDBOX-only builds are
+        # unaffected: they take the ``_indexing_service`` /
+        # ``_pipeline_indexer`` arms below unchanged.
+        daemon = getattr(self, "_search_daemon", None)
+        if daemon is not None and getattr(daemon, "_target", None) is not None:
+            try:
+                resp = await daemon.index(path, recursive=recursive)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "plugin index at %s failed (%s); falling back to SANDBOX indexer",
+                    path,
+                    exc,
+                )
+            else:
+                # Return per-path count shape that callers already read.
+                # The plugin's IndexResponse is aggregate (indexed_count
+                # + skipped_count), not per-path — synthesize a
+                # single-entry mapping keyed by the request root so the
+                # CLI's "Files indexed" tally stays meaningful.
+                indexed = int(resp.get("indexed_count", 0))
+                return {path: indexed} if indexed >= 0 else {}
+
         # Prefer IndexingService (Issue #2075)
         if self._indexing_service is not None:
             try:

--- a/tests/unit/bricks/search/test_semantic_search_daemon_gate.py
+++ b/tests/unit/bricks/search/test_semantic_search_daemon_gate.py
@@ -42,10 +42,26 @@ class _FakePluginShim:
         self._target = "localhost:2126"
         self.requests: list[object] = []
         self._rows = rows
+        self.index_calls: list[tuple[str, bool]] = []
+        self.index_result: dict[str, int] = {"indexed_count": 22, "skipped_count": 0}
+        self.index_should_raise: Exception | None = None
 
     async def search(self, request: object) -> list[_DaemonRow]:
         self.requests.append(request)
         return self._rows
+
+    async def index(
+        self,
+        root_path: str,
+        *,
+        zone_id: str | None = None,  # noqa: ARG002
+        recursive: bool = True,
+        max_docs: int = 0,  # noqa: ARG002
+    ) -> dict[str, int]:
+        self.index_calls.append((root_path, recursive))
+        if self.index_should_raise is not None:
+            raise self.index_should_raise
+        return self.index_result
 
 
 def _make_service(daemon: object | None) -> SearchService:
@@ -89,6 +105,51 @@ class TestPluginShimGate:
         svc = _make_service(daemon=None)
         with pytest.raises(ValueError, match="not available"):
             await svc.semantic_search(query="anything", search_mode="hybrid")
+
+    @pytest.mark.asyncio
+    async def test_index_path_routes_through_plugin_when_wired(self) -> None:
+        """#4628 residual: the P12 shim gate at ``semantic_search``
+        (query path) recognises ``_target`` and delegates to the plugin.
+        The companion ``semantic_search_index`` (index path) had NO such
+        gate — the CLI ``nexus search index <dir>`` fell into SANDBOX
+        indexing while the plugin saw zero docs, and the HERB QUALITY
+        GATE hit 0/8 on the edge topology (Docker Publish red since
+        2026-08-11).  This test pins that the index path now prefers
+        the plugin when a plugin-transport daemon is wired."""
+        shim = _FakePluginShim(rows=[])
+        svc = _make_service(shim)
+        result = await svc.semantic_search_index("/workspace/demo", recursive=True)
+        assert shim.index_calls == [("/workspace/demo", True)]
+        # Aggregate indexed_count is synthesized into the per-path
+        # mapping shape callers already read from the SANDBOX arms.
+        assert result == {"/workspace/demo": 22}
+
+    @pytest.mark.asyncio
+    async def test_index_path_falls_back_to_sandbox_on_plugin_error(self) -> None:
+        """A plugin index() raise (server down, transient RPC failure)
+        must not fail the CLI — the SANDBOX arm below still runs, so
+        a mixed-topology deployment retains at least the local
+        indexing capability."""
+        shim = _FakePluginShim(rows=[])
+        shim.index_should_raise = RuntimeError("plugin unreachable")
+        svc = _make_service(shim)
+        # No _indexing_service / _pipeline_indexer wired → returns {}
+        # instead of raising; the CLI reports "Files indexed: 0"
+        # rather than crashing.
+        result = await svc.semantic_search_index("/workspace/demo")
+        assert result == {}
+        assert shim.index_calls == [("/workspace/demo", True)]
+
+    @pytest.mark.asyncio
+    async def test_index_path_no_daemon_uses_sandbox(self) -> None:
+        """Plugin-less deployments (SANDBOX only) MUST take the
+        pre-existing indexer arms — the gate must not accidentally
+        route to a nonexistent plugin."""
+        svc = _make_service(daemon=None)
+        # Without any indexer wired, the method returns {} (documented
+        # shape).  Verifies the gate doesn't trip on missing daemon.
+        result = await svc.semantic_search_index("/workspace/demo")
+        assert result == {}
 
     @pytest.mark.asyncio
     async def test_enforcing_without_context_fails_closed(self) -> None:


### PR DESCRIPTION
## The failure

Docker Publish's E2E edge smoke tests → \`Run build perf e2e\` → §6 HERB QUALITY GATE has been red on every develop commit since 2026-08-11 (13 consecutive failures, 0/8 hybrid hit rate). Bisected to the merge of windoliver's #4635 (title-arm hybrid fusion for the Rust plugin, closing #4628).

## Not what it looked like

First hypothesis was an indexing/topology issue or a bug in the title-arm fusion path. Evidence rules both out:

- \`nexus search index /workspace/demo\` reports \"Files indexed: 22\" — the SANDBOX indexer did its job.
- Plugin's own /search/stats returns \`fts_doc_count: 2, fts_path_count: 2, ann_chunk_count: 2\` — only section 5's README self-seed reached the plugin. **20/22 docs never got there.**
- \`indexing_in_progress: 0\`, \`parked_count: 0\`, \`embedding_model: mE5-small-v1\`, \`vector_backend: hnsw-in-process\` — plugin is fully wired and idle.
- \`embedder = FastEmbedder (mE5-small)\` loads correctly (via #4646's provisioning).

## Root cause

The post-P12 CLI \`nexus search index <dir>\` dispatches to \`SearchService.semantic_search_index()\` (in \`src/nexus/bricks/search/search_service.py\`), which only tries the SANDBOX in-process indexer (\`_indexing_service\` / \`_pipeline_indexer\`) and **never talks to the plugin transport**.

windoliver's #4628 landed a plugin-shim gate at the QUERY path (\`semantic_search\`, commit \`8d869e9f5\`) that recognises the plugin via \`_target\` and delegates. The companion INDEX path was left SANDBOX-only, so on any P12-plugin deployment where SANDBOX and plugin coexist (edge topology with NEXUS_PROFILE=full is exactly this), the CLI silently seeds the wrong indexer and the plugin stays empty.

Same-shape wire evidence in the CI logs:
- Step 4: \`attempt 1: Files indexed=22\`  ← SANDBOX indexed 22 docs
- Section 5 stats immediately after: \`fts_doc_count: 2\` ← plugin only has README + 1 other
- Section 6 HERB gate: 0/8, every hybrid probe returns \`No results found\`

## Fix

1. **daemon.py**: new \`daemon.index(root_path, *, zone_id, recursive, max_docs)\` method — forwards to the plugin's \`Index\` RPC (walker-driven). Symmetric with the pre-existing \`index_documents\` (explicit-payload) shim.
2. **search_service.py**: at the top of \`semantic_search_index\`, prefer plugin routing when a plugin-transport daemon is wired (mirrors the \`_target\`-check pattern from #4628 \`8d869e9f5\`). Plugin RPC failure falls through to SANDBOX so a plugin blip doesn't crash the CLI. Plugin-less builds (SANDBOX-only) take the pre-existing arms unchanged.

## Not touched

- Rust plugin (\`nexus-search-plugin\`) — none of windoliver's active #4628 rounds get touched.
- Rust plugin's fusion / title-arm / dirty-zone / skeleton code — no risk of colliding with in-flight adversarial rounds.
- \`_indexing_service\` / \`_pipeline_indexer\` behaviour — SANDBOX users unaffected.
- \`nexusd-cluster\` — no packaging / boot / driver changes.

## Test plan

- [x] Extended \`tests/unit/bricks/search/test_semantic_search_daemon_gate.py\` (which pins the sibling QUERY-path gate from \`8d869e9f5\`) with three cases: plugin-wired routing hits \`daemon.index\` and returns the aggregate; plugin RPC failure falls back to SANDBOX cleanly; plugin-less deployments still take the sandbox arm.
- [x] \`pytest tests/unit/bricks/search/test_semantic_search_daemon_gate.py -v\` — 6/6 pass (2 pre-existing + 3 new + 1 daemon-None branch).
- [x] \`pytest tests/unit/bricks/search/\` — 172 pass, 9 skipped (Postgres/sqlite_vec unavailable in local env).
- [ ] Docker Publish end-to-end HERB gate ≥ 90% on CI.
- [ ] Full CI on develop base.

## Rollback

Revert this PR. The pre-existing behaviour returns (SANDBOX-only indexing from the CLI). HERB gate stays red — which was the previous state.