### PR TITLE
feat(http-api): PoC skeleton crate for pure-Rust nexus-server migration (R10 step 0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3006,6 +3006,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "nexus-http-api"
+version = "0.1.0"
+dependencies = [
+ "axum",
+ "http-body-util",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tower",
+ "tracing",
+]
+
+[[package]]
 name = "nexus-local-connector"
 version = "0.1.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,11 @@ members = [
     # walk over `sys_readdir` + `sys_read` in v1, trigram / streaming
     # / adaptive-strategy variants land in v2.
     "rust/services/search-plugin",
+    # nexus-http-api — PoC axum HTTP router for the pure-Rust
+    # nexus-server replacement epic (#4674 R10).  v0 ships only
+    # `GET /v2/status` so the axum + JSON + test-harness pattern
+    # is proven before the search/documents/auth routes land.
+    "rust/services/http-api",
     # nexusd — the nexus cluster-profile daemon assembly binary
     # (`nexusd-cluster`). Composes the nexus-vfs cluster boot
     # (`nexus_cluster::run_with_services`) with the managed_agent control

--- a/rust/services/http-api/Cargo.toml
+++ b/rust/services/http-api/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "nexus-http-api"
+version = "0.1.0"
+edition = "2021"
+description = "PoC axum-based HTTP-API crate for the nexus-server → pure-Rust migration (epic #4674).  v0 ships a single /v2/status handler so the crate + axum plumbing pattern is proven end-to-end before the router surface grows."
+
+[lib]
+name = "nexus_http_api"
+crate-type = ["rlib"]
+
+[dependencies]
+# axum HTTP surface.  Feature set matches the sibling
+# `service-matrix-adapter` axum pin in rust/services/Cargo.toml
+# (0.8 + json/http1/tokio/matched-path/query) so both crates
+# share the same tower + hyper stack when linked into the same
+# binary.
+axum = { version = "0.8", default-features = false, features = ["json", "http1", "tokio", "matched-path", "query"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "signal", "time"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tower = { version = "0.5", features = ["util"] }
+tracing = "0.1"
+
+[dev-dependencies]
+# axum's own test helpers require reqwest + a live listener.  Using
+# `tower::ServiceExt::oneshot` keeps the smoke test in-process (no
+# port binding), which is what the router's contract needs pinned
+# anyway — the caller ↔ handler pathway, not the TCP layer.
+tower = { version = "0.5", features = ["util"] }
+http-body-util = "0.1"

--- a/rust/services/http-api/src/lib.rs
+++ b/rust/services/http-api/src/lib.rs
@@ -1,0 +1,117 @@
+//! `nexus-http-api` — axum-based HTTP-API surface for the pure-Rust
+//! `nexus-server` replacement (epic #4674 review R10).
+//!
+//! # Scope of v0
+//!
+//! This crate is a **PoC skeleton**.  It ships exactly ONE route
+//! (`GET /v2/status`) — the router + handler + JSON-serialisation +
+//! test-harness pattern is proven end-to-end before the full
+//! nexus-server surface (search, documents, auth) starts landing.
+//!
+//! Every future route lands as an additive [`axum::Router::merge`]
+//! against [`router`] — the router shape is the extension seam.
+//!
+//! # Why axum
+//!
+//! Axum shares the tower + hyper stack with the existing
+//! [`service-matrix-adapter`](../services/src/matrix_adapter.rs)
+//! surface, so both HTTP crates link into the same binary at a
+//! shared version pin (0.8) with no dep-tree churn.  The matrix
+//! adapter has already proven the "axum on top of kernel syscalls"
+//! pattern in production.
+//!
+//! # What v0 does NOT do
+//!
+//! * NO auth middleware — session cookie handling stays on the
+//!   nexus-server Python side until the auth port lands (part of
+//!   the same epic, but a separately-scoped step).
+//! * NO ReBAC filter — same story.
+//! * NO wiring into `nexusd-cluster` boot — that lives one crate
+//!   over (rust/nexusd) and needs the nexus-cluster team to
+//!   register the HTTP listener alongside the gRPC one.  This
+//!   crate is standalone-testable via `axum::serve` +
+//!   `tower::ServiceExt::oneshot` so PoC verification doesn't wait
+//!   on the wiring step.
+
+use axum::{routing::get, Json, Router};
+use serde::{Deserialize, Serialize};
+
+/// Response body of [`get_status`].  Kept small on purpose — the
+/// health-check surface should read cheap and always succeed unless
+/// the process itself is unhealthy.  `version` is compile-time from
+/// [`CARGO_PKG_VERSION`](env!("CARGO_PKG_VERSION")) so it doesn't
+/// need any runtime plumbing.  Owned `String` fields so
+/// deserialisation callers don't need a `'static` byte source.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct StatusResponse {
+    pub status: String,
+    pub version: String,
+}
+
+/// Version 0 status handler — the "does the axum stack run at all"
+/// smoke test.  Returns 200 with a fixed `{status: "ok", version:
+/// <crate version>}` payload.  Future health-check upgrades (raft
+/// leader status, plugin load state, DB connectivity) attach here.
+pub async fn get_status() -> Json<StatusResponse> {
+    Json(StatusResponse {
+        status: "ok".to_string(),
+        version: env!("CARGO_PKG_VERSION").to_string(),
+    })
+}
+
+/// Root [`Router`] carrying every v0 route.  Follow-up crates in
+/// the R10 epic (search, documents, auth) will `.merge()` their
+/// own routers onto this one; the assembly binary (rust/nexusd)
+/// calls [`router`] once and gets the aggregate.
+pub fn router() -> Router {
+    Router::new().route("/v2/status", get(get_status))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::to_bytes;
+    use axum::http::{Request, StatusCode};
+    use tower::ServiceExt; // for `.oneshot`
+
+    #[tokio::test]
+    async fn status_route_returns_ok_with_version() {
+        let response = router()
+            .oneshot(
+                Request::builder()
+                    .uri("/v2/status")
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .expect("router oneshot");
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = to_bytes(response.into_body(), 4096)
+            .await
+            .expect("read body");
+        let parsed: StatusResponse = serde_json::from_slice(&body).expect("parse json");
+        assert_eq!(parsed.status, "ok");
+        assert_eq!(parsed.version, env!("CARGO_PKG_VERSION"));
+    }
+
+    #[tokio::test]
+    async fn unknown_route_returns_404() {
+        // Pins the router's default posture — new routes must be
+        // added explicitly, not by accident.  When the R10 epic
+        // starts adding /v2/search etc. this test flips on a new
+        // path (e.g. /v2/does-not-exist) so it doesn't fail on the
+        // additions.
+        let response = router()
+            .oneshot(
+                Request::builder()
+                    .uri("/v2/does-not-exist")
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .expect("router oneshot");
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+}


### PR DESCRIPTION
## Summary

- Epic #4674 R10 (nexus-server → pure-Rust production migration) lands its first step: new `rust/services/http-api/` crate with one route (`GET /v2/status`) so the router + handler + JSON + test-harness pattern is proven before the search / documents / auth routes start landing.

## What v0 ships

- `pub fn router() -> axum::Router` — aggregate router. Future routes attach via additive `.merge(...)`; the router shape is the extension seam.
- `GET /v2/status` returns `{status: "ok", version: <crate version>}`.
- 2 unit tests via `tower::ServiceExt::oneshot` (no port binding — pins the caller ↔ handler pathway which is what the router contract needs); covers happy path + 404 negative.

## What v0 deliberately does NOT do

- No auth middleware — session cookie handling stays on the nexus-server Python side until the auth port lands.
- No ReBAC filter.
- No wiring into `nexusd-cluster` boot — this crate is standalone-testable via `axum::serve` + oneshot so PoC verification does not wait on assembly-binary wiring. The assembly step lives in `rust/nexusd` and registers the HTTP listener alongside the existing gRPC one once the router surface grows enough to justify it.

## Version alignment

axum 0.8 pin matches the sibling `service-matrix-adapter` axum dep in `rust/services/Cargo.toml` so both HTTP crates share the same tower + hyper stack when linked into the same binary.

## Test plan

- [x] `cargo test -p nexus-http-api` — 2 tests pass (status_route_returns_ok_with_version, unknown_route_returns_404).
- [x] `cargo clippy -p nexus-http-api --all-targets --no-deps -- -D warnings` clean.
- [x] `cargo fmt -p nexus-http-api -- --check` clean.

Closes: nothing (epic #4674 has many more steps; this is step 0).
