### PR TITLE
feat(http-api): serve()/bind_and_serve() helpers + 3 edge-case glob E2Es

### DIFF
--- a/rust/services/http-api/src/lib.rs
+++ b/rust/services/http-api/src/lib.rs
@@ -27,7 +27,11 @@
 //!   justifies the wiring step.  Standalone-testable today via
 //!   `axum::serve` + `tests/*_e2e.rs`.
 
+use std::io;
+use std::net::SocketAddr;
+
 use axum::Router;
+use tokio::net::TcpListener;
 
 pub mod handlers;
 pub mod search_backend;
@@ -62,4 +66,39 @@ pub fn router(state: AppState) -> Router {
         .merge(handlers::status::router())
         .merge(handlers::search::router())
         .with_state(state)
+}
+
+/// Bind `addr` and serve [`router(state)`](router) until the returned
+/// future completes.  Convenience wrapper over
+/// [`axum::serve`] + [`tokio::net::TcpListener::bind`] so callers
+/// (integration tests, the future `nexusd-cluster` assembly
+/// binary) do not each re-implement the two-line startup dance.
+///
+/// Returns the [`SocketAddr`] actually bound so callers who pass
+/// `127.0.0.1:0` can learn the OS-picked port.  A shutdown hook is
+/// deliberately absent from this signature — tests drop the future
+/// when the runtime tears down, and the production binary wires
+/// its own graceful-shutdown signal on top of the raw future via
+/// [`axum::serve::Serve::with_graceful_shutdown`].
+pub async fn serve(addr: SocketAddr, state: AppState) -> io::Result<()> {
+    let listener = TcpListener::bind(addr).await?;
+    axum::serve(listener, router(state)).await
+}
+
+/// Same shape as [`serve`] but binds ahead of time so the caller
+/// can read `local_addr()` (the OS-picked port when `addr.port() == 0`)
+/// before the serve future starts.  Convenience for tests + any
+/// production caller that needs to log the bound port before the
+/// event loop runs.
+pub async fn bind_and_serve(
+    addr: SocketAddr,
+    state: AppState,
+) -> io::Result<(
+    SocketAddr,
+    impl std::future::Future<Output = io::Result<()>>,
+)> {
+    let listener = TcpListener::bind(addr).await?;
+    let bound = listener.local_addr()?;
+    let fut = async move { axum::serve(listener, router(state)).await };
+    Ok((bound, fut))
 }

--- a/rust/services/http-api/tests/glob_e2e.rs
+++ b/rust/services/http-api/tests/glob_e2e.rs
@@ -32,7 +32,7 @@ use nexus_http_api::search_proto::{
     RefreshRequest, RefreshResponse, RemoveIndexedDirectoryRequest, RemoveIndexedDirectoryResponse,
     SetZoneIndexingModeRequest, SetZoneIndexingModeResponse, StatsRequest, StatsResponse,
 };
-use nexus_http_api::{router, AppState, SearchBackend};
+use nexus_http_api::{bind_and_serve, AppState, SearchBackend};
 use tokio::net::TcpListener;
 use tokio_stream::wrappers::TcpListenerStream;
 use tonic::{Request, Response, Status};
