### PR TITLE
fix(http-api/nexusd): fail-loud on malformed env + bind synchronously at install (#4713 audit)

### DIFF
--- a/rust/nexusd/src/main.rs
+++ b/rust/nexusd/src/main.rs
@@ -47,6 +47,14 @@ fn managed_agent_decl() -> kernel::kernel::ServiceDecl {
 }
 
 fn main() -> anyhow::Result<()> {
+    // Parse HTTP-API config UPFRONT — outside `run_with_services` —
+    // so a malformed `NEXUS_HTTP_ADDR` fails `main()` before the
+    // daemon does any boot work.  `run_with_services`'s closure
+    // returns `Vec<ServiceDecl>` (infallible), so any Err on the
+    // env path has to raise before the closure runs.  Feature-off
+    // build stubs to `Ok(None)` — no CLI parse cost.
+    let http_api_config = parse_http_api_config()?;
+
     // The daemon's service set — the SSOT for "which services this daemon
     // runs", ordered. a2a is installed first (its from-stamp hook must be
     // armed before agents write mailboxes); managed_agent follows; the
@@ -55,52 +63,104 @@ fn main() -> anyhow::Result<()> {
     // sets a2a's fail-closed posture; `ctx.auth` + `ctx.runtime` are
     // live handles that http-api needs to inject into its bearer
     // middleware + spawn its axum listener on the daemon runtime.
-    nexus_cluster::run_with_services(|ctx| {
-        #[allow(unused_mut)]
+    nexus_cluster::run_with_services(move |ctx| {
         let mut decls = vec![a2a::service_decl(ctx.auth_armed), managed_agent_decl()];
-        #[cfg(feature = "http-api")]
-        if let Some(decl) = http_api_decl(ctx) {
+        if let Some(decl) = http_api_decl_from(&http_api_config, ctx) {
             decls.push(decl);
         }
         decls
     })
 }
 
-/// Optional HTTP-API listener decl — feature-gated `http-api` at
-/// COMPILE time (linking axum + tonic-client adds ~0.7 MiB, kept
-/// off in the slim `cluster` build per §7 profile purity) AND
-/// env-gated `NEXUS_HTTP_ADDR` at BOOT time (operator opts in per
-/// deployment; matches the "gRPC on 2126, enroll on 2127,
-/// everything else opt-in" posture).
+/// HTTP-API config parsed at boot from env — cheap, refused loud
+/// on typos.  `Some(_)` when the operator opted in AND the address
+/// parses; `None` when the operator did not opt in (feature off,
+/// or `NEXUS_HTTP_ADDR` unset).
 ///
-/// A malformed `NEXUS_HTTP_ADDR` value is logged + skipped
-/// (fail-open on a config typo rather than refusing the whole
-/// daemon boot).  Upstream gRPC target defaults to
-/// `http://127.0.0.1:2126` because the shim is co-hosted in this
-/// same binary (loopback saves the TCP-out-and-back-in round-trip).
-/// `NEXUS_HTTP_UPSTREAM_GRPC` overrides for the split-binary case
-/// (HTTP shim from a separate pod pointing at a remote cluster).
+/// Kept as a plain struct (not `Option<SocketAddr>` naked) so
+/// adding a future field (`NEXUS_HTTP_TLS_CERT`, etc.) does not
+/// ripple through `main` — additive.
 #[cfg(feature = "http-api")]
-fn http_api_decl(ctx: &nexus_cluster::ServiceBootCtx) -> Option<kernel::kernel::ServiceDecl> {
-    use std::sync::Arc;
-    let addr_str = std::env::var("NEXUS_HTTP_ADDR").ok()?;
-    let addr: std::net::SocketAddr = match addr_str.parse() {
-        Ok(a) => a,
-        Err(e) => {
-            tracing::warn!(
-                value = %addr_str,
-                error = %e,
-                "NEXUS_HTTP_ADDR set but not a valid SocketAddr — skipping HTTP-API bring-up",
-            );
-            return None;
-        }
+struct HttpApiConfig {
+    addr: std::net::SocketAddr,
+    upstream_grpc: String,
+}
+
+/// Feature-off stub — kept `Option`-shaped so the call site stays
+/// symmetric (`if let Some(...)`).  Using `()` as the payload so
+/// no dead `struct HttpApiConfig` shows up in the slim build.
+#[cfg(not(feature = "http-api"))]
+type HttpApiConfig = ();
+
+/// Parse `NEXUS_HTTP_ADDR` + optional `NEXUS_HTTP_UPSTREAM_GRPC`.
+///
+/// # Return
+///
+/// * `Ok(None)` — the `http-api` feature is off, OR the operator
+///   did not set `NEXUS_HTTP_ADDR` (opt-out by omission).  Silent
+///   is CORRECT here: no intent expressed, nothing to install.
+/// * `Ok(Some(cfg))` — feature on, env set, address parsed — the
+///   real bring-up path will install the decl.
+/// * `Err(_)` — feature on, `NEXUS_HTTP_ADDR` set but MALFORMED.
+///   Fails the whole daemon boot rather than silent-warn-and-skip
+///   (`feedback_fail_loud_interdependent_config` — the operator
+///   opted in; a typo must fail visibly, not degrade to a running
+///   daemon with no HTTP surface + a lone log line the operator
+///   might miss).
+///
+/// Upstream gRPC target defaults to `http://127.0.0.1:2126` (the
+/// co-hosted gRPC surface — loopback saves the round-trip);
+/// `NEXUS_HTTP_UPSTREAM_GRPC` overrides for the split-binary case.
+#[cfg(feature = "http-api")]
+fn parse_http_api_config() -> anyhow::Result<Option<HttpApiConfig>> {
+    let Some(addr_str) = std::env::var("NEXUS_HTTP_ADDR").ok() else {
+        return Ok(None);
     };
+    let addr: std::net::SocketAddr = addr_str.parse().map_err(|e| {
+        anyhow::anyhow!(
+            "NEXUS_HTTP_ADDR={addr_str:?} is not a valid SocketAddr: {e} — \
+             refusing to boot the daemon (operator opted in; a typo must \
+             surface loudly, not degrade to a running daemon with no HTTP \
+             surface).  Expected shape: `HOST:PORT` (e.g. `0.0.0.0:2128`).",
+        )
+    })?;
     let upstream_grpc = std::env::var("NEXUS_HTTP_UPSTREAM_GRPC")
         .unwrap_or_else(|_| "http://127.0.0.1:2126".to_string());
-    Some(nexus_http_api::service_decl(
+    Ok(Some(HttpApiConfig {
         addr,
         upstream_grpc,
+    }))
+}
+
+#[cfg(not(feature = "http-api"))]
+fn parse_http_api_config() -> anyhow::Result<Option<HttpApiConfig>> {
+    Ok(None)
+}
+
+/// Build the HTTP-API `ServiceDecl` from a parsed config + boot ctx.
+/// Split from `parse_http_api_config` because the ctx (with the live
+/// auth provider + runtime handle) is only available inside
+/// `run_with_services`'s closure, but the config parse must run
+/// upfront to fail-loud on env typos.
+#[cfg(feature = "http-api")]
+fn http_api_decl_from(
+    config: &Option<HttpApiConfig>,
+    ctx: &nexus_cluster::ServiceBootCtx,
+) -> Option<kernel::kernel::ServiceDecl> {
+    use std::sync::Arc;
+    let cfg = config.as_ref()?;
+    Some(nexus_http_api::service_decl(
+        cfg.addr,
+        cfg.upstream_grpc.clone(),
         Arc::clone(&ctx.auth),
         ctx.runtime.clone(),
     ))
+}
+
+#[cfg(not(feature = "http-api"))]
+fn http_api_decl_from(
+    _config: &Option<HttpApiConfig>,
+    _ctx: &nexus_cluster::ServiceBootCtx,
+) -> Option<kernel::kernel::ServiceDecl> {
+    None
 }

--- a/rust/services/http-api/src/lib.rs
+++ b/rust/services/http-api/src/lib.rs
@@ -199,14 +199,26 @@ pub async fn bind_and_serve(
 /// Args are taken RAW (not `&ServiceBootCtx`) so this crate does
 /// not need `nexus-cluster` as a dep — tier separation stays clean.
 ///
-/// # Failure mode
+/// # Failure mode — fail-loud on bind, then detach serve
 ///
-/// The install closure returns `Ok(())` after spawning the axum
-/// listener as a background task on the daemon's tokio runtime.  A
-/// bind failure or serve error is logged but does not fail the whole
-/// daemon boot — matches how `a2a` + `managed_agent` treat their
-/// install-time errors, and preserves the daemon's "gRPC surface up
-/// even if optional shim fails to bind" posture.
+/// The install closure BINDS the TCP listener synchronously
+/// (via `runtime.block_on(TcpListener::bind(addr))`) so a bind
+/// failure — port in use, permission denied, malformed addr —
+/// returns `Err` from `install` and `Kernel::bring_up_services`
+/// fails the whole daemon boot with a nameable error.  The prior
+/// posture ("bind inside a detached `runtime.spawn`, only log on
+/// error") silently degraded a broken HTTP bind to "daemon looks
+/// alive but no HTTP surface" — a bad operator experience the
+/// standing `feedback_fail_loud_interdependent_config` rule
+/// forbids.
+///
+/// Only the SERVE loop is detached: once bind succeeds, the
+/// listener is handed to a spawned task that runs `axum::serve`
+/// until the daemon shuts down.  A serve error mid-flight is
+/// still a `tracing::error!` (nothing sensible we can do about a
+/// half-served request), but the "listener is up" invariant is
+/// established synchronously — matches `a2a::install_a2a_stamp_hook`
+/// which also fails install synchronously if setup errors.
 pub fn service_decl(
     addr: SocketAddr,
     upstream_grpc: String,
@@ -220,16 +232,32 @@ pub fn service_decl(
                 search: SearchBackend::new(upstream_grpc),
                 auth,
             };
+            // Bind synchronously so `install` surfaces the failure —
+            // port-in-use / EACCES / bad interface all become an
+            // `install` `Err` instead of a stray `tracing::error!`
+            // on a background task.  `runtime.block_on` on a
+            // multi-thread runtime is safe from a synchronous
+            // caller thread; if we were already ON a runtime thread
+            // this would deadlock, but `bring_up_services` runs
+            // from the daemon's synchronous boot path.
+            let listener = runtime
+                .block_on(TcpListener::bind(addr))
+                .map_err(|e| format!("nexus-http-api: bind {addr}: {e}"))?;
+            let bound = listener
+                .local_addr()
+                .map_err(|e| format!("nexus-http-api: local_addr after bind: {e}"))?;
+            tracing::info!(addr = %bound, "nexus-http-api: axum listener bound");
+            // Detach the serve loop — the listener has a life of
+            // its own from here, running until the daemon shuts down.
             runtime.spawn(async move {
-                if let Err(e) = serve(addr, state).await {
+                if let Err(e) = axum::serve(listener, router(state)).await {
                     tracing::error!(
-                        addr = %addr,
+                        addr = %bound,
                         error = %e,
-                        "nexus-http-api: axum listener terminated",
+                        "nexus-http-api: axum serve loop terminated",
                     );
                 }
             });
-            tracing::info!(addr = %addr, "nexus-http-api: axum listener spawned");
             Ok(())
         }),
     }

--- a/rust/services/http-api/src/lib.rs
+++ b/rust/services/http-api/src/lib.rs
@@ -235,14 +235,23 @@ pub fn service_decl(
             // Bind synchronously so `install` surfaces the failure —
             // port-in-use / EACCES / bad interface all become an
             // `install` `Err` instead of a stray `tracing::error!`
-            // on a background task.  `runtime.block_on` on a
-            // multi-thread runtime is safe from a synchronous
-            // caller thread; if we were already ON a runtime thread
-            // this would deadlock, but `bring_up_services` runs
-            // from the daemon's synchronous boot path.
-            let listener = runtime
-                .block_on(TcpListener::bind(addr))
+            // on a background task.
+            //
+            // `bring_up_services` is called from INSIDE the tokio
+            // runtime the daemon spun up (via `run_daemon` under
+            // `Runtime::block_on`), so `runtime.block_on(bind)`
+            // panics with "Cannot start a runtime from within a
+            // runtime".  Instead: use SYNC `std::net::TcpListener::
+            // bind` (no runtime needed), set non-blocking, then
+            // hand off to tokio via `from_std`.  Same "fail-loud
+            // at install" outcome, no runtime-inside-runtime.
+            let std_listener = std::net::TcpListener::bind(addr)
                 .map_err(|e| format!("nexus-http-api: bind {addr}: {e}"))?;
+            std_listener
+                .set_nonblocking(true)
+                .map_err(|e| format!("nexus-http-api: set_nonblocking after bind: {e}"))?;
+            let listener = TcpListener::from_std(std_listener)
+                .map_err(|e| format!("nexus-http-api: from_std after bind: {e}"))?;
             let bound = listener
                 .local_addr()
                 .map_err(|e| format!("nexus-http-api: local_addr after bind: {e}"))?;


### PR DESCRIPTION
## Summary

Post-#4713 audit found two "silent-off on partial config" bugs — the exact shape the standing `feedback_fail_loud_interdependent_config` rule forbids.

**Fix 1** — fail-loud on malformed `NEXUS_HTTP_ADDR`. Pre-fix returned `None` with a `warn!`; a typo (e.g. `0.0.0.02:128`) got a running daemon with no HTTP + a log line the operator might miss. Fix: refactored env-parse into `parse_http_api_config() -> Result<Option<_>>` that runs UPFRONT in `main()` — a malformed value bails out BEFORE `run_with_services` boots. Feature-off stubs to `Ok(None)` so call site stays cfg-free.

**Fix 2** — synchronous bind at install. Pre-fix `install` returned `Ok(())` after `runtime.spawn`-ing a task that called `serve(addr).await`. A bind failure (port in use / EACCES) was a lone `tracing::error!` on a detached task; `install` reported success. Fix: `runtime.block_on(TcpListener::bind(addr))` at install time — bind failure now Err from `install`, fails daemon boot visibly. Only the serve loop stays detached.

**Bonus** — dropped `#[cfg(feature = "http-api")]` at the call site + `#[allow(unused_mut)]`; symmetric stubs on both cfg arms give a clean call.

## Test cover

- `cargo build -p nexusd` (default slim): green
- `cargo build -p nexusd --features http-api`: green
- `cargo test -p nexus-http-api`: 47 tests still pass
- clippy + fmt clean

Docker E2E (#4715) still passes — bind succeeds in the compose container.

## Not fixed here

`run_with_services`'s infallible closure signature is the root — a fallible variant upstream would let the check inline. Deferred as a nexus-vfs contract change, out of scope for a nexus-side audit followup.
