### PR TITLE
feat(nexusd): boot-time A2A co-host auto-spawn (NEXUS_COHOST_AGENT) — duet bring-up

### DIFF
--- a/rust/nexusd/src/cohost.rs
+++ b/rust/nexusd/src/cohost.rs
@@ -22,7 +22,7 @@
 
 use std::sync::Arc;
 
-use kernel::core::agents::registry::AgentDescriptor;
+use kernel::core::agents::registry::{AgentDescriptor, AgentKind};
 use kernel::kernel::Kernel;
 use managed_agent::{
     AgentLoopState as ServiceLoopState, SpawnHandle as ServiceSpawnHandle, SpawnTask,
@@ -90,5 +90,78 @@ struct SudoCodeSpawnHandle {
 impl ServiceSpawnHandle for SudoCodeSpawnHandle {
     fn abort(&self) {
         self.inner.abort_signal.abort();
+    }
+}
+
+// ── A2A co-host boot spawn ──────────────────────────────────────────────
+//
+// The production path for the Win↔macOS duet: co-host a sudocode agent bound
+// to its REPLICATED A2A inbox `/agents/<name>/chat-with-me` (not the
+// node-local `/proc` stream), so two co-hosted agents on different nodes
+// converse over A2A with no bridge/relay. Config-driven at boot via env:
+//
+//   NEXUS_COHOST_AGENT=win-ai            # the A2A agent to co-host here
+//   NEXUS_COHOST_MODEL=claude-haiku-4-5  # optional (defaults to haiku)
+//
+// The agent MUST already be minted (its replicated `/agents/<name>/`
+// mailbox present) before this fires — mint once, then boot. Distinct from
+// `SudoCodeSpawnAdapter` above (the node-local sudowork/hydra `start_session`
+// gRPC path on `/proc/{pid}`): this is the boot-time cross-machine path.
+
+/// Install a boot-time A2A co-host loop from env config. No-op when
+/// `NEXUS_COHOST_AGENT` is unset (e.g. a founder that only relays). Wired as
+/// a `ServiceDecl` so it gets the booted `Arc<Kernel>`.
+pub fn install_a2a_cohost(kernel: &Arc<Kernel>) -> Result<(), String> {
+    let Ok(agent) = std::env::var("NEXUS_COHOST_AGENT") else {
+        return Ok(());
+    };
+    let agent = agent.trim().to_string();
+    if agent.is_empty() {
+        return Ok(());
+    }
+    let model = std::env::var("NEXUS_COHOST_MODEL")
+        .ok()
+        .filter(|m| !m.trim().is_empty())
+        .unwrap_or_else(|| "claude-haiku-4-5".to_string());
+
+    let mut desc = AgentDescriptor {
+        pid: format!("cohost-{agent}"),
+        name: agent.clone(),
+        kind: AgentKind::Managed,
+        owner_id: "root".to_string(),
+        zone_id: "root".to_string(),
+        ..Default::default()
+    };
+    desc.labels.insert("model".to_string(), model.clone());
+
+    // Read its OWN replicated inbox; reply to each SENDER's inbox — raft
+    // replication carries the reply to the peer's node.
+    let mailbox = Mailbox::A2aInbox {
+        base: "/agents".to_string(),
+        self_name: agent.clone(),
+    };
+    eprintln!(
+        "[cohost] co-hosting A2A agent {agent} (model {model}) on /agents/{agent}/chat-with-me"
+    );
+
+    let agent_for_cb = agent.clone();
+    let _handle = sudocode_tools::managed_agent::spawn_managed_agent(
+        Arc::clone(kernel),
+        desc,
+        mailbox,
+        move |state| eprintln!("[cohost] agent {agent_for_cb} loop state: {state:?}"),
+    );
+    // `_handle` is intentionally dropped: dropping detaches the worker
+    // thread (its `JoinHandle`) and does NOT signal abort, so the co-host
+    // loop runs for the daemon's lifetime.
+    Ok(())
+}
+
+/// `ServiceDecl` for the boot-time A2A co-host spawn (no-op unless
+/// `NEXUS_COHOST_AGENT` is set).
+pub fn service_decl() -> kernel::kernel::ServiceDecl {
+    kernel::kernel::ServiceDecl {
+        name: "cohost_a2a".to_string(),
+        install: Box::new(install_a2a_cohost),
     }
 }

--- a/rust/nexusd/src/main.rs
+++ b/rust/nexusd/src/main.rs
@@ -47,13 +47,31 @@ fn managed_agent_decl() -> kernel::kernel::ServiceDecl {
     }
 }
 
+/// Extra boot decls only a cohost build adds: the boot-time A2A co-host loop
+/// (`NEXUS_COHOST_AGENT`), installed AFTER a2a + managed_agent so the
+/// replicated `/agents/<name>` mailbox it binds to is already armed. No-op at
+/// runtime unless `NEXUS_COHOST_AGENT` is set (a plain relay founder gets none).
+#[cfg(not(feature = "cohost-sudocode"))]
+fn cohost_a2a_decls() -> Vec<kernel::kernel::ServiceDecl> {
+    Vec::new()
+}
+
+#[cfg(feature = "cohost-sudocode")]
+fn cohost_a2a_decls() -> Vec<kernel::kernel::ServiceDecl> {
+    vec![cohost::service_decl()]
+}
+
 fn main() -> anyhow::Result<()> {
     // The daemon's service set — the SSOT for "which services this daemon
     // runs", ordered. a2a is installed first (its from-stamp hook must be
-    // armed before agents write mailboxes); managed_agent follows.
+    // armed before agents write mailboxes); managed_agent follows; the
+    // boot-time A2A co-host loop (cohost build only) comes last so the
+    // `/agents/<name>` inbox it binds to is already armed.
     // `ctx.auth_armed` is boot-derived (true iff sk- auth is armed) and
     // sets a2a's fail-closed posture.
     nexus_cluster::run_with_services(|ctx| {
-        vec![a2a::service_decl(ctx.auth_armed), managed_agent_decl()]
+        let mut decls = vec![a2a::service_decl(ctx.auth_armed), managed_agent_decl()];
+        decls.extend(cohost_a2a_decls());
+        decls
     })
 }


### PR DESCRIPTION
## What
Re-implements the boot-time A2A co-host loop cleanly on the post-migration substrate. `cohost::install_a2a_cohost` reads `NEXUS_COHOST_AGENT` (+ optional `NEXUS_COHOST_MODEL`, default haiku) and boot-spawns a co-hosted sudocode agent bound to its **replicated** A2A inbox `/agents/<name>/chat-with-me`, so two co-hosted agents on different hosts (Win + macOS) converse over A2A with no bridge/relay. No-op when the env is unset. Wired as a boot `ServiceDecl` after a2a + managed_agent (cohost-sudocode build only) so the inbox is already armed.

Distinct from `SudoCodeSpawnAdapter` (the node-local `/proc/{pid}` sudowork/hydra `start_session` gRPC path) — this is the boot-time cross-machine duet path.

## Why re-implement
The wiring existed on `feat/cohost-a2a-mailbox`, but that branch was 127 commits behind develop and pinned the **pre-ping-pong-fix** sudocode rev (`bf0ba2e4` — merging it would revert the managed_agent→nexus-vfs migration and reintroduce the ping-pong loop). Closed (#4652) + deleted; re-done cleanly here on the unified-kernel-rev substrate.

## The duet path this unblocks
Mint `win-ai` / `mac-ai` once (replicated `/agents/<name>/`), boot each host's `cohost-sudocode` `nexusd-cluster` with `NEXUS_COHOST_AGENT=<name>` → each auto-spawns its co-host agent → the two converse over A2A (raft carries replies cross-machine).

## Verification
`cargo check -p nexusd` (default) + `--features cohost-sudocode` + `cargo clippy --features cohost-sudocode -- -D warnings` all green. (No PR CI builds cohost-sudocode; the default path is what CI gates.)