### PR TITLE
fix(search-plugin): close DT_STREAM stale-sweep + SSOT gaps (#4692 audit)

### DIFF
--- a/rust/services/search-plugin/src/index_state.rs
+++ b/rust/services/search-plugin/src/index_state.rs
@@ -263,8 +263,20 @@ impl IndexState {
     /// Snapshot of every recorded path.  Callers use this to detect
     /// stale (deleted-from-VFS) entries during the Refresh diff.
     /// Read-lock short-held; the returned `Vec<String>` is a copy.
+    ///
+    /// Unions DT_REG cache keys with DT_STREAM checkpoint keys — a
+    /// deleted stream MUST reach the Refresh stale-sweep so its
+    /// chunks + checkpoint get purged; without this union, a fresh
+    /// DT_STREAM later created at the same path would inherit the
+    /// stale checkpoint and skip re-indexing everything below the
+    /// old offset (silent data loss).
     pub fn known_paths(&self) -> Vec<String> {
-        self.inner.read().keys().cloned().collect()
+        let files = self.inner.read();
+        let streams = self.streams.read();
+        let mut out = Vec::with_capacity(files.len() + streams.len());
+        out.extend(files.keys().cloned());
+        out.extend(streams.keys().cloned());
+        out
     }
 
     /// Look up a path's cached mtime — used in the mtime-changed

--- a/rust/services/search-plugin/src/service.rs
+++ b/rust/services/search-plugin/src/service.rs
@@ -1893,7 +1893,37 @@ enum IndexOne {
 /// working ANN sink finishes the cleanup — unless the zone has no
 /// ANN directory at all, in which case there is nothing to purge and
 /// the real mtime finalizes the skip.
-fn record_content_skip(handle: &KernelHandle, sinks: &IndexSinks<'_>, vfs_path: &str) -> IndexOne {
+/// Which map in `index_state` a skip-recording call should touch.
+///
+/// The two flavours differ ONLY in the checkpoint they leave behind:
+///
+///   * [`EntryKind::File`] records the fresh mtime into the DT_REG
+///     files map (`FileEntry`) so Refresh's verdict reports Unchanged
+///     next pass.
+///   * [`EntryKind::Stream`] records `(indexed_byte_len=0,
+///     next_chunk_index=0, mtime)` into the DT_STREAM checkpoint map
+///     (`StreamState`) — a stream that ended up empty / oversize /
+///     non-utf8 has zero chunks to preserve, so a zero-offset
+///     checkpoint at the fresh mtime is the correct "successfully
+///     converged" state.  Writing a stream path into the FILES map
+///     instead (the pre-fix behaviour) violated the
+///     `IndexState::verdict` invariant that a path lives in exactly
+///     one map — the stale-sweep `known_paths()` (a UNION) then saw
+///     the path twice, and a subsequent `index_one_stream_*` skip
+///     kept extending the stale FILES entry instead of updating the
+///     stream checkpoint.
+#[derive(Copy, Clone)]
+enum EntryKind {
+    File,
+    Stream,
+}
+
+fn record_content_skip(
+    handle: &KernelHandle,
+    sinks: &IndexSinks<'_>,
+    vfs_path: &str,
+    kind: EntryKind,
+) -> IndexOne {
     sinks.fts.delete_all_chunks(vfs_path);
     match sinks.ann {
         Some(ann) => {
@@ -1901,7 +1931,10 @@ fn record_content_skip(handle: &KernelHandle, sinks: &IndexSinks<'_>, vfs_path: 
         }
         None if sinks.zone_has_ann => {
             // Vectors may exist but are unreachable — retry tombstone.
-            sinks.state.record(vfs_path, None);
+            match kind {
+                EntryKind::File => sinks.state.record(vfs_path, None),
+                EntryKind::Stream => sinks.state.stream_advance(vfs_path, 0, 0, None),
+            }
             return IndexOne::SkippedTransient;
         }
         None => {}
@@ -1909,7 +1942,10 @@ fn record_content_skip(handle: &KernelHandle, sinks: &IndexSinks<'_>, vfs_path: 
     let mtime_ms = kernel_io::sys_stat(handle, vfs_path)
         .ok()
         .and_then(|info| info.modified_at_ms);
-    sinks.state.record(vfs_path, mtime_ms);
+    match kind {
+        EntryKind::File => sinks.state.record(vfs_path, mtime_ms),
+        EntryKind::Stream => sinks.state.stream_advance(vfs_path, 0, 0, mtime_ms),
+    }
     IndexOne::Skipped
 }
 
@@ -1926,9 +1962,15 @@ fn index_one(handle: &KernelHandle, sinks: &IndexSinks<'_>, vfs_path: &str) -> I
     // path below (safe: files aren't append-only in the same
     // sense — an edit anywhere in the middle invalidates every
     // downstream chunk).
-    if let Ok(stat) = kernel_io::sys_stat(handle, vfs_path) {
-        if stat.entry_type == kernel_io::DT_STREAM {
-            return index_one_stream_append(handle, sinks, vfs_path, stat.modified_at_ms);
+    // Single sys_stat call: reuses the entry_type-dispatch stat as the
+    // DT_REG mtime source below.  Prior code stat'd twice (once for
+    // entry_type here, once for mtime after `sys_read` succeeded) —
+    // Refresh's `visit_file` already stats each path, so a re-indexed
+    // DT_REG file was paying 3× sys_stat per pass.
+    let stat = kernel_io::sys_stat(handle, vfs_path).ok();
+    if let Some(ref s) = stat {
+        if s.entry_type == kernel_io::DT_STREAM {
+            return index_one_stream_append(handle, sinks, vfs_path, s.modified_at_ms);
         }
     }
 
@@ -1940,7 +1982,7 @@ fn index_one(handle: &KernelHandle, sinks: &IndexSinks<'_>, vfs_path: &str) -> I
         }
     };
     if bytes.is_empty() {
-        return record_content_skip(handle, sinks, vfs_path);
+        return record_content_skip(handle, sinks, vfs_path, EntryKind::File);
     }
     if bytes.len() > INDEX_MAX_FILE_BYTES {
         tracing::debug!(
@@ -1949,7 +1991,7 @@ fn index_one(handle: &KernelHandle, sinks: &IndexSinks<'_>, vfs_path: &str) -> I
             cap = INDEX_MAX_FILE_BYTES,
             "index: file over size cap — skipping",
         );
-        return record_content_skip(handle, sinks, vfs_path);
+        return record_content_skip(handle, sinks, vfs_path, EntryKind::File);
     }
     // Non-UTF8 files are treated as binary and skipped rather than
     // indexed as gibberish.  A future phase may want to add a
@@ -1959,12 +2001,10 @@ fn index_one(handle: &KernelHandle, sinks: &IndexSinks<'_>, vfs_path: &str) -> I
         Ok(s) => s,
         Err(_) => {
             tracing::debug!(path = %vfs_path, "index: non-utf8 payload — skipping");
-            return record_content_skip(handle, sinks, vfs_path);
+            return record_content_skip(handle, sinks, vfs_path, EntryKind::File);
         }
     };
-    let mtime_ms = kernel_io::sys_stat(handle, vfs_path)
-        .ok()
-        .and_then(|info| info.modified_at_ms);
+    let mtime_ms = stat.and_then(|s| s.modified_at_ms);
 
     // P4: chunk the file into semantically-coherent pieces.  The
     // chunker respects markdown-ish heading + code-fence structure
@@ -1973,7 +2013,7 @@ fn index_one(handle: &KernelHandle, sinks: &IndexSinks<'_>, vfs_path: &str) -> I
     if chunks.is_empty() {
         // Whitespace-only file — nothing to index; purge any prior
         // chunks + record per ANN reachability (review R6).
-        return record_content_skip(handle, sinks, vfs_path);
+        return record_content_skip(handle, sinks, vfs_path, EntryKind::File);
     }
     // Feature 3 — contextual chunking.  Prepends an LLM-generated
     // context prefix to every chunk's `embed_input` (leaving `text`
@@ -2138,7 +2178,7 @@ fn index_one_stream_append(
             cap = INDEX_MAX_FILE_BYTES,
             "index-stream: content over size cap — skipping",
         );
-        return record_content_skip(handle, sinks, vfs_path);
+        return record_content_skip(handle, sinks, vfs_path, EntryKind::Stream);
     }
 
     let prior = sinks.state.stream_state(vfs_path);
@@ -2310,18 +2350,18 @@ fn index_one_stream_full(
     bytes: &[u8],
 ) -> IndexOne {
     if bytes.is_empty() {
-        return record_content_skip(handle, sinks, vfs_path);
+        return record_content_skip(handle, sinks, vfs_path, EntryKind::Stream);
     }
     let text = match std::str::from_utf8(bytes) {
         Ok(s) => s,
         Err(_) => {
             tracing::debug!(path = %vfs_path, "index-stream(full): non-utf8 — skipping");
-            return record_content_skip(handle, sinks, vfs_path);
+            return record_content_skip(handle, sinks, vfs_path, EntryKind::Stream);
         }
     };
     let mut chunks = crate::chunker::chunk_document(text);
     if chunks.is_empty() {
-        return record_content_skip(handle, sinks, vfs_path);
+        return record_content_skip(handle, sinks, vfs_path, EntryKind::Stream);
     }
     if let Some(gen) = sinks.context_generator {
         crate::contextual_chunker::apply_contexts(gen, text, &mut chunks, gen.max_chunks_per_doc());

--- a/rust/services/search-plugin/tests/common/mod.rs
+++ b/rust/services/search-plugin/tests/common/mod.rs
@@ -102,6 +102,19 @@ impl MockKernel {
         entry.mtime_ms = new_mtime_ms;
     }
 
+    /// Remove a registered path — used by tests that exercise the
+    /// Refresh stale-sweep against a deleted DT_REG or DT_STREAM.
+    /// Drops the file entry AND the parent-dir listing so a fresh
+    /// walk no longer sees the child.  Idempotent — a no-op on
+    /// unknown paths (mirrors POSIX-style "delete what's there").
+    pub fn remove_path(&mut self, path: &str) {
+        self.files.remove(path);
+        let (parent, name) = split_parent(path);
+        if let Some(entries) = self.dirs.get_mut(&parent) {
+            entries.retain(|(n, _)| n != &name);
+        }
+    }
+
     pub fn add_dir(&mut self, path: &str) {
         if !self.dirs.contains_key(path) {
             self.dirs.insert(path.to_string(), Vec::new());

--- a/rust/services/search-plugin/tests/stream_append_incremental_e2e.rs
+++ b/rust/services/search-plugin/tests/stream_append_incremental_e2e.rs
@@ -125,6 +125,23 @@ fn read_stream_state(zone_root: &std::path::Path, path: &str) -> (u64, u32) {
     )
 }
 
+/// True when the on-disk state's `streams` map has an entry for `path`.
+fn stream_state_present(zone_root: &std::path::Path, path: &str) -> bool {
+    let bytes = std::fs::read(zone_root.join("index_state.json")).expect("state file exists");
+    let v: serde_json::Value = serde_json::from_slice(&bytes).expect("parse state");
+    !v["streams"][path].is_null()
+}
+
+/// True when the on-disk state's `files` map has an entry for `path`.
+/// Used to pin the SSOT invariant: a DT_STREAM path must NEVER
+/// appear in `files` — that was the pre-fix bug where
+/// `record_content_skip` cross-wrote stream paths into the files map.
+fn file_state_present(zone_root: &std::path::Path, path: &str) -> bool {
+    let bytes = std::fs::read(zone_root.join("index_state.json")).expect("state file exists");
+    let v: serde_json::Value = serde_json::from_slice(&bytes).expect("parse state");
+    !v["files"][path].is_null()
+}
+
 // ── Tests ───────────────────────────────────────────────────────
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -344,5 +361,135 @@ async fn stream_retention_trim_resets_checkpoint_and_reindexes() {
     assert!(
         q_new.results.iter().any(|r| r.path == "/logs/wal"),
         "post-trim survivor NEWTOKEN must be re-indexed",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn deleted_stream_hits_stale_sweep_and_purges_checkpoint() {
+    // Regression pin for the pre-fix `known_paths()` gap: it returned
+    // only DT_REG keys, so a deleted DT_STREAM's chunks + checkpoint
+    // lingered in the index forever.  Refresh's stale-sweep only
+    // sees a cached path via `known_paths()` — if streams were
+    // missing from the union, the sweep never fired for them.
+    //
+    // The user-visible failure without this test: query for a token
+    // in a deleted stream still returns the deleted stream's path.
+    let h = Harness::start();
+    let mock = h.mock_mut();
+    mock.add_dir("/");
+    mock.add_dir("/logs");
+    mock.add_stream("/logs/audit", b"turn-1: DELETEDTOKEN\n", 1);
+
+    let _ = index_root(&h.svc).await;
+    assert!(stream_state_present(&h.zone_root, "/logs/audit"));
+
+    // Baseline: token findable before delete.
+    let q = query(&h.svc, "DELETEDTOKEN").await;
+    assert!(q.results.iter().any(|r| r.path == "/logs/audit"));
+
+    // Delete the stream (remove from VFS): the walk no longer sees
+    // it, so the Refresh stale-sweep must drop chunks + checkpoint.
+    h.mock_mut().remove_path("/logs/audit");
+    let r = refresh_root(&h.svc).await;
+    assert!(r.error.is_none(), "refresh error: {:?}", r.error);
+    assert!(
+        r.removed_count >= 1,
+        "stale-sweep must have removed the deleted stream (got removed_count={})",
+        r.removed_count,
+    );
+
+    // Post-sweep: token must NOT be findable, and the checkpoint
+    // must be gone from the on-disk state.
+    let q = query(&h.svc, "DELETEDTOKEN").await;
+    assert!(
+        q.results.iter().all(|r| r.path != "/logs/audit"),
+        "deleted-stream chunks must be purged; got hits: {:?}",
+        q.results,
+    );
+    assert!(
+        !stream_state_present(&h.zone_root, "/logs/audit"),
+        "stream checkpoint must be dropped after stale-sweep",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn new_stream_at_previously_deleted_path_indexes_from_offset_zero() {
+    // Composite pin: if the stale-sweep failed to purge the deleted
+    // stream's checkpoint (the pre-fix bug), a NEW stream later
+    // created at the same path would inherit the stale
+    // `indexed_byte_len` and treat everything below the old offset as
+    // "already indexed" — SILENT data loss.  With the union
+    // `known_paths()` + the `EntryKind::Stream` skip-record fix, the
+    // reborn stream must index from offset 0.
+    let h = Harness::start();
+    let mock = h.mock_mut();
+    mock.add_dir("/");
+    mock.add_dir("/logs");
+    mock.add_stream("/logs/audit", b"OLDSTREAM: content in old lifetime\n", 1);
+    let _ = index_root(&h.svc).await;
+    let (old_bytes, _) = read_stream_state(&h.zone_root, "/logs/audit");
+    assert!(old_bytes > 0);
+
+    // Delete + Refresh (stale-sweep purges the old lifetime).
+    h.mock_mut().remove_path("/logs/audit");
+    let _ = refresh_root(&h.svc).await;
+    assert!(!stream_state_present(&h.zone_root, "/logs/audit"));
+
+    // Reborn at the same path with SHORTER content than the old
+    // lifetime — proves the reborn stream indexed from offset 0 and
+    // did not inherit the stale checkpoint.  A stale `indexed_byte_len`
+    // (old_bytes) larger than the reborn stream's length would trip
+    // the retention-trim branch (which happens to also recover), so
+    // instead we assert the reborn checkpoint EQUALS the reborn blob's
+    // length — impossible if the stale offset had shadowed the write.
+    h.mock_mut()
+        .add_stream("/logs/audit", b"REBORN: new content only\n", 100);
+    let r = refresh_root(&h.svc).await;
+    assert!(r.error.is_none(), "refresh error: {:?}", r.error);
+    let (new_bytes, new_chunks) = read_stream_state(&h.zone_root, "/logs/audit");
+    assert_eq!(
+        new_bytes,
+        b"REBORN: new content only\n".len() as u64,
+        "reborn stream must checkpoint at its own byte-length, NOT the deleted lifetime's",
+    );
+    assert!(new_chunks >= 1, "reborn stream must produce ≥1 chunk");
+
+    // Old token gone, new token indexed.
+    let q_old = query(&h.svc, "OLDSTREAM").await;
+    assert!(
+        q_old.results.iter().all(|r| r.path != "/logs/audit"),
+        "old-lifetime token must not survive reborn",
+    );
+    let q_new = query(&h.svc, "REBORN").await;
+    assert!(
+        q_new.results.iter().any(|r| r.path == "/logs/audit"),
+        "reborn-lifetime token must be indexed",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn empty_stream_records_checkpoint_in_streams_map_not_files_map() {
+    // Regression pin for the SSOT invariant: an empty DT_STREAM's
+    // skip-record (via `record_content_skip`) must land in the
+    // STREAMS map, not the FILES map.  The pre-fix code called the
+    // DT_REG-flavoured `sinks.state.record()` unconditionally, so a
+    // stream that started empty (or ended up empty after chunking)
+    // silently appeared in `files` — violating the "a path lives in
+    // exactly one map" invariant that `IndexState::verdict` relies
+    // on.
+    let h = Harness::start();
+    let mock = h.mock_mut();
+    mock.add_dir("/");
+    mock.add_dir("/logs");
+    // Whitespace-only stream — chunker returns empty; hits the
+    // `record_content_skip` branch inside `index_one_stream_full`
+    // via the initial full-first-pass path.
+    mock.add_stream("/logs/quiet", b"   \n\n  \t\n", 1);
+
+    let _ = index_root(&h.svc).await;
+
+    assert!(
+        !file_state_present(&h.zone_root, "/logs/quiet"),
+        "SSOT violation: DT_STREAM path must NEVER land in the files map",
     );
 }


### PR DESCRIPTION
## Summary

Followup to #4692 audit findings.  Three real issues, one silent-data-loss + two correctness.

**#1 — `known_paths()` union** — Pre-fix `IndexState::known_paths()` returned only DT_REG keys; Refresh stale-sweep iterates it. A deleted DT_STREAM's chunks + `StreamState` lingered forever. Reborn same-path stream read the stale `indexed_byte_len` → **silent data loss** on the new lifetime. Fix: union DT_REG + DT_STREAM keys.

**#2 — `record_content_skip` SSOT** — Pre-fix wrote DT_STREAM path into the FILES map on all four skip cases (empty, over-size, non-utf8, whitespace). Violated the "path lives in at most one map" invariant. Fix: `EntryKind::{File,Stream}` param picks the right map; stream skips land in STREAMS as `(0, 0, mtime)` — the correct zero-chunk checkpoint.

**#3 — Double `sys_stat`** — `index_one` stat'd twice per DT_REG (dispatch + mtime); Refresh path was 3× stat per re-indexed file. Fix: reuse the dispatch stat's `modified_at_ms`.

## Test cover

Three new regression pins in `tests/stream_append_incremental_e2e.rs`:

- `deleted_stream_hits_stale_sweep_and_purges_checkpoint` — direct pin for #1
- `new_stream_at_previously_deleted_path_indexes_from_offset_zero` — composite pin for #1 + #2
- `empty_stream_records_checkpoint_in_streams_map_not_files_map` — direct pin for #2

Also adds `MockKernel::remove_path` — the shared test-kernel double previously had no way to simulate a delete + walk.

## Full suite

247 lib + all integration tests green (batch_query, contextual_chunking, index, index_visibility, macro_expand [both], peer_fanout, query, query_expansion, semantic_query, stream_append_incremental [7 with 3 new], title_arm, dlopen_self, cross_allocator_free). clippy + fmt clean.

Audit context: this was the highest-severity of 9 findings across the recent DT_STREAM / R10 arc; the two others land as separate PRs.
