### PR TITLE
test(e2e): co-host A2A duet over Docker — real LLM agent replies over the mailbox

### DIFF
--- a/.github/workflows/cohost-duet-e2e.yml
+++ b/.github/workflows/cohost-duet-e2e.yml
@@ -1,0 +1,119 @@
+# Co-host A2A duet E2E — builds the `nexusd-cluster-cohost` image (the assembly
+# binary with the in-process sudocode runtime linked) and runs a REAL LLM agent
+# duet over the nexus A2A mailbox in a container. Guards the merged
+# spawn-AgentState / SudoCodeSpawnAdapter path against regression, over the wire.
+#
+# See dockerfiles/Dockerfile.nexusd-cohost + docker-compose.cohost-duet.yml +
+# tests/e2e/docker/test_cohost_duet_e2e.py.
+#
+# REQUIRED repo secrets (the job is a no-op without them):
+#   * COHOST_BUILD_TOKEN  — a PAT with READ on BOTH private deps
+#     (nexi-lab/nexus-vfs AND sudoprivacy/sudocode); the cohost image git-fetches
+#     them at build time via a BuildKit secret. The default GITHUB_TOKEN cannot
+#     reach the cross-org sudocode repo.
+#   * SUDOROUTER_API_KEY  — the FUNDED sudorouter key (vault "SudoRouter" entry,
+#     unlimited main pool). The LLM turn 403s on a balance-capped key, so the
+#     test's reply assertion needs a funded one.
+
+name: cohost-duet-e2e
+
+on:
+  workflow_dispatch: {}
+  push:
+    paths:
+      - 'dockerfiles/Dockerfile.nexusd-cohost'
+      - 'dockerfiles/docker-compose.cohost-duet.yml'
+      - 'tests/e2e/docker/test_cohost_duet_e2e.py'
+      - 'tests/e2e/docker/runbook_helpers.py'
+      - '.github/workflows/cohost-duet-e2e.yml'
+
+jobs:
+  cohost-duet:
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    steps:
+      - name: Checkout nexus
+        uses: actions/checkout@v4
+
+      - name: Preflight — required secrets present
+        id: preflight
+        env:
+          BUILD_TOKEN: ${{ secrets.COHOST_BUILD_TOKEN }}
+          SR_KEY: ${{ secrets.SUDOROUTER_API_KEY }}
+        run: |
+          if [ -z "$BUILD_TOKEN" ] || [ -z "$SR_KEY" ]; then
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::COHOST_BUILD_TOKEN and/or SUDOROUTER_API_KEY not set — skipping the cohost duet E2E (needs both)."
+          else
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up Docker Buildx
+        if: steps.preflight.outputs.run == 'true'
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build nexusd-cluster-cohost image
+        if: steps.preflight.outputs.run == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.COHOST_BUILD_TOKEN }}
+        run: |
+          DOCKER_BUILDKIT=1 docker build \
+            -f dockerfiles/Dockerfile.nexusd-cohost \
+            --secret id=ghtoken,env=GH_TOKEN \
+            -t nexusd-cluster-cohost:latest .
+
+      - name: Set up Python
+        if: steps.preflight.outputs.run == 'true'
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install test deps (nexus gRPC client + pytest)
+        if: steps.preflight.outputs.run == 'true'
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[test]"
+
+      - name: Start the cohost daemon
+        if: steps.preflight.outputs.run == 'true'
+        env:
+          SUDOROUTER_API_KEY: ${{ secrets.SUDOROUTER_API_KEY }}
+        run: |
+          docker compose -f dockerfiles/docker-compose.cohost-duet.yml up -d
+          docker compose -f dockerfiles/docker-compose.cohost-duet.yml ps
+
+      - name: Wait for the daemon healthy
+        if: steps.preflight.outputs.run == 'true'
+        run: |
+          deadline=$((SECONDS + 120))
+          while [ $SECONDS -lt $deadline ]; do
+            if docker exec nexus-cohost-duet bash -c 'timeout 1 bash -c "</dev/tcp/localhost/2126" 2>/dev/null'; then
+              echo "cohost daemon healthy (gRPC 2126) after ${SECONDS}s"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "::error::cohost daemon never became healthy (120s)"
+          docker compose -f dockerfiles/docker-compose.cohost-duet.yml logs --tail=200
+          exit 1
+
+      - name: Run the co-host duet E2E
+        if: steps.preflight.outputs.run == 'true'
+        env:
+          COHOST_DUET_E2E: '1'
+          SUDOROUTER_API_KEY: ${{ secrets.SUDOROUTER_API_KEY }}
+          COHOST_DUET_GRPC: localhost:2126
+        run: |
+          pytest tests/e2e/docker/test_cohost_duet_e2e.py -v
+
+      - name: Dump daemon logs on failure
+        if: failure() && steps.preflight.outputs.run == 'true'
+        run: |
+          echo "::group::nexus-cohost-duet"
+          docker logs nexus-cohost-duet --tail=400 2>&1 || echo "(no logs)"
+          echo "::endgroup::"
+
+      - name: Tear down
+        if: always() && steps.preflight.outputs.run == 'true'
+        run: |
+          docker compose -f dockerfiles/docker-compose.cohost-duet.yml down -v --remove-orphans || true

