### PR TITLE
feat(http-api): GET /v2/search/glob with cached gRPC backend (R10 step 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3010,11 +3010,19 @@ name = "nexus-http-api"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "dashmap",
  "http-body-util",
+ "prost 0.14.4",
+ "protoc-bin-vendored",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
+ "thiserror 1.0.69",
  "tokio",
+ "tokio-stream",
+ "tonic 0.14.6",
+ "tonic-prost",
+ "tonic-prost-build",
  "tower",
  "tracing",
 ]

--- a/rust/services/http-api/Cargo.toml
+++ b/rust/services/http-api/Cargo.toml
@@ -21,6 +21,33 @@ serde_json = { workspace = true }
 tower = { version = "0.5", features = ["util"] }
 tracing = "0.1"
 
+# tonic client for talking to the upstream search-plugin (and
+# eventually other gRPC services).  Version pinned to the workspace
+# `tonic = 0.14` shipping in rust/services/Cargo.toml so the two
+# crates share the same hyper stack when co-hosted in one binary.
+tonic = { workspace = true }
+prost = { workspace = true }
+tonic-prost = { workspace = true }
+
+# Sharded cache for per-upstream tonic Channel — one Channel per
+# backend address, dialed lazily on first use.  Same 6.1 pin the
+# sibling search-plugin peer-fanout uses (search-plugin/Cargo.toml).
+dashmap = "6.1"
+
+# Parked-error surfacing at the handler boundary (Ok/Err in the
+# lib, mapped to HTTP status in the axum extractor).  Same 1.0 pin
+# the sibling search-plugin uses.
+thiserror = "1"
+
+[build-dependencies]
+# Client-only proto codegen from the workspace's search proto SSOT
+# (`rust/services/proto/nexus/search/v1/search.proto`).  Same tool
+# stack the sibling search-plugin build.rs uses; the vendored
+# `protoc` keeps the build hermetic on hosts without a
+# system-installed protobuf-compiler.
+tonic-prost-build = "0.14"
+protoc-bin-vendored = "3"
+
 [dev-dependencies]
 # In-process router pathway pinning (unit tests use
 # `tower::ServiceExt::oneshot`).
@@ -32,3 +59,9 @@ http-body-util = "0.1"
 # alongside the in-process handler tests (rustls off; only need HTTP
 # to a loopback listener).
 reqwest = { version = "0.12", default-features = false, features = ["json"] }
+# `tests/glob_e2e.rs` runs a mock `SearchService` implementation on
+# an ephemeral tonic server so the axum → tonic-client → gRPC-server
+# chain is exercised end-to-end.  The mock only needs the server
+# side of tonic + the wrapping stream adapter for the listener.
+serde_json = { workspace = true }
+tokio-stream = { version = "0.1", features = ["net"] }

--- a/rust/services/http-api/build.rs
+++ b/rust/services/http-api/build.rs
@@ -1,0 +1,36 @@
+//! Compile the workspace's `nexus.search.v1` proto SSOT
+//! (`../proto/nexus/search/v1/search.proto`) into `OUT_DIR` as a
+//! CLIENT stub for `SearchServiceClient`.  The sibling
+//! `nexus-search-plugin` crate compiles the same proto with
+//! `build_server(true) + build_client(true)` for its cdylib; this
+//! crate only needs the client side (we call INTO search-plugin,
+//! we do not implement the service).
+//!
+//! Same tool stack the sibling `nexus-search-plugin/build.rs` uses.
+//! Vendored `protoc` so the build stays hermetic on hosts without a
+//! system-wide protobuf-compiler install.
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let proto = "../proto/nexus/search/v1/search.proto";
+    println!("cargo:rerun-if-changed={}", proto);
+
+    if std::env::var_os("PROTOC").is_none() {
+        std::env::set_var("PROTOC", protoc_bin_vendored::protoc_bin_path()?);
+    }
+
+    // Both server + client stubs are generated: production code
+    // (`handlers::search`) only calls the CLIENT to dial upstream
+    // `nexus-search-plugin`, but the crate's integration tests
+    // (`tests/glob_e2e.rs`) implement a mock SearchService using the
+    // server stub so the full axum→tonic-client→grpc-server chain is
+    // exercised end-to-end.  The server code is dead-stripped from
+    // release builds by LTO — same pattern the sibling
+    // `nexus-search-plugin` build.rs uses (which needs the server
+    // for production and the client for its dylib self-tests).
+    tonic_prost_build::configure()
+        .build_server(true)
+        .build_client(true)
+        .compile_protos(&[proto], &["../proto"])?;
+
+    Ok(())
+}

--- a/rust/services/http-api/src/handlers/mod.rs
+++ b/rust/services/http-api/src/handlers/mod.rs
@@ -1,0 +1,11 @@
+//! Route handler modules — one file per `/v2/*` route domain.
+//!
+//! Each submodule exports a `pub fn router() -> axum::Router<AppState>`
+//! that `crate::router` merges into the aggregate.  A handler NEVER
+//! wires state directly; it takes `axum::extract::State<AppState>`
+//! and pulls whichever backend it needs off the state struct.  This
+//! keeps `AppState` growth O(1) per new domain — a fresh domain
+//! adds a field, no handler rewire.
+
+pub mod search;
+pub mod status;

