### PR TITLE
docs(local-connector): mounting is sys_setattr(DT_MOUNT), not boot-only

### DIFF
--- a/rust/backends/local-connector/src/lib.rs
+++ b/rust/backends/local-connector/src/lib.rs
@@ -2,8 +2,17 @@
 //!
 //! Loaded by `nexusd-cluster` at startup via `--plugin-dir`. Registers
 //! as a driver named `"local-connector"` through the plugin ABI's
-//! [`declare_driver_plugin!`] macro.  Operators mount it at a VFS path
-//! with `--mount-driver local-connector:<vfs-path>:<config-json>`.
+//! [`declare_driver_plugin!`] macro.
+//!
+//! ## Mounting is a syscall — boot OR runtime, not operator-boot-only
+//!
+//! A mount of this driver is a `sys_setattr(DT_MOUNT, backend_name =
+//! "local-connector", …)` carrying the `local_root` config, so it can be
+//! created — and torn down — at **runtime** (e.g. a session launcher
+//! mounting a per-session workspace), not just at startup. The
+//! `--mount-driver local-connector:<zone>:<vfs-path>:<config-json>` boot
+//! flag is only a convenience that composes exactly that syscall at startup
+//! for the operator; it is NOT the only path to a mount.
 //!
 //! ## Config schema
 //!


### PR DESCRIPTION
## Why

The `nexus-local-connector` module docstring said only *"Operators mount it at a VFS path with `--mount-driver`"*, which reads as **boot-time / operator-only** — it misled a reader (me) into concluding the connector can only be mounted when the daemon starts.

## Reality (verified)

A driver mount is a **runtime syscall**: `sys_setattr(DT_MOUNT, backend_name = "local-connector", …)`.
- `profiles/cluster/src/lib.rs:2518–2651` applies each `--mount-driver` spec **via `sys_setattr DT_MOUNT`** (loop over `common.mount_drivers`).
- `raft/src/distributed_coordinator.rs:2225` — `wire_mount_core` handles the *driver-mount backend*.
- `kernel/.../convenience.rs:90` — "Tier 2 mount — composes `sys_setattr(DT_MOUNT, …)`".

So `--mount-driver` is only a **boot convenience** that composes that same syscall at startup; the mount can equally be created/torn down at **runtime** (e.g. a session launcher mounting a per-session workspace).

## Change

Docstring-only: replace the boot-only framing with a *"Mounting is a syscall — boot OR runtime"* note. No code change.