### PR TITLE
fix(http-api): reject in-token whitespace + share gRPC status table (#4700 audit)

### DIFF
--- a/rust/services/http-api/src/handlers/search.rs
+++ b/rust/services/http-api/src/handlers/search.rs
@@ -459,7 +459,15 @@ impl IntoResponse for SearchError {
     }
 }
 
-/// gRPC → HTTP status mapping.  Covers every `tonic::Code` variant
+/// gRPC → HTTP status mapping.  `pub(crate)` so `middleware::auth`
+/// delegates instead of maintaining its own subset table; a real
+/// `ApiKeyAuthProvider` can emit `ResourceExhausted` (rate limit)
+/// / `InvalidArgument` (malformed sk-key) which would otherwise
+/// silently degrade to 500 under a subset mapper.  Both routes
+/// (search-RPC and auth-RPC) share the same wire semantics — no
+/// reason to fork the table.
+///
+/// Covers every `tonic::Code` variant
 /// the proto SSOT (`nexus/search/v1/search.proto`) declares upstream
 /// can emit — plus the ambient retryable / auth codes any RPC can
 /// surface — so no legitimate upstream signal silently degrades to
@@ -486,7 +494,7 @@ impl IntoResponse for SearchError {
 /// as an HTTP error at all is a caller-side contract violation
 /// (`Ok` should never come through `Result::Err`), so 500 flags the
 /// bug rather than silently returning 200.
-fn grpc_status_to_http(code: tonic::Code) -> StatusCode {
+pub(crate) fn grpc_status_to_http(code: tonic::Code) -> StatusCode {
     match code {
         tonic::Code::InvalidArgument => StatusCode::BAD_REQUEST,
         tonic::Code::NotFound => StatusCode::NOT_FOUND,

--- a/rust/services/http-api/src/handlers/status.rs
+++ b/rust/services/http-api/src/handlers/status.rs
@@ -38,15 +38,11 @@ mod tests {
     use axum::http::{Request, StatusCode};
     use tower::ServiceExt;
 
-    use crate::search_backend::SearchBackend;
-
     fn test_state() -> AppState {
-        // Status handler does not touch the backend or auth; a dummy
-        // target that never gets dialed + NoAuth are fine.
-        AppState {
-            search: SearchBackend::new("http://127.0.0.1:1"),
-            auth: crate::middleware::auth::default_no_auth_provider(),
-        }
+        // Status handler does not touch the backend or auth; the
+        // `for_tests` helper's dummy target + NoAuth default fit
+        // exactly.
+        AppState::for_tests("http://127.0.0.1:1")
     }
 
     #[tokio::test]

--- a/rust/services/http-api/src/lib.rs
+++ b/rust/services/http-api/src/lib.rs
@@ -86,6 +86,26 @@ pub struct AppState {
     pub auth: Arc<dyn AuthProvider>,
 }
 
+impl AppState {
+    /// Convenience constructor for tests / probes that need a fully-
+    /// wired [`AppState`] but do not care about the exact backend
+    /// target or auth policy.  Wires the search backend at
+    /// `grpc_target` (dial-on-first-use — never dialed if the test
+    /// does not hit a search route) and the default `NoAuth`
+    /// provider so bearer parsing / rejection can be tested
+    /// separately.  Cheap: both fields are just `Arc` allocations.
+    ///
+    /// Not for production — the composition root in `nexusd` builds
+    /// the same struct field-by-field with the real `SearchBackend`
+    /// target + `ApiKeyAuthProvider`.
+    pub fn for_tests(grpc_target: impl Into<Arc<str>>) -> Self {
+        Self {
+            search: SearchBackend::new(grpc_target),
+            auth: middleware::auth::default_no_auth_provider(),
+        }
+    }
+}
+
 /// Root [`Router`] carrying every configured route domain.  Callers
 /// supply the [`AppState`] (which owns the upstream client caches)
 /// so the same crate can be exercised in tests against a mock

--- a/rust/services/http-api/src/middleware/auth.rs
+++ b/rust/services/http-api/src/middleware/auth.rs
@@ -99,6 +99,18 @@ pub fn parse_bearer(headers: &axum::http::HeaderMap) -> Result<Option<&str>, Aut
     if token.is_empty() {
         return Err(AuthRejection::MalformedHeader);
     }
+    // RFC 6750 §2.1: `b64token = 1*( ALPHA / DIGIT / "-" / "." / "_" /
+    // "~" / "+" / "/" ) *"="` — the token grammar admits NO whitespace.
+    // A header like `Bearer sk-good garbage` would otherwise trim to
+    // `"sk-good garbage"` and admit a weirdly-shaped value into log
+    // fields + the provider's `resolve` call.  Under `NoAuth` the whole
+    // string becomes the admin-context "token" — subtle correctness /
+    // observability bug.  Reject any embedded whitespace, treating it
+    // as the same MalformedHeader class as "Basic <b64>" / empty
+    // bearer.
+    if token.contains(char::is_whitespace) {
+        return Err(AuthRejection::MalformedHeader);
+    }
     Ok(Some(token))
 }
 
@@ -108,15 +120,17 @@ pub fn parse_bearer(headers: &axum::http::HeaderMap) -> Result<Option<&str>, Aut
 /// and denies a token-guessing attacker any per-attempt latency
 /// signal from the upstream).
 ///
-/// Status mapping matches the shared search-error contract:
-///   * malformed `Authorization` header → 401 Unauthorized
-///   * `tonic::Code::Unauthenticated` → 401 Unauthorized
-///   * `tonic::Code::PermissionDenied` → 403 Forbidden
-///   * `tonic::Code::Unavailable` → 503 Service Unavailable
-///   * `tonic::Code::DeadlineExceeded` → 504 Gateway Timeout
-///   * anything else (`Internal`, `Unknown`, etc.) → 500
+/// Malformed `Authorization` header → 401 Unauthorized.  All other
+/// mapping (including `Unauthenticated`, `PermissionDenied`,
+/// `ResourceExhausted`, `InvalidArgument`, `Unavailable`,
+/// `DeadlineExceeded`, `Unimplemented`, and the rest) delegates to
+/// the shared [`handlers::search::grpc_status_to_http`] table so
+/// both HTTP surfaces (search RPCs + auth-provider RPCs) speak the
+/// same wire semantics.
 ///
 /// Absent-header behaviour is provider-driven (see [`parse_bearer`]).
+///
+/// [`handlers::search::grpc_status_to_http`]: crate::handlers::search::grpc_status_to_http
 pub async fn require_bearer(
     State(state): State<AppState>,
     mut req: Request,
@@ -153,25 +167,18 @@ impl IntoResponse for AuthRejection {
                 StatusCode::UNAUTHORIZED,
                 "malformed Authorization header; expected `Bearer <token>`".to_string(),
             ),
-            AuthRejection::Rpc(s) => (status_for_auth_code(s.code()), s.message().to_string()),
+            AuthRejection::Rpc(s) => (
+                // Delegate to the shared search-module mapper — same
+                // wire semantics, no reason to fork the table.  A real
+                // `ApiKeyAuthProvider` emits `ResourceExhausted` (rate
+                // limit) → 429 and `InvalidArgument` (malformed sk-key)
+                // → 400 through the shared map; a local subset table
+                // silently swallowed both into 500 (audit finding).
+                crate::handlers::search::grpc_status_to_http(s.code()),
+                s.message().to_string(),
+            ),
         };
         (status, Json(serde_json::json!({ "error": message }))).into_response()
-    }
-}
-
-/// gRPC → HTTP mapping for auth resolution.  A tighter table than
-/// the general search mapper: an `AuthProvider` cannot legitimately
-/// emit `NotFound` / `AlreadyExists` / `ResourceExhausted` — its
-/// entire contract is "resolve credentials or reject" — so we surface
-/// only the codes it can meaningfully return + the transport-level
-/// (`Unavailable` / `DeadlineExceeded`) codes any RPC can produce.
-fn status_for_auth_code(code: tonic::Code) -> StatusCode {
-    match code {
-        tonic::Code::Unauthenticated => StatusCode::UNAUTHORIZED,
-        tonic::Code::PermissionDenied => StatusCode::FORBIDDEN,
-        tonic::Code::Unavailable => StatusCode::SERVICE_UNAVAILABLE,
-        tonic::Code::DeadlineExceeded => StatusCode::GATEWAY_TIMEOUT,
-        _ => StatusCode::INTERNAL_SERVER_ERROR,
     }
 }
 
@@ -249,29 +256,59 @@ mod tests {
     }
 
     #[test]
-    fn status_for_auth_code_maps_the_documented_table() {
-        assert_eq!(
-            status_for_auth_code(tonic::Code::Unauthenticated),
-            StatusCode::UNAUTHORIZED,
-        );
-        assert_eq!(
-            status_for_auth_code(tonic::Code::PermissionDenied),
-            StatusCode::FORBIDDEN,
-        );
-        assert_eq!(
-            status_for_auth_code(tonic::Code::Unavailable),
-            StatusCode::SERVICE_UNAVAILABLE,
-        );
-        assert_eq!(
-            status_for_auth_code(tonic::Code::DeadlineExceeded),
-            StatusCode::GATEWAY_TIMEOUT,
-        );
-        // Unmapped codes fall to 500 rather than degrade to 200 —
-        // matches the search-side mapper's fallback contract.
-        assert_eq!(
-            status_for_auth_code(tonic::Code::Internal),
-            StatusCode::INTERNAL_SERVER_ERROR,
-        );
+    fn parse_bearer_rejects_internal_whitespace_in_token() {
+        // RFC 6750 §2.1: `b64token` grammar admits NO whitespace.
+        // `Bearer sk-good garbage` would otherwise trim to
+        // `"sk-good garbage"` and slip past a NoAuth provider as
+        // "any token".  Reject as MalformedHeader.
+        //
+        // The HTTP header-value parser upstream already rejects
+        // CR/LF/NUL, so the only realistic in-token whitespace an
+        // attacker can inject is SP or HTAB.  Both must be caught
+        // here; the test-space vector below covers both plus a
+        // multi-token variant.
+        for header in [
+            "Bearer sk-good garbage",
+            "Bearer sk-x sk-y",
+            "Bearer sk-x\tsuffix",
+        ] {
+            let h = headers_with(header);
+            assert!(
+                matches!(parse_bearer(&h), Err(AuthRejection::MalformedHeader)),
+                "header {header:?} must reject internal whitespace",
+            );
+        }
+    }
+
+    #[test]
+    fn auth_rejection_rpc_covers_the_full_shared_status_table() {
+        // `AuthRejection::Rpc` now delegates to the shared search
+        // module mapper (`handlers::search::grpc_status_to_http`) —
+        // so a real `ApiKeyAuthProvider` returning
+        // `ResourceExhausted` (rate limit) surfaces as 429 not 500,
+        // and `InvalidArgument` (malformed sk-key) as 400 not 500.
+        // Pins the delegation instead of forking the mapping table.
+        use axum::response::IntoResponse;
+        for (code, expected) in [
+            (tonic::Code::Unauthenticated, StatusCode::UNAUTHORIZED),
+            (tonic::Code::PermissionDenied, StatusCode::FORBIDDEN),
+            (tonic::Code::Unavailable, StatusCode::SERVICE_UNAVAILABLE),
+            (tonic::Code::DeadlineExceeded, StatusCode::GATEWAY_TIMEOUT),
+            (
+                tonic::Code::ResourceExhausted,
+                StatusCode::TOO_MANY_REQUESTS,
+            ),
+            (tonic::Code::InvalidArgument, StatusCode::BAD_REQUEST),
+            (tonic::Code::Unimplemented, StatusCode::NOT_IMPLEMENTED),
+            (tonic::Code::Internal, StatusCode::INTERNAL_SERVER_ERROR),
+        ] {
+            let resp = AuthRejection::Rpc(tonic::Status::new(code, "test")).into_response();
+            assert_eq!(
+                resp.status(),
+                expected,
+                "code {code:?} must map to {expected}"
+            );
+        }
     }
 
     #[test]

--- a/rust/services/http-api/tests/glob_e2e.rs
+++ b/rust/services/http-api/tests/glob_e2e.rs
@@ -32,7 +32,7 @@ use nexus_http_api::search_proto::{
     RefreshRequest, RefreshResponse, RemoveIndexedDirectoryRequest, RemoveIndexedDirectoryResponse,
     SetZoneIndexingModeRequest, SetZoneIndexingModeResponse, StatsRequest, StatsResponse,
 };
-use nexus_http_api::{bind_and_serve, AppState, SearchBackend};
+use nexus_http_api::{bind_and_serve, AppState};
 use tokio::net::TcpListener;
 use tokio_stream::wrappers::TcpListenerStream;
 use tonic::{Request, Response, Status};
@@ -226,15 +226,11 @@ impl Harness {
 /// Spawn an HTTP listener bound to an OS-picked ephemeral port,
 /// pointed at `grpc_target`; return its base URL.
 async fn spawn_http_listener(grpc_target: String) -> String {
-    let state = AppState {
-        search: SearchBackend::new(grpc_target),
-        // These integration tests exercise the search route surface;
-        // NoAuth means the middleware lets every request through so
-        // the assertions here stay focused on the search chain, not
-        // on bearer parsing.  Dedicated bearer-parsing / rejection
-        // cover lives in `tests/auth_middleware_e2e.rs`.
-        auth: nexus_http_api::middleware::auth::default_no_auth_provider(),
-    };
+    // `for_tests` wires NoAuth so the middleware lets every request
+    // through — this file focuses on the glob route surface.
+    // Dedicated bearer-parsing cover lives in
+    // `tests/auth_middleware_e2e.rs`.
+    let state = AppState::for_tests(grpc_target);
     let (http_addr, fut) = bind_and_serve("127.0.0.1:0".parse().unwrap(), state)
         .await
         .expect("bind http listener");

--- a/rust/services/http-api/tests/grep_e2e.rs
+++ b/rust/services/http-api/tests/grep_e2e.rs
@@ -25,7 +25,7 @@ use nexus_http_api::search_proto::{
     RefreshRequest, RefreshResponse, RemoveIndexedDirectoryRequest, RemoveIndexedDirectoryResponse,
     SetZoneIndexingModeRequest, SetZoneIndexingModeResponse, StatsRequest, StatsResponse,
 };
-use nexus_http_api::{bind_and_serve, AppState, SearchBackend};
+use nexus_http_api::{bind_and_serve, AppState};
 use tokio::net::TcpListener;
 use tokio_stream::wrappers::TcpListenerStream;
 use tonic::{Request, Response, Status};
@@ -194,13 +194,9 @@ impl Harness {
 }
 
 async fn spawn_http_listener(grpc_target: String) -> String {
-    let state = AppState {
-        search: SearchBackend::new(grpc_target),
-        // NoAuth so this file's tests stay focused on the grep
-        // route surface; bearer parsing / rejection has its own
-        // cover in `tests/auth_middleware_e2e.rs`.
-        auth: nexus_http_api::middleware::auth::default_no_auth_provider(),
-    };
+    // `for_tests`: NoAuth so this file focuses on the grep route
+    // surface (bearer cover lives in `tests/auth_middleware_e2e.rs`).
+    let state = AppState::for_tests(grpc_target);
     let (http_addr, fut) = bind_and_serve("127.0.0.1:0".parse().unwrap(), state)
         .await
         .expect("bind http listener");

--- a/rust/services/http-api/tests/query_e2e.rs
+++ b/rust/services/http-api/tests/query_e2e.rs
@@ -33,7 +33,7 @@ use nexus_http_api::search_proto::{
     RemoveIndexedDirectoryResponse, SetZoneIndexingModeRequest, SetZoneIndexingModeResponse,
     StatsRequest, StatsResponse,
 };
-use nexus_http_api::{bind_and_serve, AppState, SearchBackend};
+use nexus_http_api::{bind_and_serve, AppState};
 use tokio::net::TcpListener;
 use tokio_stream::wrappers::TcpListenerStream;
 use tonic::{Request, Response, Status};
@@ -205,13 +205,9 @@ impl Harness {
 }
 
 async fn spawn_http_listener(grpc_target: String) -> String {
-    let state = AppState {
-        search: SearchBackend::new(grpc_target),
-        // NoAuth so this file's tests stay focused on the query
-        // route surface; bearer parsing / rejection has its own
-        // cover in `tests/auth_middleware_e2e.rs`.
-        auth: nexus_http_api::middleware::auth::default_no_auth_provider(),
-    };
+    // `for_tests`: NoAuth so this file focuses on the query route
+    // surface (bearer cover lives in `tests/auth_middleware_e2e.rs`).
+    let state = AppState::for_tests(grpc_target);
     let (http_addr, fut) = bind_and_serve("127.0.0.1:0".parse().unwrap(), state)
         .await
         .expect("bind http listener");

--- a/rust/services/http-api/tests/serve_e2e.rs
+++ b/rust/services/http-api/tests/serve_e2e.rs
@@ -11,7 +11,7 @@
 //! sibling test rather than a separate binary, so the listener setup
 //! is amortised.
 
-use nexus_http_api::{bind_and_serve, AppState, SearchBackend, StatusResponse};
+use nexus_http_api::{bind_and_serve, AppState, StatusResponse};
 
 /// Spawn the router on an ephemeral loopback port; return the base
 /// URL callers hit with `reqwest`.  Uses the crate's own
@@ -24,13 +24,9 @@ use nexus_http_api::{bind_and_serve, AppState, SearchBackend, StatusResponse};
 /// tests.  Backend-touching handlers get their own test binaries
 /// with a real mock server (`glob_e2e.rs`).
 async fn spawn_router() -> String {
-    let state = AppState {
-        search: SearchBackend::new("http://127.0.0.1:1"),
-        // Status is a PUBLIC route (bypasses auth) so this file's
-        // cover stays focused on the serve path; NoAuth here is
-        // only present because `AppState` mandates it.
-        auth: nexus_http_api::middleware::auth::default_no_auth_provider(),
-    };
+    // Status is a PUBLIC route; `for_tests` gives us a fully-wired
+    // AppState (dummy backend + NoAuth) with zero test-glue.
+    let state = AppState::for_tests("http://127.0.0.1:1");
     let (addr, fut) = bind_and_serve("127.0.0.1:0".parse().unwrap(), state)
         .await
         .expect("bind loopback ephemeral port");


### PR DESCRIPTION
## Summary

Three audit findings from #4700 review, each with a regression pin.

**#1 — `parse_bearer` admits internal whitespace** — RFC 6750 §2.1: `b64token` grammar admits NO whitespace. Pre-fix `Authorization: Bearer sk-good garbage` returned token `"sk-good garbage"`. Under NoAuth the whole weird string flowed into log fields + provider `resolve`. Fix: reject any embedded whitespace after trim → MalformedHeader → 401.

**#2 — `status_for_auth_code` swallowed retryable/caller-error codes** — Subset table covered only Unauthenticated/PermissionDenied/Unavailable/DeadlineExceeded; a real `ApiKeyAuthProvider` emitting `ResourceExhausted` (rate limit) or `InvalidArgument` (malformed sk-key) silently degraded to 500. Fix: promote `handlers::search::grpc_status_to_http` to `pub(crate)` and delegate — both surfaces speak the same wire semantics.

**#3 — `AppState::for_tests()` ergonomic constructor** — 5 test callers each hand-wired the same `AppState { search: SearchBackend::new(...), auth: default_no_auth_provider() }` literal. Fix: `AppState::for_tests(grpc_target)` collapses all 5 sites.

## Test cover

47 tests pass (15 lib + 5 auth-e2e + 7 glob + 5 grep + 13 query + 2 serve). 2 new lib tests pin whitespace rejection + delegated mapping. clippy + fmt clean.

## What still needs live cover (upfront cut)

No PR wires `ApiKeyAuthProvider` at a real composition root today — that lives in the pending nexusd-cluster wiring PR. Once that lands, a live-daemon test with a real sk-key hitting the real axum listener replaces the FixedBearer stub currently used in `auth_middleware_e2e.rs`.
