### PR TITLE
fix(http-api): cover full gRPC status table + fail loud on enum typos (#4694 audit)

### DIFF
--- a/rust/services/http-api/src/handlers/search.rs
+++ b/rust/services/http-api/src/handlers/search.rs
@@ -307,22 +307,49 @@ pub struct QueryResponseBody {
     pub error: Option<String>,
 }
 
-fn parse_query_type(s: &str) -> QueryType {
-    match s {
-        "semantic" => QueryType::Semantic,
-        "hybrid" => QueryType::Hybrid,
-        // "" / "keyword" / anything else → keyword.  Fail-open matches
-        // the proto's `UNSPECIFIED = 0 ⇒ treated as keyword` posture.
-        _ => QueryType::Keyword,
+/// Parse the `query_type` wire string into the proto enum.
+///
+/// Case-insensitive match against the three defined variants;
+/// empty string (field absent) matches the proto's
+/// `UNSPECIFIED = 0 ⇒ treated as keyword` posture and falls to
+/// `Keyword`.  A non-empty NON-matching value returns `Err` — a
+/// silent fall-through to `Keyword` would hide caller typos
+/// (`"semantik"`) as "keyword returned no hits" for weeks.  The
+/// caller maps `Err` to `400 Bad Request` so the client sees the
+/// typo immediately.
+fn parse_query_type(s: &str) -> Result<QueryType, String> {
+    if s.is_empty() {
+        return Ok(QueryType::Keyword);
+    }
+    if s.eq_ignore_ascii_case("keyword") {
+        Ok(QueryType::Keyword)
+    } else if s.eq_ignore_ascii_case("semantic") {
+        Ok(QueryType::Semantic)
+    } else if s.eq_ignore_ascii_case("hybrid") {
+        Ok(QueryType::Hybrid)
+    } else {
+        Err(format!(
+            "unknown query_type {s:?} (expected \"keyword\", \"semantic\", or \"hybrid\")"
+        ))
     }
 }
 
-fn parse_fusion_method(s: &str) -> FusionMethod {
-    match s {
-        "weighted" => FusionMethod::Weighted,
-        "rrf_weighted" => FusionMethod::RrfWeighted,
-        // "" / "rrf" / anything else → RRF.
-        _ => FusionMethod::Rrf,
+/// Parse the `fusion_method` wire string into the proto enum.
+/// Same fail-loud contract as [`parse_query_type`].
+fn parse_fusion_method(s: &str) -> Result<FusionMethod, String> {
+    if s.is_empty() {
+        return Ok(FusionMethod::Rrf);
+    }
+    if s.eq_ignore_ascii_case("rrf") {
+        Ok(FusionMethod::Rrf)
+    } else if s.eq_ignore_ascii_case("weighted") {
+        Ok(FusionMethod::Weighted)
+    } else if s.eq_ignore_ascii_case("rrf_weighted") {
+        Ok(FusionMethod::RrfWeighted)
+    } else {
+        Err(format!(
+            "unknown fusion_method {s:?} (expected \"rrf\", \"weighted\", or \"rrf_weighted\")"
+        ))
     }
 }
 
@@ -353,16 +380,19 @@ pub async fn query(
     State(state): State<AppState>,
     Json(body): Json<QueryBody>,
 ) -> Result<Json<QueryResponseBody>, SearchError> {
+    let query_type = parse_query_type(&body.query_type).map_err(SearchError::BadRequest)?;
+    let fusion_method =
+        parse_fusion_method(&body.fusion_method).map_err(SearchError::BadRequest)?;
     let mut client = state.search.client().await?;
     let req = QueryRequest {
         q: body.q,
         zone_id: body.zone_id,
         limit: body.limit,
         path_filter: body.path_filter,
-        query_type: parse_query_type(&body.query_type) as i32,
+        query_type: query_type as i32,
         auth_token: body.auth_token,
         alpha: body.alpha,
-        fusion_method: parse_fusion_method(&body.fusion_method) as i32,
+        fusion_method: fusion_method as i32,
         rrf_k: body.rrf_k,
         chunks_per_page: body.chunks_per_page,
         expand: body.expand,
@@ -393,22 +423,27 @@ pub fn router() -> Router<AppState> {
 
 /// Shared handler-level error surfaced as an HTTP response.
 ///
-/// Two-state mapping:
+/// Three-state mapping:
 ///   * `BackendUnavailable` → 503 (backend down; retry-friendly).
+///   * `BadRequest(msg)` → 400 (caller-side error caught before RPC —
+///     e.g. an unknown `query_type` string).  Emitting `Ok` and
+///     letting the request through would silently downgrade to the
+///     proto's `UNSPECIFIED = 0 ⇒ keyword` posture, hiding caller
+///     typos (`"semantik"`) as "keyword returned no hits" for weeks.
 ///   * `Rpc(status)` → gRPC `Code` mapped via [`grpc_status_to_http`]
-///     (400 InvalidArgument, 401 Unauthenticated, 403 PermissionDenied,
-///     404 NotFound, 504 DeadlineExceeded, 503 Unavailable, 500
-///     fallback so an unmapped code never silently degrades to 200).
-///     The upstream `tonic::Status::message()` rides through in the
-///     JSON body so operators debugging a hang see the source signal.
+///     — see that fn's docstring for the full table.  The upstream
+///     `tonic::Status::message()` rides through in the JSON body so
+///     operators debugging a hang see the source signal.
 ///
 /// One enum per `search.rs` — every handler in this module maps
 /// its errors through here so the error contract stays uniform
-/// across `glob`, `grep`, and every future route.
+/// across `glob`, `grep`, `query`, and every future route.
 #[derive(Debug, thiserror::Error)]
 pub enum SearchError {
     #[error("backend unavailable: {0}")]
     BackendUnavailable(#[from] BackendError),
+    #[error("bad request: {0}")]
+    BadRequest(String),
     #[error("rpc failed: {0}")]
     Rpc(tonic::Status),
 }
@@ -417,24 +452,57 @@ impl IntoResponse for SearchError {
     fn into_response(self) -> Response {
         let (status, message) = match self {
             SearchError::BackendUnavailable(e) => (StatusCode::SERVICE_UNAVAILABLE, e.to_string()),
+            SearchError::BadRequest(m) => (StatusCode::BAD_REQUEST, m),
             SearchError::Rpc(s) => (grpc_status_to_http(s.code()), s.message().to_string()),
         };
         (status, Json(serde_json::json!({ "error": message }))).into_response()
     }
 }
 
-/// gRPC → HTTP status mapping.  Only the codes handlers in this
-/// module actually surface; fallback is 500 (server-side generic
-/// error) so an unmapped code never silently degrades to 200.
-/// Kept small on purpose — expanding it later is additive.
+/// gRPC → HTTP status mapping.  Covers every `tonic::Code` variant
+/// the proto SSOT (`nexus/search/v1/search.proto`) declares upstream
+/// can emit — plus the ambient retryable / auth codes any RPC can
+/// surface — so no legitimate upstream signal silently degrades to
+/// HTTP 500 (pager-worthy).
+///
+/// Table:
+/// - `InvalidArgument` → 400 Bad Request
+/// - `NotFound` → 404 Not Found
+/// - `AlreadyExists` → 409 Conflict
+/// - `PermissionDenied` → 403 Forbidden
+/// - `ResourceExhausted` → 429 Too Many Requests (retry-after fits)
+/// - `FailedPrecondition` → 412 Precondition Failed
+/// - `Aborted` → 409 Conflict (transactional abort)
+/// - `OutOfRange` → 400 Bad Request
+/// - `Unimplemented` → 501 Not Implemented (proto declares Query returns
+///   this for non-KEYWORD query_type in P1)
+/// - `Unavailable` → 503 Service Unavailable
+/// - `DeadlineExceeded` → 504 Gateway Timeout
+/// - `Unauthenticated` → 401 Unauthorized
+/// - `Ok` / `Cancelled` / `Unknown` / `Internal` / `DataLoss` → 500
+///   Internal Server Error
+///
+/// `Ok` in the fallback is deliberate — surfacing an "Ok" gRPC status
+/// as an HTTP error at all is a caller-side contract violation
+/// (`Ok` should never come through `Result::Err`), so 500 flags the
+/// bug rather than silently returning 200.
 fn grpc_status_to_http(code: tonic::Code) -> StatusCode {
     match code {
         tonic::Code::InvalidArgument => StatusCode::BAD_REQUEST,
         tonic::Code::NotFound => StatusCode::NOT_FOUND,
+        tonic::Code::AlreadyExists => StatusCode::CONFLICT,
         tonic::Code::PermissionDenied => StatusCode::FORBIDDEN,
-        tonic::Code::Unauthenticated => StatusCode::UNAUTHORIZED,
-        tonic::Code::DeadlineExceeded => StatusCode::GATEWAY_TIMEOUT,
+        tonic::Code::ResourceExhausted => StatusCode::TOO_MANY_REQUESTS,
+        tonic::Code::FailedPrecondition => StatusCode::PRECONDITION_FAILED,
+        tonic::Code::Aborted => StatusCode::CONFLICT,
+        tonic::Code::OutOfRange => StatusCode::BAD_REQUEST,
+        tonic::Code::Unimplemented => StatusCode::NOT_IMPLEMENTED,
         tonic::Code::Unavailable => StatusCode::SERVICE_UNAVAILABLE,
+        tonic::Code::DeadlineExceeded => StatusCode::GATEWAY_TIMEOUT,
+        tonic::Code::Unauthenticated => StatusCode::UNAUTHORIZED,
+        // Ok / Cancelled / Unknown / Internal / DataLoss — no HTTP
+        // status distinguishes these usefully to a caller.  500
+        // ensures an unmapped upstream signal never surfaces as 200.
         _ => StatusCode::INTERNAL_SERVER_ERROR,
     }
 }

--- a/rust/services/http-api/tests/query_e2e.rs
+++ b/rust/services/http-api/tests/query_e2e.rs
@@ -52,6 +52,14 @@ enum MockBehaviour {
         error: Option<String>,
     },
     InvalidArgument(String),
+    /// Upstream returns a specific `tonic::Code`.  Lets a test pin
+    /// the full `code → HTTP status` mapping table in
+    /// `handlers/search.rs::grpc_status_to_http` without a
+    /// per-variant enum blow-up here.
+    RpcCode {
+        code: tonic::Code,
+        message: String,
+    },
 }
 
 #[derive(Clone)]
@@ -71,6 +79,7 @@ impl SearchService for MockSearchService {
                 error: error.clone(),
             })),
             MockBehaviour::InvalidArgument(msg) => Err(Status::invalid_argument(msg.clone())),
+            MockBehaviour::RpcCode { code, message } => Err(Status::new(*code, message.clone())),
         }
     }
 
@@ -431,11 +440,13 @@ async fn query_defaults_reach_backend_intact() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn query_unknown_query_type_falls_back_to_keyword() {
-    // A typo like "semantik" must fall through to keyword, matching
-    // the proto's `UNSPECIFIED = 0 ⇒ treated as keyword` posture.
-    // Fail-open rather than fail the request — callers that mistype
-    // still get a useful (if narrower) result set.
+async fn query_unknown_query_type_returns_400_and_never_reaches_backend() {
+    // A typo like "semantik" must be REJECTED at the handler with
+    // 400 + a caller-readable message.  Fail-loud is required — the
+    // pre-fix silent fall-through to Keyword hid typos as "keyword
+    // returned no hits" for weeks.  Empty / absent query_type still
+    // defaults to Keyword (proto UNSPECIFIED posture) — that path
+    // is pinned by `query_defaults_reach_backend_intact`.
     let h = Harness::start(MockBehaviour::Success {
         results: vec![],
         error: None,
@@ -447,12 +458,188 @@ async fn query_unknown_query_type_falls_back_to_keyword() {
         .send()
         .await
         .expect("send");
+    assert_eq!(resp.status(), reqwest::StatusCode::BAD_REQUEST);
+    let body: serde_json::Value = resp.json().await.expect("parse json");
+    assert!(
+        body["error"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("query_type"),
+        "error body must name the offending field so the caller sees the typo; got: {body}",
+    );
+    assert!(
+        h.log.queries.lock().unwrap().is_empty(),
+        "upstream RPC must NOT fire for a caller-side field error",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn query_query_type_parse_is_case_insensitive() {
+    // "SEMANTIC" (proto enum-name casing) must also work — callers
+    // eyeballing the proto and picking a value should not have to
+    // memorise the lowercase-only wire convention.
+    let h = Harness::start(MockBehaviour::Success {
+        results: vec![],
+        error: None,
+    })
+    .await;
+    let resp = reqwest::Client::new()
+        .post(format!("{}/v2/search/query", h.http_base))
+        .json(&serde_json::json!({"q": "x", "query_type": "SEMANTIC"}))
+        .send()
+        .await
+        .expect("send");
     assert_eq!(resp.status(), reqwest::StatusCode::OK);
     let recorded = h.log.queries.lock().unwrap().clone();
     assert_eq!(
         recorded[0].query_type,
-        nexus_http_api::search_proto::QueryType::Keyword as i32,
+        nexus_http_api::search_proto::QueryType::Semantic as i32,
     );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn query_unknown_fusion_method_returns_400_and_never_reaches_backend() {
+    // Same fail-loud contract as query_type — empty defaults to RRF
+    // (proto UNSPECIFIED), a typo returns 400 naming the field.
+    let h = Harness::start(MockBehaviour::Success {
+        results: vec![],
+        error: None,
+    })
+    .await;
+    let resp = reqwest::Client::new()
+        .post(format!("{}/v2/search/query", h.http_base))
+        .json(&serde_json::json!({"q": "x", "fusion_method": "rrrf"}))
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(resp.status(), reqwest::StatusCode::BAD_REQUEST);
+    let body: serde_json::Value = resp.json().await.expect("parse json");
+    assert!(
+        body["error"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("fusion_method"),
+        "error body must name the offending field; got: {body}",
+    );
+    assert!(h.log.queries.lock().unwrap().is_empty());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn query_upstream_unimplemented_maps_to_501() {
+    // The proto SSOT declares Query returns Unimplemented for
+    // query_type=Semantic/Hybrid in P1 (the vector path is not
+    // wired yet).  Pre-fix that surfaced as HTTP 500 — pager-worthy
+    // for a documented P1 signal.  Must map to 501 Not Implemented
+    // so the caller distinguishes "not built yet" from "server
+    // exploded".
+    let h = Harness::start(MockBehaviour::RpcCode {
+        code: tonic::Code::Unimplemented,
+        message: "semantic search not wired in P1".to_string(),
+    })
+    .await;
+    let resp = reqwest::Client::new()
+        .post(format!("{}/v2/search/query", h.http_base))
+        .json(&serde_json::json!({"q": "x", "query_type": "semantic"}))
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(resp.status(), reqwest::StatusCode::NOT_IMPLEMENTED);
+    let body: serde_json::Value = resp.json().await.expect("parse json");
+    assert!(body["error"]
+        .as_str()
+        .unwrap_or_default()
+        .contains("semantic"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn query_upstream_resource_exhausted_maps_to_429() {
+    // Standard mapping: ResourceExhausted → 429 Too Many Requests
+    // so caller-side retry logic ("back off + retry") kicks in
+    // rather than treating the response as a server-broken 500.
+    let h = Harness::start(MockBehaviour::RpcCode {
+        code: tonic::Code::ResourceExhausted,
+        message: "rate limit hit".to_string(),
+    })
+    .await;
+    let resp = reqwest::Client::new()
+        .post(format!("{}/v2/search/query", h.http_base))
+        .json(&serde_json::json!({"q": "x"}))
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(resp.status(), reqwest::StatusCode::TOO_MANY_REQUESTS);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn query_upstream_permission_denied_and_unauthenticated_map_correctly() {
+    // Auth-shape codes surface as their HTTP equivalents:
+    //   * Unauthenticated → 401 (caller needs a valid token)
+    //   * PermissionDenied → 403 (caller has a token but not the grant)
+    for (code, expected) in [
+        (
+            tonic::Code::Unauthenticated,
+            reqwest::StatusCode::UNAUTHORIZED,
+        ),
+        (
+            tonic::Code::PermissionDenied,
+            reqwest::StatusCode::FORBIDDEN,
+        ),
+    ] {
+        let h = Harness::start(MockBehaviour::RpcCode {
+            code,
+            message: format!("{code:?} test"),
+        })
+        .await;
+        let resp = reqwest::Client::new()
+            .post(format!("{}/v2/search/query", h.http_base))
+            .json(&serde_json::json!({"q": "x"}))
+            .send()
+            .await
+            .expect("send");
+        assert_eq!(
+            resp.status(),
+            expected,
+            "code {code:?} must map to {expected}"
+        );
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn query_upstream_not_found_and_deadline_and_failed_precondition_map_correctly() {
+    // The rest of the documented mapping table.  Batched into one
+    // test to keep the file under 700 lines while still pinning
+    // every explicit branch of `grpc_status_to_http`.
+    for (code, expected) in [
+        (tonic::Code::NotFound, reqwest::StatusCode::NOT_FOUND),
+        (tonic::Code::AlreadyExists, reqwest::StatusCode::CONFLICT),
+        (
+            tonic::Code::FailedPrecondition,
+            reqwest::StatusCode::PRECONDITION_FAILED,
+        ),
+        (tonic::Code::Aborted, reqwest::StatusCode::CONFLICT),
+        (tonic::Code::OutOfRange, reqwest::StatusCode::BAD_REQUEST),
+        (
+            tonic::Code::DeadlineExceeded,
+            reqwest::StatusCode::GATEWAY_TIMEOUT,
+        ),
+    ] {
+        let h = Harness::start(MockBehaviour::RpcCode {
+            code,
+            message: format!("{code:?} test"),
+        })
+        .await;
+        let resp = reqwest::Client::new()
+            .post(format!("{}/v2/search/query", h.http_base))
+            .json(&serde_json::json!({"q": "x"}))
+            .send()
+            .await
+            .expect("send");
+        assert_eq!(
+            resp.status(),
+            expected,
+            "code {code:?} must map to {expected}"
+        );
+    }
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]


### PR DESCRIPTION
## Summary

Followup to #4694 audit — 3 real gaps in the shared gRPC-status → HTTP mapper + enum-string parser.

**Gap 1** — `Unimplemented → 500` misroutes a documented P1 signal. Proto SSOT declares Query returns `Unimplemented` for `query_type=Semantic|Hybrid` in P1; pre-fix that surfaced as pager-worthy HTTP 500. Fix: `Unimplemented → 501 Not Implemented`.

**Gap 2** — `ResourceExhausted → 500` breaks retry semantics. Fix: `→ 429 Too Many Requests`. Same PR adds the other standard codes (`AlreadyExists → 409`, `FailedPrecondition → 412`, `Aborted → 409`, `OutOfRange → 400`) so no legitimate upstream signal silently degrades to 500. Full table now in the mapper docstring.

**Gap 3** — Enum-string parser silently swallowed typos. Pre-fix `parse_query_type("semantik")` fell through to `Keyword` — callers who mistyped saw "keyword returned no hits" for weeks. Fix: split empty-vs-typo cases. Empty ⇒ proto UNSPECIFIED posture (Keyword / RRF); non-empty non-matching ⇒ new `SearchError::BadRequest` → HTTP 400 naming the offending field. Also case-insensitive (`"SEMANTIC"` works).

## Test cover (6 new in `tests/query_e2e.rs`)

- `query_unknown_query_type_returns_400_and_never_reaches_backend`
- `query_unknown_fusion_method_returns_400_and_never_reaches_backend`
- `query_query_type_parse_is_case_insensitive`
- `query_upstream_unimplemented_maps_to_501`
- `query_upstream_resource_exhausted_maps_to_429`
- `query_upstream_permission_denied_and_unauthenticated_map_correctly` (401 / 403)
- `query_upstream_not_found_and_deadline_and_failed_precondition_map_correctly` (404 / 409 / 412 / 409 / 400 / 504)

New `MockBehaviour::RpcCode` variant on the mock service lets a test pin any `tonic::Code → HTTP status` mapping without a per-variant enum blow-up.

## Full suite

29 tests pass (2 unit + 7 glob-e2e + 5 grep-e2e + 13 query-e2e + 2 serve-e2e). clippy + fmt clean.
