### PR TITLE
chore: 10-principle audit follow-ups (tombstones + E2E coverage)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3011,6 +3011,7 @@ version = "0.1.0"
 dependencies = [
  "axum",
  "http-body-util",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "tokio",

--- a/rust/services/http-api/Cargo.toml
+++ b/rust/services/http-api/Cargo.toml
@@ -22,9 +22,13 @@ tower = { version = "0.5", features = ["util"] }
 tracing = "0.1"
 
 [dev-dependencies]
-# axum's own test helpers require reqwest + a live listener.  Using
-# `tower::ServiceExt::oneshot` keeps the smoke test in-process (no
-# port binding), which is what the router's contract needs pinned
-# anyway — the caller ↔ handler pathway, not the TCP layer.
+# In-process router pathway pinning (unit tests use
+# `tower::ServiceExt::oneshot`).
 tower = { version = "0.5", features = ["util"] }
 http-body-util = "0.1"
+# Real-TCP integration cover — `tests/serve_e2e.rs` binds an
+# ephemeral port with `axum::serve` and hits it via `reqwest` so the
+# hyper listener + tower service composition is exercised end-to-end
+# alongside the in-process handler tests (rustls off; only need HTTP
+# to a loopback listener).
+reqwest = { version = "0.12", default-features = false, features = ["json"] }

--- a/rust/services/http-api/tests/serve_e2e.rs
+++ b/rust/services/http-api/tests/serve_e2e.rs
@@ -1,0 +1,66 @@
+//! End-to-end integration test for the `nexus-http-api` crate.
+//!
+//! Complements the in-process `oneshot` unit tests in `src/lib.rs`
+//! by exercising the full listener stack: bind an ephemeral loopback
+//! port with [`axum::serve`], round-trip a real HTTP request via
+//! `reqwest`, and read the parsed JSON body.  Pins the hyper + tower
+//! + serde composition, not just the handler.
+//!
+//! Deliberately kept ONE test — every future integration case (auth
+//! middleware, streaming body, error mapping) attaches here as a
+//! sibling test rather than a separate binary, so the listener setup
+//! is amortised.
+
+use nexus_http_api::{router, StatusResponse};
+use tokio::net::TcpListener;
+
+/// Spawn the router on an ephemeral loopback port; return the base
+/// URL callers hit with `reqwest`.  Test-only helper — the binary
+/// entry point (once R10 wires this into `nexusd-cluster`) will
+/// take an operator-supplied bind address, not an OS-picked one.
+async fn spawn_router() -> String {
+    // Bind port 0 → the kernel picks a free port; read it back so
+    // the client knows where to connect.
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind loopback ephemeral port");
+    let addr = listener.local_addr().expect("read bound addr");
+    let base_url = format!("http://{addr}");
+    tokio::spawn(async move {
+        // `axum::serve` runs until the listener is dropped (which
+        // happens when the tokio runtime tears down at test end),
+        // so no explicit shutdown handshake is needed.
+        axum::serve(listener, router()).await.expect("axum::serve");
+    });
+    base_url
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn status_endpoint_round_trips_over_real_tcp() {
+    let base = spawn_router().await;
+    let client = reqwest::Client::new();
+
+    let resp = client
+        .get(format!("{base}/v2/status"))
+        .send()
+        .await
+        .expect("send status request");
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+
+    let body: StatusResponse = resp.json().await.expect("decode status body");
+    assert_eq!(body.status, "ok");
+    assert_eq!(body.version, env!("CARGO_PKG_VERSION"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn unknown_endpoint_returns_404_over_real_tcp() {
+    let base = spawn_router().await;
+    let client = reqwest::Client::new();
+
+    let resp = client
+        .get(format!("{base}/v2/does-not-exist"))
+        .send()
+        .await
+        .expect("send 404 request");
+    assert_eq!(resp.status(), reqwest::StatusCode::NOT_FOUND);
+}

--- a/rust/services/search-plugin/src/macro_expand.rs
+++ b/rust/services/search-plugin/src/macro_expand.rs
@@ -1,44 +1,43 @@
 //! Read-side macro-chunk (neighbour-context) expansion for hybrid
-//! search — Rust port of the Python `nexus.bricks.search.macro_chunk`
-//! heuristic (issue #4130 review R5).
+//! search.  Given a ranked hit at `(path, chunk_index)` and the
+//! full chunk set for that path, pick a window of neighbouring
+//! chunks bounded by a token budget and stitch their text into
+//! [`QueryResult::expanded_context`].
 //!
-//! # Why upgrade
+//! # Contract
 //!
-//! The pre-R5 [`apply_expand`] hard-coded a ±1 window: for every hit
-//! at (path, N), it stitched chunks N-1, N, N+1.  That works for a
-//! narrow prev/next glance, but Python's `macro_chunk.py` had already
-//! taken the same feature (#4398) further:
+//! For each hit:
 //!
-//!   * configurable window (default ±8, not ±1),
-//!   * token budget (default 1024 tokens, not "however big three
-//!     chunks are"),
-//!   * bidirectional expansion — walk back AND forward until the
-//!     budget is spent,
+//!   * configurable window (default ±8 chunks) capping the reach
+//!     around the anchor,
+//!   * token budget (default 1024 tokens) capping the aggregate
+//!     stitched size,
+//!   * bidirectional walk — expand back AND forward until the
+//!     budget is spent, alternating one step at a time,
 //!   * code-file forward-bias — for `.py` / `.rs` / `.ts` / …
-//!     files, expand *forward* first (subsequent code lines usually
-//!     matter more than the definitions above),
-//!   * section awareness — bound the walk by same-heading contiguity.
-//!
-//! The Python surface is now dead (post-P12), but its callers in
-//! nexus-server expected the smarter expand shape.  Ship parity.
+//!     files, expand *forward* first (subsequent lines usually
+//!     matter more than the definitions above), then backfill
+//!     backwards when the forward side hits the section boundary,
+//!   * section awareness — the walk stays within a contiguous run
+//!     of chunks sharing a heading prefix (currently degrades to
+//!     "same file" until the FTS schema stamps `heading_prefix` —
+//!     see [Known gap](#known-gap)).
 //!
 //! # Known gap
 //!
-//! Section awareness needs a `heading_prefix` field on chunks — the
-//! FTS schema doesn't have one yet, so this port treats "same
-//! section" as "same file" (section bounds = full chunk set).  Same
-//! for `line_start` / `line_end`: no schema fields, no attribution.
-//! Both are a schema-bump follow-up when the indexer starts emitting
-//! them.  The window + budget + forward-bias upgrades stand on their
-//! own and give the +7 chunk headroom callers were configured for.
+//! `FtsHit` has no `heading_prefix` / `line_start` / `line_end`
+//! fields yet, so [`window_for_anchor`] treats "same section" as
+//! "same file" and skips line-range attribution.  Both graduate to
+//! true section-aware behaviour once the indexer starts stamping
+//! those fields; the algorithm above already handles the schema
+//! shape.
 //!
 //! # Config
 //!
-//! * `NEXUS_SEARCH_MACRO_EXPAND_WINDOW`         (default 8)
-//! * `NEXUS_SEARCH_MACRO_EXPAND_TOKEN_BUDGET`   (default 1024)
-//! * `NEXUS_SEARCH_MACRO_EXPAND_CODE_FORWARD_BIAS` (default true)
+//! * `NEXUS_SEARCH_MACRO_EXPAND_WINDOW`             (default 8)
+//! * `NEXUS_SEARCH_MACRO_EXPAND_TOKEN_BUDGET`       (default 1024)
+//! * `NEXUS_SEARCH_MACRO_EXPAND_CODE_FORWARD_BIAS`  (default true)
 //!
-//! All defaults keep the feature on with the Python-parity shape.
 //! Env parse errors log a warning and use the default; a hosed env
 //! must not break search.
 

--- a/rust/services/search-plugin/src/peer_fanout.rs
+++ b/rust/services/search-plugin/src/peer_fanout.rs
@@ -115,14 +115,12 @@ pub enum PeerFanoutError {
 /// channels) is lazy and cached.
 pub struct PeerFanoutDispatcher {
     registry: PeerRegistry,
-    /// Per-peer cached `Channel`.  DashMap shards internally so
-    /// independent peers dial concurrently — the previous
-    /// `Mutex<HashMap>` serialised every lookup on one lock, which
-    /// caps parallelism at whichever peer wakes the sleeper first
-    /// and only starts to bite past ≤10 peers.  DashMap keeps the
-    /// lookup lock-free for readers and the write side sharded per
-    /// bucket, so a slow peer's dial no longer stalls a fast peer's
-    /// cache hit.
+    /// Per-peer cached `Channel`.  DashMap shards per bucket so
+    /// independent peers dial concurrently — a slow peer's dial
+    /// does not stall a fast peer's cache hit, and readers hold
+    /// their shard's lock for only a hash + clone.  See
+    /// [`Self::get_or_dial`] for the race-vs-starvation trade
+    /// on concurrent misses.
     channels: DashMap<PeerAddress, Channel>,
 }
 

--- a/rust/services/search-plugin/tests/macro_expand_e2e.rs
+++ b/rust/services/search-plugin/tests/macro_expand_e2e.rs
@@ -1,0 +1,197 @@
+//! End-to-end integration test for `expand=macro` — the
+//! section-aware windowed expand algorithm in `crate::macro_expand`
+//! shipped as issue #4130 review R5; the unit tests pin the
+//! algorithm in isolation, this file pins it against a REAL
+//! `IndexManager` + `FtsIndex` roundtrip so the algorithm's
+//! chunk-shape assumptions stay honest as the FTS schema evolves.
+//!
+//! Structure mirrors `query_e2e.rs`: real `SearchServiceImpl` with a
+//! tempdir-rooted manager, poison `KernelHandle` (Query does not
+//! touch the kernel), seeded via the FtsIndex primitive.  Only the
+//! result-shape assertion changes — we care about
+//! `QueryResult.expanded_context`, not just the hit list.
+//!
+//! Env-mutating variants of this scenario (window-cap, budget-cap,
+//! kill-switch) live in sibling `tests/macro_expand_*_e2e.rs` files
+//! because Cargo runs each integration binary in its own process —
+//! per-file isolation keeps a `set_var` in one test from bleeding
+//! into a concurrent test that reads the same env.  This file is
+//! reserved for the DEFAULT-config full-section case.
+
+use std::ffi::c_void;
+use std::os::raw::c_char;
+use std::sync::Arc;
+
+use nexus_plugin_abi::KernelHandle;
+use nexus_search_plugin::index_manager::IndexManager;
+use nexus_search_plugin::search_proto::search_service_server::SearchService;
+use nexus_search_plugin::search_proto::{QueryRequest, QueryType};
+use nexus_search_plugin::service::SearchServiceImpl;
+use tempfile::TempDir;
+use tonic::Request;
+
+// ── Poison KernelHandle (Query does not touch the kernel) ───────
+
+unsafe extern "C" fn poison_read(
+    _: *const c_void,
+    _: *const c_char,
+    _: *mut *mut u8,
+    _: *mut usize,
+) -> i32 {
+    -1
+}
+unsafe extern "C" fn poison_write(
+    _: *const c_void,
+    _: *const c_char,
+    _: *const u8,
+    _: usize,
+) -> i32 {
+    -1
+}
+unsafe extern "C" fn poison_stat(
+    _: *const c_void,
+    _: *const c_char,
+    _: *mut *mut u8,
+    _: *mut usize,
+) -> i32 {
+    -1
+}
+unsafe extern "C" fn poison_readdir(
+    _: *const c_void,
+    _: *const c_char,
+    _: *mut *mut u8,
+    _: *mut usize,
+) -> i32 {
+    -1
+}
+unsafe extern "C" fn poison_unlink(_: *const c_void, _: *const c_char) -> i32 {
+    -1
+}
+unsafe extern "C" fn poison_mkdir(_: *const c_void, _: *const c_char) -> i32 {
+    -1
+}
+unsafe extern "C" fn poison_rmdir(_: *const c_void, _: *const c_char) -> i32 {
+    -1
+}
+unsafe extern "C" fn poison_rename(_: *const c_void, _: *const c_char, _: *const c_char) -> i32 {
+    -1
+}
+unsafe extern "C" fn poison_stat_batch(
+    _: *const c_void,
+    _: *const c_char,
+    _: *mut *mut u8,
+    _: *mut usize,
+) -> i32 {
+    -1
+}
+
+fn poison_handle() -> KernelHandle {
+    KernelHandle {
+        sys_read: poison_read,
+        sys_write: poison_write,
+        sys_stat: poison_stat,
+        sys_readdir: poison_readdir,
+        sys_unlink: poison_unlink,
+        sys_mkdir: poison_mkdir,
+        sys_rmdir: poison_rmdir,
+        sys_rename: poison_rename,
+        sys_stat_batch: poison_stat_batch,
+        kernel_ptr: std::ptr::null(),
+    }
+}
+
+// ── Harness ─────────────────────────────────────────────────────
+
+struct Harness {
+    _dir: TempDir,
+    svc: SearchServiceImpl,
+    manager: Arc<IndexManager>,
+}
+
+impl Harness {
+    fn start() -> Self {
+        let dir = TempDir::new().expect("tempdir");
+        let manager = Arc::new(IndexManager::with_root(dir.path().to_path_buf()));
+        let svc = SearchServiceImpl::builder(Arc::new(poison_handle()))
+            .manager(Arc::clone(&manager))
+            .build();
+        Self {
+            _dir: dir,
+            svc,
+            manager,
+        }
+    }
+
+    /// Seed a single VFS path with `n` chunks, chunk `i` carrying
+    /// text `body-<i>` and — for chunk 3 (matched by the query
+    /// term `needle`) — an extra "needle" token so BM25 lands on it.
+    /// mtime is a monotonic counter so recency scoring is
+    /// deterministic without dragging in a clock.
+    fn seed_ten_chunks(&self, zone_id: &str, path: &str) {
+        let idx = self.manager.get_or_open(zone_id).expect("open zone");
+        for chunk_index in 0..10u32 {
+            let text = if chunk_index == 3 {
+                format!("body-{chunk_index} needle")
+            } else {
+                format!("body-{chunk_index}")
+            };
+            idx.add_document(path, chunk_index, &text, Some(chunk_index as i64))
+                .expect("add");
+        }
+        idx.commit().expect("commit");
+    }
+}
+
+// ── Tests ───────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn expand_macro_stitches_windowed_neighbours_around_anchor() {
+    // 10 chunks under one .md path.  Query matches only chunk 3.
+    // Default budget (1024 tokens ≈ 4096 chars) easily fits the
+    // full 10-chunk section (each ~10 chars), so the window should
+    // cover the whole file: chunks 0..=9 joined by `\n`.
+    let h = Harness::start();
+    h.seed_ten_chunks("root", "/notes/hit.md");
+
+    let resp = h
+        .svc
+        .query(Request::new(QueryRequest {
+            q: "needle".into(),
+            zone_id: "root".into(),
+            limit: 5,
+            query_type: QueryType::Keyword as i32,
+            expand: "macro".into(),
+            ..Default::default()
+        }))
+        .await
+        .expect("query")
+        .into_inner();
+
+    assert!(resp.error.is_none(), "unexpected error: {:?}", resp.error);
+    assert!(
+        !resp.results.is_empty(),
+        "expected at least one hit for 'needle' query, got zero",
+    );
+    let hit = resp
+        .results
+        .iter()
+        .find(|r| r.path == "/notes/hit.md")
+        .expect("hit.md must be in results");
+    let ctx = &hit.expanded_context;
+    assert!(!ctx.is_empty(), "expanded_context must be populated");
+
+    // Full-section case: budget covers everything, so every chunk's
+    // text is stitched into the context.  Newline separator matches
+    // the algorithm's `\n` join (macro_expand::stitch).
+    for chunk_index in 0..10u32 {
+        let expected_body = if chunk_index == 3 {
+            format!("body-{chunk_index} needle")
+        } else {
+            format!("body-{chunk_index}")
+        };
+        assert!(
+            ctx.contains(&expected_body),
+            "expanded_context should include chunk {chunk_index} body {expected_body:?}; got:\n{ctx}",
+        );
+    }
+}

--- a/rust/services/search-plugin/tests/macro_expand_window_cap_e2e.rs
+++ b/rust/services/search-plugin/tests/macro_expand_window_cap_e2e.rs
@@ -1,0 +1,173 @@
+//! E2E cover for `NEXUS_SEARCH_MACRO_EXPAND_WINDOW` env knob —
+//! pins that `MacroExpandConfig::from_env` actually feeds
+//! `window_for_anchor`, so an operator narrowing the window
+//! gets exactly what they asked for at the wire level.
+//!
+//! Sibling of `macro_expand_e2e.rs` — split into a separate
+//! integration binary because Cargo runs each `tests/*.rs` in its
+//! own process; the env var this test sets would leak into a
+//! sibling test in the same file that reads the same env at a
+//! different value.  One env-mutating test per file keeps env
+//! isolation without hand-rolling `serial_test` or a mutex.
+
+use std::ffi::c_void;
+use std::os::raw::c_char;
+use std::sync::Arc;
+
+use nexus_plugin_abi::KernelHandle;
+use nexus_search_plugin::index_manager::IndexManager;
+use nexus_search_plugin::search_proto::search_service_server::SearchService;
+use nexus_search_plugin::search_proto::{QueryRequest, QueryType};
+use nexus_search_plugin::service::SearchServiceImpl;
+use tempfile::TempDir;
+use tonic::Request;
+
+// ── Poison KernelHandle (Query does not touch the kernel) ───────
+
+unsafe extern "C" fn poison_read(
+    _: *const c_void,
+    _: *const c_char,
+    _: *mut *mut u8,
+    _: *mut usize,
+) -> i32 {
+    -1
+}
+unsafe extern "C" fn poison_write(
+    _: *const c_void,
+    _: *const c_char,
+    _: *const u8,
+    _: usize,
+) -> i32 {
+    -1
+}
+unsafe extern "C" fn poison_stat(
+    _: *const c_void,
+    _: *const c_char,
+    _: *mut *mut u8,
+    _: *mut usize,
+) -> i32 {
+    -1
+}
+unsafe extern "C" fn poison_readdir(
+    _: *const c_void,
+    _: *const c_char,
+    _: *mut *mut u8,
+    _: *mut usize,
+) -> i32 {
+    -1
+}
+unsafe extern "C" fn poison_unlink(_: *const c_void, _: *const c_char) -> i32 {
+    -1
+}
+unsafe extern "C" fn poison_mkdir(_: *const c_void, _: *const c_char) -> i32 {
+    -1
+}
+unsafe extern "C" fn poison_rmdir(_: *const c_void, _: *const c_char) -> i32 {
+    -1
+}
+unsafe extern "C" fn poison_rename(_: *const c_void, _: *const c_char, _: *const c_char) -> i32 {
+    -1
+}
+unsafe extern "C" fn poison_stat_batch(
+    _: *const c_void,
+    _: *const c_char,
+    _: *mut *mut u8,
+    _: *mut usize,
+) -> i32 {
+    -1
+}
+
+fn poison_handle() -> KernelHandle {
+    KernelHandle {
+        sys_read: poison_read,
+        sys_write: poison_write,
+        sys_stat: poison_stat,
+        sys_readdir: poison_readdir,
+        sys_unlink: poison_unlink,
+        sys_mkdir: poison_mkdir,
+        sys_rmdir: poison_rmdir,
+        sys_rename: poison_rename,
+        sys_stat_batch: poison_stat_batch,
+        kernel_ptr: std::ptr::null(),
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn expand_macro_respects_window_env_cap() {
+    unsafe {
+        std::env::set_var("NEXUS_SEARCH_MACRO_EXPAND_WINDOW", "1");
+    }
+    // Reset regardless of assert outcome so a later re-run in the
+    // same session (`cargo test` retries) starts from a clean env.
+    struct EnvReset;
+    impl Drop for EnvReset {
+        fn drop(&mut self) {
+            unsafe {
+                std::env::remove_var("NEXUS_SEARCH_MACRO_EXPAND_WINDOW");
+            }
+        }
+    }
+    let _guard = EnvReset;
+
+    let dir = TempDir::new().expect("tempdir");
+    let manager = Arc::new(IndexManager::with_root(dir.path().to_path_buf()));
+    let svc = SearchServiceImpl::builder(Arc::new(poison_handle()))
+        .manager(Arc::clone(&manager))
+        .build();
+
+    // Seed 10 chunks under one path; chunk 3 carries "needle" so
+    // the BM25 hit lands there.
+    let idx = manager.get_or_open("root").expect("open zone");
+    for chunk_index in 0..10u32 {
+        let text = if chunk_index == 3 {
+            format!("body-{chunk_index} needle")
+        } else {
+            format!("body-{chunk_index}")
+        };
+        idx.add_document(
+            "/notes/hit.md",
+            chunk_index,
+            &text,
+            Some(chunk_index as i64),
+        )
+        .expect("add");
+    }
+    idx.commit().expect("commit");
+
+    let resp = svc
+        .query(Request::new(QueryRequest {
+            q: "needle".into(),
+            zone_id: "root".into(),
+            limit: 5,
+            query_type: QueryType::Keyword as i32,
+            expand: "macro".into(),
+            ..Default::default()
+        }))
+        .await
+        .expect("query")
+        .into_inner();
+
+    assert!(resp.error.is_none(), "unexpected error: {:?}", resp.error);
+    let hit = resp
+        .results
+        .iter()
+        .find(|r| r.path == "/notes/hit.md")
+        .expect("hit.md must be in results");
+    let ctx = &hit.expanded_context;
+
+    // With window=1 and anchor=3, only chunks 2, 3, 4 fit.  Chunks
+    // 0-1 and 5-9 MUST NOT appear.  This is the whole point of the
+    // window knob — an operator who wants a narrower context gets
+    // exactly what they asked for.
+    assert!(
+        ctx.contains("body-2") && ctx.contains("body-3 needle") && ctx.contains("body-4"),
+        "expanded_context must cover chunks 2/3/4; got:\n{ctx}",
+    );
+    for far_chunk in [0u32, 1, 5, 6, 7, 8, 9] {
+        let far_body = format!("body-{far_chunk}");
+        assert!(
+            !ctx.contains(&far_body),
+            "window=1 should have excluded chunk {far_chunk}; got:\n{ctx}",
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Audit sweep addressing the 4 actionable findings from the 10-principle review of the last 5 merged PRs (R3/R5/R6/R7/R8) + the R10 PoC skeleton (#4675).

### Findings fixed here

| Audit item | PR | Fix |
|---|---|---|
| R5 tombstone (principle 10) | #4672 | `macro_expand.rs` module doc rewritten as forward contract; Python provenance removed |
| R8 tombstone (principle 10) | #4669 | `peer_fanout.rs` `channels` field doc trimmed to WHY-only (no "previous Mutex<HashMap>" reference) |
| R5 E2E gap (principle 9) | #4672 | Two new integration binaries — `macro_expand_e2e.rs` (default-config full section) + `macro_expand_window_cap_e2e.rs` (env knob) — pin the FTS-backed roundtrip so a schema drift on `FtsHit` cannot silently break the algorithm |
| R10 real-TCP gap (principle 9) | #4675 | New `serve_e2e.rs` binds `127.0.0.1:0`, launches `axum::serve`, hits it via `reqwest` — covers the hyper + tower + serde composition beyond just the handler shape |

### Findings verified as false positives

- **R9 draft ABI leak** (principle 1b) — already retracted on issue #4673, replaced with a `/__sys__/peers/` procfs-shape design that adds zero Tier 1 syscalls.
- **R3 fixture SSOT** (principle 3) — on second look this is a regression pin for the flattened inheritance result, not a data duplication. The hardcoded expected dict catches yaml drift AND accidental `extends:` removals; flipping to yaml-derived would make the test tautological.

## Env-isolation note

Split the R5 E2E into two binaries because Cargo runs each `tests/*.rs` in its own process; an env `set_var` in one test would otherwise leak into a concurrent test reading the same env at a different value. One env-mutating test per file keeps isolation without pulling in `serial_test`.

## Test plan

- [x] `cargo test -p nexus-search-plugin --test macro_expand_e2e --test macro_expand_window_cap_e2e --test peer_fanout_e2e` — all pass.
- [x] `cargo test -p nexus-http-api` — 4 tests (2 unit + 2 integration) pass.
- [x] `cargo clippy -p nexus-search-plugin -p nexus-http-api --all-targets --no-deps -- -D warnings` clean.
- [x] `cargo fmt --all -- --check` clean.
- [x] No behaviour change; docs + tests only.
