### PR TITLE
test(http-api): pin service_decl install under a runtime + fix stale docstring (#4717 audit)

### DIFF
--- a/rust/services/http-api/src/lib.rs
+++ b/rust/services/http-api/src/lib.rs
@@ -201,16 +201,28 @@ pub async fn bind_and_serve(
 ///
 /// # Failure mode — fail-loud on bind, then detach serve
 ///
-/// The install closure BINDS the TCP listener synchronously
-/// (via `runtime.block_on(TcpListener::bind(addr))`) so a bind
-/// failure — port in use, permission denied, malformed addr —
-/// returns `Err` from `install` and `Kernel::bring_up_services`
-/// fails the whole daemon boot with a nameable error.  The prior
-/// posture ("bind inside a detached `runtime.spawn`, only log on
-/// error") silently degraded a broken HTTP bind to "daemon looks
-/// alive but no HTTP surface" — a bad operator experience the
-/// standing `feedback_fail_loud_interdependent_config` rule
-/// forbids.
+/// The install closure BINDS the TCP listener synchronously via
+/// `std::net::TcpListener::bind` (a raw `socket` + `bind` +
+/// `listen` syscall trio — no tokio runtime needed, no I/O),
+/// then hands the fd to tokio via `set_nonblocking(true)` +
+/// `TcpListener::from_std`.  A bind failure — port in use,
+/// permission denied, bad interface — returns `Err` from
+/// `install` and `Kernel::bring_up_services` fails the whole
+/// daemon boot with a nameable error.  The prior posture ("bind
+/// inside a detached `runtime.spawn`, only log on error")
+/// silently degraded a broken HTTP bind to "daemon looks alive
+/// but no HTTP surface" — a bad operator experience the standing
+/// `feedback_fail_loud_interdependent_config` rule forbids.
+///
+/// # Why NOT `runtime.block_on(tokio::TcpListener::bind)`
+///
+/// `bring_up_services` runs INSIDE the tokio runtime the daemon
+/// spun up (via `run_daemon` under `Runtime::block_on`), so a
+/// `Handle::block_on` here panics with `Cannot start a runtime
+/// from within a runtime` — the docker-E2E-caught first
+/// iteration of this fix.  The sync `std::net::bind` path avoids
+/// runtime re-entry entirely (bind is a fast syscall, no I/O)
+/// while preserving the "Err from install" semantic.
 ///
 /// Only the SERVE loop is detached: once bind succeeds, the
 /// listener is handed to a spawned task that runs `axum::serve`
@@ -227,47 +239,65 @@ pub fn service_decl(
 ) -> kernel::kernel::ServiceDecl {
     kernel::kernel::ServiceDecl {
         name: "http_api".to_string(),
-        install: Box::new(move |_kernel| {
-            let state = AppState {
-                search: SearchBackend::new(upstream_grpc),
-                auth,
-            };
-            // Bind synchronously so `install` surfaces the failure —
-            // port-in-use / EACCES / bad interface all become an
-            // `install` `Err` instead of a stray `tracing::error!`
-            // on a background task.
-            //
-            // `bring_up_services` is called from INSIDE the tokio
-            // runtime the daemon spun up (via `run_daemon` under
-            // `Runtime::block_on`), so `runtime.block_on(bind)`
-            // panics with "Cannot start a runtime from within a
-            // runtime".  Instead: use SYNC `std::net::TcpListener::
-            // bind` (no runtime needed), set non-blocking, then
-            // hand off to tokio via `from_std`.  Same "fail-loud
-            // at install" outcome, no runtime-inside-runtime.
-            let std_listener = std::net::TcpListener::bind(addr)
-                .map_err(|e| format!("nexus-http-api: bind {addr}: {e}"))?;
-            std_listener
-                .set_nonblocking(true)
-                .map_err(|e| format!("nexus-http-api: set_nonblocking after bind: {e}"))?;
-            let listener = TcpListener::from_std(std_listener)
-                .map_err(|e| format!("nexus-http-api: from_std after bind: {e}"))?;
-            let bound = listener
-                .local_addr()
-                .map_err(|e| format!("nexus-http-api: local_addr after bind: {e}"))?;
-            tracing::info!(addr = %bound, "nexus-http-api: axum listener bound");
-            // Detach the serve loop — the listener has a life of
-            // its own from here, running until the daemon shuts down.
-            runtime.spawn(async move {
-                if let Err(e) = axum::serve(listener, router(state)).await {
-                    tracing::error!(
-                        addr = %bound,
-                        error = %e,
-                        "nexus-http-api: axum serve loop terminated",
-                    );
-                }
-            });
-            Ok(())
-        }),
+        install: Box::new(move |_kernel| install_impl(addr, upstream_grpc, auth, runtime)),
     }
+}
+
+/// The install-closure body extracted as a plain fn so it is
+/// callable from a test WITHOUT constructing a real `Arc<Kernel>`
+/// (a full `Kernel` needs a metastore + backends + observers —
+/// heavy for a bind-only regression pin).
+///
+/// Marked `pub` (not `pub(crate)`) purely so the integration test
+/// `tests/serve_e2e.rs` — a separate compilation unit — can drive
+/// it under a real tokio runtime.  Production callers should use
+/// [`service_decl`], not this fn directly; a `#[doc(hidden)]`
+/// annotation keeps it out of the rustdoc surface.
+#[doc(hidden)]
+pub fn install_impl(
+    addr: SocketAddr,
+    upstream_grpc: String,
+    auth: Arc<dyn AuthProvider>,
+    runtime: tokio::runtime::Handle,
+) -> Result<(), String> {
+    let state = AppState {
+        search: SearchBackend::new(upstream_grpc),
+        auth,
+    };
+    // Bind synchronously so `install` surfaces the failure —
+    // port-in-use / EACCES / bad interface all become an
+    // `install` `Err` instead of a stray `tracing::error!`
+    // on a background task.
+    //
+    // Use SYNC `std::net::TcpListener::bind` (no runtime needed —
+    // `bind` is a raw `socket`+`bind`+`listen` syscall trio),
+    // then hand off to tokio via `from_std`.  A prior iteration
+    // used `runtime.block_on(tokio::TcpListener::bind)` — WRONG:
+    // `bring_up_services` runs INSIDE the tokio runtime the
+    // daemon spun up, so `block_on` panics with "Cannot start a
+    // runtime from within a runtime".  The sync path avoids
+    // runtime re-entry entirely.
+    let std_listener = std::net::TcpListener::bind(addr)
+        .map_err(|e| format!("nexus-http-api: bind {addr}: {e}"))?;
+    std_listener
+        .set_nonblocking(true)
+        .map_err(|e| format!("nexus-http-api: set_nonblocking after bind: {e}"))?;
+    let listener = TcpListener::from_std(std_listener)
+        .map_err(|e| format!("nexus-http-api: from_std after bind: {e}"))?;
+    let bound = listener
+        .local_addr()
+        .map_err(|e| format!("nexus-http-api: local_addr after bind: {e}"))?;
+    tracing::info!(addr = %bound, "nexus-http-api: axum listener bound");
+    // Detach the serve loop — the listener has a life of
+    // its own from here, running until the daemon shuts down.
+    runtime.spawn(async move {
+        if let Err(e) = axum::serve(listener, router(state)).await {
+            tracing::error!(
+                addr = %bound,
+                error = %e,
+                "nexus-http-api: axum serve loop terminated",
+            );
+        }
+    });
+    Ok(())
 }

--- a/rust/services/http-api/tests/serve_e2e.rs
+++ b/rust/services/http-api/tests/serve_e2e.rs
@@ -65,3 +65,101 @@ async fn unknown_endpoint_returns_404_over_real_tcp() {
         .expect("send 404 request");
     assert_eq!(resp.status(), reqwest::StatusCode::NOT_FOUND);
 }
+
+/// Regression pin — the `service_decl` install path must not
+/// re-enter the tokio runtime.
+///
+/// The R10-audit-followup PR (#4717) initially used
+/// `runtime.block_on(tokio::net::TcpListener::bind(addr))` inside
+/// the install closure — WRONG: `bring_up_services` is invoked
+/// FROM a runtime worker, so `block_on` panicked with
+/// `Cannot start a runtime from within a runtime` — caught only
+/// by the docker E2E (#4715), post-push.  This test invokes the
+/// same code path (`install_impl` — the install-closure body
+/// factored out of `service_decl` so tests can drive it without
+/// constructing a full `Arc<Kernel>`) UNDER a real
+/// `#[tokio::test(flavor = "multi_thread")]` runtime, so a
+/// regression trips locally instead of live.
+///
+/// Uses the `default_no_auth_provider` + a dummy upstream that
+/// never gets dialed (the install path only touches the
+/// listener, not the search backend), so a passing test proves
+/// EXACTLY the "install completes cleanly from a runtime thread"
+/// invariant — nothing else.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn service_decl_install_body_runs_under_a_tokio_runtime() {
+    use nexus_http_api::middleware::auth::default_no_auth_provider;
+    use tokio::net::TcpListener;
+
+    // Bind ephemeral to get an unused port, then drop the
+    // listener BEFORE handing the addr to `install_impl` so its
+    // own bind succeeds against the same port (SO_REUSEADDR
+    // handles the TIME_WAIT window on the OS).
+    let probe = TcpListener::bind("127.0.0.1:0").await.expect("probe bind");
+    let addr = probe.local_addr().expect("probe local_addr");
+    drop(probe);
+
+    let handle = tokio::runtime::Handle::current();
+    // Direct call — same path `ServiceDecl::install` takes at
+    // daemon boot, minus the `_kernel: &Arc<Kernel>` param the
+    // body ignores.  A runtime-in-runtime panic here would
+    // abort the test with "Cannot start a runtime from within a
+    // runtime".
+    let result = nexus_http_api::install_impl(
+        addr,
+        "http://127.0.0.1:1".to_string(),
+        default_no_auth_provider(),
+        handle,
+    );
+    assert!(
+        result.is_ok(),
+        "install must succeed under a runtime; got {result:?}",
+    );
+
+    // Positive-side check: the listener really is bound + serving.
+    // Give the spawned serve task a tick to start accepting.
+    tokio::task::yield_now().await;
+    let resp = reqwest::get(format!("http://{addr}/v2/status"))
+        .await
+        .expect("GET /v2/status after install");
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+}
+
+/// Bind-failure branch: a second install on the SAME address must
+/// return `Err` (port in use), not `Ok(())`-then-`tracing::error!`
+/// on a background task.  Pins the "fail-loud at install" contract
+/// the #4713 audit's finding #2 was about.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn service_decl_install_body_returns_err_on_bind_failure() {
+    use nexus_http_api::middleware::auth::default_no_auth_provider;
+
+    // First install: succeeds, holds the port.
+    let probe = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("probe bind");
+    let addr = probe.local_addr().expect("probe local_addr");
+    drop(probe);
+
+    let handle = tokio::runtime::Handle::current();
+    let first = nexus_http_api::install_impl(
+        addr,
+        "http://127.0.0.1:1".to_string(),
+        default_no_auth_provider(),
+        handle.clone(),
+    );
+    assert!(first.is_ok(), "first install must succeed; got {first:?}");
+
+    // Second install on the SAME address — must Err loudly
+    // (address in use) instead of the pre-fix silent-log posture.
+    let second = nexus_http_api::install_impl(
+        addr,
+        "http://127.0.0.1:1".to_string(),
+        default_no_auth_provider(),
+        handle,
+    );
+    let err = second.expect_err("second install on same addr must Err");
+    assert!(
+        err.contains("bind") && err.contains(&addr.to_string()),
+        "bind error must name the operation + address so an operator can debug; got {err:?}",
+    );
+}


