### PR TITLE
feat(search): fold LLM query expansion into nexus-search-plugin cdylib

### DIFF
--- a/rust/services/search-plugin/src/lib.rs
+++ b/rust/services/search-plugin/src/lib.rs
@@ -64,6 +64,7 @@ pub mod indexed_dirs_state;
 pub mod kernel_io;
 pub mod parked_state;
 pub mod query_cache;
+pub mod query_expansion;
 pub mod scoring;
 pub mod service;
 pub mod title_index;

--- a/rust/services/search-plugin/src/query_expansion.rs
+++ b/rust/services/search-plugin/src/query_expansion.rs
@@ -1,0 +1,832 @@
+//! LLM-driven query expansion — optional pre-dispatch middleware
+//! that widens a single user query into N paraphrased variants
+//! before the Query pipeline fans them out and fuses the union.
+//!
+//! # Why it lives inside the plugin
+//!
+//! The Python `nexus.bricks.search.query_expansion.QueryExpansionService`
+//! ran the same job upstream of the (now-deleted) Python SearchDaemon.
+//! Pulling it into the plugin's `Query` handler makes a pure-cluster
+//! deployment — nexusd-cluster + `nexus-search-plugin` cdylib alone —
+//! feature-complete for LLM-widened search without needing the
+//! `nexus-server` container.
+//!
+//! # Contract
+//!
+//! Opt-in ONLY.  `NEXUS_SEARCH_QUERY_EXPANSION=true` gates the
+//! feature; every deployment defaults OFF because LLM calls cost
+//! money and add latency.  Once opted in, all four other env vars
+//! (`_ENDPOINT`, `_MODEL`, `_API_KEY`, and optionally `_TIMEOUT_MS` /
+//! `_MAX_VARIANTS`) must be present — partial config is a LOUD Err
+//! (per the standing "fail loud on interdependent config" rule) so
+//! a typo cannot silently degrade the query pipeline into a slow
+//! LLM round-trip that does nothing.
+//!
+//! # Middleware position
+//!
+//! The wrapper lives in `service::SearchServiceImpl::query` and
+//! runs BEFORE the cache lookup / spawn_blocking fan-out.  On the
+//! success path it invokes the existing single-query pipeline N+1
+//! times (original + N variants), each of which pays its own cache
+//! bill, then fuses the ranked lists with `fusion::rrf_multi`.  On
+//! any failure (LLM timeout / non-200 / parse error) the wrapper
+//! degrades transparently to the single-query path — a broken LLM
+//! endpoint must never take base search down with it.
+//!
+//! # Cache
+//!
+//! An in-process content-hash LRU on the expansion result deflates
+//! repeated identical queries from an LLM call + N pipeline runs
+//! down to a cheap hashmap lookup + N pipeline runs (each of which
+//! then hits the existing per-zone query cache).  Bounded at
+//! [`EXPANSION_CACHE_MAX`] to keep memory predictable — an operator
+//! flooding a plugin with unique queries never grows the cache
+//! unboundedly.
+
+use std::collections::HashMap;
+use std::collections::VecDeque;
+use std::time::Duration;
+
+use parking_lot::Mutex;
+
+/// Kill-switch — set to `true`/`1`/`yes` to enable expansion.
+/// Absent or any other value = DISABLED (the default).
+pub const EXPANSION_ENABLED_ENV: &str = "NEXUS_SEARCH_QUERY_EXPANSION";
+/// OpenAI-compatible chat-completions endpoint URL (e.g.
+/// `https://openrouter.ai/api/v1/chat/completions` or
+/// `https://api.openai.com/v1/chat/completions`).
+pub const EXPANSION_ENDPOINT_ENV: &str = "NEXUS_SEARCH_QUERY_EXPANSION_ENDPOINT";
+/// Chat model name sent in the request body (e.g.
+/// `deepseek/deepseek-chat` or `anthropic/claude-3-haiku`).
+pub const EXPANSION_MODEL_ENV: &str = "NEXUS_SEARCH_QUERY_EXPANSION_MODEL";
+/// Bearer token for the endpoint.  Sent as `Authorization: Bearer <key>`.
+pub const EXPANSION_API_KEY_ENV: &str = "NEXUS_SEARCH_QUERY_EXPANSION_API_KEY";
+/// Per-request timeout in milliseconds (default 3000 ms — LLMs are
+/// slow, but a query pipeline that stalls the whole response for
+/// 30 s to widen a query is worse than no expansion).
+pub const EXPANSION_TIMEOUT_MS_ENV: &str = "NEXUS_SEARCH_QUERY_EXPANSION_TIMEOUT_MS";
+/// Cap on the number of variants the LLM is asked to produce
+/// (default 3).  A larger N linearly multiplies pipeline cost per
+/// query; ≤5 keeps the tail latency civil.
+pub const EXPANSION_MAX_VARIANTS_ENV: &str = "NEXUS_SEARCH_QUERY_EXPANSION_MAX_VARIANTS";
+
+const DEFAULT_TIMEOUT_MS: u64 = 3_000;
+const DEFAULT_MAX_VARIANTS: usize = 3;
+/// Bound the per-query variant count so a runaway env / LLM cannot
+/// blow the fan-out.  Requests above this cap are clamped.
+const HARD_MAX_VARIANTS: usize = 8;
+/// Cache size — bounded FIFO on (query → variants).  A few hundred
+/// entries covers the working set for a single plugin instance; the
+/// aim is deflating repeated identical queries, not memoising the
+/// whole corpus.
+const EXPANSION_CACHE_MAX: usize = 256;
+
+/// Errors from the expansion layer.  All variants keep base search
+/// alive — the query() wrapper logs the error and falls through to
+/// the single-query path, so `Misconfigured` at boot / `Http` at
+/// runtime never returns an RPC-level failure to the caller.
+#[derive(Debug, thiserror::Error)]
+pub enum ExpansionError {
+    /// Feature is enabled but env config is incomplete or malformed.
+    /// Surfaced at Query-time (lazy: no boot-time check) but stable
+    /// for the process lifetime — the caller can log once and cache
+    /// the failure to avoid a log flood.
+    #[error("query expansion misconfigured: {0}")]
+    Misconfigured(String),
+
+    /// HTTP transport / non-2xx status / body parse failure.  All of
+    /// these are transient from the plugin's perspective and must
+    /// not surface as a Query RPC error.
+    #[error("query expansion HTTP failed: {0}")]
+    Http(String),
+}
+
+/// Parsed env contract.  `from_env` returns `Ok(None)` when the
+/// kill-switch is OFF and `Err(Misconfigured)` when the switch is ON
+/// but one of the required companion vars is missing — per the
+/// standing "fail loud on interdependent config" rule.  A silent
+/// fallback would mean an operator who ticked the box gets a slow
+/// query pipeline that quietly does no expansion.
+#[derive(Debug, Clone)]
+pub struct QueryExpansionConfig {
+    pub endpoint: String,
+    pub model: String,
+    pub api_key: String,
+    pub timeout: Duration,
+    pub max_variants: usize,
+}
+
+impl QueryExpansionConfig {
+    /// Read the `NEXUS_SEARCH_QUERY_EXPANSION*` contract from
+    /// process env.
+    pub fn from_env() -> Result<Option<Self>, ExpansionError> {
+        Self::from_lookup(|k| std::env::var(k).ok())
+    }
+
+    /// Env-shape parser with an injectable lookup so unit tests
+    /// never race process-global env across parallel test threads.
+    pub fn from_lookup(
+        get: impl Fn(&str) -> Option<String>,
+    ) -> Result<Option<Self>, ExpansionError> {
+        let enabled = get(EXPANSION_ENABLED_ENV)
+            .map(|v| parse_bool(&v))
+            .unwrap_or(false);
+        if !enabled {
+            return Ok(None);
+        }
+        let endpoint = get(EXPANSION_ENDPOINT_ENV)
+            .filter(|v| !v.trim().is_empty())
+            .map(|v| v.trim().to_string())
+            .ok_or_else(|| {
+                ExpansionError::Misconfigured(format!(
+                    "{EXPANSION_ENABLED_ENV}=true but {EXPANSION_ENDPOINT_ENV} is unset — \
+                     the expander needs an OpenAI-compatible chat-completions URL",
+                ))
+            })?;
+        let model = get(EXPANSION_MODEL_ENV)
+            .filter(|v| !v.trim().is_empty())
+            .map(|v| v.trim().to_string())
+            .ok_or_else(|| {
+                ExpansionError::Misconfigured(format!(
+                    "{EXPANSION_ENABLED_ENV}=true but {EXPANSION_MODEL_ENV} is unset — \
+                     the expander needs an explicit chat model name",
+                ))
+            })?;
+        let api_key = get(EXPANSION_API_KEY_ENV)
+            .filter(|v| !v.trim().is_empty())
+            .map(|v| v.trim().to_string())
+            .ok_or_else(|| {
+                ExpansionError::Misconfigured(format!(
+                    "{EXPANSION_ENABLED_ENV}=true but {EXPANSION_API_KEY_ENV} is unset — \
+                     the expander needs a bearer token for the endpoint",
+                ))
+            })?;
+        let timeout_ms = match get(EXPANSION_TIMEOUT_MS_ENV).filter(|v| !v.trim().is_empty()) {
+            Some(t) => t
+                .trim()
+                .parse::<u64>()
+                .ok()
+                .filter(|s| *s > 0)
+                .ok_or_else(|| {
+                    ExpansionError::Misconfigured(format!(
+                        "{EXPANSION_TIMEOUT_MS_ENV}={t:?} is not a positive integer",
+                    ))
+                })?,
+            None => DEFAULT_TIMEOUT_MS,
+        };
+        let max_variants = match get(EXPANSION_MAX_VARIANTS_ENV).filter(|v| !v.trim().is_empty()) {
+            Some(v) => v
+                .trim()
+                .parse::<usize>()
+                .ok()
+                .filter(|n| *n > 0)
+                .ok_or_else(|| {
+                    ExpansionError::Misconfigured(format!(
+                        "{EXPANSION_MAX_VARIANTS_ENV}={v:?} is not a positive integer",
+                    ))
+                })?,
+            None => DEFAULT_MAX_VARIANTS,
+        }
+        .min(HARD_MAX_VARIANTS);
+        Ok(Some(Self {
+            endpoint,
+            model,
+            api_key,
+            timeout: Duration::from_millis(timeout_ms),
+            max_variants,
+        }))
+    }
+}
+
+fn parse_bool(raw: &str) -> bool {
+    matches!(
+        raw.trim().to_ascii_lowercase().as_str(),
+        "1" | "true" | "yes" | "on"
+    )
+}
+
+/// Batch query-widening contract.  One trait so tests can swap the
+/// live HTTP expander for a canned mock without stubbing reqwest.
+pub trait QueryExpander: Send + Sync {
+    /// Return up to `max_variants` paraphrased alternatives of
+    /// `query`.  Duplicates of the original are the caller's
+    /// responsibility to strip — the trait is intentionally
+    /// permissive so a well-behaved LLM's occasional near-echo does
+    /// not surface as an error.
+    fn expand(&self, query: &str, max_variants: usize) -> Result<Vec<String>, ExpansionError>;
+}
+
+// ── HttpQueryExpander ─────────────────────────────────────────────
+//
+// Blocking HTTP against an OpenAI-compatible chat-completions
+// endpoint.  Same reasoning as `RemoteEmbedder`: every call site in
+// the service runs inside `spawn_blocking`, and reqwest::blocking
+// drives its own dedicated runtime thread — the plugin's tokio pool
+// is never re-entered by a synchronous send.
+
+#[derive(serde::Serialize)]
+struct ChatMessage<'a> {
+    role: &'a str,
+    content: &'a str,
+}
+
+#[derive(serde::Serialize)]
+struct ChatRequest<'a> {
+    model: &'a str,
+    messages: Vec<ChatMessage<'a>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    response_format: Option<ResponseFormat<'a>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    temperature: Option<f32>,
+}
+
+#[derive(serde::Serialize)]
+struct ResponseFormat<'a> {
+    #[serde(rename = "type")]
+    type_: &'a str,
+}
+
+#[derive(serde::Deserialize)]
+struct ChatResponse {
+    choices: Vec<ChatChoice>,
+}
+
+#[derive(serde::Deserialize)]
+struct ChatChoice {
+    message: ChatChoiceMessage,
+}
+
+#[derive(serde::Deserialize)]
+struct ChatChoiceMessage {
+    content: String,
+}
+
+/// Live HTTP query expander.  Sends a single chat-completion request
+/// asking for JSON `{"variants": [...]}` and parses the assistant's
+/// content out of the response envelope.  Fails LOUD on any HTTP or
+/// parse error — the wrapper in service.rs converts those to a
+/// tracing warning and falls through to the single-query path.
+pub struct HttpQueryExpander {
+    client: reqwest::blocking::Client,
+    config: QueryExpansionConfig,
+}
+
+impl HttpQueryExpander {
+    /// Build the HTTP client for `config`.  No network I/O happens
+    /// here.
+    pub fn new(config: QueryExpansionConfig) -> Result<Self, ExpansionError> {
+        let client = reqwest::blocking::Client::builder()
+            .timeout(config.timeout)
+            .build()
+            .map_err(|e| ExpansionError::Http(format!("expander HTTP client: {e}")))?;
+        Ok(Self { client, config })
+    }
+}
+
+/// Prompt sent as the SYSTEM message.  Kept short and provider-
+/// agnostic — OpenRouter / OpenAI / any downstream OpenAI-compatible
+/// gateway will happily forward it.  JSON response requested via
+/// both the system prompt AND the `response_format: json_object`
+/// hint; providers that ignore the hint still parse fine because
+/// the prompt itself instructs strict JSON output.
+const SYSTEM_PROMPT: &str = "\
+You rewrite a search query into short paraphrased variants that a \
+BM25 keyword index and a dense vector index will both retrieve well. \
+Preserve intent; vary wording, synonyms, and named-entity forms. \
+Do not add commentary. Reply ONLY with a strict JSON object of the \
+shape {\"variants\": [\"variant one\", \"variant two\", ...]}, no \
+Markdown, no code fences.";
+
+impl QueryExpander for HttpQueryExpander {
+    fn expand(&self, query: &str, max_variants: usize) -> Result<Vec<String>, ExpansionError> {
+        if query.trim().is_empty() || max_variants == 0 {
+            return Ok(Vec::new());
+        }
+        let capped = max_variants.min(HARD_MAX_VARIANTS);
+        let user = format!("Original query: {query}\nProduce up to {capped} paraphrased variants.");
+        let body = ChatRequest {
+            model: &self.config.model,
+            messages: vec![
+                ChatMessage {
+                    role: "system",
+                    content: SYSTEM_PROMPT,
+                },
+                ChatMessage {
+                    role: "user",
+                    content: &user,
+                },
+            ],
+            response_format: Some(ResponseFormat {
+                type_: "json_object",
+            }),
+            temperature: Some(0.3),
+        };
+        let resp = self
+            .client
+            .post(&self.config.endpoint)
+            .bearer_auth(&self.config.api_key)
+            .json(&body)
+            .send()
+            .map_err(|e| {
+                ExpansionError::Http(format!("expand request to {}: {e}", self.config.endpoint))
+            })?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let excerpt: String = resp.text().unwrap_or_default().chars().take(300).collect();
+            return Err(ExpansionError::Http(format!(
+                "expand endpoint returned {status}: {excerpt}",
+            )));
+        }
+        let parsed: ChatResponse = resp
+            .json()
+            .map_err(|e| ExpansionError::Http(format!("expand response parse: {e}")))?;
+        let content = parsed
+            .choices
+            .into_iter()
+            .next()
+            .map(|c| c.message.content)
+            .ok_or_else(|| ExpansionError::Http("expand response had no choices".to_string()))?;
+        parse_variants(&content, capped)
+            .map_err(|e| ExpansionError::Http(format!("expand content parse: {e}")))
+    }
+}
+
+/// Extract the variant list from an LLM's content string.  Accepts
+/// strict `{"variants":[...]}`, tolerates surrounding whitespace or
+/// stray Markdown fences that a model may emit despite the system
+/// prompt, and hard-caps the returned Vec to `max`.
+fn parse_variants(raw: &str, max: usize) -> Result<Vec<String>, String> {
+    #[derive(serde::Deserialize)]
+    struct Envelope {
+        variants: Vec<String>,
+    }
+    let cleaned = strip_code_fences(raw.trim());
+    let env: Envelope = serde_json::from_str(cleaned)
+        .map_err(|e| format!("expected JSON with `variants` array: {e} — got: {cleaned}"))?;
+    let out: Vec<String> = env
+        .variants
+        .into_iter()
+        .filter_map(|v| {
+            let t = v.trim();
+            if t.is_empty() {
+                None
+            } else {
+                Some(t.to_string())
+            }
+        })
+        .take(max)
+        .collect();
+    Ok(out)
+}
+
+/// Trim ```json … ``` fences a chatty model may still emit.  Also
+/// handles a bare ``` opening.  Returns a slice into the original.
+fn strip_code_fences(s: &str) -> &str {
+    let s = s.trim();
+    // Common shapes: ```json\n...\n```   or   ```\n...\n```
+    if let Some(rest) = s.strip_prefix("```json") {
+        let rest = rest.trim_start_matches('\n').trim_start();
+        if let Some(inner) = rest.strip_suffix("```") {
+            return inner.trim();
+        }
+    }
+    if let Some(rest) = s.strip_prefix("```") {
+        let rest = rest.trim_start_matches('\n').trim_start();
+        if let Some(inner) = rest.strip_suffix("```") {
+            return inner.trim();
+        }
+    }
+    s
+}
+
+// ── Cache ─────────────────────────────────────────────────────────
+//
+// Bounded FIFO on `query → Vec<String>`.  Not an LRU — LRU accounting
+// under a Mutex is a non-trivial win at this bound (≤ 256 entries),
+// and a FIFO gives predictable eviction: the oldest entry drops when
+// we cross the ceiling.  parking_lot::Mutex avoids poisoning; the
+// critical section is a hashmap lookup + optional insert, so a
+// single mutex is fine even under a moderate query burst.
+
+/// Thread-safe expansion cache — see the module comment for why FIFO
+/// is chosen over LRU.
+pub struct ExpansionCache {
+    inner: Mutex<CacheInner>,
+    max: usize,
+}
+
+struct CacheInner {
+    map: HashMap<String, Vec<String>>,
+    order: VecDeque<String>,
+}
+
+impl ExpansionCache {
+    /// Fresh cache bounded at [`EXPANSION_CACHE_MAX`].
+    pub fn new() -> Self {
+        Self::with_capacity(EXPANSION_CACHE_MAX)
+    }
+
+    /// Test hook — tighter bound for eviction-behavior assertions.
+    pub fn with_capacity(max: usize) -> Self {
+        assert!(max > 0, "ExpansionCache capacity must be > 0");
+        Self {
+            inner: Mutex::new(CacheInner {
+                map: HashMap::with_capacity(max),
+                order: VecDeque::with_capacity(max),
+            }),
+            max,
+        }
+    }
+
+    /// Lookup — clones the value on hit so callers do not hold the
+    /// mutex across the (long-running) pipeline fan-out.
+    pub fn get(&self, query: &str) -> Option<Vec<String>> {
+        let g = self.inner.lock();
+        g.map.get(query).cloned()
+    }
+
+    /// Insert — evicts the oldest entry when the cache would exceed
+    /// its capacity.  Re-inserting an existing key OVERWRITES the
+    /// value in place: the previous entry keeps its position in the
+    /// FIFO order (no O(n) order-vec scan on every touch) and the
+    /// FIFO length is unchanged, so it does NOT force an eviction.
+    pub fn insert(&self, query: String, variants: Vec<String>) {
+        let mut g = self.inner.lock();
+        // Re-insert of an existing key: overwrite in place, keep FIFO
+        // position, no eviction.  The map's `insert` doubles as
+        // "update if present" so a single call covers both — the
+        // hit-rate case for the cache never touches `order`.
+        if let std::collections::hash_map::Entry::Occupied(mut e) = g.map.entry(query.clone()) {
+            e.insert(variants);
+            return;
+        }
+        // Vacant path: evict the oldest before inserting so the
+        // FIFO stays at ≤ `max`.
+        if g.order.len() >= self.max {
+            if let Some(evicted) = g.order.pop_front() {
+                g.map.remove(&evicted);
+            }
+        }
+        g.order.push_back(query.clone());
+        g.map.insert(query, variants);
+    }
+
+    /// Live entry count — for tests only.
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        self.inner.lock().map.len()
+    }
+}
+
+impl Default for ExpansionCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ── Best-effort builder ───────────────────────────────────────────
+
+/// Live expander + the config it was built from.  Returned by
+/// [`build_default_expander`] so the caller has both the concrete
+/// expander to wire into the service and the config fields (e.g.
+/// `max_variants`) that the wrapper needs at query time.
+pub type BuiltExpander = (Box<dyn QueryExpander>, QueryExpansionConfig);
+
+/// Build the configured expander from env, if any.  Returns
+/// `Ok(None)` when the kill-switch is off (the common case) and
+/// `Err` when the switch is on but the config is malformed — the
+/// caller's job is to log the error and disable expansion for this
+/// process to avoid a log flood.
+pub fn build_default_expander() -> Result<Option<BuiltExpander>, ExpansionError> {
+    let Some(cfg) = QueryExpansionConfig::from_env()? else {
+        return Ok(None);
+    };
+    let expander = HttpQueryExpander::new(cfg.clone())?;
+    Ok(Some((Box::new(expander), cfg)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn lookup(pairs: &[(&str, &str)]) -> impl Fn(&str) -> Option<String> {
+        let owned: Vec<(String, String)> = pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect();
+        move |k| {
+            owned
+                .iter()
+                .find(|(key, _)| key == k)
+                .map(|(_, v)| v.clone())
+        }
+    }
+
+    #[test]
+    fn config_disabled_by_default() {
+        let cfg = QueryExpansionConfig::from_lookup(lookup(&[])).unwrap();
+        assert!(cfg.is_none());
+        let cfg =
+            QueryExpansionConfig::from_lookup(lookup(&[(EXPANSION_ENABLED_ENV, "false")])).unwrap();
+        assert!(cfg.is_none());
+    }
+
+    #[test]
+    fn config_enabled_but_missing_endpoint_errors() {
+        let err = QueryExpansionConfig::from_lookup(lookup(&[
+            (EXPANSION_ENABLED_ENV, "true"),
+            (EXPANSION_MODEL_ENV, "m"),
+            (EXPANSION_API_KEY_ENV, "sk-x"),
+        ]))
+        .unwrap_err();
+        assert!(
+            matches!(err, ExpansionError::Misconfigured(m) if m.contains(EXPANSION_ENDPOINT_ENV))
+        );
+    }
+
+    #[test]
+    fn config_enabled_but_missing_model_errors() {
+        let err = QueryExpansionConfig::from_lookup(lookup(&[
+            (EXPANSION_ENABLED_ENV, "1"),
+            (EXPANSION_ENDPOINT_ENV, "http://x/v1/chat/completions"),
+            (EXPANSION_API_KEY_ENV, "sk-x"),
+        ]))
+        .unwrap_err();
+        assert!(matches!(err, ExpansionError::Misconfigured(m) if m.contains(EXPANSION_MODEL_ENV)));
+    }
+
+    #[test]
+    fn config_enabled_but_missing_key_errors() {
+        let err = QueryExpansionConfig::from_lookup(lookup(&[
+            (EXPANSION_ENABLED_ENV, "yes"),
+            (EXPANSION_ENDPOINT_ENV, "http://x/v1/chat/completions"),
+            (EXPANSION_MODEL_ENV, "m"),
+        ]))
+        .unwrap_err();
+        assert!(
+            matches!(err, ExpansionError::Misconfigured(m) if m.contains(EXPANSION_API_KEY_ENV))
+        );
+    }
+
+    #[test]
+    fn config_full_set_parses_and_applies_defaults() {
+        let cfg = QueryExpansionConfig::from_lookup(lookup(&[
+            (EXPANSION_ENABLED_ENV, "true"),
+            (
+                EXPANSION_ENDPOINT_ENV,
+                " http://localhost:9/v1/chat/completions ",
+            ),
+            (EXPANSION_MODEL_ENV, " deepseek-chat "),
+            (EXPANSION_API_KEY_ENV, "sk-test"),
+        ]))
+        .unwrap()
+        .expect("config present");
+        assert_eq!(cfg.endpoint, "http://localhost:9/v1/chat/completions");
+        assert_eq!(cfg.model, "deepseek-chat");
+        assert_eq!(cfg.api_key, "sk-test");
+        assert_eq!(cfg.timeout, Duration::from_millis(DEFAULT_TIMEOUT_MS));
+        assert_eq!(cfg.max_variants, DEFAULT_MAX_VARIANTS);
+    }
+
+    #[test]
+    fn config_rejects_bad_numeric_env() {
+        let err = QueryExpansionConfig::from_lookup(lookup(&[
+            (EXPANSION_ENABLED_ENV, "true"),
+            (EXPANSION_ENDPOINT_ENV, "http://x/v1/chat/completions"),
+            (EXPANSION_MODEL_ENV, "m"),
+            (EXPANSION_API_KEY_ENV, "sk-x"),
+            (EXPANSION_TIMEOUT_MS_ENV, "soon"),
+        ]))
+        .unwrap_err();
+        assert!(
+            matches!(err, ExpansionError::Misconfigured(m) if m.contains(EXPANSION_TIMEOUT_MS_ENV))
+        );
+
+        let err = QueryExpansionConfig::from_lookup(lookup(&[
+            (EXPANSION_ENABLED_ENV, "true"),
+            (EXPANSION_ENDPOINT_ENV, "http://x/v1/chat/completions"),
+            (EXPANSION_MODEL_ENV, "m"),
+            (EXPANSION_API_KEY_ENV, "sk-x"),
+            (EXPANSION_MAX_VARIANTS_ENV, "0"),
+        ]))
+        .unwrap_err();
+        assert!(
+            matches!(err, ExpansionError::Misconfigured(m) if m.contains(EXPANSION_MAX_VARIANTS_ENV))
+        );
+    }
+
+    #[test]
+    fn config_clamps_max_variants_to_hard_ceiling() {
+        let cfg = QueryExpansionConfig::from_lookup(lookup(&[
+            (EXPANSION_ENABLED_ENV, "true"),
+            (EXPANSION_ENDPOINT_ENV, "http://x/v1/chat/completions"),
+            (EXPANSION_MODEL_ENV, "m"),
+            (EXPANSION_API_KEY_ENV, "sk-x"),
+            (EXPANSION_MAX_VARIANTS_ENV, "999"),
+        ]))
+        .unwrap()
+        .expect("config present");
+        assert_eq!(cfg.max_variants, HARD_MAX_VARIANTS);
+    }
+
+    #[test]
+    fn parse_variants_accepts_strict_json() {
+        let out = parse_variants(r#"{"variants":["a","b","c"]}"#, 5).unwrap();
+        assert_eq!(out, vec!["a", "b", "c"]);
+    }
+
+    #[test]
+    fn parse_variants_strips_code_fences() {
+        let out = parse_variants("```json\n{\"variants\":[\"alpha\",\"beta\"]}\n```", 5).unwrap();
+        assert_eq!(out, vec!["alpha", "beta"]);
+
+        let out = parse_variants("```\n{\"variants\":[\"x\"]}\n```", 5).unwrap();
+        assert_eq!(out, vec!["x"]);
+    }
+
+    #[test]
+    fn parse_variants_caps_and_trims_empty() {
+        let out =
+            parse_variants(r#"{"variants":["one","", "  ","two","three","four"]}"#, 2).unwrap();
+        assert_eq!(out, vec!["one", "two"]);
+    }
+
+    #[test]
+    fn parse_variants_rejects_non_json() {
+        let err = parse_variants("not json at all", 5).unwrap_err();
+        assert!(err.contains("expected JSON"));
+    }
+
+    #[test]
+    fn cache_hit_returns_clone() {
+        let c = ExpansionCache::with_capacity(4);
+        c.insert("q".into(), vec!["a".into(), "b".into()]);
+        assert_eq!(c.get("q"), Some(vec!["a".into(), "b".into()]));
+        assert_eq!(c.get("missing"), None);
+    }
+
+    #[test]
+    fn cache_evicts_oldest_at_capacity() {
+        let c = ExpansionCache::with_capacity(2);
+        c.insert("a".into(), vec!["1".into()]);
+        c.insert("b".into(), vec!["2".into()]);
+        c.insert("c".into(), vec!["3".into()]);
+        assert_eq!(c.len(), 2, "cache must stay at ceiling");
+        assert_eq!(c.get("a"), None, "oldest entry must evict");
+        assert_eq!(c.get("b"), Some(vec!["2".into()]));
+        assert_eq!(c.get("c"), Some(vec!["3".into()]));
+    }
+
+    #[test]
+    fn cache_reinsert_updates_value_without_growth() {
+        let c = ExpansionCache::with_capacity(2);
+        c.insert("q".into(), vec!["v1".into()]);
+        c.insert("q".into(), vec!["v2".into()]);
+        assert_eq!(c.len(), 1);
+        assert_eq!(c.get("q"), Some(vec!["v2".into()]));
+    }
+
+    // ── HttpQueryExpander end-to-end via one-shot HTTP server ─────
+
+    /// One-request localhost HTTP server — mirrors the same helper
+    /// in embedder.rs tests.  Accepts a single connection, reads the
+    /// full request (headers + Content-Length body), writes the
+    /// canned response, returns the raw request text for assertions.
+    fn spawn_one_shot_http(
+        status_line: &'static str,
+        body: String,
+    ) -> (std::net::SocketAddr, std::thread::JoinHandle<String>) {
+        use std::io::{Read, Write};
+
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let handle = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut buf = Vec::new();
+            let mut tmp = [0u8; 4096];
+            let header_end = loop {
+                let n = stream.read(&mut tmp).unwrap();
+                assert!(n > 0, "client closed before end of headers");
+                buf.extend_from_slice(&tmp[..n]);
+                if let Some(pos) = buf.windows(4).position(|w| w == b"\r\n\r\n") {
+                    break pos + 4;
+                }
+            };
+            let headers = String::from_utf8_lossy(&buf[..header_end]).to_string();
+            let content_length = headers
+                .lines()
+                .find_map(|l| {
+                    let (k, v) = l.split_once(':')?;
+                    k.eq_ignore_ascii_case("content-length")
+                        .then(|| v.trim().parse::<usize>().ok())
+                        .flatten()
+                })
+                .unwrap_or(0);
+            while buf.len() < header_end + content_length {
+                let n = stream.read(&mut tmp).unwrap();
+                assert!(n > 0, "client closed mid-body");
+                buf.extend_from_slice(&tmp[..n]);
+            }
+            let request = String::from_utf8_lossy(&buf).to_string();
+            let resp = format!(
+                "HTTP/1.1 {status_line}\r\nContent-Type: application/json\r\n\
+                 Content-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len(),
+            );
+            stream.write_all(resp.as_bytes()).unwrap();
+            request
+        });
+        (addr, handle)
+    }
+
+    fn test_config(endpoint: String) -> QueryExpansionConfig {
+        QueryExpansionConfig {
+            endpoint,
+            model: "test-chat".to_string(),
+            api_key: "sk-test".to_string(),
+            timeout: Duration::from_secs(5),
+            max_variants: 3,
+        }
+    }
+
+    #[test]
+    fn http_expander_sends_auth_and_parses_variants() {
+        let body = serde_json::json!({
+            "choices": [{
+                "message": {
+                    "content": "{\"variants\": [\"first alt\", \"second alt\", \"third alt\"]}"
+                }
+            }]
+        })
+        .to_string();
+        let (addr, handle) = spawn_one_shot_http("200 OK", body);
+        let expander =
+            HttpQueryExpander::new(test_config(format!("http://{addr}/v1/chat/completions")))
+                .unwrap();
+
+        let out = expander.expand("how does auth work", 3).unwrap();
+        assert_eq!(out, vec!["first alt", "second alt", "third alt"]);
+
+        let request = handle.join().unwrap().to_lowercase();
+        assert!(
+            request.contains("authorization: bearer sk-test"),
+            "missing bearer auth in {request}",
+        );
+        assert!(
+            request.contains("\"model\":\"test-chat\""),
+            "missing model in body: {request}",
+        );
+        assert!(
+            request.contains("how does auth work"),
+            "missing original query in body: {request}",
+        );
+    }
+
+    #[test]
+    fn http_expander_surfaces_non_2xx_as_http_error() {
+        let (addr, handle) = spawn_one_shot_http(
+            "429 Too Many Requests",
+            r#"{"error":{"message":"quota exceeded"}}"#.to_string(),
+        );
+        let expander =
+            HttpQueryExpander::new(test_config(format!("http://{addr}/v1/chat/completions")))
+                .unwrap();
+        let err = expander.expand("q", 3).unwrap_err();
+        match err {
+            ExpansionError::Http(m) => {
+                assert!(m.contains("429"), "status missing: {m}");
+                assert!(m.contains("quota exceeded"), "body excerpt missing: {m}");
+            }
+            other => panic!("expected Http, got {other:?}"),
+        }
+        let _ = handle.join().unwrap();
+    }
+
+    #[test]
+    fn http_expander_surfaces_bad_content_as_http_error() {
+        // 200 OK but the assistant returned garbage — must surface
+        // as ExpansionError::Http so the wrapper degrades gracefully.
+        let body = serde_json::json!({
+            "choices": [{"message": {"content": "sorry, I can't do that"}}]
+        })
+        .to_string();
+        let (addr, handle) = spawn_one_shot_http("200 OK", body);
+        let expander =
+            HttpQueryExpander::new(test_config(format!("http://{addr}/v1/chat/completions")))
+                .unwrap();
+        let err = expander.expand("q", 3).unwrap_err();
+        assert!(matches!(err, ExpansionError::Http(_)));
+        let _ = handle.join().unwrap();
+    }
+
+    #[test]
+    fn http_expander_empty_query_returns_empty_without_dialing() {
+        // Unroutable URL — an empty query must not dial the network.
+        let expander =
+            HttpQueryExpander::new(test_config("http://127.0.0.1:9/v1/chat/completions".into()))
+                .unwrap();
+        assert!(expander.expand("   ", 3).unwrap().is_empty());
+        assert!(expander.expand("q", 0).unwrap().is_empty());
+    }
+}

--- a/rust/services/search-plugin/src/service.rs
+++ b/rust/services/search-plugin/src/service.rs
@@ -9,6 +9,7 @@
 //! starving another gRPC request handling on the same executor.
 
 use std::sync::Arc;
+use std::sync::OnceLock;
 
 use futures_util::StreamExt;
 use nexus_plugin_abi::KernelHandle;
@@ -22,6 +23,20 @@ use crate::fts_index::FtsHit;
 use crate::fusion::{self, DEFAULT_ALPHA, DEFAULT_RRF_K};
 use crate::index_manager::IndexManager;
 use crate::kernel_io::{self, DirEntry, KernelIoError, DT_DIR, DT_REG};
+use crate::query_expansion::{build_default_expander, ExpansionCache, QueryExpander};
+
+// Task-local guard set by `query_with_expansion` when it fans a
+// query out into N+1 variants and recursively re-enters `query()`
+// for each.  Its purpose is one-shot re-entry suppression: the
+// trait method checks IN_EXPANSION at the top and, if set, skips
+// the expansion pre-dispatch entirely — otherwise each variant
+// call would try to expand itself and recurse forever.  Task-locals
+// propagate across `.await` within the same task (which is where
+// the recursion lives) and don't cross spawn_blocking (which is
+// fine — the blocking body doesn't touch expansion state).
+tokio::task_local! {
+    static IN_EXPANSION: ();
+}
 use crate::search_proto::search_service_server::SearchService;
 use crate::search_proto::{
     AddIndexedDirectoryRequest, AddIndexedDirectoryResponse, BatchQueryRequest, BatchQueryResponse,
@@ -154,6 +169,27 @@ pub struct SearchServiceImpl {
     /// read `NEXUS_SEARCH_TITLE_ARM` per query (production);
     /// `Some(_)` pins it (tests must not race the process env).
     title_arm: Option<bool>,
+    /// LLM query-expansion state.  Lazily populated on the first
+    /// Query — `None` inside means the kill-switch is off (or
+    /// misconfiguration was logged once and disabled for the process
+    /// lifetime, per the standing "fail loud on partial config"
+    /// rule); `Some` means expansion runs.  A single `OnceLock`
+    /// means: no re-parse of env per query, no double-logging on
+    /// misconfig, no runtime-reconfig via env (change env ⇒ restart).
+    expander_slot: Arc<OnceLock<Option<Arc<ExpanderHandle>>>>,
+    /// Small bounded cache of `(query → variants)` — dedups repeated
+    /// identical queries so we only pay one LLM round-trip per
+    /// distinct question.  Shared across all callers.
+    expansion_cache: Arc<ExpansionCache>,
+}
+
+/// Bundle used by the query wrapper — the live expander plus the
+/// config-derived variant cap.  Boxed together so a builder-injected
+/// mock carries the same `max_variants` control as an env-configured
+/// live expander.
+pub struct ExpanderHandle {
+    pub expander: Arc<dyn QueryExpander>,
+    pub max_variants: usize,
 }
 
 /// RAII increment of [`SearchServiceImpl::indexing_ops`].
@@ -201,6 +237,7 @@ impl SearchServiceImpl {
             query_cache: None,
             embed_cache: None,
             title_arm: None,
+            expander: None,
         }
     }
 
@@ -230,6 +267,163 @@ impl SearchServiceImpl {
         }
         *slot = Some(Arc::clone(&built));
         Ok(built)
+    }
+
+    /// LLM query expander for THIS process, or `None` if the
+    /// kill-switch is off / config was misconfigured (already logged
+    /// once at first-call time so a second query does not re-log).
+    /// Init is lazy — a keyword-only deployment that never wires the
+    /// expander pays nothing.
+    fn get_or_init_expander(&self) -> Option<Arc<ExpanderHandle>> {
+        self.expander_slot
+            .get_or_init(|| match build_default_expander() {
+                Ok(None) => None,
+                Ok(Some((expander, cfg))) => {
+                    tracing::info!(
+                        endpoint = %cfg.endpoint,
+                        model = %cfg.model,
+                        max_variants = cfg.max_variants,
+                        "search-plugin: query expansion enabled",
+                    );
+                    let expander: Arc<dyn QueryExpander> = Arc::from(expander);
+                    Some(Arc::new(ExpanderHandle {
+                        expander,
+                        max_variants: cfg.max_variants,
+                    }))
+                }
+                Err(e) => {
+                    // Log ONCE — subsequent get_or_init calls hit the
+                    // cached None and stay silent.  Env-triggered
+                    // reconfig requires a plugin restart, deliberate
+                    // (op-side simplicity > log flood suppression).
+                    tracing::error!(
+                        err = %e,
+                        "search-plugin: query expansion misconfigured — \
+                         disabled for this process; fix the env and restart",
+                    );
+                    None
+                }
+            })
+            .clone()
+    }
+
+    /// N+1 variant fan-out for LLM query expansion.  Called by
+    /// [`SearchService::query`] when the outer request hit the
+    /// expander pre-dispatch.  Runs the original query plus each
+    /// LLM-produced variant through the full single-query pipeline
+    /// (each recursive call sees `IN_EXPANSION` set and skips
+    /// re-expansion), then fuses the ranked lists with
+    /// [`crate::fusion::rrf_multi`].
+    ///
+    /// Failure posture: any expander error (misconfig / HTTP / bad
+    /// JSON / spawn-join) degrades to a single-shot original-query
+    /// call.  The trait method's contract to the caller is
+    /// preserved regardless of LLM health.
+    async fn query_with_expansion(
+        &self,
+        req: QueryRequest,
+        handle: Arc<ExpanderHandle>,
+    ) -> Result<Response<QueryResponse>, Status> {
+        // Cache lookup first — dedupes the LLM round-trip across
+        // callers who hit the plugin with the same phrasing.
+        let variants: Vec<String> = if let Some(cached) = self.expansion_cache.get(&req.q) {
+            cached
+        } else {
+            let query_owned = req.q.clone();
+            let max = handle.max_variants;
+            let expander = Arc::clone(&handle.expander);
+            let joined =
+                tokio::task::spawn_blocking(move || expander.expand(&query_owned, max)).await;
+            match joined {
+                Ok(Ok(v)) => {
+                    self.expansion_cache.insert(req.q.clone(), v.clone());
+                    v
+                }
+                Ok(Err(e)) => {
+                    tracing::warn!(
+                        err = %e,
+                        "search-plugin: query expansion HTTP failed — degrading to single-query path",
+                    );
+                    return IN_EXPANSION.scope((), self.query(Request::new(req))).await;
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        err = %e,
+                        "search-plugin: query expansion spawn joined error — degrading to single-query path",
+                    );
+                    return IN_EXPANSION.scope((), self.query(Request::new(req))).await;
+                }
+            }
+        };
+
+        // Union `[original + distinct-variants]` — drop echoes of the
+        // original so we don't double-weight it in the fusion.
+        let mut all_queries: Vec<String> = Vec::with_capacity(variants.len() + 1);
+        all_queries.push(req.q.clone());
+        for v in variants {
+            let trimmed = v.trim();
+            if !trimmed.is_empty() && trimmed != req.q.trim() {
+                all_queries.push(trimmed.to_string());
+            }
+        }
+        if all_queries.len() == 1 {
+            // LLM returned nothing useful (empty list, or only an
+            // echo of the original).  Straight-through — no fusion
+            // overhead for a single arm.
+            return IN_EXPANSION.scope((), self.query(Request::new(req))).await;
+        }
+
+        let limit = if req.limit == 0 {
+            DEFAULT_QUERY_LIMIT
+        } else {
+            req.limit as usize
+        };
+        let rrf_k = FusionOpts::from_request(&req).rrf_k;
+
+        // Fan out sequentially — the recursive `query` call already
+        // fans keyword+semantic+title internally onto the blocking
+        // pool, and running the whole outer set concurrently would
+        // multiply worker-pool contention by (N+1) with no reduction
+        // in wall-clock (each variant hits the same cache-warmed
+        // sinks after the first).  Keep it linear until measurements
+        // demand otherwise.
+        let mut per_variant: Vec<Vec<QueryResult>> = Vec::with_capacity(all_queries.len());
+        for variant_q in all_queries {
+            let mut variant_req = req.clone();
+            variant_req.q = variant_q;
+            let resp = IN_EXPANSION
+                .scope((), self.query(Request::new(variant_req)))
+                .await?
+                .into_inner();
+            // Skip broken/empty variant contributions — they add
+            // nothing to the fusion and would surface as a spurious
+            // 0-score arm that penalises real hits.
+            if resp.error.is_none() && !resp.results.is_empty() {
+                per_variant.push(resp.results);
+            }
+        }
+
+        if per_variant.is_empty() {
+            // Every arm (including original) returned empty or
+            // errored — legitimate empty response.
+            return Ok(Response::new(QueryResponse {
+                results: Vec::new(),
+                error: None,
+            }));
+        }
+
+        let arms: Vec<(fusion::ArmKind, &[QueryResult])> = per_variant
+            .iter()
+            .map(|r| (fusion::ArmKind::Chunk, r.as_slice()))
+            .collect();
+        let mut fused = fusion::rrf_multi(&arms, rrf_k);
+        if fused.len() > limit {
+            fused.truncate(limit);
+        }
+        Ok(Response::new(QueryResponse {
+            results: fused,
+            error: None,
+        }))
     }
 
     /// Embedder resolution for INDEXING paths (review R2).  Returns
