### PR TITLE
refactor(search): promote collect_plugin_documents off private surface

### DIFF
--- a/docs/surface-coverage/api-rpc-surface-coverage.yaml
+++ b/docs/surface-coverage/api-rpc-surface-coverage.yaml
@@ -3394,7 +3394,7 @@ operations:
       source: src/nexus/server/_kernel_syscall_dispatch.py:52
     grpc_expose:
       name: list
-      source: src/nexus/bricks/search/search_service.py:513
+      source: src/nexus/bricks/search/search_service.py:480
   profiles:
     lite: supported
     sandbox: supported
@@ -4583,7 +4583,7 @@ operations:
   transports:
     grpc_expose:
       name: glob_batch
-      source: src/nexus/bricks/search/search_service.py:2094
+      source: src/nexus/bricks/search/search_service.py:2061
   profiles:
     lite: supported
     sandbox: supported
@@ -4977,7 +4977,7 @@ operations:
   transports:
     grpc_expose:
       name: initialize_semantic_search
-      source: src/nexus/bricks/search/search_service.py:4975
+      source: src/nexus/bricks/search/search_service.py:4942
   profiles:
     lite: supported
     sandbox: supported
@@ -7695,7 +7695,7 @@ operations:
       source: src/nexus/cli/commands/search.py:1
     grpc_expose:
       name: glob
-      source: src/nexus/bricks/search/search_service.py:1841
+      source: src/nexus/bricks/search/search_service.py:1808
     http:
       name: POST /api/v2/search/glob
       source: src/nexus/server/api/v2/routers/search.py:1627
@@ -7722,7 +7722,7 @@ operations:
       source: src/nexus/cli/commands/search.py:1
     grpc_expose:
       name: grep
-      source: src/nexus/bricks/search/search_service.py:2151
+      source: src/nexus/bricks/search/search_service.py:2118
     http:
       name: POST /api/v2/search/grep
       source: src/nexus/server/api/v2/routers/search.py:1504
@@ -7916,7 +7916,7 @@ operations:
   transports:
     grpc_expose:
       name: semantic_search
-      source: src/nexus/bricks/search/search_service.py:4482
+      source: src/nexus/bricks/search/search_service.py:4449
     mcp:
       name: nexus_semantic_search
       source: src/nexus/config/tool_profiles.yaml:1
@@ -7937,7 +7937,7 @@ operations:
   transports:
     grpc_expose:
       name: semantic_search_index
-      source: src/nexus/bricks/search/search_service.py:4833
+      source: src/nexus/bricks/search/search_service.py:4800
   profiles:
     lite: supported
     sandbox: supported
@@ -7954,7 +7954,7 @@ operations:
   transports:
     grpc_expose:
       name: semantic_search_stats
-      source: src/nexus/bricks/search/search_service.py:4927
+      source: src/nexus/bricks/search/search_service.py:4894
   profiles:
     lite: supported
     sandbox: supported

--- a/src/nexus/bricks/search/indexing_service.py
+++ b/src/nexus/bricks/search/indexing_service.py
@@ -529,6 +529,58 @@ class IndexingService:
             content = await self._file_reader.read_text(path)
         return content
 
