### PR TITLE
chore(hub): register nexus_hub_status in tool_profiles + surface coverage

### DIFF
--- a/docs/surface-coverage/api-rpc-surface-coverage.yaml
+++ b/docs/surface-coverage/api-rpc-surface-coverage.yaml
@@ -4920,6 +4920,23 @@ operations:
   perf_link: null
   gap_issue: 4205
   owning_issue: 4138
+- id: hub.status
+  module: hub
+  summary: Read hub health via the MCP admin surface; sandbox federation control plane.
+  transports:
+    mcp:
+      name: nexus_hub_status
+      source: src/nexus/config/tool_profiles.yaml:1
+  profiles:
+    lite: supported
+    sandbox: supported
+    full: supported
+  usage_example: 'MCP: tools/call nexus_hub_status {}; CLI: nexus hub status'
+  correctness_test: tests/unit/cli/test_hub_remote.py::test_remote_status_calls_mcp_tool_and_renders_json
+  perf_class: control
+  perf_link: admin/control-plane status check; not on a query hot path
+  gap_issue: null
+  owning_issue: 4130
 - id: identity.brick
   module: identity
   summary: ''
@@ -11482,6 +11499,14 @@ parity_warnings:
   - grpc_typed
   - http
   - mcp
+  - sdk
+- operation_id: hub.status
+  has:
+  - mcp
+  missing:
+  - cli
+  - grpc_typed
+  - http
   - sdk
 - operation_id: identity.cli
   has:

--- a/src/nexus/config/tool_profiles.yaml
+++ b/src/nexus/config/tool_profiles.yaml
@@ -60,5 +60,6 @@ profiles:
       - nexus_discovery_get_tool_details
       - nexus_discovery_load_tools
       - nexus_hub_admin
+      - nexus_hub_status
 
 default_profile: minimal

--- a/tests/surface_coverage/test_inventory.py
+++ b/tests/surface_coverage/test_inventory.py
@@ -69,7 +69,7 @@ def test_freshness(tmp_path: Path, existing_coverage):
         "Then commit the updated YAML."
     )
     if COVERAGE_HTML.exists():
-        assert render_html(fresh) == COVERAGE_HTML.read_text(), (
+        assert render_html(fresh) == COVERAGE_HTML.read_text(encoding="utf-8"), (
             "api-rpc-surface-coverage drift: committed HTML differs from regenerated YAML.\n"
             "Run: uv run python scripts/render_api_surface_coverage.py\n"
             "The local HTML is generated and should not be committed."
@@ -82,7 +82,7 @@ def test_render_determinism(existing_coverage):
     if not COVERAGE_HTML.exists():
         pytest.skip("no coverage HTML committed yet")
     rendered = render_html(existing_coverage)
-    committed = COVERAGE_HTML.read_text()
+    committed = COVERAGE_HTML.read_text(encoding="utf-8")
     assert rendered == committed, (
         "api-rpc-surface-coverage drift: committed HTML differs from re-render.\n"
         "Run: uv run python scripts/render_api_surface_coverage.py\n"

--- a/tests/unit/bricks/mcp/test_tool_profiles.py
+++ b/tests/unit/bricks/mcp/test_tool_profiles.py
@@ -464,6 +464,7 @@ class TestDefaultConfigValidity:
                 "nexus_glob",
                 "nexus_grep",
                 "nexus_hub_admin",
+                "nexus_hub_status",
                 "nexus_list_files",
                 "nexus_list_workflows",
                 "nexus_mkdir",


### PR DESCRIPTION
Two-part fix for a pre-existing test failure that PR #4666's audit surfaced but couldn't fix cleanly (needed a tool_profiles.yaml change plus a coverage-YAML regen, both in this PR).

## Motivation

nexus_hub_status has been a registered MCP tool for a while (src/nexus/bricks/mcp/server.py:596), but wasn't listed in src/nexus/config/tool_profiles.yaml. Consequences:
- Surface-coverage extractor didn't detect it → no hub.status row in the YAML
- tests/surface_coverage/test_issue_4130_sandbox_federation_surface.py asserts hub.status must be in the ops set → pre-existing failure
- Any deployment tier reading tool_profiles.yaml's allowlist had the tool hidden

## Changes

- src/nexus/config/tool_profiles.yaml: add nexus_hub_status to 'full' profile alongside nexus_hub_admin
- docs/surface-coverage/api-rpc-surface-coverage.yaml: regenerated with new tool visible; filled in summary/usage_example/correctness_test at tests/unit/cli/test_hub_remote.py/perf_class/perf_link/owning_issue=4130
- tests/surface_coverage/test_inventory.py: fix two read_text() calls missing encoding='utf-8' (Windows CN locale would gbk-decode-fail)

## Test results

- test_issue_4130_sandbox_federation_surface.py: 4/4 (was 1 failing pre-existing)
- test_inventory.py::test_freshness: passes locally

## Scope note

Other pre-existing surface-coverage failures (test_issue_4131, test_issue_4136) are unrelated stale-row gaps in mcp.tool_profile_* / delete.file rows; separate cleanup.