@@ -270,6 +464,7 @@ pub struct SearchServiceBuilder {
     query_cache: Option<crate::query_cache::SharedQueryCache>,
     embed_cache: Option<Arc<QueryEmbedCache>>,
     title_arm: Option<bool>,
+    expander: Option<Arc<ExpanderHandle>>,
 }
 
 impl SearchServiceBuilder {
@@ -313,7 +508,27 @@ impl SearchServiceBuilder {
         self
     }
 
+    /// Pre-seed the LLM query expander slot — tests inject a mock
+    /// [`crate::query_expansion::QueryExpander`] here (wrapped in
+    /// [`ExpanderHandle`] with the desired `max_variants`) so
+    /// [`get_or_init_expander`] skips the env-driven build step.
+    pub fn expander(mut self, expander: Arc<ExpanderHandle>) -> Self {
+        self.expander = Some(expander);
+        self
+    }
+
     pub fn build(self) -> SearchServiceImpl {
+        // Pre-populate the OnceLock when the builder seeded an
+        // expander so tests never race the env-driven build.  A
+        // fresh (unseeded) OnceLock triggers env parse on the first
+        // Query.
+        let expander_slot: OnceLock<Option<Arc<ExpanderHandle>>> = OnceLock::new();
+        if let Some(h) = self.expander {
+            // set() only fails when already initialised; a freshly-
+            // built OnceLock is empty by construction, so ignoring
+            // the Result is safe.
+            let _ = expander_slot.set(Some(h));
+        }
         SearchServiceImpl {
             handle: self.handle,
             manager: self
@@ -328,6 +543,8 @@ impl SearchServiceBuilder {
                 .unwrap_or_else(|| Arc::new(QueryEmbedCache::from_env())),
             indexing_ops: Arc::new(std::sync::atomic::AtomicU32::new(0)),
             title_arm: self.title_arm,
+            expander_slot: Arc::new(expander_slot),
+            expansion_cache: Arc::new(ExpansionCache::new()),
         }
     }
 }
@@ -2452,6 +2669,18 @@ impl SearchService for SearchServiceImpl {
                 results: Vec::new(),
                 error: Some("q must not be empty".into()),
             }));
