### PR TITLE
chore(deps): lockstep bump nexus-vfs d3b182951 + cohost sudocode f5b15e97

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "a2a"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=6cad75f7b43e49b60c9a345521695e915a6d7b47#6cad75f7b43e49b60c9a345521695e915a6d7b47"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=d3b182951569d22604e03b0a2b47e950fa96c77e#d3b182951569d22604e03b0a2b47e950fa96c77e"
 dependencies = [
  "contracts",
  "kernel",
@@ -233,8 +233,8 @@ checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "api"
-version = "0.1.26"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=4bc7cba61a278d077bb40938bc9e498b9b261180#4bc7cba61a278d077bb40938bc9e498b9b261180"
+version = "0.1.27"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=f5b15e97208930b57049fc4960a4148bc4ff9303#f5b15e97208930b57049fc4960a4148bc4ff9303"
 dependencies = [
  "base64 0.22.1",
  "httpdate",
@@ -327,7 +327,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 [[package]]
 name = "auth"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=6cad75f7b43e49b60c9a345521695e915a6d7b47#6cad75f7b43e49b60c9a345521695e915a6d7b47"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=d3b182951569d22604e03b0a2b47e950fa96c77e#d3b182951569d22604e03b0a2b47e950fa96c77e"
 dependencies = [
  "contracts",
  "dashmap",
@@ -430,7 +430,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=6cad75f7b43e49b60c9a345521695e915a6d7b47#6cad75f7b43e49b60c9a345521695e915a6d7b47"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=d3b182951569d22604e03b0a2b47e950fa96c77e#d3b182951569d22604e03b0a2b47e950fa96c77e"
 dependencies = [
  "ahash",
  "base64 0.22.1",
@@ -847,8 +847,8 @@ dependencies = [
 
 [[package]]
 name = "commands"
-version = "0.1.26"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=4bc7cba61a278d077bb40938bc9e498b9b261180#4bc7cba61a278d077bb40938bc9e498b9b261180"
+version = "0.1.27"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=f5b15e97208930b57049fc4960a4148bc4ff9303#f5b15e97208930b57049fc4960a4148bc4ff9303"
 dependencies = [
  "plugins",
  "runtime",
@@ -917,7 +917,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=6cad75f7b43e49b60c9a345521695e915a6d7b47#6cad75f7b43e49b60c9a345521695e915a6d7b47"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=d3b182951569d22604e03b0a2b47e950fa96c77e#d3b182951569d22604e03b0a2b47e950fa96c77e"
 dependencies = [
  "parking_lot",
  "serde",
@@ -2540,7 +2540,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=6cad75f7b43e49b60c9a345521695e915a6d7b47#6cad75f7b43e49b60c9a345521695e915a6d7b47"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=d3b182951569d22604e03b0a2b47e950fa96c77e#d3b182951569d22604e03b0a2b47e950fa96c77e"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -2608,7 +2608,7 @@ checksum = "0c2cdeb66e45e9f36bfad5bbdb4d2384e70936afbee843c6f6543f0c551ebb25"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=6cad75f7b43e49b60c9a345521695e915a6d7b47#6cad75f7b43e49b60c9a345521695e915a6d7b47"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=d3b182951569d22604e03b0a2b47e950fa96c77e#d3b182951569d22604e03b0a2b47e950fa96c77e"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -2990,7 +2990,7 @@ dependencies = [
 [[package]]
 name = "nexus-cluster"
 version = "0.1.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=6cad75f7b43e49b60c9a345521695e915a6d7b47#6cad75f7b43e49b60c9a345521695e915a6d7b47"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=d3b182951569d22604e03b0a2b47e950fa96c77e#d3b182951569d22604e03b0a2b47e950fa96c77e"
 dependencies = [
  "a2a",
  "anyhow",
@@ -3064,7 +3064,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=6cad75f7b43e49b60c9a345521695e915a6d7b47#6cad75f7b43e49b60c9a345521695e915a6d7b47"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=d3b182951569d22604e03b0a2b47e950fa96c77e#d3b182951569d22604e03b0a2b47e950fa96c77e"
 
 [[package]]
 name = "nexus-search-plugin"
@@ -3121,8 +3121,8 @@ dependencies = [
 
 [[package]]
 name = "nexus-vfs-client"
-version = "0.1.26"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=4bc7cba61a278d077bb40938bc9e498b9b261180#4bc7cba61a278d077bb40938bc9e498b9b261180"
+version = "0.1.27"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=f5b15e97208930b57049fc4960a4148bc4ff9303#f5b15e97208930b57049fc4960a4148bc4ff9303"
 dependencies = [
  "prost 0.13.5",
  "protoc-bin-vendored",
@@ -3578,8 +3578,8 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plugins"
-version = "0.1.26"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=4bc7cba61a278d077bb40938bc9e498b9b261180#4bc7cba61a278d077bb40938bc9e498b9b261180"
+version = "0.1.27"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=f5b15e97208930b57049fc4960a4148bc4ff9303#f5b15e97208930b57049fc4960a4148bc4ff9303"
 dependencies = [
  "serde",
  "serde_json",
@@ -3704,7 +3704,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "once_cell",
@@ -3724,7 +3724,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "petgraph 0.8.3",
@@ -3745,7 +3745,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -3758,7 +3758,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -3993,7 +3993,7 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 [[package]]
 name = "raft"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=6cad75f7b43e49b60c9a345521695e915a6d7b47#6cad75f7b43e49b60c9a345521695e915a6d7b47"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=d3b182951569d22604e03b0a2b47e950fa96c77e#d3b182951569d22604e03b0a2b47e950fa96c77e"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -4422,8 +4422,8 @@ dependencies = [
 
 [[package]]
 name = "runtime"
-version = "0.1.26"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=4bc7cba61a278d077bb40938bc9e498b9b261180#4bc7cba61a278d077bb40938bc9e498b9b261180"
+version = "0.1.27"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=f5b15e97208930b57049fc4960a4148bc4ff9303#f5b15e97208930b57049fc4960a4148bc4ff9303"
 dependencies = [
  "a2a",
  "agent-client-protocol",
@@ -5329,8 +5329,8 @@ dependencies = [
 
 [[package]]
 name = "telemetry"
-version = "0.1.26"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=4bc7cba61a278d077bb40938bc9e498b9b261180#4bc7cba61a278d077bb40938bc9e498b9b261180"
+version = "0.1.27"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=f5b15e97208930b57049fc4960a4148bc4ff9303#f5b15e97208930b57049fc4960a4148bc4ff9303"
 dependencies = [
  "chrono",
  "dirs",
@@ -5720,8 +5720,8 @@ dependencies = [
 
 [[package]]
 name = "tools"
-version = "0.1.26"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=4bc7cba61a278d077bb40938bc9e498b9b261180#4bc7cba61a278d077bb40938bc9e498b9b261180"
+version = "0.1.27"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=f5b15e97208930b57049fc4960a4148bc4ff9303#f5b15e97208930b57049fc4960a4148bc4ff9303"
 dependencies = [
  "api",
  "async-trait",
@@ -5864,7 +5864,7 @@ dependencies = [
 [[package]]
 name = "transport"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=6cad75f7b43e49b60c9a345521695e915a6d7b47#6cad75f7b43e49b60c9a345521695e915a6d7b47"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=d3b182951569d22604e03b0a2b47e950fa96c77e#d3b182951569d22604e03b0a2b47e950fa96c77e"
 dependencies = [
  "axum",
  "backends",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -229,24 +229,24 @@ exclude = ["nexus-fuse"]
 #
 # Bump alongside the rest of nexus-vfs updates when a downstream
 # change needs newer kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "6cad75f7b43e49b60c9a345521695e915a6d7b47" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "6cad75f7b43e49b60c9a345521695e915a6d7b47" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "6cad75f7b43e49b60c9a345521695e915a6d7b47" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "6cad75f7b43e49b60c9a345521695e915a6d7b47", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "6cad75f7b43e49b60c9a345521695e915a6d7b47", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "6cad75f7b43e49b60c9a345521695e915a6d7b47", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "6cad75f7b43e49b60c9a345521695e915a6d7b47" }
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "d3b182951569d22604e03b0a2b47e950fa96c77e" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "d3b182951569d22604e03b0a2b47e950fa96c77e" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "d3b182951569d22604e03b0a2b47e950fa96c77e" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "d3b182951569d22604e03b0a2b47e950fa96c77e", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "d3b182951569d22604e03b0a2b47e950fa96c77e", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "d3b182951569d22604e03b0a2b47e950fa96c77e", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "d3b182951569d22604e03b0a2b47e950fa96c77e" }
 # The cluster daemon library entry (`nexus_cluster::run_with_services`),
 # consumed by the nexus-side assembly binary (`rust/nexusd`) that composes
 # the kernel/federation boot with the nexus service set via the
 # ServiceRegistry bring-up seam.
-nexus-cluster = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "6cad75f7b43e49b60c9a345521695e915a6d7b47" }
+nexus-cluster = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "d3b182951569d22604e03b0a2b47e950fa96c77e" }
 # a2a messaging substrate. `default-features = false` leaves the
 # `install` feature (which pulls raft to arm the stream-wakeup observer)
 # OFF, so nexus-side consumers link only the stamp hook and stay
 # raft-free — they reach raft through kernel.sys_* (§6.1). The substrate
 # is armed in production at cluster boot in nexus-vfs, not here.
-a2a = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "6cad75f7b43e49b60c9a345521695e915a6d7b47", default-features = false }
+a2a = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "d3b182951569d22604e03b0a2b47e950fa96c77e", default-features = false }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/rust/nexusd/Cargo.toml
+++ b/rust/nexusd/Cargo.toml
@@ -56,8 +56,8 @@ anyhow = "1"
 # the api + runtime crates); `sudocode-runtime` names the `AgentLoopState`
 # / `SpawnHandle` types the adapter maps. Pinned to the sudocode main merge
 # commit of #392 (co-host readiness).
-sudocode-runtime = { package = "runtime", git = "https://github.com/sudoprivacy/sudocode", rev = "4bc7cba61a278d077bb40938bc9e498b9b261180", optional = true }
-sudocode-tools = { package = "tools", git = "https://github.com/sudoprivacy/sudocode", rev = "4bc7cba61a278d077bb40938bc9e498b9b261180", optional = true }
+sudocode-runtime = { package = "runtime", git = "https://github.com/sudoprivacy/sudocode", rev = "f5b15e97208930b57049fc4960a4148bc4ff9303", optional = true }
+sudocode-tools = { package = "tools", git = "https://github.com/sudoprivacy/sudocode", rev = "f5b15e97208930b57049fc4960a4148bc4ff9303", optional = true }
 # Named directly to spell `kernel::kernel::{ServiceDecl, Kernel}` — the
 # managed-agent boot decl's return type (both builds) and the co-host
 # adapter's `SpawnTask<Kernel>` (cohost build). Already present transitively


### PR DESCRIPTION
## What

Lockstep bump of the two pins that must move together for the in-process
co-host seam:

- **workspace nexus-vfs pin** `6cad75f7b` → `d3b182951` (current nexus-vfs `main`)
- **nexusd co-host `sudocode` pin** `4bc7cba6` → `f5b15e97` (sudocode #482, which
  pins the SAME nexus-vfs rev `d3b182951`)

## Why

`d3b182951` restores two federation clean-slate features to develop that were
dropped when the pin last moved to a nexus-vfs `main` tip that lacked them
(they had only ever lived on a side branch):

- `reset` subcommand — one command for a truly-fresh node (clears data-dir AND
  identity.json), the fix for the phantom-voter / auto-rejoin-stale deadlock.
- raft fail-loud when an unreachable voter blocks quorum (diagnostic; names the
  dead voter + the fix).

Both are directly relevant to the cross-org / Win↔Mac co-host duet. It also
pulls #238 (`sys_stat` DT_STREAM last-append time).

The co-host `SpawnTask<Kernel>` seam links nexusd's own `kernel` (workspace pin)
and sudocode's `kernel` (git dep) — they MUST resolve to one rev or the type
won't unify. sudocode #482 bumped its co-host `kernel`/`a2a` pin to the same
`d3b182951`, so this bump keeps the seam single-typed.

## Test

- Lockfile regenerated; no residual old revs (`6cad75f7b` / `4bc7cba6` = 0).
- Default-feature build validated by CI here.
- The `--features cohost-sudocode` seam is validated by a Linux release build of
  the deploy binary (the on-VM cohost broker for the cross-org duet).
