### PR TITLE
fix(search): switch plugin index routing to IndexDocuments (was: walker) — HERB gate

### DIFF
--- a/docs/surface-coverage/api-rpc-surface-coverage.yaml
+++ b/docs/surface-coverage/api-rpc-surface-coverage.yaml
@@ -3394,7 +3394,7 @@ operations:
       source: src/nexus/server/_kernel_syscall_dispatch.py:52
     grpc_expose:
       name: list
-      source: src/nexus/bricks/search/search_service.py:464
+      source: src/nexus/bricks/search/search_service.py:515
   profiles:
     lite: supported
     sandbox: supported
@@ -4583,7 +4583,7 @@ operations:
   transports:
     grpc_expose:
       name: glob_batch
-      source: src/nexus/bricks/search/search_service.py:2045
+      source: src/nexus/bricks/search/search_service.py:2096
   profiles:
     lite: supported
     sandbox: supported
@@ -4977,7 +4977,7 @@ operations:
   transports:
     grpc_expose:
       name: initialize_semantic_search
-      source: src/nexus/bricks/search/search_service.py:4901
+      source: src/nexus/bricks/search/search_service.py:4979
   profiles:
     lite: supported
     sandbox: supported
@@ -7713,7 +7713,7 @@ operations:
       source: src/nexus/cli/commands/search.py:1
     grpc_expose:
       name: glob
-      source: src/nexus/bricks/search/search_service.py:1792
+      source: src/nexus/bricks/search/search_service.py:1843
     http:
       name: POST /api/v2/search/glob
       source: src/nexus/server/api/v2/routers/search.py:1624
@@ -7740,7 +7740,7 @@ operations:
       source: src/nexus/cli/commands/search.py:1
     grpc_expose:
       name: grep
-      source: src/nexus/bricks/search/search_service.py:2102
+      source: src/nexus/bricks/search/search_service.py:2153
     http:
       name: POST /api/v2/search/grep
       source: src/nexus/server/api/v2/routers/search.py:1501
@@ -7934,7 +7934,7 @@ operations:
   transports:
     grpc_expose:
       name: semantic_search
-      source: src/nexus/bricks/search/search_service.py:4433
+      source: src/nexus/bricks/search/search_service.py:4484
     mcp:
       name: nexus_semantic_search
       source: src/nexus/config/tool_profiles.yaml:1
@@ -7955,7 +7955,7 @@ operations:
   transports:
     grpc_expose:
       name: semantic_search_index
-      source: src/nexus/bricks/search/search_service.py:4784
+      source: src/nexus/bricks/search/search_service.py:4835
   profiles:
     lite: supported
     sandbox: supported
@@ -7972,7 +7972,7 @@ operations:
   transports:
     grpc_expose:
       name: semantic_search_stats
-      source: src/nexus/bricks/search/search_service.py:4853
+      source: src/nexus/bricks/search/search_service.py:4931
   profiles:
     lite: supported
     sandbox: supported

--- a/docs/surface-coverage/api-rpc-surface-coverage.yaml
+++ b/docs/surface-coverage/api-rpc-surface-coverage.yaml
@@ -3394,7 +3394,7 @@ operations:
       source: src/nexus/server/_kernel_syscall_dispatch.py:52
     grpc_expose:
       name: list
-      source: src/nexus/bricks/search/search_service.py:515
+      source: src/nexus/bricks/search/search_service.py:513
   profiles:
     lite: supported
     sandbox: supported
@@ -4583,7 +4583,7 @@ operations:
   transports:
     grpc_expose:
       name: glob_batch
-      source: src/nexus/bricks/search/search_service.py:2096
+      source: src/nexus/bricks/search/search_service.py:2094
   profiles:
     lite: supported
     sandbox: supported
@@ -4977,7 +4977,7 @@ operations:
   transports:
     grpc_expose:
       name: initialize_semantic_search
-      source: src/nexus/bricks/search/search_service.py:4979
+      source: src/nexus/bricks/search/search_service.py:4975
   profiles:
     lite: supported
     sandbox: supported