--- a/dockerfiles/Dockerfile.nexusd-cohost
+++ b/dockerfiles/Dockerfile.nexusd-cohost
@@ -1,0 +1,76 @@
+# nexusd-cluster **co-host** image — the assembly binary WITH the in-process
+# sudocode agent runtime linked (`--features cohost-sudocode`).
+#
+# Distinct from `Dockerfile.nexusd-cluster` (the slim pure-VFS binary built
+# from the nexus-vfs `rust/profiles/cluster` context). This one builds
+# `nexus/rust/nexusd` — the assembly that injects
+# `sudocode_tools::managed_agent::SudoCodeSpawnAdapter` via
+# `install_managed_agent_with_spawn`, so a minted agent runs a real LLM loop
+# in-process (KernelFsBackend file tools, send_message mailbox reply). Used by
+# the co-host A2A duet compose (`docker-compose.cohost-duet.yml`).
+#
+# Both cross-repo deps (nexi-lab/nexus-vfs @ the Cargo.toml pin, and
+# sudoprivacy/sudocode @ the nexusd/Cargo.toml pin) are PRIVATE, so the build
+# authenticates git via a BuildKit secret rather than a git token baked into a
+# layer. Build:
+#
+#   DOCKER_BUILDKIT=1 docker build \
+#     -f dockerfiles/Dockerfile.nexusd-cohost \
+#     --secret id=ghtoken,env=GH_TOKEN \
+#     -t nexusd-cluster-cohost:latest .
+#
+# with `GH_TOKEN=$(gh auth token)` (needs read on both private repos).
+# `.dockerignore` already excludes target/ + .git/, so `COPY .` is the source
+# tree only.
+
+FROM rust:1-slim-bookworm AS builder
+
+# protobuf-compiler: the git-fetched raft crate's build.rs shells out to protoc.
+# python3{,-dev}: pyo3-build-config probes for an interpreter at compile time.
+# git + ca-certificates: authenticated fetch of the two private git deps.
+# Point apt at a China mirror (Aliyun) first — deb.debian.org is unreliable
+# through the local China proxy (persistent 502s); CI (clean network) is
+# unaffected either way. Rewrite both the deb822 and legacy sources files.
+RUN { sed -i 's|deb.debian.org|mirrors.aliyun.com|g; s|security.debian.org|mirrors.aliyun.com|g' /etc/apt/sources.list.d/debian.sources 2>/dev/null || true; } \
+    && { sed -i 's|deb.debian.org|mirrors.aliyun.com|g; s|security.debian.org|mirrors.aliyun.com|g' /etc/apt/sources.list 2>/dev/null || true; } \
+    && apt-get -o Acquire::Retries=6 update && apt-get -o Acquire::Retries=6 install -y --no-install-recommends \
+        protobuf-compiler \
+        python3 \
+        python3-dev \
+        git \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# The nexus assembly source (rust/nexusd + workspace). target/ and .git/ are
+# .dockerignore'd, so this is the source tree only.
+COPY . /build/nexus
+
+# `--locked` honors the workspace Cargo.lock (single SSOT for the nexus-vfs +
+# sudocode revs); the secret token authenticates the private git fetches and
+# never lands in a layer. `--path rust/nexusd` builds ONLY the assembly + its
+# deps (not the whole workspace — search-plugin etc. stay out).
+RUN --mount=type=secret,id=ghtoken \
+    git config --global url."https://$(cat /run/secrets/ghtoken)@github.com/".insteadOf "https://github.com/" \
+    && cargo install \
+        --locked \
+        --path /build/nexus/rust/nexusd \
+        --features cohost-sudocode \
+        --bin nexusd-cluster \
+    && git config --global --remove-section url."https://$(cat /run/secrets/ghtoken)@github.com/"
+
+# ---------- Production image ----------
+FROM debian:bookworm-slim
+
+# bash: the compose healthcheck uses `bash -c '</dev/tcp/localhost/2126'`.
+# ca-certificates: the co-host agent's LLM turn makes an outbound HTTPS call
+# to the provider (sudorouter) — rustls needs the system trust roots.
+RUN { sed -i 's|deb.debian.org|mirrors.aliyun.com|g; s|security.debian.org|mirrors.aliyun.com|g' /etc/apt/sources.list.d/debian.sources 2>/dev/null || true; } \
+    && { sed -i 's|deb.debian.org|mirrors.aliyun.com|g; s|security.debian.org|mirrors.aliyun.com|g' /etc/apt/sources.list 2>/dev/null || true; } \
+    && apt-get -o Acquire::Retries=6 update && apt-get -o Acquire::Retries=6 install -y --no-install-recommends \
+        bash \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /usr/local/cargo/bin/nexusd-cluster /usr/local/bin/nexusd-cluster
+
+ENTRYPOINT ["nexusd-cluster"]

