### PR TITLE
refactor(http-api): DRY parse_wire_enum + exhaustive gRPC map + drop tombstone mock variant (#4697 audit)

### DIFF
--- a/rust/services/http-api/src/handlers/search.rs
+++ b/rust/services/http-api/src/handlers/search.rs
@@ -307,50 +307,73 @@ pub struct QueryResponseBody {
     pub error: Option<String>,
 }
 
-/// Parse the `query_type` wire string into the proto enum.
+/// Shared "wire-string to proto enum" parser used by
+/// [`parse_query_type`] + [`parse_fusion_method`].
 ///
-/// Case-insensitive match against the three defined variants;
-/// empty string (field absent) matches the proto's
-/// `UNSPECIFIED = 0 ⇒ treated as keyword` posture and falls to
-/// `Keyword`.  A non-empty NON-matching value returns `Err` — a
-/// silent fall-through to `Keyword` would hide caller typos
-/// (`"semantik"`) as "keyword returned no hits" for weeks.  The
-/// caller maps `Err` to `400 Bad Request` so the client sees the
-/// typo immediately.
-fn parse_query_type(s: &str) -> Result<QueryType, String> {
+/// # Contract
+///
+/// * Empty `s` — returns `Ok(default)`.  Matches the proto's
+///   `UNSPECIFIED = 0` posture: an absent field means "server
+///   default", not an error.
+/// * Case-insensitive match against `variants` — returns `Ok(variant)`.
+/// * Non-empty NON-matching `s` — returns `Err` naming the field and
+///   listing the accepted values.  The caller maps this to `400 Bad
+///   Request` so a caller typo (`"semantik"`) surfaces as an
+///   actionable error instead of silently degrading to the default.
+///
+/// Extracted at the extract-on-second-occurrence trigger — both
+/// query_type and fusion_method share the identical
+/// "empty→default, N case-insensitive branches, else Err naming the
+/// field" template.
+fn parse_wire_enum<T: Copy>(
+    s: &str,
+    field: &str,
+    default: T,
+    variants: &[(&str, T)],
+) -> Result<T, String> {
     if s.is_empty() {
-        return Ok(QueryType::Keyword);
+        return Ok(default);
     }
-    if s.eq_ignore_ascii_case("keyword") {
-        Ok(QueryType::Keyword)
-    } else if s.eq_ignore_ascii_case("semantic") {
-        Ok(QueryType::Semantic)
-    } else if s.eq_ignore_ascii_case("hybrid") {
-        Ok(QueryType::Hybrid)
-    } else {
-        Err(format!(
-            "unknown query_type {s:?} (expected \"keyword\", \"semantic\", or \"hybrid\")"
-        ))
+    for (name, variant) in variants {
+        if s.eq_ignore_ascii_case(name) {
+            return Ok(*variant);
+        }
     }
+    let names: Vec<String> = variants.iter().map(|(n, _)| format!("\"{n}\"")).collect();
+    Err(format!(
+        "unknown {field} {s:?} (expected {})",
+        names.join(", ")
+    ))
+}
+
+/// Parse the `query_type` wire string into the proto enum.
+/// See [`parse_wire_enum`] for the shared empty-vs-typo contract.
+fn parse_query_type(s: &str) -> Result<QueryType, String> {
+    parse_wire_enum(
+        s,
+        "query_type",
+        QueryType::Keyword,
+        &[
+            ("keyword", QueryType::Keyword),
+            ("semantic", QueryType::Semantic),
+            ("hybrid", QueryType::Hybrid),
+        ],
+    )
 }
 
 /// Parse the `fusion_method` wire string into the proto enum.
-/// Same fail-loud contract as [`parse_query_type`].
+/// See [`parse_wire_enum`] for the shared empty-vs-typo contract.
 fn parse_fusion_method(s: &str) -> Result<FusionMethod, String> {
-    if s.is_empty() {
-        return Ok(FusionMethod::Rrf);
-    }
-    if s.eq_ignore_ascii_case("rrf") {
-        Ok(FusionMethod::Rrf)
-    } else if s.eq_ignore_ascii_case("weighted") {
-        Ok(FusionMethod::Weighted)
-    } else if s.eq_ignore_ascii_case("rrf_weighted") {
-        Ok(FusionMethod::RrfWeighted)
-    } else {
-        Err(format!(
-            "unknown fusion_method {s:?} (expected \"rrf\", \"weighted\", or \"rrf_weighted\")"
-        ))
-    }
+    parse_wire_enum(
+        s,
+        "fusion_method",
+        FusionMethod::Rrf,
+        &[
+            ("rrf", FusionMethod::Rrf),
+            ("weighted", FusionMethod::Weighted),
+            ("rrf_weighted", FusionMethod::RrfWeighted),
+        ],
+    )
 }
 
 fn hit_from_proto(r: ProtoQueryResult) -> QueryHit {
@@ -503,6 +526,17 @@ fn grpc_status_to_http(code: tonic::Code) -> StatusCode {
         // Ok / Cancelled / Unknown / Internal / DataLoss — no HTTP
         // status distinguishes these usefully to a caller.  500
         // ensures an unmapped upstream signal never surfaces as 200.
-        _ => StatusCode::INTERNAL_SERVER_ERROR,
+        //
+        // Exhaustive rather than `_` so a tonic upgrade that adds a
+        // new `Code` variant breaks the build here loudly instead of
+        // silently degrading production callers to 500.  When that
+        // happens: add the new variant with a considered HTTP mapping
+        // (or leave it in this fallback group with a docstring
+        // update) — do NOT add `_ => 500` back.
+        tonic::Code::Ok
+        | tonic::Code::Cancelled
+        | tonic::Code::Unknown
+        | tonic::Code::Internal
+        | tonic::Code::DataLoss => StatusCode::INTERNAL_SERVER_ERROR,
     }
 }

--- a/rust/services/http-api/tests/query_e2e.rs
+++ b/rust/services/http-api/tests/query_e2e.rs
@@ -51,15 +51,13 @@ enum MockBehaviour {
         results: Vec<QueryResult>,
         error: Option<String>,
     },
-    InvalidArgument(String),
     /// Upstream returns a specific `tonic::Code`.  Lets a test pin
     /// the full `code → HTTP status` mapping table in
     /// `handlers/search.rs::grpc_status_to_http` without a
-    /// per-variant enum blow-up here.
-    RpcCode {
-        code: tonic::Code,
-        message: String,
-    },
+    /// per-variant enum blow-up here.  Subsumes the earlier
+    /// `InvalidArgument(String)` variant (which was a strict subset
+    /// of `RpcCode { code: tonic::Code::InvalidArgument, .. }`).
+    RpcCode { code: tonic::Code, message: String },
 }
 
 #[derive(Clone)]
@@ -78,7 +76,6 @@ impl SearchService for MockSearchService {
                 results: results.clone(),
                 error: error.clone(),
             })),
