### PR TITLE
feat(search-plugin): append-incremental DT_STREAM indexing (P4, sudocode FR-C)

### DIFF
--- a/rust/services/search-plugin/src/index_state.rs
+++ b/rust/services/search-plugin/src/index_state.rs
@@ -85,6 +85,47 @@ pub struct FileEntry {
     pub mtime_ms: Option<i64>,
 }
 
+/// Per-DT_STREAM cache entry (append-incremental indexing, P4).
+///
+/// A DT_STREAM is an append-only log — full re-chunking on every
+/// refresh is O(K·N) across K refreshes on a stream growing with
+/// each refresh, i.e. O(N²) total cost for the sudocode transcript
+/// use case.  This cache records HOW MUCH of the stream we already
+/// chunked so a refresh can chunk only the tail bytes past the last
+/// checkpoint and continue chunk_index from where the prior pass
+/// left off.  With this in place the total cost drops to O(N) across
+/// all refreshes.
+///
+/// Correctness invariants (see [`IndexState::stream_state`] +
+/// [`IndexState::stream_advance`]):
+///   * `indexed_byte_len` is a byte-count into the deframed content
+///     the host-shim `sys_read` returns for a DT_STREAM (nexus-vfs
+///     #235 posture).  A retention-trim on the stream (sudden
+///     shrink of the returned blob) invalidates the checkpoint —
+///     the caller detects `new_len < indexed_byte_len` and calls
+///     [`IndexState::forget_stream`] to force a full re-chunk.
+///   * `next_chunk_index` is monotonic — the plugin's chunker
+///     assigns 0-based chunk indices, so appending starts at
+///     `next_chunk_index` and produces the next-N indices for the
+///     newly-chunked tail.  The chunk keys under (path, index) in
+///     FTS + ANN never collide with prior chunks.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub struct StreamState {
+    /// Bytes into the deframed content already chunked + indexed.
+    /// A stream that has never been indexed has no entry here (the
+    /// caller reads `stream_state().unwrap_or_default()` and the
+    /// default is zero, which correctly triggers a full first pass).
+    pub indexed_byte_len: u64,
+    /// The chunk_index the NEXT append-chunk will use.  Equals the
+    /// total chunk count at the last successful indexing pass.
+    pub next_chunk_index: u32,
+    /// Kernel-reported `modified_at_ms` at last successful index —
+    /// same shape as [`FileEntry::mtime_ms`], enabling the same
+    /// Refresh mtime-verdict pathway.  A stream whose last-append
+    /// time has not moved since this stamp needs no work.
+    pub mtime_ms: Option<i64>,
+}
+
 /// On-disk shape of the state cache.
 #[derive(Debug, Serialize, Deserialize, Default)]
 struct Persisted {
@@ -92,6 +133,13 @@ struct Persisted {
     version: u32,
     #[serde(default)]
     files: HashMap<String, FileEntry>,
+    /// Append-incremental checkpoints for DT_STREAM paths (P4).
+    /// Empty on legacy state files; older readers ignore the field
+    /// via `#[serde(default)]` on write / read.  Sibling map to
+    /// `files` — paths never overlap because DT_STREAM vs DT_REG is
+    /// enforced upstream at the entry-type gate.
+    #[serde(default)]
+    streams: HashMap<String, StreamState>,
     /// Embedder generation the recorded mtimes were completed under
     /// (review R8).  ANN storage is keyed by embedder tag, so a model
     /// swap opens a FRESH ann directory — mtimes recorded under the
@@ -106,6 +154,11 @@ struct Persisted {
 pub struct IndexState {
     dir: PathBuf,
     inner: RwLock<HashMap<String, FileEntry>>,
+    /// Sibling map for append-incremental DT_STREAM checkpoints
+    /// (see [`StreamState`]).  Loaded from + saved to the same
+    /// on-disk file as `inner`; separate map so DT_REG vs
+    /// DT_STREAM paths never collide on lookup.
+    streams: RwLock<HashMap<String, StreamState>>,
     embedder_tag: RwLock<Option<String>>,
 }
 
@@ -118,7 +171,7 @@ impl IndexState {
             .map_err(|e| StateError::CreateDir(zone_root.display().to_string(), e.to_string()))?;
         let path = zone_root.join(STATE_FILE);
         let mut persisted_tag: Option<String> = None;
-        let inner = if path.exists() {
+        let (inner, streams) = if path.exists() {
             let bytes = std::fs::read(&path)
                 .map_err(|e| StateError::Read(path.display().to_string(), e.to_string()))?;
             let persisted: Persisted = serde_json::from_slice(&bytes)
@@ -143,23 +196,31 @@ impl IndexState {
                     path = %path.display(),
                     "index_state version mismatch — nulling mtimes; next refresh reindexes + sweeps",
                 );
-                persisted
+                let files: HashMap<String, FileEntry> = persisted
                     .files
                     .into_iter()
                     .map(|(p, mut entry)| {
                         entry.mtime_ms = None;
                         (p, entry)
                     })
-                    .collect()
+                    .collect();
+                // DT_STREAM checkpoints are a strict speed-up over a
+                // full re-chunk; a version bump doesn't change the
+                // chunk layout so we could keep them, but nulling
+                // them here mirrors the file behaviour — the next
+                // refresh does a full pass anyway, which will
+                // rebuild the checkpoints cleanly.
+                (files, HashMap::new())
             } else {
-                persisted.files
+                (persisted.files, persisted.streams)
             }
         } else {
-            HashMap::new()
+            (HashMap::new(), HashMap::new())
         };
         Ok(Self {
             dir: zone_root,
             inner: RwLock::new(inner),
+            streams: RwLock::new(streams),
             embedder_tag: RwLock::new(persisted_tag),
         })
     }
@@ -184,6 +245,12 @@ impl IndexState {
             for entry in files.values_mut() {
                 entry.mtime_ms = None;
             }
+            // Same reasoning for streams — chunks land in the
+            // per-tag ann-<tag> dir, so a model swap must force a
+            // full re-embed.  Drop the whole checkpoint (not just
+            // the mtime) so the next refresh does a fresh full
+            // pass and repopulates from the new embedder.
+            self.streams.write().clear();
             true
         } else {
             // First generation stamp (legacy state / fresh zone):
@@ -212,17 +279,28 @@ impl IndexState {
     ///   have a concrete mtime for the file.
     /// - `RefreshVerdict::Changed` if new / edited / has-no-mtime
     ///   (fail-open: re-index rather than risk staleness).
+    ///
+    /// Consults both the [`FileEntry`] map (DT_REG paths) and the
+    /// [`StreamState`] map (DT_STREAM paths) — a path is only in
+    /// one at a time (upstream entry-type gate enforces).  The
+    /// stream check short-circuits Refresh's per-path sys_read
+    /// entirely for a quiescent stream, which matters because a
+    /// DT_STREAM's sys_read is a whole-log memcopy — much more
+    /// expensive than a regular-file sys_stat.
     pub fn verdict(&self, path: &str, fresh_mtime: Option<i64>) -> RefreshVerdict {
-        let cached = self.inner.read().get(path).cloned();
-        match (cached, fresh_mtime) {
-            (
-                Some(FileEntry {
-                    mtime_ms: Some(cached_ms),
-                }),
-                Some(fresh_ms),
-            ) if cached_ms == fresh_ms => RefreshVerdict::Unchanged,
-            _ => RefreshVerdict::Changed,
+        let cached_file_mtime = self.inner.read().get(path).and_then(|e| e.mtime_ms);
+        if let (Some(cached_ms), Some(fresh_ms)) = (cached_file_mtime, fresh_mtime) {
+            if cached_ms == fresh_ms {
+                return RefreshVerdict::Unchanged;
+            }
         }
+        let cached_stream_mtime = self.streams.read().get(path).and_then(|s| s.mtime_ms);
+        if let (Some(cached_ms), Some(fresh_ms)) = (cached_stream_mtime, fresh_mtime) {
+            if cached_ms == fresh_ms {
+                return RefreshVerdict::Unchanged;
+            }
+        }
+        RefreshVerdict::Changed
     }
 
     /// Record a successful index of `path` at `mtime_ms`.  Called
@@ -239,6 +317,51 @@ impl IndexState {
     /// FTS + ANN deletes when a file was removed from the corpus.
     pub fn forget(&self, path: &str) {
         self.inner.write().remove(path);
+        // A path removed from the corpus can't stay in the stream
+        // checkpoint map either — otherwise a fresh sys_setattr
+        // creating a new DT_STREAM at the same path would inherit
+        // stale offsets and skip chunking the initial content.
+        self.streams.write().remove(path);
+    }
+
+    // ── DT_STREAM append-incremental checkpoints (P4) ─────────────
+
+    /// Current checkpoint for `path` — `None` when the stream has
+    /// never been indexed on this zone.  The caller uses the
+    /// returned `indexed_byte_len` to slice the tail bytes and
+    /// `next_chunk_index` to continue the chunk-index sequence.
+    pub fn stream_state(&self, path: &str) -> Option<StreamState> {
+        self.streams.read().get(path).cloned()
+    }
+
+    /// Record a successful append-index pass — new absolute
+    /// byte-length + chunk count.  Called AFTER FTS + ANN adds
+    /// land, same posture as [`Self::record`] for regular files.
+    /// Never regresses the checkpoint — a stale caller trying to
+    /// write a smaller value must call [`Self::forget_stream`]
+    /// first, which is the retention-trim recovery path.
+    pub fn stream_advance(
+        &self,
+        path: &str,
+        new_indexed_byte_len: u64,
+        new_next_chunk_index: u32,
+        mtime_ms: Option<i64>,
+    ) {
+        self.streams.write().insert(
+            path.to_string(),
+            StreamState {
+                indexed_byte_len: new_indexed_byte_len,
+                next_chunk_index: new_next_chunk_index,
+                mtime_ms,
+            },
+        );
+    }
+
+    /// Drop the checkpoint for `path` — retention-trim recovery
+    /// (kernel-side stream retention advanced past our
+    /// checkpoint's byte offset) and full re-index paths.
+    pub fn forget_stream(&self, path: &str) {
+        self.streams.write().remove(path);
     }
 
     /// Number of cached entries — used by tests + operator
@@ -260,6 +383,7 @@ impl IndexState {
         let persisted = Persisted {
             version: STATE_VERSION,
             files: self.inner.read().clone(),
+            streams: self.streams.read().clone(),
             embedder_tag: self.embedder_tag.read().clone(),
         };
         let bytes =

--- a/rust/services/search-plugin/src/kernel_io.rs
+++ b/rust/services/search-plugin/src/kernel_io.rs
@@ -141,14 +141,20 @@ pub fn sys_read(handle: &KernelHandle, path: &str) -> Result<Vec<u8>, KernelIoEr
 }
 
 /// Subset of `StatResult`'s JSON shape that the plugin walker cares
-/// about.  Serde ignores unknown fields (`entry_type`, `size`,
-/// `zone_id`, `path`, …) so this stays additive-compatible with any
-/// future schema growth on the kernel side.  `modified_at_ms` is
-/// `null`-safe: older kernels that predate the field return it as
-/// `null` and the walker degrades to "unknown mtime, sort last".
+/// about.  Serde ignores unknown fields (`size`, `zone_id`, `path`,
+/// …) so this stays additive-compatible with any future schema
+/// growth on the kernel side.  `modified_at_ms` is `null`-safe:
+/// older kernels that predate the field return it as `null` and the
+/// walker degrades to "unknown mtime, sort last".  `entry_type` is
+/// `0` (DT_REG) on legacy kernels that omit it — a safe default
+/// because DT_REG is the pre-DT_STREAM regular-file behaviour and
+/// the P4 append-incremental path stays gated on the DT_STREAM
+/// value it never sees.
 #[derive(Debug, Deserialize)]
 pub struct StatInfo {
     pub modified_at_ms: Option<i64>,
+    #[serde(default)]
+    pub entry_type: u8,
 }
 
 /// Wrap `handle.sys_stat(path)`.

--- a/rust/services/search-plugin/src/service.rs
+++ b/rust/services/search-plugin/src/service.rs
@@ -1914,6 +1914,24 @@ fn record_content_skip(handle: &KernelHandle, sinks: &IndexSinks<'_>, vfs_path: 
 }
 
 fn index_one(handle: &KernelHandle, sinks: &IndexSinks<'_>, vfs_path: &str) -> IndexOne {
+    // DT_STREAM append-incremental path (P4).  A stream's
+    // sys_read collects the whole deframed log every time (host-
+    // shim posture per nexus-vfs #235); re-chunking that from
+    // scratch on every refresh is O(N) per refresh, and refreshes
+    // scale with appends, so total cost is O(N^2) for a
+    // keep-forever transcript.  Detect DT_STREAM via sys_stat and
+    // dispatch to the append helper which uses `index_state`'s
+    // stream-checkpoint to chunk only the tail bytes past the
+    // last-indexed offset.  DT_REG stays on the full-re-chunk
+    // path below (safe: files aren't append-only in the same
+    // sense — an edit anywhere in the middle invalidates every
+    // downstream chunk).
+    if let Ok(stat) = kernel_io::sys_stat(handle, vfs_path) {
+        if stat.entry_type == kernel_io::DT_STREAM {
+            return index_one_stream_append(handle, sinks, vfs_path, stat.modified_at_ms);
+        }
+    }
+
     let bytes = match kernel_io::sys_read(handle, vfs_path) {
         Ok(b) => b,
         Err(e) => {
@@ -2055,6 +2073,314 @@ fn index_one(handle: &KernelHandle, sinks: &IndexSinks<'_>, vfs_path: &str) -> I
         IndexOne::Added
     } else {
         sinks.state.record(vfs_path, None);
+        IndexOne::AddedAnnRetry
+    }
+}
+
+/// Append-incremental indexer for DT_STREAM paths (P4).  Dispatched
+/// from [`index_one`] when `sys_stat` reports `DT_STREAM`.
+///
+/// # Contract
+///
+/// Reads the whole deframed stream via `sys_read` (host-shim
+/// collects, per nexus-vfs #235), then:
+///
+///   * If the current byte-length equals the last-indexed
+///     checkpoint AND we have a matching mtime, treat as unchanged
+///     (Skipped — the walker counted this as a "seen" path so no
+///     stale-sweep will drop it).
+///   * If the current length is LESS than the checkpoint, treat
+///     as retention-trim recovery: drop every prior chunk from
+///     FTS + ANN, forget the checkpoint, then fall through into a
+///     full re-index.
+///   * Otherwise (append): chunk only the tail bytes past
+///     `indexed_byte_len`, assign chunk indices continuing from
+///     `next_chunk_index`, `add_document` / `add_vector` (do NOT
+///     `delete_all_chunks` — that would nuke the append-only work
+///     we're trying to preserve).
+///
+/// # Why not `add_document`-with-delete
+///
+/// Prior chunks for the stream are addressed by `(path, chunk_index)`
+/// under the FTS / ANN idempotent-upsert contract.  Reusing chunk
+/// indices from a fresh chunking pass could collide with prior
+/// chunks that DID cover the same content — the whole point of the
+/// checkpoint is to preserve prior chunks untouched.  Continuation
+/// indices avoid the collision.
+///
+/// # Retention-trim contract
+///
+/// A kernel-side retention advance (WAL cold-tier trim) reduces the
+/// stream's readable content.  Detected here as `new_len < checkpoint`.
+/// The recovery path drops every prior chunk (which no longer maps to
+/// live bytes anyway — the plugin's chunk_text stored in the FTS
+/// document would be a snapshot the WAL no longer serves) and does a
+/// full re-index of whatever's still there.  Callers of the retention-
+/// trimmed prefix's chunks after this pass get zero hits on that
+/// content, which is correct — the primary source is gone.
+fn index_one_stream_append(
+    handle: &KernelHandle,
+    sinks: &IndexSinks<'_>,
+    vfs_path: &str,
+    mtime_ms: Option<i64>,
+) -> IndexOne {
+    let bytes = match kernel_io::sys_read(handle, vfs_path) {
+        Ok(b) => b,
+        Err(e) => {
+            tracing::debug!(path = %vfs_path, err = ?e, "index-stream: sys_read failed — skipping");
+            return IndexOne::SkippedTransient;
+        }
+    };
+    if bytes.len() > INDEX_MAX_FILE_BYTES {
+        tracing::debug!(
+            path = %vfs_path,
+            len = bytes.len(),
+            cap = INDEX_MAX_FILE_BYTES,
+            "index-stream: content over size cap — skipping",
+        );
+        return record_content_skip(handle, sinks, vfs_path);
+    }
+
+    let prior = sinks.state.stream_state(vfs_path);
+    let indexed_byte_len = prior.as_ref().map(|s| s.indexed_byte_len).unwrap_or(0);
+    let next_chunk_index = prior.as_ref().map(|s| s.next_chunk_index).unwrap_or(0);
+
+    let new_len = bytes.len() as u64;
+    if new_len < indexed_byte_len {
+        // Retention-trim recovery: kernel-side dropped the prefix
+        // we already indexed.  Cannot delta-append against a
+        // shorter blob; wipe prior chunks + reset checkpoint, then
+        // fall into a fresh full pass.  Failure to drop chunks is
+        // still SkippedTransient — a partial cleanup would leave
+        // dangling chunks with stale text.
+        tracing::info!(
+            path = %vfs_path,
+            new_len,
+            prior_indexed = indexed_byte_len,
+            "index-stream: retention-trim detected — dropping prior chunks + re-indexing",
+        );
+        sinks.fts.delete_all_chunks(vfs_path);
+        if let Some(ann) = sinks.ann {
+            ann.delete_all_chunks(vfs_path);
+        }
+        sinks.state.forget_stream(vfs_path);
+        return index_one_stream_full(handle, sinks, vfs_path, mtime_ms, &bytes);
+    }
+
+    if new_len == indexed_byte_len {
+        // Nothing appended since last pass — a no-op for both
+        // sinks.  Keep the checkpoint's mtime fresh so a subsequent
+        // Refresh's `verdict()` sees Unchanged (matches how record()
+        // works for DT_REG).  Return Skipped so the walker counts
+        // it correctly.
+        if let Some(prior_state) = prior {
+            if prior_state.mtime_ms != mtime_ms {
+                sinks
+                    .state
+                    .stream_advance(vfs_path, indexed_byte_len, next_chunk_index, mtime_ms);
+            }
+        }
+        return IndexOne::Skipped;
+    }
+
+    // Append case: chunk only the tail past the checkpoint.
+    let tail_bytes = &bytes[indexed_byte_len as usize..];
+    let tail_text = match std::str::from_utf8(tail_bytes) {
+        Ok(s) => s,
+        Err(_) => {
+            tracing::debug!(
+                path = %vfs_path,
+                "index-stream: non-utf8 tail — skipping (whole stream stays at prior checkpoint)",
+            );
+            return IndexOne::Skipped;
+        }
+    };
+    let mut new_chunks = crate::chunker::chunk_document(tail_text);
+    if new_chunks.is_empty() {
+        // Tail is whitespace-only — record the new byte-length so we
+        // don't re-scan on next refresh, but nothing to index.
+        sinks
+            .state
+            .stream_advance(vfs_path, new_len, next_chunk_index, mtime_ms);
+        return IndexOne::Skipped;
+    }
+    if let Some(gen) = sinks.context_generator {
+        crate::contextual_chunker::apply_contexts(
+            gen,
+            tail_text,
+            &mut new_chunks,
+            gen.max_chunks_per_doc(),
+        );
+    }
+
+    // FTS side — append only, no delete_all_chunks (that would
+    // nuke prior chunks we're preserving).  chunk_index continues
+    // from next_chunk_index.
+    for (i, chunk) in new_chunks.iter().enumerate() {
+        let global_idx = next_chunk_index + i as u32;
+        if let Err(e) = sinks
+            .fts
+            .add_document(vfs_path, global_idx, &chunk.text, mtime_ms)
+        {
+            tracing::warn!(
+                path = %vfs_path,
+                chunk = global_idx,
+                err = %e,
+                "index-stream: fts add_document failed — skipping remaining tail chunks",
+            );
+            return IndexOne::SkippedTransient;
+        }
+    }
+
+    // ANN side — same append-only posture.  Embed the tail chunks
+    // as a batch; a broken embedder leaves ANN incomplete and the
+    // checkpoint at the OLD offset so a retry can catch up.
+    let mut ann_complete = !(sinks.embed_broken || sinks.embedder.is_none() && sinks.zone_has_ann);
+    if let (Some(ann), Some(embedder)) = (sinks.ann, sinks.embedder) {
+        let inputs: Vec<&str> = new_chunks.iter().map(|c| c.embed_input.as_str()).collect();
+        match embedder.embed_batch(&inputs) {
+            Ok(vecs) if vecs.len() == new_chunks.len() => {
+                for (i, vec) in vecs.iter().enumerate() {
+                    let global_idx = next_chunk_index + i as u32;
+                    if let Err(e) = ann.add_vector(vfs_path, global_idx, vec) {
+                        ann_complete = false;
+                        tracing::warn!(
+                            path = %vfs_path,
+                            chunk = global_idx,
+                            err = %e,
+                            "index-stream: ann add_vector failed — will retry on next refresh",
+                        );
+                    }
+                }
+            }
+            Ok(vecs) => {
+                ann_complete = false;
+                tracing::warn!(
+                    path = %vfs_path,
+                    got = vecs.len(),
+                    expected = new_chunks.len(),
+                    "index-stream: embedder returned wrong vec count — will retry",
+                );
+            }
+            Err(e) => {
+                ann_complete = false;
+                tracing::warn!(
+                    path = %vfs_path,
+                    err = %e,
+                    "index-stream: embed failed — will retry on next refresh",
+                );
+            }
+        }
+    }
+
+    // Advance the checkpoint ONLY when both sinks converged.  A
+    // partial ANN failure holds the byte-length at the prior value
+    // so the next refresh re-attempts the same tail — same retry
+    // posture as DT_REG's `AddedAnnRetry` (mtime cache stays at
+    // None so verdict is Changed).
+    let new_next_chunk_index = next_chunk_index + new_chunks.len() as u32;
+    if ann_complete {
+        sinks
+            .state
+            .stream_advance(vfs_path, new_len, new_next_chunk_index, mtime_ms);
+        IndexOne::Added
+    } else {
+        // FTS side did land — keep it visible on the next refresh
+        // by advancing the byte-length; but do NOT stamp mtime so
+        // Refresh's verdict stays Changed and the pass retries.
+        sinks
+            .state
+            .stream_advance(vfs_path, new_len, new_next_chunk_index, None);
+        IndexOne::AddedAnnRetry
+    }
+}
+
+/// Full re-index of a DT_STREAM's current content — used by the
+/// retention-trim recovery path in [`index_one_stream_append`].
+/// Not a general entry point; the append path always tries the
+/// incremental route first.  Behaviour mirrors the DT_REG
+/// [`index_one`] hot path but never returns `SkippedTransient` on
+/// read (the caller already read the bytes) and always resets the
+/// checkpoint to `(new_len, chunk_count)`.
+fn index_one_stream_full(
+    handle: &KernelHandle,
+    sinks: &IndexSinks<'_>,
+    vfs_path: &str,
+    mtime_ms: Option<i64>,
+    bytes: &[u8],
+) -> IndexOne {
+    if bytes.is_empty() {
+        return record_content_skip(handle, sinks, vfs_path);
+    }
+    let text = match std::str::from_utf8(bytes) {
+        Ok(s) => s,
+        Err(_) => {
+            tracing::debug!(path = %vfs_path, "index-stream(full): non-utf8 — skipping");
+            return record_content_skip(handle, sinks, vfs_path);
+        }
+    };
+    let mut chunks = crate::chunker::chunk_document(text);
+    if chunks.is_empty() {
+        return record_content_skip(handle, sinks, vfs_path);
+    }
+    if let Some(gen) = sinks.context_generator {
+        crate::contextual_chunker::apply_contexts(gen, text, &mut chunks, gen.max_chunks_per_doc());
+    }
+
+    // Full pass on a wiped stream — FTS side is add-only (the
+    // caller already dropped prior chunks in the retention-trim
+    // branch).  chunk_index restarts at 0.
+    for chunk in &chunks {
+        if let Err(e) = sinks
+            .fts
+            .add_document(vfs_path, chunk.chunk_index, &chunk.text, mtime_ms)
+        {
+            tracing::warn!(
+                path = %vfs_path,
+                chunk = chunk.chunk_index,
+                err = %e,
+                "index-stream(full): fts add_document failed",
+            );
+            return IndexOne::SkippedTransient;
+        }
+    }
+    let mut ann_complete = !(sinks.embed_broken || sinks.embedder.is_none() && sinks.zone_has_ann);
+    if let (Some(ann), Some(embedder)) = (sinks.ann, sinks.embedder) {
+        let inputs: Vec<&str> = chunks.iter().map(|c| c.embed_input.as_str()).collect();
+        match embedder.embed_batch(&inputs) {
+            Ok(vecs) if vecs.len() == chunks.len() => {
+                for (chunk, vec) in chunks.iter().zip(vecs.iter()) {
+                    if let Err(e) = ann.add_vector(vfs_path, chunk.chunk_index, vec) {
+                        ann_complete = false;
+                        tracing::warn!(
+                            path = %vfs_path,
+                            chunk = chunk.chunk_index,
+                            err = %e,
+                            "index-stream(full): ann add_vector failed",
+                        );
+                    }
+                }
+            }
+            _ => {
+                ann_complete = false;
+                tracing::warn!(
+                    path = %vfs_path,
+                    "index-stream(full): embed_batch failed — will retry",
+                );
+            }
+        }
+    }
+    let new_next_chunk_index = chunks.len() as u32;
+    let new_len = bytes.len() as u64;
+    if ann_complete {
+        sinks
+            .state
+            .stream_advance(vfs_path, new_len, new_next_chunk_index, mtime_ms);
+        IndexOne::Added
+    } else {
+        sinks
+            .state
+            .stream_advance(vfs_path, new_len, new_next_chunk_index, None);
         IndexOne::AddedAnnRetry
     }
 }

--- a/rust/services/search-plugin/tests/common/mod.rs
+++ b/rust/services/search-plugin/tests/common/mod.rs
@@ -27,6 +27,12 @@ use nexus_plugin_abi::KernelHandle;
 struct FileEntry {
     bytes: Vec<u8>,
     mtime_ms: i64,
+    /// entry_type reported by `sys_stat` — `0` (DT_REG) for regular
+    /// files, `4` (DT_STREAM) for streams.  Kept per-entry so the
+    /// mock's stat matches the shape a real kernel returns; the
+    /// append-incremental plugin path keys off this to dispatch
+    /// DT_STREAM through the P4 incremental branch.
+    entry_type: u8,
 }
 
 /// In-memory kernel: `files` are regular-file/stream contents, `dirs`
@@ -50,6 +56,7 @@ impl MockKernel {
             FileEntry {
                 bytes: bytes.to_vec(),
                 mtime_ms,
+                entry_type: 0, // DT_REG
             },
         );
         let (parent, name) = split_parent(path);
@@ -70,6 +77,7 @@ impl MockKernel {
             FileEntry {
                 bytes: bytes.to_vec(),
                 mtime_ms,
+                entry_type: 4, // DT_STREAM
             },
         );
         let (parent, name) = split_parent(path);
@@ -77,6 +85,21 @@ impl MockKernel {
             .entry(parent)
             .or_default()
             .push((name, 4 /* DT_STREAM */));
+    }
+
+    /// Append bytes to an existing DT_STREAM path (idempotent test-
+    /// side model of a stream `push`).  Bumps the stored mtime so
+    /// the plugin's Refresh verdict flips to `Changed`.  Panics if
+    /// `path` was not registered via [`Self::add_stream`] — appending
+    /// to a regular file is not a legal test action.
+    pub fn append_to_stream(&mut self, path: &str, extra: &[u8], new_mtime_ms: i64) {
+        let entry = self
+            .files
+            .get_mut(path)
+            .expect("append_to_stream: path not registered");
+        assert_eq!(entry.entry_type, 4, "append_to_stream requires DT_STREAM");
+        entry.bytes.extend_from_slice(extra);
+        entry.mtime_ms = new_mtime_ms;
     }
 
     pub fn add_dir(&mut self, path: &str) {
@@ -176,7 +199,7 @@ unsafe extern "C" fn mock_sys_stat(
     if let Some(entry) = kernel.files.get(p) {
         let payload = serde_json::json!({
             "path": p,
-            "entry_type": 0,
+            "entry_type": entry.entry_type,
             "size": entry.bytes.len(),
             "zone_id": "root",
             "modified_at_ms": entry.mtime_ms,

--- a/rust/services/search-plugin/tests/stream_append_incremental_e2e.rs
+++ b/rust/services/search-plugin/tests/stream_append_incremental_e2e.rs
@@ -1,0 +1,348 @@
+//! End-to-end coverage for the DT_STREAM append-incremental
+//! indexing path (P4 — sudocode FR-C).
+//!
+//! The plugin's `index_one` short-circuits DT_STREAM through a
+//! per-path checkpoint (`indexed_byte_len` + `next_chunk_index`).
+//! On refresh, only the tail bytes past the checkpoint get
+//! chunked + added; prior chunks stay untouched.  For an
+//! append-only keep-forever transcript this drops the K-refresh
+//! cost from O(K·N) to O(N).
+//!
+//! These tests use the shared `common::MockKernel` — a real
+//! `IndexManager` + real FTS + real ANN (no embedder wired, so
+//! keyword-only) run against an in-memory VFS whose `sys_read`
+//! returns the whole deframed stream (matches nexus-vfs #235's
+//! host-shim contract).
+
+use std::sync::Arc;
+
+use nexus_search_plugin::index_manager::IndexManager;
+use nexus_search_plugin::search_proto::search_service_server::SearchService;
+use nexus_search_plugin::search_proto::{IndexRequest, QueryRequest, QueryType, RefreshRequest};
+use nexus_search_plugin::service::SearchServiceImpl;
+use tempfile::TempDir;
+use tonic::Request;
+
+mod common;
+use common::{handle_for, MockKernel};
+
+// ── Harness ─────────────────────────────────────────────────────
+
+struct Harness {
+    _dir: TempDir,
+    mock: *mut MockKernel,
+    svc: SearchServiceImpl,
+    /// Kept for tests that inspect the on-disk state file.
+    zone_root: std::path::PathBuf,
+}
+
+impl Harness {
+    fn start() -> Self {
+        let dir = TempDir::new().expect("tempdir");
+        let zone_root = dir.path().join("root");
+        let mock = Box::into_raw(Box::new(MockKernel::new()));
+        let handle = handle_for(mock);
+        let manager = Arc::new(IndexManager::with_root(dir.path().to_path_buf()));
+        let svc = SearchServiceImpl::builder(Arc::new(handle))
+            .manager(manager)
+            .build();
+        Self {
+            _dir: dir,
+            mock,
+            svc,
+            zone_root,
+        }
+    }
+
+    #[allow(clippy::mut_from_ref)]
+    fn mock_mut(&self) -> &mut MockKernel {
+        // SAFETY: `self` owns the box; per-test single-threaded.
+        unsafe { &mut *self.mock }
+    }
+}
+
+impl Drop for Harness {
+    fn drop(&mut self) {
+        unsafe { drop(Box::from_raw(self.mock)) };
+    }
+}
+
+async fn index_root(svc: &SearchServiceImpl) -> nexus_search_plugin::search_proto::IndexResponse {
+    svc.index(Request::new(IndexRequest {
+        root_path: "/".into(),
+        zone_id: "root".into(),
+        recursive: true,
+        max_docs: 0,
+        auth_token: String::new(),
+    }))
+    .await
+    .expect("index")
+    .into_inner()
+}
+
+async fn refresh_root(
+    svc: &SearchServiceImpl,
+) -> nexus_search_plugin::search_proto::RefreshResponse {
+    svc.refresh(Request::new(RefreshRequest {
+        root_path: "/".into(),
+        zone_id: "root".into(),
+        recursive: true,
+        max_docs: 0,
+        auth_token: String::new(),
+    }))
+    .await
+    .expect("refresh")
+    .into_inner()
+}
+
+async fn query(
+    svc: &SearchServiceImpl,
+    q: &str,
+) -> nexus_search_plugin::search_proto::QueryResponse {
+    svc.query(Request::new(QueryRequest {
+        q: q.into(),
+        zone_id: "root".into(),
+        limit: 100,
+        query_type: QueryType::Keyword as i32,
+        ..Default::default()
+    }))
+    .await
+    .expect("query")
+    .into_inner()
+}
+
+// Read the on-disk StreamState checkpoint for `path` — proves the
+// plugin persisted the append-checkpoint across the RPC boundary,
+// not just carried it in memory.
+fn read_stream_state(zone_root: &std::path::Path, path: &str) -> (u64, u32) {
+    let bytes = std::fs::read(zone_root.join("index_state.json")).expect("state file exists");
+    let v: serde_json::Value = serde_json::from_slice(&bytes).expect("parse state");
+    let entry = &v["streams"][path];
+    assert!(!entry.is_null(), "stream state for {path} must be present");
+    (
+        entry["indexed_byte_len"].as_u64().unwrap(),
+        entry["next_chunk_index"].as_u64().unwrap() as u32,
+    )
+}
+
+// ── Tests ───────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn stream_append_only_chunks_the_tail() {
+    // Seed a DT_STREAM with token in an early frame.  First Index
+    // full-chunks it.  Then append more content with a token in the
+    // new tail; a subsequent Refresh must ONLY add chunks for the
+    // tail (chunk_index continues; the checkpoint advances by the
+    // exact tail byte count), and both tokens must remain findable
+    // — proving prior chunks stayed put across the incremental pass.
+    let h = Harness::start();
+    let mock = h.mock_mut();
+    mock.add_dir("/");
+    mock.add_dir("/logs");
+    mock.add_stream(
+        "/logs/audit-stream",
+        b"turn-1: user asked ALPHATOKEN\n",
+        1_700_000_000_000,
+    );
+
+    let r1 = index_root(&h.svc).await;
+    assert!(r1.error.is_none(), "unexpected index error: {:?}", r1.error);
+    assert!(r1.indexed_count >= 1);
+
+    let (byte_len_1, chunk_count_1) = read_stream_state(&h.zone_root, "/logs/audit-stream");
+    assert_eq!(
+        byte_len_1, 30,
+        "first-pass checkpoint must equal the seeded byte length"
+    );
+    assert!(chunk_count_1 >= 1, "first pass must have produced ≥1 chunk");
+
+    // Baseline keyword hit before append.
+    let q1 = query(&h.svc, "ALPHATOKEN").await;
+    assert!(q1.error.is_none());
+    let paths1: Vec<&str> = q1.results.iter().map(|r| r.path.as_str()).collect();
+    assert!(
+        paths1.contains(&"/logs/audit-stream"),
+        "ALPHATOKEN must be indexed after first pass; got {paths1:?}",
+    );
+
+    // Append a new turn to the stream — mtime advances so the
+    // Refresh verdict flips to Changed.
+    mock.append_to_stream(
+        "/logs/audit-stream",
+        b"turn-2: agent said BETATOKEN\n",
+        1_700_000_000_100,
+    );
+
+    let r2 = refresh_root(&h.svc).await;
+    assert!(
+        r2.error.is_none(),
+        "unexpected refresh error: {:?}",
+        r2.error
+    );
+
+    // Checkpoint MUST have advanced by exactly the appended byte
+    // count, and chunk_count MUST have grown (new tail chunks were
+    // added, not replacements).
+    let (byte_len_2, chunk_count_2) = read_stream_state(&h.zone_root, "/logs/audit-stream");
+    assert_eq!(
+        byte_len_2,
+        30 + 29,
+        "checkpoint advances by exactly the appended bytes"
+    );
+    assert!(
+        chunk_count_2 > chunk_count_1,
+        "chunk_count must grow on append (was {chunk_count_1}, now {chunk_count_2})",
+    );
+
+    // BOTH tokens must be findable — proving the old chunk survived
+    // the incremental pass AND the new chunk was added.
+    let q_old = query(&h.svc, "ALPHATOKEN").await;
+    assert!(
+        q_old.results.iter().any(|r| r.path == "/logs/audit-stream"),
+        "old token from prior chunks must survive incremental append",
+    );
+    let q_new = query(&h.svc, "BETATOKEN").await;
+    assert!(
+        q_new.results.iter().any(|r| r.path == "/logs/audit-stream"),
+        "new token from appended tail must be indexed",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn stream_unchanged_refresh_is_noop_at_checkpoint() {
+    // A refresh that sees no new bytes AND the same mtime MUST NOT
+    // re-index the stream — it stays a `unchanged` verdict via the
+    // per-path mtime cache (populated by the full first pass).
+    // Proves the FR-B recency signal + the P4 checkpoint agree on
+    // the "quiescent stream → zero work" case.
+    let h = Harness::start();
+    let mock = h.mock_mut();
+    mock.add_dir("/");
+    mock.add_dir("/logs");
+    mock.add_stream("/logs/audit-stream", b"turn-1: hello\n", 1_700_000_000_000);
+
+    let _ = index_root(&h.svc).await;
+    let (before_bytes, before_chunks) = read_stream_state(&h.zone_root, "/logs/audit-stream");
+
+    let r = refresh_root(&h.svc).await;
+    assert!(r.error.is_none());
+    assert_eq!(
+        r.reindexed_count, 0,
+        "quiescent stream must not re-index on refresh",
+    );
+    assert!(
+        r.unchanged_count >= 1,
+        "quiescent stream must count as unchanged"
+    );
+
+    let (after_bytes, after_chunks) = read_stream_state(&h.zone_root, "/logs/audit-stream");
+    assert_eq!(
+        (before_bytes, before_chunks),
+        (after_bytes, after_chunks),
+        "checkpoint must NOT move on a no-op refresh",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn stream_multi_append_chunk_count_is_monotonic() {
+    // 3 successive appends → chunk_count strictly monotonic across
+    // refreshes; byte-length monotonic too.  Pins the "we truly
+    // incrementally-chunked each tail, not full-re-chunked" contract
+    // beyond a single append.
+    let h = Harness::start();
+    let mock = h.mock_mut();
+    mock.add_dir("/");
+    mock.add_dir("/logs");
+    mock.add_stream("/logs/s", b"chunk1 alpha\n", 1);
+    let _ = index_root(&h.svc).await;
+    let (b1, c1) = read_stream_state(&h.zone_root, "/logs/s");
+
+    mock.append_to_stream("/logs/s", b"chunk2 beta\n", 2);
+    let _ = refresh_root(&h.svc).await;
+    let (b2, c2) = read_stream_state(&h.zone_root, "/logs/s");
+
+    mock.append_to_stream("/logs/s", b"chunk3 gamma\n", 3);
+    let _ = refresh_root(&h.svc).await;
+    let (b3, c3) = read_stream_state(&h.zone_root, "/logs/s");
+
+    assert!(
+        b1 < b2 && b2 < b3,
+        "byte-len strictly monotonic across 3 appends: {b1}<{b2}<{b3}"
+    );
+    assert!(
+        c1 <= c2 && c2 <= c3,
+        "chunk count monotonic: {c1}<={c2}<={c3}"
+    );
+    assert!(c3 > c1, "chunk count grew across 3 appends: {c1} → {c3}");
+
+    // Every token findable.
+    for token in ["alpha", "beta", "gamma"] {
+        let q = query(&h.svc, token).await;
+        assert!(
+            q.results.iter().any(|r| r.path == "/logs/s"),
+            "token {token} must survive multi-append incremental pass",
+        );
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn stream_retention_trim_resets_checkpoint_and_reindexes() {
+    // Retention-trim: the kernel-side WAL trims sealed cold
+    // segments, so `sys_read` returns FEWER bytes than we last
+    // checkpointed.  The plugin must detect this and drop prior
+    // chunks + reset the checkpoint + re-index whatever's left.
+    // Without this recovery the plugin's chunk indices would
+    // collide with truncated bytes and Search would return stale
+    // content the WAL no longer serves.
+    let h = Harness::start();
+    let mock = h.mock_mut();
+    mock.add_dir("/");
+    mock.add_dir("/logs");
+    mock.add_stream(
+        "/logs/wal",
+        b"turn-1: OLDTOKEN\nturn-2: MIDTOKEN\nturn-3: NEWTOKEN\n",
+        1,
+    );
+
+    let _ = index_root(&h.svc).await;
+    let (b1, _c1) = read_stream_state(&h.zone_root, "/logs/wal");
+    assert!(b1 > 0);
+    // Baseline: all three tokens findable.
+    for token in ["OLDTOKEN", "MIDTOKEN", "NEWTOKEN"] {
+        let q = query(&h.svc, token).await;
+        assert!(
+            q.results.iter().any(|r| r.path == "/logs/wal"),
+            "baseline token {token} must index",
+        );
+    }
+
+    // Simulate retention-trim: replace the stream content with a
+    // strictly shorter blob (only the newest turn survives; the
+    // OLDTOKEN + MIDTOKEN turns are now trimmed away).  Bump mtime
+    // so the Refresh verdict flips to Changed.
+    let mock = h.mock_mut();
+    // Drop the prior registration so add_stream fully replaces.
+    // (The mock preserves entry_type + dirs; add_stream on an
+    // existing path just overwrites the FileEntry — which is what
+    // we want for a trim simulation.)
+    mock.add_stream("/logs/wal", b"turn-3: NEWTOKEN\n", 2);
+
+    let r = refresh_root(&h.svc).await;
+    assert!(r.error.is_none(), "unexpected refresh error: {:?}", r.error);
+
+    // Checkpoint must have RESET (not just advanced) — the retention
+    // recovery drops prior chunks and re-chunks the shorter blob
+    // from offset 0.
+    let (b2, _c2) = read_stream_state(&h.zone_root, "/logs/wal");
+    assert!(
+        b2 < b1,
+        "post-trim byte-len ({b2}) must be strictly less than pre-trim ({b1})",
+    );
+
+    // NEWTOKEN must still be findable — the fresh re-index picked it up.
+    let q_new = query(&h.svc, "NEWTOKEN").await;
+    assert!(
+        q_new.results.iter().any(|r| r.path == "/logs/wal"),
+        "post-trim survivor NEWTOKEN must be re-indexed",
+    );
+}


### PR DESCRIPTION
## Summary

sudocode FR-C (2026-08-22): append-incremental DT_STREAM indexing.

For a keep-forever append-only stream (audit / mailbox / session transcript), full re-chunking on every Refresh is O(N) per pass; K refreshes over a growing stream sum to O(K·N) — O(N²) for the sudocode transcript case where every agent turn fires a refresh.  This PR adds per-path append checkpoints so a refresh chunks only the tail bytes past the prior checkpoint, dropping total cost to O(N).

## Design

- **State** — `StreamState { indexed_byte_len, next_chunk_index, mtime_ms }` sibling map to the existing `FileEntry` mtime cache in `index_state.rs`.  Persisted alongside via serde-default (older readers ignore new field).  `IndexState::verdict()` consults BOTH maps so a quiescent stream short-circuits before sys_read.
- **Dispatch** — `index_one` calls sys_stat first (needed for mtime anyway); when `entry_type == DT_STREAM` dispatches to a new `index_one_stream_append`.  DT_REG stays on untouched full-re-chunk path (files are not append-only; middle edit invalidates every downstream chunk).
- **Append path**:
  1. sys_read → whole deframed log (nexus-vfs #235 host-shim contract)
  2. Prior checkpoint lookup; on first pass, offset = 0 (full initial chunk)
  3. `new_len == checkpoint` → refresh mtime + return Skipped
  4. `new_len < checkpoint` → retention-trim recovery: drop all prior chunks, forget checkpoint, re-index shorter blob via `index_one_stream_full`
  5. Otherwise → chunk `&bytes[indexed..new_len]`, assign `chunk_index = next_chunk_index + i`, add (NOT delete_all_chunks)
  6. Advance checkpoint only when both sinks converged; partial ANN failure holds byte-length at prior value → retry next refresh

- **kernel_io** — `StatInfo` grows `entry_type: u8` (serde default = 0 for backward compat with older kernels).

## Correctness invariants

- Chunk keys `(path, chunk_index)` never collide with prior chunks — continuation indices avoid the pitfall of a fresh chunking pass reusing indices that already point at prior content
- Retention-trim recovery drops the whole chunk set (prior chunks stored `chunk_text` snapshots the WAL no longer serves; keeping them would return stale hits)
- Partial ANN failure preserves the FTS side and forces retry via mtime cache in `None` state
- Embedder-generation swap clears the stream map (semantic vectors live under per-tag ann-<tag> dir)

## Test plan

New: `tests/stream_append_incremental_e2e.rs` — 4 E2E against shared MockKernel harness (extended to model per-entry stream `entry_type` in sys_stat + `append_to_stream` helper):

- `stream_append_only_chunks_the_tail` — checkpoint advances by exactly the appended byte count; chunk_count grows; both old + new tokens findable (proves prior chunks preserved)
- `stream_unchanged_refresh_is_noop_at_checkpoint` — quiescent stream counts as Unchanged; checkpoint does not move
- `stream_multi_append_chunk_count_is_monotonic` — 3 successive appends produce strictly-monotonic byte_len + monotonic chunk_count; every token findable
- `stream_retention_trim_resets_checkpoint_and_reindexes` — strictly-shorter blob drops prior chunks + resets checkpoint + re-indexes survivors

Full suite: 247 lib + 62 integration tests pass.  Clippy + fmt clean.

## References

- FR-B (nexus-vfs #238, merged) — provides the live `modified_at_ms` this path relies on for the verdict cache
- FR-A (nexus-vfs #235 + nexus #4682, both merged) — DT_STREAM search coverage upstream this depends on
- Design SSOT: https://s.shareone.vip/s/nexus-search-architecture §6.3
