### PR TITLE
test(e2e/docker): http-api real-daemon + real sk-* + real ApiKeyAuthProvider (R10)

### DIFF
--- a/.github/workflows/http-api-e2e.yml
+++ b/.github/workflows/http-api-e2e.yml
@@ -1,0 +1,182 @@
+name: http-api E2E
+
+# Runs `tests/e2e/docker/test_http_api.py` against the single-node
+# HTTP-API-featured cluster in
+# `dockerfiles/docker-compose.http-api-e2e.yml`.  Locks the R10
+# wiring: `nexusd-cluster --features http-api` binds axum on
+# `NEXUS_HTTP_ADDR` behind the real `ApiKeyAuthProvider`
+# (`NEXUS_API_KEY_SECRET` set, no `--insecure-no-auth`), and a
+# REAL `sk-*` minted by `nexusd-cluster auth mint` is admitted
+# end-to-end while an absent / wrong bearer surfaces 401.
+#
+# Independent of `search-plugin-e2e.yml` — that one covers the
+# plugin surface with auth off; THIS one covers the auth surface
+# with the plugin off.  The two axes are deliberately tested
+# separately to keep failure signals sharp.
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main, develop]
+    paths:
+      - 'dockerfiles/Dockerfile.nexusd-cluster-httpapi'
+      - 'dockerfiles/docker-compose.http-api-e2e.yml'
+      - 'dockerfiles/Dockerfile.federation-test'
+      - 'rust/services/http-api/**'
+      - 'rust/nexusd/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'tests/e2e/docker/test_http_api.py'
+      - 'tests/e2e/docker/runbook_helpers.py'
+      - '.github/workflows/http-api-e2e.yml'
+  pull_request:
+    branches: [main, develop]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  http-api-e2e:
+    name: http-api E2E (Docker)
+    runs-on: ubuntu-latest
+    # Cold cache: cluster image build + compose up + 5 tests is
+    # ~8-10 min.  Warm gha cache shaves the rust compile.  20 min
+    # upper bound leaves margin for slow-building rust deps —
+    # matches the sibling search-plugin-e2e budget.
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect http-api-relevant changes
+        id: changes
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git fetch --no-tags --prune origin "${{ github.base_ref }}"
+          git diff --name-only "origin/${{ github.base_ref }}"...HEAD > /tmp/changed_files.txt
+          cat /tmp/changed_files.txt
+          # Workflow file itself is intentionally NOT in the regex —
+          # matches the sibling federation-e2e + search-plugin-e2e
+          # rationale (workflow-only edits should not trigger the
+          # whole compose stack).
+          if grep -Eq '^(dockerfiles/(Dockerfile\.(nexusd-cluster-httpapi|federation-test)|docker-compose\.http-api-e2e\.yml)|rust/services/http-api/|rust/nexusd/|Cargo\.toml$|Cargo\.lock$|tests/e2e/docker/(test_http_api|runbook_helpers)\.py$)' /tmp/changed_files.txt; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Skip http-api E2E
+        if: steps.changes.outputs.run != 'true'
+        run: |
+          echo "No http-api-relevant files changed; reporting required check without running suite."
+
+      - name: Set up Docker Buildx
+        if: steps.changes.outputs.run == 'true'
+        uses: docker/setup-buildx-action@v3
+
+      # Pin SSOT: the nexus-vfs SHA the cluster binary compiles
+      # against lives in `Cargo.toml`'s workspace dep rev.  Parse
+      # once and reuse for the checkout step below — same pattern
+      # as `search-plugin-e2e.yml`.
+      - name: Read NEXUS_VFS_REV from Cargo.toml
+        if: steps.changes.outputs.run == 'true'
+        id: vfs_rev
+        run: |
+          sha=$(grep -oP '(?<=rev = ")[a-f0-9]{40}' Cargo.toml | sort -u | head -1)
+          if [ -z "$sha" ]; then
+            echo "::error::Could not parse nexus-vfs SHA from Cargo.toml"
+            exit 1
+          fi
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+          echo "Resolved nexus-vfs SHA: $sha"
+
+      - name: Checkout nexus-vfs source at pinned SHA
+        if: steps.changes.outputs.run == 'true'
+        uses: actions/checkout@v4
+        with:
+          repository: nexi-lab/nexus-vfs
+          ref: ${{ steps.vfs_rev.outputs.sha }}
+          path: nexus-vfs-src
+          fetch-depth: 1
+
+      - name: Build nexusd-cluster-httpapi image
+        if: steps.changes.outputs.run == 'true'
+        env:
+          # Authenticates the two private git deps (nexus-vfs +
+          # sudocode-tools).  The Dockerfile consumes it as a
+          # BuildKit secret rather than an ARG so the token does
+          # not land in a layer.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: dockerfiles/Dockerfile.nexusd-cluster-httpapi
+          build-contexts: |
+            nexus-vfs-src=nexus-vfs-src
+          load: true
+          tags: nexusd-cluster-httpapi:latest
+          secrets: |
+            "ghtoken=${{ secrets.GITHUB_TOKEN }}"
+          # Scoped separately from the search-plugin cache since the
+          # `--features http-api` build produces a different binary.
+          cache-from: type=gha,scope=http-api-cluster
+          cache-to: type=gha,scope=http-api-cluster,mode=max
+
+      - name: Build federation-test image
+        if: steps.changes.outputs.run == 'true'
+        env:
+          BUILDX_BUILDER: default
+        run: |
+          docker compose -f dockerfiles/docker-compose.http-api-e2e.yml build test
+
+      - name: Start http-api cluster
+        if: steps.changes.outputs.run == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          docker compose -f dockerfiles/docker-compose.http-api-e2e.yml up -d node
+          docker compose -f dockerfiles/docker-compose.http-api-e2e.yml ps
+
+      - name: Wait for node healthy
+        if: steps.changes.outputs.run == 'true'
+        run: |
+          deadline=$((SECONDS + 180))
+          while [ $SECONDS -lt $deadline ]; do
+            # Use the compose healthcheck's own probe — `curl /v2/status`
+            # is stricter than raw TCP (bind without a spawn passes
+            # TCP but fails HTTP).
+            if docker exec nexus-http-api-node curl -fsS http://localhost:2128/v2/status 2>/dev/null; then
+              echo "Node healthy (/v2/status returned 200) after ${SECONDS}s"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "::error::Timed out waiting for cluster ready (180s)"
+          docker compose -f dockerfiles/docker-compose.http-api-e2e.yml logs --tail=300
+          exit 1
+
+      - name: Run http-api E2E tests
+        if: steps.changes.outputs.run == 'true'
+        run: |
+          docker compose -f dockerfiles/docker-compose.http-api-e2e.yml \
+            run --rm test
+
+      - name: Dump container logs on failure
+        if: failure() && steps.changes.outputs.run == 'true'
+        run: |
+          echo "::group::nexus-http-api-node"
+          docker logs nexus-http-api-node --tail=400 2>&1 || echo "(no logs)"
+          echo "::endgroup::"
+
+      - name: Tear down
+        if: always() && steps.changes.outputs.run == 'true'
+        run: |
+          docker compose -f dockerfiles/docker-compose.http-api-e2e.yml down -v --remove-orphans || true

