### PR TITLE
feat(nexusd): wire nexus-http-api as an opt-in ServiceDecl (R10)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,8 +7,19 @@ name = "a2a"
 version = "0.1.0"
 source = "git+https://github.com/nexi-lab/nexus-vfs?rev=08460a7909fa600baba3922a4f8852e351aeee42#08460a7909fa600baba3922a4f8852e351aeee42"
 dependencies = [
- "contracts",
- "kernel",
+ "contracts 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=08460a7909fa600baba3922a4f8852e351aeee42)",
+ "kernel 0.10.1 (git+https://github.com/nexi-lab/nexus-vfs?rev=08460a7909fa600baba3922a4f8852e351aeee42)",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "a2a"
+version = "0.1.0"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b#601c2af20b85a324496a7c95b8aba5cb20848e3b"
+dependencies = [
+ "contracts 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b)",
+ "kernel 0.10.1 (git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b)",
  "serde",
  "serde_json",
 ]
@@ -327,12 +338,12 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 [[package]]
 name = "auth"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=08460a7909fa600baba3922a4f8852e351aeee42#08460a7909fa600baba3922a4f8852e351aeee42"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b#601c2af20b85a324496a7c95b8aba5cb20848e3b"
 dependencies = [
- "contracts",
+ "contracts 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b)",
  "dashmap",
  "hmac 0.13.0",
- "kernel",
+ "kernel 0.10.1 (git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b)",
  "parking_lot",
  "rand 0.10.2",
  "serde",
@@ -430,13 +441,13 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=08460a7909fa600baba3922a4f8852e351aeee42#08460a7909fa600baba3922a4f8852e351aeee42"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b#601c2af20b85a324496a7c95b8aba5cb20848e3b"
 dependencies = [
  "ahash",
  "base64 0.22.1",
  "blake3",
  "chrono",
- "contracts",
+ "contracts 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b)",
  "crc32fast",
  "dashmap",
  "encoding_rs",
@@ -444,8 +455,8 @@ dependencies = [
  "futures",
  "globset",
  "hmac 0.13.0",
- "kernel",
- "lib",
+ "kernel 0.10.1 (git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b)",
+ "lib 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b)",
  "libc",
  "lru 0.18.1",
  "memchr",
@@ -918,6 +929,15 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 name = "contracts"
 version = "0.1.0"
 source = "git+https://github.com/nexi-lab/nexus-vfs?rev=08460a7909fa600baba3922a4f8852e351aeee42#08460a7909fa600baba3922a4f8852e351aeee42"
+dependencies = [
+ "parking_lot",
+ "serde",
+]
+
+[[package]]
+name = "contracts"
+version = "0.1.0"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b#601c2af20b85a324496a7c95b8aba5cb20848e3b"
 dependencies = [
  "parking_lot",
  "serde",
@@ -2549,20 +2569,66 @@ dependencies = [
  "bloomfilter",
  "bytes",
  "chrono",
- "contracts",
+ "contracts 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=08460a7909fa600baba3922a4f8852e351aeee42)",
  "crc32fast",
  "dashmap",
  "ed25519-dalek",
  "fastcdc",
  "futures",
  "globset",
- "lib",
+ "lib 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=08460a7909fa600baba3922a4f8852e351aeee42)",
  "libc",
  "libloading 0.8.9",
  "lru 0.18.1",
  "memchr",
  "memmap2",
- "nexus-plugin-abi",
+ "nexus-plugin-abi 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=08460a7909fa600baba3922a4f8852e351aeee42)",
+ "parking_lot",
+ "prost 0.14.4",
+ "protoc-bin-vendored",
+ "rayon",
+ "redb",
+ "regex",
+ "roaring",
+ "serde",
+ "serde_json",
+ "smallvec",
+ "string-interner",
+ "tempfile",
+ "tokio",
+ "tonic 0.14.6",
+ "tonic-prost",
+ "tonic-prost-build",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "kernel"
+version = "0.10.1"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b#601c2af20b85a324496a7c95b8aba5cb20848e3b"
+dependencies = [
+ "ahash",
+ "arc-swap",
+ "base64 0.22.1",
+ "blake3",
+ "bloomfilter",
+ "bytes",
+ "chrono",
+ "contracts 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b)",
+ "crc32fast",
+ "dashmap",
+ "ed25519-dalek",
+ "fastcdc",
+ "futures",
+ "globset",
+ "lib 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b)",
+ "libc",
+ "libloading 0.8.9",
+ "lru 0.18.1",
+ "memchr",
+ "memmap2",
+ "nexus-plugin-abi 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b)",
  "parking_lot",
  "prost 0.14.4",
  "protoc-bin-vendored",
@@ -2614,7 +2680,43 @@ dependencies = [
  "arc-swap",
  "base64 0.22.1",
  "blake3",
- "contracts",
+ "contracts 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=08460a7909fa600baba3922a4f8852e351aeee42)",
+ "crc32fast",
+ "dashmap",
+ "getrandom 0.4.3",
+ "globset",
+ "memchr",
+ "parking_lot",
+ "pem",
+ "regex",
+ "regex-syntax",
+ "ring",
+ "roaring",
+ "rustls",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "string-interner",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "tokio-rustls",
+ "tokio-stream",
+ "tonic 0.14.6",
+ "tracing",
+ "x509-parser",
+]
+
+[[package]]
+name = "lib"
+version = "0.1.0"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b#601c2af20b85a324496a7c95b8aba5cb20848e3b"
+dependencies = [
+ "ahash",
+ "arc-swap",
+ "base64 0.22.1",
+ "blake3",
+ "contracts 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b)",
  "crc32fast",
  "dashmap",
  "getrandom 0.4.3",
@@ -2815,10 +2917,27 @@ name = "managed-agent"
 version = "0.1.0"
 source = "git+https://github.com/nexi-lab/nexus-vfs?rev=08460a7909fa600baba3922a4f8852e351aeee42#08460a7909fa600baba3922a4f8852e351aeee42"
 dependencies = [
- "a2a",
- "contracts",
+ "a2a 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=08460a7909fa600baba3922a4f8852e351aeee42)",
+ "contracts 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=08460a7909fa600baba3922a4f8852e351aeee42)",
  "dashmap",
- "kernel",
+ "kernel 0.10.1 (git+https://github.com/nexi-lab/nexus-vfs?rev=08460a7909fa600baba3922a4f8852e351aeee42)",
+ "parking_lot",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "managed-agent"
+version = "0.1.0"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b#601c2af20b85a324496a7c95b8aba5cb20848e3b"
+dependencies = [
+ "a2a 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b)",
+ "contracts 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b)",
+ "dashmap",
+ "kernel 0.10.1 (git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b)",
  "parking_lot",
  "serde",
  "serde_json",
@@ -3008,17 +3127,17 @@ dependencies = [
 [[package]]
 name = "nexus-cluster"
 version = "0.1.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=08460a7909fa600baba3922a4f8852e351aeee42#08460a7909fa600baba3922a4f8852e351aeee42"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b#601c2af20b85a324496a7c95b8aba5cb20848e3b"
 dependencies = [
- "a2a",
+ "a2a 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b)",
  "anyhow",
  "auth",
  "backends",
  "clap",
- "contracts",
+ "contracts 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b)",
  "gethostname",
- "kernel",
- "managed-agent",
+ "kernel 0.10.1 (git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b)",
+ "managed-agent 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b)",
  "raft 0.1.0",
  "rand 0.10.2",
  "tokio",
@@ -3036,7 +3155,7 @@ dependencies = [
  "async-trait",
  "fuser",
  "libc",
- "nexus-plugin-abi",
+ "nexus-plugin-abi 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b)",
  "nfsserve",
  "tempfile",
  "tokio",
@@ -3051,9 +3170,10 @@ name = "nexus-http-api"
 version = "0.1.0"
 dependencies = [
  "axum",
- "contracts",
+ "contracts 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b)",
  "dashmap",
  "http-body-util",
+ "kernel 0.10.1 (git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b)",
  "prost 0.14.4",
  "protoc-bin-vendored",
  "reqwest 0.12.28",
@@ -3075,8 +3195,8 @@ name = "nexus-local-connector"
 version = "0.1.1"
 dependencies = [
  "backends",
- "kernel",
- "nexus-plugin-abi",
+ "kernel 0.10.1 (git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b)",
+ "nexus-plugin-abi 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b)",
  "serde_json",
  "tempfile",
  "tracing",
@@ -3086,6 +3206,11 @@ dependencies = [
 name = "nexus-plugin-abi"
 version = "0.1.0"
 source = "git+https://github.com/nexi-lab/nexus-vfs?rev=08460a7909fa600baba3922a4f8852e351aeee42#08460a7909fa600baba3922a4f8852e351aeee42"
+
+[[package]]
+name = "nexus-plugin-abi"
+version = "0.1.0"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b#601c2af20b85a324496a7c95b8aba5cb20848e3b"
 
 [[package]]
 name = "nexus-search-plugin"
@@ -3100,7 +3225,7 @@ dependencies = [
  "hnsw_rs",
  "libloading 0.8.9",
  "mimalloc",
- "nexus-plugin-abi",
+ "nexus-plugin-abi 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b)",
  "ort",
  "parking_lot",
  "prost 0.14.4",
@@ -3126,9 +3251,9 @@ version = "0.1.4"
 dependencies = [
  "backends",
  "clap",
- "kernel",
+ "kernel 0.10.1 (git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b)",
  "libloading 0.8.9",
- "nexus-plugin-abi",
+ "nexus-plugin-abi 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b)",
  "prost 0.14.4",
  "services",
  "tempfile",
@@ -3157,13 +3282,15 @@ dependencies = [
 name = "nexusd"
 version = "0.1.0"
 dependencies = [
- "a2a",
+ "a2a 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b)",
  "anyhow",
  "backends",
- "kernel",
- "managed-agent",
+ "kernel 0.10.1 (git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b)",
+ "managed-agent 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b)",
  "nexus-cluster",
+ "nexus-http-api",
  "tools",
+ "tracing",
 ]
 
 [[package]]
@@ -4013,16 +4140,16 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 [[package]]
 name = "raft"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=08460a7909fa600baba3922a4f8852e351aeee42#08460a7909fa600baba3922a4f8852e351aeee42"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b#601c2af20b85a324496a7c95b8aba5cb20848e3b"
 dependencies = [
  "base64 0.22.1",
  "bincode",
  "bytes",
- "contracts",
+ "contracts 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b)",
  "dashmap",
  "gethostname",
- "kernel",
- "lib",
+ "kernel 0.10.1 (git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b)",
+ "lib 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b)",
  "parking_lot",
  "pem",
  "prost 0.14.4",
@@ -4445,7 +4572,7 @@ name = "runtime"
 version = "0.1.27"
 source = "git+https://github.com/sudoprivacy/sudocode?rev=470939a5b7e11ef076b1e531703b8b3821c9f739#470939a5b7e11ef076b1e531703b8b3821c9f739"
 dependencies = [
- "a2a",
+ "a2a 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=08460a7909fa600baba3922a4f8852e351aeee42)",
  "agent-client-protocol",
  "agent-client-protocol-schema",
  "agent-client-protocol-tokio",
@@ -4459,9 +4586,9 @@ dependencies = [
  "getrandom 0.2.17",
  "glob",
  "image",
- "kernel",
+ "kernel 0.10.1 (git+https://github.com/nexi-lab/nexus-vfs?rev=08460a7909fa600baba3922a4f8852e351aeee42)",
  "keyring",
- "lib",
+ "lib 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=08460a7909fa600baba3922a4f8852e351aeee42)",
  "nexus-vfs-client",
  "nix 0.29.0",
  "plugins",
@@ -4856,19 +4983,19 @@ dependencies = [
 name = "services"
 version = "0.1.0"
 dependencies = [
- "a2a",
+ "a2a 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b)",
  "aes-gcm",
  "async-trait",
  "axum",
  "base32",
  "bincode",
  "chrono",
- "contracts",
+ "contracts 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b)",
  "dashmap",
  "fjall",
  "futures",
  "hmac 0.12.1",
- "kernel",
+ "kernel 0.10.1 (git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b)",
  "libc",
  "parking_lot",
  "prost 0.14.4",
@@ -5143,9 +5270,9 @@ dependencies = [
 [[package]]
 name = "subprocess"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=08460a7909fa600baba3922a4f8852e351aeee42#08460a7909fa600baba3922a4f8852e351aeee42"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b#601c2af20b85a324496a7c95b8aba5cb20848e3b"
 dependencies = [
- "kernel",
+ "kernel 0.10.1 (git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b)",
  "libc",
  "tokio",
 ]
@@ -5761,7 +5888,7 @@ dependencies = [
  "commands",
  "flate2",
  "futures",
- "managed-agent",
+ "managed-agent 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=08460a7909fa600baba3922a4f8852e351aeee42)",
  "plugins",
  "reqwest 0.12.28",
  "runtime",
@@ -5897,21 +6024,21 @@ dependencies = [
 [[package]]
 name = "transport"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=08460a7909fa600baba3922a4f8852e351aeee42#08460a7909fa600baba3922a4f8852e351aeee42"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b#601c2af20b85a324496a7c95b8aba5cb20848e3b"
 dependencies = [
  "axum",
  "backends",
  "base64 0.22.1",
  "bytes",
  "chrono",
- "contracts",
+ "contracts 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b)",
  "dashmap",
  "futures",
  "http",
  "http-body",
  "http-body-util",
- "kernel",
- "lib",
+ "kernel 0.10.1 (git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b)",
+ "lib 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b)",
  "parking_lot",
  "pem",
  "prost 0.14.4",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,21 +5,10 @@ version = 4
 [[package]]
 name = "a2a"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=08460a7909fa600baba3922a4f8852e351aeee42#08460a7909fa600baba3922a4f8852e351aeee42"
-dependencies = [
- "contracts 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=08460a7909fa600baba3922a4f8852e351aeee42)",
- "kernel 0.10.1 (git+https://github.com/nexi-lab/nexus-vfs?rev=08460a7909fa600baba3922a4f8852e351aeee42)",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "a2a"
-version = "0.1.0"
 source = "git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b#601c2af20b85a324496a7c95b8aba5cb20848e3b"
 dependencies = [
- "contracts 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b)",
- "kernel 0.10.1 (git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b)",
+ "contracts",
+ "kernel",
  "serde",
  "serde_json",
 ]
@@ -245,7 +234,7 @@ checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 [[package]]
 name = "api"
 version = "0.1.27"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=470939a5b7e11ef076b1e531703b8b3821c9f739#470939a5b7e11ef076b1e531703b8b3821c9f739"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=c638b5c3b646a925ade780461a662a5d92e5099b#c638b5c3b646a925ade780461a662a5d92e5099b"
 dependencies = [
  "base64 0.22.1",
  "httpdate",
@@ -340,10 +329,10 @@ name = "auth"
 version = "0.1.0"
 source = "git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b#601c2af20b85a324496a7c95b8aba5cb20848e3b"
 dependencies = [
- "contracts 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b)",
+ "contracts",
  "dashmap",
  "hmac 0.13.0",
- "kernel 0.10.1 (git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b)",
+ "kernel",
  "parking_lot",
  "rand 0.10.2",
  "serde",
@@ -447,7 +436,7 @@ dependencies = [
  "base64 0.22.1",
  "blake3",
  "chrono",
- "contracts 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b)",
+ "contracts",
  "crc32fast",
  "dashmap",
  "encoding_rs",
@@ -455,8 +444,8 @@ dependencies = [
  "futures",
  "globset",
  "hmac 0.13.0",
- "kernel 0.10.1 (git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b)",
- "lib 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b)",
+ "kernel",
+ "lib",
  "libc",
  "lru 0.18.1",
  "memchr",
@@ -859,7 +848,7 @@ dependencies = [
 [[package]]
 name = "commands"
 version = "0.1.27"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=470939a5b7e11ef076b1e531703b8b3821c9f739#470939a5b7e11ef076b1e531703b8b3821c9f739"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=c638b5c3b646a925ade780461a662a5d92e5099b#c638b5c3b646a925ade780461a662a5d92e5099b"
 dependencies = [
  "plugins",
  "runtime",
@@ -924,15 +913,6 @@ name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
-
-[[package]]
-name = "contracts"
-version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=08460a7909fa600baba3922a4f8852e351aeee42#08460a7909fa600baba3922a4f8852e351aeee42"
-dependencies = [
- "parking_lot",
- "serde",
-]
 
 [[package]]
 name = "contracts"
@@ -2560,52 +2540,6 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=08460a7909fa600baba3922a4f8852e351aeee42#08460a7909fa600baba3922a4f8852e351aeee42"
-dependencies = [
- "ahash",
- "arc-swap",
- "base64 0.22.1",
- "blake3",
- "bloomfilter",
- "bytes",
- "chrono",
- "contracts 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=08460a7909fa600baba3922a4f8852e351aeee42)",
- "crc32fast",
- "dashmap",
- "ed25519-dalek",
- "fastcdc",
- "futures",
- "globset",
- "lib 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=08460a7909fa600baba3922a4f8852e351aeee42)",
- "libc",
- "libloading 0.8.9",
- "lru 0.18.1",
- "memchr",
- "memmap2",
- "nexus-plugin-abi 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=08460a7909fa600baba3922a4f8852e351aeee42)",
- "parking_lot",
- "prost 0.14.4",
- "protoc-bin-vendored",
- "rayon",
- "redb",
- "regex",
- "roaring",
- "serde",
- "serde_json",
- "smallvec",
- "string-interner",
- "tempfile",
- "tokio",
- "tonic 0.14.6",
- "tonic-prost",
- "tonic-prost-build",
- "tracing",
- "uuid",
-]
-
-[[package]]
-name = "kernel"
-version = "0.10.1"
 source = "git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b#601c2af20b85a324496a7c95b8aba5cb20848e3b"
 dependencies = [
  "ahash",
@@ -2615,20 +2549,20 @@ dependencies = [
  "bloomfilter",
  "bytes",
  "chrono",
- "contracts 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b)",
+ "contracts",
  "crc32fast",
  "dashmap",
  "ed25519-dalek",
  "fastcdc",
  "futures",
  "globset",
- "lib 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b)",
+ "lib",
  "libc",
  "libloading 0.8.9",
  "lru 0.18.1",
  "memchr",
  "memmap2",
- "nexus-plugin-abi 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b)",
+ "nexus-plugin-abi",
  "parking_lot",
  "prost 0.14.4",
  "protoc-bin-vendored",
@@ -2674,49 +2608,13 @@ checksum = "0c2cdeb66e45e9f36bfad5bbdb4d2384e70936afbee843c6f6543f0c551ebb25"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=08460a7909fa600baba3922a4f8852e351aeee42#08460a7909fa600baba3922a4f8852e351aeee42"
-dependencies = [
- "ahash",
- "arc-swap",
- "base64 0.22.1",
- "blake3",
- "contracts 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=08460a7909fa600baba3922a4f8852e351aeee42)",
- "crc32fast",
- "dashmap",
- "getrandom 0.4.3",
- "globset",
- "memchr",
- "parking_lot",
- "pem",
- "regex",
- "regex-syntax",
- "ring",
- "roaring",
- "rustls",
- "serde",
- "serde_json",
- "sha2 0.11.0",
- "string-interner",
- "thiserror 2.0.18",
- "time",
- "tokio",
- "tokio-rustls",
- "tokio-stream",
- "tonic 0.14.6",
- "tracing",
- "x509-parser",
-]
-
-[[package]]
-name = "lib"
-version = "0.1.0"
 source = "git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b#601c2af20b85a324496a7c95b8aba5cb20848e3b"
 dependencies = [
  "ahash",
  "arc-swap",
  "base64 0.22.1",
  "blake3",
- "contracts 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b)",
+ "contracts",
  "crc32fast",
  "dashmap",
  "getrandom 0.4.3",
@@ -2915,29 +2813,12 @@ checksum = "fc04a4c58212d57930a24bf47d3fa87485264a3a054e9c10e042eb373573ad3c"
 [[package]]
 name = "managed-agent"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=08460a7909fa600baba3922a4f8852e351aeee42#08460a7909fa600baba3922a4f8852e351aeee42"
-dependencies = [
- "a2a 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=08460a7909fa600baba3922a4f8852e351aeee42)",
- "contracts 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=08460a7909fa600baba3922a4f8852e351aeee42)",
- "dashmap",
- "kernel 0.10.1 (git+https://github.com/nexi-lab/nexus-vfs?rev=08460a7909fa600baba3922a4f8852e351aeee42)",
- "parking_lot",
- "serde",
- "serde_json",
- "tokio",
- "tracing",
- "uuid",
-]
-
-[[package]]
-name = "managed-agent"
-version = "0.1.0"
 source = "git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b#601c2af20b85a324496a7c95b8aba5cb20848e3b"
 dependencies = [
- "a2a 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b)",
- "contracts 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b)",
+ "a2a",
+ "contracts",
  "dashmap",
- "kernel 0.10.1 (git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b)",
+ "kernel",
  "parking_lot",
  "serde",
  "serde_json",
@@ -3129,15 +3010,15 @@ name = "nexus-cluster"
 version = "0.1.1"
 source = "git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b#601c2af20b85a324496a7c95b8aba5cb20848e3b"
 dependencies = [
- "a2a 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b)",
+ "a2a",
  "anyhow",
  "auth",
  "backends",
  "clap",
- "contracts 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b)",
+ "contracts",
  "gethostname",
- "kernel 0.10.1 (git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b)",
- "managed-agent 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b)",
+ "kernel",
+ "managed-agent",
  "raft 0.1.0",
  "rand 0.10.2",
  "tokio",
@@ -3155,7 +3036,7 @@ dependencies = [
  "async-trait",
  "fuser",
  "libc",
- "nexus-plugin-abi 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b)",
+ "nexus-plugin-abi",
  "nfsserve",
  "tempfile",
  "tokio",
@@ -3170,10 +3051,10 @@ name = "nexus-http-api"
 version = "0.1.0"
 dependencies = [
  "axum",
- "contracts 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b)",
+ "contracts",
  "dashmap",
  "http-body-util",
- "kernel 0.10.1 (git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b)",
+ "kernel",
  "prost 0.14.4",
  "protoc-bin-vendored",
  "reqwest 0.12.28",
@@ -3195,17 +3076,12 @@ name = "nexus-local-connector"
 version = "0.1.1"
 dependencies = [
  "backends",
- "kernel 0.10.1 (git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b)",
- "nexus-plugin-abi 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b)",
+ "kernel",
+ "nexus-plugin-abi",
  "serde_json",
  "tempfile",
  "tracing",
 ]
-
-[[package]]
-name = "nexus-plugin-abi"
-version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=08460a7909fa600baba3922a4f8852e351aeee42#08460a7909fa600baba3922a4f8852e351aeee42"
 
 [[package]]
 name = "nexus-plugin-abi"
@@ -3225,7 +3101,7 @@ dependencies = [
  "hnsw_rs",
  "libloading 0.8.9",
  "mimalloc",
- "nexus-plugin-abi 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b)",
+ "nexus-plugin-abi",
  "ort",
  "parking_lot",
  "prost 0.14.4",
@@ -3251,9 +3127,9 @@ version = "0.1.4"
 dependencies = [
  "backends",
  "clap",
- "kernel 0.10.1 (git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b)",
+ "kernel",
  "libloading 0.8.9",
- "nexus-plugin-abi 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b)",
+ "nexus-plugin-abi",
  "prost 0.14.4",
  "services",
  "tempfile",
@@ -3268,7 +3144,7 @@ dependencies = [
 [[package]]
 name = "nexus-vfs-client"
 version = "0.1.27"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=470939a5b7e11ef076b1e531703b8b3821c9f739#470939a5b7e11ef076b1e531703b8b3821c9f739"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=c638b5c3b646a925ade780461a662a5d92e5099b#c638b5c3b646a925ade780461a662a5d92e5099b"
 dependencies = [
  "prost 0.13.5",
  "protoc-bin-vendored",
@@ -3282,11 +3158,11 @@ dependencies = [
 name = "nexusd"
 version = "0.1.0"
 dependencies = [
- "a2a 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b)",
+ "a2a",
  "anyhow",
  "backends",
- "kernel 0.10.1 (git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b)",
- "managed-agent 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b)",
+ "kernel",
+ "managed-agent",
  "nexus-cluster",
  "nexus-http-api",
  "tools",
@@ -3726,7 +3602,7 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 [[package]]
 name = "plugins"
 version = "0.1.27"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=470939a5b7e11ef076b1e531703b8b3821c9f739#470939a5b7e11ef076b1e531703b8b3821c9f739"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=c638b5c3b646a925ade780461a662a5d92e5099b#c638b5c3b646a925ade780461a662a5d92e5099b"
 dependencies = [
  "serde",
  "serde_json",
@@ -3851,7 +3727,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "once_cell",
@@ -3871,7 +3747,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "petgraph 0.8.3",
@@ -3892,7 +3768,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -3905,7 +3781,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -4145,11 +4021,11 @@ dependencies = [
  "base64 0.22.1",
  "bincode",
  "bytes",
- "contracts 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b)",
+ "contracts",
  "dashmap",
  "gethostname",
- "kernel 0.10.1 (git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b)",
- "lib 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b)",
+ "kernel",
+ "lib",
  "parking_lot",
  "pem",
  "prost 0.14.4",
@@ -4570,9 +4446,9 @@ dependencies = [
 [[package]]
 name = "runtime"
 version = "0.1.27"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=470939a5b7e11ef076b1e531703b8b3821c9f739#470939a5b7e11ef076b1e531703b8b3821c9f739"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=c638b5c3b646a925ade780461a662a5d92e5099b#c638b5c3b646a925ade780461a662a5d92e5099b"
 dependencies = [
- "a2a 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=08460a7909fa600baba3922a4f8852e351aeee42)",
+ "a2a",
  "agent-client-protocol",
  "agent-client-protocol-schema",
  "agent-client-protocol-tokio",
@@ -4586,9 +4462,9 @@ dependencies = [
  "getrandom 0.2.17",
  "glob",
  "image",
- "kernel 0.10.1 (git+https://github.com/nexi-lab/nexus-vfs?rev=08460a7909fa600baba3922a4f8852e351aeee42)",
+ "kernel",
  "keyring",
- "lib 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=08460a7909fa600baba3922a4f8852e351aeee42)",
+ "lib",
  "nexus-vfs-client",
  "nix 0.29.0",
  "plugins",
@@ -4983,19 +4859,19 @@ dependencies = [
 name = "services"
 version = "0.1.0"
 dependencies = [
- "a2a 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b)",
+ "a2a",
  "aes-gcm",
  "async-trait",
  "axum",
  "base32",
  "bincode",
  "chrono",
- "contracts 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b)",
+ "contracts",
  "dashmap",
  "fjall",
  "futures",
  "hmac 0.12.1",
- "kernel 0.10.1 (git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b)",
+ "kernel",
  "libc",
  "parking_lot",
  "prost 0.14.4",
@@ -5272,7 +5148,7 @@ name = "subprocess"
 version = "0.1.0"
 source = "git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b#601c2af20b85a324496a7c95b8aba5cb20848e3b"
 dependencies = [
- "kernel 0.10.1 (git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b)",
+ "kernel",
  "libc",
  "tokio",
 ]
@@ -5489,7 +5365,7 @@ dependencies = [
 [[package]]
 name = "telemetry"
 version = "0.1.27"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=470939a5b7e11ef076b1e531703b8b3821c9f739#470939a5b7e11ef076b1e531703b8b3821c9f739"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=c638b5c3b646a925ade780461a662a5d92e5099b#c638b5c3b646a925ade780461a662a5d92e5099b"
 dependencies = [
  "chrono",
  "dirs",
@@ -5880,7 +5756,7 @@ dependencies = [
 [[package]]
 name = "tools"
 version = "0.1.27"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=470939a5b7e11ef076b1e531703b8b3821c9f739#470939a5b7e11ef076b1e531703b8b3821c9f739"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=c638b5c3b646a925ade780461a662a5d92e5099b#c638b5c3b646a925ade780461a662a5d92e5099b"
 dependencies = [
  "api",
  "async-trait",
@@ -5888,7 +5764,7 @@ dependencies = [
  "commands",
  "flate2",
  "futures",
- "managed-agent 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=08460a7909fa600baba3922a4f8852e351aeee42)",
+ "managed-agent",
  "plugins",
  "reqwest 0.12.28",
  "runtime",
@@ -6031,14 +5907,14 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "chrono",
- "contracts 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b)",
+ "contracts",
  "dashmap",
  "futures",
  "http",
  "http-body",
  "http-body-util",
- "kernel 0.10.1 (git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b)",
- "lib 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b)",
+ "kernel",
+ "lib",
  "parking_lot",
  "pem",
  "prost 0.14.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -229,30 +229,30 @@ exclude = ["nexus-fuse"]
 #
 # Bump alongside the rest of nexus-vfs updates when a downstream
 # change needs newer kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "08460a7909fa600baba3922a4f8852e351aeee42" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "08460a7909fa600baba3922a4f8852e351aeee42" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "08460a7909fa600baba3922a4f8852e351aeee42" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "08460a7909fa600baba3922a4f8852e351aeee42", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "08460a7909fa600baba3922a4f8852e351aeee42", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "08460a7909fa600baba3922a4f8852e351aeee42", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "08460a7909fa600baba3922a4f8852e351aeee42" }
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "601c2af20b85a324496a7c95b8aba5cb20848e3b" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "601c2af20b85a324496a7c95b8aba5cb20848e3b" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "601c2af20b85a324496a7c95b8aba5cb20848e3b" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "601c2af20b85a324496a7c95b8aba5cb20848e3b", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "601c2af20b85a324496a7c95b8aba5cb20848e3b", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "601c2af20b85a324496a7c95b8aba5cb20848e3b", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "601c2af20b85a324496a7c95b8aba5cb20848e3b" }
 # The cluster daemon library entry (`nexus_cluster::run_with_services`),
 # consumed by the nexus-side assembly binary (`rust/nexusd`) that composes
 # the kernel/federation boot with the nexus service set via the
 # ServiceRegistry bring-up seam.
-nexus-cluster = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "08460a7909fa600baba3922a4f8852e351aeee42" }
+nexus-cluster = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "601c2af20b85a324496a7c95b8aba5cb20848e3b" }
 # a2a messaging substrate. `default-features = false` leaves the
 # `install` feature (which pulls raft to arm the stream-wakeup observer)
 # OFF, so nexus-side consumers link only the stamp hook and stay
 # raft-free — they reach raft through kernel.sys_* (§6.1). The substrate
 # is armed in production at cluster boot in nexus-vfs, not here.
-a2a = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "08460a7909fa600baba3922a4f8852e351aeee42", default-features = false }
+a2a = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "601c2af20b85a324496a7c95b8aba5cb20848e3b", default-features = false }
 # managed-agent control plane + the shared subprocess host — RELOCATED into
 # nexus-vfs (kernel-tier) so the production nexusd-cluster carries the agent
 # control plane. `subprocess-host` enables the raw ACP-subprocess spawner (the
 # nexus-side acp path + managed-agent both use HostedSubprocess).
-managed-agent = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "08460a7909fa600baba3922a4f8852e351aeee42", default-features = false }
-subprocess = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "08460a7909fa600baba3922a4f8852e351aeee42" }
+managed-agent = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "601c2af20b85a324496a7c95b8aba5cb20848e3b", default-features = false }
+subprocess = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "601c2af20b85a324496a7c95b8aba5cb20848e3b" }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir --no-deps --prefix=/install .
 # enforces agreement) — an unpinned install tracks nexus-vfs HEAD and
 # ships an untested kernel (#4343). --locked honors the source tree's
 # Cargo.lock.
-ARG NEXUS_VFS_REV=08460a7909fa600baba3922a4f8852e351aeee42
+ARG NEXUS_VFS_REV=601c2af20b85a324496a7c95b8aba5cb20848e3b
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-cluster nexus-cluster
 
 # -- Runtime stage --

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -25,7 +25,7 @@ WORKDIR /build
 # (CI preflight enforces agreement) — an unpinned install tracks HEAD
 # and can skew the raft contract against the cluster/witness images.
 # --locked honors the source tree's Cargo.lock.
-ARG NEXUS_VFS_REV=08460a7909fa600baba3922a4f8852e351aeee42
+ARG NEXUS_VFS_REV=601c2af20b85a324496a7c95b8aba5cb20848e3b
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexus-raft-server raft
 
 # ---------- Production image ----------

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=08460a7909fa600baba3922a4f8852e351aeee42
+ARG NEXUS_VFS_REV=601c2af20b85a324496a7c95b8aba5cb20848e3b
 RUN cargo install \
     --locked \
     --git https://github.com/nexi-lab/nexus-vfs \

--- a/rust/nexusd/Cargo.toml
+++ b/rust/nexusd/Cargo.toml
@@ -58,7 +58,7 @@ anyhow = "1"
 # nexus-side co-host glue and no runtime enum to map (the adapter reports
 # `kernel::AgentState` directly). Pinned to sudocode main (spawn AgentState
 # collapse).
-sudocode-tools = { package = "tools", git = "https://github.com/sudoprivacy/sudocode", rev = "470939a5b7e11ef076b1e531703b8b3821c9f739", optional = true }
+sudocode-tools = { package = "tools", git = "https://github.com/sudoprivacy/sudocode", rev = "c638b5c3b646a925ade780461a662a5d92e5099b", optional = true }
 # Named directly to spell `kernel::kernel::{ServiceDecl, Kernel}` — the
 # managed-agent boot decl's return type (both builds) and the co-host
 # adapter's `SpawnTask<Kernel>` (cohost build). Already present transitively

--- a/rust/nexusd/Cargo.toml
+++ b/rust/nexusd/Cargo.toml
@@ -18,6 +18,15 @@ default = []
 # so the shipped binary keeps the sudowork/edge size budget; only an
 # S3-serving tier builds `--features driver-s3`.
 driver-s3 = ["dep:backends", "backends/driver-s3"]
+# Opt-in HTTP-API axum listener over the search-plugin gRPC surface
+# (part of the R10 nexus-server → pure-Rust migration; epic #4674).
+# Linking axum + tonic-client + reqwest transitively adds ~0.7 MiB
+# of binary weight — kept OFF in the default slim `cluster` build to
+# stay under the §7 size budget.  A cluster tier that serves HTTP
+# builds `--features http-api`.  Runtime bring-up ALSO requires
+# `NEXUS_HTTP_ADDR` (see `http_api_decl` in main.rs) — the feature
+# gates the CODE, the env gates the LISTENER.
+http-api = ["dep:nexus-http-api", "dep:tracing"]
 # Co-host the real sudocode managed-agent runtime IN-PROCESS. Off by
 # default so the slim `cluster` binary stays sudocode-free (profile purity
 # — §7); a cohost-enabled build statically links `sudocode-tools` (which
@@ -68,13 +77,13 @@ kernel = { workspace = true, default-features = false }
 
 # HTTP-API axum shim over the search-plugin gRPC surface (part of
 # the R10 nexus-server → pure-Rust migration; epic #4674).  Wired
-# in conditionally — only builds a live listener when
-# `NEXUS_HTTP_ADDR` is set on the environment.  Zero cost when the
-# env is unset (the service decl is not even appended to the
-# bring-up list).
-nexus-http-api = { path = "../services/http-api" }
+# in conditionally — only builds a live listener when the
+# `http-api` feature is enabled AND `NEXUS_HTTP_ADDR` is set on the
+# environment.  Zero cost in the default slim `cluster` build
+# (feature off ⇒ crate not linked, ~0.7 MiB weight not shipped).
+nexus-http-api = { path = "../services/http-api", optional = true }
 # One-line log of "HTTP-API skipped due to malformed NEXUS_HTTP_ADDR"
-# in `http_api_decl`.  The rest of nexusd inherits tracing via
-# `nexus-cluster`'s `install_tracing` — this direct dep spares main.rs
-# from wrapping the log call in a feature gate.
-tracing = "0.1"
+# in `http_api_decl`.  Only linked when the `http-api` feature is on;
+# the rest of nexusd inherits tracing via `nexus-cluster`'s
+# `install_tracing` (which itself pulls tracing in unconditionally).
+tracing = { version = "0.1", optional = true }

--- a/rust/nexusd/Cargo.toml
+++ b/rust/nexusd/Cargo.toml
@@ -65,3 +65,16 @@ sudocode-tools = { package = "tools", git = "https://github.com/sudoprivacy/sudo
 # via services / nexus-cluster at the same workspace pin, so this direct dep
 # adds no new compilation and keeps one `Kernel` type.
 kernel = { workspace = true, default-features = false }
+
+# HTTP-API axum shim over the search-plugin gRPC surface (part of
+# the R10 nexus-server → pure-Rust migration; epic #4674).  Wired
+# in conditionally — only builds a live listener when
+# `NEXUS_HTTP_ADDR` is set on the environment.  Zero cost when the
+# env is unset (the service decl is not even appended to the
+# bring-up list).
+nexus-http-api = { path = "../services/http-api" }
+# One-line log of "HTTP-API skipped due to malformed NEXUS_HTTP_ADDR"
+# in `http_api_decl`.  The rest of nexusd inherits tracing via
+# `nexus-cluster`'s `install_tracing` — this direct dep spares main.rs
+# from wrapping the log call in a feature gate.
+tracing = "0.1"

--- a/rust/nexusd/src/main.rs
+++ b/rust/nexusd/src/main.rs
@@ -50,14 +50,15 @@ fn main() -> anyhow::Result<()> {
     // The daemon's service set — the SSOT for "which services this daemon
     // runs", ordered. a2a is installed first (its from-stamp hook must be
     // armed before agents write mailboxes); managed_agent follows; the
-    // optional HTTP-API listener slots in last (its axum listener does
-    // not depend on the other services' hooks, so ordering is free).
+    // optional HTTP-API listener (feature-gated `http-api`) slots in last.
     // `ctx.auth_armed` is boot-derived (true iff sk- auth is armed) and
     // sets a2a's fail-closed posture; `ctx.auth` + `ctx.runtime` are
     // live handles that http-api needs to inject into its bearer
     // middleware + spawn its axum listener on the daemon runtime.
     nexus_cluster::run_with_services(|ctx| {
+        #[allow(unused_mut)]
         let mut decls = vec![a2a::service_decl(ctx.auth_armed), managed_agent_decl()];
+        #[cfg(feature = "http-api")]
         if let Some(decl) = http_api_decl(ctx) {
             decls.push(decl);
         }
@@ -65,20 +66,21 @@ fn main() -> anyhow::Result<()> {
     })
 }
 
-/// Optional HTTP-API listener decl.  Present only when the operator
-/// sets `NEXUS_HTTP_ADDR` (e.g. `NEXUS_HTTP_ADDR=0.0.0.0:2128`) —
-/// keeps the default slim-cluster boot HTTP-surface-free (matches
-/// the existing "gRPC on 2126, enroll on 2127, everything else
-/// opt-in" posture).  A malformed value is logged + skipped
-/// (fail-open on a config typo rather than refusing the whole
-/// daemon boot); an operator diagnosing "why no HTTP" reads the
-/// log line, an operator who never asked for HTTP is unaffected.
+/// Optional HTTP-API listener decl — feature-gated `http-api` at
+/// COMPILE time (linking axum + tonic-client adds ~0.7 MiB, kept
+/// off in the slim `cluster` build per §7 profile purity) AND
+/// env-gated `NEXUS_HTTP_ADDR` at BOOT time (operator opts in per
+/// deployment; matches the "gRPC on 2126, enroll on 2127,
+/// everything else opt-in" posture).
 ///
-/// Upstream gRPC target defaults to `http://127.0.0.1:2126` because
-/// the shim is co-hosted in this same binary (loopback saves the
-/// TCP-out-and-back-in round-trip).  `NEXUS_HTTP_UPSTREAM_GRPC`
-/// overrides for the split-binary case (e.g. serving the HTTP shim
-/// from a separate pod pointing at a remote search-plugin cluster).
+/// A malformed `NEXUS_HTTP_ADDR` value is logged + skipped
+/// (fail-open on a config typo rather than refusing the whole
+/// daemon boot).  Upstream gRPC target defaults to
+/// `http://127.0.0.1:2126` because the shim is co-hosted in this
+/// same binary (loopback saves the TCP-out-and-back-in round-trip).
+/// `NEXUS_HTTP_UPSTREAM_GRPC` overrides for the split-binary case
+/// (HTTP shim from a separate pod pointing at a remote cluster).
+#[cfg(feature = "http-api")]
 fn http_api_decl(ctx: &nexus_cluster::ServiceBootCtx) -> Option<kernel::kernel::ServiceDecl> {
     use std::sync::Arc;
     let addr_str = std::env::var("NEXUS_HTTP_ADDR").ok()?;

--- a/rust/nexusd/src/main.rs
+++ b/rust/nexusd/src/main.rs
@@ -49,10 +49,56 @@ fn managed_agent_decl() -> kernel::kernel::ServiceDecl {
 fn main() -> anyhow::Result<()> {
     // The daemon's service set — the SSOT for "which services this daemon
     // runs", ordered. a2a is installed first (its from-stamp hook must be
-    // armed before agents write mailboxes); managed_agent follows.
+    // armed before agents write mailboxes); managed_agent follows; the
+    // optional HTTP-API listener slots in last (its axum listener does
+    // not depend on the other services' hooks, so ordering is free).
     // `ctx.auth_armed` is boot-derived (true iff sk- auth is armed) and
-    // sets a2a's fail-closed posture.
+    // sets a2a's fail-closed posture; `ctx.auth` + `ctx.runtime` are
+    // live handles that http-api needs to inject into its bearer
+    // middleware + spawn its axum listener on the daemon runtime.
     nexus_cluster::run_with_services(|ctx| {
-        vec![a2a::service_decl(ctx.auth_armed), managed_agent_decl()]
+        let mut decls = vec![a2a::service_decl(ctx.auth_armed), managed_agent_decl()];
+        if let Some(decl) = http_api_decl(ctx) {
+            decls.push(decl);
+        }
+        decls
     })
+}
+
+/// Optional HTTP-API listener decl.  Present only when the operator
+/// sets `NEXUS_HTTP_ADDR` (e.g. `NEXUS_HTTP_ADDR=0.0.0.0:2128`) —
+/// keeps the default slim-cluster boot HTTP-surface-free (matches
+/// the existing "gRPC on 2126, enroll on 2127, everything else
+/// opt-in" posture).  A malformed value is logged + skipped
+/// (fail-open on a config typo rather than refusing the whole
+/// daemon boot); an operator diagnosing "why no HTTP" reads the
+/// log line, an operator who never asked for HTTP is unaffected.
+///
+/// Upstream gRPC target defaults to `http://127.0.0.1:2126` because
+/// the shim is co-hosted in this same binary (loopback saves the
+/// TCP-out-and-back-in round-trip).  `NEXUS_HTTP_UPSTREAM_GRPC`
+/// overrides for the split-binary case (e.g. serving the HTTP shim
+/// from a separate pod pointing at a remote search-plugin cluster).
+fn http_api_decl(ctx: &nexus_cluster::ServiceBootCtx) -> Option<kernel::kernel::ServiceDecl> {
+    use std::sync::Arc;
+    let addr_str = std::env::var("NEXUS_HTTP_ADDR").ok()?;
+    let addr: std::net::SocketAddr = match addr_str.parse() {
+        Ok(a) => a,
+        Err(e) => {
+            tracing::warn!(
+                value = %addr_str,
+                error = %e,
+                "NEXUS_HTTP_ADDR set but not a valid SocketAddr — skipping HTTP-API bring-up",
+            );
+            return None;
+        }
+    };
+    let upstream_grpc = std::env::var("NEXUS_HTTP_UPSTREAM_GRPC")
+        .unwrap_or_else(|_| "http://127.0.0.1:2126".to_string());
+    Some(nexus_http_api::service_decl(
+        addr,
+        upstream_grpc,
+        Arc::clone(&ctx.auth),
+        ctx.runtime.clone(),
+    ))
 }

--- a/rust/services/http-api/Cargo.toml
+++ b/rust/services/http-api/Cargo.toml
@@ -48,6 +48,14 @@ dashmap = "6.1"
 contracts = { workspace = true }
 transport = { workspace = true }
 
+# `kernel::kernel::ServiceDecl` — the boot-declaration shape the
+# daemon's `Kernel::bring_up_services` consumes.  This crate exports
+# `service_decl(addr, upstream_grpc, auth, runtime)` returning that
+# shape so `nexusd-cluster::main` can slot it into the same
+# `Vec<ServiceDecl>` a2a + managed_agent live in.  `default-features
+# = false` mirrors the nexusd binary's own kernel pin.
+kernel = { workspace = true }
+
 # Parked-error surfacing at the handler boundary (Ok/Err in the
 # lib, mapped to HTTP status in the axum extractor).  Same 1.0 pin
 # the sibling search-plugin uses.

--- a/rust/services/http-api/src/lib.rs
+++ b/rust/services/http-api/src/lib.rs
@@ -175,3 +175,62 @@ pub async fn bind_and_serve(
     let fut = async move { axum::serve(listener, router(state)).await };
     Ok((bound, fut))
 }
+
+/// Build a [`kernel::kernel::ServiceDecl`] that spawns the HTTP-API
+/// listener on `addr` at daemon bring-up.  The install closure
+/// captures the resolved auth provider + runtime handle at
+/// decl-BUILD time so the daemon does not have to plumb them
+/// through the kernel's install signature (which only exposes
+/// `&Arc<Kernel>`).
+///
+/// # Wiring
+///
+/// Callers construct this from `nexus_cluster::ServiceBootCtx`:
+///
+/// ```ignore
+/// nexus_http_api::service_decl(
+///     addr,                              // parsed from NEXUS_HTTP_ADDR
+///     "http://127.0.0.1:2126".into(),    // co-hosted gRPC target
+///     std::sync::Arc::clone(&ctx.auth),
+///     ctx.runtime.clone(),
+/// )
+/// ```
+///
+/// Args are taken RAW (not `&ServiceBootCtx`) so this crate does
+/// not need `nexus-cluster` as a dep — tier separation stays clean.
+///
+/// # Failure mode
+///
+/// The install closure returns `Ok(())` after spawning the axum
+/// listener as a background task on the daemon's tokio runtime.  A
+/// bind failure or serve error is logged but does not fail the whole
+/// daemon boot — matches how `a2a` + `managed_agent` treat their
+/// install-time errors, and preserves the daemon's "gRPC surface up
+/// even if optional shim fails to bind" posture.
+pub fn service_decl(
+    addr: SocketAddr,
+    upstream_grpc: String,
+    auth: Arc<dyn AuthProvider>,
+    runtime: tokio::runtime::Handle,
+) -> kernel::kernel::ServiceDecl {
+    kernel::kernel::ServiceDecl {
+        name: "http_api".to_string(),
+        install: Box::new(move |_kernel| {
+            let state = AppState {
+                search: SearchBackend::new(upstream_grpc),
+                auth,
+            };
+            runtime.spawn(async move {
+                if let Err(e) = serve(addr, state).await {
+                    tracing::error!(
+                        addr = %addr,
+                        error = %e,
+                        "nexus-http-api: axum listener terminated",
+                    );
+                }
+            });
+            tracing::info!(addr = %addr, "nexus-http-api: axum listener spawned");
+            Ok(())
+        }),
+    }
+}


### PR DESCRIPTION
## Summary

Downstream of nexus-vfs #250 (widened `ServiceBootCtx`). Wires the R10 pure-Rust HTTP surface as an opt-in service that binds only when the operator sets `NEXUS_HTTP_ADDR`.

## Wiring shape

- `nexus_http_api::service_decl(addr, upstream_grpc, auth, runtime) -> ServiceDecl` — thin builder in http-api's `lib.rs`. Takes RAW args (not `&ServiceBootCtx`) so http-api stays free of a `nexus-cluster` dep (tier separation).
- `nexusd::main::http_api_decl(ctx)` — parses `NEXUS_HTTP_ADDR` + optional `NEXUS_HTTP_UPSTREAM_GRPC` (default `http://127.0.0.1:2126`). Returns `Option<ServiceDecl>` — absent env cleanly skips bring-up; malformed value logs + skips (fail-open on config typo).

## SRP + orthogonality

- http-api takes RAW handles at decl-build time, not a `&ServiceBootCtx` — lets it stay usable outside a `nexus-cluster` composition.
- `NEXUS_HTTP_ADDR` parsed at composition root, NOT inside http-api — http-api takes no policy stance on its bind ceremony.
- Upstream gRPC default matches co-hosted layout (`nexusd-cluster` gRPC on 2126). Overrideable for split-binary case.

## Cargo pin bump

Workspace nexus-vfs rev `08460a7909` → `601c2af20b` — picks up the widened `ServiceBootCtx`. All 8 nexus-vfs workspace deps bumped in lockstep.

## Test cover

- `cargo build -p nexusd` green; `cargo check` green
- `cargo test -p nexus-http-api`: 47 tests still pass; clippy + fmt clean
- Live E2E (real docker daemon + real minted sk-*) lands in the companion PR — this is the wire step

## Zero-cost when off

`NEXUS_HTTP_ADDR` unset ⇒ no listener, no tokio task. Existing single-node dev + all current docker-compose harnesses unaffected.
