### PR TITLE
feat(search): fold LLM contextual chunking into nexus-search-plugin cdylib

### DIFF
--- a/rust/services/search-plugin/src/contextual_chunker.rs
+++ b/rust/services/search-plugin/src/contextual_chunker.rs
@@ -1,0 +1,775 @@
+//! Anthropic-style contextual chunking — at index time, ask an LLM
+//! to produce a short "context prefix" for each chunk that resolves
+//! pronouns and adds surrounding section context, then prepend the
+//! prefix to `Chunk::embed_input` (NOT `Chunk::text`).  Semantic
+//! recall lifts on ambiguous queries; BM25 stays clean because the
+//! context never enters `chunk_text`.
+//!
+//! # Why it lives inside the plugin
+//!
+//! Mirrors the Python
+//! `nexus.bricks.search.contextual_chunking.ContextualChunker`.
+//! Pulling it into the plugin's indexing path makes a pure-cluster
+//! deployment feature-complete for contextual chunking without
+//! needing the `nexus-server` container.
+//!
+//! # Contract
+//!
+//! Opt-in ONLY.  `NEXUS_SEARCH_CONTEXTUAL_CHUNKING=true` gates the
+//! feature; every deployment defaults OFF because contextual
+//! chunking is the most expensive of the three LLM knobs (one LLM
+//! call per chunk × N chunks per doc × M docs indexed).  Once opted
+//! in, all four other env vars (`_ENDPOINT`, `_MODEL`, `_API_KEY`,
+//! and optionally `_CONCURRENCY`) must be present — partial config
+//! is a LOUD Err (per the standing "fail loud on interdependent
+//! config" rule).
+//!
+//! # Env config is SEPARATE from Feature 1 (query expansion)
+//!
+//! Query expansion benefits from strong reasoning (DeepSeek, GPT-4o,
+//! Claude 3.5); contextual chunking benefits from cheap fast models
+//! (Haiku, GPT-4o-mini).  Two distinct env prefixes so operators can
+//! point each at the right cost/latency point.
+//!
+//! # Failure posture
+//!
+//! Per-chunk generation failure returns `None` for that slot; the
+//! chunk stays unchanged (its `embed_input` = plain heading-prefixed
+//! text as `chunker::chunk_document` produced it).  A broken LLM
+//! endpoint MUST NOT stall indexing or drop chunks — the FTS side
+//! is authoritative for keyword search, and semantic recall stays
+//! functional without contextual prefixes.
+//!
+//! # Concurrency
+//!
+//! Sync API driven by `reqwest::blocking` — every call site in the
+//! indexing pipeline already runs inside `spawn_blocking`, so blocking
+//! HTTP keeps the plugin's tokio pool free.  `generate_batch`
+//! internally fans chunks out via `std::thread::scope` bounded by
+//! [`ContextualChunkingConfig::concurrency`] (default 4) so a doc
+//! with 50 chunks doesn't serialise 50 × 3 s HTTP round-trips.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+use parking_lot::Mutex;
+
+/// Kill-switch — set to `true`/`1`/`yes` to enable contextual
+/// chunking.  Absent or any other value = DISABLED (the default).
+pub const CONTEXTUAL_ENABLED_ENV: &str = "NEXUS_SEARCH_CONTEXTUAL_CHUNKING";
+/// OpenAI-compatible chat-completions endpoint URL.  Separate from
+/// query expansion's endpoint so operators can point contextual
+/// chunking at a cheaper/faster model.
+pub const CONTEXTUAL_ENDPOINT_ENV: &str = "NEXUS_SEARCH_CONTEXTUAL_ENDPOINT";
+/// Chat model name (e.g. `anthropic/claude-3-haiku`,
+/// `openai/gpt-4o-mini`).
+pub const CONTEXTUAL_MODEL_ENV: &str = "NEXUS_SEARCH_CONTEXTUAL_MODEL";
+/// Bearer token for the endpoint.
+pub const CONTEXTUAL_API_KEY_ENV: &str = "NEXUS_SEARCH_CONTEXTUAL_API_KEY";
+/// Per-request timeout in milliseconds (default 5000 ms).  Larger
+/// than query expansion's 3 s — contextual chunking runs at
+/// indexing time (background), not on the caller-visible query path.
+pub const CONTEXTUAL_TIMEOUT_MS_ENV: &str = "NEXUS_SEARCH_CONTEXTUAL_TIMEOUT_MS";
+/// Bounded intra-doc parallelism — default 4.  A doc with N chunks
+/// runs `min(N, concurrency)` HTTP round-trips at a time via a
+/// `std::thread::scope` fan-out.
+pub const CONTEXTUAL_CONCURRENCY_ENV: &str = "NEXUS_SEARCH_CONTEXTUAL_CONCURRENCY";
+/// Cap on how much of the surrounding document is sent to the LLM
+/// alongside each chunk (default 8 KB).  Truncation keeps the LLM
+/// bill bounded — a monster README shouldn't cost 100 KB of context
+/// per chunk.
+pub const CONTEXTUAL_DOC_CAP_ENV: &str = "NEXUS_SEARCH_CONTEXTUAL_DOC_CAP_BYTES";
+
+const DEFAULT_TIMEOUT_MS: u64 = 5_000;
+const DEFAULT_CONCURRENCY: usize = 4;
+/// Ceiling on concurrency so a runaway env value can't blow the
+/// thread count on a small-corpus host.
+const HARD_MAX_CONCURRENCY: usize = 32;
+const DEFAULT_DOC_CAP_BYTES: usize = 8 * 1024;
+
+/// Errors from the contextual-chunking layer.  All variants keep
+/// indexing alive — the caller (`index_one` / `do_index_documents`)
+/// logs the error and treats the chunk as un-contexted (chunk still
+/// indexed with plain `embed_input`).
+#[derive(Debug, thiserror::Error)]
+pub enum ContextualError {
+    /// Feature is enabled but env config is incomplete or malformed.
+    #[error("contextual chunking misconfigured: {0}")]
+    Misconfigured(String),
+
+    /// HTTP transport / non-2xx status / body parse failure.
+    #[error("contextual chunking HTTP failed: {0}")]
+    Http(String),
+}
+
+/// Parsed env contract.  Same fail-loud semantics as
+/// [`crate::query_expansion::QueryExpansionConfig`].
+#[derive(Debug, Clone)]
+pub struct ContextualChunkingConfig {
+    pub endpoint: String,
+    pub model: String,
+    pub api_key: String,
+    pub timeout: Duration,
+    pub concurrency: usize,
+    pub doc_cap_bytes: usize,
+}
+
+impl ContextualChunkingConfig {
+    /// Read the `NEXUS_SEARCH_CONTEXTUAL_*` contract from process env.
+    pub fn from_env() -> Result<Option<Self>, ContextualError> {
+        Self::from_lookup(|k| std::env::var(k).ok())
+    }
+
+    /// Env-shape parser with an injectable lookup so unit tests never
+    /// race process-global env across parallel test threads.
+    pub fn from_lookup(
+        get: impl Fn(&str) -> Option<String>,
+    ) -> Result<Option<Self>, ContextualError> {
+        let enabled = get(CONTEXTUAL_ENABLED_ENV)
+            .map(|v| parse_bool(&v))
+            .unwrap_or(false);
+        if !enabled {
+            return Ok(None);
+        }
+        let endpoint = get(CONTEXTUAL_ENDPOINT_ENV)
+            .filter(|v| !v.trim().is_empty())
+            .map(|v| v.trim().to_string())
+            .ok_or_else(|| {
+                ContextualError::Misconfigured(format!(
+                    "{CONTEXTUAL_ENABLED_ENV}=true but {CONTEXTUAL_ENDPOINT_ENV} is unset — \
+                     the generator needs an OpenAI-compatible chat-completions URL",
+                ))
+            })?;
+        let model = get(CONTEXTUAL_MODEL_ENV)
+            .filter(|v| !v.trim().is_empty())
+            .map(|v| v.trim().to_string())
+            .ok_or_else(|| {
+                ContextualError::Misconfigured(format!(
+                    "{CONTEXTUAL_ENABLED_ENV}=true but {CONTEXTUAL_MODEL_ENV} is unset — \
+                     the generator needs an explicit chat model name",
+                ))
+            })?;
+        let api_key = get(CONTEXTUAL_API_KEY_ENV)
+            .filter(|v| !v.trim().is_empty())
+            .map(|v| v.trim().to_string())
+            .ok_or_else(|| {
+                ContextualError::Misconfigured(format!(
+                    "{CONTEXTUAL_ENABLED_ENV}=true but {CONTEXTUAL_API_KEY_ENV} is unset — \
+                     the generator needs a bearer token for the endpoint",
+                ))
+            })?;
+        let timeout_ms = parse_positive_u64(&get, CONTEXTUAL_TIMEOUT_MS_ENV, DEFAULT_TIMEOUT_MS)?;
+        let concurrency =
+            parse_positive_usize(&get, CONTEXTUAL_CONCURRENCY_ENV, DEFAULT_CONCURRENCY)?
+                .min(HARD_MAX_CONCURRENCY);
+        let doc_cap_bytes =
+            parse_positive_usize(&get, CONTEXTUAL_DOC_CAP_ENV, DEFAULT_DOC_CAP_BYTES)?;
+        Ok(Some(Self {
+            endpoint,
+            model,
+            api_key,
+            timeout: Duration::from_millis(timeout_ms),
+            concurrency,
+            doc_cap_bytes,
+        }))
+    }
+}
+
+fn parse_positive_u64(
+    get: &impl Fn(&str) -> Option<String>,
+    key: &str,
+    default: u64,
+) -> Result<u64, ContextualError> {
+    match get(key).filter(|v| !v.trim().is_empty()) {
+        None => Ok(default),
+        Some(raw) => raw
+            .trim()
+            .parse::<u64>()
+            .ok()
+            .filter(|v| *v > 0)
+            .ok_or_else(|| {
+                ContextualError::Misconfigured(format!("{key}={raw:?} is not a positive integer"))
+            }),
+    }
+}
+
+fn parse_positive_usize(
+    get: &impl Fn(&str) -> Option<String>,
+    key: &str,
+    default: usize,
+) -> Result<usize, ContextualError> {
+    match get(key).filter(|v| !v.trim().is_empty()) {
+        None => Ok(default),
+        Some(raw) => raw
+            .trim()
+            .parse::<usize>()
+            .ok()
+            .filter(|v| *v > 0)
+            .ok_or_else(|| {
+                ContextualError::Misconfigured(format!("{key}={raw:?} is not a positive integer"))
+            }),
+    }
+}
+
+fn parse_bool(raw: &str) -> bool {
+    matches!(
+        raw.trim().to_ascii_lowercase().as_str(),
+        "1" | "true" | "yes" | "on"
+    )
+}
+
+/// Context-prefix generator contract.  One trait so tests can swap
+/// the live HTTP generator for a canned mock without stubbing
+/// reqwest.  Sync API — every call site runs inside `spawn_blocking`.
+pub trait ContextGenerator: Send + Sync {
+    /// For each `chunk_text`, produce an optional short context
+    /// prefix that summarises where the chunk sits in `document_text`.
+    /// Returns one `Option<String>` per input chunk, in the same
+    /// order.  `None` = generation failed for that chunk; the caller
+    /// leaves the chunk's `embed_input` unchanged.
+    fn generate_batch(&self, document_text: &str, chunk_texts: &[&str]) -> Vec<Option<String>>;
+}
+
+// ── HttpContextGenerator ─────────────────────────────────────────
+
+#[derive(serde::Serialize)]
+struct ChatMessage<'a> {
+    role: &'a str,
+    content: &'a str,
+}
+
+#[derive(serde::Serialize)]
+struct ChatRequest<'a> {
+    model: &'a str,
+    messages: Vec<ChatMessage<'a>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    temperature: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    max_tokens: Option<u32>,
+}
+
+#[derive(serde::Deserialize)]
+struct ChatResponse {
+    choices: Vec<ChatChoice>,
+}
+
+#[derive(serde::Deserialize)]
+struct ChatChoice {
+    message: ChatChoiceMessage,
+}
+
+#[derive(serde::Deserialize)]
+struct ChatChoiceMessage {
+    content: String,
+}
+
+/// System prompt — cargo-culted from Anthropic's original contextual-
+/// retrieval blog and tightened for our indexing pipeline.  Kept
+/// deliberately short so a small model (Haiku, gpt-4o-mini) can
+/// follow it reliably.  The user message carries the doc + chunk.
+const SYSTEM_PROMPT: &str = "\
+You produce a one-to-two-sentence context prefix that situates a text \
+chunk within its source document.  The prefix will be prepended to the \
+chunk for a semantic-search embedder.  Resolve pronouns, add the section \
+title if relevant, and note the topic.  Reply with ONLY the prefix — no \
+Markdown, no explanations, no quotation marks.";
+
+/// Ceiling on the returned context length (chars) to keep the
+/// embedder input from ballooning if a chatty model over-answers.
+const CONTEXT_MAX_CHARS: usize = 400;
+
+/// Live HTTP context generator.
+pub struct HttpContextGenerator {
+    client: reqwest::blocking::Client,
+    config: ContextualChunkingConfig,
+}
+
+impl HttpContextGenerator {
+    /// Build the HTTP client for `config`.  No network I/O happens
+    /// here.
+    pub fn new(config: ContextualChunkingConfig) -> Result<Self, ContextualError> {
+        let client = reqwest::blocking::Client::builder()
+            .timeout(config.timeout)
+            .build()
+            .map_err(|e| ContextualError::Http(format!("generator HTTP client: {e}")))?;
+        Ok(Self { client, config })
+    }
+
+    /// Single-chunk HTTP round-trip.  `Ok(Some(prefix))` on success,
+    /// `Ok(None)` when the model returned an empty string (rare but
+    /// legal), `Err(...)` on transport / status / parse failure.
+    fn generate_one(
+        &self,
+        document_excerpt: &str,
+        chunk_text: &str,
+    ) -> Result<Option<String>, ContextualError> {
+        let user = format!(
+            "<document>\n{document_excerpt}\n</document>\n\n\
+             <chunk>\n{chunk_text}\n</chunk>\n\n\
+             Produce the context prefix for the chunk above."
+        );
+        let body = ChatRequest {
+            model: &self.config.model,
+            messages: vec![
+                ChatMessage {
+                    role: "system",
+                    content: SYSTEM_PROMPT,
+                },
+                ChatMessage {
+                    role: "user",
+                    content: &user,
+                },
+            ],
+            temperature: Some(0.0),
+            max_tokens: Some(120),
+        };
+        let resp = self
+            .client
+            .post(&self.config.endpoint)
+            .bearer_auth(&self.config.api_key)
+            .json(&body)
+            .send()
+            .map_err(|e| {
+                ContextualError::Http(format!(
+                    "contextual request to {}: {e}",
+                    self.config.endpoint
+                ))
+            })?;
+        let status = resp.status();
+        if !status.is_success() {
+            let excerpt: String = resp.text().unwrap_or_default().chars().take(300).collect();
+            return Err(ContextualError::Http(format!(
+                "contextual endpoint returned {status}: {excerpt}",
+            )));
+        }
+        let parsed: ChatResponse = resp
+            .json()
+            .map_err(|e| ContextualError::Http(format!("contextual response parse: {e}")))?;
+        let content = parsed
+            .choices
+            .into_iter()
+            .next()
+            .map(|c| c.message.content)
+            .unwrap_or_default();
+        let trimmed = content.trim();
+        if trimmed.is_empty() {
+            return Ok(None);
+        }
+        Ok(Some(clip_chars(trimmed, CONTEXT_MAX_CHARS)))
+    }
+}
+
+impl ContextGenerator for HttpContextGenerator {
+    fn generate_batch(&self, document_text: &str, chunk_texts: &[&str]) -> Vec<Option<String>> {
+        if chunk_texts.is_empty() {
+            return Vec::new();
+        }
+        // Truncate the document once, share it across chunks.  Keeps
+        // per-chunk request size bounded regardless of doc length.
+        let doc_excerpt = clip_chars(document_text, self.config.doc_cap_bytes);
+
+        let concurrency = self.config.concurrency.min(chunk_texts.len()).max(1);
+        let out: Mutex<Vec<Option<String>>> = Mutex::new(vec![None; chunk_texts.len()]);
+        let next = AtomicUsize::new(0);
+
+        std::thread::scope(|s| {
+            for _ in 0..concurrency {
+                s.spawn(|| loop {
+                    let i = next.fetch_add(1, Ordering::SeqCst);
+                    if i >= chunk_texts.len() {
+                        return;
+                    }
+                    match self.generate_one(&doc_excerpt, chunk_texts[i]) {
+                        Ok(v) => {
+                            out.lock()[i] = v;
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                chunk_index = i,
+                                err = %e,
+                                "search-plugin: contextual chunking failed for chunk — leaving embed_input unchanged",
+                            );
+                            // out[i] already None
+                        }
+                    }
+                });
+            }
+        });
+
+        out.into_inner()
+    }
+}
+
+/// Truncate to at most `max` characters, on a char boundary.
+fn clip_chars(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        return s.to_string();
+    }
+    s.chars().take(max).collect()
+}
+
+/// Shared handle so the service builds the generator once and
+/// hands out `Arc` clones (matches [`crate::embedder::Embedder`]
+/// posture).
+pub type SharedContextGenerator = std::sync::Arc<dyn ContextGenerator>;
+
+/// Best-effort builder — reads the config from env, wraps it in a
+/// generator.  Returns `Ok(None)` when the kill-switch is OFF.
+pub fn build_default_generator() -> Result<Option<SharedContextGenerator>, ContextualError> {
+    let Some(cfg) = ContextualChunkingConfig::from_env()? else {
+        return Ok(None);
+    };
+    tracing::info!(
+        endpoint = %cfg.endpoint,
+        model = %cfg.model,
+        concurrency = cfg.concurrency,
+        "search-plugin: contextual chunking enabled (expensive: 1 LLM call per chunk)",
+    );
+    let generator = HttpContextGenerator::new(cfg)?;
+    Ok(Some(std::sync::Arc::new(generator)))
+}
+
+/// Apply context prefixes to chunks in-place.  Called by
+/// `index_one` / `do_index_documents` right AFTER
+/// `chunk_document(text)` and BEFORE the embedder runs.
+///
+/// Prepends `<context>\n\n` to each chunk's `embed_input`; leaves
+/// `chunk.text` (which drives BM25) UNCHANGED — this is the whole
+/// point of the split-input design in `chunker::Chunk`.
+///
+/// Chunks whose generator returned `None` pass through untouched
+/// (graceful degradation).
+pub fn apply_contexts(
+    generator: &dyn ContextGenerator,
+    document_text: &str,
+    chunks: &mut [crate::chunker::Chunk],
+) {
+    if chunks.is_empty() {
+        return;
+    }
+    let chunk_texts: Vec<&str> = chunks.iter().map(|c| c.text.as_str()).collect();
+    let contexts = generator.generate_batch(document_text, &chunk_texts);
+    for (chunk, maybe_ctx) in chunks.iter_mut().zip(contexts) {
+        if let Some(ctx) = maybe_ctx {
+            let new_input = format!("{ctx}\n\n{}", chunk.embed_input);
+            chunk.embed_input = new_input;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn lookup(pairs: &[(&str, &str)]) -> impl Fn(&str) -> Option<String> {
+        let owned: Vec<(String, String)> = pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect();
+        move |k| {
+            owned
+                .iter()
+                .find(|(key, _)| key == k)
+                .map(|(_, v)| v.clone())
+        }
+    }
+
+    #[test]
+    fn config_disabled_by_default() {
+        assert!(ContextualChunkingConfig::from_lookup(lookup(&[]))
+            .unwrap()
+            .is_none());
+        assert!(ContextualChunkingConfig::from_lookup(lookup(&[(
+            CONTEXTUAL_ENABLED_ENV,
+            "false"
+        )]))
+        .unwrap()
+        .is_none());
+    }
+
+    #[test]
+    fn config_enabled_but_missing_pieces_errors_loud() {
+        for (missing_key, present) in [
+            (
+                CONTEXTUAL_ENDPOINT_ENV,
+                vec![CONTEXTUAL_MODEL_ENV, CONTEXTUAL_API_KEY_ENV],
+            ),
+            (
+                CONTEXTUAL_MODEL_ENV,
+                vec![CONTEXTUAL_ENDPOINT_ENV, CONTEXTUAL_API_KEY_ENV],
+            ),
+            (
+                CONTEXTUAL_API_KEY_ENV,
+                vec![CONTEXTUAL_ENDPOINT_ENV, CONTEXTUAL_MODEL_ENV],
+            ),
+        ] {
+            let mut pairs = vec![(CONTEXTUAL_ENABLED_ENV, "true")];
+            for k in present {
+                pairs.push((k, "x"));
+            }
+            let err = ContextualChunkingConfig::from_lookup(lookup(&pairs)).unwrap_err();
+            assert!(
+                matches!(err, ContextualError::Misconfigured(ref m) if m.contains(missing_key)),
+                "missing {missing_key}: {err:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn config_full_set_parses_and_applies_defaults() {
+        let cfg = ContextualChunkingConfig::from_lookup(lookup(&[
+            (CONTEXTUAL_ENABLED_ENV, "true"),
+            (
+                CONTEXTUAL_ENDPOINT_ENV,
+                "http://localhost:9/v1/chat/completions",
+            ),
+            (CONTEXTUAL_MODEL_ENV, "claude-3-haiku"),
+            (CONTEXTUAL_API_KEY_ENV, "sk-test"),
+        ]))
+        .unwrap()
+        .expect("config present");
+        assert_eq!(cfg.model, "claude-3-haiku");
+        assert_eq!(cfg.timeout, Duration::from_millis(DEFAULT_TIMEOUT_MS));
+        assert_eq!(cfg.concurrency, DEFAULT_CONCURRENCY);
+        assert_eq!(cfg.doc_cap_bytes, DEFAULT_DOC_CAP_BYTES);
+    }
+
+    #[test]
+    fn config_clamps_concurrency_to_hard_ceiling() {
+        let cfg = ContextualChunkingConfig::from_lookup(lookup(&[
+            (CONTEXTUAL_ENABLED_ENV, "true"),
+            (CONTEXTUAL_ENDPOINT_ENV, "http://x/v1/chat/completions"),
+            (CONTEXTUAL_MODEL_ENV, "m"),
+            (CONTEXTUAL_API_KEY_ENV, "sk-x"),
+            (CONTEXTUAL_CONCURRENCY_ENV, "999"),
+        ]))
+        .unwrap()
+        .expect("config present");
+        assert_eq!(cfg.concurrency, HARD_MAX_CONCURRENCY);
+    }
+
+    #[test]
+    fn config_rejects_bad_numeric_env() {
+        for bad_key in [
+            CONTEXTUAL_TIMEOUT_MS_ENV,
+            CONTEXTUAL_CONCURRENCY_ENV,
+            CONTEXTUAL_DOC_CAP_ENV,
+        ] {
+            let err = ContextualChunkingConfig::from_lookup(lookup(&[
+                (CONTEXTUAL_ENABLED_ENV, "true"),
+                (CONTEXTUAL_ENDPOINT_ENV, "http://x/v1/chat/completions"),
+                (CONTEXTUAL_MODEL_ENV, "m"),
+                (CONTEXTUAL_API_KEY_ENV, "sk-x"),
+                (bad_key, "not-a-number"),
+            ]))
+            .unwrap_err();
+            assert!(
+                matches!(err, ContextualError::Misconfigured(ref m) if m.contains(bad_key)),
+                "bad {bad_key}: {err:?}",
+            );
+        }
+    }
+
+    // ── apply_contexts + MockContextGenerator ────────────────────
+
+    struct MockContextGenerator {
+        prefixes: Vec<Option<String>>,
+    }
+
+    impl ContextGenerator for MockContextGenerator {
+        fn generate_batch(&self, _doc: &str, chunks: &[&str]) -> Vec<Option<String>> {
+            // Pad / truncate the canned list to match the caller's
+            // chunk count so a mock configured with N prefixes can
+            // drive a document of any size.
+            let mut out = self.prefixes.clone();
+            out.resize(chunks.len(), None);
+            out
+        }
+    }
+
+    fn make_chunks(pairs: &[(&str, &str)]) -> Vec<crate::chunker::Chunk> {
+        pairs
+            .iter()
+            .enumerate()
+            .map(|(i, (text, embed))| crate::chunker::Chunk {
+                chunk_index: i as u32,
+                text: (*text).to_string(),
+                embed_input: (*embed).to_string(),
+            })
+            .collect()
+    }
+
+    #[test]
+    fn apply_contexts_prepends_to_embed_input_only() {
+        let mut chunks = make_chunks(&[
+            ("body A", "heading A > body A"),
+            ("body B", "heading B > body B"),
+        ]);
+        let gen = MockContextGenerator {
+            prefixes: vec![Some("ctx-A".into()), Some("ctx-B".into())],
+        };
+        apply_contexts(&gen, "the whole document", &mut chunks);
+
+        // text UNCHANGED.
+        assert_eq!(chunks[0].text, "body A");
+        assert_eq!(chunks[1].text, "body B");
+        // embed_input PREPENDED with the context prefix + a blank line.
+        assert_eq!(chunks[0].embed_input, "ctx-A\n\nheading A > body A");
+        assert_eq!(chunks[1].embed_input, "ctx-B\n\nheading B > body B");
+    }
+
+    #[test]
+    fn apply_contexts_leaves_none_slots_unchanged() {
+        let mut chunks = make_chunks(&[
+            ("body A", "embed A"),
+            ("body B", "embed B"),
+            ("body C", "embed C"),
+        ]);
+        let gen = MockContextGenerator {
+            prefixes: vec![Some("ctx-A".into()), None, Some("ctx-C".into())],
+        };
+        apply_contexts(&gen, "doc", &mut chunks);
+
+        assert_eq!(chunks[0].embed_input, "ctx-A\n\nembed A");
+        // None -> chunk B unchanged.
+        assert_eq!(chunks[1].embed_input, "embed B");
+        assert_eq!(chunks[2].embed_input, "ctx-C\n\nembed C");
+    }
+
+    #[test]
+    fn apply_contexts_no_op_on_empty_chunks() {
+        let mut chunks: Vec<crate::chunker::Chunk> = Vec::new();
+        let gen = MockContextGenerator { prefixes: vec![] };
+        apply_contexts(&gen, "doc", &mut chunks);
+        assert!(chunks.is_empty());
+    }
+
+    // ── HttpContextGenerator over one-shot server ───────────────
+
+    fn spawn_one_shot_http(
+        status_line: &'static str,
+        body: String,
+    ) -> (std::net::SocketAddr, std::thread::JoinHandle<String>) {
+        use std::io::{Read, Write};
+
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let handle = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut buf = Vec::new();
+            let mut tmp = [0u8; 4096];
+            let header_end = loop {
+                let n = stream.read(&mut tmp).unwrap();
+                assert!(n > 0, "client closed before end of headers");
+                buf.extend_from_slice(&tmp[..n]);
+                if let Some(pos) = buf.windows(4).position(|w| w == b"\r\n\r\n") {
+                    break pos + 4;
+                }
+            };
+            let headers = String::from_utf8_lossy(&buf[..header_end]).to_string();
+            let content_length = headers
+                .lines()
+                .find_map(|l| {
+                    let (k, v) = l.split_once(':')?;
+                    k.eq_ignore_ascii_case("content-length")
+                        .then(|| v.trim().parse::<usize>().ok())
+                        .flatten()
+                })
+                .unwrap_or(0);
+            while buf.len() < header_end + content_length {
+                let n = stream.read(&mut tmp).unwrap();
+                assert!(n > 0, "client closed mid-body");
+                buf.extend_from_slice(&tmp[..n]);
+            }
+            let request = String::from_utf8_lossy(&buf).to_string();
+            let resp = format!(
+                "HTTP/1.1 {status_line}\r\nContent-Type: application/json\r\n\
+                 Content-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len(),
+            );
+            stream.write_all(resp.as_bytes()).unwrap();
+            request
+        });
+        (addr, handle)
+    }
+
+    fn test_config(endpoint: String) -> ContextualChunkingConfig {
+        ContextualChunkingConfig {
+            endpoint,
+            model: "test-model".to_string(),
+            api_key: "sk-test".to_string(),
+            timeout: Duration::from_secs(5),
+            concurrency: 1,
+            doc_cap_bytes: 4096,
+        }
+    }
+
+    #[test]
+    fn http_generator_parses_prefix_from_choices() {
+        let body = serde_json::json!({
+            "choices": [{
+                "message": {"content": "This chunk describes X in section Y."}
+            }]
+        })
+        .to_string();
+        let (addr, handle) = spawn_one_shot_http("200 OK", body);
+        let gen =
+            HttpContextGenerator::new(test_config(format!("http://{addr}/v1/chat/completions")))
+                .unwrap();
+
+        let out = gen.generate_batch("full doc", &["chunk text"]);
+        assert_eq!(
+            out,
+            vec![Some("This chunk describes X in section Y.".to_string())]
+        );
+        let request = handle.join().unwrap().to_lowercase();
+        assert!(request.contains("authorization: bearer sk-test"));
+    }
+
+    #[test]
+    fn http_generator_empty_content_returns_none_slot() {
+        // 200 OK but empty content — treat as "no useful prefix" and
+        // pass through; do NOT surface as an error.
+        let body = serde_json::json!({
+            "choices": [{"message": {"content": "  "}}]
+        })
+        .to_string();
+        let (addr, _) = spawn_one_shot_http("200 OK", body);
+        let gen =
+            HttpContextGenerator::new(test_config(format!("http://{addr}/v1/chat/completions")))
+                .unwrap();
+        let out = gen.generate_batch("doc", &["chunk"]);
+        assert_eq!(out, vec![None]);
+    }
+
+    #[test]
+    fn http_generator_non_2xx_returns_none_slot() {
+        let (addr, _) = spawn_one_shot_http("500 Internal Server Error", "boom".to_string());
+        let gen =
+            HttpContextGenerator::new(test_config(format!("http://{addr}/v1/chat/completions")))
+                .unwrap();
+        // The generate_batch wrapper converts the internal error to
+        // a None slot + a warning log — indexing must NEVER be
+        // stalled by a broken LLM endpoint.
+        let out = gen.generate_batch("doc", &["chunk"]);
+        assert_eq!(out, vec![None]);
+    }
+
+    #[test]
+    fn http_generator_empty_chunk_list_returns_empty() {
+        let gen =
+            HttpContextGenerator::new(test_config("http://127.0.0.1:1/v1/chat/completions".into()))
+                .unwrap();
+        assert!(gen.generate_batch("doc", &[]).is_empty());
+    }
+
+    #[test]
+    fn clip_chars_stays_on_char_boundary() {
+        // Multi-byte chars — clip_chars must never split them.
+        let s = "αβγδε".repeat(200);
+        let clipped = clip_chars(&s, 50);
+        assert_eq!(clipped.chars().count(), 50);
+        // Round-trips as valid UTF-8 (implicit — String is always UTF-8).
+        assert!(std::str::from_utf8(clipped.as_bytes()).is_ok());
+    }
+}

--- a/rust/services/search-plugin/src/lib.rs
+++ b/rust/services/search-plugin/src/lib.rs
@@ -54,6 +54,7 @@ pub mod search_proto {
 
 pub mod ann_index;
 pub mod chunker;
+pub mod contextual_chunker;
 pub mod embed_cache;
 pub mod embedder;
 pub mod federation;

--- a/rust/services/search-plugin/src/service.rs
+++ b/rust/services/search-plugin/src/service.rs
@@ -17,6 +17,9 @@ use parking_lot::Mutex;
 use tonic::{async_trait, Request, Response, Status};
 
 use crate::ann_index::AnnHit;
+use crate::contextual_chunker::{
+    build_default_generator, ContextGenerator, SharedContextGenerator,
+};
 use crate::embed_cache::{embed_query_cached, QueryEmbedCache};
 use crate::embedder::{build_default_embedder, EmbedError, Embedder};
 use crate::federation::{build_default_dispatcher, merge_ranked, SharedFederationDispatcher};
@@ -199,6 +202,14 @@ pub struct SearchServiceImpl {
     /// the trait `query` handler kicks a peer fan-out concurrent with
     /// the local pipeline and fuses the union.
     federation: Option<SharedFederationDispatcher>,
+    /// Contextual chunking generator (Feature 3 of the plugin-
+    /// migration plan).  `None` when `NEXUS_SEARCH_CONTEXTUAL_
+    /// CHUNKING` is off — indexing runs at zero extra cost.  When
+    /// present, `chunk_document(text)` is followed by an LLM round-
+    /// trip per chunk that yields a short context prefix; the prefix
+    /// is prepended to `Chunk::embed_input` (not `Chunk::text`) so
+    /// semantic recall lifts without polluting BM25.
+    context_generator: Option<SharedContextGenerator>,
 }
 
 /// Bundle used by the query wrapper — the live expander plus the
@@ -258,6 +269,8 @@ impl SearchServiceImpl {
             expander: None,
             federation: None,
             federation_from_env: true,
+            context_generator: None,
+            context_from_env: true,
         }
     }
 
@@ -549,6 +562,12 @@ pub struct SearchServiceBuilder {
     /// to `false` via [`SearchServiceBuilder::no_federation`] so the
     /// process env can't leak in and race a test's expectations.
     federation_from_env: bool,
+    context_generator: Option<SharedContextGenerator>,
+    /// Whether an unset `.context_generator()` should fall back to
+    /// [`build_default_generator`] (env-driven).  Tests default this
+    /// to `false` via [`SearchServiceBuilder::no_context_generator`]
+    /// so process env can't leak into a test's expectations.
+    context_from_env: bool,
 }
 
 impl SearchServiceBuilder {
@@ -620,6 +639,25 @@ impl SearchServiceBuilder {
         self
     }
 
+    /// Inject a pre-built context generator — tests hand in a mock
+    /// [`crate::contextual_chunker::ContextGenerator`] so the wrapper
+    /// doesn't need env parsing.
+    pub fn context_generator(mut self, generator: SharedContextGenerator) -> Self {
+        self.context_generator = Some(generator);
+        self.context_from_env = false;
+        self
+    }
+
+    /// Disable env-driven contextual-chunking resolution.  Tests that
+    /// leave `.context_generator()` unset must call this so a stray
+    /// `NEXUS_SEARCH_CONTEXTUAL_CHUNKING=true` in the host env can't
+    /// leak into the built service.
+    pub fn no_context_generator(mut self) -> Self {
+        self.context_generator = None;
+        self.context_from_env = false;
+        self
+    }
+
     pub fn build(self) -> SearchServiceImpl {
         // Pre-populate the OnceLock when the builder seeded an
         // expander so tests never race the env-driven build.  A
@@ -647,6 +685,21 @@ impl SearchServiceBuilder {
                 }
             }
         });
+        let context_generator = self.context_generator.or_else(|| {
+            if !self.context_from_env {
+                return None;
+            }
+            match build_default_generator() {
+                Ok(v) => v,
+                Err(e) => {
+                    tracing::error!(
+                        err = %e,
+                        "search-plugin: contextual chunking misconfigured — disabling for this process",
+                    );
+                    None
+                }
+            }
+        });
         SearchServiceImpl {
             handle: self.handle,
             manager: self
@@ -664,6 +717,7 @@ impl SearchServiceBuilder {
             expander_slot: Arc::new(expander_slot),
             expansion_cache: Arc::new(ExpansionCache::new()),
             federation,
+            context_generator,
         }
     }
 }