@@ -7713,7 +7713,7 @@ operations:
       source: src/nexus/cli/commands/search.py:1
     grpc_expose:
       name: glob
-      source: src/nexus/bricks/search/search_service.py:1843
+      source: src/nexus/bricks/search/search_service.py:1841
     http:
       name: POST /api/v2/search/glob
       source: src/nexus/server/api/v2/routers/search.py:1624
@@ -7740,7 +7740,7 @@ operations:
       source: src/nexus/cli/commands/search.py:1
     grpc_expose:
       name: grep
-      source: src/nexus/bricks/search/search_service.py:2153
+      source: src/nexus/bricks/search/search_service.py:2151
     http:
       name: POST /api/v2/search/grep
       source: src/nexus/server/api/v2/routers/search.py:1501
@@ -7934,7 +7934,7 @@ operations:
   transports:
     grpc_expose:
       name: semantic_search
-      source: src/nexus/bricks/search/search_service.py:4484
+      source: src/nexus/bricks/search/search_service.py:4482
     mcp:
       name: nexus_semantic_search
       source: src/nexus/config/tool_profiles.yaml:1
@@ -7955,7 +7955,7 @@ operations:
   transports:
     grpc_expose:
       name: semantic_search_index
-      source: src/nexus/bricks/search/search_service.py:4835
+      source: src/nexus/bricks/search/search_service.py:4833
   profiles:
     lite: supported
     sandbox: supported
@@ -7972,7 +7972,7 @@ operations:
   transports:
     grpc_expose:
       name: semantic_search_stats
-      source: src/nexus/bricks/search/search_service.py:4931
+      source: src/nexus/bricks/search/search_service.py:4927
   profiles:
     lite: supported
     sandbox: supported

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -344,42 +344,6 @@ class SearchDaemon:
             "skipped_count": resp.skipped_count,
         }
 