+    async def collect_plugin_documents(
+        self,
+        path: str,
+        recursive: bool,
+    ) -> list[dict[str, Any]]:
+        """Enumerate + read files under ``path`` and produce the
+        ``[{path, text}, ...]`` payload the plugin's ``IndexDocuments``
+        RPC (and ``SearchDaemon.index_documents`` shim) expects.
+
+        The plugin's cdylib sidecar runs against a DIFFERENT kernel VFS
+        than the Python nexus-server container — so cross-node
+        replication that lands files here doesn't automatically make
+        them readable by the plugin's walker.  Enumerate + read on THIS
+        side and POST the payload, so the plugin ingests documents
+        without ever having to resolve them through its own file
+        surface.
+
+        Filters the same binary-extension set the sandbox indexer
+        already filters; skips per-file read errors rather than failing
+        the whole seed (matches ``index_batch``'s per-file
+        try/except).  Non-recursive callers pass ``recursive=False``
+        and get exactly one ``{path, text}`` dict — the underlying
+        reader raises for missing/non-text paths, which callers already
+        treat as a fallback trigger.
+
+        Public because ``search_service._collect_docs_for_plugin`` used
+        to reach into ``_file_reader`` + ``_read_content`` directly (an
+        SLF001 leak); consolidating the read here also dedupes the
+        list-then-read loop shape with ``index_batch``.
+        """
+        if not recursive:
+            content = await self._read_content(path)
+            return [{"path": path, "text": content}]
+
+        files_result = await self._file_reader.list_files(path, recursive=True)
+        files = files_result.items if hasattr(files_result, "items") else files_result
+        docs: list[dict[str, Any]] = []
+        for entry in files:
+            file_path = (
+                entry if isinstance(entry, str) else entry.get("path") or entry.get("name", "")
+            )
+            if not file_path or file_path.endswith("/"):
+                continue
+            if file_path.endswith(_BINARY_EXTENSIONS):
+                continue
+            try:
+                content = await self._read_content(file_path)
+            except Exception:
+                continue
+            docs.append({"path": file_path, "text": content})
+        return docs
+
     @staticmethod
     def _query_file_model(
         session: Any,

--- a/src/nexus/bricks/search/search_service.py
+++ b/src/nexus/bricks/search/search_service.py
@@ -194,48 +194,15 @@ async def _collect_docs_for_plugin(
     path: str,
     recursive: bool,
 ) -> list[dict[str, Any]]:
-    """Enumerate + read files under ``path`` via the SANDBOX indexer's
-    file_reader, producing the ``[{path, text, ...}]`` payload the
-    plugin's ``IndexDocuments`` RPC (and ``SearchDaemon.index_documents``
-    shim) expects.
+    """Thin adapter around ``IndexingService.collect_plugin_documents``.
 
-    Reuses ``indexer._file_reader`` for enumeration + read because that
-    reader resolves paths via THIS container's kernel VFS — which does
-    contain the files, unlike the plugin sidecar's disjoint kernel.
-    Filters binaries the same way the sandbox indexer does.
-
-    Returns an empty list when nothing indexable is under ``path``;
-    callers short-circuit rather than sending an empty POST.
+    Kept as a module-level function so callers that hold an ``indexer``
+    reference don't need to know about the internal type; the actual
+    enumeration + read + binary-filter logic lives on the indexer per
+    issue #4130 review R6 (was reaching into private ``_file_reader`` +
+    ``_read_content`` here).
     """
-    from nexus.bricks.search.indexing_service import _BINARY_EXTENSIONS
-
-    reader = indexer._file_reader  # noqa: SLF001
-
-    if not recursive:
-        # Single-file caller — read directly; the underlying reader
-        # raises for a non-existent or non-text file, which the caller
-        # already handles as a fallback trigger.
-        content = await indexer._read_content(path)  # noqa: SLF001
-        return [{"path": path, "text": content}]
-
-    files_result = await reader.list_files(path, recursive=True)
-    files = files_result.items if hasattr(files_result, "items") else files_result
-
-    docs: list[dict[str, Any]] = []
-    for entry in files:
-        file_path = entry if isinstance(entry, str) else entry.get("path") or entry.get("name", "")
-        if not file_path or file_path.endswith("/"):
-            continue
-        if file_path.endswith(_BINARY_EXTENSIONS):
-            continue
-        try:
-            content = await indexer._read_content(file_path)  # noqa: SLF001
-        except Exception:
-            # Skip individually rather than failing the whole seed —
-            # matches the sandbox indexer's per-file try/except.
-            continue
-        docs.append({"path": file_path, "text": content})
-    return docs
+    return await indexer.collect_plugin_documents(path, recursive)
 
 
 class SearchService:

--- a/tests/integration/bricks/search/test_indexing_service.py
+++ b/tests/integration/bricks/search/test_indexing_service.py
@@ -786,3 +786,87 @@ class TestGetIndexStats:
         assert "embedding_provider" in stats
         assert "vector_db" in stats
         assert stats["vector_db"] == {"backend": "mock"}
+
+
+class TestCollectPluginDocuments:
+    """Issue #4130 R6: public replacement for the private-surface leak
+    ``search_service._collect_docs_for_plugin`` had against
+    ``_file_reader`` + ``_read_content``."""
+
+    @pytest.mark.asyncio
+    async def test_single_file_returns_one_doc(self) -> None:
+        service, _, _, _ = _build_service(
+            content="hello world",
+            searchable_text=None,
+        )
+
+        docs = await service.collect_plugin_documents("/a.md", recursive=False)
+
+        assert docs == [{"path": "/a.md", "text": "hello world"}]
+
+    @pytest.mark.asyncio
+    async def test_recursive_walks_and_reads_each_file(self) -> None:
+        service, _, _, reader = _build_service(
+            file_list=["/x/a.md", "/x/b.py", "/x/sub/c.txt"],
+            content="body",
+            searchable_text=None,
+        )
+
+        docs = await service.collect_plugin_documents("/x", recursive=True)
+
+        assert [d["path"] for d in docs] == ["/x/a.md", "/x/b.py", "/x/sub/c.txt"]
+        assert all(d["text"] == "body" for d in docs)
+
+    @pytest.mark.asyncio
+    async def test_recursive_skips_binary_extensions(self) -> None:
+        service, _, _, _ = _build_service(
+            file_list=["/x/a.md", "/x/blob.zip", "/x/img.png"],
+            content="body",
+        )
+
+        docs = await service.collect_plugin_documents("/x", recursive=True)
+
+        # Only the .md survives; .zip + .png filtered by _BINARY_EXTENSIONS.
+        assert [d["path"] for d in docs] == ["/x/a.md"]
+
+    @pytest.mark.asyncio
+    async def test_recursive_ignores_directory_entries(self) -> None:
+        service, _, _, _ = _build_service(
+            # Trailing slash marks a directory entry — must not be read.
+            file_list=["/x/a.md", "/x/sub/", ""],
+        )
+
+        docs = await service.collect_plugin_documents("/x", recursive=True)
+
+        assert [d["path"] for d in docs] == ["/x/a.md"]
+
+    @pytest.mark.asyncio
+    async def test_recursive_skips_per_file_read_errors(self) -> None:
+        service, _, _, reader = _build_service(
+            file_list=["/x/a.md", "/x/b.md", "/x/c.md"],
+        )
+
+        # First and third read succeed with "body"; middle raises.
+        reader.read_text = AsyncMock(
+            side_effect=["body", RuntimeError("io fail"), "body"],
+        )
+        reader.get_searchable_text.return_value = None
+
+        docs = await service.collect_plugin_documents("/x", recursive=True)
+
+        assert [d["path"] for d in docs] == ["/x/a.md", "/x/c.md"]
+
+    @pytest.mark.asyncio
+    async def test_recursive_accepts_dict_entries_from_reader(self) -> None:
+        # Some FileReader implementations return dicts (path/name);
+        # collect_plugin_documents must extract .path or .name — the
+        # same shape ``index_batch`` handles.
+        service, _, _, _ = _build_service(
+            file_list=[{"path": "/x/a.md"}, {"name": "/x/b.md"}],
+            content="body",
+            searchable_text=None,
+        )
+
+        docs = await service.collect_plugin_documents("/x", recursive=True)
+
+        assert sorted(d["path"] for d in docs) == ["/x/a.md", "/x/b.md"]

--- a/tests/unit/bricks/search/test_semantic_search_daemon_gate.py
+++ b/tests/unit/bricks/search/test_semantic_search_daemon_gate.py
@@ -130,20 +130,18 @@ class TestPluginShimGate:
         shim = _FakePluginShim(rows=[])
         svc = _make_service(shim)
 
-        # Fake SANDBOX indexer supplies the file_reader shim +
-        # _read_content coroutine that the plugin-arm re-uses for
-        # enumeration.  ``_indexing_service`` is a real attribute on
-        # SearchService, so wire it via setattr.
+        # Fake SANDBOX indexer supplies the public
+        # ``collect_plugin_documents`` coroutine the plugin-arm calls
+        # for enumeration.  ``_indexing_service`` is a real attribute
+        # on SearchService, so wire it via setattr.
         indexer = MagicMock()
-        indexer._file_reader = MagicMock()
-        indexer._file_reader.list_files = AsyncMock(
+        indexer.collect_plugin_documents = AsyncMock(
             return_value=[
-                {"path": "/w/a.md"},
-                {"path": "/w/b.md"},
-                {"path": "/w/skip.png"},  # binary — filtered
+                {"path": "/w/a.md", "text": "body-of-/w/a.md"},
+                {"path": "/w/b.md", "text": "body-of-/w/b.md"},
+                # Binary already filtered inside collect_plugin_documents.
             ]
         )
-        indexer._read_content = AsyncMock(side_effect=lambda p: f"body-of-{p}")
         svc._indexing_service = indexer  # noqa: SLF001
 
         result = await svc.semantic_search_index("/w", recursive=True)
@@ -168,9 +166,9 @@ class TestPluginShimGate:
         svc = _make_service(shim)
 
         indexer = MagicMock()
-        indexer._file_reader = MagicMock()
-        indexer._file_reader.list_files = AsyncMock(return_value=[{"path": "/w/a.md"}])
-        indexer._read_content = AsyncMock(return_value="body")
+        indexer.collect_plugin_documents = AsyncMock(
+            return_value=[{"path": "/w/a.md", "text": "body"}]
+        )
         # Wire index_directory too so the SANDBOX fallback can run and
         # produces a documented shape.
         indexer.index_directory = AsyncMock(return_value={})


### PR DESCRIPTION
## Summary

- Issue #4130 review R6: `search_service._collect_docs_for_plugin` was reaching into `indexer._file_reader` + `indexer._read_content` (two `# noqa: SLF001` leaks). Promote onto `IndexingService.collect_plugin_documents` as a public method; module-level shim collapses to a delegator.

## Test plan

- 33 pass (27 pre-existing + 6 new `TestCollectPluginDocuments`).
- 6 pass on retargeted `TestPluginShimGate`.
- ruff clean.
