### PR TITLE
test(search-plugin): assert plaintext gate directly, not a downstream connect

### DIFF
--- a/rust/services/search-plugin/src/peer_fanout.rs
+++ b/rust/services/search-plugin/src/peer_fanout.rs
@@ -401,16 +401,21 @@ mod tests {
         let reg = registry_with(vec![("example.internal", 2126)], vec!["root"], false, true);
         let d = PeerFanoutDispatcher::new(reg);
         let peer = &d.registry.peers()[0].clone();
-        let err = d.dial(peer).await.unwrap_err();
-        // With allow_insecure_peer=true we PASS the gate and try to
-        // connect; the connect fails (unresolvable host), which is
-        // the expected downstream failure.
+        let res = d.dial(peer).await;
+        // The ONLY thing under test is the security gate: with
+        // allow_insecure_peer=true the plaintext-off-loopback refusal
+        // must NOT fire. Whatever happens downstream is environment-
+        // dependent and must not be asserted on — the gate is checked
+        // before any DNS/connect, and `dial` does an eager `connect()`,
+        // so the downstream result is `ConnectFailed` on a normal
+        // network (host is NXDOMAIN) but `Ok` behind a hijacking
+        // resolver/TUN proxy that fakes the A record AND accepts the
+        // TCP handshake. Asserting a specific downstream error made the
+        // test fail in the latter environment for a reason that has
+        // nothing to do with the gate it exists to lock down.
         assert!(
-            matches!(
-                err,
-                PeerFanoutError::ConnectFailed { .. } | PeerFanoutError::BadEndpoint { .. }
-            ),
-            "escape flag must pass the gate; got {err:?}"
+            !matches!(res, Err(PeerFanoutError::PlaintextOffLoopback { .. })),
+            "escape flag must pass the plaintext-off-loopback gate; got {res:?}"
         );
     }
 


### PR DESCRIPTION
`dial_allows_plaintext_off_loopback_with_escape_flag` asserted a specific **downstream** error (`ConnectFailed | BadEndpoint`) as a proxy for what it actually verifies: that with `allow_insecure_peer=true` the plaintext-off-loopback refusal does **not** fire.

`dial()` checks that gate before any DNS/connect, then does an **eager** `connect()`. So the downstream result is environment-dependent:
- normal network: the test host (`example.internal`) is NXDOMAIN → `ConnectFailed` → test passed.
- behind a hijacking resolver / TUN proxy (Clash, some ISPs): the name resolves to a fake IP **and** the proxy accepts the TCP handshake → `dial` returns `Ok` → `.unwrap_err()` panics.

The gate is the only thing under test, so assert exactly that — the result is not `PlaintextOffLoopback` — and ignore the environment-dependent downstream. Robust everywhere; still fully covers the security property. Sibling tests already assert the gate directly (the refuse-by-default case returns `PlaintextOffLoopback` before connect) and are unaffected.

Verified: full `nexus-search-plugin` lib suite 247/247 green locally (was 246/247 on a hijacking-resolver box).