--- a/rust/services/http-api/src/handlers/search.rs
+++ b/rust/services/http-api/src/handlers/search.rs
@@ -1,0 +1,147 @@
+//! `/v2/search/*` — HTTP shims over the upstream
+//! `nexus.search.v1.SearchService` gRPC surface.  Each handler
+//! parses query params, builds a typed proto request, dispatches
+//! through the cached [`SearchBackend`] client, and serialises the
+//! response as JSON.
+//!
+//! # Auth / ReBAC
+//!
+//! Deliberately absent from this crate — sits in the middleware
+//! layer above once the auth port lands (see the epic issue for
+//! the sequence).  Handlers here operate on the callable
+//! contract only; a caller with tokenised access is presumed
+//! already granted.
+
+use axum::extract::{Query, State};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::routing::get;
+use axum::{Json, Router};
+use serde::{Deserialize, Serialize};
+
+use crate::search_proto::GlobRequest;
+use crate::{AppState, BackendError};
+
+/// Query params for `GET /v2/search/glob`.  Field names match the
+/// proto's [`GlobRequest`] snake_case names 1:1 so a caller
+/// hitting the HTTP surface reads the same doc as one hitting the
+/// gRPC surface directly.
+#[derive(Debug, Clone, Deserialize)]
+pub struct GlobQuery {
+    /// Directory the glob walks under.  Defaults to `/` when
+    /// unspecified so a caller can drop the param for full-tree
+    /// searches.
+    #[serde(default = "default_root")]
+    pub root_path: String,
+    /// Glob pattern (fnmatch-style: `*.rs`, `**/*.md`).
+    pub pattern: String,
+    /// Cap on returned paths.  0 (or absent) = server default.
+    #[serde(default)]
+    pub max_results: u32,
+    /// Auth token forwarded through to the RPC.  Optional here
+    /// because auth middleware is separately scoped; when the
+    /// middleware lands it will populate this field before the
+    /// handler runs.
+    #[serde(default)]
+    pub auth_token: String,
+    /// Sort results by most-recent-mtime first when `true`.
+    #[serde(default)]
+    pub sort_recency: bool,
+}
+
+fn default_root() -> String {
+    "/".to_string()
+}
+
+/// Response body of [`glob`].  Owned fields so deserialisation
+/// callers do not need a `'static` byte source; field names
+/// mirror the proto response so wire ↔ HTTP round-trips are
+/// name-identical (a caller migrating from the gRPC surface
+/// keeps its JSON parser).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct GlobResponse {
+    pub paths: Vec<String>,
+    pub truncated: bool,
+    /// Present only when the upstream reported an application
+    /// error (RPC transport errors surface as HTTP 5xx instead).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// Handler for `GET /v2/search/glob`.
+pub async fn glob(
+    State(state): State<AppState>,
+    Query(params): Query<GlobQuery>,
+) -> Result<Json<GlobResponse>, GlobError> {
+    let mut client = state
+        .search
+        .client()
+        .await
+        .map_err(GlobError::BackendUnavailable)?;
+
+    let req = GlobRequest {
+        root_path: params.root_path,
+        pattern: params.pattern,
+        max_results: params.max_results,
+        auth_token: params.auth_token,
+        sort_recency: params.sort_recency,
+    };
+
+    let resp = client
+        .glob(tonic::Request::new(req))
+        .await
+        .map_err(GlobError::Rpc)?
+        .into_inner();
+
+    Ok(Json(GlobResponse {
+        paths: resp.paths,
+        truncated: resp.truncated,
+        error: resp.error,
+    }))
+}
+
+pub fn router() -> Router<AppState> {
+    Router::new().route("/v2/search/glob", get(glob))
+}
+
+/// Handler-level errors surfaced as HTTP responses.
+///
+/// Two-state mapping:
+///   * `BackendUnavailable` → 503 (backend down; retry-friendly).
+///   * `Rpc(status)` → status.code() mapped to the closest HTTP
+///     status (400 for client-side bad request, 500 for anything
+///     else) with the tonic message in the body so operators
+///     debugging a hang can see the underlying signal.
+#[derive(Debug, thiserror::Error)]
+pub enum GlobError {
+    #[error("backend unavailable: {0}")]
+    BackendUnavailable(#[from] BackendError),
+    #[error("rpc failed: {0}")]
+    Rpc(tonic::Status),
+}
+
+impl IntoResponse for GlobError {
+    fn into_response(self) -> Response {
+        let (status, message) = match self {
+            GlobError::BackendUnavailable(e) => (StatusCode::SERVICE_UNAVAILABLE, e.to_string()),
+            GlobError::Rpc(s) => (grpc_status_to_http(s.code()), s.message().to_string()),
+        };
+        (status, Json(serde_json::json!({ "error": message }))).into_response()
+    }
+}
+
+/// gRPC → HTTP status mapping.  Only the codes glob actually
+/// surfaces at the handler; the fallback is 500 (server-side
+/// generic error) so an unmapped code never silently degrades to
+/// 200.  Kept small on purpose — expanding it later is additive.
+fn grpc_status_to_http(code: tonic::Code) -> StatusCode {
+    match code {
+        tonic::Code::InvalidArgument => StatusCode::BAD_REQUEST,
+        tonic::Code::NotFound => StatusCode::NOT_FOUND,
+        tonic::Code::PermissionDenied => StatusCode::FORBIDDEN,
+        tonic::Code::Unauthenticated => StatusCode::UNAUTHORIZED,
+        tonic::Code::DeadlineExceeded => StatusCode::GATEWAY_TIMEOUT,
+        tonic::Code::Unavailable => StatusCode::SERVICE_UNAVAILABLE,
+        _ => StatusCode::INTERNAL_SERVER_ERROR,
+    }
+}

--- a/rust/services/http-api/src/handlers/status.rs
+++ b/rust/services/http-api/src/handlers/status.rs
@@ -1,0 +1,87 @@
+//! `GET /v2/status` — smoke handler.  Returns `{status: "ok",
+//! version: <crate version>}`.  Compile-time version from
+//! `CARGO_PKG_VERSION` so no runtime plumbing is needed for the
+//! health check.
+//!
+//! Future upgrades (raft leader status, plugin load state, DB
+//! connectivity) attach to [`StatusResponse`] and the handler body,
+//! not the route wiring.
+
+use axum::{routing::get, Json, Router};
+use serde::{Deserialize, Serialize};
+
+use crate::AppState;
+
+/// Response body of [`get_status`].  Owned `String` fields so
+/// deserialisation callers do not need a `'static` byte source.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct StatusResponse {
+    pub status: String,
+    pub version: String,
+}
+
+pub async fn get_status() -> Json<StatusResponse> {
+    Json(StatusResponse {
+        status: "ok".to_string(),
+        version: env!("CARGO_PKG_VERSION").to_string(),
+    })
+}
+
+pub fn router() -> Router<AppState> {
+    Router::new().route("/v2/status", get(get_status))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::to_bytes;
+    use axum::http::{Request, StatusCode};
+    use tower::ServiceExt;
+
+    use crate::search_backend::SearchBackend;
+
+    fn test_state() -> AppState {
+        // Status handler does not touch the backend; a dummy
+        // target that never gets dialed is fine.
+        AppState {
+            search: SearchBackend::new("http://127.0.0.1:1"),
+        }
+    }
+
+    #[tokio::test]
+    async fn status_route_returns_ok_with_version() {
+        let response = router()
+            .with_state(test_state())
+            .oneshot(
+                Request::builder()
+                    .uri("/v2/status")
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .expect("router oneshot");
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = to_bytes(response.into_body(), 4096)
+            .await
+            .expect("read body");
+        let parsed: StatusResponse = serde_json::from_slice(&body).expect("parse json");
+        assert_eq!(parsed.status, "ok");
+        assert_eq!(parsed.version, env!("CARGO_PKG_VERSION"));
+    }
+
+    #[tokio::test]
+    async fn unknown_route_returns_404() {
+        let response = router()
+            .with_state(test_state())
+            .oneshot(
+                Request::builder()
+                    .uri("/v2/does-not-exist")
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .expect("router oneshot");
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+}

--- a/rust/services/http-api/src/lib.rs
+++ b/rust/services/http-api/src/lib.rs
@@ -1,117 +1,65 @@
 //! `nexus-http-api` — axum-based HTTP-API surface for the pure-Rust
-//! `nexus-server` replacement (epic #4674 review R10).
+//! `nexus-server` migration (epic #4674 review R10).
 //!
-//! # Scope of v0
+//! # What this crate does
 //!
-//! This crate is a **PoC skeleton**.  It ships exactly ONE route
-//! (`GET /v2/status`) — the router + handler + JSON-serialisation +
-//! test-harness pattern is proven end-to-end before the full
-//! nexus-server surface (search, documents, auth) starts landing.
+//! Serves the `/v2/*` HTTP surface, translating each route into a
+//! typed gRPC call against the appropriate upstream service (search,
+//! documents, auth — one route domain per file under `handlers/`).
+//! Handlers are pure axum functions taking an `axum::extract::State`
+//! holding the upstream client cache; the router itself is a plain
+//! `axum::Router` assembled by [`router`].
 //!
-//! Every future route lands as an additive [`axum::Router::merge`]
-//! against [`router`] — the router shape is the extension seam.
+//! # Extension seam
 //!
-//! # Why axum
+//! Every new route domain lands as an additive `Router::merge` on
+//! [`router`] and a new file under `handlers/`.  The state grows by
+//! adding a new field to [`AppState`] — a fresh domain does not
+//! rewire existing handlers.
 //!
-//! Axum shares the tower + hyper stack with the existing
-//! [`service-matrix-adapter`](../services/src/matrix_adapter.rs)
-//! surface, so both HTTP crates link into the same binary at a
-//! shared version pin (0.8) with no dep-tree churn.  The matrix
-//! adapter has already proven the "axum on top of kernel syscalls"
-//! pattern in production.
+//! # Deliberately absent
 //!
-//! # What v0 does NOT do
-//!
-//! * NO auth middleware — session cookie handling stays on the
-//!   nexus-server Python side until the auth port lands (part of
-//!   the same epic, but a separately-scoped step).
-//! * NO ReBAC filter — same story.
-//! * NO wiring into `nexusd-cluster` boot — that lives one crate
-//!   over (rust/nexusd) and needs the nexus-cluster team to
-//!   register the HTTP listener alongside the gRPC one.  This
-//!   crate is standalone-testable via `axum::serve` +
-//!   `tower::ServiceExt::oneshot` so PoC verification doesn't wait
-//!   on the wiring step.
+//! * NO auth middleware — session cookie handling is a separate epic
+//!   step (part of the same #4674 arc).
+//! * NO ReBAC post-filter — same story.
+//! * NO wiring into `nexusd-cluster` boot — the assembly binary in
+//!   `rust/nexusd` picks the crate up once the router surface
+//!   justifies the wiring step.  Standalone-testable today via
+//!   `axum::serve` + `tests/*_e2e.rs`.
 
-use axum::{routing::get, Json, Router};
-use serde::{Deserialize, Serialize};
+use axum::Router;
 
-/// Response body of [`get_status`].  Kept small on purpose — the
-/// health-check surface should read cheap and always succeed unless
-/// the process itself is unhealthy.  `version` is compile-time from
-/// [`CARGO_PKG_VERSION`](env!("CARGO_PKG_VERSION")) so it doesn't
-/// need any runtime plumbing.  Owned `String` fields so
-/// deserialisation callers don't need a `'static` byte source.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct StatusResponse {
-    pub status: String,
-    pub version: String,
+pub mod handlers;
+pub mod search_backend;
+
+/// Client stubs for the workspace's `nexus.search.v1` proto SSOT
+/// — generated at build time by `build.rs` from
+/// `rust/services/proto/nexus/search/v1/search.proto`.  Client-only
+/// (this crate never implements the service).
+pub mod search_proto {
+    #![allow(clippy::all)]
+    #![allow(unused_qualifications)]
+    tonic::include_proto!("nexus.search.v1");
 }
 
-/// Version 0 status handler — the "does the axum stack run at all"
-/// smoke test.  Returns 200 with a fixed `{status: "ok", version:
-/// <crate version>}` payload.  Future health-check upgrades (raft
-/// leader status, plugin load state, DB connectivity) attach here.
-pub async fn get_status() -> Json<StatusResponse> {
-    Json(StatusResponse {
-        status: "ok".to_string(),
-        version: env!("CARGO_PKG_VERSION").to_string(),
-    })
+pub use handlers::status::StatusResponse;
+pub use search_backend::{BackendError, SearchBackend};
+
+/// Shared state handed to every axum handler through
+/// `axum::extract::State`.  Cheap to clone (`Arc` fields inside
+/// each backend); one instance per process.
+#[derive(Clone)]
+pub struct AppState {
+    pub search: SearchBackend,
 }
 
-/// Root [`Router`] carrying every v0 route.  Follow-up crates in
-/// the R10 epic (search, documents, auth) will `.merge()` their
-/// own routers onto this one; the assembly binary (rust/nexusd)
-/// calls [`router`] once and gets the aggregate.
-pub fn router() -> Router {
-    Router::new().route("/v2/status", get(get_status))
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use axum::body::to_bytes;
-    use axum::http::{Request, StatusCode};
-    use tower::ServiceExt; // for `.oneshot`
-
-    #[tokio::test]
-    async fn status_route_returns_ok_with_version() {
-        let response = router()
-            .oneshot(
-                Request::builder()
-                    .uri("/v2/status")
-                    .body(axum::body::Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .expect("router oneshot");
-
-        assert_eq!(response.status(), StatusCode::OK);
-
-        let body = to_bytes(response.into_body(), 4096)
-            .await
-            .expect("read body");
-        let parsed: StatusResponse = serde_json::from_slice(&body).expect("parse json");
-        assert_eq!(parsed.status, "ok");
-        assert_eq!(parsed.version, env!("CARGO_PKG_VERSION"));
-    }
-
-    #[tokio::test]
-    async fn unknown_route_returns_404() {
-        // Pins the router's default posture — new routes must be
-        // added explicitly, not by accident.  When the R10 epic
-        // starts adding /v2/search etc. this test flips on a new
-        // path (e.g. /v2/does-not-exist) so it doesn't fail on the
-        // additions.
-        let response = router()
-            .oneshot(
-                Request::builder()
-                    .uri("/v2/does-not-exist")
-                    .body(axum::body::Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .expect("router oneshot");
-        assert_eq!(response.status(), StatusCode::NOT_FOUND);
-    }
+/// Root [`Router`] carrying every configured route domain.  Callers
+/// supply the [`AppState`] (which owns the upstream client caches)
+/// so the same crate can be exercised in tests against a mock
+/// backend and in production against the real search-plugin.
+pub fn router(state: AppState) -> Router {
+    Router::new()
+        .merge(handlers::status::router())
+        .merge(handlers::search::router())
+        .with_state(state)
 }

--- a/rust/services/http-api/src/search_backend.rs
+++ b/rust/services/http-api/src/search_backend.rs
@@ -1,0 +1,110 @@
+//! Upstream `nexus.search.v1.SearchService` client — one long-lived
+//! `tonic::transport::Channel` per backend address, dialed lazily
+//! on first use and cached for the process lifetime.
+//!
+//! # Why cache
+//!
+//! Every request through [`SearchBackend::client`] would otherwise
+//! open a fresh TCP + gRPC handshake — the search-plugin cluster is
+//! a stable set of upstreams and a per-request dial makes p99 dive
+//! for no benefit.  The sibling `nexus-search-plugin::peer_fanout`
+//! uses the same DashMap-per-address shape for its own peer client
+//! cache; we mirror the pattern.
+//!
+//! # Race posture
+//!
+//! Two concurrent misses on the same address can both dial before
+//! either publishes — DashMap's `entry().or_insert()` picks a
+//! winner atomically and the loser's Channel gets dropped.  We
+//! accept the extra dial (bounded by tonic's connect timeout) to
+//! avoid holding a shard write-lock across `.await`, which would
+//! starve every sibling address hashing to the same shard.  Same
+//! rationale documented on `peer_fanout::PeerFanoutDispatcher::get_or_dial`.
+
+use std::sync::Arc;
+
+use dashmap::DashMap;
+use tonic::transport::{Channel, Endpoint};
+
+use crate::search_proto::search_service_client::SearchServiceClient;
+
+/// Errors surfaced by [`SearchBackend`] when the upstream cannot be
+/// reached.  Kept small — every variant maps 1:1 to an HTTP status
+/// at the handler boundary via `axum::response::IntoResponse` (see
+/// `handlers/search.rs`).
+#[derive(Debug, thiserror::Error)]
+pub enum BackendError {
+    /// The target string is not a valid gRPC endpoint (bad scheme,
+    /// bad host:port, tonic could not parse).  Config bug — the
+    /// operator gave us a garbage address.
+    #[error("invalid backend endpoint {target}: {source}")]
+    InvalidEndpoint {
+        target: String,
+        #[source]
+        source: tonic::transport::Error,
+    },
+
+    /// Dial failed.  Backend down, DNS blackholed, network partition
+    /// — any transport error hitting the wire before we send the RPC.
+    #[error("connect to backend {target} failed: {source}")]
+    ConnectFailed {
+        target: String,
+        #[source]
+        source: tonic::transport::Error,
+    },
+}
+
+/// Live upstream registry — one entry per gRPC backend address.
+/// Cheap to construct; the dial happens on first [`Self::client`]
+/// call and the Channel is cached for the process lifetime.
+///
+/// Cloneable via `Arc` so axum's `State` extractor can hand every
+/// handler a shared reference to the same cache.
+#[derive(Clone)]
+pub struct SearchBackend {
+    default_target: Arc<str>,
+    channels: Arc<DashMap<Arc<str>, Channel>>,
+}
+
+impl SearchBackend {
+    /// Construct a backend that routes every request to `default_target`.
+    /// `default_target` is a full gRPC endpoint (e.g. `http://127.0.0.1:2126`);
+    /// the address is stored as `Arc<str>` so cache lookups avoid a
+    /// per-request `String` clone.
+    pub fn new(default_target: impl Into<Arc<str>>) -> Self {
+        Self {
+            default_target: default_target.into(),
+            channels: Arc::new(DashMap::new()),
+        }
+    }
+
+    /// Return a `SearchServiceClient` wired to the default target,
+    /// dialing lazily on first call.  Cheap on subsequent calls —
+    /// the Channel is cached and `SearchServiceClient::new` is a
+    /// no-op wrapper around the shared Channel handle.
+    pub async fn client(&self) -> Result<SearchServiceClient<Channel>, BackendError> {
+        let channel = self.get_or_dial(Arc::clone(&self.default_target)).await?;
+        // 64 MiB matches the sibling `peer_fanout::fan_out` cap so
+        // an operator upgrading either side of the wire doesn't hit
+        // an asymmetric decode ceiling.
+        Ok(SearchServiceClient::new(channel).max_decoding_message_size(64 * 1024 * 1024))
+    }
+
+    async fn get_or_dial(&self, target: Arc<str>) -> Result<Channel, BackendError> {
+        if let Some(c) = self.channels.get(&target) {
+            return Ok(c.clone());
+        }
+        let endpoint = Endpoint::from_shared(target.as_ref().to_string()).map_err(|e| {
+            BackendError::InvalidEndpoint {
+                target: target.as_ref().to_string(),
+                source: e,
+            }
+        })?;
+        let channel = endpoint.connect_lazy();
+        // `connect_lazy` never fails — the first RPC dial is where
+        // errors surface (as `tonic::Status`, handled by the
+        // handler).  Cache immediately so concurrent requesters
+        // share the Channel.
+        Ok(self.channels.entry(target).or_insert(channel).clone())
+    }
+}

--- a/rust/services/http-api/tests/glob_e2e.rs
+++ b/rust/services/http-api/tests/glob_e2e.rs
@@ -1,0 +1,359 @@
+//! Real-chain E2E cover for `GET /v2/search/glob` — exercises
+//!
+//!   reqwest client → axum listener → tonic client → gRPC server
+//!
+//! end-to-end.  The gRPC "server" is an in-process
+//! [`nexus_search_plugin_proto::SearchService`] implementation
+//! that returns canned data; the axum listener runs the real
+//! [`nexus_http_api::router`] against a [`SearchBackend`]
+//! pointed at the mock server's port.
+//!
+//! Pins:
+//!   * router → backend dial: `SearchBackend` actually reaches the
+//!     configured target and gets a routable Channel.
+//!   * handler → proto mapping: HTTP query params translate to the
+//!     right [`GlobRequest`] fields at the gRPC boundary.
+//!   * proto → HTTP mapping: [`GlobResponse`] fields round-trip
+//!     into the JSON body callers observe.
+//!   * error mapping: an `InvalidArgument` from the upstream
+//!     surfaces as HTTP 400, not 500.
+
+use std::sync::{Arc, Mutex};
+
+use nexus_http_api::search_proto::search_service_server::{SearchService, SearchServiceServer};
+use nexus_http_api::search_proto::{
+    AddIndexedDirectoryRequest, AddIndexedDirectoryResponse, BatchQueryRequest, BatchQueryResponse,
+    GlobRequest, GlobResponse, GrepRequest, GrepResponse, HealthRequest, HealthResponse,
+    IndexDocumentsRequest, IndexDocumentsResponse, IndexRequest, IndexResponse,
+    ListIndexedDirectoriesRequest, ListIndexedDirectoriesResponse, ListZoneIndexingModesRequest,
+    ListZoneIndexingModesResponse, LocateRequest, LocateResponse, NotifyFileChangeRequest,
+    NotifyFileChangeResponse, ParkedDiscardRequest, ParkedDiscardResponse, ParkedListRequest,
+    ParkedListResponse, ParkedRetryRequest, ParkedRetryResponse, QueryRequest, QueryResponse,
+    RefreshRequest, RefreshResponse, RemoveIndexedDirectoryRequest, RemoveIndexedDirectoryResponse,
+    SetZoneIndexingModeRequest, SetZoneIndexingModeResponse, StatsRequest, StatsResponse,
+};
+use nexus_http_api::{router, AppState, SearchBackend};
+use tokio::net::TcpListener;
+use tokio_stream::wrappers::TcpListenerStream;
+use tonic::{Request, Response, Status};
+
+// ── Mock SearchService ──────────────────────────────────────────
+//
+// Only `Glob` has real logic; every other RPC is `unimplemented!`
+// because the glob handler never touches them.  The mock records
+// each incoming request so tests can assert the handler mapped
+// query params correctly at the gRPC boundary.
+
+#[derive(Default, Clone)]
+struct RequestLog {
+    globs: Arc<Mutex<Vec<GlobRequest>>>,
+}
+
+#[derive(Clone)]
+enum MockBehaviour {
+    Success {
+        paths: Vec<String>,
+        truncated: bool,
+        error: Option<String>,
+    },
+    InvalidArgument(String),
+}
+
+#[derive(Clone)]
+struct MockSearchService {
+    log: RequestLog,
+    behaviour: MockBehaviour,
+}
+
+#[tonic::async_trait]
+impl SearchService for MockSearchService {
+    async fn glob(&self, req: Request<GlobRequest>) -> Result<Response<GlobResponse>, Status> {
+        let inner = req.into_inner();
+        self.log.globs.lock().unwrap().push(inner);
+        match &self.behaviour {
+            MockBehaviour::Success {
+                paths,
+                truncated,
+                error,
+            } => Ok(Response::new(GlobResponse {
+                paths: paths.clone(),
+                truncated: *truncated,
+                error: error.clone(),
+            })),
+            MockBehaviour::InvalidArgument(msg) => Err(Status::invalid_argument(msg.clone())),
+        }
+    }
+
+    // ── unused RPCs — every other method is unreachable from the
+    // glob handler; loud panic beats silent stub if a regression
+    // rewires. ──────────────────────────────────────────────────
+
+    async fn grep(&self, _: Request<GrepRequest>) -> Result<Response<GrepResponse>, Status> {
+        unreachable!("glob handler must not call grep")
+    }
+    async fn query(&self, _: Request<QueryRequest>) -> Result<Response<QueryResponse>, Status> {
+        unreachable!()
+    }
+    async fn index(&self, _: Request<IndexRequest>) -> Result<Response<IndexResponse>, Status> {
+        unreachable!()
+    }
+    async fn refresh(
+        &self,
+        _: Request<RefreshRequest>,
+    ) -> Result<Response<RefreshResponse>, Status> {
+        unreachable!()
+    }
+    async fn batch_query(
+        &self,
+        _: Request<BatchQueryRequest>,
+    ) -> Result<Response<BatchQueryResponse>, Status> {
+        unreachable!()
+    }
+    async fn index_documents(
+        &self,
+        _: Request<IndexDocumentsRequest>,
+    ) -> Result<Response<IndexDocumentsResponse>, Status> {
+        unreachable!()
+    }
+    async fn notify_file_change(
+        &self,
+        _: Request<NotifyFileChangeRequest>,
+    ) -> Result<Response<NotifyFileChangeResponse>, Status> {
+        unreachable!()
+    }
+    async fn locate(&self, _: Request<LocateRequest>) -> Result<Response<LocateResponse>, Status> {
+        unreachable!()
+    }
+    async fn parked_list(
+        &self,
+        _: Request<ParkedListRequest>,
+    ) -> Result<Response<ParkedListResponse>, Status> {
+        unreachable!()
+    }
+    async fn parked_retry(
+        &self,
+        _: Request<ParkedRetryRequest>,
+    ) -> Result<Response<ParkedRetryResponse>, Status> {
+        unreachable!()
+    }
+    async fn parked_discard(
+        &self,
+        _: Request<ParkedDiscardRequest>,
+    ) -> Result<Response<ParkedDiscardResponse>, Status> {
+        unreachable!()
+    }
+    async fn add_indexed_directory(
+        &self,
+        _: Request<AddIndexedDirectoryRequest>,
+    ) -> Result<Response<AddIndexedDirectoryResponse>, Status> {
+        unreachable!()
+    }
+    async fn remove_indexed_directory(
+        &self,
+        _: Request<RemoveIndexedDirectoryRequest>,
+    ) -> Result<Response<RemoveIndexedDirectoryResponse>, Status> {
+        unreachable!()
+    }
+    async fn list_indexed_directories(
+        &self,
+        _: Request<ListIndexedDirectoriesRequest>,
+    ) -> Result<Response<ListIndexedDirectoriesResponse>, Status> {
+        unreachable!()
+    }
+    async fn set_zone_indexing_mode(
+        &self,
+        _: Request<SetZoneIndexingModeRequest>,
+    ) -> Result<Response<SetZoneIndexingModeResponse>, Status> {
+        unreachable!()
+    }
+    async fn list_zone_indexing_modes(
+        &self,
+        _: Request<ListZoneIndexingModesRequest>,
+    ) -> Result<Response<ListZoneIndexingModesResponse>, Status> {
+        unreachable!()
+    }
+    async fn health(&self, _: Request<HealthRequest>) -> Result<Response<HealthResponse>, Status> {
+        unreachable!()
+    }
+    async fn stats(&self, _: Request<StatsRequest>) -> Result<Response<StatsResponse>, Status> {
+        unreachable!()
+    }
+}
+
+// ── Harness ─────────────────────────────────────────────────────
+
+struct Harness {
+    http_base: String,
+    log: RequestLog,
+}
+
+impl Harness {
+    async fn start(behaviour: MockBehaviour) -> Self {
+        // 1. Mock gRPC server on ephemeral port.
+        let grpc_listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind grpc listener");
+        let grpc_addr = grpc_listener.local_addr().expect("grpc addr");
+        let grpc_target = format!("http://{grpc_addr}");
+        let log = RequestLog::default();
+        let mock = MockSearchService {
+            log: log.clone(),
+            behaviour,
+        };
+        tokio::spawn(async move {
+            tonic::transport::Server::builder()
+                .add_service(SearchServiceServer::new(mock))
+                .serve_with_incoming(TcpListenerStream::new(grpc_listener))
+                .await
+                .expect("mock grpc serve");
+        });
+
+        // 2. axum listener with SearchBackend pointed at the mock.
+        let http_listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind http listener");
+        let http_addr = http_listener.local_addr().expect("http addr");
+        let state = AppState {
+            search: SearchBackend::new(grpc_target),
+        };
+        tokio::spawn(async move {
+            axum::serve(http_listener, router(state))
+                .await
+                .expect("axum::serve");
+        });
+
+        Self {
+            http_base: format!("http://{http_addr}"),
+            log,
+        }
+    }
+}
+
+// ── Tests ───────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn glob_happy_path_round_trips_full_chain() {
+    let h = Harness::start(MockBehaviour::Success {
+        paths: vec!["/a.rs".to_string(), "/nested/b.rs".to_string()],
+        truncated: false,
+        error: None,
+    })
+    .await;
+
+    let resp = reqwest::Client::new()
+        .get(format!(
+            "{}/v2/search/glob?root_path=/&pattern=*.rs&max_results=10&sort_recency=true",
+            h.http_base
+        ))
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+
+    let body: serde_json::Value = resp.json().await.expect("parse json");
+    assert_eq!(
+        body["paths"],
+        serde_json::json!(["/a.rs", "/nested/b.rs"]),
+        "paths must round-trip verbatim",
+    );
+    assert_eq!(body["truncated"], serde_json::Value::Bool(false));
+    // `error` is skip_serializing_if=None on GlobResponse — absent
+    // rather than JSON null so the callers reading serde_json's
+    // `get("error")` see `None` in the happy path.
+    assert!(body.get("error").is_none() || body["error"].is_null());
+
+    // Handler-to-proto boundary — verify every query param mapped
+    // to the corresponding GlobRequest field.
+    let recorded = h.log.globs.lock().unwrap().clone();
+    assert_eq!(recorded.len(), 1, "exactly one upstream Glob call");
+    assert_eq!(recorded[0].root_path, "/");
+    assert_eq!(recorded[0].pattern, "*.rs");
+    assert_eq!(recorded[0].max_results, 10);
+    assert!(recorded[0].sort_recency);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn glob_missing_pattern_returns_400() {
+    let h = Harness::start(MockBehaviour::Success {
+        paths: vec![],
+        truncated: false,
+        error: None,
+    })
+    .await;
+
+    let resp = reqwest::Client::new()
+        .get(format!("{}/v2/search/glob?root_path=/", h.http_base))
+        .send()
+        .await
+        .expect("send");
+    // axum's Query extractor rejects the request with 400 when a
+    // required param is absent (pattern has no default).  The
+    // mock never sees the RPC.
+    assert_eq!(
+        resp.status(),
+        reqwest::StatusCode::BAD_REQUEST,
+        "missing required pattern must not reach the backend",
+    );
+    assert!(
+        h.log.globs.lock().unwrap().is_empty(),
+        "upstream RPC must NOT fire on a rejected request",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn glob_upstream_invalid_argument_maps_to_400() {
+    let h = Harness::start(MockBehaviour::InvalidArgument(
+        "bad pattern: unbalanced bracket".to_string(),
+    ))
+    .await;
+
+    let resp = reqwest::Client::new()
+        .get(format!(
+            "{}/v2/search/glob?root_path=/&pattern=%5Bunbalanced",
+            h.http_base
+        ))
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(
+        resp.status(),
+        reqwest::StatusCode::BAD_REQUEST,
+        "tonic InvalidArgument must map to HTTP 400, not 500",
+    );
+
+    // Body carries the upstream message so operators can debug.
+    let body: serde_json::Value = resp.json().await.expect("parse json");
+    assert!(
+        body["error"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("unbalanced"),
+        "error body must include upstream message; got: {body}",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn glob_defaults_root_path_to_slash_when_absent() {
+    // root_path has serde default = "/"; pattern is required.
+    let h = Harness::start(MockBehaviour::Success {
+        paths: vec![],
+        truncated: false,
+        error: None,
+    })
+    .await;
+
+    let resp = reqwest::Client::new()
+        .get(format!("{}/v2/search/glob?pattern=*.md", h.http_base))
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+
+    let recorded = h.log.globs.lock().unwrap().clone();
+    assert_eq!(recorded.len(), 1);
+    assert_eq!(
+        recorded[0].root_path, "/",
+        "absent root_path must default to '/'",
+    );
+    assert_eq!(recorded[0].pattern, "*.md");
+}

--- a/rust/services/http-api/tests/serve_e2e.rs
+++ b/rust/services/http-api/tests/serve_e2e.rs
@@ -11,26 +11,34 @@
 //! sibling test rather than a separate binary, so the listener setup
 //! is amortised.
 
-use nexus_http_api::{router, StatusResponse};
+use nexus_http_api::{router, AppState, SearchBackend, StatusResponse};
 use tokio::net::TcpListener;
 
 /// Spawn the router on an ephemeral loopback port; return the base
 /// URL callers hit with `reqwest`.  Test-only helper — the binary
 /// entry point (once R10 wires this into `nexusd-cluster`) will
 /// take an operator-supplied bind address, not an OS-picked one.
+///
+/// The status handler does not touch the search backend, so a
+/// dummy target that never gets dialed is fine for this file's
+/// tests.  Backend-touching handlers get their own test binaries
+/// with a real mock server (`glob_e2e.rs`).
 async fn spawn_router() -> String {
-    // Bind port 0 → the kernel picks a free port; read it back so
-    // the client knows where to connect.
     let listener = TcpListener::bind("127.0.0.1:0")
         .await
         .expect("bind loopback ephemeral port");
     let addr = listener.local_addr().expect("read bound addr");
     let base_url = format!("http://{addr}");
+    let state = AppState {
+        search: SearchBackend::new("http://127.0.0.1:1"),
+    };
     tokio::spawn(async move {
         // `axum::serve` runs until the listener is dropped (which
         // happens when the tokio runtime tears down at test end),
         // so no explicit shutdown handshake is needed.
-        axum::serve(listener, router()).await.expect("axum::serve");
+        axum::serve(listener, router(state))
+            .await
+            .expect("axum::serve");
     });
     base_url
 }


### PR DESCRIPTION
## Summary

Second step of the R10 pure-Rust nexus-server migration (#4674).  PR #4675 shipped the axum skeleton with `GET /v2/status` and no upstream service; this lands the first REAL route — glob — plus all supporting infrastructure future routes plug into.

## Route

`GET /v2/search/glob?root_path=<p>&pattern=<glob>&max_results=<n>` parses query params, dispatches through a cached tonic client to upstream `nexus.search.v1.SearchService/Glob`, returns JSON.  Field names 1:1 with the proto so a caller migrating from the gRPC surface keeps its JSON parser.

## Architecture (proactive 10-principle audit result)

- **1a simple**: 4 files (build.rs, search_backend.rs, handlers/status.rs, handlers/search.rs).  Each does one thing.
- **1b infra unchanged**: no kernel ABI touch; no search-plugin crate dep (uses only the proto).
- **1c file layout**: `handlers/` module opens the seam — new route domain = new file, no lib.rs edit beyond one `.merge()`.  `AppState` growth = O(1) per domain.
- **1d SRP**: handler = HTTP surface; SearchBackend = Channel cache; proto stubs = generated.
- **2a no leak**: http-api ⊥ search-plugin (both consume proto SSOT independently).
- **3 SSOT**: `rust/services/proto/nexus/search/v1/search.proto` is single source; both crates codegen from it.
- **4 DRY**: no duplicated request/response types; proto is the shared shape.
- **5 ephemeral**: Channel cache is in-memory; no state persistence.
- **6 perf**: `connect_lazy` + DashMap cache — one dial per upstream per process, not per request.  Sharded lock so concurrent lookups on independent peers do not contend.
- **7 raft**: N/A (glob is read-only through search-plugin; no consensus).
- **8 systematic**: introduces the `handlers/` + `AppState` + backend-cache pattern once, so every follow-up route lands in one file.  Not "patch a route onto lib.rs".
- **9 E2E**: 8 tests — 4 spawn a real mock gRPC server on ephemeral port + real axum on ephemeral port + real reqwest, exercising the full chain.
- **10 no tombstones**: no reference to what the crate replaces; describes what it does.

## Error mapping

Two-state:
- `BackendError` → HTTP 503 (retry-friendly).
- `tonic::Status` → HTTP status by `Code` (400 InvalidArgument, 401 Unauthenticated, 403 PermissionDenied, 404 NotFound, 504 DeadlineExceeded, 503 Unavailable, 500 fallback).  Upstream message rides through in the JSON body.

## Deliberately absent

- No auth middleware.
- No ReBAC filter.
- No wiring into `nexusd-cluster` boot.

Each is a separately-scoped step in the same #4674 arc.

## Test plan

- [x] `cargo test -p nexus-http-api` — 8 pass (2 unit + 4 glob-e2e + 2 serve-e2e).
- [x] `cargo clippy -p nexus-http-api --all-targets --no-deps -- -D warnings` clean.
- [x] `cargo fmt -p nexus-http-api -- --check` clean.
