### PR TITLE
chore(deps): bump nexus-vfs 08460a79 + sudocode 470939a5 (runtime-flavor bridge)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "a2a"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=f3031eef1cd21208e1729d7a06ab50399a13cd66#f3031eef1cd21208e1729d7a06ab50399a13cd66"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=08460a7909fa600baba3922a4f8852e351aeee42#08460a7909fa600baba3922a4f8852e351aeee42"
 dependencies = [
  "contracts",
  "kernel",
@@ -234,7 +234,7 @@ checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 [[package]]
 name = "api"
 version = "0.1.27"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=dd887ce186b75cf4b23a1905f3b6ea454016cf3a#dd887ce186b75cf4b23a1905f3b6ea454016cf3a"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=470939a5b7e11ef076b1e531703b8b3821c9f739#470939a5b7e11ef076b1e531703b8b3821c9f739"
 dependencies = [
  "base64 0.22.1",
  "httpdate",
@@ -327,7 +327,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 [[package]]
 name = "auth"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=f3031eef1cd21208e1729d7a06ab50399a13cd66#f3031eef1cd21208e1729d7a06ab50399a13cd66"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=08460a7909fa600baba3922a4f8852e351aeee42#08460a7909fa600baba3922a4f8852e351aeee42"
 dependencies = [
  "contracts",
  "dashmap",
@@ -430,7 +430,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=f3031eef1cd21208e1729d7a06ab50399a13cd66#f3031eef1cd21208e1729d7a06ab50399a13cd66"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=08460a7909fa600baba3922a4f8852e351aeee42#08460a7909fa600baba3922a4f8852e351aeee42"
 dependencies = [
  "ahash",
  "base64 0.22.1",
@@ -848,7 +848,7 @@ dependencies = [
 [[package]]
 name = "commands"
 version = "0.1.27"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=dd887ce186b75cf4b23a1905f3b6ea454016cf3a#dd887ce186b75cf4b23a1905f3b6ea454016cf3a"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=470939a5b7e11ef076b1e531703b8b3821c9f739#470939a5b7e11ef076b1e531703b8b3821c9f739"
 dependencies = [
  "plugins",
  "runtime",
@@ -917,7 +917,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=f3031eef1cd21208e1729d7a06ab50399a13cd66#f3031eef1cd21208e1729d7a06ab50399a13cd66"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=08460a7909fa600baba3922a4f8852e351aeee42#08460a7909fa600baba3922a4f8852e351aeee42"
 dependencies = [
  "parking_lot",
  "serde",
@@ -2540,7 +2540,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=f3031eef1cd21208e1729d7a06ab50399a13cd66#f3031eef1cd21208e1729d7a06ab50399a13cd66"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=08460a7909fa600baba3922a4f8852e351aeee42#08460a7909fa600baba3922a4f8852e351aeee42"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -2608,7 +2608,7 @@ checksum = "0c2cdeb66e45e9f36bfad5bbdb4d2384e70936afbee843c6f6543f0c551ebb25"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=f3031eef1cd21208e1729d7a06ab50399a13cd66#f3031eef1cd21208e1729d7a06ab50399a13cd66"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=08460a7909fa600baba3922a4f8852e351aeee42#08460a7909fa600baba3922a4f8852e351aeee42"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -2813,7 +2813,7 @@ checksum = "fc04a4c58212d57930a24bf47d3fa87485264a3a054e9c10e042eb373573ad3c"
 [[package]]
 name = "managed-agent"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=f3031eef1cd21208e1729d7a06ab50399a13cd66#f3031eef1cd21208e1729d7a06ab50399a13cd66"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=08460a7909fa600baba3922a4f8852e351aeee42#08460a7909fa600baba3922a4f8852e351aeee42"
 dependencies = [
  "a2a",
  "contracts",
@@ -3008,7 +3008,7 @@ dependencies = [
 [[package]]
 name = "nexus-cluster"
 version = "0.1.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=f3031eef1cd21208e1729d7a06ab50399a13cd66#f3031eef1cd21208e1729d7a06ab50399a13cd66"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=08460a7909fa600baba3922a4f8852e351aeee42#08460a7909fa600baba3922a4f8852e351aeee42"
 dependencies = [
  "a2a",
  "anyhow",
@@ -3085,7 +3085,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=f3031eef1cd21208e1729d7a06ab50399a13cd66#f3031eef1cd21208e1729d7a06ab50399a13cd66"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=08460a7909fa600baba3922a4f8852e351aeee42#08460a7909fa600baba3922a4f8852e351aeee42"
 
 [[package]]
 name = "nexus-search-plugin"
@@ -3143,7 +3143,7 @@ dependencies = [
 [[package]]
 name = "nexus-vfs-client"
 version = "0.1.27"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=dd887ce186b75cf4b23a1905f3b6ea454016cf3a#dd887ce186b75cf4b23a1905f3b6ea454016cf3a"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=470939a5b7e11ef076b1e531703b8b3821c9f739#470939a5b7e11ef076b1e531703b8b3821c9f739"
 dependencies = [
  "prost 0.13.5",
  "protoc-bin-vendored",
@@ -3599,7 +3599,7 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 [[package]]
 name = "plugins"
 version = "0.1.27"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=dd887ce186b75cf4b23a1905f3b6ea454016cf3a#dd887ce186b75cf4b23a1905f3b6ea454016cf3a"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=470939a5b7e11ef076b1e531703b8b3821c9f739#470939a5b7e11ef076b1e531703b8b3821c9f739"
 dependencies = [
  "serde",
  "serde_json",
@@ -4013,7 +4013,7 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 [[package]]
 name = "raft"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=f3031eef1cd21208e1729d7a06ab50399a13cd66#f3031eef1cd21208e1729d7a06ab50399a13cd66"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=08460a7909fa600baba3922a4f8852e351aeee42#08460a7909fa600baba3922a4f8852e351aeee42"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -4443,7 +4443,7 @@ dependencies = [
 [[package]]
 name = "runtime"
 version = "0.1.27"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=dd887ce186b75cf4b23a1905f3b6ea454016cf3a#dd887ce186b75cf4b23a1905f3b6ea454016cf3a"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=470939a5b7e11ef076b1e531703b8b3821c9f739#470939a5b7e11ef076b1e531703b8b3821c9f739"
 dependencies = [
  "a2a",
  "agent-client-protocol",
@@ -4461,6 +4461,7 @@ dependencies = [
  "image",
  "kernel",
  "keyring",
+ "lib",
  "nexus-vfs-client",
  "nix 0.29.0",
  "plugins",
@@ -5142,7 +5143,7 @@ dependencies = [
 [[package]]
 name = "subprocess"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=f3031eef1cd21208e1729d7a06ab50399a13cd66#f3031eef1cd21208e1729d7a06ab50399a13cd66"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=08460a7909fa600baba3922a4f8852e351aeee42#08460a7909fa600baba3922a4f8852e351aeee42"
 dependencies = [
  "kernel",
  "libc",
@@ -5361,7 +5362,7 @@ dependencies = [
 [[package]]
 name = "telemetry"
 version = "0.1.27"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=dd887ce186b75cf4b23a1905f3b6ea454016cf3a#dd887ce186b75cf4b23a1905f3b6ea454016cf3a"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=470939a5b7e11ef076b1e531703b8b3821c9f739#470939a5b7e11ef076b1e531703b8b3821c9f739"
 dependencies = [
  "chrono",
  "dirs",
@@ -5752,7 +5753,7 @@ dependencies = [
 [[package]]
 name = "tools"
 version = "0.1.27"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=dd887ce186b75cf4b23a1905f3b6ea454016cf3a#dd887ce186b75cf4b23a1905f3b6ea454016cf3a"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=470939a5b7e11ef076b1e531703b8b3821c9f739#470939a5b7e11ef076b1e531703b8b3821c9f739"
 dependencies = [
  "api",
  "async-trait",
@@ -5896,7 +5897,7 @@ dependencies = [
 [[package]]
 name = "transport"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=f3031eef1cd21208e1729d7a06ab50399a13cd66#f3031eef1cd21208e1729d7a06ab50399a13cd66"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=08460a7909fa600baba3922a4f8852e351aeee42#08460a7909fa600baba3922a4f8852e351aeee42"
 dependencies = [
  "axum",
  "backends",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -229,30 +229,30 @@ exclude = ["nexus-fuse"]
 #
 # Bump alongside the rest of nexus-vfs updates when a downstream
 # change needs newer kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "f3031eef1cd21208e1729d7a06ab50399a13cd66" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "f3031eef1cd21208e1729d7a06ab50399a13cd66" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "f3031eef1cd21208e1729d7a06ab50399a13cd66" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "f3031eef1cd21208e1729d7a06ab50399a13cd66", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "f3031eef1cd21208e1729d7a06ab50399a13cd66", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "f3031eef1cd21208e1729d7a06ab50399a13cd66", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "f3031eef1cd21208e1729d7a06ab50399a13cd66" }
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "08460a7909fa600baba3922a4f8852e351aeee42" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "08460a7909fa600baba3922a4f8852e351aeee42" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "08460a7909fa600baba3922a4f8852e351aeee42" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "08460a7909fa600baba3922a4f8852e351aeee42", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "08460a7909fa600baba3922a4f8852e351aeee42", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "08460a7909fa600baba3922a4f8852e351aeee42", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "08460a7909fa600baba3922a4f8852e351aeee42" }
 # The cluster daemon library entry (`nexus_cluster::run_with_services`),
 # consumed by the nexus-side assembly binary (`rust/nexusd`) that composes
 # the kernel/federation boot with the nexus service set via the
 # ServiceRegistry bring-up seam.
-nexus-cluster = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "f3031eef1cd21208e1729d7a06ab50399a13cd66" }
+nexus-cluster = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "08460a7909fa600baba3922a4f8852e351aeee42" }
 # a2a messaging substrate. `default-features = false` leaves the
 # `install` feature (which pulls raft to arm the stream-wakeup observer)
 # OFF, so nexus-side consumers link only the stamp hook and stay
 # raft-free — they reach raft through kernel.sys_* (§6.1). The substrate
 # is armed in production at cluster boot in nexus-vfs, not here.
-a2a = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "f3031eef1cd21208e1729d7a06ab50399a13cd66", default-features = false }
+a2a = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "08460a7909fa600baba3922a4f8852e351aeee42", default-features = false }
 # managed-agent control plane + the shared subprocess host — RELOCATED into
 # nexus-vfs (kernel-tier) so the production nexusd-cluster carries the agent
 # control plane. `subprocess-host` enables the raw ACP-subprocess spawner (the
 # nexus-side acp path + managed-agent both use HostedSubprocess).
-managed-agent = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "f3031eef1cd21208e1729d7a06ab50399a13cd66", default-features = false }
-subprocess = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "f3031eef1cd21208e1729d7a06ab50399a13cd66" }
+managed-agent = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "08460a7909fa600baba3922a4f8852e351aeee42", default-features = false }
+subprocess = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "08460a7909fa600baba3922a4f8852e351aeee42" }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir --no-deps --prefix=/install .
 # enforces agreement) — an unpinned install tracks nexus-vfs HEAD and
 # ships an untested kernel (#4343). --locked honors the source tree's
 # Cargo.lock.
-ARG NEXUS_VFS_REV=f3031eef1cd21208e1729d7a06ab50399a13cd66
+ARG NEXUS_VFS_REV=08460a7909fa600baba3922a4f8852e351aeee42
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-cluster nexus-cluster
 
 # -- Runtime stage --

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -25,7 +25,7 @@ WORKDIR /build
 # (CI preflight enforces agreement) — an unpinned install tracks HEAD
 # and can skew the raft contract against the cluster/witness images.
 # --locked honors the source tree's Cargo.lock.
-ARG NEXUS_VFS_REV=f3031eef1cd21208e1729d7a06ab50399a13cd66
+ARG NEXUS_VFS_REV=08460a7909fa600baba3922a4f8852e351aeee42
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexus-raft-server raft
 
 # ---------- Production image ----------

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=f3031eef1cd21208e1729d7a06ab50399a13cd66
+ARG NEXUS_VFS_REV=08460a7909fa600baba3922a4f8852e351aeee42
 RUN cargo install \
     --locked \
     --git https://github.com/nexi-lab/nexus-vfs \

--- a/rust/nexusd/Cargo.toml
+++ b/rust/nexusd/Cargo.toml
@@ -24,7 +24,7 @@ driver-s3 = ["dep:backends", "backends/driver-s3"]
 # carries `SudoCodeSpawnAdapter` next to the loop it wraps) and injects it
 # via `install_managed_agent_with_spawn`, so a minted agent runs a real LLM
 # loop doing in-process `KernelSyscall` calls (no gRPC on its fs path).
-# The kernel rev MUST match the workspace pin (both at nexus-vfs `f3031ee`)
+# The kernel rev MUST match the workspace pin (both at nexus-vfs `08460a7`)
 # so `SpawnTask<Kernel>` is one type across the seam.
 cohost-sudocode = ["dep:sudocode-tools"]
 
@@ -51,14 +51,14 @@ anyhow = "1"
 # ── Co-host (opt-in `cohost-sudocode`) ──────────────────────────────────
 # The real sudocode agent runtime, linked ONLY when co-hosting. `sudocode-
 # tools` reaches `kernel` at the SAME nexus-vfs rev the workspace pins
-# (`f3031ee`), so `Kernel` / `AgentDescriptor` / `KernelSyscall` / `AgentState`
+# (`08460a7`), so `Kernel` / `AgentDescriptor` / `KernelSyscall` / `AgentState`
 # unify across the seam and `SpawnTask<Kernel>` is a single monomorphised
 # type. `sudocode-tools` carries BOTH the `spawn_managed_agent` factory and
 # the `SudoCodeSpawnAdapter` this binary injects at boot — there is no
 # nexus-side co-host glue and no runtime enum to map (the adapter reports
 # `kernel::AgentState` directly). Pinned to sudocode main (spawn AgentState
 # collapse).
-sudocode-tools = { package = "tools", git = "https://github.com/sudoprivacy/sudocode", rev = "dd887ce186b75cf4b23a1905f3b6ea454016cf3a", optional = true }
+sudocode-tools = { package = "tools", git = "https://github.com/sudoprivacy/sudocode", rev = "470939a5b7e11ef076b1e531703b8b3821c9f739", optional = true }
 # Named directly to spell `kernel::kernel::{ServiceDecl, Kernel}` — the
 # managed-agent boot decl's return type (both builds) and the co-host
 # adapter's `SpawnTask<Kernel>` (cohost build). Already present transitively


### PR DESCRIPTION
Carries **nexus-vfs #249** (`lib::rt` — the SSOT sync→async bridge correct for any runtime flavor; retires the raft/kernel copies) + **sudocode #496** (bash tool bridge → `lib::rt::block_on_portable`) into the cohost binary. Together they unblock the co-host managed-agent's **current-thread** runtime crossing into async raft (federated mailbox reply-write) and running Bash tools without the `block_in_place` panic. Bumps 11 nexus-vfs pins + sudocode-tools + Cargo.lock + 3 Docker ARGs. Cohost binary builds clean against the real pins.