-            MockBehaviour::InvalidArgument(msg) => Err(Status::invalid_argument(msg.clone())),
             MockBehaviour::RpcCode { code, message } => Err(Status::new(*code, message.clone())),
         }
     }
@@ -679,9 +676,10 @@ async fn query_missing_body_returns_400() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn query_upstream_invalid_argument_maps_to_400() {
-    let h = Harness::start(MockBehaviour::InvalidArgument(
-        "bad recency_weight: out of range".to_string(),
-    ))
+    let h = Harness::start(MockBehaviour::RpcCode {
+        code: tonic::Code::InvalidArgument,
+        message: "bad recency_weight: out of range".to_string(),
+    })
     .await;
     let resp = reqwest::Client::new()
         .post(format!("{}/v2/search/query", h.http_base))


### PR DESCRIPTION
## Summary

Three quality gaps from the #4697 audit — no correctness change, all three about keeping the file maintainable + failure-loud.

**#1 — Extract `parse_wire_enum` helper (DRY)** — `parse_query_type` + `parse_fusion_method` had structurally identical bodies. Extracted a generic `parse_wire_enum<T: Copy>(s, field, default, variants)` that both call with their default + variant table. Any third wire-enum field reuses the helper.

**#2 — `grpc_status_to_http` fallback is exhaustive** — Pre-fix `_ => 500` meant a tonic upgrade adding a new `Code` variant would silently degrade production to 500. Fix: enumerate the fallback set (`Ok | Cancelled | Unknown | Internal | DataLoss => 500`). New tonic variants now break the build here loudly with a docstring pointing the contributor to add a considered mapping.

**#3 — Delete tombstone `MockBehaviour::InvalidArgument`** — Previously #4697 added `MockBehaviour::RpcCode { code, message }` alongside the pre-existing `MockBehaviour::InvalidArgument(String)` without removing the latter. The old variant is a strict subset of the new. Fix: drop it; migrate the one caller to `RpcCode { code: tonic::Code::InvalidArgument, .. }`.

## Test cover

Full suite green: 14 lib + 5 auth-e2e + 7 glob + 5 grep + 13 query + 2 serve = 46. clippy `--all-targets` + fmt clean.