--- a/.github/workflows/http-api-e2e.yml
+++ b/.github/workflows/http-api-e2e.yml
@@ -122,7 +122,17 @@ jobs:
           build-contexts: |
             nexus-vfs-src=nexus-vfs-src
           load: true
-          tags: nexusd-cluster-httpapi:latest
+          # Two tags: the specific `-httpapi` name for clarity in
+          # local `docker images` listings, PLUS the generic
+          # `nexusd-cluster:latest` because `Dockerfile.federation-test`
+          # (the sibling test-runner image) starts with `FROM
+          # nexusd-cluster:latest`.  Without this second tag the
+          # federation-test build tries to pull from Docker Hub and
+          # 401s (`insufficient_scope`).  Same shape the
+          # search-plugin-e2e workflow uses.
+          tags: |
+            nexusd-cluster-httpapi:latest
+            nexusd-cluster:latest
           secrets: |
             "ghtoken=${{ secrets.GITHUB_TOKEN }}"
           # Scoped separately from the search-plugin cache since the

--- a/dockerfiles/Dockerfile.nexusd-cluster-httpapi
+++ b/dockerfiles/Dockerfile.nexusd-cluster-httpapi
@@ -1,0 +1,88 @@
+# nexusd-cluster **http-api** image — the assembly binary with the
+# axum HTTP shim linked (`--features http-api`).
+#
+# Distinct from `Dockerfile.nexusd-cluster` (upstream slim binary) and
+# `Dockerfile.nexusd-cohost` (in-process sudocode runtime): this one
+# builds `nexus/rust/nexusd` with the `http-api` feature so the
+# resulting `nexusd-cluster` binary links `nexus-http-api` + its
+# axum / tonic-client transitive deps.  ~0.7 MiB heavier than the
+# slim variant — that's the size the §7 profile purity gate keeps
+# out of the default cluster shipped everywhere else.
+#
+# Used by the HTTP-API E2E compose
+# (`docker-compose.http-api-e2e.yml`) which boots this daemon with
+# `NEXUS_HTTP_ADDR=0.0.0.0:2128` + `NEXUS_API_KEY_SECRET=<secret>`
+# so the axum listener is armed AND the ApiKey auth posture is on
+# (rather than NoAuth) — the real acceptance test for the R10 arc.
+#
+# Both cross-repo deps (nexi-lab/nexus-vfs @ the Cargo.toml pin, and
+# sudoprivacy/sudocode @ the nexusd/Cargo.toml pin — the http-api
+# feature does NOT enable cohost-sudocode; sudocode-tools stays a
+# lockstep-pinned build dep only) are PRIVATE, so the build
+# authenticates git via a BuildKit secret rather than a git token
+# baked into a layer.  Build:
+#
+#   DOCKER_BUILDKIT=1 docker build \
+#     -f dockerfiles/Dockerfile.nexusd-cluster-httpapi \
+#     --secret id=ghtoken,env=GH_TOKEN \
+#     -t nexusd-cluster-httpapi:latest .
+#
+# with `GH_TOKEN=$(gh auth token)` (needs read on both private repos).
+# `.dockerignore` already excludes target/ + .git/, so `COPY .` is
+# the source tree only.
+
+FROM rust:1-slim-bookworm AS builder
+
+# protobuf-compiler: the git-fetched raft crate's build.rs shells out to protoc.
+# python3{,-dev}: pyo3-build-config probes for an interpreter at compile time.
+# git + ca-certificates: authenticated fetch of the two private git deps.
+# Point apt at a China mirror (Aliyun) first — deb.debian.org is unreliable
+# through the local China proxy (persistent 502s); CI (clean network) is
+# unaffected either way.
+RUN { sed -i 's|deb.debian.org|mirrors.aliyun.com|g; s|security.debian.org|mirrors.aliyun.com|g' /etc/apt/sources.list.d/debian.sources 2>/dev/null || true; } \
+    && { sed -i 's|deb.debian.org|mirrors.aliyun.com|g; s|security.debian.org|mirrors.aliyun.com|g' /etc/apt/sources.list 2>/dev/null || true; } \
+    && apt-get -o Acquire::Retries=6 update && apt-get -o Acquire::Retries=6 install -y --no-install-recommends \
+        protobuf-compiler \
+        python3 \
+        python3-dev \
+        git \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# The nexus assembly source (rust/nexusd + workspace).  target/ and .git/
+# are .dockerignore'd, so this is the source tree only.
+COPY . /build/nexus
+
+# `--locked` honors the workspace Cargo.lock; the secret token
+# authenticates the private git fetches and never lands in a layer.
+# `--features http-api` links the axum HTTP shim + tonic-client (the
+# feature the R10 wiring PR added to `rust/nexusd/Cargo.toml`).
+RUN --mount=type=secret,id=ghtoken \
+    git config --global url."https://$(cat /run/secrets/ghtoken)@github.com/".insteadOf "https://github.com/" \
+    && cargo install \
+        --locked \
+        --path /build/nexus/rust/nexusd \
+        --features http-api \
+        --bin nexusd-cluster \
+    && git config --global --remove-section url."https://$(cat /run/secrets/ghtoken)@github.com/"
+
+# ---------- Production image ----------
+FROM debian:bookworm-slim
+
+# bash: the compose entrypoint uses bash + tcp/udp health probes.
+# ca-certificates: rustls trust roots (federation + a2a peer TLS).
+# curl: the compose healthcheck hits `/v2/status` over loopback HTTP —
+# more targeted than the raw TCP probe every other suite uses, since
+# `/v2/status` returning 200 proves the axum listener is ALIVE not
+# just bound (a bind without a spawn would pass a raw TCP probe).
+RUN { sed -i 's|deb.debian.org|mirrors.aliyun.com|g; s|security.debian.org|mirrors.aliyun.com|g' /etc/apt/sources.list.d/debian.sources 2>/dev/null || true; } \
+    && { sed -i 's|deb.debian.org|mirrors.aliyun.com|g; s|security.debian.org|mirrors.aliyun.com|g' /etc/apt/sources.list 2>/dev/null || true; } \
+    && apt-get -o Acquire::Retries=6 update && apt-get -o Acquire::Retries=6 install -y --no-install-recommends \
+        bash \
+        ca-certificates \
+        curl \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /usr/local/cargo/bin/nexusd-cluster /usr/local/bin/nexusd-cluster
+
+ENTRYPOINT ["nexusd-cluster"]

