### PR TITLE
chore(http-api): parse_bearer docstring + glob/grep mock tombstone cleanup (audit followups)

### DIFF
--- a/rust/services/http-api/src/middleware/auth.rs
+++ b/rust/services/http-api/src/middleware/auth.rs
@@ -74,10 +74,15 @@ use crate::AppState;
 ///   provider decides — `NoAuth` accepts, `ApiKeyAuthProvider`
 ///   rejects with `Unauthenticated`.
 /// * `Err(AuthRejection::MalformedHeader)` — the header is PRESENT
-///   but not a well-formed `Bearer <non-empty-token>` (wrong
-///   scheme, non-ASCII bytes, empty after `Bearer`).  A caller
-///   that ships an `Authorization` header CLEARLY intended to
-///   authenticate; a silent fall-through to empty-token would
+///   but not a well-formed `Bearer <non-empty-token>`:
+///     * wrong scheme (e.g. `Basic <b64>` / `Digest realm=…`),
+///     * non-ASCII bytes,
+///     * empty after `Bearer`, OR
+///     * contains embedded whitespace (SP / HTAB) after trim —
+///       RFC 6750 §2.1 `b64token` admits no whitespace.
+///
+///   A caller that ships an `Authorization` header CLEARLY intended
+///   to authenticate; a silent fall-through to empty-token would
 ///   read a `Basic dXNlcjpwYXNz` header as "no credentials" and
 ///   admit the request under `NoAuth`.  Reject immediately.
 ///

--- a/rust/services/http-api/tests/glob_e2e.rs
+++ b/rust/services/http-api/tests/glob_e2e.rs
@@ -56,7 +56,10 @@ enum MockBehaviour {
         truncated: bool,
         error: Option<String>,
     },
-    InvalidArgument(String),
+    /// Upstream returns a specific `tonic::Code`.  Same shape as the
+    /// query-side mock (see `query_e2e.rs`); subsumes the earlier
+    /// `InvalidArgument(String)` variant which was a strict subset.
+    RpcCode { code: tonic::Code, message: String },
 }
 
 #[derive(Clone)]
@@ -80,7 +83,7 @@ impl SearchService for MockSearchService {
                 truncated: *truncated,
                 error: error.clone(),
             })),
-            MockBehaviour::InvalidArgument(msg) => Err(Status::invalid_argument(msg.clone())),
+            MockBehaviour::RpcCode { code, message } => Err(Status::new(*code, message.clone())),
         }
     }
 
@@ -338,9 +341,10 @@ async fn glob_missing_pattern_returns_400() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn glob_upstream_invalid_argument_maps_to_400() {
-    let h = Harness::start(MockBehaviour::InvalidArgument(
-        "bad pattern: unbalanced bracket".to_string(),
-    ))
+    let h = Harness::start(MockBehaviour::RpcCode {
+        code: tonic::Code::InvalidArgument,
+        message: "bad pattern: unbalanced bracket".to_string(),
+    })
     .await;
 
     let resp = reqwest::Client::new()

--- a/rust/services/http-api/tests/grep_e2e.rs
+++ b/rust/services/http-api/tests/grep_e2e.rs
@@ -44,7 +44,10 @@ enum MockBehaviour {
         truncated: bool,
         error: Option<String>,
     },
-    InvalidArgument(String),
+    /// Upstream returns a specific `tonic::Code`.  Same shape as the
+    /// query-side + glob-side mocks; subsumes the earlier
+    /// `InvalidArgument(String)` variant which was a strict subset.
+    RpcCode { code: tonic::Code, message: String },
 }
 
 #[derive(Clone)]
@@ -68,7 +71,7 @@ impl SearchService for MockSearchService {
                 truncated: *truncated,
                 error: error.clone(),
             })),
-            MockBehaviour::InvalidArgument(msg) => Err(Status::invalid_argument(msg.clone())),
+            MockBehaviour::RpcCode { code, message } => Err(Status::new(*code, message.clone())),
         }
     }
 
@@ -323,9 +326,10 @@ async fn grep_missing_pattern_returns_400() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn grep_upstream_invalid_argument_maps_to_400() {
-    let h = Harness::start(MockBehaviour::InvalidArgument(
-        "bad regex: unclosed character class".to_string(),
-    ))
+    let h = Harness::start(MockBehaviour::RpcCode {
+        code: tonic::Code::InvalidArgument,
+        message: "bad regex: unclosed character class".to_string(),
+    })
     .await;
 
     let resp = reqwest::Client::new()


### PR DESCRIPTION
## Summary

Two audit-followup nits, no behaviour change.

**#1 — `parse_bearer` docstring drift** — The whitespace-rejection branch added in #4704 was documented as a mid-body inline comment but not in the "Return shape" bullet list. Extended the `MalformedHeader` bullet to enumerate the four rejection cases.

**#2 — Delete tombstone `MockBehaviour::InvalidArgument` in glob/grep e2e mocks** — #4705 removed the tombstone from the query mock; glob + grep e2e mocks still carried the identical subset variant. Same class — deleted; sole callers migrated to `RpcCode { code: tonic::Code::InvalidArgument, .. }`.

## Full suite

47 tests pass (unchanged count). clippy + fmt clean.
