### PR TITLE
fix(plugins): allocator-correct cross-boundary buffer frees (nexus-vfs#236)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "a2a"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=b98c08e62fe0bb1f3474a78a89b0c7864639e521#b98c08e62fe0bb1f3474a78a89b0c7864639e521"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=6cad75f7b43e49b60c9a345521695e915a6d7b47#6cad75f7b43e49b60c9a345521695e915a6d7b47"
 dependencies = [
  "contracts",
  "kernel",
@@ -233,8 +233,8 @@ checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "api"
-version = "0.1.25"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=052980a4859a4504d31c898483f763f91dfad1b6#052980a4859a4504d31c898483f763f91dfad1b6"
+version = "0.1.26"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=4bc7cba61a278d077bb40938bc9e498b9b261180#4bc7cba61a278d077bb40938bc9e498b9b261180"
 dependencies = [
  "base64 0.22.1",
  "httpdate",
@@ -327,7 +327,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 [[package]]
 name = "auth"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=b98c08e62fe0bb1f3474a78a89b0c7864639e521#b98c08e62fe0bb1f3474a78a89b0c7864639e521"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=6cad75f7b43e49b60c9a345521695e915a6d7b47#6cad75f7b43e49b60c9a345521695e915a6d7b47"
 dependencies = [
  "contracts",
  "dashmap",
@@ -430,7 +430,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=b98c08e62fe0bb1f3474a78a89b0c7864639e521#b98c08e62fe0bb1f3474a78a89b0c7864639e521"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=6cad75f7b43e49b60c9a345521695e915a6d7b47#6cad75f7b43e49b60c9a345521695e915a6d7b47"
 dependencies = [
  "ahash",
  "base64 0.22.1",
@@ -847,8 +847,8 @@ dependencies = [
 
 [[package]]
 name = "commands"
-version = "0.1.25"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=052980a4859a4504d31c898483f763f91dfad1b6#052980a4859a4504d31c898483f763f91dfad1b6"
+version = "0.1.26"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=4bc7cba61a278d077bb40938bc9e498b9b261180#4bc7cba61a278d077bb40938bc9e498b9b261180"
 dependencies = [
  "plugins",
  "runtime",
@@ -917,7 +917,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=b98c08e62fe0bb1f3474a78a89b0c7864639e521#b98c08e62fe0bb1f3474a78a89b0c7864639e521"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=6cad75f7b43e49b60c9a345521695e915a6d7b47#6cad75f7b43e49b60c9a345521695e915a6d7b47"
 dependencies = [
  "parking_lot",
  "serde",
@@ -2540,7 +2540,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=b98c08e62fe0bb1f3474a78a89b0c7864639e521#b98c08e62fe0bb1f3474a78a89b0c7864639e521"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=6cad75f7b43e49b60c9a345521695e915a6d7b47#6cad75f7b43e49b60c9a345521695e915a6d7b47"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -2608,7 +2608,7 @@ checksum = "0c2cdeb66e45e9f36bfad5bbdb4d2384e70936afbee843c6f6543f0c551ebb25"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=b98c08e62fe0bb1f3474a78a89b0c7864639e521#b98c08e62fe0bb1f3474a78a89b0c7864639e521"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=6cad75f7b43e49b60c9a345521695e915a6d7b47#6cad75f7b43e49b60c9a345521695e915a6d7b47"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -2672,6 +2672,15 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "libmimalloc-sys"
+version = "0.1.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "libredox"
@@ -2861,6 +2870,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "mimalloc"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d4139bb28d14ad1facf21d5eb8825051b326e172d216b39f6d31df53cc97862"
+dependencies = [
+ "libmimalloc-sys",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2972,7 +2990,7 @@ dependencies = [
 [[package]]
 name = "nexus-cluster"
 version = "0.1.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=b98c08e62fe0bb1f3474a78a89b0c7864639e521#b98c08e62fe0bb1f3474a78a89b0c7864639e521"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=6cad75f7b43e49b60c9a345521695e915a6d7b47#6cad75f7b43e49b60c9a345521695e915a6d7b47"
 dependencies = [
  "a2a",
  "anyhow",
@@ -3046,7 +3064,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=b98c08e62fe0bb1f3474a78a89b0c7864639e521#b98c08e62fe0bb1f3474a78a89b0c7864639e521"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=6cad75f7b43e49b60c9a345521695e915a6d7b47#6cad75f7b43e49b60c9a345521695e915a6d7b47"
 
 [[package]]
 name = "nexus-search-plugin"
@@ -3060,6 +3078,7 @@ dependencies = [
  "globset",
  "hnsw_rs",
  "libloading 0.8.9",
+ "mimalloc",
  "nexus-plugin-abi",
  "ort",
  "parking_lot",
@@ -3102,8 +3121,8 @@ dependencies = [
 
 [[package]]
 name = "nexus-vfs-client"
-version = "0.1.25"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=052980a4859a4504d31c898483f763f91dfad1b6#052980a4859a4504d31c898483f763f91dfad1b6"
+version = "0.1.26"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=4bc7cba61a278d077bb40938bc9e498b9b261180#4bc7cba61a278d077bb40938bc9e498b9b261180"
 dependencies = [
  "prost 0.13.5",
  "protoc-bin-vendored",
@@ -3559,8 +3578,8 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plugins"
-version = "0.1.25"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=052980a4859a4504d31c898483f763f91dfad1b6#052980a4859a4504d31c898483f763f91dfad1b6"
+version = "0.1.26"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=4bc7cba61a278d077bb40938bc9e498b9b261180#4bc7cba61a278d077bb40938bc9e498b9b261180"
 dependencies = [
  "serde",
  "serde_json",
@@ -3974,7 +3993,7 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 [[package]]
 name = "raft"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=b98c08e62fe0bb1f3474a78a89b0c7864639e521#b98c08e62fe0bb1f3474a78a89b0c7864639e521"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=6cad75f7b43e49b60c9a345521695e915a6d7b47#6cad75f7b43e49b60c9a345521695e915a6d7b47"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -4403,8 +4422,8 @@ dependencies = [
 
 [[package]]
 name = "runtime"
-version = "0.1.25"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=052980a4859a4504d31c898483f763f91dfad1b6#052980a4859a4504d31c898483f763f91dfad1b6"
+version = "0.1.26"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=4bc7cba61a278d077bb40938bc9e498b9b261180#4bc7cba61a278d077bb40938bc9e498b9b261180"
 dependencies = [
  "a2a",
  "agent-client-protocol",
@@ -5310,8 +5329,8 @@ dependencies = [
 
 [[package]]
 name = "telemetry"
-version = "0.1.25"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=052980a4859a4504d31c898483f763f91dfad1b6#052980a4859a4504d31c898483f763f91dfad1b6"
+version = "0.1.26"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=4bc7cba61a278d077bb40938bc9e498b9b261180#4bc7cba61a278d077bb40938bc9e498b9b261180"
 dependencies = [
  "chrono",
  "dirs",
@@ -5701,8 +5720,8 @@ dependencies = [
 
 [[package]]
 name = "tools"
-version = "0.1.25"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=052980a4859a4504d31c898483f763f91dfad1b6#052980a4859a4504d31c898483f763f91dfad1b6"
+version = "0.1.26"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=4bc7cba61a278d077bb40938bc9e498b9b261180#4bc7cba61a278d077bb40938bc9e498b9b261180"
 dependencies = [
  "api",
  "async-trait",
@@ -5845,7 +5864,7 @@ dependencies = [
 [[package]]
 name = "transport"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=b98c08e62fe0bb1f3474a78a89b0c7864639e521#b98c08e62fe0bb1f3474a78a89b0c7864639e521"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=6cad75f7b43e49b60c9a345521695e915a6d7b47#6cad75f7b43e49b60c9a345521695e915a6d7b47"
 dependencies = [
  "axum",
  "backends",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -229,24 +229,24 @@ exclude = ["nexus-fuse"]
 #
 # Bump alongside the rest of nexus-vfs updates when a downstream
 # change needs newer kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "b98c08e62fe0bb1f3474a78a89b0c7864639e521" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "b98c08e62fe0bb1f3474a78a89b0c7864639e521" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "b98c08e62fe0bb1f3474a78a89b0c7864639e521" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "b98c08e62fe0bb1f3474a78a89b0c7864639e521", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "b98c08e62fe0bb1f3474a78a89b0c7864639e521", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "b98c08e62fe0bb1f3474a78a89b0c7864639e521", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "b98c08e62fe0bb1f3474a78a89b0c7864639e521" }
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "6cad75f7b43e49b60c9a345521695e915a6d7b47" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "6cad75f7b43e49b60c9a345521695e915a6d7b47" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "6cad75f7b43e49b60c9a345521695e915a6d7b47" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "6cad75f7b43e49b60c9a345521695e915a6d7b47", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "6cad75f7b43e49b60c9a345521695e915a6d7b47", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "6cad75f7b43e49b60c9a345521695e915a6d7b47", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "6cad75f7b43e49b60c9a345521695e915a6d7b47" }
 # The cluster daemon library entry (`nexus_cluster::run_with_services`),
 # consumed by the nexus-side assembly binary (`rust/nexusd`) that composes
 # the kernel/federation boot with the nexus service set via the
 # ServiceRegistry bring-up seam.
-nexus-cluster = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "b98c08e62fe0bb1f3474a78a89b0c7864639e521" }
+nexus-cluster = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "6cad75f7b43e49b60c9a345521695e915a6d7b47" }
 # a2a messaging substrate. `default-features = false` leaves the
 # `install` feature (which pulls raft to arm the stream-wakeup observer)
 # OFF, so nexus-side consumers link only the stamp hook and stay
 # raft-free — they reach raft through kernel.sys_* (§6.1). The substrate
 # is armed in production at cluster boot in nexus-vfs, not here.
-a2a = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "b98c08e62fe0bb1f3474a78a89b0c7864639e521", default-features = false }
+a2a = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "6cad75f7b43e49b60c9a345521695e915a6d7b47", default-features = false }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir --no-deps --prefix=/install .
 # enforces agreement) — an unpinned install tracks nexus-vfs HEAD and
 # ships an untested kernel (#4343). --locked honors the source tree's
 # Cargo.lock.
-ARG NEXUS_VFS_REV=b98c08e62fe0bb1f3474a78a89b0c7864639e521
+ARG NEXUS_VFS_REV=6cad75f7b43e49b60c9a345521695e915a6d7b47
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-cluster nexus-cluster
 
 # -- Runtime stage --

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -25,7 +25,7 @@ WORKDIR /build
 # (CI preflight enforces agreement) — an unpinned install tracks HEAD
 # and can skew the raft contract against the cluster/witness images.
 # --locked honors the source tree's Cargo.lock.
-ARG NEXUS_VFS_REV=b98c08e62fe0bb1f3474a78a89b0c7864639e521
+ARG NEXUS_VFS_REV=6cad75f7b43e49b60c9a345521695e915a6d7b47
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexus-raft-server raft
 
 # ---------- Production image ----------

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=b98c08e62fe0bb1f3474a78a89b0c7864639e521
+ARG NEXUS_VFS_REV=6cad75f7b43e49b60c9a345521695e915a6d7b47
 RUN cargo install \
     --locked \
     --git https://github.com/nexi-lab/nexus-vfs \

--- a/rust/backends/local-connector/src/lib.rs
+++ b/rust/backends/local-connector/src/lib.rs
@@ -272,6 +272,7 @@ mod tests {
             sys_rmdir: stub_sys_path,
             sys_rename: stub_sys_rename,
             sys_stat_batch: stub_sys_stat_batch,
+            free_buf: nexus_plugin_abi::nexus_free,
             kernel_ptr: std::ptr::null(),
         }
     }

--- a/rust/nexusd/Cargo.toml
+++ b/rust/nexusd/Cargo.toml
@@ -56,8 +56,8 @@ anyhow = "1"
 # the api + runtime crates); `sudocode-runtime` names the `AgentLoopState`
 # / `SpawnHandle` types the adapter maps. Pinned to the sudocode main merge
 # commit of #392 (co-host readiness).
-sudocode-runtime = { package = "runtime", git = "https://github.com/sudoprivacy/sudocode", rev = "052980a4859a4504d31c898483f763f91dfad1b6", optional = true }
-sudocode-tools = { package = "tools", git = "https://github.com/sudoprivacy/sudocode", rev = "052980a4859a4504d31c898483f763f91dfad1b6", optional = true }
+sudocode-runtime = { package = "runtime", git = "https://github.com/sudoprivacy/sudocode", rev = "4bc7cba61a278d077bb40938bc9e498b9b261180", optional = true }
+sudocode-tools = { package = "tools", git = "https://github.com/sudoprivacy/sudocode", rev = "4bc7cba61a278d077bb40938bc9e498b9b261180", optional = true }
 # Named directly to spell `kernel::kernel::{ServiceDecl, Kernel}` — the
 # managed-agent boot decl's return type (both builds) and the co-host
 # adapter's `SpawnTask<Kernel>` (cohost build). Already present transitively

--- a/rust/services/fuse-plugin/src/kernel_callbacks.rs
+++ b/rust/services/fuse-plugin/src/kernel_callbacks.rs
@@ -6,8 +6,10 @@
 //! for writes), translates Rust `&str` ↔ `CString`, dispatches
 //! through the `extern "C"` fn pointer on the handle, and on success
 //! takes ownership of the kernel-allocated out-buffer + frees it via
-//! [`nexus_plugin_abi::nexus_free`] before returning a Rust-side
-//! `String` / `Vec<u8>`.
+//! the handle's [`KernelHandle::free_buf`] callback (NOT the plugin's
+//! own `nexus_free` — these buffers are HOST-allocated and the kernel
+//! links a different global allocator; a cross-heap free segfaults on
+//! Windows) before returning a Rust-side `String` / `Vec<u8>`.
 //!
 //! The returned `Err(i32)` is the raw C-ABI rc — mapping to a
 //! platform-specific error code (Errno for fuser, NTSTATUS for
@@ -25,7 +27,7 @@
 
 use std::ffi::CString;
 
-use nexus_plugin_abi::{nexus_free, KernelHandle};
+use nexus_plugin_abi::{KernelHandle, NexusFreeFn};
 
 /// Raw `i32` "I/O error" used when the kernel callback can't be
 /// invoked at all (e.g. NUL in the path string).  Maps to
@@ -52,7 +54,7 @@ pub fn sys_stat(kernel: &KernelHandle, path: &str) -> Result<String, i32> {
     if rc != 0 {
         return Err(rc);
     }
-    consume_string_out(out_buf, out_len)
+    consume_string_out(kernel.free_buf, out_buf, out_len)
 }
 
 /// Wrapper around the C `sys_read` callback.  Returns the full file
@@ -72,7 +74,7 @@ pub fn sys_read(kernel: &KernelHandle, path: &str) -> Result<Vec<u8>, i32> {
     if rc != 0 {
         return Err(rc);
     }
-    consume_bytes_out(out_buf, out_len)
+    consume_bytes_out(kernel.free_buf, out_buf, out_len)
 }
 
 /// Wrapper around the C `sys_write` callback.
@@ -109,7 +111,7 @@ pub fn sys_readdir(kernel: &KernelHandle, parent_path: &str) -> Result<String, i
     if rc != 0 {
         return Err(rc);
     }
-    consume_string_out(out_buf, out_len)
+    consume_string_out(kernel.free_buf, out_buf, out_len)
 }
 
 /// Wrapper around the C `sys_unlink` callback.
@@ -194,7 +196,7 @@ pub fn sys_stat_batch(
     if rc != 0 {
         return Err(rc);
     }
-    let json = consume_string_out(out_buf, out_len)?;
+    let json = consume_string_out(kernel.free_buf, out_buf, out_len)?;
     Ok(parse_stat_batch_output(&json))
 }
 
@@ -303,6 +305,7 @@ mod nfs_async {
     pub async fn sys_stat_async(kernel: &KernelHandle, path: &str) -> Result<String, i32> {
         let c_path = CString::new(path).map_err(|_| ERRNO_IO_RAW)?;
         let fn_ptr = kernel.sys_stat;
+        let free_buf = kernel.free_buf;
         let kptr = kernel.kernel_ptr as usize;
         tokio::task::spawn_blocking(move || {
             let kptr = kptr as *const std::ffi::c_void;
@@ -312,7 +315,7 @@ mod nfs_async {
             if rc != 0 {
                 return Err(rc);
             }
-            consume_string_out(out_buf, out_len)
+            consume_string_out(free_buf, out_buf, out_len)
         })
         .await
         .unwrap_or(Err(ERRNO_IO_RAW))
@@ -322,6 +325,7 @@ mod nfs_async {
     pub async fn sys_read_async(kernel: &KernelHandle, path: &str) -> Result<Vec<u8>, i32> {
         let c_path = CString::new(path).map_err(|_| ERRNO_IO_RAW)?;
         let fn_ptr = kernel.sys_read;
+        let free_buf = kernel.free_buf;
         let kptr = kernel.kernel_ptr as usize;
         tokio::task::spawn_blocking(move || {
             let kptr = kptr as *const std::ffi::c_void;
@@ -331,7 +335,7 @@ mod nfs_async {
             if rc != 0 {
                 return Err(rc);
             }
-            consume_bytes_out(out_buf, out_len)
+            consume_bytes_out(free_buf, out_buf, out_len)
         })
         .await
         .unwrap_or(Err(ERRNO_IO_RAW))
@@ -368,6 +372,7 @@ mod nfs_async {
     ) -> Result<String, i32> {
         let c_path = CString::new(parent_path).map_err(|_| ERRNO_IO_RAW)?;
         let fn_ptr = kernel.sys_readdir;
+        let free_buf = kernel.free_buf;
         let kptr = kernel.kernel_ptr as usize;
         tokio::task::spawn_blocking(move || {
             let kptr = kptr as *const std::ffi::c_void;
@@ -377,7 +382,7 @@ mod nfs_async {
             if rc != 0 {
                 return Err(rc);
             }
-            consume_string_out(out_buf, out_len)
+            consume_string_out(free_buf, out_buf, out_len)
         })
         .await
         .unwrap_or(Err(ERRNO_IO_RAW))
@@ -529,29 +534,39 @@ pub fn parse_readdir(json: &str) -> Vec<(String, u64)> {
 
 // ── private helpers ─────────────────────────────────────────────────
 
-/// Consume a kernel-allocated `(out_buf, out_len)` pair as a UTF-8
-/// `String`, freeing the buffer via `nexus_free` even on parse
-/// failure.  Both `sys_stat` and `sys_readdir` return JSON payloads
-/// with this exact lifecycle.
-fn consume_string_out(out_buf: *mut u8, out_len: usize) -> Result<String, i32> {
+/// Consume a HOST-allocated `(out_buf, out_len)` pair as a UTF-8
+/// `String`, freeing the buffer via the host's `free_buf` even on
+/// parse failure.  Both `sys_stat` and `sys_readdir` return JSON
+/// payloads with this exact lifecycle.  `free_buf` MUST be the buffer's
+/// allocating side (the host), never the plugin's `nexus_free` — the
+/// two link different allocators (see the module docs).
+fn consume_string_out(
+    free_buf: NexusFreeFn,
+    out_buf: *mut u8,
+    out_len: usize,
+) -> Result<String, i32> {
     unsafe {
         let slice = std::slice::from_raw_parts(out_buf, out_len);
         let s = std::str::from_utf8(slice)
             .map(|s| s.to_string())
             .map_err(|_| ERRNO_IO_RAW);
-        nexus_free(out_buf, out_len);
+        free_buf(out_buf, out_len);
         s
     }
 }
 
-/// Consume a kernel-allocated `(out_buf, out_len)` pair as a byte
-/// vector, freeing the buffer via `nexus_free`.  Used by `sys_read`
+/// Consume a HOST-allocated `(out_buf, out_len)` pair as a byte vector,
+/// freeing the buffer via the host's `free_buf`.  Used by `sys_read`
 /// which doesn't constrain encoding.
-fn consume_bytes_out(out_buf: *mut u8, out_len: usize) -> Result<Vec<u8>, i32> {
+fn consume_bytes_out(
+    free_buf: NexusFreeFn,
+    out_buf: *mut u8,
+    out_len: usize,
+) -> Result<Vec<u8>, i32> {
     unsafe {
         let slice = std::slice::from_raw_parts(out_buf, out_len);
         let v = slice.to_vec();
-        nexus_free(out_buf, out_len);
+        free_buf(out_buf, out_len);
         Ok(v)
     }
 }

--- a/rust/services/fuse-plugin/src/lib.rs
+++ b/rust/services/fuse-plugin/src/lib.rs
@@ -428,6 +428,7 @@ unsafe fn kernel_handle_clone(src: &KernelHandle) -> KernelHandle {
         sys_rmdir: src.sys_rmdir,
         sys_rename: src.sys_rename,
         sys_stat_batch: src.sys_stat_batch,
+        free_buf: src.free_buf,
         kernel_ptr: src.kernel_ptr,
     }
 }

--- a/rust/services/fuse-plugin/tests/nfs_integration.rs
+++ b/rust/services/fuse-plugin/tests/nfs_integration.rs
@@ -259,6 +259,7 @@ fn mock_kernel_handle(mock: &MockKernel) -> KernelHandle {
         sys_rmdir: mock_sys_rmdir,
         sys_rename: mock_sys_rename,
         sys_stat_batch: mock_sys_stat_batch,
+        free_buf: nexus_plugin_abi::nexus_free,
         kernel_ptr: mock as *const MockKernel as *const c_void,
     }
 }
@@ -682,6 +683,7 @@ fn slow_mock_kernel_handle(mock: &SlowMockKernel) -> KernelHandle {
         sys_rmdir: mock_sys_rmdir_for_slow,
         sys_rename: mock_sys_rename_for_slow,
         sys_stat_batch: mock_sys_stat_batch_for_slow,
+        free_buf: nexus_plugin_abi::nexus_free,
         kernel_ptr: mock as *const SlowMockKernel as *const c_void,
     }
 }

--- a/rust/services/search-plugin/Cargo.toml
+++ b/rust/services/search-plugin/Cargo.toml
@@ -159,6 +159,13 @@ tempfile = "3"
 # resolution + `nexus_plugin_grpc_services` JSON contract on all
 # three `libloading`-supported platforms.
 libloading = "0.8"
+# cross_allocator_free_e2e.rs sets mimalloc as the test binary's global
+# allocator (mirroring the cluster host) so a Grep across the FFI
+# boundary into the system-allocator cdylib faithfully reproduces the
+# Windows cross-heap free bug (nexus-vfs#236).  prost encodes the Grep
+# request / decodes the response through the same plugin-ABI path.
+mimalloc = { workspace = true }
+prost = { workspace = true }
 # TcpListenerStream — federation_e2e.rs binds a peer plugin to a
 # loopback ephemeral port + wraps it as a Stream so tonic's
 # `serve_with_incoming` can drive it (Server::serve wants a

--- a/rust/services/search-plugin/examples/standalone_host.rs
+++ b/rust/services/search-plugin/examples/standalone_host.rs
@@ -176,6 +176,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         sys_rmdir: deny_rmdir,
         sys_rename: deny_rename,
         sys_stat_batch: deny_stat_batch,
+        free_buf: nexus_plugin_abi::nexus_free,
         kernel_ptr: kernel as *const c_void,
     };
 

--- a/rust/services/search-plugin/src/kernel_io.rs
+++ b/rust/services/search-plugin/src/kernel_io.rs
@@ -2,14 +2,17 @@
 //!
 //! Every syscall the search walker needs (`sys_readdir` + `sys_read`)
 //! is exposed here as a Rust-ergonomic `Result<T, KernelIoError>`
-//! function.  Keeps the `unsafe extern "C"` FFI + `nexus_free`
+//! function.  Keeps the `unsafe extern "C"` FFI + `free_buf`
 //! bookkeeping in one place so the walker / grep loop stays in
-//! straight-line Rust.
+//! straight-line Rust.  Buffers these callbacks return are HOST-
+//! allocated, so they are freed with `handle.free_buf`, never the
+//! plugin's own `nexus_free` (different allocators — see the ABI's
+//! `KernelHandle::free_buf` contract).
 
 use std::ffi::{CString, NulError};
 use std::slice;
 
-use nexus_plugin_abi::{nexus_free, KernelHandle};
+use nexus_plugin_abi::KernelHandle;
 use serde::Deserialize;
 
 /// Errors surfaced from the kernel-side callbacks.  Mirrors the
@@ -89,12 +92,15 @@ pub fn sys_readdir(handle: &KernelHandle, path: &str) -> Result<Vec<DirEntry>, K
         0 => {
             // SAFETY: on Ok, the callback populated `out_ptr` with a
             // heap-allocated buffer of `out_len` bytes; we borrow it
-            // for the parse then hand it back to `nexus_free`.
+            // for the parse then hand it back via `handle.free_buf`.
             let bytes = unsafe { slice::from_raw_parts(out_ptr, out_len) };
             let parsed =
                 serde_json::from_slice::<Vec<DirEntry>>(bytes).map_err(KernelIoError::JsonParse);
-            // Free regardless of parse outcome — kernel owns the alloc.
-            unsafe { nexus_free(out_ptr, out_len) };
+            // Free regardless of parse outcome. The HOST allocated this
+            // buffer, so it must be freed by the host via `free_buf` —
+            // NOT the plugin's `nexus_free` (the kernel links mimalloc,
+            // this plugin the system allocator; a cross-heap free segfaults).
+            unsafe { (handle.free_buf)(out_ptr, out_len) };
             parsed
         }
         -1 => Err(KernelIoError::NotFound),
@@ -125,7 +131,8 @@ pub fn sys_read(handle: &KernelHandle, path: &str) -> Result<Vec<u8>, KernelIoEr
         0 => {
             let bytes = unsafe { slice::from_raw_parts(out_ptr, out_len) };
             let owned = bytes.to_vec();
-            unsafe { nexus_free(out_ptr, out_len) };
+            // Host-allocated buffer → free via the host's `free_buf`.
+            unsafe { (handle.free_buf)(out_ptr, out_len) };
             Ok(owned)
         }
         -1 => Err(KernelIoError::NotFound),
@@ -168,7 +175,8 @@ pub fn sys_stat(handle: &KernelHandle, path: &str) -> Result<StatInfo, KernelIoE
         0 => {
             let bytes = unsafe { slice::from_raw_parts(out_ptr, out_len) };
             let parsed: Result<StatInfo, _> = serde_json::from_slice(bytes);
-            unsafe { nexus_free(out_ptr, out_len) };
+            // Host-allocated buffer → free via the host's `free_buf`.
+            unsafe { (handle.free_buf)(out_ptr, out_len) };
             parsed.map_err(KernelIoError::JsonParse)
         }
         -1 => Err(KernelIoError::NotFound),

--- a/rust/services/search-plugin/src/lib.rs
+++ b/rust/services/search-plugin/src/lib.rs
@@ -115,6 +115,7 @@ fn dup_kernel_handle(h: &KernelHandle) -> KernelHandle {
         sys_rmdir: h.sys_rmdir,
         sys_rename: h.sys_rename,
         sys_stat_batch: h.sys_stat_batch,
+        free_buf: h.free_buf,
         kernel_ptr: h.kernel_ptr,
     }
 }

--- a/rust/services/search-plugin/tests/batch_query_e2e.rs
+++ b/rust/services/search-plugin/tests/batch_query_e2e.rs
@@ -223,6 +223,7 @@ fn handle_for(kernel: *const MockKernel) -> KernelHandle {
         sys_rmdir: unused_sys_rmdir,
         sys_rename: unused_sys_rename,
         sys_stat_batch: unused_sys_stat_batch,
+        free_buf: nexus_plugin_abi::nexus_free,
         kernel_ptr: kernel as *const c_void,
     }
 }

--- a/rust/services/search-plugin/tests/contextual_chunking_e2e.rs
+++ b/rust/services/search-plugin/tests/contextual_chunking_e2e.rs
@@ -97,6 +97,7 @@ fn poison_handle() -> KernelHandle {
         sys_rmdir: poison_rmdir,
         sys_rename: poison_rename,
         sys_stat_batch: poison_stat_batch,
+        free_buf: nexus_plugin_abi::nexus_free,
         kernel_ptr: std::ptr::null(),
     }
 }
@@ -613,6 +614,7 @@ fn handle_for(k: *const MockKernel) -> KernelHandle {
         sys_rmdir: unused_rmdir,
         sys_rename: unused_rename,
         sys_stat_batch: unused_stat_batch,
+        free_buf: nexus_plugin_abi::nexus_free,
         kernel_ptr: k as *const c_void,
     }
 }

--- a/rust/services/search-plugin/tests/cross_allocator_free_e2e.rs
+++ b/rust/services/search-plugin/tests/cross_allocator_free_e2e.rs
@@ -1,0 +1,289 @@
+//! Cross-allocator FFI regression — nexus-vfs#236.
+//!
+//! The cluster HOST links **mimalloc** as its global allocator; a plugin
+//! cdylib links the **system** allocator. Any heap buffer that crosses
+//! the plugin C-ABI boundary must be freed by the side that ALLOCATED
+//! it, or the free lands on the wrong heap. On Windows that is a hard
+//! segfault (`HeapFree` rejects a mimalloc pointer); the Linux Docker
+//! search-plugin E2E masks it (a foreign `free` there defers the
+//! corruption instead of trapping), so it is NOT a faithful guard.
+//!
+//! This test reproduces the real thing without Docker: it sets mimalloc
+//! as THIS binary's global allocator (playing the cluster host), dlopens
+//! the REAL search-plugin cdylib (system allocator), wires a `KernelHandle`
+//! whose `sys_*` callbacks allocate buffers HERE (mimalloc) and whose
+//! `free_buf` frees them HERE (mimalloc), then drives a live `Grep`:
+//!
+//!   * every `sys_read`/`sys_readdir` the plugin makes hands it a
+//!     mimalloc buffer it must free through `handle.free_buf` (host) —
+//!     before the fix it freed them with its own `nexus_free` (system)
+//!     and this test SEGFAULTED on Windows;
+//!   * the `Grep` response is a system-allocated buffer the host frees
+//!     through the plugin's exported `nexus_free` (plugin allocator).
+//!
+//! A clean pass (match found, process alive) proves both directions of
+//! the ownership rule hold across two real allocators.
+
+use std::collections::HashMap;
+use std::ffi::{c_void, CStr, CString};
+use std::os::raw::c_char;
+use std::path::PathBuf;
+use std::process::Command;
+
+use nexus_plugin_abi::{KernelHandle, NexusFreeFn, ServiceCreateFn, ServiceDispatchFn};
+use nexus_search_plugin::search_proto::{GrepRequest, GrepResponse};
+use prost::Message;
+
+// The whole point: a DIFFERENT global allocator than the system one the
+// cdylib links, so a cross-boundary free is a genuine cross-heap free.
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
+#[cfg(target_os = "linux")]
+const PLUGIN_FILE: &str = "libnexus_search_plugin.so";
+#[cfg(target_os = "macos")]
+const PLUGIN_FILE: &str = "libnexus_search_plugin.dylib";
+#[cfg(target_os = "windows")]
+const PLUGIN_FILE: &str = "nexus_search_plugin.dll";
+
+fn plugin_path() -> PathBuf {
+    let exe = std::env::current_exe().expect("current_exe");
+    let target_profile_dir = exe
+        .parent()
+        .and_then(|p| p.parent())
+        .unwrap_or_else(|| panic!("unexpected test binary layout: {}", exe.display()));
+    target_profile_dir.join(PLUGIN_FILE)
+}
+
+fn ensure_cdylib_built(plugin: &std::path::Path) {
+    if plugin.exists() {
+        return;
+    }
+    let mut cmd = Command::new(env!("CARGO"));
+    cmd.args(["build", "-p", "nexus-search-plugin"]);
+    if !cfg!(debug_assertions) {
+        cmd.arg("--release");
+    }
+    let status = cmd.status().expect("invoke cargo");
+    assert!(
+        status.success(),
+        "cargo build -p nexus-search-plugin failed"
+    );
+    assert!(plugin.exists(), "cdylib still not at {}", plugin.display());
+}
+
+// ── In-memory host VFS the plugin walks over the C-ABI ──────────────
+
+struct HostFs {
+    /// path → file bytes (regular files only).
+    files: HashMap<String, Vec<u8>>,
+    /// parent dir → children `(name, entry_type)` (0 = DT_REG, 1 = DT_DIR).
+    dirs: HashMap<String, Vec<(String, u8)>>,
+}
+
+/// Hand a buffer to the plugin as an exact-capacity boxed slice — this
+/// allocation happens in the TEST binary (mimalloc), and `host_free_buf`
+/// (also mimalloc) is what the plugin must call back to release it.
+unsafe fn yield_buf(bytes: Vec<u8>, out_buf: *mut *mut u8, out_len: *mut usize) {
+    let boxed = bytes.into_boxed_slice();
+    *out_len = boxed.len();
+    *out_buf = Box::into_raw(boxed) as *mut u8;
+}
+
+unsafe extern "C" fn host_free_buf(ptr: *mut u8, len: usize) {
+    if !ptr.is_null() && len > 0 {
+        drop(Vec::from_raw_parts(ptr, len, len));
+    }
+}
+
+unsafe extern "C" fn host_sys_read(
+    k: *const c_void,
+    path: *const c_char,
+    out_buf: *mut *mut u8,
+    out_len: *mut usize,
+) -> i32 {
+    let fs = &*(k as *const HostFs);
+    let Ok(p) = CStr::from_ptr(path).to_str() else {
+        return -2;
+    };
+    match fs.files.get(p) {
+        Some(bytes) => {
+            yield_buf(bytes.clone(), out_buf, out_len);
+            0
+        }
+        None => -1,
+    }
+}
+
+unsafe extern "C" fn host_sys_readdir(
+    k: *const c_void,
+    path: *const c_char,
+    out_buf: *mut *mut u8,
+    out_len: *mut usize,
+) -> i32 {
+    let fs = &*(k as *const HostFs);
+    let Ok(p) = CStr::from_ptr(path).to_str() else {
+        return -2;
+    };
+    match fs.dirs.get(p) {
+        Some(entries) => {
+            // The kernel's readdir JSON shape: [{"name":..,"entry_type":..}].
+            let mut json = String::from("[");
+            for (i, (name, et)) in entries.iter().enumerate() {
+                if i > 0 {
+                    json.push(',');
+                }
+                json.push_str(&format!("{{\"name\":\"{name}\",\"entry_type\":{et}}}"));
+            }
+            json.push(']');
+            yield_buf(json.into_bytes(), out_buf, out_len);
+            0
+        }
+        None => -1,
+    }
+}
+
+unsafe extern "C" fn host_sys_stat(
+    k: *const c_void,
+    path: *const c_char,
+    out_buf: *mut *mut u8,
+    out_len: *mut usize,
+) -> i32 {
+    let fs = &*(k as *const HostFs);
+    let Ok(p) = CStr::from_ptr(path).to_str() else {
+        return -2;
+    };
+    let json = if let Some(bytes) = fs.files.get(p) {
+        format!(
+            r#"{{"path":"{p}","entry_type":0,"size":{},"zone_id":"root","modified_at_ms":0}}"#,
+            bytes.len()
+        )
+    } else if fs.dirs.contains_key(p) {
+        format!(
+            r#"{{"path":"{p}","entry_type":1,"size":0,"zone_id":"root","modified_at_ms":null}}"#
+        )
+    } else {
+        return -1;
+    };
+    yield_buf(json.into_bytes(), out_buf, out_len);
+    0
+}
+
+// grep never invokes these — poison to -1 so a stray call fails loud.
+unsafe extern "C" fn stub_write(_: *const c_void, _: *const c_char, _: *const u8, _: usize) -> i32 {
+    -1
+}
+unsafe extern "C" fn stub_path(_: *const c_void, _: *const c_char) -> i32 {
+    -1
+}
+unsafe extern "C" fn stub_rename(_: *const c_void, _: *const c_char, _: *const c_char) -> i32 {
+    -1
+}
+unsafe extern "C" fn stub_stat_batch(
+    _: *const c_void,
+    _: *const c_char,
+    _: *mut *mut u8,
+    _: *mut usize,
+) -> i32 {
+    -1
+}
+
+fn handle_for(fs: *const HostFs) -> KernelHandle {
+    KernelHandle {
+        sys_read: host_sys_read,
+        sys_write: stub_write,
+        sys_stat: host_sys_stat,
+        sys_readdir: host_sys_readdir,
+        sys_unlink: stub_path,
+        sys_mkdir: stub_path,
+        sys_rmdir: stub_path,
+        sys_rename: stub_rename,
+        sys_stat_batch: stub_stat_batch,
+        free_buf: host_free_buf,
+        kernel_ptr: fs as *const c_void,
+    }
+}
+
+#[test]
+fn grep_over_cdylib_survives_cross_allocator_free() {
+    let plugin = plugin_path();
+    ensure_cdylib_built(&plugin);
+
+    let lib = unsafe { libloading::Library::new(&plugin) }
+        .unwrap_or_else(|e| panic!("dlopen({}) failed: {e}", plugin.display()));
+
+    // Seed a tiny VFS: one file under root whose content the grep matches.
+    let mut files = HashMap::new();
+    files.insert(
+        "/notes.txt".to_string(),
+        b"alpha beta\ngamma NEEDLE delta\nepsilon\n".to_vec(),
+    );
+    let mut dirs = HashMap::new();
+    dirs.insert("/".to_string(), vec![("notes.txt".to_string(), 0u8)]);
+    // Box so the pointer stays stable + valid for the plugin's lifetime.
+    let fs = Box::new(HostFs { files, dirs });
+    let handle = handle_for(&*fs as *const HostFs);
+
+    unsafe {
+        let create: libloading::Symbol<ServiceCreateFn> = lib
+            .get(b"nexus_service_create")
+            .expect("resolve nexus_service_create");
+        let dispatch: libloading::Symbol<ServiceDispatchFn> = lib
+            .get(b"nexus_service_dispatch")
+            .expect("resolve nexus_service_dispatch");
+        let destroy: libloading::Symbol<unsafe extern "C" fn(*mut c_void)> = lib
+            .get(b"nexus_service_destroy")
+            .expect("resolve nexus_service_destroy");
+        // The plugin's OWN free — the host uses it to release the
+        // plugin-allocated dispatch response on the plugin's allocator.
+        let plugin_free: libloading::Symbol<NexusFreeFn> =
+            lib.get(b"nexus_free").expect("resolve nexus_free");
+
+        let svc = create(&handle as *const KernelHandle);
+        assert!(!svc.is_null(), "nexus_service_create returned null");
+
+        // Drive a real Grep. Internally the plugin walks the VFS via our
+        // mimalloc-allocating sys_readdir / sys_read and frees each buffer
+        // through handle.free_buf — the exact path that segfaulted on
+        // Windows before the fix.
+        let req = GrepRequest {
+            root_path: "/".to_string(),
+            pattern: "NEEDLE".to_string(),
+            ..Default::default()
+        };
+        let payload = req.encode_to_vec();
+        let method = CString::new("/nexus.search.v1.SearchService/Grep").unwrap();
+
+        let mut out_buf: *mut u8 = std::ptr::null_mut();
+        let mut out_len: usize = 0;
+        let rc = dispatch(
+            svc,
+            method.as_ptr(),
+            payload.as_ptr(),
+            payload.len(),
+            &mut out_buf,
+            &mut out_len,
+        );
+        assert_eq!(rc, 0, "Grep dispatch returned error code {rc}");
+
+        // Copy the plugin-allocated response out (into a mimalloc Vec),
+        // then free the plugin buffer via the plugin's OWN allocator.
+        let resp_bytes = std::slice::from_raw_parts(out_buf, out_len).to_vec();
+        plugin_free(out_buf, out_len);
+
+        let resp = GrepResponse::decode(&resp_bytes[..]).expect("decode GrepResponse");
+        assert!(
+            resp.matches
+                .iter()
+                .any(|m| m.path == "/notes.txt" && m.line.contains("NEEDLE")),
+            "grep did not surface the seeded match; got {:?}",
+            resp.matches,
+        );
+
+        destroy(svc);
+    }
+
+    // Keep the host VFS alive until after destroy — the plugin held a
+    // copy of the handle pointing at it for the whole dispatch.
+    drop(fs);
+}

--- a/rust/services/search-plugin/tests/index_e2e.rs
+++ b/rust/services/search-plugin/tests/index_e2e.rs
@@ -246,6 +246,7 @@ fn handle_for(kernel: *const MockKernel) -> KernelHandle {
         sys_rmdir: unused_sys_rmdir,
         sys_rename: unused_sys_rename,
         sys_stat_batch: unused_sys_stat_batch,
+        free_buf: nexus_plugin_abi::nexus_free,
         kernel_ptr: kernel as *const c_void,
     }
 }

--- a/rust/services/search-plugin/tests/index_visibility_e2e.rs
+++ b/rust/services/search-plugin/tests/index_visibility_e2e.rs
@@ -134,6 +134,7 @@ fn handle_for(kernel: *const MockKernel) -> KernelHandle {
         sys_rmdir: unused_sys_rmdir,
         sys_rename: unused_sys_rename,
         sys_stat_batch: unused_sys_stat_batch,
+        free_buf: nexus_plugin_abi::nexus_free,
         kernel_ptr: kernel as *const c_void,
     }
 }

--- a/rust/services/search-plugin/tests/macro_expand_e2e.rs
+++ b/rust/services/search-plugin/tests/macro_expand_e2e.rs
@@ -96,6 +96,7 @@ fn poison_handle() -> KernelHandle {
         sys_rmdir: poison_rmdir,
         sys_rename: poison_rename,
         sys_stat_batch: poison_stat_batch,
+        free_buf: nexus_plugin_abi::nexus_free,
         kernel_ptr: std::ptr::null(),
     }
 }

--- a/rust/services/search-plugin/tests/macro_expand_window_cap_e2e.rs
+++ b/rust/services/search-plugin/tests/macro_expand_window_cap_e2e.rs
@@ -88,6 +88,7 @@ fn poison_handle() -> KernelHandle {
         sys_rmdir: poison_rmdir,
         sys_rename: poison_rename,
         sys_stat_batch: poison_stat_batch,
+        free_buf: nexus_plugin_abi::nexus_free,
         kernel_ptr: std::ptr::null(),
     }
 }

--- a/rust/services/search-plugin/tests/peer_fanout_e2e.rs
+++ b/rust/services/search-plugin/tests/peer_fanout_e2e.rs
@@ -101,6 +101,7 @@ fn poison_handle() -> KernelHandle {
         sys_rmdir: poison_rmdir,
         sys_rename: poison_rename,
         sys_stat_batch: poison_stat_batch,
+        free_buf: nexus_plugin_abi::nexus_free,
         kernel_ptr: std::ptr::null(),
     }
 }

--- a/rust/services/search-plugin/tests/query_e2e.rs
+++ b/rust/services/search-plugin/tests/query_e2e.rs
@@ -103,6 +103,7 @@ fn poison_handle() -> KernelHandle {
         sys_rmdir: poison_rmdir,
         sys_rename: poison_rename,
         sys_stat_batch: poison_stat_batch,
+        free_buf: nexus_plugin_abi::nexus_free,
         kernel_ptr: std::ptr::null(),
     }
 }

--- a/rust/services/search-plugin/tests/query_expansion_e2e.rs
+++ b/rust/services/search-plugin/tests/query_expansion_e2e.rs
@@ -95,6 +95,7 @@ fn poison_handle() -> KernelHandle {
         sys_rmdir: poison_rmdir,
         sys_rename: poison_rename,
         sys_stat_batch: poison_stat_batch,
+        free_buf: nexus_plugin_abi::nexus_free,
         kernel_ptr: std::ptr::null(),
     }
 }

--- a/rust/services/search-plugin/tests/semantic_query_e2e.rs
+++ b/rust/services/search-plugin/tests/semantic_query_e2e.rs
@@ -253,6 +253,7 @@ fn handle_for(kernel: *const MockKernel) -> KernelHandle {
         sys_rmdir: unused_sys_rmdir,
         sys_rename: unused_sys_rename,
         sys_stat_batch: unused_sys_stat_batch,
+        free_buf: nexus_plugin_abi::nexus_free,
         kernel_ptr: kernel as *const c_void,
     }
 }

--- a/rust/services/search-plugin/tests/title_arm_e2e.rs
+++ b/rust/services/search-plugin/tests/title_arm_e2e.rs
@@ -217,6 +217,7 @@ fn handle_for(kernel: *const MockKernel) -> KernelHandle {
         sys_rmdir: unused_sys_rmdir,
         sys_rename: unused_sys_rename,
         sys_stat_batch: unused_sys_stat_batch,
+        free_buf: nexus_plugin_abi::nexus_free,
         kernel_ptr: kernel as *const c_void,
     }
 }

--- a/rust/services/vault/src/lib.rs
+++ b/rust/services/vault/src/lib.rs
@@ -556,6 +556,7 @@ mod dylib_e2e {
             sys_rmdir: noop_rmdir,
             sys_rename: noop_rename,
             sys_stat_batch: noop_stat_batch,
+            free_buf: nexus_plugin_abi::nexus_free,
             kernel_ptr: std::ptr::null(),
         }
     }


### PR DESCRIPTION
Downstream half of nexus-vfs#237 — fixes the Windows plugin-host segfault filed as nexus-vfs#236.

## Problem

The plugin C-ABI moves heap buffers both ways: host `sys_*` callbacks allocate for the plugin; `nexus_service_dispatch` / `nexus_driver_*` allocate for the host. Each buffer was freed by whichever side **consumed** it, through the single `nexus_free` compiled into both binaries. The kernel links **mimalloc**; the plugin cdylibs link the **system** allocator — disjoint heaps — so every cross-boundary free was a cross-heap free: **STATUS_HEAP_CORRUPTION on Windows** (search-plugin grep, every FUSE `sys_read`/`readdir`), silently deferred on Linux (why the Docker search-plugin E2E is green and never caught it).

## Fix (pairs with nexus-vfs#237, `PLUGIN_API_VERSION` 5 → 6)

- **search-plugin** (`kernel_io.rs`) + **fuse-plugin** (`kernel_callbacks.rs`, sync + macOS async) free host buffers via the new `handle.free_buf` instead of `nexus_free`.
- `dup_kernel_handle` / `kernel_handle_clone` copy the new `free_buf` field; every test-mock + example vtable supplies it.
- **Pin bump** to nexus-vfs `6cad75f7b` (v6 ABI) + sudocode `4bc7cba61` (#465), Dockerfiles + `Cargo.lock` in lockstep (single nexus-vfs rev — pin-consistency gate).

## Verification — faithful cross-allocator regression (not maskable)

New `cross_allocator_free_e2e.rs`: a **mimalloc**-global test binary (mirroring the cluster host) dlopens the real **system**-allocator cdylib and drives a live **Grep** across the FFI boundary. Passes with the fix on Windows; reverting one free site to `nexus_free` reproduces `STATUS_HEAP_CORRUPTION (0xc0000374)` exactly — the guard the Linux-only Docker E2E cannot be. Full search-plugin / fuse-plugin / vault / local-connector suites green locally on Windows against the merged v6 ABI.