--- a/dockerfiles/docker-compose.http-api-e2e.yml
+++ b/dockerfiles/docker-compose.http-api-e2e.yml
@@ -1,0 +1,180 @@
+# HTTP-API E2E — single-node cluster with the axum HTTP listener armed
+# =========================================================================
+# Compose for `tests/e2e/docker/test_http_api.py` — the acceptance test
+# for the R10 nexus-server → pure-Rust migration wiring:
+#   * `nexusd-cluster --features http-api` (PR #4713) links the axum
+#     listener behind `NEXUS_HTTP_ADDR`
+#   * Auth posture: `NEXUS_API_KEY_SECRET` set (no `--insecure-no-auth`),
+#     so `ApiKeyAuthProvider` arms and http-api's bearer middleware
+#     routes through the SAME `Arc<dyn AuthProvider>` the kernel gRPC
+#     interceptor uses (SSOT — verified by widened ServiceBootCtx in
+#     nexus-vfs #250)
+#
+# The pytest test asserts:
+#   1. `GET /v2/status` → 200 without auth (public route)
+#   2. `POST /v2/search/query` without `Authorization` → 401
+#      (`ApiKeyAuthProvider` rejects the empty token — proves the
+#      `require_bearer` middleware is wired at the composition root,
+#      not just in the crate's unit tests)
+#   3. `POST /v2/search/query` with a wrong `Bearer sk-*` → 401
+#      (proves the provider actually resolves against the minted key
+#      store — a stub would 200 any well-formed token)
+#   4. `POST /v2/search/query` with the RIGHT minted `Bearer sk-*` →
+#      NOT-401 (proves the wired provider accepts the real key; the
+#      upstream `SearchService` returns Unimplemented / Unavailable
+#      because no plugin is loaded — that path is covered by the
+#      sibling search-plugin E2E)
+#
+# Deliberately does NOT bake the search-plugin cdylib into this image:
+# testing the middleware + auth plane, not the full search chain.
+# Search backends are covered by `docker-compose.search-plugin-e2e.yml`
+# (which runs with `--insecure-no-auth` because that suite is about
+# the plugin surface, not auth).
+#
+# Usage:
+#   docker compose -f dockerfiles/docker-compose.http-api-e2e.yml up -d node
+#   docker compose -f dockerfiles/docker-compose.http-api-e2e.yml run --rm test
+#   docker compose -f dockerfiles/docker-compose.http-api-e2e.yml down -v
+
+services:
+  node:
+    build:
+      context: ..
+      dockerfile: dockerfiles/Dockerfile.nexusd-cluster-httpapi
+      secrets:
+        - ghtoken
+    image: nexusd-cluster-httpapi:latest
+    container_name: nexus-http-api-node
+    hostname: node
+    environment:
+      NEXUS_HOSTNAME: node
+      NEXUS_BIND_ADDR: 0.0.0.0:2126
+      NEXUS_ADVERTISE_ADDR: node:2126
+      NEXUS_DATA_DIR: /app/data
+      NEXUS_NO_TLS: "true"
+      # `NEXUS_API_KEY_SECRET` arms `ApiKeyAuthProvider` — the mint
+      # subcommand + the daemon both need this so the HMAC of minted
+      # keys hashes identically on both sides.  Any non-empty value
+      # works for the E2E; production reads it from
+      # `<data_dir>/tls/api-key-secret`.
+      NEXUS_API_KEY_SECRET: "http-api-e2e-secret-not-a-production-value"
+      # `NEXUS_HTTP_ADDR` arms the axum listener via the http-api
+      # `service_decl` in `rust/nexusd/src/main.rs`.  Unset ⇒ the
+      # listener is not installed even in the `http-api`-featured
+      # binary (two-gate design).  Bind on all interfaces so the
+      # sibling `test` service can reach it.
+      NEXUS_HTTP_ADDR: 0.0.0.0:2128
+      # Upstream gRPC target — the same `nexusd-cluster` process's
+      # gRPC on 2126 (co-hosted).  The default in http-api's
+      # service_decl is `http://127.0.0.1:2126`, made explicit here
+      # for the docs value.
+      NEXUS_HTTP_UPSTREAM_GRPC: "http://127.0.0.1:2126"
+      RUST_LOG: info,nexus_raft=info,nexus_http_api=debug
+    # Entrypoint does two things in order:
+    #   1. `nexusd-cluster auth mint …` — offline (before the daemon
+    #      opens the redb).  Prints the raw `sk-*` on stdout; we tee
+    #      it into `/shared/sk-key` so the `test` service can read
+    #      it via the shared volume.
+    #   2. `exec nexusd-cluster …` — same shape as every other
+    #      compose file, minus `--insecure-no-auth` (the whole point
+    #      of THIS suite is that ApiKey posture is on).
+    #
+    # NOTE: does NOT pass `--insecure-no-auth`.  The auth-posture
+    # invariant on 0.0.0.0-bind + no-tls is relaxed when
+    # `NEXUS_API_KEY_SECRET` is set (auth is armed, so the loopback
+    # invariant's purpose — prevent unauthenticated remote calls —
+    # is already satisfied).
+    entrypoint:
+      - /bin/bash
+      - -c
+      - |
+        set -e
+        DATA_DIR="$${NEXUS_DATA_DIR:-/app/data}"
+        KEY_FILE="/shared/sk-key"
+
+        mkdir -p "$$(dirname "$$KEY_FILE")"
+        if [ ! -s "$$KEY_FILE" ]; then
+          echo "http-api-e2e: minting admin sk-* key offline …" >&2
+          nexusd-cluster auth mint \
+            --subject-type user \
+            --subject-id admin \
+            --admin \
+            --name http-api-e2e \
+            --data-dir "$$DATA_DIR" \
+            > "$$KEY_FILE"
+          echo "http-api-e2e: minted; key length=$$(wc -c < "$$KEY_FILE") bytes" >&2
+        fi
+
+        exec nexusd-cluster \
+          --bind-addr "$${NEXUS_BIND_ADDR:-0.0.0.0:2126}" \
+          --data-dir "$$DATA_DIR" \
+          --no-tls
+    command: []
+    volumes:
+      - http_api_node_data:/app/data
+      - http_api_shared_key:/shared
+    networks:
+      - nexus-http-api-net
+    healthcheck:
+      # `curl -fsS /v2/status` is a stricter probe than `< /dev/tcp` —
+      # a bare TCP-open pass on 2128 could mean "listener bound but
+      # tokio task hasn't started yet"; a 200 on `/v2/status` proves
+      # the axum router is live AND the public sub-router is wired.
+      test: ["CMD-SHELL", "curl -fsS http://localhost:2128/v2/status || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 24
+      start_period: 30s
+
+  test:
+    build:
+      context: ..
+      dockerfile: dockerfiles/Dockerfile.federation-test
+    image: nexus-federation-test:latest
+    container_name: nexus-http-api-test
+    profiles:
+      - run
+    depends_on:
+      node:
+        condition: service_healthy
+    user: "0:0"
+    volumes:
+      - ..:/workspace:ro
+      # docker-log shell-out (same pattern as sibling suites) for
+      # boot-line assertions if needed.
+      - /var/run/docker.sock:/var/run/docker.sock
+      # Shared volume with the daemon: the minted sk-* key file
+      # written by the daemon's entrypoint lands here read-only.
+      - http_api_shared_key:/shared:ro
+    environment:
+      NEXUS_HTTP_API_E2E: "1"
+      NEXUS_HTTP_URL: "http://node:2128"
+      NEXUS_HTTP_NODE_CONTAINER: "nexus-http-api-node"
+      # The test reads /shared/sk-key at fixture setup time and
+      # exports it into request headers.  Env-vars stay out of it
+      # so the key never lands in `docker inspect`.
+      NEXUS_HTTP_KEY_FILE: "/shared/sk-key"
+    networks:
+      - nexus-http-api-net
+    command:
+      - pytest
+      - tests/e2e/docker/test_http_api.py
+      - -v
+      - --no-header
+      - -o
+      - addopts=
+
+networks:
+  nexus-http-api-net:
+    name: nexus-http-api-net
+    driver: bridge
+
+secrets:
+  ghtoken:
+    environment: GH_TOKEN
+
+volumes:
+  http_api_node_data:
+    name: nexus-http-api-node-data
+  http_api_shared_key:
+    name: nexus-http-api-shared-key

--- a/tests/e2e/docker/test_http_api.py
+++ b/tests/e2e/docker/test_http_api.py
@@ -192,9 +192,7 @@ class TestBearerRejection:
         # an admin OperationContext — this test would then fail here,
         # exposing that the composition root did not swap NoAuth for
         # the real provider.
-        status, body = _http_post_json(
-            f"{HTTP_URL}/v2/search/query", {"q": "anything"}
-        )
+        status, body = _http_post_json(f"{HTTP_URL}/v2/search/query", {"q": "anything"})
         assert status == 401, (
             f"protected route without bearer must 401 under real "
             f"ApiKeyAuthProvider; got {status} {body}"
@@ -268,6 +266,5 @@ class TestBearerAdmission:
             headers={"Authorization": f"Bearer {sk_key}"},
         )
         assert status == 200, (
-            f"public route with a valid bearer must still 200; "
-            f"got {status} {body}"
+            f"public route with a valid bearer must still 200; got {status} {body}"
         )

--- a/tests/e2e/docker/test_http_api.py
+++ b/tests/e2e/docker/test_http_api.py
@@ -1,0 +1,273 @@
+"""HTTP-API E2E — locks the R10 wiring against a REAL nexusd-cluster.
+
+The R10 arc lands a pure-Rust HTTP surface (`rust/services/http-api/`)
+that a `--features http-api`-featured `nexusd-cluster` binds via
+`NEXUS_HTTP_ADDR`.  This suite spins up the single-node compose in
+`dockerfiles/docker-compose.http-api-e2e.yml` and drives the real
+axum listener over real TCP with a real minted `sk-*` key against a
+real `ApiKeyAuthProvider` — the acceptance test the crate's own
+unit tests + auth-middleware E2E cannot cover (all their auth
+providers are stubs).
+
+## Scenarios
+
+  * `test_status_is_public_without_auth` — the `/v2/status` sub-router
+    is deliberately outside the bearer middleware so liveness probes
+    (kube, docker healthchecks) work before any bearer exists.
+  * `test_search_query_without_bearer_returns_401` — proves the
+    middleware is wired at the composition root (not just imported).
+    Without wiring, `ApiKeyAuthProvider` never runs and the request
+    reaches the upstream search backend, which would return an
+    unauthenticated-but-unhelpful status.
+  * `test_search_query_with_wrong_bearer_returns_401` — proves the
+    provider actually resolves against the minted key store.  A
+    stub-that-accepts-anything would 200-through here.
+  * `test_search_query_with_valid_bearer_is_not_401` — proves the
+    minted key is admitted end-to-end.  The status is intentionally
+    "NOT 401" rather than "200" because this compose does not bake
+    the search-plugin cdylib (deliberately — testing the auth plane,
+    not the search chain), so the upstream `SearchService` returns
+    Unimplemented → HTTP 501 or Unavailable → 503.  Both count as
+    "auth admitted, backend downstream." Real search happy-path with
+    a real plugin lives in `test_search_plugin.py`.
+
+## The stdlib-only choice
+
+Uses `urllib.request` rather than `requests` / `httpx` so the test
+runs on the shared `nexus-federation-test` image without a bespoke
+`pip install` layer — same reason `test_search_plugin.py` uses raw
+grpc rather than reaching for anything higher-level.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import urllib.error
+import urllib.request
+
+import pytest
+
+from tests.e2e.docker.runbook_helpers import wait_healthy
+
+pytestmark = [
+    pytest.mark.xdist_group("http-api-e2e"),
+    pytest.mark.skipif(
+        os.environ.get("NEXUS_HTTP_API_E2E") != "1",
+        reason="HTTP-API E2E suite needs the docker-compose.http-api-e2e stack; "
+        "set NEXUS_HTTP_API_E2E=1 to enable (CI sets this automatically).",
+    ),
+]
+
+
+HTTP_URL = os.environ.get("NEXUS_HTTP_URL", "http://node:2128")
+KEY_FILE = os.environ.get("NEXUS_HTTP_KEY_FILE", "/shared/sk-key")
+# gRPC port on the same daemon — used only for the readiness gate (TCP
+# probe on 2126 has been the convention across every sibling suite;
+# 2128 is HTTP so we use `wait_healthy` on the gRPC port and then rely
+# on the compose healthcheck for the axum listener).
+NODE_GRPC = os.environ.get("NEXUS_HTTP_NODE_GRPC", "node:2126")
+
+
+# ---------------------------------------------------------------------------
+# Module-scoped setup
+# ---------------------------------------------------------------------------
+@pytest.fixture(scope="module", autouse=True)
+def _cluster_ready() -> None:
+    """Hard-fail if the daemon isn't reachable.
+
+    The compose healthcheck already gates the `test` service on
+    `curl /v2/status → 200`, so by the time this fixture runs the
+    listener is up.  The TCP probe on 2126 here is defensive — proves
+    the gRPC surface is also alive (the http-api handler forwards to
+    it, so a 2126-down cluster would surface as 503 for every search
+    request even with a valid bearer, which would mislead the "wrong
+    bearer" and "no bearer" assertions below).
+    """
+    wait_healthy([NODE_GRPC])
+
+
+@pytest.fixture(scope="module")
+def sk_key() -> str:
+    """Read the sk-* the daemon entrypoint minted before boot.
+
+    The daemon's entrypoint ran `nexusd-cluster auth mint --subject-type
+    user --subject-id admin --admin --name http-api-e2e` OFFLINE (before
+    the redb was opened by the daemon) and tee'd its stdout into
+    `/shared/sk-key`, mounted read-only on this container via a shared
+    docker volume.  A missing / empty file means the mint step failed
+    or the compose wiring drifted — fail loud with the actual path so
+    an operator running the suite locally can debug.
+    """
+    path = pathlib.Path(KEY_FILE)
+    assert path.is_file(), (
+        f"minted sk-* key file {path} is missing — either the daemon's "
+        f"entrypoint mint step failed or the compose shared-volume wiring "
+        f"drifted; check `docker logs nexus-http-api-node` for the mint output."
+    )
+    key = path.read_text().strip()
+    assert key.startswith("sk-"), (
+        f"minted key at {path} does not start with 'sk-' — got {key[:8]!r}. "
+        f"The mint subcommand should print the raw key on stdout; a stderr "
+        f"log line leaked into the file suggests the entrypoint's shell "
+        f"redirection was wrong."
+    )
+    return key
+
+
+# ---------------------------------------------------------------------------
+# Wire helpers — stdlib only
+# ---------------------------------------------------------------------------
+def _http_get(url: str, headers: dict[str, str] | None = None) -> tuple[int, dict]:
+    """`urllib.request` GET returning (status, parsed_json_body).
+
+    Non-2xx statuses raise `HTTPError`; we catch and read the body from
+    the exception so callers can pin error-body JSON shapes.
+    """
+    req = urllib.request.Request(url, headers=headers or {}, method="GET")
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            body = resp.read().decode("utf-8", errors="replace")
+            return resp.status, (json.loads(body) if body else {})
+    except urllib.error.HTTPError as e:
+        body = e.read().decode("utf-8", errors="replace")
+        try:
+            return e.code, json.loads(body)
+        except json.JSONDecodeError:
+            return e.code, {"_raw": body}
+
+
+def _http_post_json(
+    url: str, body: dict, headers: dict[str, str] | None = None
+) -> tuple[int, dict]:
+    """`urllib.request` POST with a JSON body; same return shape as `_http_get`."""
+    payload = json.dumps(body).encode("utf-8")
+    hdrs = {"Content-Type": "application/json", **(headers or {})}
+    req = urllib.request.Request(url, data=payload, headers=hdrs, method="POST")
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            resp_body = resp.read().decode("utf-8", errors="replace")
+            return resp.status, (json.loads(resp_body) if resp_body else {})
+    except urllib.error.HTTPError as e:
+        resp_body = e.read().decode("utf-8", errors="replace")
+        try:
+            return e.code, json.loads(resp_body)
+        except json.JSONDecodeError:
+            return e.code, {"_raw": resp_body}
+
+
+# ===========================================================================
+# Tests
+# ===========================================================================
+class TestPublicRoute:
+    """`/v2/status` is deliberately outside the bearer middleware."""
+
+    def test_status_is_public_without_auth(self) -> None:
+        # No `Authorization` header — a strict `ApiKeyAuthProvider` on a
+        # protected route would 401 this.  `/v2/status` lives on the
+        # PUBLIC sub-router (see `router()` in `rust/services/http-api/
+        # src/lib.rs`) so it bypasses the bearer gate entirely.
+        status, body = _http_get(f"{HTTP_URL}/v2/status")
+        assert status == 200, f"public status route must 200 without auth; got {status} {body}"
+        assert body.get("status") == "ok", f"unexpected status body: {body}"
+
+    def test_status_shape_is_stable(self) -> None:
+        # Pins the wire contract of the readiness endpoint — a caller
+        # (kube liveness probe, docker healthcheck, operator curl)
+        # should see the same fields on every release.
+        status, body = _http_get(f"{HTTP_URL}/v2/status")
+        assert status == 200
+        for required in ("status", "version"):
+            assert required in body, f"missing required field {required!r} in {body}"
+
+
+class TestBearerRejection:
+    """`/v2/search/query` is behind `require_bearer` (protected sub-router)."""
+
+    def test_search_query_without_bearer_returns_401(self) -> None:
+        # Absent header → parser returns Ok(None) → middleware calls
+        # `resolve` with empty token → `ApiKeyAuthProvider` rejects
+        # empty → 401.  A NoAuth-wired daemon would 200-through with
+        # an admin OperationContext — this test would then fail here,
+        # exposing that the composition root did not swap NoAuth for
+        # the real provider.
+        status, body = _http_post_json(
+            f"{HTTP_URL}/v2/search/query", {"q": "anything"}
+        )
+        assert status == 401, (
+            f"protected route without bearer must 401 under real "
+            f"ApiKeyAuthProvider; got {status} {body}"
+        )
+
+    def test_search_query_with_wrong_bearer_returns_401(self) -> None:
+        # Well-formed bearer that the provider does NOT resolve → 401.
+        # Proves the provider actually consults the key store — a stub
+        # that admits any well-formed token would 200-through.
+        status, body = _http_post_json(
+            f"{HTTP_URL}/v2/search/query",
+            {"q": "anything"},
+            headers={"Authorization": "Bearer sk-this-key-was-never-minted"},
+        )
+        assert status == 401, (
+            f"unresolved bearer must 401 (provider must consult the key "
+            f"store, not just check header shape); got {status} {body}"
+        )
+
+
+class TestBearerAdmission:
+    """The real minted `sk-*` key must be admitted end-to-end."""
+
+    def test_search_query_with_valid_bearer_is_not_401(self, sk_key: str) -> None:
+        # `sk_key` is what `nexusd-cluster auth mint --admin` printed
+        # during the daemon's boot entrypoint — a REAL key backed by a
+        # REAL redb row.  Middleware calls `ApiKeyAuthProvider::resolve`
+        # → provider hashes the token → finds the row → returns an
+        # admin `OperationContext` → request forwarded to the upstream
+        # search backend.
+        #
+        # Assertion is NOT-401 (rather than 200) because this compose
+        # deliberately does not load the search-plugin cdylib — the
+        # upstream `SearchService` is unregistered, so the RPC returns
+        # `Unimplemented` (mapped to HTTP 501) or `Unavailable`
+        # (mapped to 503).  Both prove the auth path succeeded; the
+        # search happy-path is covered by the sibling
+        # search-plugin-e2e suite (which runs `--insecure-no-auth`
+        # for the same reason — those two axes are tested
+        # independently).
+        status, body = _http_post_json(
+            f"{HTTP_URL}/v2/search/query",
+            {"q": "anything"},
+            headers={"Authorization": f"Bearer {sk_key}"},
+        )
+        assert status != 401, (
+            f"valid minted sk-* must be admitted; got 401 {body}. "
+            f"Either the mint step secret mismatched the daemon "
+            f"NEXUS_API_KEY_SECRET (HMAC mismatch) or the daemon booted "
+            f"under NoAuth (composition-root wiring regressed)."
+        )
+        # Also assert not 500 — the shared `grpc_status_to_http` mapper
+        # in the http-api handler routes `Ok/Cancelled/Unknown/Internal/
+        # DataLoss → 500`; a 500 here would mean the upstream RPC hit
+        # one of those codes (unexpected shape).  501 / 503 are the
+        # documented no-plugin outcomes.
+        assert status in (501, 503, 200), (
+            f"expected 501 (Unimplemented — no plugin loaded) / 503 "
+            f"(Unavailable) / 200 (plugin loaded — unlikely in this "
+            f"suite); got {status} {body}"
+        )
+
+    def test_public_status_ignores_bearer_when_present(self, sk_key: str) -> None:
+        # Sending a bearer to a public route must not cause it to
+        # attempt bearer resolution — a strict provider that 500s on
+        # unresolvable tokens (there isn't one wired here, but the
+        # contract must be strict) still would not touch a public
+        # route.  Belt-and-braces pin that the sub-router split holds.
+        status, body = _http_get(
+            f"{HTTP_URL}/v2/status",
+            headers={"Authorization": f"Bearer {sk_key}"},
+        )
+        assert status == 200, (
+            f"public route with a valid bearer must still 200; "
+            f"got {status} {body}"
+        )


### PR DESCRIPTION
## Summary

Acceptance test for the R10 nexus-server → pure-Rust migration wire (nexus #4713 + nexus-vfs #250 + sudocode #498). Boots a `nexusd-cluster --features http-api` in docker with a REAL `ApiKeyAuthProvider` armed (`NEXUS_API_KEY_SECRET` set, no `--insecure-no-auth`) and drives the real axum listener over real TCP with a real minted `sk-*` key.

## Why this test exists

The crate's own unit tests + auth-middleware E2E all use STUB providers (`NoAuth`, `FixedBearer`). Nothing before this suite proved that:
- `nexusd::main::http_api_decl` really passes `Arc::clone(&ctx.auth)` (not a fresh `NoAuth`)
- `ServiceBootCtx.auth` IS the SAME `Arc<dyn AuthProvider>` the kernel gRPC interceptor uses (SSOT invariant)
- A real `nexusd-cluster auth mint`-minted `sk-*` hashes identically to what `ApiKeyAuthProvider::resolve` expects
- The axum listener actually starts + binds under a real tokio runtime

## Assertions (6 tests, 3 classes)

- **TestPublicRoute** — GET /v2/status returns 200 without bearer; response shape stable
- **TestBearerRejection** — POST /v2/search/query without bearer → 401; with WRONG bearer → 401 (proves provider consults key store, not just header shape)
- **TestBearerAdmission** — POST /v2/search/query with real minted `sk-*` → NOT 401 (accepts 501/503/200; this compose doesn't bake the search-plugin — testing the AUTH plane, not the search chain); public route ignores bearer when present

## Mint-before-boot dance

Daemon container's entrypoint runs `nexusd-cluster auth mint --subject-type user --subject-id admin --admin` OFFLINE (before redb opens for serving), tees the raw sk-* to `/shared/sk-key` on a docker named volume, then `exec`s the daemon. Test service mounts the volume read-only.

## Independence from search-plugin-e2e

- search-plugin-e2e: `--insecure-no-auth` — tests search chain without auth axis
- http-api-e2e: `NEXUS_API_KEY_SECRET` — tests auth chain without search axis

Keeps failure signals sharp — testing both at once would leave "which one broke" ambiguous.

## Files

- `dockerfiles/Dockerfile.nexusd-cluster-httpapi` — clone of cohost Dockerfile with `--features http-api`
- `dockerfiles/docker-compose.http-api-e2e.yml` — single-node cluster + shared-key volume + test service
- `tests/e2e/docker/test_http_api.py` — 6 tests, stdlib-only (urllib.request)
- `.github/workflows/http-api-e2e.yml` — CI, mirrors search-plugin-e2e workflow

No existing files touched.
