### PR TITLE
fix(search-plugin): enforce cross-map SSOT in IndexState + close 3rd wire-reachable delete site (#4702 audit)

### DIFF
--- a/rust/services/search-plugin/src/index_state.rs
+++ b/rust/services/search-plugin/src/index_state.rs
@@ -319,10 +319,23 @@ impl IndexState {
     /// per-file after both FTS and ANN adds land, before the
     /// commit — so a mid-Refresh crash leaves the cache reflecting
     /// only files that made it through the writer transaction.
+    ///
+    /// # SSOT invariant — auto-purges any DT_STREAM checkpoint
+    ///
+    /// A path lives in EXACTLY ONE of `inner` (DT_REG) / `streams`
+    /// (DT_STREAM) at any time.  `record()` writes the DT_REG side
+    /// AND removes any lingering DT_STREAM checkpoint so the
+    /// invariant is enforced at the owner — callers do not need to
+    /// dispatch by entry-kind first.  Symmetric with
+    /// [`Self::stream_advance`].  If the invariant were caller-
+    /// enforced, three sites in `service.rs` had to guard it
+    /// individually (audit history: #4696 / #4702 / follow-ups);
+    /// moving the guard to the SSOT closes the whole class.
     pub fn record(&self, path: &str, mtime_ms: Option<i64>) {
         self.inner
             .write()
             .insert(path.to_string(), FileEntry { mtime_ms });
+        self.streams.write().remove(path);
     }
 
     /// Drop a path from the cache — called after the corresponding
@@ -352,6 +365,14 @@ impl IndexState {
     /// Never regresses the checkpoint — a stale caller trying to
     /// write a smaller value must call [`Self::forget_stream`]
     /// first, which is the retention-trim recovery path.
+    ///
+    /// # SSOT invariant — auto-purges any DT_REG entry
+    ///
+    /// Mirror of [`Self::record`]: the "path lives in at most one
+    /// map" invariant is owner-enforced.  A path that flips
+    /// DT_REG → DT_STREAM (e.g. a fresh `sys_setattr` on a
+    /// previously-regular path) automatically loses its FILES
+    /// entry when the stream side records its first checkpoint.
     pub fn stream_advance(
         &self,
         path: &str,
@@ -367,6 +388,33 @@ impl IndexState {
                 mtime_ms,
             },
         );
+        self.inner.write().remove(path);
+    }
+
+    /// Record a "known but has no verified content" tombstone —
+    /// keeps `path` visible to Refresh's stale-sweep while
+    /// forcing the next visit to verdict `Changed`.
+    ///
+    /// Auto-dispatches by current map presence so the tombstone
+    /// lands in the map that already tracks `path`:
+    ///   * Path already in the STREAMS map ⇒ `stream_advance(path,
+    ///     0, 0, None)` — preserves the "this is a stream"
+    ///     classification so a subsequent Refresh takes the
+    ///     DT_STREAM verdict path.
+    ///   * Otherwise ⇒ `record(path, None)` — the DT_REG default.
+    ///
+    /// After the call, `path` lives in exactly one map (the
+    /// auto-purge on [`Self::record`] / [`Self::stream_advance`]
+    /// enforces it).  Callers previously did this dispatch
+    /// inline via `if state.stream_state(path).is_some() { … }
+    /// else { … }` at 3 sites in `service.rs`; consolidating here
+    /// closes the "path in both maps" invariant at the owner.
+    pub fn tombstone(&self, path: &str) {
+        if self.streams.read().contains_key(path) {
+            self.stream_advance(path, 0, 0, None);
+        } else {
+            self.record(path, None);
+        }
     }
 
     /// Drop the checkpoint for `path` — retention-trim recovery
@@ -621,6 +669,88 @@ mod tests {
         let s = IndexState::open_or_create(dir).expect("reopen-2");
         assert!(!s.ensure_embedder_generation("tag-b"));
         assert!(s.ensure_embedder_generation("tag-a"));
+    }
+
+    #[test]
+    fn record_auto_purges_any_prior_stream_checkpoint_for_same_path() {
+        // SSOT invariant: a path lives in AT MOST one map.
+        // `record()` writing the DT_REG side must remove any stale
+        // DT_STREAM checkpoint for the same path — otherwise
+        // callers who forget to call `forget_stream` first (audit
+        // history: 3 sites in service.rs did this) leak the invariant.
+        let s = IndexState::open_or_create(tempdir()).expect("open");
+        s.stream_advance("/p", 100, 5, Some(1));
+        assert!(s.stream_state("/p").is_some());
+        s.record("/p", Some(2));
+        assert_eq!(
+            s.stream_state("/p"),
+            None,
+            "record() must auto-purge the stale DT_STREAM checkpoint",
+        );
+        assert_eq!(s.cached_mtime("/p"), Some(Some(2)));
+    }
+
+    #[test]
+    fn stream_advance_auto_purges_any_prior_file_entry_for_same_path() {
+        // Symmetric to record's auto-purge — path flipping
+        // DT_REG → DT_STREAM (e.g. fresh sys_setattr) must lose
+        // its FILES entry so `verdict()` reads a single-source
+        // truth.
+        let s = IndexState::open_or_create(tempdir()).expect("open");
+        s.record("/p", Some(1));
+        assert_eq!(s.cached_mtime("/p"), Some(Some(1)));
+        s.stream_advance("/p", 50, 3, Some(2));
+        assert_eq!(
+            s.cached_mtime("/p"),
+            None,
+            "stream_advance() must auto-purge the stale DT_REG entry",
+        );
+        assert!(s.stream_state("/p").is_some());
+    }
+
+    #[test]
+    fn tombstone_lands_in_streams_map_when_path_is_a_stream() {
+        // `tombstone(path)` — the tombstone helper collapses the
+        // pre-existing 3-site `if state.stream_state(path).is_some()
+        // { stream_advance(0,0,None) } else { record(None) }`
+        // dispatch into a single call.  For a DT_STREAM path the
+        // tombstone must land in the STREAMS map as a `(0, 0, None)`
+        // checkpoint, so the next Refresh takes the DT_STREAM
+        // verdict path (matches the visit's stat dispatch).
+        let s = IndexState::open_or_create(tempdir()).expect("open");
+        s.stream_advance("/stream", 42, 3, Some(1));
+        s.tombstone("/stream");
+        let stream = s.stream_state("/stream").expect("still in streams map");
+        assert_eq!(stream.indexed_byte_len, 0, "tombstone resets byte-len");
+        assert_eq!(stream.next_chunk_index, 0, "tombstone resets chunk-index");
+        assert_eq!(stream.mtime_ms, None, "tombstone drops mtime");
+        // And nothing leaked into the files map.
+        assert_eq!(s.cached_mtime("/stream"), None);
+    }
+
+    #[test]
+    fn tombstone_lands_in_files_map_when_path_is_a_regular_file() {
+        // Symmetric: a DT_REG path (or a not-yet-seen path)
+        // tombstones as `record(None)`, landing in the FILES map.
+        let s = IndexState::open_or_create(tempdir()).expect("open");
+        s.record("/reg", Some(1));
+        s.tombstone("/reg");
+        assert_eq!(s.cached_mtime("/reg"), Some(None), "tombstone drops mtime");
+        assert_eq!(
+            s.stream_state("/reg"),
+            None,
+            "regular-file tombstone must not leak into STREAMS map",
+        );
+    }
+
+    #[test]
+    fn tombstone_of_unknown_path_defaults_to_files_map() {
+        // A never-seen path has no prior classification; default to
+        // `record(None)` (matches the DT_REG-heavy Refresh sweep).
+        let s = IndexState::open_or_create(tempdir()).expect("open");
+        s.tombstone("/unknown");
+        assert_eq!(s.cached_mtime("/unknown"), Some(None));
+        assert_eq!(s.stream_state("/unknown"), None);
     }
 
     #[test]

--- a/rust/services/search-plugin/src/service.rs
+++ b/rust/services/search-plugin/src/service.rs
@@ -2439,7 +2439,6 @@ fn index_one_stream_full(
 /// (idempotent); the tombstone survives until a refresh with a
 /// working ANN sink completes the removal.
 fn remove_one(sinks: &IndexSinks<'_>, vfs_path: &str, zone_has_ann: bool) -> bool {
-    let was_stream = sinks.state.stream_state(vfs_path).is_some();
     sinks.fts.delete_all_chunks(vfs_path);
     match sinks.ann {
         Some(ann) => {
@@ -2455,18 +2454,11 @@ fn remove_one(sinks: &IndexSinks<'_>, vfs_path: &str, zone_has_ann: bool) -> boo
         None => {
             // Keep the tombstone: mtime None so the entry always
             // verdicts Changed and never masquerades as current.
-            // Preserve the checkpoint SHAPE — a DT_STREAM tombstone
-            // must land in the STREAMS map (as a `(0, 0, None)`
-            // checkpoint), not the FILES map, so a subsequent
-            // `verdict()` reads it from the right side and so
-            // `known_paths()` doesn't double-count.  Same SSOT
-            // invariant the sibling `record_content_skip` fix
-            // enforces (see `EntryKind` docs).
-            if was_stream {
-                sinks.state.stream_advance(vfs_path, 0, 0, None);
-            } else {
-                sinks.state.record(vfs_path, None);
-            }
+            // `tombstone()` picks the correct map (STREAMS if the
+            // path already checkpoints there, FILES otherwise) and
+            // auto-purges the other so the SSOT invariant holds —
+            // callers do not need to dispatch by entry-kind first.
+            sinks.state.tombstone(vfs_path);
             tracing::warn!(
                 path = %vfs_path,
                 "refresh sweep: ANN sink unavailable — kept deletion tombstone",
@@ -2861,7 +2853,6 @@ fn do_index_documents(
         // ANN → retry tombstone kept) — the zone did not converge
         // this pass (review R8).
         let content_skip = |path: &str| -> bool {
-            let was_stream = state.stream_state(path).is_some();
             fts.delete_all_chunks(path);
             match ann.as_ref() {
                 Some(a) => {
@@ -2872,17 +2863,9 @@ fn do_index_documents(
                 None if zone_has_ann => {
                     // Vectors may exist but are unreachable — retry
                     // tombstone so a later pass finishes the purge.
-                    // Same SSOT-preserving branch as `remove_one`'s
-                    // tombstone: a DT_STREAM path lands in the
-                    // STREAMS map, not the FILES map.  `Document`
-                    // paths are DT_REG-shaped in practice, but
-                    // nothing at the type level enforces that, so
-                    // the branch stays defensive.
-                    if was_stream {
-                        state.stream_advance(path, 0, 0, None);
-                    } else {
-                        state.record(path, None);
-                    }
+                    // `tombstone()` dispatches to the correct map
+                    // (matches the `remove_one` posture).
+                    state.tombstone(path);
                     true
                 }
                 None => {
@@ -3083,7 +3066,15 @@ fn do_notify_file_change(
             // would keep returning the deleted path (review R3).
             // Refresh sees the tombstone, misses the path in the
             // walk, and removes FTS remnants + ANN + state together.
-            state.record(path, None);
+            //
+            // `tombstone()` picks the correct map (STREAMS if the
+            // deleted path is a DT_STREAM, FILES otherwise); wire-
+            // reachable — a client can `NotifyFileChange{change_type=
+            // "delete", path=<DT_STREAM path>}` and pre-fix
+            // `state.record(path, None)` cross-wrote a stream path
+            // into the FILES map (same SSOT class as the earlier
+            // #4696 / #4702 fixes).
+            state.tombstone(path);
             if let Err(e) = fts.commit() {
                 return Err(format!("fts commit: {e}"));
             }

--- a/rust/services/search-plugin/tests/stream_append_incremental_e2e.rs
+++ b/rust/services/search-plugin/tests/stream_append_incremental_e2e.rs
@@ -527,16 +527,23 @@ async fn retention_trim_to_empty_records_stream_skip_in_streams_map_not_files_ma
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn deleted_stream_tombstone_never_lands_in_files_map() {
-    // Companion pin for the `remove_one` tombstone-branch fix.
-    // When ANN is unavailable during a sweep, `remove_one` keeps a
-    // tombstone (`mtime = None`) so the path stays in `known_paths()`
-    // and a later pass finishes the purge.  Pre-fix the tombstone
-    // always went to the FILES map — even for a DT_STREAM path —
-    // same cross-map class as `record_content_skip`.  This harness
-    // always has an ANN sink, so `remove_one` hits the
-    // successful-purge branch here; the assertion is broader — no
-    // branch of `remove_one` may leave a DT_STREAM path in the
-    // FILES map.
+    // Pin for the `remove_one` tombstone branch — the ACTUAL fixed
+    // branch, not just the surrounding surface.  The tombstone
+    // branch fires when `sinks.ann == None` (no embedder wired) BUT
+    // `zone_has_ann == true` (an `ann-*/` dir exists on disk from a
+    // prior indexing pass).  Force that combination by creating an
+    // empty `ann-KEYWORD/` dir before Refresh — otherwise
+    // `zone_has_ann_dir()` returns false and the sweep takes the
+    // early `state.forget()` branch, leaving the fixed code
+    // unexercised (a pre-audit test with the same shape passed even
+    // on pre-fix code because it never reached the fixed branch).
+    //
+    // Pre-fix, the tombstone always called `state.record(path, None)`
+    // regardless of the deleted path's entry-type, cross-writing a
+    // DT_STREAM path into the FILES map (SSOT violation → duplicate
+    // `known_paths()` entries → double-processing at the next sweep).
+    // Post-fix + the SSOT enforcement in `IndexState`, the tombstone
+    // lands in the STREAMS map for a DT_STREAM path.
     let h = Harness::start();
     let mock = h.mock_mut();
     mock.add_dir("/");
@@ -546,12 +553,71 @@ async fn deleted_stream_tombstone_never_lands_in_files_map() {
     assert!(stream_state_present(&h.zone_root, "/logs/audit"));
     assert!(!file_state_present(&h.zone_root, "/logs/audit"));
 
-    // Delete + Refresh → `remove_one` fires for the stream path.
+    // Force the fixed tombstone branch: create an empty ann-*/ dir
+    // so `zone_has_ann_dir()` returns true while `sinks.ann` stays
+    // None (no embedder wired in this harness).  `remove_one`'s
+    // pattern-match now falls through to `None if zone_has_ann` —
+    // the branch this test is meant to pin.
+    std::fs::create_dir_all(h.zone_root.join("ann-KEYWORD"))
+        .expect("create empty ann-*/ dir to force zone_has_ann=true");
+
+    // Delete + Refresh → `remove_one` fires the tombstone branch.
     h.mock_mut().remove_path("/logs/audit");
     let _ = refresh_root(&h.svc).await;
 
     assert!(
         !file_state_present(&h.zone_root, "/logs/audit"),
-        "SSOT violation: `remove_one` cross-wrote DT_STREAM path into FILES map",
+        "SSOT violation: `remove_one` tombstone cross-wrote DT_STREAM path into FILES map",
+    );
+    // Also positive: the tombstone landed in the STREAMS map (as a
+    // `(0, 0, None)` checkpoint) so `known_paths()` still returns
+    // the path for the next sweep to purge.
+    assert!(
+        stream_state_present(&h.zone_root, "/logs/audit"),
+        "tombstone must remain in STREAMS map so next refresh purges cleanly",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn notify_file_change_delete_of_stream_never_cross_writes() {
+    // Wire-reachable regression pin for the 3rd cross-map site.  A
+    // client can hit `NotifyFileChange{change_type="delete", path=
+    // <DT_STREAM path>}` and — pre-fix — `do_notify_file_change`'s
+    // delete branch unconditionally called `state.record(path, None)`,
+    // cross-writing a stream path into the FILES map.  Same SSOT
+    // class as #4696 / #4702.  Fix: dispatches via `state.tombstone(
+    // path)`, which lands in the STREAMS map for a stream path
+    // (and the FILES map for a DT_REG path).
+    let h = Harness::start();
+    let mock = h.mock_mut();
+    mock.add_dir("/");
+    mock.add_dir("/logs");
+    mock.add_stream("/logs/audit", b"turn-1: X\n", 1);
+    let _ = index_root(&h.svc).await;
+    assert!(stream_state_present(&h.zone_root, "/logs/audit"));
+
+    // Simulate the wire call — invoke the RPC surface directly.
+    use nexus_search_plugin::search_proto::NotifyFileChangeRequest;
+    let ack = h
+        .svc
+        .notify_file_change(Request::new(NotifyFileChangeRequest {
+            zone_id: "root".into(),
+            path: "/logs/audit".into(),
+            change_type: "delete".into(),
+            auth_token: String::new(),
+        }))
+        .await
+        .expect("notify_file_change")
+        .into_inner();
+    assert_eq!(ack.status, "accepted");
+
+    // SSOT invariant.
+    assert!(
+        !file_state_present(&h.zone_root, "/logs/audit"),
+        "SSOT violation: NotifyFileChange(delete) cross-wrote DT_STREAM path into FILES map",
+    );
+    assert!(
+        stream_state_present(&h.zone_root, "/logs/audit"),
+        "tombstone for DT_STREAM must remain in STREAMS map so the next refresh purges cleanly",
     );
 }


### PR DESCRIPTION
## Summary

Post-#4702 audit found the same bug class at a THIRD wire-reachable site (`NotifyFileChange(delete)` on a DT_STREAM path) AND that the `deleted_stream_tombstone_...` test pin from #4702 did not actually exercise the fixed branch (harness had no `ann-*` dir → sweep took the early `state.forget()` return). Rather than a 4th spot-fix, this PR moves the invariant enforcement into the SSOT owner.

## Root fix — enforce "path lives in one map" in IndexState

- `record()` — writes DT_REG side AND auto-purges any DT_STREAM checkpoint for `path`. Mirror of `forget()`.
- `stream_advance()` — writes STREAMS side AND auto-purges any DT_REG entry.
- New `pub fn tombstone(path)` — dispatches by current map presence. Collapses the 3-site inline `if state.stream_state(path).is_some() { … } else { … }` guard into one call.

Any future caller that writes to state cannot break the invariant — the owner enforces it unconditionally.

## Simplify callers

Three sites all become `state.tombstone(path)`:
- `remove_one` tombstone branch
- `content_skip` closure in `do_index_documents`
- `do_notify_file_change("delete")` — was `state.record(path, None)` unconditionally, the 3rd cross-map site (NEW FIX)

## Test cover

5 new lib unit tests in `index_state.rs` pinning auto-purge on record + stream_advance, tombstone dispatch for stream / regular / unknown paths.

Integration:
- `deleted_stream_tombstone_never_lands_in_files_map` — corrected to force `zone_has_ann_dir()=true` by creating an empty `ann-KEYWORD/` dir before the sweep. Previous comment ("harness always has an ANN sink") was factually wrong. Now actually exercises the fixed branch.
- `notify_file_change_delete_of_stream_never_cross_writes` — wire-reachable pin. Invokes the RPC surface directly.

## Full suite

252 lib tests + 9 stream_append_incremental_e2e. clippy + fmt clean.

## Why this closes the class

Previously the invariant was CALLER-enforced at N sites — every new caller had to remember the `if was_stream` guard. Audit found 3; the 3rd was defensive-only until it surfaced as reachable. Post-fix, a 4th site that writes without checking cannot break the invariant.
