### PR TITLE
feat(http-api): grep + query routes + shared SearchError (R10)

### DIFF
--- a/rust/services/http-api/src/handlers/search.rs
+++ b/rust/services/http-api/src/handlers/search.rs
@@ -11,6 +11,13 @@
 //! the sequence).  Handlers here operate on the callable
 //! contract only; a caller with tokenised access is presumed
 //! already granted.
+//!
+//! # Error shape (shared)
+//!
+//! Every handler surfaces backend / RPC errors as [`SearchError`];
+//! the [`IntoResponse`] impl maps `BackendError` → HTTP 503 and
+//! `tonic::Status` → HTTP status by gRPC `Code`.  A new handler
+//! reuses the enum + mapper instead of hand-rolling its own.
 
 use axum::extract::{Query, State};
 use axum::http::StatusCode;
@@ -19,8 +26,10 @@ use axum::routing::get;
 use axum::{Json, Router};
 use serde::{Deserialize, Serialize};
 
-use crate::search_proto::GlobRequest;
+use crate::search_proto::{GlobRequest, GrepRequest};
 use crate::{AppState, BackendError};
+
+// ── /v2/search/glob ──────────────────────────────────────────────
 
 /// Query params for `GET /v2/search/glob`.  Field names match the
 /// proto's [`GlobRequest`] snake_case names 1:1 so a caller