@@ -1636,6 +1690,11 @@ struct IndexSinks<'a> {
     /// (safe to finalize) from "vectors exist but the ANN sink is
     /// unreachable" (keep a retry tombstone) — review R6.
     zone_has_ann: bool,
+    /// Feature 3 — optional contextual-chunking generator.  When
+    /// present, `chunk_document(text)` results are enriched via one
+    /// LLM call per chunk (bounded parallelism per doc) BEFORE they
+    /// hit the embedder.  `None` = plain chunk_document output.
+    context_generator: Option<&'a dyn ContextGenerator>,
 }
 
 /// Walk `root_path` and index every regular file.  Same walker Glob +
@@ -1657,6 +1716,7 @@ fn do_index(
     manager: &IndexManager,
     embedder: Option<&Arc<dyn Embedder>>,
     embed_broken: bool,
+    context_generator: Option<&dyn ContextGenerator>,
     root_path: &str,
     zone_id: &str,
     recursive: bool,
@@ -1716,6 +1776,7 @@ fn do_index(
         state: &state,
         embed_broken,
         zone_has_ann: zone_has_ann_dir(manager, zone_id),
+        context_generator,
     };
 
     let mut indexed: u32 = 0;
@@ -1911,11 +1972,21 @@ fn index_one(handle: &KernelHandle, sinks: &IndexSinks<'_>, vfs_path: &str) -> I
     // P4: chunk the file into semantically-coherent pieces.  The
     // chunker respects markdown-ish heading + code-fence structure
     // and keeps each chunk under the embedder's soft budget.
-    let chunks = crate::chunker::chunk_document(text);
+    let mut chunks = crate::chunker::chunk_document(text);
     if chunks.is_empty() {
         // Whitespace-only file — nothing to index; purge any prior
         // chunks + record per ANN reachability (review R6).
         return record_content_skip(handle, sinks, vfs_path);
+    }
+    // Feature 3 — contextual chunking.  Prepends an LLM-generated
+    // context prefix to every chunk's `embed_input` (leaving `text`
+    // alone so BM25 stays clean).  Only runs when
+    // NEXUS_SEARCH_CONTEXTUAL_CHUNKING=true wired a generator; per-
+    // chunk failures pass through silently (chunk keeps the plain
+    // `chunk_document` embed_input) — indexing must never stall
+    // because the LLM is down.
+    if let Some(gen) = sinks.context_generator {
+        crate::contextual_chunker::apply_contexts(gen, text, &mut chunks);
     }
 
     // FTS side: drop the file's old chunk set, add the fresh one.
@@ -2110,6 +2181,7 @@ fn do_refresh(
     manager: &IndexManager,
     embedder: Option<&Arc<dyn Embedder>>,
     embed_broken: bool,
+    context_generator: Option<&dyn ContextGenerator>,
     root_path: &str,
     zone_id: &str,
     recursive: bool,
@@ -2158,6 +2230,7 @@ fn do_refresh(
         state: &state,
         embed_broken,
         zone_has_ann: zone_has_ann_dir(manager, zone_id),
+        context_generator,
     };
 
     let mut counts = RefreshCounts::default();
@@ -2353,10 +2426,12 @@ fn do_refresh(
 /// the caller rather than sys_read.  Each doc's `zone_id` overrides
 /// the request-level default.  Groups by zone so we open each
 /// zone's FTS + ANN + IndexState once, not per doc.
+#[allow(clippy::too_many_arguments)]
 fn do_index_documents(
     manager: &IndexManager,
     embedder: Option<&Arc<dyn Embedder>>,
     embed_broken: bool,
+    context_generator: Option<&dyn ContextGenerator>,
     default_zone: &str,
     documents: Vec<crate::search_proto::DocumentInput>,
     cache: &crate::query_cache::SharedQueryCache,
@@ -2459,13 +2534,19 @@ fn do_index_documents(
                 total_skipped += 1;
                 continue;
             }
-            let chunks = crate::chunker::chunk_document(&doc.text);
+            let mut chunks = crate::chunker::chunk_document(&doc.text);
             if chunks.is_empty() {
                 if content_skip(&doc.path) {
                     zone_transient += 1;
                 }
                 total_skipped += 1;
                 continue;
+            }
+            // Feature 3 — contextual chunking (see index_one's twin
+            // insertion point).  Per-chunk LLM failure = None ⇒ that
+            // chunk keeps its plain embed_input.
+            if let Some(gen) = context_generator {
+                crate::contextual_chunker::apply_contexts(gen, &doc.text, &mut chunks);
             }
             // FTS: drop-old-then-add-new (mirrors do_index).
             fts.delete_all_chunks(&doc.path);
@@ -3253,6 +3334,7 @@ impl SearchService for SearchServiceImpl {
         // and re-runs Index.  This matches the "graceful degradation"
         // posture SemanticQuery uses.
         let (embedder, embed_broken) = self.indexing_embedder();
+        let context_generator = self.context_generator.clone();
         // Retain the zone id for post-outcome cache invalidation
         // (the closure below moves the owned copy into
         // spawn_blocking).
@@ -3264,6 +3346,7 @@ impl SearchService for SearchServiceImpl {
                 &manager,
                 embedder.as_ref(),
                 embed_broken,
+                context_generator.as_deref(),
                 &root,
                 &zone_id,
                 recursive,
@@ -3320,6 +3403,7 @@ impl SearchService for SearchServiceImpl {
         // embedder means ANN stays unchanged this Refresh; keyword
         // side still incrementally updates.
         let (embedder, embed_broken) = self.indexing_embedder();
+        let context_generator = self.context_generator.clone();
         let zone_for_invalidate = zone_id.clone();
         let outcome = tokio::task::spawn_blocking(move || {
             let _indexing = indexing; // held until the WORK ends, not the RPC
@@ -3328,6 +3412,7 @@ impl SearchService for SearchServiceImpl {
                 &manager,
                 embedder.as_ref(),
                 embed_broken,
+                context_generator.as_deref(),
                 &root,
                 &zone_id,
                 recursive,
@@ -3458,6 +3543,7 @@ impl SearchService for SearchServiceImpl {
         let default_zone = resolve_zone(&req.zone_id).to_string();
         let manager = Arc::clone(&self.manager);
         let (embedder, embed_broken) = self.indexing_embedder();
+        let context_generator = self.context_generator.clone();
         let cache = Arc::clone(&self.query_cache);
         let outcome = tokio::task::spawn_blocking(move || {
             let _indexing = indexing; // held until the WORK ends, not the RPC
@@ -3465,6 +3551,7 @@ impl SearchService for SearchServiceImpl {
                 &manager,
                 embedder.as_ref(),
                 embed_broken,
+                context_generator.as_deref(),
                 &default_zone,
                 req.documents,
                 &cache,

--- a/rust/services/search-plugin/tests/contextual_chunking_e2e.rs
+++ b/rust/services/search-plugin/tests/contextual_chunking_e2e.rs
@@ -1,0 +1,425 @@
+//! End-to-end integration test for LLM contextual chunking
+//! (Feature 3 of the "fold nexus-server search runtime into the
+//! plugin" migration).
+//!
+//! Drives the real `SearchServiceImpl::index_documents` RPC on a
+//! tempdir-rooted `IndexManager` with a mock embedder that captures
+//! the exact `embed_input` strings the embedder receives.  A mock
+//! `ContextGenerator` returns pre-programmed context prefixes; the
+//! test asserts that:
+//!
+//! - `chunk.text` (what BM25 sees) is UNCHANGED, and
+//! - `chunk.embed_input` (what the embedder sees) is PREFIXED with
+//!   the mock's context, exactly as `apply_contexts` claims.
+
+use std::ffi::c_void;
+use std::os::raw::c_char;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use nexus_plugin_abi::KernelHandle;
+use nexus_search_plugin::contextual_chunker::ContextGenerator;
+use nexus_search_plugin::embedder::{EmbedError, Embedder};
+use nexus_search_plugin::index_manager::IndexManager;
+use nexus_search_plugin::search_proto::search_service_server::SearchService;
+use nexus_search_plugin::search_proto::{
+    DocumentInput, IndexDocumentsRequest, LocateRequest, QueryRequest, QueryType,
+};
+use nexus_search_plugin::service::SearchServiceImpl;
+use tempfile::TempDir;
+use tonic::Request;
+
+// ── Poison KernelHandle — index_documents never calls sys_* ─────
+
+unsafe extern "C" fn poison_read(
+    _: *const c_void,
+    _: *const c_char,
+    _: *mut *mut u8,
+    _: *mut usize,
+) -> i32 {
+    -1
+}
+unsafe extern "C" fn poison_write(
+    _: *const c_void,
+    _: *const c_char,
+    _: *const u8,
+    _: usize,
+) -> i32 {
+    -1
+}
+unsafe extern "C" fn poison_stat(
+    _: *const c_void,
+    _: *const c_char,
+    _: *mut *mut u8,
+    _: *mut usize,
+) -> i32 {
+    -1
+}
+unsafe extern "C" fn poison_readdir(
+    _: *const c_void,
+    _: *const c_char,
+    _: *mut *mut u8,
+    _: *mut usize,
+) -> i32 {
+    -1
+}
+unsafe extern "C" fn poison_unlink(_: *const c_void, _: *const c_char) -> i32 {
+    -1
+}
+unsafe extern "C" fn poison_mkdir(_: *const c_void, _: *const c_char) -> i32 {
+    -1
+}
+unsafe extern "C" fn poison_rmdir(_: *const c_void, _: *const c_char) -> i32 {
+    -1
+}
+unsafe extern "C" fn poison_rename(_: *const c_void, _: *const c_char, _: *const c_char) -> i32 {
+    -1
+}
+unsafe extern "C" fn poison_stat_batch(
+    _: *const c_void,
+    _: *const c_char,
+    _: *mut *mut u8,
+    _: *mut usize,
+) -> i32 {
+    -1
+}
+
+fn poison_handle() -> KernelHandle {
+    KernelHandle {
+        sys_read: poison_read,
+        sys_write: poison_write,
+        sys_stat: poison_stat,
+        sys_readdir: poison_readdir,
+        sys_unlink: poison_unlink,
+        sys_mkdir: poison_mkdir,
+        sys_rmdir: poison_rmdir,
+        sys_rename: poison_rename,
+        sys_stat_batch: poison_stat_batch,
+        kernel_ptr: std::ptr::null(),
+    }
+}
+
+// ── Mock embedder that captures embed_input strings ─────────────
+//
+// The test's whole point is checking what the embedder RECEIVES —
+// so use a mock that stashes every input into a shared Vec and
+// returns fixed 4-dim vectors (matching the AnnIndex dim we pin
+// via `.dim()`).
+
+struct CapturingEmbedder {
+    captured: parking_lot::Mutex<Vec<String>>,
+}
+
+impl CapturingEmbedder {
+    fn new() -> Arc<Self> {
+        Arc::new(Self {
+            captured: parking_lot::Mutex::new(Vec::new()),
+        })
+    }
+
+    fn take_captured(&self) -> Vec<String> {
+        std::mem::take(&mut *self.captured.lock())
+    }
+}
+
+impl Embedder for CapturingEmbedder {
+    fn embed_batch(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>, EmbedError> {
+        let mut g = self.captured.lock();
+        for t in texts {
+            g.push((*t).to_string());
+        }
+        Ok(texts.iter().map(|_| vec![0.1_f32, 0.2, 0.3, 0.4]).collect())
+    }
+
+    fn dim(&self) -> usize {
+        4
+    }
+
+    fn tag(&self) -> &str {
+        "capturing-mock"
+    }
+}
+
+// ── Mock context generator with a call counter ──────────────────
+
+struct MockContextGenerator {
+    prefix_pattern: String,
+    calls: AtomicUsize,
+    fail_indices: Vec<usize>,
+}
+
+impl MockContextGenerator {
+    fn new(prefix_pattern: &str) -> Arc<Self> {
+        Arc::new(Self {
+            prefix_pattern: prefix_pattern.to_string(),
+            calls: AtomicUsize::new(0),
+            fail_indices: Vec::new(),
+        })
+    }
+
+    fn with_failures(prefix_pattern: &str, fail_indices: Vec<usize>) -> Arc<Self> {
+        Arc::new(Self {
+            prefix_pattern: prefix_pattern.to_string(),
+            calls: AtomicUsize::new(0),
+            fail_indices,
+        })
+    }
+
+    fn calls(&self) -> usize {
+        self.calls.load(Ordering::SeqCst)
+    }
+}
+
+impl ContextGenerator for MockContextGenerator {
+    fn generate_batch(&self, _doc: &str, chunks: &[&str]) -> Vec<Option<String>> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        chunks
+            .iter()
+            .enumerate()
+            .map(|(i, _)| {
+                if self.fail_indices.contains(&i) {
+                    None
+                } else {
+                    Some(format!("{}{i}", self.prefix_pattern))
+                }
+            })
+            .collect()
+    }
+}
+
+// ── Harness ─────────────────────────────────────────────────────
+
+struct Harness {
+    _dir: TempDir,
+    svc: SearchServiceImpl,
+    embedder: Arc<CapturingEmbedder>,
+    manager: Arc<IndexManager>,
+    generator: Arc<MockContextGenerator>,
+}
+
+impl Harness {
+    fn start(generator: Arc<MockContextGenerator>) -> Self {
+        let dir = TempDir::new().expect("tempdir");
+        let manager = Arc::new(IndexManager::with_root(dir.path().to_path_buf()));
+        let embedder = CapturingEmbedder::new();
+        let svc = SearchServiceImpl::builder(Arc::new(poison_handle()))
+            .manager(Arc::clone(&manager))
+            .embedder(embedder.clone() as Arc<dyn Embedder>)
+            .context_generator(generator.clone() as Arc<dyn ContextGenerator>)
+            .build();
+        Self {
+            _dir: dir,
+            svc,
+            embedder,
+            manager,
+            generator,
+        }
+    }
+
+    fn start_without_generator() -> Self {
+        let dir = TempDir::new().expect("tempdir");
+        let manager = Arc::new(IndexManager::with_root(dir.path().to_path_buf()));
+        let embedder = CapturingEmbedder::new();
+        let svc = SearchServiceImpl::builder(Arc::new(poison_handle()))
+            .manager(Arc::clone(&manager))
+            .embedder(embedder.clone() as Arc<dyn Embedder>)
+            .no_context_generator()
+            .build();
+        // Unused sentinel — no generator wired.
+        let generator = MockContextGenerator::new("unused-");
+        Self {
+            _dir: dir,
+            svc,
+            embedder,
+            manager,
+            generator,
+        }
+    }
+
+    async fn index_doc(&self, path: &str, text: &str) {
+        let resp = self
+            .svc
+            .index_documents(Request::new(IndexDocumentsRequest {
+                documents: vec![DocumentInput {
+                    path: path.to_string(),
+                    text: text.to_string(),
+                    mtime_ms: Some(1_700_000_000_000),
+                    zone_id: "root".to_string(),
+                }],
+                zone_id: "root".to_string(),
+                auth_token: String::new(),
+            }))
+            .await
+            .expect("index_documents")
+            .into_inner();
+        assert!(
+            resp.error.is_none(),
+            "index_documents error: {:?}",
+            resp.error
+        );
+        assert!(resp.indexed_count >= 1, "expected at least 1 indexed");
+    }
+}
+
+// ── Tests ───────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn contextual_prefix_lands_on_embed_input_not_chunk_text() {
+    // Index a single doc long enough to force multiple chunks — the
+    // chunker's CHUNK_TARGET_CHARS is 1600, so 4 × 500-char sections
+    // will typically produce ≥ 2 chunks.
+    let text = format!(
+        "# Section 1\n\n{}\n\n# Section 2\n\n{}\n\n# Section 3\n\n{}",
+        "α ".repeat(400),
+        "β ".repeat(400),
+        "γ ".repeat(400),
+    );
+
+    let gen = MockContextGenerator::new("CTX-");
+    let h = Harness::start(gen);
+    h.index_doc("/notes/big.md", &text).await;
+
+    // Every embedder input must start with our mock's "CTX-<i>\n\n"
+    // prefix — proof that apply_contexts landed BEFORE embed_batch.
+    let captured = h.embedder.take_captured();
+    assert!(!captured.is_empty(), "no embed inputs captured");
+    for input in &captured {
+        assert!(
+            input.starts_with("CTX-"),
+            "embed_input missing context prefix: {input:?}",
+        );
+        assert!(
+            input.contains("\n\n"),
+            "embed_input missing prefix separator: {input:?}",
+        );
+    }
+    assert!(h.generator.calls() >= 1, "generator was never called");
+
+    // Now check the OTHER half of the contract: chunk_text (what
+    // BM25 sees, what LocateResponse returns) must NOT carry the
+    // prefix.  Query for the mock prefix — it should return ZERO
+    // hits because it never entered the FTS index.
+    let resp = h
+        .svc
+        .query(Request::new(QueryRequest {
+            q: "CTX".to_string(),
+            zone_id: "root".to_string(),
+            limit: 10,
+            query_type: QueryType::Keyword as i32,
+            ..Default::default()
+        }))
+        .await
+        .expect("query")
+        .into_inner();
+    assert!(
+        resp.results.is_empty(),
+        "context prefix leaked into FTS index: {:?}",
+        resp.results.iter().map(|r| &r.path).collect::<Vec<_>>(),
+    );
+
+    // And Locate — confirms the doc actually landed with the
+    // expected chunk count (indirectly proves BM25 side wasn't
+    // corrupted by the context wrapper).
+    let loc = h
+        .svc
+        .locate(Request::new(LocateRequest {
+            path: "/notes/big.md".to_string(),
+            zone_id: "root".to_string(),
+            auth_token: String::new(),
+        }))
+        .await
+        .expect("locate")
+        .into_inner();
+    assert!(loc.indexed, "locate reports doc missing from FTS");
+    assert!(loc.chunk_count > 0, "locate reports zero chunks");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn no_generator_wired_is_a_transparent_pass_through() {
+    let text = format!("# Heading\n\n{}", "body content ".repeat(300));
+    let h = Harness::start_without_generator();
+    h.index_doc("/notes/nogen.md", &text).await;
+
+    let captured = h.embedder.take_captured();
+    assert!(!captured.is_empty(), "no embed inputs captured");
+    // Without a generator, chunker::Chunk::embed_input is the plain
+    // heading-prefixed text — no "CTX-" or any other mock prefix.
+    for input in &captured {
+        assert!(
+            !input.starts_with("CTX-"),
+            "generator ran despite .no_context_generator(): {input:?}",
+        );
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn per_chunk_generator_failure_leaves_that_chunk_unprefixed() {
+    // Long doc → multiple chunks.  Generator fails on chunk index 0
+    // (returns None); every other chunk gets prefixed.
+    let text = format!(
+        "# Section A\n\n{}\n\n# Section B\n\n{}\n\n# Section C\n\n{}",
+        "alpha ".repeat(400),
+        "beta ".repeat(400),
+        "gamma ".repeat(400),
+    );
+
+    let gen = MockContextGenerator::with_failures("OK-", vec![0]);
+    let h = Harness::start(gen);
+    h.index_doc("/notes/partial.md", &text).await;
+
+    let captured = h.embedder.take_captured();
+    assert!(
+        captured.len() >= 2,
+        "need at least 2 chunks; got {}",
+        captured.len()
+    );
+    // Chunk 0 must NOT start with OK- (generator returned None).
+    assert!(
+        !captured[0].starts_with("OK-"),
+        "chunk 0 was prefixed despite generator returning None: {:?}",
+        captured[0],
+    );
+    // Chunk 1+ MUST start with OK-.
+    for (i, input) in captured.iter().enumerate().skip(1) {
+        assert!(
+            input.starts_with("OK-"),
+            "chunk {i} missing prefix: {input:?}",
+        );
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn empty_document_never_calls_generator() {
+    // Whitespace-only docs skip chunking entirely, so the generator
+    // must not be called for them.
+    let gen = MockContextGenerator::new("EMPTY-");
+    let h = Harness::start(gen);
+    // index_documents accepts empty text but records it as skipped;
+    // the assertion inside `index_doc` on `indexed_count >= 1` would
+    // trip, so open-code this test.
+    let resp = h
+        .svc
+        .index_documents(Request::new(IndexDocumentsRequest {
+            documents: vec![DocumentInput {
+                path: "/empty.md".to_string(),
+                text: "  \n\n  ".to_string(),
+                mtime_ms: Some(1_700_000_000_000),
+                zone_id: "root".to_string(),
+            }],
+            zone_id: "root".to_string(),
+            auth_token: String::new(),
+        }))
+        .await
+        .expect("index_documents")
+        .into_inner();
+    assert_eq!(resp.indexed_count, 0);
+    assert_eq!(resp.skipped_count, 1);
+    assert_eq!(h.generator.calls(), 0, "generator called for empty doc");
+    // Sanity: no embed calls either.
+    assert!(
+        h.embedder.take_captured().is_empty(),
+        "embedder called for empty doc",
+    );
+    // Manager touch: opening the zone is fine.
+    let _idx = h.manager.get_or_open("root").expect("open");
+}


### PR DESCRIPTION
## Summary

**Feature 3 of 3** in the "fold nexus-server search runtime into the plugin" migration.  At index time, ask an LLM to produce a short "context prefix" per chunk that resolves pronouns and adds section context — then prepend the prefix to `Chunk::embed_input` (NOT `Chunk::text`) so semantic recall lifts on ambiguous queries without polluting BM25.

Third and final of the three plugin-side features.  Preceded by PR #4661 (query expansion) and PR #4662 (federation).  After the trio merges + soaks, a 4th PR deletes `contextual_chunking.py` + `federated_search.py` + `query_expansion.py` from `nexi-lab/nexus`.

## COST WARNING (please read before enabling)

Contextual chunking is the most expensive of the three LLM knobs: **one LLM call per chunk × N chunks per doc × M docs indexed**.  A 10 k-doc corpus at 10 chunks each is 100 k LLM calls.  Ship with:

- Kill-switch **DEFAULT OFF** — must be explicitly enabled via `NEXUS_SEARCH_CONTEXTUAL_CHUNKING=true`.
- Model env is **SEPARATE** from query expansion's — operators point contextual chunking at a **cheap fast model** (Haiku, gpt-4o-mini) and reserve strong models for query expansion.
- Bounded intra-doc parallelism via `std::thread::scope` (default 4, `NEXUS_SEARCH_CONTEXTUAL_CONCURRENCY` overrides).
- Doc-cap byte limit on what's sent as context alongside each chunk (default 8 KB, `NEXUS_SEARCH_CONTEXTUAL_DOC_CAP_BYTES`).

## Design points

- **The core trick — `Chunk::text` stays clean.**  BM25 corpus is unchanged; only `embed_input` (what the embedder sees) gets the prefix.  Recall lifts on semantic/hybrid queries; keyword queries are byte-identical to a run without contextual chunking.
- **Sync API** (`ContextGenerator: Send + Sync`) driven by `reqwest::blocking` — every call site already runs inside `spawn_blocking`.  Bounded parallelism is `std::thread::scope`, no async runtime bridging inside the sync body.
- **Per-chunk failure = None** for that slot; chunk stays unprefixed (graceful degradation).  A broken LLM endpoint MUST NEVER stall indexing or drop chunks.
- **Wired into all three indexing paths**: `do_index`, `do_refresh`, `do_index_documents`.  IndexSinks gains `context_generator: Option<&dyn ContextGenerator>`; the seam call `apply_contexts(gen, text, &mut chunks)` is inserted right after `chunk_document()`.

## Files

- `src/contextual_chunker.rs` — module (13 unit tests, HTTP mock covers happy path + 2xx-empty + non-2xx + empty-batch)
- `src/service.rs` — thread the generator through IndexSinks + all three do_* fns + builder + `.no_context_generator()` test opt-out
- `src/lib.rs` — register module
- `tests/contextual_chunking_e2e.rs` — 4 E2E tests via real `SearchServiceImpl::index_documents` RPC with a capturing embedder mock + canned generator mock

## Test plan

- [x] `cargo test -p nexus-search-plugin --lib contextual_chunker` — 13/13 green
- [x] `cargo test -p nexus-search-plugin --test contextual_chunking_e2e` — 4/4 green
- [x] Full lib suite 198/198 green
- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy` on new files — clean (2 pre-existing warnings in service.rs unrelated)
- [ ] CI green