### PR TITLE
perf(search-plugin): shard peer-fanout channel cache with DashMap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3028,6 +3028,7 @@ version = "0.1.0"
 dependencies = [
  "anndists",
  "bytes",
+ "dashmap",
  "fastembed",
  "futures-util",
  "globset",

--- a/rust/services/search-plugin/Cargo.toml
+++ b/rust/services/search-plugin/Cargo.toml
@@ -133,6 +133,15 @@ reqwest = { version = "0.13", default-features = false, features = [
 # so contention is negligible, and parking_lot avoids poisoning.
 parking_lot = "0.12"
 
+# Sharded concurrent hashmap for the peer-fanout dispatcher's
+# per-peer Channel cache.  Same 6.1 pin the sibling `rust/services`
+# crate uses (see rust/services/Cargo.toml).  The old
+# `Mutex<HashMap>` shape serialised every peer's channel lookup on
+# one lock — fine at ≤10 peers, painful past that; DashMap's shard-
+# per-bucket lets independent peers dial concurrently without ever
+# contending.
+dashmap = "6.1"
+
 # Ergonomic error enums for the fts_index module.
 thiserror = "1"
 

--- a/rust/services/search-plugin/src/ann_index.rs
+++ b/rust/services/search-plugin/src/ann_index.rs
@@ -672,7 +672,7 @@ mod tests {
         let dir = tempdir().join("ann");
         let idx = AnnIndex::open_or_create(dir, 4).expect("open");
         let err = idx
-            .add_vector("/x", 0, &vec![0.0; 4])
+            .add_vector("/x", 0, &[0.0; 4])
             .expect_err("must reject zero vec");
         assert!(
             matches!(err, AnnError::ZeroVector(_)),

--- a/rust/services/search-plugin/src/contextual_chunker.rs
+++ b/rust/services/search-plugin/src/contextual_chunker.rs
@@ -745,9 +745,9 @@ mod tests {
 
         assert_eq!(chunks[0].embed_input, "OK-0\n\nembed 0");
         assert_eq!(chunks[1].embed_input, "OK-1\n\nembed 1");
-        for i in 2..5 {
+        for (i, chunk) in chunks.iter().enumerate().take(5).skip(2) {
             assert_eq!(
-                chunks[i].embed_input,
+                chunk.embed_input,
                 format!("embed {i}"),
                 "chunk {i} past the cap should be untouched"
             );

--- a/rust/services/search-plugin/src/peer_fanout.rs
+++ b/rust/services/search-plugin/src/peer_fanout.rs
@@ -36,11 +36,10 @@
 //! REFUSED unless `NEXUS_SEARCH_ALLOW_INSECURE_PEER=true` per the
 //! standing "refuse plaintext off-loopback" rule.
 
-use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
-use parking_lot::Mutex;
+use dashmap::DashMap;
 use tonic::transport::{Channel, ClientTlsConfig, Endpoint};
 
 use crate::peer_registry::{PeerAddress, PeerRegistry};
@@ -116,7 +115,15 @@ pub enum PeerFanoutError {
 /// channels) is lazy and cached.
 pub struct PeerFanoutDispatcher {
     registry: PeerRegistry,
-    channels: Mutex<HashMap<PeerAddress, Channel>>,
+    /// Per-peer cached `Channel`.  DashMap shards internally so
+    /// independent peers dial concurrently — the previous
+    /// `Mutex<HashMap>` serialised every lookup on one lock, which
+    /// caps parallelism at whichever peer wakes the sleeper first
+    /// and only starts to bite past ≤10 peers.  DashMap keeps the
+    /// lookup lock-free for readers and the write side sharded per
+    /// bucket, so a slow peer's dial no longer stalls a fast peer's
+    /// cache hit.
+    channels: DashMap<PeerAddress, Channel>,
 }
 
 impl PeerFanoutDispatcher {
@@ -124,7 +131,7 @@ impl PeerFanoutDispatcher {
     pub fn new(registry: PeerRegistry) -> Self {
         Self {
             registry,
-            channels: Mutex::new(HashMap::new()),
+            channels: DashMap::new(),
         }
     }
 
@@ -204,27 +211,25 @@ impl PeerFanoutDispatcher {
         out
     }
 
-    /// Lazy channel lookup — dial once per peer, reuse the Channel
-    /// forever.  Locking is coarse (a single Mutex around the whole
-    /// map) but the critical section is HashMap lookup + optional
-    /// build, both microsecond-scale; per-peer sharding is over-kill
-    /// at the current ≤10-peer scale.  TODO(perf): shard to a
-    /// DashMap or per-peer OnceLock if peer fleets grow beyond that.
+    /// Lazy channel lookup — dial once per peer, reuse the `Channel`
+    /// forever.  The cache is a [`DashMap`] so independent peer
+    /// lookups never contend, and the read-fast-path holds a per-
+    /// bucket shard lock for the length of a single hash + clone.
+    ///
+    /// Race note: two concurrent misses on the same peer can BOTH
+    /// dial before either publishes.  We accept the extra dial (it
+    /// is bounded by [`CONNECT_TIMEOUT`] and the winner just replaces
+    /// itself in the map) — using [`DashMap::entry`] to serialise
+    /// dials would hold a shard write-lock across an `.await`, which
+    /// would starve every other peer sharing that shard.  Redundant
+    /// dial → transient bandwidth; held lock across await → deadlock
+    /// risk for the sibling peers.  Trade the former.
     async fn get_or_dial(&self, peer: &PeerAddress) -> Result<Channel, PeerFanoutError> {
-        {
-            let g = self.channels.lock();
-            if let Some(c) = g.get(peer) {
-                return Ok(c.clone());
-            }
+        if let Some(c) = self.channels.get(peer) {
+            return Ok(c.clone());
         }
         let channel = self.dial(peer).await?;
-        let mut g = self.channels.lock();
-        // Race — another task may have dialled while we were awaiting.
-        if let Some(existing) = g.get(peer) {
-            return Ok(existing.clone());
-        }
-        g.insert(peer.clone(), channel.clone());
-        Ok(channel)
+        Ok(self.channels.entry(peer.clone()).or_insert(channel).clone())
     }
 
     /// Build a Channel to `peer`, gated by the TLS + loopback rules.

--- a/rust/services/search-plugin/src/service.rs
+++ b/rust/services/search-plugin/src/service.rs
@@ -2034,7 +2034,7 @@ fn index_one(handle: &KernelHandle, sinks: &IndexSinks<'_>, vfs_path: &str) -> I
     // mtime while the zone's OLD vectors stay live — when the
     // embedder returns, Refresh reads Unchanged forever and
     // semantic/hybrid ranking silently serves pre-edit vectors.
-    let mut ann_complete = !sinks.embed_broken && !(sinks.embedder.is_none() && sinks.zone_has_ann);
+    let mut ann_complete = !(sinks.embed_broken || sinks.embedder.is_none() && sinks.zone_has_ann);
     if let (Some(ann), Some(embedder)) = (sinks.ann, sinks.embedder) {
         let inputs: Vec<&str> = chunks.iter().map(|c| c.embed_input.as_str()).collect();
         match embedder.embed_batch(&inputs) {
@@ -2593,7 +2593,7 @@ fn do_index_documents(
             // forever-keyword-only doc; review R1).
             // Same completion invariant as index_one (review R7):
             // embedder absent + existing ann-* dirs ⇒ stay retryable.
-            let mut ann_complete = !embed_broken && !(embedder.is_none() && zone_has_ann);
+            let mut ann_complete = !(embed_broken || embedder.is_none() && zone_has_ann);
             if let (Some(ann), Some(emb)) = (ann.as_ref(), embedder) {
                 let inputs: Vec<&str> = chunks.iter().map(|c| c.embed_input.as_str()).collect();
                 match emb.embed_batch(&inputs) {

--- a/rust/services/search-plugin/tests/batch_query_e2e.rs
+++ b/rust/services/search-plugin/tests/batch_query_e2e.rs
@@ -330,6 +330,7 @@ impl<E: Embedder + 'static> Harness<E> {
         }
     }
 
+    #[allow(clippy::mut_from_ref)]
     fn mock_mut(&self) -> &mut MockKernel {
         unsafe { &mut *self.mock }
     }

--- a/rust/services/search-plugin/tests/index_e2e.rs
+++ b/rust/services/search-plugin/tests/index_e2e.rs
@@ -278,6 +278,7 @@ impl Harness {
         }
     }
 
+    #[allow(clippy::mut_from_ref)]
     fn mock_mut(&self) -> &mut MockKernel {
         // SAFETY: `self` owns the box; no other reference exists
         // (tests are single-threaded per-test).

--- a/rust/services/search-plugin/tests/semantic_query_e2e.rs
+++ b/rust/services/search-plugin/tests/semantic_query_e2e.rs
@@ -267,6 +267,7 @@ impl Harness {
         }
     }
 
+    #[allow(clippy::mut_from_ref)]
     fn mock_mut(&self) -> &mut MockKernel {
         unsafe { &mut *self.mock }
     }

--- a/rust/services/search-plugin/tests/title_arm_e2e.rs
+++ b/rust/services/search-plugin/tests/title_arm_e2e.rs
@@ -251,6 +251,7 @@ impl Harness {
         }
     }
 
+    #[allow(clippy::mut_from_ref)]
     fn mock_mut(&self) -> &mut MockKernel {
         unsafe { &mut *self.mock }
     }


### PR DESCRIPTION
## Summary

- Swap the peer-fanout dispatcher's `Mutex<HashMap<PeerAddress, Channel>>` for `DashMap<PeerAddress, Channel>` so independent peers dial and read concurrently instead of serialising on one lock. Was noted `TODO(perf)` at the current ≤10-peer scale; this closes it before the fleet grows.
- Fold the four rust-1.93 clippy tightenings that would otherwise trip `-D warnings` on `cargo clippy --workspace` (all pre-existing on develop, per `feedback_no_pre_existing_ci`).

## Design note

`DashMap::entry().or_insert()` publishes the dialled Channel atomically. Two racing misses on the same peer can both dial before either publishes; we accept the extra dial (bounded by `CONNECT_TIMEOUT`; winner just replaces itself) because holding a shard write-lock across `dial().await` would starve every sibling peer sharing that shard. Redundant dial → transient bandwidth; held lock across await → deadlock class. Trade the former.

No wire-format change, no proto change, no caller-visible behaviour change.

## Test plan

- [x] `cargo test -p nexus-search-plugin --test peer_fanout_e2e` — all 6 E2E scenarios green.
- [x] `cargo test -p nexus-search-plugin --lib ann_index::` — 13 tests green (touched by clippy sweep).
- [x] `cargo test -p nexus-search-plugin --lib contextual_chunker::` — 14 tests green (touched by clippy sweep).
- [x] `cargo clippy -p nexus-search-plugin --all-targets --no-deps -- -D warnings` — clean.
- [x] `cargo fmt -p nexus-search-plugin -- --check` — clean.