### PR DESCRIPTION
## Summary

Post-#4717 audit found two `feedback_no_deferred_shrug` violations my prior commit message flagged but did not close.

**#1 — Stale docstring** referenced `runtime.block_on(TcpListener::bind(addr))` — the intermediate WRONG approach that panicked in the docker E2E. Actual code uses sync `std::net::bind` + `from_std`. Rewrote the "Failure mode" block + added a "Why NOT `runtime.block_on(bind)`" subsection so the next contributor doesn't repeat the mistake.

**#2 — No local regression pin.** The docker E2E was the ONLY guard on "install closure must not re-enter the runtime" — any refactor could bring `Handle::block_on` back and only trip live.

Fix: factored the install-closure body out of `service_decl` into `#[doc(hidden)] pub fn install_impl(...)` — testable without constructing an `Arc<Kernel>`. Two new tests in `tests/serve_e2e.rs`:

- `service_decl_install_body_runs_under_a_tokio_runtime` — reproduces the docker-E2E scenario locally (`#[tokio::test(flavor = "multi_thread")]` calls `install_impl` directly + asserts `/v2/status` serves). A regression re-panics with "Cannot start a runtime from within a runtime" now caught pre-push.
- `service_decl_install_body_returns_err_on_bind_failure` — pins the fail-loud-on-bind contract (second install on same addr must Err loudly, not silent-log).

## Test cover

- serve_e2e: 4 pass (2 new)
- Full http-api: 49 total pass
- clippy + fmt clean

## Why `pub` not `pub(crate)`

Integration tests are separate compilation units; `pub(crate)` is invisible. Kept `pub` with `#[doc(hidden)]` — production callers use `service_decl`; only tests reach `install_impl`. Standard escape for testable internals; no ABI expansion.
