### PR TITLE
docs(mcp): rewrite TestDefaultConfigValidity docstring — remove tombstone

### DIFF
--- a/tests/unit/bricks/mcp/test_tool_profiles.py
+++ b/tests/unit/bricks/mcp/test_tool_profiles.py
@@ -400,14 +400,13 @@ class TestGrantToolsFailure:
 class TestDefaultConfigValidity:
     """Validate default tool_profiles.yaml load + inheritance-resolver behaviour.
 
-    The yaml itself is the SSOT for which tools each profile grants;
-    this test used to hard-code the FLATTENED per-profile tool set
-    which meant every add to yaml required a paired edit here — a
-    SSOT dup we no longer keep.  Instead these tests verify the
-    resolver contract (inheritance is additive, ``extends`` links
-    are well-formed, the default_profile field is honoured) using
-    the yaml as the source and a re-implemented flatten as the
-    oracle.
+    The yaml is the sole SSOT for which tools each profile grants.
+    Tests verify the resolver contract — every yaml profile surfaces
+    on the loaded config, loader output matches an independent
+    test-side flatten of the yaml, inheritance is additive, and the
+    ``default_profile`` field routes through ``get_default()`` —
+    with the yaml as the source of truth and a re-implemented
+    flatten as the oracle.
     """
 
     _CONFIG_PATH = Path(__file__).parents[4] / "src" / "nexus" / "config" / "tool_profiles.yaml"


### PR DESCRIPTION
## Summary

Audit follow-up for **principle 10** ("过程中被替代掉的系统，删干净，也不用在新代码里给他立墓碑").

PR #4677 shipped the correct SSOT-compliant refactor but the class docstring left a soft tombstone describing what the class **used to** do:

> this test used to hard-code the FLATTENED per-profile tool set which meant every add to yaml required a paired edit here — a SSOT dup we no longer keep.

Rewrite as a forward description — what the class ASSERTS about the resolver, not what its previous shape was. Git history carries the refactor story.

## Test plan

- [x] `pytest tests/unit/bricks/mcp/test_tool_profiles.py::TestDefaultConfigValidity` — 5/5.
- [x] ruff clean.
- [x] docs only; no behaviour change.