+        }
+        // LLM query-expansion pre-dispatch.  Runs ONLY at the outer
+        // call — variant fan-out sets IN_EXPANSION so each recursive
+        // re-entry drops straight to the single-query pipeline.  The
+        // wrapper itself degrades to single-query on any expander
+        // error (misconfigured / HTTP / timeout), so a broken LLM
+        // endpoint never takes base search down with it.
+        let already_expanding = IN_EXPANSION.try_with(|_| ()).is_ok();
+        if !already_expanding {
+            if let Some(handle) = self.get_or_init_expander() {
+                return self.query_with_expansion(req, handle).await;
+            }
         }
         // Canonicalise the zone BEFORE cache lookup so the cache
         // and Index/Refresh invalidation agree on the key.  Wire

--- a/rust/services/search-plugin/tests/query_expansion_e2e.rs
+++ b/rust/services/search-plugin/tests/query_expansion_e2e.rs
@@ -1,0 +1,396 @@
+//! End-to-end integration test for the LLM query-expansion wrapper
+//! (Feature 1 of the "fold nexus-server search runtime into the
+//! plugin" migration).
+//!
+//! Real `SearchServiceImpl` + real `IndexManager` on a tempdir + real
+//! tokio async runtime + real `fusion::rrf_multi` — the ONLY test
+//! double is a canned `QueryExpander` implementation that returns
+//! pre-programmed variant lists and counts how many times the wrapper
+//! called it.  Every test therefore drives the exact code path a
+//! production request takes, up to and including the recursive
+//! re-entry that the `IN_EXPANSION` task-local guards.
+
+use std::ffi::c_void;
+use std::os::raw::c_char;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use nexus_plugin_abi::KernelHandle;
+use nexus_search_plugin::index_manager::IndexManager;
+use nexus_search_plugin::query_expansion::{ExpansionError, QueryExpander};
+use nexus_search_plugin::search_proto::search_service_server::SearchService;
+use nexus_search_plugin::search_proto::{QueryRequest, QueryType};
+use nexus_search_plugin::service::{ExpanderHandle, SearchServiceImpl};
+use tempfile::TempDir;
+use tonic::Request;
+
+// ── Poison KernelHandle ─────────────────────────────────────────
+//
+// Same poison callbacks query_e2e uses — Query never touches the
+// kernel; if a regression rewires that, these -1 returns propagate as
+// visible zero-hit results.
+
+unsafe extern "C" fn poison_read(
+    _: *const c_void,
+    _: *const c_char,
+    _: *mut *mut u8,
+    _: *mut usize,
+) -> i32 {
+    -1
+}
+unsafe extern "C" fn poison_write(
+    _: *const c_void,
+    _: *const c_char,
+    _: *const u8,
+    _: usize,
+) -> i32 {
+    -1
+}
+unsafe extern "C" fn poison_stat(
+    _: *const c_void,
+    _: *const c_char,
+    _: *mut *mut u8,
+    _: *mut usize,
+) -> i32 {
+    -1
+}
+unsafe extern "C" fn poison_readdir(
+    _: *const c_void,
+    _: *const c_char,
+    _: *mut *mut u8,
+    _: *mut usize,
+) -> i32 {
+    -1
+}
+unsafe extern "C" fn poison_unlink(_: *const c_void, _: *const c_char) -> i32 {
+    -1
+}
+unsafe extern "C" fn poison_mkdir(_: *const c_void, _: *const c_char) -> i32 {
+    -1
+}
+unsafe extern "C" fn poison_rmdir(_: *const c_void, _: *const c_char) -> i32 {
+    -1
+}
+unsafe extern "C" fn poison_rename(_: *const c_void, _: *const c_char, _: *const c_char) -> i32 {
+    -1
+}
+unsafe extern "C" fn poison_stat_batch(
+    _: *const c_void,
+    _: *const c_char,
+    _: *mut *mut u8,
+    _: *mut usize,
+) -> i32 {
+    -1
+}
+
+fn poison_handle() -> KernelHandle {
+    KernelHandle {
+        sys_read: poison_read,
+        sys_write: poison_write,
+        sys_stat: poison_stat,
+        sys_readdir: poison_readdir,
+        sys_unlink: poison_unlink,
+        sys_mkdir: poison_mkdir,
+        sys_rmdir: poison_rmdir,
+        sys_rename: poison_rename,
+        sys_stat_batch: poison_stat_batch,
+        kernel_ptr: std::ptr::null(),
+    }
+}
+
+// ── Mock expander ───────────────────────────────────────────────
+//
+// Canned variants + call counter.  Behaviour is fully deterministic;
+// each test constructs one, wraps it in an ExpanderHandle, hands it
+// to the builder, and inspects `calls()` after the query.
+
+enum MockBehaviour {
+    /// Return this fixed list of variants regardless of the query.
+    Fixed(Vec<String>),
+    /// Return an ExpansionError (simulates HTTP failure / timeout).
+    Fail(String),
+}
+
+struct MockExpander {
+    behaviour: MockBehaviour,
+    calls: AtomicUsize,
+    last_query: parking_lot::Mutex<Option<String>>,
+}
+
+impl MockExpander {
+    fn fixed(variants: Vec<&str>) -> Arc<Self> {
+        Arc::new(Self {
+            behaviour: MockBehaviour::Fixed(variants.into_iter().map(String::from).collect()),
+            calls: AtomicUsize::new(0),
+            last_query: parking_lot::Mutex::new(None),
+        })
+    }
+
+    fn failing(msg: &str) -> Arc<Self> {
+        Arc::new(Self {
+            behaviour: MockBehaviour::Fail(msg.to_string()),
+            calls: AtomicUsize::new(0),
+            last_query: parking_lot::Mutex::new(None),
+        })
+    }
+
+    fn calls(&self) -> usize {
+        self.calls.load(Ordering::SeqCst)
+    }
+
+    fn last_query(&self) -> Option<String> {
+        self.last_query.lock().clone()
+    }
+}
+
+impl QueryExpander for MockExpander {
+    fn expand(&self, query: &str, _max_variants: usize) -> Result<Vec<String>, ExpansionError> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        *self.last_query.lock() = Some(query.to_string());
+        match &self.behaviour {
+            MockBehaviour::Fixed(v) => Ok(v.clone()),
+            MockBehaviour::Fail(m) => Err(ExpansionError::Http(m.clone())),
+        }
+    }
+}
+
+// ── Harness ─────────────────────────────────────────────────────
+
+struct Harness {
+    _dir: TempDir,
+    svc: SearchServiceImpl,
+    manager: Arc<IndexManager>,
+}
+
+impl Harness {
+    fn start(expander: Arc<MockExpander>, max_variants: usize) -> Self {
+        let dir = TempDir::new().expect("tempdir");
+        let manager = Arc::new(IndexManager::with_root(dir.path().to_path_buf()));
+        let handle = Arc::new(ExpanderHandle {
+            expander: expander as Arc<dyn QueryExpander>,
+            max_variants,
+        });
+        let svc = SearchServiceImpl::builder(Arc::new(poison_handle()))
+            .manager(Arc::clone(&manager))
+            .expander(handle)
+            .build();
+        Self {
+            _dir: dir,
+            svc,
+            manager,
+        }
+    }
+
+    fn start_without_expander() -> Self {
+        let dir = TempDir::new().expect("tempdir");
+        let manager = Arc::new(IndexManager::with_root(dir.path().to_path_buf()));
+        let svc = SearchServiceImpl::builder(Arc::new(poison_handle()))
+            .manager(Arc::clone(&manager))
+            .build();
+        Self {
+            _dir: dir,
+            svc,
+            manager,
+        }
+    }
+
+    fn seed_default_corpus(&self) {
+        // Chosen so each query-variant touches a DIFFERENT subset:
+        //   "widget"       → hello.md, x.log
+        //   "authentication" → auth.md
+        //   "login"          → auth.md, login.md
+        // Fusion should union all three.
+        let idx = self.manager.get_or_open("root").expect("open zone");
+        idx.add_document(
+            "/notes/hello.md",
+            0,
+            "hello world widget alpha",
+            Some(1_700_000_000_000),
+        )
+        .expect("add-1");
+        idx.add_document(
+            "/logs/x.log",
+            0,
+            "widget beta arrived",
+            Some(1_700_000_000_100),
+        )
+        .expect("add-2");
+        idx.add_document(
+            "/notes/auth.md",
+            0,
+            "how authentication and login work together",
+            Some(1_700_000_000_200),
+        )
+        .expect("add-3");
+        idx.add_document(
+            "/notes/login.md",
+            0,
+            "login form design and password reset",
+            Some(1_700_000_000_300),
+        )
+        .expect("add-4");
+        idx.commit().expect("commit");
+    }
+
+    async fn query(&self, q: &str) -> nexus_search_plugin::search_proto::QueryResponse {
+        self.svc
+            .query(Request::new(QueryRequest {
+                q: q.to_string(),
+                zone_id: "root".to_string(),
+                limit: 20,
+                query_type: QueryType::Keyword as i32,
+                ..Default::default()
+            }))
+            .await
+            .expect("query")
+            .into_inner()
+    }
+}
+
+// ── Tests ───────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn expansion_fans_out_and_unions_variant_hits() {
+    // Original "authentication" alone matches only auth.md;
+    // variants add coverage of login.md.  Fused result must union
+    // the two, and the expander must have been called exactly once
+    // (the ORIGINAL query — not once per variant re-entry).
+    let mock = MockExpander::fixed(vec!["login", "password reset"]);
+    let h = Harness::start(mock.clone(), 3);
+    h.seed_default_corpus();
+
+    let resp = h.query("authentication").await;
+    assert!(resp.error.is_none(), "unexpected error: {:?}", resp.error);
+
+    let paths: Vec<&str> = resp.results.iter().map(|r| r.path.as_str()).collect();
+    assert!(
+        paths.contains(&"/notes/auth.md"),
+        "auth.md missing from {paths:?}"
+    );
+    assert!(
+        paths.contains(&"/notes/login.md"),
+        "login.md missing from {paths:?}"
+    );
+
+    assert_eq!(
+        mock.calls(),
+        1,
+        "expander must be called exactly once (outer request only, re-entries skipped)",
+    );
+    assert_eq!(mock.last_query().as_deref(), Some("authentication"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn expansion_disabled_when_no_expander_wired() {
+    // No .expander() on the builder → get_or_init_expander() returns
+    // None → the query drops straight to the single-query pipeline.
+    // Result parity: exactly what a query without expansion looks like.
+    let h = Harness::start_without_expander();
+    h.seed_default_corpus();
+
+    let resp = h.query("widget").await;
+    assert!(resp.error.is_none(), "unexpected error: {:?}", resp.error);
+
+    let paths: Vec<&str> = resp.results.iter().map(|r| r.path.as_str()).collect();
+    assert!(paths.contains(&"/notes/hello.md"));
+    assert!(paths.contains(&"/logs/x.log"));
+    assert!(!paths.contains(&"/notes/auth.md"));
+    assert!(!paths.contains(&"/notes/login.md"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn expansion_llm_failure_degrades_to_single_query() {
+    // Mock returns Err(Http) — wrapper must log the warning and
+    // fall through to a single-shot original query.  Result parity:
+    // same as the "no expander wired" test.
+    let mock = MockExpander::failing("simulated 500");
+    let h = Harness::start(mock.clone(), 3);
+    h.seed_default_corpus();
+
+    let resp = h.query("widget").await;
+    assert!(resp.error.is_none(), "unexpected error: {:?}", resp.error);
+
+    let paths: Vec<&str> = resp.results.iter().map(|r| r.path.as_str()).collect();
+    assert!(paths.contains(&"/notes/hello.md"));
+    assert!(paths.contains(&"/logs/x.log"));
+    // No expansion actually reached fusion — auth.md must NOT appear.
+    assert!(!paths.contains(&"/notes/auth.md"));
+
+    assert_eq!(
+        mock.calls(),
+        1,
+        "expander must have been called once (and failed)"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn expansion_empty_variants_falls_through() {
+    // Mock returns an empty variant list — nothing useful to fuse,
+    // wrapper straight-throughs to the single-query path.
+    let mock = MockExpander::fixed(vec![]);
+    let h = Harness::start(mock.clone(), 3);
+    h.seed_default_corpus();
+
+    let resp = h.query("widget").await;
+    assert!(resp.error.is_none());
+    let paths: Vec<&str> = resp.results.iter().map(|r| r.path.as_str()).collect();
+    assert!(paths.contains(&"/notes/hello.md"));
+    assert!(paths.contains(&"/logs/x.log"));
+    assert_eq!(
+        mock.calls(),
+        1,
+        "expander called exactly once (returned empty)"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn expansion_echo_variants_are_dropped() {
+    // Model politely re-returns the original query as one of its
+    // "variants".  We must NOT re-run the original arm twice — that
+    // would double-weight it in the fusion.  Fusion still fires
+    // (there's a real variant "login") but the "authentication"
+    // echo is skipped.
+    let mock = MockExpander::fixed(vec!["authentication", "login"]);
+    let h = Harness::start(mock.clone(), 3);
+    h.seed_default_corpus();
+
+    let resp = h.query("authentication").await;
+    assert!(resp.error.is_none());
+    let paths: Vec<&str> = resp.results.iter().map(|r| r.path.as_str()).collect();
+    assert!(paths.contains(&"/notes/auth.md"));
+    assert!(paths.contains(&"/notes/login.md"));
+
+    assert_eq!(mock.calls(), 1);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn expansion_second_identical_query_hits_the_cache() {
+    // ExpansionCache dedupes repeated identical queries.  Second
+    // query with the same text must not call the mock a second time.
+    let mock = MockExpander::fixed(vec!["login"]);
+    let h = Harness::start(mock.clone(), 3);
+    h.seed_default_corpus();
+
+    let _ = h.query("authentication").await;
+    assert_eq!(mock.calls(), 1, "first query must call the expander");
+
+    let _ = h.query("authentication").await;
+    assert_eq!(mock.calls(), 1, "second identical query must hit the cache");
+
+    // Distinct query is a miss and calls the expander again.
+    let _ = h.query("widget").await;
+    assert_eq!(mock.calls(), 2, "distinct query bypasses the cache");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn expansion_wrapper_preserves_empty_q_early_return() {
+    // The empty-q guard in the trait method must fire BEFORE the
+    // expander check — otherwise we'd waste an LLM round-trip on a
+    // query the server is going to reject anyway.
+    let mock = MockExpander::fixed(vec!["something"]);
+    let h = Harness::start(mock.clone(), 3);
+
+    let resp = h.query("").await;
+    assert!(resp.error.is_some(), "empty q must error");
+    assert_eq!(mock.calls(), 0, "expander must NOT be called for empty q");
+}


### PR DESCRIPTION
## Summary

**Feature 1 of 3** in the "fold nexus-server search runtime into the plugin" migration. Adds LLM-driven query expansion inside the Rust `nexus-search-plugin` cdylib — one LLM round-trip per query widens the search into N+1 variants and fuses the ranked lists via `rrf_multi`. Transparent to callers, opt-in via env, degrades cleanly on LLM failure.

Purpose: make a pure-cluster deployment (`nexusd-cluster` + `nexus-search-plugin` cdylib alone) feature-complete for LLM-widened search, without needing the Python `nexus-server` container for this tier. Follow-ups: federation (F2) + contextual chunking (F3), each in its own PR. After all three land, a 4th PR deletes the corresponding Python modules.

## Design points

- **Env-driven config** (`NEXUS_SEARCH_QUERY_EXPANSION*`) — kill-switch defaults OFF. Once ON, endpoint + model + api-key must all be present; a partial config is a LOUD `Misconfigured` error per the standing "fail loud on interdependent config" rule.
- **Lazy init** via `std::sync::OnceLock` — env parsed once on first Query. Misconfig logs one error and disables expansion for the process (env reconfig needs a restart).
- **Recursion-safety** via `tokio::task_local!` — variant fan-out re-enters the trait `query()`; the outer wrapper skips re-expansion when the task-local is set. Task-locals propagate across `.await` within the same task, don't cross `spawn_blocking` (fine — blocking body doesn't touch expansion state).
- **Cache** — bounded FIFO on `(query → variants)` deflates repeated identical queries to a hashmap lookup + fan-out (each variant then hits the existing per-zone query cache).
- **Failure posture** — any expander error (HTTP timeout, non-2xx, bad JSON) falls through to the single-query path. Base search never breaks because the LLM is down.
- **Echo drop** — a model that returns the original query as one of its "variants" would double-weight it in fusion; wrapper drops such echoes.
- **Sequential fan-out** — each recursive `query()` already fans keyword+semantic+title internally on the blocking pool. Concurrent variants would multiply pool contention by (N+1) with no wall-clock win. Kept linear until measurements demand otherwise.

## Files

- `src/query_expansion.rs` — module: config, `HttpQueryExpander`, `ExpansionCache`, 18 unit tests
- `src/service.rs` — wire `query_with_expansion` fan-out + pre-dispatch hook in trait `query()`
- `src/lib.rs` — register module
- `tests/query_expansion_e2e.rs` — 7 integration tests over the real service + real IndexManager, mock expander

## Test plan

- [x] `cargo test -p nexus-search-plugin --lib query_expansion` — 18/18 green
- [x] `cargo test -p nexus-search-plugin --test query_expansion_e2e` — 7/7 green
- [x] Full lib suite still passes (203/203)
- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy` on new files — clean (2 pre-existing warnings in service.rs are unrelated to this PR)
- [ ] CI green