-    async def index(
-        self,
-        root_path: str,
-        *,
-        zone_id: str | None = None,
-        recursive: bool = True,
-        max_docs: int = 0,
-    ) -> dict[str, Any]:
-        """Forward a walker-driven Index request to the Rust plugin.
-
-        Post-P12 companion to :meth:`index_documents` — the plugin walks
-        the VFS from ``root_path`` via ``sys_readdir``, reads each file,
-        chunks + indexes.  Used by ``SearchService.semantic_search_index``
-        when the wired daemon is the plugin proxy (this shim), so the
-        pre-existing ``nexus search index <path>`` CLI seeds the plugin
-        instead of only the SANDBOX in-process indexer (#4628 residual —
-        the P12 shim gate #4628 landed the query-path routing but the
-        index-path routing was still SANDBOX-only).
-
-        ``max_docs=0`` maps to the plugin's server-side default (10_000).
-        """
-        req = search_pb2.IndexRequest(
-            root_path=root_path,
-            zone_id=zone_id or "",
-            recursive=recursive,
-            max_docs=max_docs,
-        )
-        resp = await self._get_stub().Index(req)
-        # Fail closed on populated error, matching index_documents.
-        if resp.HasField("error"):
-            raise RuntimeError(f"plugin index failed: {resp.error}")
-        return {
-            "indexed_count": resp.indexed_count,
-            "skipped_count": resp.skipped_count,
-        }
-
     async def notify_file_change(
         self,
         path: str,

--- a/src/nexus/bricks/search/search_service.py
+++ b/src/nexus/bricks/search/search_service.py
@@ -223,9 +223,7 @@ async def _collect_docs_for_plugin(
 
     docs: list[dict[str, Any]] = []
     for entry in files:
-        file_path = (
-            entry if isinstance(entry, str) else entry.get("path") or entry.get("name", "")
-        )
+        file_path = entry if isinstance(entry, str) else entry.get("path") or entry.get("name", "")
         if not file_path or file_path.endswith("/"):
             continue
         if file_path.endswith(_BINARY_EXTENSIONS):
@@ -4884,8 +4882,7 @@ class SearchService:
                 docs = await _collect_docs_for_plugin(indexer, path, recursive)
             except Exception as exc:  # noqa: BLE001
                 logger.warning(
-                    "enumerate for plugin index at %s failed (%s); "
-                    "falling back to SANDBOX indexer",
+                    "enumerate for plugin index at %s failed (%s); falling back to SANDBOX indexer",
                     path,
                     exc,
                 )
@@ -4900,8 +4897,7 @@ class SearchService:
                     resp = await daemon.index_documents(docs)
                 except Exception as exc:  # noqa: BLE001
                     logger.warning(
-                        "plugin index_documents at %s failed (%s); "
-                        "falling back to SANDBOX indexer",
+                        "plugin index_documents at %s failed (%s); falling back to SANDBOX indexer",
                         path,
                         exc,
                     )

--- a/src/nexus/bricks/search/search_service.py
+++ b/src/nexus/bricks/search/search_service.py
@@ -189,6 +189,57 @@ def _result_to_dict(r: Any) -> dict[str, Any]:
     }
 
 
+async def _collect_docs_for_plugin(
+    indexer: Any,
+    path: str,
+    recursive: bool,
+) -> list[dict[str, Any]]:
+    """Enumerate + read files under ``path`` via the SANDBOX indexer's
+    file_reader, producing the ``[{path, text, ...}]`` payload the
+    plugin's ``IndexDocuments`` RPC (and ``SearchDaemon.index_documents``
+    shim) expects.
+
+    Reuses ``indexer._file_reader`` for enumeration + read because that
+    reader resolves paths via THIS container's kernel VFS — which does
+    contain the files, unlike the plugin sidecar's disjoint kernel.
+    Filters binaries the same way the sandbox indexer does.
+
+    Returns an empty list when nothing indexable is under ``path``;
+    callers short-circuit rather than sending an empty POST.
+    """
+    from nexus.bricks.search.indexing_service import _BINARY_EXTENSIONS
+
+    reader = indexer._file_reader  # noqa: SLF001
+
+    if not recursive:
+        # Single-file caller — read directly; the underlying reader
+        # raises for a non-existent or non-text file, which the caller
+        # already handles as a fallback trigger.
+        content = await indexer._read_content(path)  # noqa: SLF001
+        return [{"path": path, "text": content}]
+
+    files_result = await reader.list_files(path, recursive=True)
+    files = files_result.items if hasattr(files_result, "items") else files_result
+
+    docs: list[dict[str, Any]] = []
+    for entry in files:
+        file_path = (
+            entry if isinstance(entry, str) else entry.get("path") or entry.get("name", "")
+        )
+        if not file_path or file_path.endswith("/"):
+            continue
+        if file_path.endswith(_BINARY_EXTENSIONS):
+            continue
+        try:
+            content = await indexer._read_content(file_path)  # noqa: SLF001
+        except Exception:
+            # Skip individually rather than failing the whole seed —
+            # matches the sandbox indexer's per-file try/except.
+            continue
+        docs.append({"path": file_path, "text": content})
+    return docs
+
+
 class SearchService:
     """Independent search service extracted from NexusFS.
 
@@ -4799,37 +4850,64 @@ class SearchService:
         Raises:
             ValueError: If semantic search is not initialized
         """
-        # Prefer the P12 plugin when a plugin-transport daemon is wired
-        # (#4628 residual — the shim gate at ``semantic_search``
-        # recognises ``_target`` for the QUERY path, but the INDEX path
-        # here stayed SANDBOX-only until now).  Without this arm the
-        # CLI ``nexus search index <dir>`` reports "Files indexed: N"
-        # from the SANDBOX in-process indexer while the plugin sees
-        # zero — an edge deployment's HERB gate hits hybrid on an
-        # unseeded plugin and returns 0/8 (Docker Publish HERB gate
-        # 2026-08-11..).
+        # Prefer the P12 plugin when a plugin-transport daemon is
+        # wired (#4628 residual — the shim gate at ``semantic_search``
+        # recognises ``_target`` for the QUERY path, but the INDEX
+        # path here stayed SANDBOX-only until now).  Without this arm
+        # the CLI ``nexus search index <dir>`` reports "Files indexed:
+        # N" from the SANDBOX in-process indexer while the plugin
+        # sees zero — an edge deployment's HERB gate hits hybrid on
+        # an unseeded plugin and returns 0/8 (Docker Publish HERB
+        # gate 2026-08-11..).
+        #
+        # We use the EXPLICIT-payload path (``IndexDocuments``), not
+        # the plugin's walker (``Index`` RPC).  In the sidecar edge
+        # topology the plugin runs in a separate container whose
+        # kernel VFS is disjoint from nexus-server's — a shared
+        # /workspace bind mount populates the OS FS but NOT the
+        # plugin's in-memory VFS, so the plugin's own walk finds
+        # nothing.  Reading files here (via ``_indexing_service``'s
+        # file_reader, which resolves from THIS container's VFS) and
+        # POSTing the bytes is topology-independent.
         #
         # Plugin-less deployments and SANDBOX-only builds are
         # unaffected: they take the ``_indexing_service`` /
         # ``_pipeline_indexer`` arms below unchanged.
         daemon = getattr(self, "_search_daemon", None)
-        if daemon is not None and getattr(daemon, "_target", None) is not None:
+        indexer = self._indexing_service
+        if (
+            daemon is not None
+            and getattr(daemon, "_target", None) is not None
+            and indexer is not None
+        ):
             try:
-                resp = await daemon.index(path, recursive=recursive)
+                docs = await _collect_docs_for_plugin(indexer, path, recursive)
             except Exception as exc:  # noqa: BLE001
                 logger.warning(
-                    "plugin index at %s failed (%s); falling back to SANDBOX indexer",
+                    "enumerate for plugin index at %s failed (%s); "
+                    "falling back to SANDBOX indexer",
                     path,
                     exc,
                 )
-            else:
-                # Return per-path count shape that callers already read.
-                # The plugin's IndexResponse is aggregate (indexed_count
-                # + skipped_count), not per-path — synthesize a
-                # single-entry mapping keyed by the request root so the
-                # CLI's "Files indexed" tally stays meaningful.
-                indexed = int(resp.get("indexed_count", 0))
-                return {path: indexed} if indexed >= 0 else {}
+                docs = None
+
+            if docs is not None:
+                if not docs:
+                    # Nothing indexable under ``path`` — SANDBOX would
+                    # also find nothing; short-circuit with a clean 0.
+                    return {path: 0}
+                try:
+                    resp = await daemon.index_documents(docs)
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning(
+                        "plugin index_documents at %s failed (%s); "
+                        "falling back to SANDBOX indexer",
+                        path,
+                        exc,
+                    )
+                else:
+                    indexed = int(resp.get("indexed", 0))
+                    return {path: indexed} if indexed >= 0 else {}
 
         # Prefer IndexingService (Issue #2075)
         if self._indexing_service is not None:

--- a/tests/unit/bricks/search/test_semantic_search_daemon_gate.py
+++ b/tests/unit/bricks/search/test_semantic_search_daemon_gate.py
@@ -47,7 +47,11 @@ class _FakePluginShim:
         # tests inspect this to confirm the fanout enumerated the
         # right corpus before POSTing.
         self.index_documents_calls: list[list[dict[str, Any]]] = []
-        self.index_documents_result: dict[str, Any] = {"indexed": 3, "skipped": [], "skipped_count": 0}
+        self.index_documents_result: dict[str, Any] = {
+            "indexed": 3,
+            "skipped": [],
+            "skipped_count": 0,
+        }
         self.index_documents_should_raise: Exception | None = None
 
     async def search(self, request: object) -> list[_DaemonRow]:

--- a/tests/unit/bricks/search/test_semantic_search_daemon_gate.py
+++ b/tests/unit/bricks/search/test_semantic_search_daemon_gate.py
@@ -18,7 +18,8 @@ These tests pin the fixed gate:
 from __future__ import annotations
 
 from dataclasses import dataclass
-from unittest.mock import MagicMock
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -42,26 +43,27 @@ class _FakePluginShim:
         self._target = "localhost:2126"
         self.requests: list[object] = []
         self._rows = rows
-        self.index_calls: list[tuple[str, bool]] = []
-        self.index_result: dict[str, int] = {"indexed_count": 22, "skipped_count": 0}
-        self.index_should_raise: Exception | None = None
+        # Recorded documents that the index_documents RPC received —
+        # tests inspect this to confirm the fanout enumerated the
+        # right corpus before POSTing.
+        self.index_documents_calls: list[list[dict[str, Any]]] = []
+        self.index_documents_result: dict[str, Any] = {"indexed": 3, "skipped": [], "skipped_count": 0}
+        self.index_documents_should_raise: Exception | None = None
 
     async def search(self, request: object) -> list[_DaemonRow]:
         self.requests.append(request)
         return self._rows
 
-    async def index(
+    async def index_documents(
         self,
-        root_path: str,
+        documents: list[dict[str, Any]],
         *,
         zone_id: str | None = None,  # noqa: ARG002
-        recursive: bool = True,
-        max_docs: int = 0,  # noqa: ARG002
-    ) -> dict[str, int]:
-        self.index_calls.append((root_path, recursive))
-        if self.index_should_raise is not None:
-            raise self.index_should_raise
-        return self.index_result
+    ) -> dict[str, Any]:
+        self.index_documents_calls.append(documents)
+        if self.index_documents_should_raise is not None:
+            raise self.index_documents_should_raise
+        return self.index_documents_result
 
 
 def _make_service(daemon: object | None) -> SearchService:
@@ -110,35 +112,71 @@ class TestPluginShimGate:
     async def test_index_path_routes_through_plugin_when_wired(self) -> None:
         """#4628 residual: the P12 shim gate at ``semantic_search``
         (query path) recognises ``_target`` and delegates to the plugin.
-        The companion ``semantic_search_index`` (index path) had NO such
-        gate — the CLI ``nexus search index <dir>`` fell into SANDBOX
-        indexing while the plugin saw zero docs, and the HERB QUALITY
-        GATE hit 0/8 on the edge topology (Docker Publish red since
-        2026-08-11).  This test pins that the index path now prefers
-        the plugin when a plugin-transport daemon is wired."""
+        The companion ``semantic_search_index`` (index path) had NO
+        such gate — the CLI ``nexus search index <dir>`` fell into
+        SANDBOX indexing while the plugin saw zero docs, and the HERB
+        QUALITY GATE hit 0/8 on the edge topology (Docker Publish red
+        since 2026-08-11).
+
+        The plugin path enumerates + reads through the SANDBOX
+        indexer's ``file_reader`` (nexus-server's own kernel VFS —
+        which the plugin's sidecar kernel cannot see through the
+        shared /workspace bind mount) and POSTs the bytes via
+        IndexDocuments, so the fanout is topology-independent."""
         shim = _FakePluginShim(rows=[])
         svc = _make_service(shim)
-        result = await svc.semantic_search_index("/workspace/demo", recursive=True)
-        assert shim.index_calls == [("/workspace/demo", True)]
-        # Aggregate indexed_count is synthesized into the per-path
-        # mapping shape callers already read from the SANDBOX arms.
-        assert result == {"/workspace/demo": 22}
+
+        # Fake SANDBOX indexer supplies the file_reader shim +
+        # _read_content coroutine that the plugin-arm re-uses for
+        # enumeration.  ``_indexing_service`` is a real attribute on
+        # SearchService, so wire it via setattr.
+        indexer = MagicMock()
+        indexer._file_reader = MagicMock()
+        indexer._file_reader.list_files = AsyncMock(
+            return_value=[
+                {"path": "/w/a.md"},
+                {"path": "/w/b.md"},
+                {"path": "/w/skip.png"},  # binary — filtered
+            ]
+        )
+        indexer._read_content = AsyncMock(side_effect=lambda p: f"body-of-{p}")
+        svc._indexing_service = indexer  # noqa: SLF001
+
+        result = await svc.semantic_search_index("/w", recursive=True)
+
+        # Binary is filtered; two text docs POSTed to plugin.
+        assert len(shim.index_documents_calls) == 1
+        posted = shim.index_documents_calls[0]
+        assert [d["path"] for d in posted] == ["/w/a.md", "/w/b.md"]
+        assert posted[0]["text"] == "body-of-/w/a.md"
+        # Aggregate indexed count is surfaced via the per-path mapping
+        # shape callers already read from the SANDBOX arms.
+        assert result == {"/w": 3}
 
     @pytest.mark.asyncio
     async def test_index_path_falls_back_to_sandbox_on_plugin_error(self) -> None:
-        """A plugin index() raise (server down, transient RPC failure)
-        must not fail the CLI — the SANDBOX arm below still runs, so
-        a mixed-topology deployment retains at least the local
-        indexing capability."""
+        """A plugin index_documents() raise (server down, transient RPC
+        failure) must not fail the CLI — the SANDBOX arm below still
+        runs, so a mixed-topology deployment retains at least the
+        local indexing capability."""
         shim = _FakePluginShim(rows=[])
-        shim.index_should_raise = RuntimeError("plugin unreachable")
+        shim.index_documents_should_raise = RuntimeError("plugin unreachable")
         svc = _make_service(shim)
-        # No _indexing_service / _pipeline_indexer wired → returns {}
-        # instead of raising; the CLI reports "Files indexed: 0"
-        # rather than crashing.
-        result = await svc.semantic_search_index("/workspace/demo")
+
+        indexer = MagicMock()
+        indexer._file_reader = MagicMock()
+        indexer._file_reader.list_files = AsyncMock(return_value=[{"path": "/w/a.md"}])
+        indexer._read_content = AsyncMock(return_value="body")
+        # Wire index_directory too so the SANDBOX fallback can run and
+        # produces a documented shape.
+        indexer.index_directory = AsyncMock(return_value={})
+        indexer.index_document = AsyncMock(side_effect=ValueError("dir not file"))
+        svc._indexing_service = indexer  # noqa: SLF001
+
+        result = await svc.semantic_search_index("/w", recursive=True)
+        # Plugin was tried once + raised; SANDBOX ran too (empty result).
+        assert len(shim.index_documents_calls) == 1
         assert result == {}
-        assert shim.index_calls == [("/workspace/demo", True)]
 
     @pytest.mark.asyncio
     async def test_index_path_no_daemon_uses_sandbox(self) -> None:


### PR DESCRIPTION
Follow-up to #4658. That fix routed \`semantic_search_index\` to the plugin via the walker-based \`Index\` RPC. In the sidecar edge topology (Docker Publish workflow), the plugin sidecar runs in a separate container whose kernel VFS is disjoint from nexus-server's — the shared \`/workspace\` bind mount populates the OS FS but NOT the plugin's in-memory VFS.

Post-#4658 CI evidence:
\`\`\`
plugin index at /workspace/demo failed
(plugin index failed: root_path not found);
falling back to SANDBOX indexer
\`\`\`

Fallback fired, HERB gate stayed red on 32001482747.

## Fix

Use the EXPLICIT-payload path (\`IndexDocuments\`) instead of the walker. Enumerate + read via the SANDBOX indexer's \`_file_reader.list_files()\` + \`_read_content()\` — nexus-server's own kernel VFS which has the files — then POST the bytes to the plugin via the pre-existing \`daemon.index_documents\` shim. The same POST /search/index self-seed pattern in test_build_perf_e2e.py section 5 has been proven to reach the plugin.

Binary-extension filtering matches the SANDBOX indexer.
Fallback to SANDBOX on enumerate / RPC failure stays intact from #4658.

## Test plan

- [x] 6/6 gate tests pass (rewrote plugin-routing test to assert IndexDocuments POST shape + fallback)
- [x] 172/172 search unit tests pass
- [x] surface-coverage YAML regen
- [ ] Docker Publish HERB gate 8/8 on develop tip post-merge

## Cleanup

Removed the \`daemon.index()\` walker shim added in #4658 — no callers.