@@ -188,45 +188,79 @@ struct Harness {
 }
 
 impl Harness {
+    /// Wire a mock gRPC server + an axum listener pointed at it,
+    /// both on OS-picked ephemeral ports.  Uses the crate's public
+    /// [`bind_and_serve`] helper for the HTTP half — same call
+    /// production uses, so a regression in the helper trips this
+    /// test alongside anything else that binds.
     async fn start(behaviour: MockBehaviour) -> Self {
-        // 1. Mock gRPC server on ephemeral port.
-        let grpc_listener = TcpListener::bind("127.0.0.1:0")
-            .await
-            .expect("bind grpc listener");
-        let grpc_addr = grpc_listener.local_addr().expect("grpc addr");
-        let grpc_target = format!("http://{grpc_addr}");
-        let log = RequestLog::default();
-        let mock = MockSearchService {
-            log: log.clone(),
-            behaviour,
-        };
-        tokio::spawn(async move {
-            tonic::transport::Server::builder()
-                .add_service(SearchServiceServer::new(mock))
-                .serve_with_incoming(TcpListenerStream::new(grpc_listener))
-                .await
-                .expect("mock grpc serve");
-        });
+        let (grpc_target, log) = spawn_mock_grpc_server(behaviour).await;
+        let http_base = spawn_http_listener(grpc_target).await;
+        Self { http_base, log }
+    }
 
-        // 2. axum listener with SearchBackend pointed at the mock.
-        let http_listener = TcpListener::bind("127.0.0.1:0")
+    /// Same shape as [`Self::start`] but skips the mock gRPC server
+    /// — the backend points at an address that refuses connections,
+    /// exercising the "upstream down" branch of the handler's error
+    /// mapping.  The `log` is a placeholder (no mock = no requests
+    /// to record); tests using this constructor inspect only the
+    /// HTTP response, never the log.
+    async fn start_pointing_at_dead_backend() -> Self {
+        // Reserve an ephemeral port, then drop the listener — no
+        // one is now listening on that port, so any dial refuses
+        // immediately (deterministic vs picking a "hopefully
+        // unused" fixed port that could occasionally collide).
+        let listener = TcpListener::bind("127.0.0.1:0")
             .await
-            .expect("bind http listener");
-        let http_addr = http_listener.local_addr().expect("http addr");
-        let state = AppState {
-            search: SearchBackend::new(grpc_target),
-        };
-        tokio::spawn(async move {
-            axum::serve(http_listener, router(state))
-                .await
-                .expect("axum::serve");
-        });
-
+            .expect("bind + release ephemeral port");
+        let dead_addr = listener.local_addr().expect("dead addr");
+        drop(listener);
+        let http_base = spawn_http_listener(format!("http://{dead_addr}")).await;
         Self {
-            http_base: format!("http://{http_addr}"),
-            log,
+            http_base,
+            log: RequestLog::default(),
         }
     }
+}
+
+/// Spawn an HTTP listener bound to an OS-picked ephemeral port,
+/// pointed at `grpc_target`; return its base URL.
+async fn spawn_http_listener(grpc_target: String) -> String {
+    let state = AppState {
+        search: SearchBackend::new(grpc_target),
+    };
+    let (http_addr, fut) = bind_and_serve("127.0.0.1:0".parse().unwrap(), state)
+        .await
+        .expect("bind http listener");
+    tokio::spawn(async move {
+        fut.await.expect("axum::serve");
+    });
+    format!("http://{http_addr}")
+}
+
+/// Spawn a mock `SearchService` implementation on an ephemeral
+/// tonic port; return the gRPC target URL + the request log the
+/// mock stamps every incoming request onto.  Extracted so
+/// [`Harness::start`] and any future backend-touching test can
+/// share the mock lifecycle.
+async fn spawn_mock_grpc_server(behaviour: MockBehaviour) -> (String, RequestLog) {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind grpc listener");
+    let addr = listener.local_addr().expect("grpc addr");
+    let log = RequestLog::default();
+    let mock = MockSearchService {
+        log: log.clone(),
+        behaviour,
+    };
+    tokio::spawn(async move {
+        tonic::transport::Server::builder()
+            .add_service(SearchServiceServer::new(mock))
+            .serve_with_incoming(TcpListenerStream::new(listener))
+            .await
+            .expect("mock grpc serve");
+    });
+    (format!("http://{addr}"), log)
 }
 
 // ── Tests ───────────────────────────────────────────────────────