@@ -72,13 +81,8 @@ pub struct GlobResponse {
 pub async fn glob(
     State(state): State<AppState>,
     Query(params): Query<GlobQuery>,
-) -> Result<Json<GlobResponse>, GlobError> {
-    let mut client = state
-        .search
-        .client()
-        .await
-        .map_err(GlobError::BackendUnavailable)?;
-
+) -> Result<Json<GlobResponse>, SearchError> {
+    let mut client = state.search.client().await?;
     let req = GlobRequest {
         root_path: params.root_path,
         pattern: params.pattern,
@@ -86,13 +90,11 @@ pub async fn glob(
         auth_token: params.auth_token,
         sort_recency: params.sort_recency,
     };
-
     let resp = client
         .glob(tonic::Request::new(req))
         .await
-        .map_err(GlobError::Rpc)?
+        .map_err(SearchError::Rpc)?
         .into_inner();
-
     Ok(Json(GlobResponse {
         paths: resp.paths,
         truncated: resp.truncated,
@@ -100,40 +102,155 @@ pub async fn glob(
     }))
 }
 
-pub fn router() -> Router<AppState> {
-    Router::new().route("/v2/search/glob", get(glob))
+// ── /v2/search/grep ──────────────────────────────────────────────
+
+/// Query params for `GET /v2/search/grep`.  Field names match the
+/// proto's [`GrepRequest`] snake_case names 1:1 (same policy as
+/// [`GlobQuery`]).
+#[derive(Debug, Clone, Deserialize)]
+pub struct GrepQuery {
+    /// Directory the grep walks under.  Defaults to `/` for the
+    /// same reason as [`GlobQuery::root_path`].
+    #[serde(default = "default_root")]
+    pub root_path: String,
+    /// Regex compiled with the server-side `regex` crate.  Anchors,
+    /// groups, and inline flags (`(?i)`) all work.
+    pub pattern: String,
+    /// Optional file-name filter (globset syntax).  Empty ⇒ scan
+    /// every regular file.
+    #[serde(default)]
+    pub file_pattern: String,
+    /// Case-insensitive match — kept as a separate wire field so
+    /// "explicit case-insensitive" and "pattern contains `(?i)`"
+    /// stay distinguishable.
+    #[serde(default)]
+    pub ignore_case: bool,
+    /// Safety cap; 0 (or absent) = server-side default (1_000).
+    #[serde(default)]
+    pub max_results: u32,
+    /// Lines of context before each match (default 0).
+    #[serde(default)]
+    pub before_context: u32,
+    /// Lines of context after each match (default 0).
+    #[serde(default)]
+    pub after_context: u32,
+    /// Invert: return lines that do NOT match the pattern.
+    #[serde(default)]
+    pub invert_match: bool,
+    #[serde(default)]
+    pub auth_token: String,
+    /// Sort matches by containing-file mtime descending.
+    #[serde(default)]
+    pub sort_recency: bool,
 }
 
-/// Handler-level errors surfaced as HTTP responses.
+/// One match row in [`GrepResponse::matches`].  Same field names as
+/// the proto's `GrepMatch`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct GrepMatch {
+    pub path: String,
+    pub line_number: u32,
+    pub line: String,
+    #[serde(default)]
+    pub before: Vec<String>,
+    #[serde(default)]
+    pub after: Vec<String>,
+}
+
+/// Response body of [`grep`].  Same shape / policy as
+/// [`GlobResponse`].
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct GrepResponse {
+    pub matches: Vec<GrepMatch>,
+    pub truncated: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// Handler for `GET /v2/search/grep`.
+pub async fn grep(
+    State(state): State<AppState>,
+    Query(params): Query<GrepQuery>,
+) -> Result<Json<GrepResponse>, SearchError> {
+    let mut client = state.search.client().await?;
+    let req = GrepRequest {
+        root_path: params.root_path,
+        pattern: params.pattern,
+        file_pattern: params.file_pattern,
+        ignore_case: params.ignore_case,
+        max_results: params.max_results,
+        before_context: params.before_context,
+        after_context: params.after_context,
+        invert_match: params.invert_match,
+        auth_token: params.auth_token,
+        sort_recency: params.sort_recency,
+    };
+    let resp = client
+        .grep(tonic::Request::new(req))
+        .await
+        .map_err(SearchError::Rpc)?
+        .into_inner();
+    Ok(Json(GrepResponse {
+        matches: resp
+            .matches
+            .into_iter()
+            .map(|m| GrepMatch {
+                path: m.path,
+                line_number: m.line_number,
+                line: m.line,
+                before: m.before,
+                after: m.after,
+            })
+            .collect(),
+        truncated: resp.truncated,
+        error: resp.error,
+    }))
+}
+
+// ── Router + shared error ────────────────────────────────────────
+
+pub fn router() -> Router<AppState> {
+    Router::new()
+        .route("/v2/search/glob", get(glob))
+        .route("/v2/search/grep", get(grep))
+}
+
+/// Shared handler-level error surfaced as an HTTP response.
 ///
 /// Two-state mapping:
 ///   * `BackendUnavailable` → 503 (backend down; retry-friendly).
-///   * `Rpc(status)` → status.code() mapped to the closest HTTP
-///     status (400 for client-side bad request, 500 for anything
-///     else) with the tonic message in the body so operators
-///     debugging a hang can see the underlying signal.
+///   * `Rpc(status)` → gRPC `Code` mapped via [`grpc_status_to_http`]
+///     (400 InvalidArgument, 401 Unauthenticated, 403 PermissionDenied,
+///     404 NotFound, 504 DeadlineExceeded, 503 Unavailable, 500
+///     fallback so an unmapped code never silently degrades to 200).
+///     The upstream `tonic::Status::message()` rides through in the
+///     JSON body so operators debugging a hang see the source signal.
+///
+/// One enum per `search.rs` — every handler in this module maps
+/// its errors through here so the error contract stays uniform
+/// across `glob`, `grep`, and every future route.
 #[derive(Debug, thiserror::Error)]
-pub enum GlobError {
+pub enum SearchError {
     #[error("backend unavailable: {0}")]
     BackendUnavailable(#[from] BackendError),
     #[error("rpc failed: {0}")]
     Rpc(tonic::Status),
 }
 
-impl IntoResponse for GlobError {
+impl IntoResponse for SearchError {
     fn into_response(self) -> Response {
         let (status, message) = match self {
-            GlobError::BackendUnavailable(e) => (StatusCode::SERVICE_UNAVAILABLE, e.to_string()),
-            GlobError::Rpc(s) => (grpc_status_to_http(s.code()), s.message().to_string()),
+            SearchError::BackendUnavailable(e) => (StatusCode::SERVICE_UNAVAILABLE, e.to_string()),
+            SearchError::Rpc(s) => (grpc_status_to_http(s.code()), s.message().to_string()),
         };
         (status, Json(serde_json::json!({ "error": message }))).into_response()
     }
 }
 
-/// gRPC → HTTP status mapping.  Only the codes glob actually
-/// surfaces at the handler; the fallback is 500 (server-side
-/// generic error) so an unmapped code never silently degrades to
-/// 200.  Kept small on purpose — expanding it later is additive.
+/// gRPC → HTTP status mapping.  Only the codes handlers in this
+/// module actually surface; fallback is 500 (server-side generic
+/// error) so an unmapped code never silently degrades to 200.
+/// Kept small on purpose — expanding it later is additive.
 fn grpc_status_to_http(code: tonic::Code) -> StatusCode {
     match code {
         tonic::Code::InvalidArgument => StatusCode::BAD_REQUEST,

--- a/rust/services/http-api/src/handlers/search.rs
+++ b/rust/services/http-api/src/handlers/search.rs
@@ -19,14 +19,19 @@
 //! `tonic::Status` → HTTP status by gRPC `Code`.  A new handler
 //! reuses the enum + mapper instead of hand-rolling its own.
 
+use std::collections::HashMap;
+
 use axum::extract::{Query, State};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
-use axum::routing::get;
+use axum::routing::{get, post};
 use axum::{Json, Router};
 use serde::{Deserialize, Serialize};
 
-use crate::search_proto::{GlobRequest, GrepRequest};
+use crate::search_proto::{
+    FusionMethod, GlobRequest, GrepRequest, QueryRequest, QueryResult as ProtoQueryResult,
+    QueryType,
+};
 use crate::{AppState, BackendError};
 
 // ── /v2/search/glob ──────────────────────────────────────────────
@@ -207,12 +212,183 @@ pub async fn grep(
     }))
 }
 
+// ── /v2/search/query ─────────────────────────────────────────────
+
+/// JSON body for `POST /v2/search/query`.  Field names match the
+/// proto's [`QueryRequest`] snake_case names 1:1 (same policy as
+/// [`GlobQuery`] / [`GrepQuery`]).  Enum-shaped fields land as
+/// wire-friendly lowercase strings so a caller reading the proto
+/// enum values and a caller reading this doc reach the same shape.
+#[derive(Debug, Clone, Deserialize)]
+pub struct QueryBody {
+    /// Query text.
+    pub q: String,
+    /// Zone scoping.  Empty ⇒ ROOT_ZONE_ID.
+    #[serde(default)]
+    pub zone_id: String,
+    /// Max results returned.  0 ⇒ server-side default (10).
+    #[serde(default)]
+    pub limit: u32,
+    /// Optional path-prefix filter.
+    #[serde(default)]
+    pub path_filter: String,
+    /// `"keyword"` (default) / `"semantic"` / `"hybrid"`.
+    /// Wire-friendly string rather than the raw enum int so callers
+    /// don't have to memorise the proto numeric.  An unknown value
+    /// falls through to `"keyword"` — the same fail-open posture the
+    /// proto's `UNSPECIFIED = 0` treats as keyword.
+    #[serde(default)]
+    pub query_type: String,
+    #[serde(default)]
+    pub auth_token: String,
+    #[serde(default)]
+    pub alpha: f32,
+    /// `"rrf"` (default) / `"weighted"` / `"rrf_weighted"`.
+    #[serde(default)]
+    pub fusion_method: String,
+    #[serde(default)]
+    pub rrf_k: u32,
+    /// Per-document chunk cap for pooling (#4542). 0 = no pooling.
+    #[serde(default)]
+    pub chunks_per_page: u32,
+    /// `"macro"` (neighbour context expansion) / anything else ⇒
+    /// none.  Absent ⇒ none.
+    #[serde(default)]
+    pub expand: String,
+    /// `""` / `"off"` (default) / `"on"` / `"auto"`.
+    #[serde(default)]
+    pub recency_mode: String,
+    #[serde(default)]
+    pub recency_weight: f32,
+    #[serde(default)]
+    pub recency_half_life_days: f32,
+    /// Per-prefix score multiplier map.  Empty ⇒ no per-prefix boost.
+    #[serde(default)]
+    pub path_prefix_boosts: HashMap<String, f32>,
+}
+
+/// One result row in [`QueryResponseBody::results`].  Every field
+/// mirrors the proto's [`QueryResult`](ProtoQueryResult) so a
+/// caller migrating from the gRPC surface keeps its JSON parser.
+/// Optional fields serialise as absent (`skip_serializing_if =
+/// Option::is_none`) so the wire stays compact for the common case
+/// where an attribution field did not apply.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct QueryHit {
+    pub path: String,
+    pub chunk_index: u32,
+    pub chunk_text: String,
+    pub score: f32,
+    pub zone_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mtime_ms: Option<i64>,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub expanded_context: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title_score: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub keyword_score: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub vector_score: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tier_boost: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub recency_boost: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expansion_variant_index: Option<u32>,
+}
+
+/// Response body of [`query`].  Same absent-when-none policy as
+/// [`GlobResponse`] / [`GrepResponse`] for the `error` field.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct QueryResponseBody {
+    pub results: Vec<QueryHit>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+fn parse_query_type(s: &str) -> QueryType {
+    match s {
+        "semantic" => QueryType::Semantic,
+        "hybrid" => QueryType::Hybrid,
+        // "" / "keyword" / anything else → keyword.  Fail-open matches
+        // the proto's `UNSPECIFIED = 0 ⇒ treated as keyword` posture.
+        _ => QueryType::Keyword,
+    }
+}
+
+fn parse_fusion_method(s: &str) -> FusionMethod {
+    match s {
+        "weighted" => FusionMethod::Weighted,
+        "rrf_weighted" => FusionMethod::RrfWeighted,
+        // "" / "rrf" / anything else → RRF.
+        _ => FusionMethod::Rrf,
+    }
+}
+
+fn hit_from_proto(r: ProtoQueryResult) -> QueryHit {
+    QueryHit {
+        path: r.path,
+        chunk_index: r.chunk_index,
+        chunk_text: r.chunk_text,
+        score: r.score,
+        zone_id: r.zone_id,
+        mtime_ms: r.mtime_ms,
+        expanded_context: r.expanded_context,
+        title_score: r.title_score,
+        keyword_score: r.keyword_score,
+        vector_score: r.vector_score,
+        tier_boost: r.tier_boost,
+        recency_boost: r.recency_boost,
+        expansion_variant_index: r.expansion_variant_index,
+    }
+}
+
+/// Handler for `POST /v2/search/query`.  JSON body variant of the
+/// proto's `Query` RPC — GET-with-query-string would work for
+/// simple cases but the request shape (hybrid knobs + recency
+/// tuple + `path_prefix_boosts` map) is JSON-shaped in practice,
+/// so a POST body keeps the wire honest.
+pub async fn query(
+    State(state): State<AppState>,
+    Json(body): Json<QueryBody>,
+) -> Result<Json<QueryResponseBody>, SearchError> {
+    let mut client = state.search.client().await?;
+    let req = QueryRequest {
+        q: body.q,
+        zone_id: body.zone_id,
+        limit: body.limit,
+        path_filter: body.path_filter,
+        query_type: parse_query_type(&body.query_type) as i32,
+        auth_token: body.auth_token,
+        alpha: body.alpha,
+        fusion_method: parse_fusion_method(&body.fusion_method) as i32,
+        rrf_k: body.rrf_k,
+        chunks_per_page: body.chunks_per_page,
+        expand: body.expand,
+        recency_mode: body.recency_mode,
+        recency_weight: body.recency_weight,
+        recency_half_life_days: body.recency_half_life_days,
+        path_prefix_boosts: body.path_prefix_boosts,
+    };
+    let resp = client
+        .query(tonic::Request::new(req))
+        .await
+        .map_err(SearchError::Rpc)?
+        .into_inner();
+    Ok(Json(QueryResponseBody {
+        results: resp.results.into_iter().map(hit_from_proto).collect(),
+        error: resp.error,
+    }))
+}
+
 // ── Router + shared error ────────────────────────────────────────
 
 pub fn router() -> Router<AppState> {
     Router::new()
         .route("/v2/search/glob", get(glob))
         .route("/v2/search/grep", get(grep))
+        .route("/v2/search/query", post(query))
 }
 
 /// Shared handler-level error surfaced as an HTTP response.

--- a/rust/services/http-api/tests/grep_e2e.rs
+++ b/rust/services/http-api/tests/grep_e2e.rs
@@ -1,0 +1,412 @@
+//! Real-chain E2E cover for `GET /v2/search/grep` — same posture
+//! as `glob_e2e.rs`: mock gRPC server on ephemeral port + axum
+//! listener pointed at it + reqwest hits the router.
+//!
+//! Pins:
+//!   * handler → proto mapping: HTTP query params translate to the
+//!     right [`GrepRequest`] fields at the gRPC boundary (checked
+//!     via the mock's request log)
+//!   * proto → HTTP mapping: [`GrepResponse.matches`] round-trips
+//!     with `line_number`, `line`, `before`, `after` intact
+//!   * error mapping: `InvalidArgument` → 400, upstream-down → 503
+//!   * defaults: absent `root_path` → `/`; absent numeric knobs → 0
+
+use std::sync::{Arc, Mutex};
+
+use nexus_http_api::search_proto::search_service_server::{SearchService, SearchServiceServer};
+use nexus_http_api::search_proto::{
+    AddIndexedDirectoryRequest, AddIndexedDirectoryResponse, BatchQueryRequest, BatchQueryResponse,
+    GlobRequest, GlobResponse, GrepMatch, GrepRequest, GrepResponse, HealthRequest, HealthResponse,
+    IndexDocumentsRequest, IndexDocumentsResponse, IndexRequest, IndexResponse,
+    ListIndexedDirectoriesRequest, ListIndexedDirectoriesResponse, ListZoneIndexingModesRequest,
+    ListZoneIndexingModesResponse, LocateRequest, LocateResponse, NotifyFileChangeRequest,
+    NotifyFileChangeResponse, ParkedDiscardRequest, ParkedDiscardResponse, ParkedListRequest,
+    ParkedListResponse, ParkedRetryRequest, ParkedRetryResponse, QueryRequest, QueryResponse,
+    RefreshRequest, RefreshResponse, RemoveIndexedDirectoryRequest, RemoveIndexedDirectoryResponse,
+    SetZoneIndexingModeRequest, SetZoneIndexingModeResponse, StatsRequest, StatsResponse,
+};
+use nexus_http_api::{bind_and_serve, AppState, SearchBackend};
+use tokio::net::TcpListener;
+use tokio_stream::wrappers::TcpListenerStream;
+use tonic::{Request, Response, Status};
+
+// ── Mock SearchService ─────────────────────────────────────────
+
+#[derive(Default, Clone)]
+struct RequestLog {
+    greps: Arc<Mutex<Vec<GrepRequest>>>,
+}
+
+#[derive(Clone)]
+enum MockBehaviour {
+    Success {
+        matches: Vec<GrepMatch>,
+        truncated: bool,
+        error: Option<String>,
+    },
+    InvalidArgument(String),
+}
+
+#[derive(Clone)]
+struct MockSearchService {
+    log: RequestLog,
+    behaviour: MockBehaviour,
+}
+
+#[tonic::async_trait]
+impl SearchService for MockSearchService {
+    async fn grep(&self, req: Request<GrepRequest>) -> Result<Response<GrepResponse>, Status> {
+        let inner = req.into_inner();
+        self.log.greps.lock().unwrap().push(inner);
+        match &self.behaviour {
+            MockBehaviour::Success {
+                matches,
+                truncated,
+                error,
+            } => Ok(Response::new(GrepResponse {
+                matches: matches.clone(),
+                truncated: *truncated,
+                error: error.clone(),
+            })),
+            MockBehaviour::InvalidArgument(msg) => Err(Status::invalid_argument(msg.clone())),
+        }
+    }
+
+    // Every other RPC must be unreachable — grep handler never calls them.
+    async fn glob(&self, _: Request<GlobRequest>) -> Result<Response<GlobResponse>, Status> {
+        unreachable!("grep handler must not call glob")
+    }
+    async fn query(&self, _: Request<QueryRequest>) -> Result<Response<QueryResponse>, Status> {
+        unreachable!()
+    }
+    async fn index(&self, _: Request<IndexRequest>) -> Result<Response<IndexResponse>, Status> {
+        unreachable!()
+    }
+    async fn refresh(
+        &self,
+        _: Request<RefreshRequest>,
+    ) -> Result<Response<RefreshResponse>, Status> {
+        unreachable!()
+    }
+    async fn batch_query(
+        &self,
+        _: Request<BatchQueryRequest>,
+    ) -> Result<Response<BatchQueryResponse>, Status> {
+        unreachable!()
+    }
+    async fn index_documents(
+        &self,
+        _: Request<IndexDocumentsRequest>,
+    ) -> Result<Response<IndexDocumentsResponse>, Status> {
+        unreachable!()
+    }
+    async fn notify_file_change(
+        &self,
+        _: Request<NotifyFileChangeRequest>,
+    ) -> Result<Response<NotifyFileChangeResponse>, Status> {
+        unreachable!()
+    }
+    async fn locate(&self, _: Request<LocateRequest>) -> Result<Response<LocateResponse>, Status> {
+        unreachable!()
+    }
+    async fn parked_list(
+        &self,
+        _: Request<ParkedListRequest>,
+    ) -> Result<Response<ParkedListResponse>, Status> {
+        unreachable!()
+    }
+    async fn parked_retry(
+        &self,
+        _: Request<ParkedRetryRequest>,
+    ) -> Result<Response<ParkedRetryResponse>, Status> {
+        unreachable!()
+    }
+    async fn parked_discard(
+        &self,
+        _: Request<ParkedDiscardRequest>,
+    ) -> Result<Response<ParkedDiscardResponse>, Status> {
+        unreachable!()
+    }
+    async fn add_indexed_directory(
+        &self,
+        _: Request<AddIndexedDirectoryRequest>,
+    ) -> Result<Response<AddIndexedDirectoryResponse>, Status> {
+        unreachable!()
+    }
+    async fn remove_indexed_directory(
+        &self,
+        _: Request<RemoveIndexedDirectoryRequest>,
+    ) -> Result<Response<RemoveIndexedDirectoryResponse>, Status> {
+        unreachable!()
+    }
+    async fn list_indexed_directories(
+        &self,
+        _: Request<ListIndexedDirectoriesRequest>,
+    ) -> Result<Response<ListIndexedDirectoriesResponse>, Status> {
+        unreachable!()
+    }
+    async fn set_zone_indexing_mode(
+        &self,
+        _: Request<SetZoneIndexingModeRequest>,
+    ) -> Result<Response<SetZoneIndexingModeResponse>, Status> {
+        unreachable!()
+    }
+    async fn list_zone_indexing_modes(
+        &self,
+        _: Request<ListZoneIndexingModesRequest>,
+    ) -> Result<Response<ListZoneIndexingModesResponse>, Status> {
+        unreachable!()
+    }
+    async fn health(&self, _: Request<HealthRequest>) -> Result<Response<HealthResponse>, Status> {
+        unreachable!()
+    }
+    async fn stats(&self, _: Request<StatsRequest>) -> Result<Response<StatsResponse>, Status> {
+        unreachable!()
+    }
+}
+
+// ── Harness ────────────────────────────────────────────────────
+
+struct Harness {
+    http_base: String,
+    log: RequestLog,
+}
+
+impl Harness {
+    async fn start(behaviour: MockBehaviour) -> Self {
+        let (grpc_target, log) = spawn_mock_grpc_server(behaviour).await;
+        let http_base = spawn_http_listener(grpc_target).await;
+        Self { http_base, log }
+    }
+
+    async fn start_pointing_at_dead_backend() -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind + release ephemeral port");
+        let dead_addr = listener.local_addr().expect("dead addr");
+        drop(listener);
+        let http_base = spawn_http_listener(format!("http://{dead_addr}")).await;
+        Self {
+            http_base,
+            log: RequestLog::default(),
+        }
+    }
+}
+
+async fn spawn_http_listener(grpc_target: String) -> String {
+    let state = AppState {
+        search: SearchBackend::new(grpc_target),
+    };
+    let (http_addr, fut) = bind_and_serve("127.0.0.1:0".parse().unwrap(), state)
+        .await
+        .expect("bind http listener");
+    tokio::spawn(async move {
+        fut.await.expect("axum::serve");
+    });
+    format!("http://{http_addr}")
+}
+
+async fn spawn_mock_grpc_server(behaviour: MockBehaviour) -> (String, RequestLog) {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind grpc listener");
+    let addr = listener.local_addr().expect("grpc addr");
+    let log = RequestLog::default();
+    let mock = MockSearchService {
+        log: log.clone(),
+        behaviour,
+    };
+    tokio::spawn(async move {
+        tonic::transport::Server::builder()
+            .add_service(SearchServiceServer::new(mock))
+            .serve_with_incoming(TcpListenerStream::new(listener))
+            .await
+            .expect("mock grpc serve");
+    });
+    (format!("http://{addr}"), log)
+}
+
+// ── Tests ──────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn grep_happy_path_round_trips_full_chain() {
+    let h = Harness::start(MockBehaviour::Success {
+        matches: vec![
+            GrepMatch {
+                path: "/notes/a.md".to_string(),
+                line_number: 12,
+                line: "the widget hums along".to_string(),
+                before: vec!["previous line".to_string()],
+                after: vec!["following line".to_string()],
+            },
+            GrepMatch {
+                path: "/logs/x.log".to_string(),
+                line_number: 4,
+                line: "widget assembled".to_string(),
+                before: vec![],
+                after: vec![],
+            },
+        ],
+        truncated: false,
+        error: None,
+    })
+    .await;
+
+    let resp = reqwest::Client::new()
+        .get(format!(
+            "{}/v2/search/grep?root_path=/&pattern=widget&file_pattern=*.md&ignore_case=true&max_results=50&before_context=1&after_context=1&sort_recency=true",
+            h.http_base
+        ))
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+
+    let body: serde_json::Value = resp.json().await.expect("parse json");
+    assert_eq!(body["matches"].as_array().unwrap().len(), 2);
+    assert_eq!(body["matches"][0]["path"], "/notes/a.md");
+    assert_eq!(body["matches"][0]["line_number"], 12);
+    assert_eq!(body["matches"][0]["line"], "the widget hums along");
+    assert_eq!(
+        body["matches"][0]["before"],
+        serde_json::json!(["previous line"]),
+    );
+    assert_eq!(
+        body["matches"][0]["after"],
+        serde_json::json!(["following line"]),
+    );
+    assert_eq!(body["truncated"], serde_json::Value::Bool(false));
+    assert!(body.get("error").is_none() || body["error"].is_null());
+
+    // Handler → proto boundary: every field must reach the backend.
+    let recorded = h.log.greps.lock().unwrap().clone();
+    assert_eq!(recorded.len(), 1, "exactly one upstream Grep call");
+    let r = &recorded[0];
+    assert_eq!(r.root_path, "/");
+    assert_eq!(r.pattern, "widget");
+    assert_eq!(r.file_pattern, "*.md");
+    assert!(r.ignore_case);
+    assert_eq!(r.max_results, 50);
+    assert_eq!(r.before_context, 1);
+    assert_eq!(r.after_context, 1);
+    assert!(r.sort_recency);
+    assert!(
+        !r.invert_match,
+        "invert_match defaults to false when absent"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn grep_missing_pattern_returns_400() {
+    let h = Harness::start(MockBehaviour::Success {
+        matches: vec![],
+        truncated: false,
+        error: None,
+    })
+    .await;
+
+    let resp = reqwest::Client::new()
+        .get(format!("{}/v2/search/grep?root_path=/", h.http_base))
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(
+        resp.status(),
+        reqwest::StatusCode::BAD_REQUEST,
+        "missing required `pattern` must not reach the backend",
+    );
+    assert!(
+        h.log.greps.lock().unwrap().is_empty(),
+        "upstream RPC must NOT fire on a rejected request",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn grep_upstream_invalid_argument_maps_to_400() {
+    let h = Harness::start(MockBehaviour::InvalidArgument(
+        "bad regex: unclosed character class".to_string(),
+    ))
+    .await;
+
+    let resp = reqwest::Client::new()
+        .get(format!(
+            "{}/v2/search/grep?root_path=/&pattern=%5Bunclosed",
+            h.http_base
+        ))
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(
+        resp.status(),
+        reqwest::StatusCode::BAD_REQUEST,
+        "tonic InvalidArgument must map to HTTP 400, not 500",
+    );
+    let body: serde_json::Value = resp.json().await.expect("parse json");
+    assert!(
+        body["error"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("unclosed"),
+        "error body must include upstream message; got: {body}",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn grep_upstream_down_maps_to_503() {
+    let h = Harness::start_pointing_at_dead_backend().await;
+    let resp = reqwest::Client::new()
+        .get(format!(
+            "{}/v2/search/grep?root_path=/&pattern=widget",
+            h.http_base
+        ))
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(
+        resp.status(),
+        reqwest::StatusCode::SERVICE_UNAVAILABLE,
+        "connection refused must surface as 503, not 500 or hang",
+    );
+    let body: serde_json::Value = resp.json().await.expect("parse json");
+    assert!(
+        body["error"].as_str().is_some(),
+        "503 body must carry an error message for operators; got: {body}",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn grep_defaults_reach_backend_intact() {
+    // Absent optional params: root_path defaults to `/`; every
+    // numeric knob defaults to 0 (backend interprets 0 as "server
+    // default" for cap fields).  Verify the handler doesn't
+    // silently rewrite any of them.
+    let h = Harness::start(MockBehaviour::Success {
+        matches: vec![],
+        truncated: false,
+        error: None,
+    })
+    .await;
+
+    let resp = reqwest::Client::new()
+        .get(format!("{}/v2/search/grep?pattern=needle", h.http_base))
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+
+    let recorded = h.log.greps.lock().unwrap().clone();
+    assert_eq!(recorded.len(), 1);
+    let r = &recorded[0];
+    assert_eq!(r.root_path, "/", "absent root_path defaults to '/'");
+    assert_eq!(r.pattern, "needle");
+    assert_eq!(r.file_pattern, "");
+    assert!(!r.ignore_case);
+    assert_eq!(
+        r.max_results, 0,
+        "absent max_results defaults to 0 (server default)"
+    );
+    assert_eq!(r.before_context, 0);
+    assert_eq!(r.after_context, 0);
+    assert!(!r.invert_match);
+    assert!(!r.sort_recency);
+}

--- a/rust/services/http-api/tests/query_e2e.rs
+++ b/rust/services/http-api/tests/query_e2e.rs
@@ -1,0 +1,530 @@
+//! Real-chain E2E cover for `POST /v2/search/query` — same posture
+//! as `glob_e2e.rs` / `grep_e2e.rs`: mock gRPC server on ephemeral
+//! port + axum listener pointed at it + reqwest hits the router
+//! with a JSON body.
+//!
+//! Pins:
+//!   * JSON body → proto mapping: every field on `QueryBody` reaches
+//!     the corresponding `QueryRequest` field at the gRPC boundary,
+//!     including the enum-shaped ones (`query_type` "hybrid" →
+//!     `QueryType::Hybrid`; `fusion_method` "rrf_weighted" →
+//!     `FusionMethod::RrfWeighted`) and the `path_prefix_boosts`
+//!     map.
+//!   * proto → HTTP mapping: `QueryResult`'s optional attribution
+//!     fields (title_score, keyword_score, vector_score, tier_boost,
+//!     recency_boost, expansion_variant_index) survive round-trip
+//!     into JSON, with absent-when-None omission for compactness.
+//!   * error mapping: `InvalidArgument` → 400; upstream-down → 503.
+//!   * defaults: absent optional params fall through with proto
+//!     defaults, not silently rewritten.
+
+use std::sync::{Arc, Mutex};
+
+use nexus_http_api::search_proto::search_service_server::{SearchService, SearchServiceServer};
+use nexus_http_api::search_proto::{
+    AddIndexedDirectoryRequest, AddIndexedDirectoryResponse, BatchQueryRequest, BatchQueryResponse,
+    GlobRequest, GlobResponse, GrepRequest, GrepResponse, HealthRequest, HealthResponse,
+    IndexDocumentsRequest, IndexDocumentsResponse, IndexRequest, IndexResponse,
+    ListIndexedDirectoriesRequest, ListIndexedDirectoriesResponse, ListZoneIndexingModesRequest,
+    ListZoneIndexingModesResponse, LocateRequest, LocateResponse, NotifyFileChangeRequest,
+    NotifyFileChangeResponse, ParkedDiscardRequest, ParkedDiscardResponse, ParkedListRequest,
+    ParkedListResponse, ParkedRetryRequest, ParkedRetryResponse, QueryRequest, QueryResponse,
+    QueryResult, RefreshRequest, RefreshResponse, RemoveIndexedDirectoryRequest,
+    RemoveIndexedDirectoryResponse, SetZoneIndexingModeRequest, SetZoneIndexingModeResponse,
+    StatsRequest, StatsResponse,
+};
+use nexus_http_api::{bind_and_serve, AppState, SearchBackend};
+use tokio::net::TcpListener;
+use tokio_stream::wrappers::TcpListenerStream;
+use tonic::{Request, Response, Status};
+
+// ── Mock SearchService ─────────────────────────────────────────
+
+#[derive(Default, Clone)]
+struct RequestLog {
+    queries: Arc<Mutex<Vec<QueryRequest>>>,
+}
+
+#[derive(Clone)]
+enum MockBehaviour {
+    Success {
+        results: Vec<QueryResult>,
+        error: Option<String>,
+    },
+    InvalidArgument(String),
+}
+
+#[derive(Clone)]
+struct MockSearchService {
+    log: RequestLog,
+    behaviour: MockBehaviour,
+}
+
+#[tonic::async_trait]
+impl SearchService for MockSearchService {
+    async fn query(&self, req: Request<QueryRequest>) -> Result<Response<QueryResponse>, Status> {
+        let inner = req.into_inner();
+        self.log.queries.lock().unwrap().push(inner);
+        match &self.behaviour {
+            MockBehaviour::Success { results, error } => Ok(Response::new(QueryResponse {
+                results: results.clone(),
+                error: error.clone(),
+            })),
+            MockBehaviour::InvalidArgument(msg) => Err(Status::invalid_argument(msg.clone())),
+        }
+    }
+
+    // Every other RPC unreachable — query handler never calls them.
+    async fn glob(&self, _: Request<GlobRequest>) -> Result<Response<GlobResponse>, Status> {
+        unreachable!()
+    }
+    async fn grep(&self, _: Request<GrepRequest>) -> Result<Response<GrepResponse>, Status> {
+        unreachable!()
+    }
+    async fn index(&self, _: Request<IndexRequest>) -> Result<Response<IndexResponse>, Status> {
+        unreachable!()
+    }
+    async fn refresh(
+        &self,
+        _: Request<RefreshRequest>,
+    ) -> Result<Response<RefreshResponse>, Status> {
+        unreachable!()
+    }
+    async fn batch_query(
+        &self,
+        _: Request<BatchQueryRequest>,
+    ) -> Result<Response<BatchQueryResponse>, Status> {
+        unreachable!()
+    }
+    async fn index_documents(
+        &self,
+        _: Request<IndexDocumentsRequest>,
+    ) -> Result<Response<IndexDocumentsResponse>, Status> {
+        unreachable!()
+    }
+    async fn notify_file_change(
+        &self,
+        _: Request<NotifyFileChangeRequest>,
+    ) -> Result<Response<NotifyFileChangeResponse>, Status> {
+        unreachable!()
+    }
+    async fn locate(&self, _: Request<LocateRequest>) -> Result<Response<LocateResponse>, Status> {
+        unreachable!()
+    }
+    async fn parked_list(
+        &self,
+        _: Request<ParkedListRequest>,
+    ) -> Result<Response<ParkedListResponse>, Status> {
+        unreachable!()
+    }
+    async fn parked_retry(
+        &self,
+        _: Request<ParkedRetryRequest>,
+    ) -> Result<Response<ParkedRetryResponse>, Status> {
+        unreachable!()
+    }
+    async fn parked_discard(
+        &self,
+        _: Request<ParkedDiscardRequest>,
+    ) -> Result<Response<ParkedDiscardResponse>, Status> {
+        unreachable!()
+    }
+    async fn add_indexed_directory(
+        &self,
+        _: Request<AddIndexedDirectoryRequest>,
+    ) -> Result<Response<AddIndexedDirectoryResponse>, Status> {
+        unreachable!()
+    }
+    async fn remove_indexed_directory(
+        &self,
+        _: Request<RemoveIndexedDirectoryRequest>,
+    ) -> Result<Response<RemoveIndexedDirectoryResponse>, Status> {
+        unreachable!()
+    }
+    async fn list_indexed_directories(
+        &self,
+        _: Request<ListIndexedDirectoriesRequest>,
+    ) -> Result<Response<ListIndexedDirectoriesResponse>, Status> {
+        unreachable!()
+    }
+    async fn set_zone_indexing_mode(
+        &self,
+        _: Request<SetZoneIndexingModeRequest>,
+    ) -> Result<Response<SetZoneIndexingModeResponse>, Status> {
+        unreachable!()
+    }
+    async fn list_zone_indexing_modes(
+        &self,
+        _: Request<ListZoneIndexingModesRequest>,
+    ) -> Result<Response<ListZoneIndexingModesResponse>, Status> {
+        unreachable!()
+    }
+    async fn health(&self, _: Request<HealthRequest>) -> Result<Response<HealthResponse>, Status> {
+        unreachable!()
+    }
+    async fn stats(&self, _: Request<StatsRequest>) -> Result<Response<StatsResponse>, Status> {
+        unreachable!()
+    }
+}
+
+// ── Harness ────────────────────────────────────────────────────
+
+struct Harness {
+    http_base: String,
+    log: RequestLog,
+}
+
+impl Harness {
+    async fn start(behaviour: MockBehaviour) -> Self {
+        let (grpc_target, log) = spawn_mock_grpc_server(behaviour).await;
+        let http_base = spawn_http_listener(grpc_target).await;
+        Self { http_base, log }
+    }
+
+    async fn start_pointing_at_dead_backend() -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind + release ephemeral port");
+        let dead_addr = listener.local_addr().expect("dead addr");
+        drop(listener);
+        let http_base = spawn_http_listener(format!("http://{dead_addr}")).await;
+        Self {
+            http_base,
+            log: RequestLog::default(),
+        }
+    }
+}
+
+async fn spawn_http_listener(grpc_target: String) -> String {
+    let state = AppState {
+        search: SearchBackend::new(grpc_target),
+    };
+    let (http_addr, fut) = bind_and_serve("127.0.0.1:0".parse().unwrap(), state)
+        .await
+        .expect("bind http listener");
+    tokio::spawn(async move {
+        fut.await.expect("axum::serve");
+    });
+    format!("http://{http_addr}")
+}
+
+async fn spawn_mock_grpc_server(behaviour: MockBehaviour) -> (String, RequestLog) {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind grpc listener");
+    let addr = listener.local_addr().expect("grpc addr");
+    let log = RequestLog::default();
+    let mock = MockSearchService {
+        log: log.clone(),
+        behaviour,
+    };
+    tokio::spawn(async move {
+        tonic::transport::Server::builder()
+            .add_service(SearchServiceServer::new(mock))
+            .serve_with_incoming(TcpListenerStream::new(listener))
+            .await
+            .expect("mock grpc serve");
+    });
+    (format!("http://{addr}"), log)
+}
+
+fn full_hit() -> QueryResult {
+    QueryResult {
+        path: "/notes/a.md".to_string(),
+        chunk_index: 3,
+        chunk_text: "the widget hums along".to_string(),
+        score: 0.87,
+        zone_id: "root".to_string(),
+        mtime_ms: Some(1_700_000_000_000),
+        expanded_context: "prior chunk\n\nthe widget hums along\n\nfollowing chunk".to_string(),
+        title_score: Some(4.5),
+        keyword_score: Some(2.1),
+        vector_score: Some(0.83),
+        tier_boost: Some(1.5),
+        recency_boost: Some(1.2),
+        expansion_variant_index: Some(2),
+    }
+}
+
+// ── Tests ──────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn query_happy_path_round_trips_full_chain() {
+    let h = Harness::start(MockBehaviour::Success {
+        results: vec![full_hit()],
+        error: None,
+    })
+    .await;
+
+    let body = serde_json::json!({
+        "q": "widget",
+        "zone_id": "root",
+        "limit": 15,
+        "path_filter": "/notes",
+        "query_type": "hybrid",
+        "auth_token": "sk-test",
+        "alpha": 0.6,
+        "fusion_method": "rrf_weighted",
+        "rrf_k": 42,
+        "chunks_per_page": 3,
+        "expand": "macro",
+        "recency_mode": "auto",
+        "recency_weight": 0.4,
+        "recency_half_life_days": 7.0,
+        "path_prefix_boosts": {"/notes/": 1.5, "/tmp/": 0.25},
+    });
+    let resp = reqwest::Client::new()
+        .post(format!("{}/v2/search/query", h.http_base))
+        .json(&body)
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+
+    let parsed: serde_json::Value = resp.json().await.expect("parse json");
+    let hit = &parsed["results"][0];
+    assert_eq!(hit["path"], "/notes/a.md");
+    assert_eq!(hit["chunk_index"], 3);
+    assert_eq!(hit["chunk_text"], "the widget hums along");
+    assert_eq!(hit["score"], 0.87);
+    assert_eq!(hit["zone_id"], "root");
+    assert_eq!(hit["mtime_ms"], 1_700_000_000_000i64);
+    assert!(hit["expanded_context"]
+        .as_str()
+        .unwrap()
+        .contains("prior chunk"));
+    assert_eq!(hit["title_score"], 4.5);
+    assert_eq!(hit["keyword_score"], 2.1);
+    assert_eq!(hit["vector_score"], 0.83);
+    assert_eq!(hit["tier_boost"], 1.5);
+    assert_eq!(hit["recency_boost"], 1.2);
+    assert_eq!(hit["expansion_variant_index"], 2);
+    assert!(parsed.get("error").is_none() || parsed["error"].is_null());
+
+    // Handler → proto boundary — every JSON field reaches the RPC.
+    let recorded = h.log.queries.lock().unwrap().clone();
+    assert_eq!(recorded.len(), 1, "exactly one upstream Query call");
+    let r = &recorded[0];
+    assert_eq!(r.q, "widget");
+    assert_eq!(r.zone_id, "root");
+    assert_eq!(r.limit, 15);
+    assert_eq!(r.path_filter, "/notes");
+    assert_eq!(
+        r.query_type,
+        nexus_http_api::search_proto::QueryType::Hybrid as i32,
+        "query_type=hybrid must map to proto Hybrid enum",
+    );
+    assert_eq!(r.auth_token, "sk-test");
+    assert_eq!(r.alpha, 0.6);
+    assert_eq!(
+        r.fusion_method,
+        nexus_http_api::search_proto::FusionMethod::RrfWeighted as i32,
+        "fusion_method=rrf_weighted must map to proto RrfWeighted enum",
+    );
+    assert_eq!(r.rrf_k, 42);
+    assert_eq!(r.chunks_per_page, 3);
+    assert_eq!(r.expand, "macro");
+    assert_eq!(r.recency_mode, "auto");
+    assert_eq!(r.recency_weight, 0.4);
+    assert_eq!(r.recency_half_life_days, 7.0);
+    assert_eq!(r.path_prefix_boosts.get("/notes/"), Some(&1.5));
+    assert_eq!(r.path_prefix_boosts.get("/tmp/"), Some(&0.25));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn query_optional_attribution_fields_absent_when_none() {
+    // A hit with every Option<f32>/mtime attribution field as None
+    // must serialise WITHOUT those keys (skip_serializing_if =
+    // Option::is_none), keeping the wire compact for the common
+    // case where a boost / arm did not apply.
+    let bare = QueryResult {
+        path: "/x.md".to_string(),
+        chunk_index: 0,
+        chunk_text: "hello".to_string(),
+        score: 1.0,
+        zone_id: "root".to_string(),
+        mtime_ms: None,
+        expanded_context: String::new(),
+        title_score: None,
+        keyword_score: None,
+        vector_score: None,
+        tier_boost: None,
+        recency_boost: None,
+        expansion_variant_index: None,
+    };
+    let h = Harness::start(MockBehaviour::Success {
+        results: vec![bare],
+        error: None,
+    })
+    .await;
+    let resp = reqwest::Client::new()
+        .post(format!("{}/v2/search/query", h.http_base))
+        .json(&serde_json::json!({"q": "hello"}))
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+    let parsed: serde_json::Value = resp.json().await.expect("parse json");
+    let hit = &parsed["results"][0];
+    for absent_key in [
+        "mtime_ms",
+        "title_score",
+        "keyword_score",
+        "vector_score",
+        "tier_boost",
+        "recency_boost",
+        "expansion_variant_index",
+    ] {
+        assert!(
+            hit.get(absent_key).is_none(),
+            "{absent_key} must be absent from JSON when None (skip_serializing_if); got: {hit}",
+        );
+    }
+    // expanded_context is also skip-serializing-if empty.
+    assert!(
+        hit.get("expanded_context").is_none(),
+        "empty expanded_context must be absent",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn query_defaults_reach_backend_intact() {
+    // Absent optional fields (everything but `q`) must reach the
+    // backend as their proto defaults, not silently rewritten.
+    let h = Harness::start(MockBehaviour::Success {
+        results: vec![],
+        error: None,
+    })
+    .await;
+    let resp = reqwest::Client::new()
+        .post(format!("{}/v2/search/query", h.http_base))
+        .json(&serde_json::json!({"q": "needle"}))
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+
+    let recorded = h.log.queries.lock().unwrap().clone();
+    assert_eq!(recorded.len(), 1);
+    let r = &recorded[0];
+    assert_eq!(r.q, "needle");
+    assert_eq!(r.zone_id, "");
+    assert_eq!(r.limit, 0, "absent limit defaults to 0 (server default)");
+    assert_eq!(r.path_filter, "");
+    assert_eq!(
+        r.query_type,
+        nexus_http_api::search_proto::QueryType::Keyword as i32,
+        "absent/empty query_type defaults to keyword",
+    );
+    assert_eq!(
+        r.fusion_method,
+        nexus_http_api::search_proto::FusionMethod::Rrf as i32,
+        "absent/empty fusion_method defaults to RRF",
+    );
+    assert_eq!(r.rrf_k, 0);
+    assert_eq!(r.chunks_per_page, 0);
+    assert_eq!(r.expand, "");
+    assert_eq!(r.recency_mode, "");
+    assert_eq!(r.recency_weight, 0.0);
+    assert_eq!(r.recency_half_life_days, 0.0);
+    assert!(r.path_prefix_boosts.is_empty());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn query_unknown_query_type_falls_back_to_keyword() {
+    // A typo like "semantik" must fall through to keyword, matching
+    // the proto's `UNSPECIFIED = 0 ⇒ treated as keyword` posture.
+    // Fail-open rather than fail the request — callers that mistype
+    // still get a useful (if narrower) result set.
+    let h = Harness::start(MockBehaviour::Success {
+        results: vec![],
+        error: None,
+    })
+    .await;
+    let resp = reqwest::Client::new()
+        .post(format!("{}/v2/search/query", h.http_base))
+        .json(&serde_json::json!({"q": "x", "query_type": "semantik"}))
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+    let recorded = h.log.queries.lock().unwrap().clone();
+    assert_eq!(
+        recorded[0].query_type,
+        nexus_http_api::search_proto::QueryType::Keyword as i32,
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn query_missing_body_returns_400() {
+    // POST without a body (or with a body missing the required `q`
+    // field) must be rejected before the mock sees it.
+    let h = Harness::start(MockBehaviour::Success {
+        results: vec![],
+        error: None,
+    })
+    .await;
+    let resp = reqwest::Client::new()
+        .post(format!("{}/v2/search/query", h.http_base))
+        .header("content-type", "application/json")
+        .body("{}")
+        .send()
+        .await
+        .expect("send");
+    // axum Json extractor returns 422 for missing-required-field
+    // deserialisation errors; matches the pattern the query
+    // extractor uses for missing GET params (which returns 400).
+    // Either is acceptable; assert on the 4xx family.
+    assert!(
+        resp.status().is_client_error(),
+        "missing `q` must produce a 4xx, got {}",
+        resp.status(),
+    );
+    assert!(
+        h.log.queries.lock().unwrap().is_empty(),
+        "upstream RPC must NOT fire on a rejected request",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn query_upstream_invalid_argument_maps_to_400() {
+    let h = Harness::start(MockBehaviour::InvalidArgument(
+        "bad recency_weight: out of range".to_string(),
+    ))
+    .await;
+    let resp = reqwest::Client::new()
+        .post(format!("{}/v2/search/query", h.http_base))
+        .json(&serde_json::json!({"q": "x", "recency_weight": 99.0}))
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(
+        resp.status(),
+        reqwest::StatusCode::BAD_REQUEST,
+        "tonic InvalidArgument must map to HTTP 400, not 500",
+    );
+    let body: serde_json::Value = resp.json().await.expect("parse json");
+    assert!(
+        body["error"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("recency_weight"),
+        "error body must include upstream message; got: {body}",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn query_upstream_down_maps_to_503() {
+    let h = Harness::start_pointing_at_dead_backend().await;
+    let resp = reqwest::Client::new()
+        .post(format!("{}/v2/search/query", h.http_base))
+        .json(&serde_json::json!({"q": "x"}))
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(
+        resp.status(),
+        reqwest::StatusCode::SERVICE_UNAVAILABLE,
+        "connection refused must surface as 503, not 500/hang",
+    );
+}


### PR DESCRIPTION
## Summary

Two more real routes under R10 arc (#4674).  Same pattern as glob (PR #4678); both share the extracted `SearchError`.

**Commit 1** — `GET /v2/search/grep`. Same query-param shape as glob; regex + file_pattern + context knobs reach the backend intact.  Extract shared `SearchError` + `grpc_status_to_http` mapper (extract-on-second-occurrence trigger; every future handler in this file reuses).

**Commit 2** — `POST /v2/search/query`. JSON body via `axum::extract::Json<QueryBody>` (the richer request shape — query + hybrid-fusion knobs + recency tuple + path_prefix_boosts map — is JSON-shaped in practice).  Enum-shaped fields (`query_type`, `fusion_method`) surface as lowercase strings on the wire (`"keyword"|"semantic"|"hybrid"`, `"rrf"|"weighted"|"rrf_weighted"`) so callers do not memorise proto numeric ints; unknown values fall through to keyword / RRF per proto UNSPECIFIED semantics.

## Response attribution (query)

`QueryHit` carries every proto `QueryResult` attribution field (title_score, keyword_score, vector_score, tier_boost, recency_boost, expansion_variant_index, expanded_context) with `skip_serializing_if = Option::is_none` — wire stays compact when a boost / arm did not apply.

## Test cover

- `tests/grep_e2e.rs` — 5 scenarios (happy round-trip, missing pattern → 400, upstream InvalidArgument → 400, upstream-down → 503, defaults intact)
- `tests/query_e2e.rs` — 7 scenarios (happy round-trip incl. enum + map + attribution fields, absent-when-None serialisation, defaults intact, unknown query_type falls open, missing `q` → 4xx, upstream InvalidArgument → 400, upstream-down → 503)

Full suite: 23 tests pass (2 unit + 7 glob-e2e + 5 grep-e2e + 7 query-e2e + 2 serve-e2e).  clippy + fmt clean.

## R10 arc status

`handlers::search::router()` now merges 3 routes; zero touch on `lib.rs` / `AppState` / `SearchBackend`.  Extension seam held across all three.

- Landed: ✅ status, ✅ glob, ✅ grep (this PR), ✅ query (this PR)
- Next: auth middleware (tower `.layer()` above the router), then Rust ReBAC, then nexusd-cluster wiring
