### PR TITLE
feat(http-api): bearer-token auth middleware over /v2/search/* (R10)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3050,6 +3050,7 @@ name = "nexus-http-api"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "contracts",
  "dashmap",
  "http-body-util",
  "prost 0.14.4",
@@ -3065,6 +3066,7 @@ dependencies = [
  "tonic-prost-build",
  "tower",
  "tracing",
+ "transport",
 ]
 
 [[package]]

--- a/rust/services/http-api/Cargo.toml
+++ b/rust/services/http-api/Cargo.toml
@@ -34,6 +34,20 @@ tonic-prost = { workspace = true }
 # sibling search-plugin peer-fanout uses (search-plugin/Cargo.toml).
 dashmap = "6.1"
 
+# Bearer-token → `OperationContext` SSOT.
+#
+# The `AuthProvider` trait + `AuthCredentials` + kernel-default
+# `NoAuth` live in the nexus-vfs `transport` crate (same rev as
+# `contracts`).  Reusing them means the http-api middleware, the
+# kernel gRPC interceptor (`transport::grpc::VfsServiceImpl::authenticate`),
+# and any future service on the auth plane all resolve credentials
+# through ONE trait — not each inventing its own.  The resolved
+# `OperationContext` is the SSOT struct every `kernel::sys_*`
+# already consumes, so injecting it into request extensions is
+# byte-compatible with future direct-syscall handler paths.
+contracts = { workspace = true }
+transport = { workspace = true }
+
 # Parked-error surfacing at the handler boundary (Ok/Err in the
 # lib, mapped to HTTP status in the axum extractor).  Same 1.0 pin
 # the sibling search-plugin uses.

--- a/rust/services/http-api/src/handlers/status.rs
+++ b/rust/services/http-api/src/handlers/status.rs
@@ -41,10 +41,11 @@ mod tests {
     use crate::search_backend::SearchBackend;
 
     fn test_state() -> AppState {
-        // Status handler does not touch the backend; a dummy
-        // target that never gets dialed is fine.
+        // Status handler does not touch the backend or auth; a dummy
+        // target that never gets dialed + NoAuth are fine.
         AppState {
             search: SearchBackend::new("http://127.0.0.1:1"),
+            auth: crate::middleware::auth::default_no_auth_provider(),
         }
     }
 

--- a/rust/services/http-api/src/lib.rs
+++ b/rust/services/http-api/src/lib.rs
@@ -17,11 +17,26 @@
 //! adding a new field to [`AppState`] — a fresh domain does not
 //! rewire existing handlers.
 //!
+//! # Auth
+//!
+//! `/v2/status` is PUBLIC (health-probe target that runs before any
+//! bearer exists); every `/v2/search/*` route is protected by
+//! [`middleware::auth::require_bearer`], which resolves the incoming
+//! `Authorization: Bearer <token>` through the shared
+//! [`transport::auth::AuthProvider`] on [`AppState`] and stamps the
+//! resulting `contracts::OperationContext` into request extensions.
+//! Handlers that need per-request identity extract it via
+//! `axum::Extension<OperationContext>`; handlers that do not simply
+//! ignore it.  Default provider is `NoAuth` (single-node dev pass-
+//! through); real deployments swap it for `auth::ApiKeyAuthProvider`
+//! at the composition root.
+//!
 //! # Deliberately absent
 //!
-//! * NO auth middleware — session cookie handling is a separate epic
-//!   step (part of the same #4674 arc).
-//! * NO ReBAC post-filter — same story.
+//! * NO ReBAC post-filter — separate epic step (`bricks/permissions/
+//!   rebac.py` → Rust); the middleware here is authN only.
+//! * NO mTLS peer plane — waits on this crate's HTTP listener
+//!   growing a rustls stack (see the middleware module docs).
 //! * NO wiring into `nexusd-cluster` boot — the assembly binary in
 //!   `rust/nexusd` picks the crate up once the router surface
 //!   justifies the wiring step.  Standalone-testable today via
@@ -29,11 +44,15 @@
 
 use std::io;
 use std::net::SocketAddr;
+use std::sync::Arc;
 
+use axum::middleware::from_fn_with_state;
 use axum::Router;
 use tokio::net::TcpListener;
+use transport::auth::AuthProvider;
 
 pub mod handlers;
+pub mod middleware;
 pub mod search_backend;
 
 /// Client stubs for the workspace's `nexus.search.v1` proto SSOT
@@ -52,20 +71,54 @@ pub use search_backend::{BackendError, SearchBackend};
 /// Shared state handed to every axum handler through
 /// `axum::extract::State`.  Cheap to clone (`Arc` fields inside
 /// each backend); one instance per process.
+///
+/// # `auth`
+///
+/// The `AuthProvider` used by [`middleware::auth::require_bearer`]
+/// to resolve incoming bearer tokens.  Trait-object so a single
+/// binary can pick `NoAuth` for dev, `ApiKeyAuthProvider` for
+/// production, or a test double.  See
+/// [`middleware::auth::default_no_auth_provider`] for the
+/// single-node default.
 #[derive(Clone)]
 pub struct AppState {
     pub search: SearchBackend,
+    pub auth: Arc<dyn AuthProvider>,
 }
 
 /// Root [`Router`] carrying every configured route domain.  Callers
 /// supply the [`AppState`] (which owns the upstream client caches)
 /// so the same crate can be exercised in tests against a mock
 /// backend and in production against the real search-plugin.
+///
+/// # Layering
+///
+/// The router splits into two sub-routers by auth posture:
+///
+/// * `public_router` — routes callable BEFORE a bearer exists
+///   (liveness probes, unauth-metadata endpoints).  Currently just
+///   `/v2/status`.
+/// * `protected_router` — routes wrapped by
+///   [`middleware::auth::require_bearer`].  Every `/v2/search/*`
+///   handler lives here.
+///
+/// Both sub-routers share the same [`AppState`]; only the middleware
+/// stack differs.  A new domain lands as an additive merge on
+/// whichever sub-router matches its auth posture — handlers stay
+/// unaware of the split beyond optionally extracting
+/// `Extension<OperationContext>`.
 pub fn router(state: AppState) -> Router {
-    Router::new()
+    let public_router = Router::new()
         .merge(handlers::status::router())
+        .with_state(state.clone());
+    let protected_router = Router::new()
         .merge(handlers::search::router())
-        .with_state(state)
+        .layer(from_fn_with_state(
+            state.clone(),
+            middleware::auth::require_bearer,
+        ))
+        .with_state(state);
+    Router::new().merge(public_router).merge(protected_router)
 }
 
 /// Bind `addr` and serve [`router(state)`](router) until the returned

--- a/rust/services/http-api/src/middleware/auth.rs
+++ b/rust/services/http-api/src/middleware/auth.rs
@@ -1,0 +1,493 @@
+//! Bearer-token auth middleware for the `/v2/*` protected routes.
+//!
+//! # What this does
+//!
+//! Reads `Authorization: Bearer <token>` off the incoming request,
+//! resolves it through the shared [`AuthProvider`] on [`AppState`],
+//! and — on success — stamps the resulting [`OperationContext`] into
+//! request extensions.  Downstream handlers pull the context via
+//! `axum::Extension<OperationContext>`; a caller that does not need
+//! per-request identity simply does not extract it.  A missing /
+//! malformed / rejected token short-circuits with the appropriate
+//! HTTP status; the underlying handler never runs.
+//!
+//! # Why this crate reuses the transport trait
+//!
+//! [`transport::auth::AuthProvider`] is the SSOT trait every
+//! authenticated `nexus.*.v1` gRPC surface already consumes via
+//! `transport::grpc::VfsServiceImpl::authenticate`, and its resolved
+//! [`OperationContext`] is the SSOT struct every `kernel::sys_*` in
+//! turn consumes.  A local trait would be a needless divergence — the
+//! bearer plane the middleware validates is exactly the plane the
+//! kernel + gRPC surface already accept.
+//!
+//! # First-cut scope (per epic #4674 R10 "auth middleware" step)
+//!
+//! * `Authorization: Bearer <token>` header extraction only —
+//!   plaintext axum stack ships no rustls today, so mTLS peer plane
+//!   is out of scope until the HTTP surface gains a TLS listener.
+//! * `NoAuth` default keeps single-node dev unblocked (matches the
+//!   `nexusd` kernel default).
+//! * `/v2/status` stays PUBLIC (health endpoint used by liveness
+//!   probes before any token exists); every `/v2/search/*` route is
+//!   protected.
+//!
+//! # Explicit non-goals (documented so a follow-up PR knows the
+//! # cutline and does not re-tread ground):
+//!
+//! * mTLS peer plane — pending the HTTP surface's rustls wiring
+//!   (needs a `TlsConnectInfo` shape equivalent to the gRPC path's
+//!   `transport::peer_identity::from_request`).
+//! * Cookie-session handling — Python `nexus-server` does NOT use
+//!   session cookies (the only cookie is an OAuth-CSRF binding, not
+//!   an identity carrier); nothing to port.
+//! * ReBAC post-filter — separate epic step (`src/nexus/bricks/
+//!   permissions/rebac.py` → Rust); this middleware does authN only,
+//!   never authZ.
+//! * Cache invalidation observer — `ApiKeyAuthProvider` HMAC-caches
+//!   at the transport layer already; when a real provider is wired
+//!   into `AppState` its invalidation stream rides on the same raft
+//!   observer path the gRPC interceptor uses.
+
+use std::sync::Arc;
+
+use axum::extract::{Request, State};
+use axum::http::{header, StatusCode};
+use axum::middleware::Next;
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use transport::auth::{AuthCredentials, AuthProvider};
+
+use crate::AppState;
+
+/// Extract the bearer token from an `Authorization` header.
+///
+/// # Return shape
+///
+/// * `Ok(Some(tok))` — well-formed `Authorization: Bearer <token>`
+///   with a non-empty token after trim.
+/// * `Ok(None)` — the header is ABSENT.  Callers pass this to the
+///   provider as an empty token; matches
+///   `transport::grpc::VfsServiceImpl::authenticate`, which always
+///   calls `resolve` with `AuthCredentials::from_token(inner.auth_token())`
+///   (an empty string when the caller supplied no token).  The
+///   provider decides — `NoAuth` accepts, `ApiKeyAuthProvider`
+///   rejects with `Unauthenticated`.
+/// * `Err(AuthRejection::MalformedHeader)` — the header is PRESENT
+///   but not a well-formed `Bearer <non-empty-token>` (wrong
+///   scheme, non-ASCII bytes, empty after `Bearer`).  A caller
+///   that ships an `Authorization` header CLEARLY intended to
+///   authenticate; a silent fall-through to empty-token would
+///   read a `Basic dXNlcjpwYXNz` header as "no credentials" and
+///   admit the request under `NoAuth`.  Reject immediately.
+///
+/// Case-insensitive scheme match — RFC 7235 §2.1 says the scheme
+/// is case-insensitive, so `bearer` / `BEARER` are equally valid.
+pub fn parse_bearer(headers: &axum::http::HeaderMap) -> Result<Option<&str>, AuthRejection> {
+    let Some(raw_value) = headers.get(header::AUTHORIZATION) else {
+        return Ok(None);
+    };
+    let raw = raw_value
+        .to_str()
+        .map_err(|_| AuthRejection::MalformedHeader)?;
+    let scheme_end = raw.find(' ').ok_or(AuthRejection::MalformedHeader)?;
+    let (scheme, rest) = raw.split_at(scheme_end);
+    if !scheme.eq_ignore_ascii_case("Bearer") {
+        return Err(AuthRejection::MalformedHeader);
+    }
+    let token = rest.trim_start();
+    if token.is_empty() {
+        return Err(AuthRejection::MalformedHeader);
+    }
+    Ok(Some(token))
+}
+
+/// Middleware entry point wired via `axum::middleware::from_fn_with_state`
+/// under [`crate::router`].  Runs BEFORE the handler; a rejected
+/// request never reaches upstream tonic (saves the RPC round-trip
+/// and denies a token-guessing attacker any per-attempt latency
+/// signal from the upstream).
+///
+/// Status mapping matches the shared search-error contract:
+///   * malformed `Authorization` header → 401 Unauthorized
+///   * `tonic::Code::Unauthenticated` → 401 Unauthorized
+///   * `tonic::Code::PermissionDenied` → 403 Forbidden
+///   * `tonic::Code::Unavailable` → 503 Service Unavailable
+///   * `tonic::Code::DeadlineExceeded` → 504 Gateway Timeout
+///   * anything else (`Internal`, `Unknown`, etc.) → 500
+///
+/// Absent-header behaviour is provider-driven (see [`parse_bearer`]).
+pub async fn require_bearer(
+    State(state): State<AppState>,
+    mut req: Request,
+    next: Next,
+) -> Result<Response, AuthRejection> {
+    let token = parse_bearer(req.headers())?.unwrap_or("");
+    let ctx = state
+        .auth
+        .resolve(&AuthCredentials::from_token(token))
+        .map_err(AuthRejection::Rpc)?;
+    req.extensions_mut().insert(ctx);
+    Ok(next.run(req).await)
+}
+
+/// Rejections the middleware surfaces before a protected handler
+/// runs.  Local to this module — the shape is "auth failed", not
+/// "search / query returned an error".
+#[derive(Debug, thiserror::Error)]
+pub enum AuthRejection {
+    /// `Authorization` header is present but not a well-formed
+    /// `Bearer <non-empty-token>`.  ABSENT headers do NOT map here —
+    /// they pass through to the provider as an empty token (matches
+    /// gRPC's `authenticate` posture).
+    #[error("malformed Authorization header; expected `Bearer <token>`")]
+    MalformedHeader,
+    #[error("bearer resolution failed: {0}")]
+    Rpc(tonic::Status),
+}
+
+impl IntoResponse for AuthRejection {
+    fn into_response(self) -> Response {
+        let (status, message) = match self {
+            AuthRejection::MalformedHeader => (
+                StatusCode::UNAUTHORIZED,
+                "malformed Authorization header; expected `Bearer <token>`".to_string(),
+            ),
+            AuthRejection::Rpc(s) => (status_for_auth_code(s.code()), s.message().to_string()),
+        };
+        (status, Json(serde_json::json!({ "error": message }))).into_response()
+    }
+}
+
+/// gRPC → HTTP mapping for auth resolution.  A tighter table than
+/// the general search mapper: an `AuthProvider` cannot legitimately
+/// emit `NotFound` / `AlreadyExists` / `ResourceExhausted` — its
+/// entire contract is "resolve credentials or reject" — so we surface
+/// only the codes it can meaningfully return + the transport-level
+/// (`Unavailable` / `DeadlineExceeded`) codes any RPC can produce.
+fn status_for_auth_code(code: tonic::Code) -> StatusCode {
+    match code {
+        tonic::Code::Unauthenticated => StatusCode::UNAUTHORIZED,
+        tonic::Code::PermissionDenied => StatusCode::FORBIDDEN,
+        tonic::Code::Unavailable => StatusCode::SERVICE_UNAVAILABLE,
+        tonic::Code::DeadlineExceeded => StatusCode::GATEWAY_TIMEOUT,
+        _ => StatusCode::INTERNAL_SERVER_ERROR,
+    }
+}
+
+/// Default `Arc<dyn AuthProvider>` used by callers that have no
+/// real provider wired yet.  Matches the kernel's `NoAuth` default:
+/// every token → an admin `OperationContext` — SAFE ONLY for
+/// single-node dev / tests.  Callers that federate or serve agents
+/// MUST swap this out for a real provider (e.g.
+/// `auth::ApiKeyAuthProvider`) before serving traffic.
+pub fn default_no_auth_provider() -> Arc<dyn AuthProvider> {
+    Arc::new(transport::auth::NoAuth)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use contracts::operation_context::OperationContext;
+
+    fn headers_with(auth: &str) -> axum::http::HeaderMap {
+        let mut h = axum::http::HeaderMap::new();
+        h.insert(header::AUTHORIZATION, auth.parse().unwrap());
+        h
+    }
+
+    #[test]
+    fn parse_bearer_returns_token_for_well_formed_header() {
+        let h = headers_with("Bearer sk-abcdef123456");
+        assert_eq!(parse_bearer(&h).unwrap(), Some("sk-abcdef123456"));
+    }
+
+    #[test]
+    fn parse_bearer_is_case_insensitive_on_scheme() {
+        // RFC 7235 §2.1 — scheme is case-insensitive.
+        for header in ["bearer sk-x", "BEARER sk-x", "Bearer sk-x"] {
+            let h = headers_with(header);
+            assert_eq!(parse_bearer(&h).unwrap(), Some("sk-x"), "scheme {header:?}");
+        }
+    }
+
+    #[test]
+    fn parse_bearer_returns_ok_none_when_header_absent() {
+        // Absent header ≠ malformed header — absent falls through to
+        // the provider as empty-token (matches gRPC posture).  The
+        // middleware then relies on the provider to accept or reject.
+        let h = axum::http::HeaderMap::new();
+        assert!(matches!(parse_bearer(&h), Ok(None)));
+    }
+
+    #[test]
+    fn parse_bearer_rejects_non_bearer_scheme() {
+        // `Basic ...` was clearly INTENDED to authenticate; treating
+        // it as "no credentials" would be a silent contract break
+        // (the base64 body would slip past a NoAuth provider as
+        // "any token").  Reject as malformed → 401.
+        for header in ["Basic dXNlcjpwYXNz", "Digest realm=\"x\""] {
+            let h = headers_with(header);
+            assert!(
+                matches!(parse_bearer(&h), Err(AuthRejection::MalformedHeader)),
+                "scheme {header:?} must reject",
+            );
+        }
+    }
+
+    #[test]
+    fn parse_bearer_rejects_empty_token_after_bearer() {
+        // A caller sending `Bearer ` shipped the header — same
+        // "intent to authenticate" argument as non-Bearer schemes.
+        for header in ["Bearer ", "Bearer   ", "Bearer\t"] {
+            let h = headers_with(header);
+            assert!(
+                matches!(parse_bearer(&h), Err(AuthRejection::MalformedHeader)),
+                "header {header:?} must reject",
+            );
+        }
+    }
+
+    #[test]
+    fn status_for_auth_code_maps_the_documented_table() {
+        assert_eq!(
+            status_for_auth_code(tonic::Code::Unauthenticated),
+            StatusCode::UNAUTHORIZED,
+        );
+        assert_eq!(
+            status_for_auth_code(tonic::Code::PermissionDenied),
+            StatusCode::FORBIDDEN,
+        );
+        assert_eq!(
+            status_for_auth_code(tonic::Code::Unavailable),
+            StatusCode::SERVICE_UNAVAILABLE,
+        );
+        assert_eq!(
+            status_for_auth_code(tonic::Code::DeadlineExceeded),
+            StatusCode::GATEWAY_TIMEOUT,
+        );
+        // Unmapped codes fall to 500 rather than degrade to 200 —
+        // matches the search-side mapper's fallback contract.
+        assert_eq!(
+            status_for_auth_code(tonic::Code::Internal),
+            StatusCode::INTERNAL_SERVER_ERROR,
+        );
+    }
+
+    #[test]
+    fn default_no_auth_provider_returns_admin_context_for_any_token() {
+        let p = default_no_auth_provider();
+        for token in ["", "any", "sk-fake"] {
+            let ctx = p.resolve(&AuthCredentials::from_token(token)).unwrap();
+            assert_eq!(ctx.user_id, "cluster-internal");
+            assert!(ctx.is_admin, "NoAuth default must remain admin");
+        }
+    }
+
+    /// Reject-all provider — pins the rejection branch of
+    /// `require_bearer` without dragging a real key store into the
+    /// crate.  The `RejectAll` in `transport::auth::tests` is
+    /// gated `#[cfg(test)]` and therefore not visible cross-crate,
+    /// so this crate carries its own tiny copy.
+    struct RejectAll;
+    impl AuthProvider for RejectAll {
+        fn resolve(&self, _: &AuthCredentials<'_>) -> Result<OperationContext, tonic::Status> {
+            Err(tonic::Status::unauthenticated("bearer rejected"))
+        }
+    }
+
+    #[tokio::test]
+    async fn require_bearer_absent_header_defers_to_provider_reject_becomes_401() {
+        use axum::body::Body;
+        use axum::http::Request;
+        use axum::Router;
+        use tower::ServiceExt;
+
+        // Absent header → empty token passed to provider.  A strict
+        // provider (RejectAll) then returns Unauthenticated → 401.
+        // Pins the "absent header = provider decides" contract:
+        // NoAuth would let the same request through (proven by the
+        // sibling glob_e2e / grep_e2e / query_e2e files which run
+        // against NoAuth and never send a bearer).
+        async fn inner_ok() -> &'static str {
+            "reached"
+        }
+        let state = AppState {
+            search: crate::SearchBackend::new("http://127.0.0.1:1"),
+            auth: Arc::new(RejectAll),
+        };
+        let app: Router = Router::new()
+            .route("/protected", axum::routing::get(inner_ok))
+            .layer(axum::middleware::from_fn_with_state(
+                state.clone(),
+                require_bearer,
+            ))
+            .with_state(state);
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/protected")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn require_bearer_absent_header_with_noauth_provider_lets_request_through() {
+        use axum::body::Body;
+        use axum::http::Request;
+        use axum::Router;
+        use tower::ServiceExt;
+
+        // Absent header under NoAuth: provider accepts empty token
+        // → middleware lets the request reach the handler.  This is
+        // the single-node dev posture the sibling e2e files rely on.
+        async fn inner_ok() -> &'static str {
+            "reached"
+        }
+        let state = AppState {
+            search: crate::SearchBackend::new("http://127.0.0.1:1"),
+            auth: default_no_auth_provider(),
+        };
+        let app: Router = Router::new()
+            .route("/protected", axum::routing::get(inner_ok))
+            .layer(axum::middleware::from_fn_with_state(
+                state.clone(),
+                require_bearer,
+            ))
+            .with_state(state);
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/protected")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn require_bearer_returns_401_on_malformed_header_regardless_of_provider() {
+        // A malformed header (non-Bearer scheme) is rejected at the
+        // parser BEFORE the provider is called — so even a permissive
+        // NoAuth provider does NOT admit the request.  Prevents a
+        // `Basic <base64>` header from being silently read as
+        // "no credentials".
+        use axum::body::Body;
+        use axum::http::Request;
+        use axum::Router;
+        use tower::ServiceExt;
+
+        async fn inner_ok() -> &'static str {
+            "reached"
+        }
+        let state = AppState {
+            search: crate::SearchBackend::new("http://127.0.0.1:1"),
+            auth: default_no_auth_provider(),
+        };
+        let app: Router = Router::new()
+            .route("/protected", axum::routing::get(inner_ok))
+            .layer(axum::middleware::from_fn_with_state(
+                state.clone(),
+                require_bearer,
+            ))
+            .with_state(state);
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/protected")
+                    .header(header::AUTHORIZATION, "Basic dXNlcjpwYXNz")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn require_bearer_returns_401_when_provider_rejects_the_token() {
+        use axum::body::Body;
+        use axum::http::Request;
+        use axum::Router;
+        use tower::ServiceExt;
+
+        async fn inner_ok() -> &'static str {
+            "reached"
+        }
+        let state = AppState {
+            search: crate::SearchBackend::new("http://127.0.0.1:1"),
+            auth: Arc::new(RejectAll),
+        };
+        let app: Router = Router::new()
+            .route("/protected", axum::routing::get(inner_ok))
+            .layer(axum::middleware::from_fn_with_state(
+                state.clone(),
+                require_bearer,
+            ))
+            .with_state(state);
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/protected")
+                    .header(header::AUTHORIZATION, "Bearer sk-does-not-resolve")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn require_bearer_injects_operation_context_when_provider_accepts() {
+        use axum::body::Body;
+        use axum::http::Request;
+        use axum::response::IntoResponse;
+        use axum::Extension;
+        use axum::Router;
+        use tower::ServiceExt;
+
+        // The handler MUST see the resolved OperationContext — proves
+        // the middleware inserted it into extensions before the
+        // handler ran.  Returns the user_id in the body so the test
+        // can pin the exact identity that landed.
+        async fn echo_user_id(Extension(ctx): Extension<OperationContext>) -> impl IntoResponse {
+            ctx.user_id.clone()
+        }
+        let state = AppState {
+            search: crate::SearchBackend::new("http://127.0.0.1:1"),
+            auth: default_no_auth_provider(), // returns "cluster-internal"
+        };
+        let app: Router = Router::new()
+            .route("/protected", axum::routing::get(echo_user_id))
+            .layer(axum::middleware::from_fn_with_state(
+                state.clone(),
+                require_bearer,
+            ))
+            .with_state(state);
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/protected")
+                    .header(header::AUTHORIZATION, "Bearer any-token")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(resp.into_body(), 1024).await.unwrap();
+        assert_eq!(&bytes[..], b"cluster-internal");
+    }
+}

--- a/rust/services/http-api/src/middleware/mod.rs
+++ b/rust/services/http-api/src/middleware/mod.rs
@@ -1,0 +1,7 @@
+//! Tower middleware wired above [`crate::router`].
+//!
+//! Kept in a sibling module to `handlers/` so a new middleware layer
+//! (auth, rate-limit, request-id, tracing) does not touch handler
+//! code — layers compose additively at `router()` assembly time.
+
+pub mod auth;

--- a/rust/services/http-api/tests/auth_middleware_e2e.rs
+++ b/rust/services/http-api/tests/auth_middleware_e2e.rs
@@ -1,0 +1,352 @@
+//! Route-level E2E cover for `middleware::auth::require_bearer`.
+//!
+//! Sibling tests (`glob_e2e.rs`, `grep_e2e.rs`, `query_e2e.rs`) wire
+//! `NoAuth` so their assertions stay focused on the search chain;
+//! this file wires a NON-`NoAuth` provider and exercises the auth
+//! posture through the same real-TCP + reqwest + mock-tonic stack.
+//!
+//! Pins:
+//!   * `/v2/status` remains PUBLIC even under a strict provider
+//!     (liveness probes must not require a bearer).
+//!   * `/v2/search/*` REJECTS every request without a well-formed
+//!     bearer (401) — the upstream mock never sees the request.
+//!   * A provider that accepts the bearer lets the search request
+//!     through to the mock (200).
+//!   * A provider that rejects the bearer surfaces 401 with the
+//!     upstream `tonic::Status::message()` in the JSON body.
+
+use std::sync::Arc;
+
+use contracts::operation_context::OperationContext;
+use nexus_http_api::search_proto::search_service_server::{SearchService, SearchServiceServer};
+use nexus_http_api::search_proto::{
+    AddIndexedDirectoryRequest, AddIndexedDirectoryResponse, BatchQueryRequest, BatchQueryResponse,
+    GlobRequest, GlobResponse, GrepRequest, GrepResponse, HealthRequest, HealthResponse,
+    IndexDocumentsRequest, IndexDocumentsResponse, IndexRequest, IndexResponse,
+    ListIndexedDirectoriesRequest, ListIndexedDirectoriesResponse, ListZoneIndexingModesRequest,
+    ListZoneIndexingModesResponse, LocateRequest, LocateResponse, NotifyFileChangeRequest,
+    NotifyFileChangeResponse, ParkedDiscardRequest, ParkedDiscardResponse, ParkedListRequest,
+    ParkedListResponse, ParkedRetryRequest, ParkedRetryResponse, QueryRequest, QueryResponse,
+    RefreshRequest, RefreshResponse, RemoveIndexedDirectoryRequest, RemoveIndexedDirectoryResponse,
+    SetZoneIndexingModeRequest, SetZoneIndexingModeResponse, StatsRequest, StatsResponse,
+};
+use nexus_http_api::{bind_and_serve, AppState, SearchBackend};
+use tokio::net::TcpListener;
+use tokio::sync::Mutex;
+use tokio_stream::wrappers::TcpListenerStream;
+use tonic::{Request, Response, Status};
+use transport::auth::{AuthCredentials, AuthProvider};
+
+// ── Auth providers used by this file ──────────────────────────
+
+/// Accepts one specific bearer, rejects everything else.  Enough
+/// to exercise both branches of the middleware; concrete
+/// `ApiKeyAuthProvider` cover lives in the transport crate's own
+/// tests.
+struct FixedBearer {
+    accepted: &'static str,
+}
+
+impl AuthProvider for FixedBearer {
+    fn resolve(&self, creds: &AuthCredentials<'_>) -> Result<OperationContext, tonic::Status> {
+        if creds.token == self.accepted {
+            Ok(OperationContext::new(
+                "test-user",
+                "root",
+                true,
+                None,
+                false,
+            ))
+        } else {
+            Err(tonic::Status::unauthenticated("wrong-token"))
+        }
+    }
+}
+
+// ── Mock SearchService — records glob hits so the test can
+// prove the middleware DID or DID NOT forward the request.
+
+#[derive(Default, Clone)]
+struct RequestLog {
+    globs: Arc<Mutex<Vec<GlobRequest>>>,
+}
+
+#[derive(Clone)]
+struct MockSearchService {
+    log: RequestLog,
+}
+
+#[tonic::async_trait]
+impl SearchService for MockSearchService {
+    async fn glob(&self, req: Request<GlobRequest>) -> Result<Response<GlobResponse>, Status> {
+        self.log.globs.lock().await.push(req.into_inner());
+        Ok(Response::new(GlobResponse {
+            paths: vec!["/hit.md".into()],
+            truncated: false,
+            error: None,
+        }))
+    }
+
+    async fn grep(&self, _: Request<GrepRequest>) -> Result<Response<GrepResponse>, Status> {
+        unreachable!()
+    }
+    async fn query(&self, _: Request<QueryRequest>) -> Result<Response<QueryResponse>, Status> {
+        unreachable!()
+    }
+    async fn index(&self, _: Request<IndexRequest>) -> Result<Response<IndexResponse>, Status> {
+        unreachable!()
+    }
+    async fn refresh(
+        &self,
+        _: Request<RefreshRequest>,
+    ) -> Result<Response<RefreshResponse>, Status> {
+        unreachable!()
+    }
+    async fn batch_query(
+        &self,
+        _: Request<BatchQueryRequest>,
+    ) -> Result<Response<BatchQueryResponse>, Status> {
+        unreachable!()
+    }
+    async fn index_documents(
+        &self,
+        _: Request<IndexDocumentsRequest>,
+    ) -> Result<Response<IndexDocumentsResponse>, Status> {
+        unreachable!()
+    }
+    async fn notify_file_change(
+        &self,
+        _: Request<NotifyFileChangeRequest>,
+    ) -> Result<Response<NotifyFileChangeResponse>, Status> {
+        unreachable!()
+    }
+    async fn locate(&self, _: Request<LocateRequest>) -> Result<Response<LocateResponse>, Status> {
+        unreachable!()
+    }
+    async fn parked_list(
+        &self,
+        _: Request<ParkedListRequest>,
+    ) -> Result<Response<ParkedListResponse>, Status> {
+        unreachable!()
+    }
+    async fn parked_retry(
+        &self,
+        _: Request<ParkedRetryRequest>,
+    ) -> Result<Response<ParkedRetryResponse>, Status> {
+        unreachable!()
+    }
+    async fn parked_discard(
+        &self,
+        _: Request<ParkedDiscardRequest>,
+    ) -> Result<Response<ParkedDiscardResponse>, Status> {
+        unreachable!()
+    }
+    async fn add_indexed_directory(
+        &self,
+        _: Request<AddIndexedDirectoryRequest>,
+    ) -> Result<Response<AddIndexedDirectoryResponse>, Status> {
+        unreachable!()
+    }
+    async fn remove_indexed_directory(
+        &self,
+        _: Request<RemoveIndexedDirectoryRequest>,
+    ) -> Result<Response<RemoveIndexedDirectoryResponse>, Status> {
+        unreachable!()
+    }
+    async fn list_indexed_directories(
+        &self,
+        _: Request<ListIndexedDirectoriesRequest>,
+    ) -> Result<Response<ListIndexedDirectoriesResponse>, Status> {
+        unreachable!()
+    }
+    async fn set_zone_indexing_mode(
+        &self,
+        _: Request<SetZoneIndexingModeRequest>,
+    ) -> Result<Response<SetZoneIndexingModeResponse>, Status> {
+        unreachable!()
+    }
+    async fn list_zone_indexing_modes(
+        &self,
+        _: Request<ListZoneIndexingModesRequest>,
+    ) -> Result<Response<ListZoneIndexingModesResponse>, Status> {
+        unreachable!()
+    }
+    async fn health(&self, _: Request<HealthRequest>) -> Result<Response<HealthResponse>, Status> {
+        unreachable!()
+    }
+    async fn stats(&self, _: Request<StatsRequest>) -> Result<Response<StatsResponse>, Status> {
+        unreachable!()
+    }
+}
+
+// ── Harness ────────────────────────────────────────────────────
+
+struct Harness {
+    http_base: String,
+    log: RequestLog,
+}
+
+impl Harness {
+    async fn start(auth: Arc<dyn AuthProvider>) -> Self {
+        let (grpc_target, log) = spawn_mock_grpc().await;
+        let state = AppState {
+            search: SearchBackend::new(grpc_target),
+            auth,
+        };
+        let (addr, fut) = bind_and_serve("127.0.0.1:0".parse().unwrap(), state)
+            .await
+            .expect("bind");
+        tokio::spawn(async move {
+            fut.await.expect("serve");
+        });
+        Self {
+            http_base: format!("http://{addr}"),
+            log,
+        }
+    }
+}
+
+async fn spawn_mock_grpc() -> (String, RequestLog) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let addr = listener.local_addr().unwrap();
+    let log = RequestLog::default();
+    let mock = MockSearchService { log: log.clone() };
+    tokio::spawn(async move {
+        tonic::transport::Server::builder()
+            .add_service(SearchServiceServer::new(mock))
+            .serve_with_incoming(TcpListenerStream::new(listener))
+            .await
+            .expect("serve mock");
+    });
+    (format!("http://{addr}"), log)
+}
+
+// ── Tests ──────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn public_status_bypasses_auth_even_under_strict_provider() {
+    // A liveness probe MUST reach /v2/status without a bearer,
+    // even under a provider that would reject one — the router's
+    // sub-router split (public / protected) is what makes this
+    // possible.
+    let h = Harness::start(Arc::new(FixedBearer {
+        accepted: "sk-never-sent",
+    }))
+    .await;
+    let resp = reqwest::get(format!("{}/v2/status", h.http_base))
+        .await
+        .expect("get");
+    assert_eq!(
+        resp.status(),
+        reqwest::StatusCode::OK,
+        "public status route must bypass auth middleware",
+    );
+    let body: serde_json::Value = resp.json().await.expect("json");
+    assert_eq!(body["status"], "ok");
+    assert!(
+        h.log.globs.lock().await.is_empty(),
+        "status must never dial the search backend",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn search_glob_without_bearer_under_strict_provider_returns_401_and_never_dials_upstream() {
+    // Absent header → middleware calls `resolve` with empty token
+    // → FixedBearer rejects → 401.  The 401 comes from the PROVIDER,
+    // not the middleware parser (see `require_bearer_absent_header_
+    // defers_to_provider_reject_becomes_401` in the lib unit tests).
+    // Contrast: sibling `glob_e2e.rs` uses NoAuth and lets absent-
+    // header requests through; the auth posture is a provider choice.
+    let h = Harness::start(Arc::new(FixedBearer {
+        accepted: "sk-anything",
+    }))
+    .await;
+    let resp = reqwest::get(format!("{}/v2/search/glob?pattern=%2A.md", h.http_base))
+        .await
+        .expect("get");
+    assert_eq!(resp.status(), reqwest::StatusCode::UNAUTHORIZED);
+    let body: serde_json::Value = resp.json().await.expect("json");
+    // Message flows through from `tonic::Status::message()` on the
+    // provider's rejection — pin the exact upstream signal so an
+    // operator debugging a 401 can distinguish provider-side reject
+    // ("wrong-token") from middleware-side reject ("malformed…").
+    assert!(
+        body["error"].as_str().unwrap_or("").contains("wrong-token"),
+        "provider message must ride through into JSON body; got: {body}",
+    );
+    assert!(
+        h.log.globs.lock().await.is_empty(),
+        "rejected bearer must NOT reach the backend",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn search_glob_with_wrong_bearer_returns_401_from_provider_message() {
+    let h = Harness::start(Arc::new(FixedBearer {
+        accepted: "sk-real-token",
+    }))
+    .await;
+    let resp = reqwest::Client::new()
+        .get(format!("{}/v2/search/glob?pattern=%2A.md", h.http_base))
+        .header(reqwest::header::AUTHORIZATION, "Bearer sk-fake-token")
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(resp.status(), reqwest::StatusCode::UNAUTHORIZED);
+    let body: serde_json::Value = resp.json().await.expect("json");
+    assert!(
+        body["error"].as_str().unwrap_or("").contains("wrong-token"),
+        "provider's tonic::Status::message() must ride through into the JSON body; got: {body}",
+    );
+    assert!(
+        h.log.globs.lock().await.is_empty(),
+        "rejected bearer must NOT reach the backend",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn search_glob_with_accepted_bearer_reaches_backend_and_returns_200() {
+    let h = Harness::start(Arc::new(FixedBearer {
+        accepted: "sk-real-token",
+    }))
+    .await;
+    let resp = reqwest::Client::new()
+        .get(format!("{}/v2/search/glob?pattern=%2A.md", h.http_base))
+        .header(reqwest::header::AUTHORIZATION, "Bearer sk-real-token")
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+    let body: serde_json::Value = resp.json().await.expect("json");
+    assert_eq!(body["paths"][0], "/hit.md");
+
+    let logged = h.log.globs.lock().await;
+    assert_eq!(
+        logged.len(),
+        1,
+        "accepted bearer must reach the search backend exactly once",
+    );
+    assert_eq!(logged[0].pattern, "*.md");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn search_glob_with_non_bearer_scheme_returns_401() {
+    // `Authorization: Basic ...` is well-formed but not the Bearer
+    // scheme the middleware accepts.  Must surface 401 rather than
+    // silently reading the base64 body as a raw token.
+    let h = Harness::start(Arc::new(FixedBearer {
+        accepted: "irrelevant",
+    }))
+    .await;
+    let resp = reqwest::Client::new()
+        .get(format!("{}/v2/search/glob?pattern=%2A.md", h.http_base))
+        .header(reqwest::header::AUTHORIZATION, "Basic dXNlcjpwYXNzd29yZA==")
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(resp.status(), reqwest::StatusCode::UNAUTHORIZED);
+    assert!(
+        h.log.globs.lock().await.is_empty(),
+        "non-Bearer scheme must not reach the backend",
+    );
+}

--- a/rust/services/http-api/tests/glob_e2e.rs
+++ b/rust/services/http-api/tests/glob_e2e.rs
@@ -228,6 +228,12 @@ impl Harness {
 async fn spawn_http_listener(grpc_target: String) -> String {
     let state = AppState {
         search: SearchBackend::new(grpc_target),
+        // These integration tests exercise the search route surface;
+        // NoAuth means the middleware lets every request through so
+        // the assertions here stay focused on the search chain, not
+        // on bearer parsing.  Dedicated bearer-parsing / rejection
+        // cover lives in `tests/auth_middleware_e2e.rs`.
+        auth: nexus_http_api::middleware::auth::default_no_auth_provider(),
     };
     let (http_addr, fut) = bind_and_serve("127.0.0.1:0".parse().unwrap(), state)
         .await

--- a/rust/services/http-api/tests/grep_e2e.rs
+++ b/rust/services/http-api/tests/grep_e2e.rs
@@ -196,6 +196,10 @@ impl Harness {
 async fn spawn_http_listener(grpc_target: String) -> String {
     let state = AppState {
         search: SearchBackend::new(grpc_target),
+        // NoAuth so this file's tests stay focused on the grep
+        // route surface; bearer parsing / rejection has its own
+        // cover in `tests/auth_middleware_e2e.rs`.
+        auth: nexus_http_api::middleware::auth::default_no_auth_provider(),
     };
     let (http_addr, fut) = bind_and_serve("127.0.0.1:0".parse().unwrap(), state)
         .await

--- a/rust/services/http-api/tests/query_e2e.rs
+++ b/rust/services/http-api/tests/query_e2e.rs
@@ -207,6 +207,10 @@ impl Harness {
 async fn spawn_http_listener(grpc_target: String) -> String {
     let state = AppState {
         search: SearchBackend::new(grpc_target),
+        // NoAuth so this file's tests stay focused on the query
+        // route surface; bearer parsing / rejection has its own
+        // cover in `tests/auth_middleware_e2e.rs`.
+        auth: nexus_http_api::middleware::auth::default_no_auth_provider(),
     };
     let (http_addr, fut) = bind_and_serve("127.0.0.1:0".parse().unwrap(), state)
         .await

--- a/rust/services/http-api/tests/serve_e2e.rs
+++ b/rust/services/http-api/tests/serve_e2e.rs
@@ -26,6 +26,10 @@ use nexus_http_api::{bind_and_serve, AppState, SearchBackend, StatusResponse};
 async fn spawn_router() -> String {
     let state = AppState {
         search: SearchBackend::new("http://127.0.0.1:1"),
+        // Status is a PUBLIC route (bypasses auth) so this file's
+        // cover stays focused on the serve path; NoAuth here is
+        // only present because `AppState` mandates it.
+        auth: nexus_http_api::middleware::auth::default_no_auth_provider(),
     };
     let (addr, fut) = bind_and_serve("127.0.0.1:0".parse().unwrap(), state)
         .await


### PR DESCRIPTION
## Summary

Fourth R10 landing: bearer-token auth middleware over `/v2/search/*` via `tower` `.layer()` above the axum router. Public `/v2/status` bypasses auth (liveness probe target); every search route is protected.

## Design

- **Reuses `transport::auth::AuthProvider`** — the SSOT trait every authenticated `nexus.*.v1` gRPC surface already consumes via `transport::grpc::VfsServiceImpl::authenticate`. Resolved `contracts::OperationContext` is the SSOT struct every `kernel::sys_*` consumes. No local trait, no invented shape.
- **Absent header → provider decides** — mirrors the gRPC posture (`resolve` always called with `AuthCredentials::from_token(inner.auth_token())`, empty string when caller supplied none). `NoAuth` accepts (dev), `ApiKeyAuthProvider` rejects with 401 (prod).
- **Malformed header → 401 immediately** — a present-but-wrong `Basic <base64>` header ships intent to authenticate; silently reading as "no credentials" would let it through under `NoAuth`. Reject at the parser, never call the provider.
- **Router sub-split** — public (`/v2/status`) + protected (`/v2/search/*`); new domains land as additive `.merge()` on whichever sub-router matches posture.

## Explicit non-goals (documented so a follow-up PR knows the cutline)

- mTLS peer plane — waits on HTTP surface rustls stack
- Cookie sessions — Python `nexus-server` does NOT use session cookies; nothing to port
- ReBAC post-filter — separate epic step; this middleware is authN only
- Cache invalidation observer — real provider will ride the raft observer path already used by the gRPC interceptor

## Test cover

**Lib (14 unit tests, 9 new):** parse_bearer happy/case-insensitive/absent/non-Bearer/empty; status mapping table; NoAuth default; require_bearer with absent+strict/absent+NoAuth/wrong-token/malformed/accepted (extension-injected).

**Integration (5 new in `tests/auth_middleware_e2e.rs`):** real TCP + reqwest + mock-tonic — public-status-bypasses, glob-without-bearer, glob-with-wrong-bearer (provider message rides through JSON), glob-with-accepted-bearer (full-chain 200), glob-with-Basic-scheme (never reaches backend even under NoAuth).

**Full suite**: 46 tests pass (14 lib + 5 auth-e2e + 7 glob-e2e + 5 grep-e2e + 13 query-e2e + 2 serve-e2e). clippy `--all-targets` + fmt clean.

## R10 arc status

- ✅ Landed: status, glob, grep, query, **auth middleware** (this PR)
- Next: nexusd-cluster wiring — `AppState.auth` swap from `NoAuth` to `ApiKeyAuthProvider` at the composition root (separate PR on the nexusd side)
- Then: Rust ReBAC post-filter