@@ -356,4 +390,96 @@ async fn glob_defaults_root_path_to_slash_when_absent() {
         "absent root_path must default to '/'",
     );
     assert_eq!(recorded[0].pattern, "*.md");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn glob_upstream_down_maps_to_503() {
+    // No mock server; the backend points at a port that refuses
+    // connections.  tonic's dial surfaces as `Status::Unavailable`,
+    // which `grpc_status_to_http` maps to HTTP 503.  Verifies the
+    // handler surfaces a retry-friendly status instead of hanging
+    // or returning 500 when the upstream is down.
+    let h = Harness::start_pointing_at_dead_backend().await;
+
+    let resp = reqwest::Client::new()
+        .get(format!(
+            "{}/v2/search/glob?root_path=/&pattern=*.rs",
+            h.http_base
+        ))
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(
+        resp.status(),
+        reqwest::StatusCode::SERVICE_UNAVAILABLE,
+        "connection refused must surface as 503, not 500 or hang",
+    );
+    let body: serde_json::Value = resp.json().await.expect("parse json");
+    assert!(
+        body["error"].as_str().is_some(),
+        "503 body must carry an error message for operators; got: {body}",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn glob_sort_recency_false_propagates_to_backend() {
+    // Serde bool default is `false`; verify `sort_recency=false`
+    // reaches the backend as `false` (not silently `true` from a
+    // default-derivation bug).  Paired with the happy-path test
+    // asserting `sort_recency=true` reaches the backend.
+    let h = Harness::start(MockBehaviour::Success {
+        paths: vec![],
+        truncated: false,
+        error: None,
+    })
+    .await;
+
+    let resp = reqwest::Client::new()
+        .get(format!(
+            "{}/v2/search/glob?root_path=/&pattern=*.rs&sort_recency=false",
+            h.http_base
+        ))
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+
+    let recorded = h.log.globs.lock().unwrap().clone();
+    assert_eq!(recorded.len(), 1);
+    assert!(
+        !recorded[0].sort_recency,
+        "sort_recency=false must reach backend as false",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn glob_max_results_zero_propagates_to_backend() {
+    // `max_results=0` is the wire-level "server default" sentinel
+    // (documented on GlobQuery); verify it reaches the backend
+    // as 0 rather than being silently rewritten to some client-
+    // side cap.  Fresh callers relying on the sentinel behaviour
+    // would get quietly wrong page sizes without this pin.
+    let h = Harness::start(MockBehaviour::Success {
+        paths: vec![],
+        truncated: false,
+        error: None,
+    })
+    .await;
+
+    let resp = reqwest::Client::new()
+        .get(format!(
+            "{}/v2/search/glob?root_path=/&pattern=*.rs&max_results=0",
+            h.http_base
+        ))
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+
+    let recorded = h.log.globs.lock().unwrap().clone();
+    assert_eq!(recorded.len(), 1);
+    assert_eq!(
+        recorded[0].max_results, 0,
+        "max_results=0 (server-default sentinel) must reach backend as 0",
+    );
 }

--- a/rust/services/http-api/tests/serve_e2e.rs
+++ b/rust/services/http-api/tests/serve_e2e.rs
@@ -11,36 +11,29 @@
 //! sibling test rather than a separate binary, so the listener setup
 //! is amortised.
 
-use nexus_http_api::{router, AppState, SearchBackend, StatusResponse};
-use tokio::net::TcpListener;
+use nexus_http_api::{bind_and_serve, AppState, SearchBackend, StatusResponse};
 
 /// Spawn the router on an ephemeral loopback port; return the base
-/// URL callers hit with `reqwest`.  Test-only helper — the binary
-/// entry point (once R10 wires this into `nexusd-cluster`) will
-/// take an operator-supplied bind address, not an OS-picked one.
+/// URL callers hit with `reqwest`.  Uses the crate's own
+/// [`bind_and_serve`] helper — the same call the production
+/// `nexusd-cluster` assembly binary will use — so a regression in
+/// the helper trips this test alongside anything else that binds.
 ///
 /// The status handler does not touch the search backend, so a
 /// dummy target that never gets dialed is fine for this file's
 /// tests.  Backend-touching handlers get their own test binaries
 /// with a real mock server (`glob_e2e.rs`).
 async fn spawn_router() -> String {
-    let listener = TcpListener::bind("127.0.0.1:0")
-        .await
-        .expect("bind loopback ephemeral port");
-    let addr = listener.local_addr().expect("read bound addr");
-    let base_url = format!("http://{addr}");
     let state = AppState {
         search: SearchBackend::new("http://127.0.0.1:1"),
     };
+    let (addr, fut) = bind_and_serve("127.0.0.1:0".parse().unwrap(), state)
+        .await
+        .expect("bind loopback ephemeral port");
     tokio::spawn(async move {
-        // `axum::serve` runs until the listener is dropped (which
-        // happens when the tokio runtime tears down at test end),
-        // so no explicit shutdown handshake is needed.
-        axum::serve(listener, router(state))
-            .await
-            .expect("axum::serve");
+        fut.await.expect("axum::serve");
     });
-    base_url
+    format!("http://{addr}")
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]


### PR DESCRIPTION
## Summary

Audit follow-up for principles **4 (DRY)** + **9 (E2E coverage)** on PR #4678 (`GET /v2/search/glob`).

## DRY — extract listener boilerplate

Both integration test binaries were rolling their own `TcpListener::bind` + `axum::serve` dance; the `nexusd-cluster` assembly binary landing next would have been the third caller.  Extract to two public helpers:

- `serve(addr, state)` — bind + serve until the future completes.
- `bind_and_serve(addr, state) -> (SocketAddr, impl Future)` — returns the bound port before the serve future starts (test + prod logger use).

Test binaries flip to the helpers so a regression in the helper trips their tests alongside anything else that binds.

## E2E — 3 edge scenarios

- `glob_upstream_down_maps_to_503` — no mock server; backend at a released ephemeral port so any dial refuses.  Verifies `tonic::Status::Unavailable` → HTTP 503, not 500 or hang.
- `glob_sort_recency_false_propagates_to_backend` — pairs the happy path assertion (`true`); catches a serde-default derivation bug.
- `glob_max_results_zero_propagates_to_backend` — sentinel value ("server default") must reach backend as 0, not silently rewritten.

## Test plan

- [x] `cargo test -p nexus-http-api` — 11 pass (2 unit + 7 glob-e2e + 2 serve-e2e).
- [x] `cargo clippy -p nexus-http-api --all-targets --no-deps -- -D warnings` clean.
- [x] `cargo fmt -p nexus-http-api -- --check` clean.
- [x] No production handler behaviour change.