--- a/dockerfiles/docker-compose.cohost-duet.yml
+++ b/dockerfiles/docker-compose.cohost-duet.yml
@@ -1,0 +1,73 @@
+# Co-host A2A duet — REAL sudocode LLM agents conversing over the nexus A2A
+# mailbox, hosted in the `nexusd-cluster-cohost` daemon (the assembly binary
+# built `--features cohost-sudocode`). Proves the daemon path end to end:
+#   Call managed_agent.start_session_v1 → SudoCodeSpawnAdapter.spawn →
+#   spawn_managed_agent → agent binds A2aInbox /agents/<name>/chat-with-me →
+#   reads a seeded MailboxEnvelope → REAL LLM turn → send_message reply to the
+#   peer's A2A inbox.
+#
+# The Docker counterpart of the in-process unit proof
+# (sudocode `tools/tests/cohost_live_llm.rs`) — same factory, but over a real
+# gRPC daemon in a container, so it also exercises the wire path and runs in CI.
+#
+# Increment 1 (this file): ONE cohost node, both agents local. `/agents` is the
+# node's own tree (no federation needed for same-node A2A). Increment 2 layers
+# the 2-node federated shape (docker-compose.mtls-federation-test.yml) so
+# `/agents/*` replicates and the two agents live on DIFFERENT nodes.
+#
+# Prereqs:
+#   1. Build the image:
+#        GH_TOKEN=$(gh auth token) DOCKER_BUILDKIT=1 docker build \
+#          -f dockerfiles/Dockerfile.nexusd-cohost \
+#          --secret id=ghtoken,env=GH_TOKEN -t nexusd-cluster-cohost:latest .
+#   2. Export the FUNDED sudorouter key (vault "SudoRouter" entry → the
+#      UNLIMITED main-pool key, console name "cohost-test"):
+#        export SUDOROUTER_API_KEY=sk-…
+#   3. docker compose -f dockerfiles/docker-compose.cohost-duet.yml up
+#
+# The pytest harness (tests/e2e/docker/test_cohost_duet_e2e.py) then drives
+# start_session + the seed message + the PONG assertion.
+
+services:
+  cohost:
+    image: nexusd-cluster-cohost:latest
+    container_name: nexus-cohost-duet
+    hostname: cohost
+    environment:
+      # The FUNDED sudorouter key — required, fail loud if unset. sudocode's
+      # provider resolver reads it from the generated sudocode.json (proxy
+      # passthrough), NOT from ANTHROPIC_* env.
+      SUDOROUTER_API_KEY: ${SUDOROUTER_API_KEY:?set SUDOROUTER_API_KEY to the funded sudorouter sk- key}
+      # New API gateway endpoint (mainland-reachable). `hk` is a legacy alias.
+      SUDOROUTER_BASE_URL: ${SUDOROUTER_BASE_URL:-https://api.sudorouter.ai/v1}
+      SUDO_CODE_CONFIG_HOME: /config
+      RUST_LOG: ${RUST_LOG:-warn}
+      # Plain logs so the test's log greps aren't split by ANSI colour codes.
+      NO_COLOR: "1"
+    # Generate the co-host agents' provider config from the env key at boot
+    # (key stays in env, never in the image/repo), then exec the daemon
+    # auth-off + plaintext — the simplest posture for the same-node duet proof.
+    entrypoint:
+      - /bin/sh
+      - -c
+      - |
+        set -e
+        mkdir -p /config
+        cat > /config/sudocode.json <<EOF
+        {"auth_modes":{"proxy":{"sudorouter":{"baseUrl":"$${SUDOROUTER_BASE_URL}","apiKey":"$${SUDOROUTER_API_KEY}"}}}}
+        EOF
+        exec nexusd-cluster --bind-addr 0.0.0.0:2126 --data-dir /app/data --no-tls --insecure-no-auth
+    ports:
+      - "2126:2126"
+    healthcheck:
+      test: ["CMD-SHELL", "bash -c '</dev/tcp/localhost/2126' 2>/dev/null || exit 1"]
+      interval: 2s
+      timeout: 2s
+      retries: 40
+      start_period: 3s
+    networks:
+      - cohost-net
+
+networks:
+  cohost-net:
+    driver: bridge

--- a/tests/e2e/docker/test_cohost_duet_e2e.py
+++ b/tests/e2e/docker/test_cohost_duet_e2e.py
@@ -1,0 +1,141 @@
+"""Co-host A2A duet E2E — a REAL sudocode LLM agent conversing over the nexus
+A2A mailbox, hosted in a ``nexusd-cluster-cohost`` container.
+
+This is the Docker counterpart of the in-process unit proof
+(sudocode ``tools/tests/cohost_live_llm.rs``): it drives the SAME
+``spawn_managed_agent`` factory, but through a real gRPC daemon over the wire,
+so it also exercises the control-plane ``Call`` path and the A2A mailbox
+replication substrate.
+
+Flow (see ``dockerfiles/docker-compose.cohost-duet.yml``):
+
+1. ``Call managed_agent.start_session_v1`` spawns the co-host agent
+   ``mac-ai`` — ``SudoCodeSpawnAdapter.spawn`` → ``spawn_managed_agent`` binds
+   it to its replicated A2A inbox ``/agents/mac-ai/chat-with-me``.
+2. We seed a ``MailboxEnvelope`` ``{from: win-ai, to: mac-ai, body: …}`` there.
+3. The agent reads it, runs a REAL LLM turn (funded sudorouter key), and calls
+   ``send_message`` to reply into the SENDER's inbox
+   ``/agents/win-ai/chat-with-me`` — where we assert the reply lands.
+
+Gated: skips unless the ``docker-compose.cohost-duet`` stack is up (the compose
+sets ``COHOST_DUET_E2E=1``) AND a funded ``SUDOROUTER_API_KEY`` is available —
+the LLM turn 403s on a balance-capped key.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+
+import pytest
+
+from tests.e2e.docker import runbook_helpers as rh
+
+# The compose's `test` service (CI) sets COHOST_DUET_E2E=1; local runs export it.
+_STACK_UP = os.environ.get("COHOST_DUET_E2E") == "1"
+_HAS_KEY = bool(os.environ.get("SUDOROUTER_API_KEY"))
+
+pytestmark = pytest.mark.skipif(
+    not (_STACK_UP and _HAS_KEY),
+    reason=(
+        "cohost-duet E2E needs the docker-compose.cohost-duet stack up "
+        "(COHOST_DUET_E2E=1) and a funded SUDOROUTER_API_KEY (the LLM turn "
+        "403s on a balance-capped key)"
+    ),
+)
+
+# gRPC endpoint of the cohost daemon (compose maps 2126 to the host).
+GRPC = os.environ.get("COHOST_DUET_GRPC", "localhost:2126")
+# Auth-off daemon (`--insecure-no-auth`); the client key is ignored.
+API_KEY = getattr(rh, "ADMIN_API_KEY", "")
+
+RESPONDER = "mac-ai"
+SEEDER = "win-ai"
+MODEL = os.environ.get("COHOST_DUET_MODEL", "claude-sonnet-4-6")
+
+# Budget for the whole turn: LLM latency + a mailbox round-trip. Sonnet PONGs
+# in ~4s locally; 120s is generous headroom for a loaded CI runner.
+REPLY_TIMEOUT_S = 120
+
+
+def _inbox(agent: str) -> str:
+    return f"/agents/{agent}/chat-with-me"
+
+
+def _wait_daemon_ready(timeout_s: int = 60) -> None:
+    deadline = time.time() + timeout_s
+    last = None
+    while time.time() < deadline:
+        stat = rh.vfs_stat(GRPC, "/", api_key=API_KEY, timeout=5)
+        if isinstance(stat, dict) and "error" not in stat:
+            return
+        last = stat
+        time.sleep(1)
+    pytest.fail(f"cohost daemon on {GRPC} never became reachable in {timeout_s}s (last={last})")
+
+
+def _decode(read_result) -> str:
+    if hasattr(rh, "decode_content"):
+        out = rh.decode_content(read_result)
+    else:
+        out = read_result
+    if isinstance(out, (bytes, bytearray)):
+        return out.decode("utf-8", "replace")
+    return out if isinstance(out, str) else str(out)
+
+
+def test_cohost_agent_replies_over_a2a_mailbox() -> None:
+    """A daemon-hosted co-host agent LLM-replies to a peer over the A2A mailbox."""
+    _wait_daemon_ready()
+
+    # 1. Spawn the responder via the control plane. The adapter binds it to its
+    #    replicated A2A inbox /agents/mac-ai/chat-with-me.
+    started = rh.grpc_call(
+        GRPC,
+        "managed_agent.start_session_v1",
+        {"agent_id": RESPONDER, "model": MODEL, "owner_id": "root", "zone_id": "root"},
+        api_key=API_KEY,
+        timeout=30,
+    )
+    assert "error" not in started, f"start_session failed: {started}"
+    assert started.get("result", {}).get("session_id"), f"no session_id: {started}"
+
+    # Give the loop a beat to arm its sys_watch on the inbox.
+    time.sleep(2)
+
+    # 2. Seed one message from win-ai into mac-ai's inbox.
+    envelope = json.dumps(
+        {
+            "from": SEEDER,
+            "to": RESPONDER,
+            "body": (
+                "You are being tested over a nexus A2A mailbox. "
+                "Reply with exactly one word: PONG"
+            ),
+        }
+    ).encode()
+    seeded = rh.vfs_write(GRPC, _inbox(RESPONDER), envelope, api_key=API_KEY)
+    assert "error" not in seeded, f"seed write failed: {seeded}"
+
+    # 3. The agent reads it, runs a real LLM turn, and send_message-replies into
+    #    the SEEDER's inbox. Poll for the reply.
+    deadline = time.time() + REPLY_TIMEOUT_S
+    reply_text = ""
+    while time.time() < deadline:
+        read = rh.vfs_read(GRPC, _inbox(SEEDER), api_key=API_KEY)
+        if not (isinstance(read, dict) and "error" in read):
+            body = _decode(read).strip()
+            if body:
+                reply_text = body
+                break
+        time.sleep(2)
+
+    assert reply_text, (
+        f"{RESPONDER} never replied into {_inbox(SEEDER)} within {REPLY_TIMEOUT_S}s"
+    )
+    # The reply is a MailboxEnvelope stamped from the responder, carrying its
+    # LLM output. Assert both the routing (from == responder) and the content.
+    parsed = json.loads(reply_text)
+    assert parsed.get("from") == RESPONDER, f"reply not from {RESPONDER}: {parsed}"
+    assert "PONG" in parsed.get("body", "").upper(), f"unexpected LLM reply: {parsed}"

--- a/tests/e2e/docker/test_cohost_duet_e2e.py
+++ b/tests/e2e/docker/test_cohost_duet_e2e.py
@@ -75,11 +75,8 @@ def _wait_daemon_ready(timeout_s: int = 60) -> None:
     pytest.fail(f"cohost daemon on {GRPC} never became reachable in {timeout_s}s (last={last})")
 
 
-def _decode(read_result) -> str:
-    if hasattr(rh, "decode_content"):
-        out = rh.decode_content(read_result)
-    else:
-        out = read_result
+def _decode(read_result: object) -> str:
+    out = rh.decode_content(read_result) if hasattr(rh, "decode_content") else read_result
     if isinstance(out, (bytes, bytearray)):
         return out.decode("utf-8", "replace")
     return out if isinstance(out, str) else str(out)


### PR DESCRIPTION
## What
A Docker E2E that runs a **real sudocode LLM agent** over the nexus A2A mailbox — the containerised counterpart of the in-process proof (sudocode `tools/tests/cohost_live_llm.rs`). It guards the just-merged spawn-`AgentState` collapse + `SudoCodeSpawnAdapter` path against regression, over the wire.

## Flow (proven locally, green)
`Call managed_agent.start_session_v1` spawns co-host `mac-ai` → `SudoCodeSpawnAdapter.spawn` → `spawn_managed_agent` binds it to `/agents/mac-ai/chat-with-me` → we seed `{from: win-ai, body: "…PONG"}` → the agent reads it, runs a **real LLM turn**, and `send_message`-replies `{"from":"mac-ai","to":"win-ai","body":"PONG"}` into `/agents/win-ai/chat-with-me`.

Local: image builds (165 MB), `docker compose up`, `pytest` green in ~20s.

## Files
- **`dockerfiles/Dockerfile.nexusd-cohost`** — builds `rust/nexusd --features cohost-sudocode`. Both PRIVATE git deps (nexus-vfs + sudocode) fetched via a **BuildKit token secret** (never baked into a layer). Aliyun apt mirror (the local China proxy 502s `deb.debian.org`; CI's clean network is unaffected).
- **`dockerfiles/docker-compose.cohost-duet.yml`** — single-node auth-off daemon; the entrypoint generates the agents' `sudocode.json` (`auth_modes.proxy.sudorouter`) from `SUDOROUTER_API_KEY` at boot, so the key stays in env, never in the image/repo.
- **`tests/e2e/docker/test_cohost_duet_e2e.py`** — reuses `runbook_helpers`; asserts the PONG routing. Skips unless the stack is up + a **funded** `SUDOROUTER_API_KEY` is present (a balance-capped key 403s the turn).
- **`.github/workflows/cohost-duet-e2e.yml`** — builds the image + runs the duet.

## Required repo secrets (documented in the workflow; it's a no-op without them)
- `COHOST_BUILD_TOKEN` — PAT with READ on **both** `nexi-lab/nexus-vfs` and `sudoprivacy/sudocode` (the default `GITHUB_TOKEN` can't reach the cross-org sudocode repo).
- `SUDOROUTER_API_KEY` — the funded sudorouter key (unlimited main pool).

Increment 1 (same-node). Increment 2 = 2-node federated (reuse the mtls-federation compose shape) so `/agents/*` replicates across nodes; then real Win↔macOS.