### PR TITLE
feat(http-api): /v2/documents/{index,refresh,batch,stats} routes (R10)

### DIFF
--- a/rust/services/http-api/src/handlers/documents.rs
+++ b/rust/services/http-api/src/handlers/documents.rs
@@ -1,0 +1,333 @@
+//! `/v2/documents/*` — HTTP shims over the upstream
+//! `nexus.search.v1.SearchService` write / meta RPCs.
+//!
+//! Sibling of [`crate::handlers::search`] (which owns the read RPCs
+//! — glob / grep / query).  The split follows the Python
+//! `nexus-server` two-router shape (search=read, documents=
+//! write+meta) so callers migrating from FastAPI keep their URL
+//! namespaces intact.
+//!
+//! Every handler here reuses [`crate::handlers::search::SearchError`]
+//! (same wire mapping table — `Unimplemented → 501`,
+//! `ResourceExhausted → 429`, etc.) and slots under the same
+//! bearer-middleware sub-router as the search routes (see
+//! [`crate::router`]).
+//!
+//! # Endpoints
+//!
+//! * `POST /v2/documents/index`   — full recursive walk from
+//!   `root_path`, indexes every regular file the plugin sees.
+//!   Maps to `SearchService::Index`.
+//! * `POST /v2/documents/refresh` — incremental mtime-diff pass
+//!   over an already-indexed subtree.  Maps to
+//!   `SearchService::Refresh`.
+//! * `POST /v2/documents/batch`   — explicit upsert of a list of
+//!   documents (`{path, text, mtime_ms?, zone_id?}`).  Maps to
+//!   `SearchService::IndexDocuments`.
+//! * `GET  /v2/documents/stats`   — index diagnostics
+//!   (fts_doc_count / fts_path_count / ann_chunk_count / etc.).
+//!   Maps to `SearchService::Stats`.
+
+use axum::extract::{Query, State};
+use axum::routing::{get, post};
+use axum::{Json, Router};
+use serde::{Deserialize, Serialize};
+
+use crate::handlers::search::SearchError;
+use crate::search_proto::{
+    DocumentInput as ProtoDocumentInput, IndexDocumentsRequest, IndexRequest, RefreshRequest,
+    StatsRequest,
+};
+use crate::AppState;
+
+// ── shared field-shape helpers ───────────────────────────────────
+
+fn default_zone() -> String {
+    // Empty ⇒ server-side default (ROOT_ZONE_ID); matches the
+    // sibling search routes.  Kept as an explicit helper so a
+    // future zone-required route can flip the shape without
+    // touching every field.
+    String::new()
+}
+
+// ── /v2/documents/index ──────────────────────────────────────────
+
+/// JSON body for `POST /v2/documents/index`.  Field names match
+/// the proto's [`IndexRequest`] snake_case names 1:1 — same policy
+/// as [`crate::handlers::search::QueryBody`].
+#[derive(Debug, Clone, Deserialize)]
+pub struct IndexBody {
+    /// Walk start.  Absolute VFS path (starts with `/`).
+    pub root_path: String,
+    /// Zone scope; empty ⇒ ROOT_ZONE_ID.
+    #[serde(default = "default_zone")]
+    pub zone_id: String,
+    /// Recurse into subdirectories.  Absent / false ⇒ direct
+    /// children of `root_path` only (matches Python default).
+    #[serde(default)]
+    pub recursive: bool,
+    /// Cap on documents visited.  0 ⇒ server default (10_000);
+    /// callers indexing a larger corpus call `Index` repeatedly
+    /// with narrower `root_path` scopes.
+    #[serde(default)]
+    pub max_docs: u32,
+    #[serde(default)]
+    pub auth_token: String,
+}
+
+/// Response body of [`index`].  Mirrors proto `IndexResponse`; the
+/// optional error rides through per the sibling-handler convention.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct IndexResponseBody {
+    pub indexed_count: u32,
+    pub skipped_count: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// Handler for `POST /v2/documents/index`.
+pub async fn index(
+    State(state): State<AppState>,
+    Json(body): Json<IndexBody>,
+) -> Result<Json<IndexResponseBody>, SearchError> {
+    let mut client = state.search.client().await?;
+    let req = IndexRequest {
+        root_path: body.root_path,
+        zone_id: body.zone_id,
+        recursive: body.recursive,
+        max_docs: body.max_docs,
+        auth_token: body.auth_token,
+    };
+    let resp = client
+        .index(tonic::Request::new(req))
+        .await
+        .map_err(SearchError::Rpc)?
+        .into_inner();
+    Ok(Json(IndexResponseBody {
+        indexed_count: resp.indexed_count,
+        skipped_count: resp.skipped_count,
+        error: resp.error,
+    }))
+}
+
+// ── /v2/documents/refresh ────────────────────────────────────────
+
+/// JSON body for `POST /v2/documents/refresh`.  Same field-shape as
+/// [`IndexBody`] — mtime-diff Refresh + full Index take the same
+/// `root_path` + `recursive` + `max_docs` scope.
+#[derive(Debug, Clone, Deserialize)]
+pub struct RefreshBody {
+    pub root_path: String,
+    #[serde(default = "default_zone")]
+    pub zone_id: String,
+    #[serde(default)]
+    pub recursive: bool,
+    #[serde(default)]
+    pub max_docs: u32,
+    #[serde(default)]
+    pub auth_token: String,
+}
+
+/// Response body of [`refresh`].  Adds `unchanged_count` +
+/// `removed_count` + `truncated` fields to the Index shape — the
+/// whole point of Refresh is telling apart "reindexed / dropped /
+/// still-current" so a caller can gate a "healthy-empty is real"
+/// decision.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RefreshResponseBody {
+    pub reindexed_count: u32,
+    pub removed_count: u32,
+    pub unchanged_count: u32,
+    pub skipped_count: u32,
+    pub truncated: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// Handler for `POST /v2/documents/refresh`.
+pub async fn refresh(
+    State(state): State<AppState>,
+    Json(body): Json<RefreshBody>,
+) -> Result<Json<RefreshResponseBody>, SearchError> {
+    let mut client = state.search.client().await?;
+    let req = RefreshRequest {
+        root_path: body.root_path,
+        zone_id: body.zone_id,
+        recursive: body.recursive,
+        max_docs: body.max_docs,
+        auth_token: body.auth_token,
+    };
+    let resp = client
+        .refresh(tonic::Request::new(req))
+        .await
+        .map_err(SearchError::Rpc)?
+        .into_inner();
+    Ok(Json(RefreshResponseBody {
+        reindexed_count: resp.reindexed_count,
+        removed_count: resp.removed_count,
+        unchanged_count: resp.unchanged_count,
+        skipped_count: resp.skipped_count,
+        truncated: resp.truncated,
+        error: resp.error,
+    }))
+}
+
+// ── /v2/documents/batch ──────────────────────────────────────────
+
+/// One document in a [`BatchBody`] — the proto's `DocumentInput`
+/// shape mirrored on the wire.  A batch may span zones; each doc
+/// carries an optional `zone_id` that overrides the batch-wide
+/// default.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DocumentInput {
+    pub path: String,
+    pub text: String,
+    /// Optional millisecond-resolution mtime.  Absent ⇒ plugin
+    /// skips the P6 recency signal for this doc.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mtime_ms: Option<i64>,
+    /// Per-doc zone override.  Empty ⇒ falls back to the
+    /// batch-wide [`BatchBody::zone_id`].
+    #[serde(default = "default_zone")]
+    pub zone_id: String,
+}
+
+/// JSON body for `POST /v2/documents/batch`.  Explicit upsert —
+/// caller ships each document's text; the plugin does not read
+/// the VFS.  Used by nexus-server today for user-visible document
+/// posts (as opposed to the `Index` RPC which walks the VFS).
+#[derive(Debug, Clone, Deserialize)]
+pub struct BatchBody {
+    pub documents: Vec<DocumentInput>,
+    /// Batch-wide zone default; per-doc `zone_id` overrides.
+    #[serde(default = "default_zone")]
+    pub zone_id: String,
+    #[serde(default)]
+    pub auth_token: String,
+}
+
+/// Response body of [`batch`].  `parked_paths` surfaces docs that
+/// hit a transient failure and got parked for retry (see the
+/// `ParkedList` RPC surface, exposed elsewhere) — kept optional-
+/// but-always-present because an empty vec is the wire's "no
+/// parking" signal.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct BatchResponseBody {
+    pub indexed_count: u32,
+    pub skipped_count: u32,
+    pub parked_paths: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// Handler for `POST /v2/documents/batch`.
+pub async fn batch(
+    State(state): State<AppState>,
+    Json(body): Json<BatchBody>,
+) -> Result<Json<BatchResponseBody>, SearchError> {
+    let mut client = state.search.client().await?;
+    let req = IndexDocumentsRequest {
+        documents: body
+            .documents
+            .into_iter()
+            .map(|d| ProtoDocumentInput {
+                path: d.path,
+                text: d.text,
+                mtime_ms: d.mtime_ms,
+                zone_id: d.zone_id,
+            })
+            .collect(),
+        zone_id: body.zone_id,
+        auth_token: body.auth_token,
+    };
+    let resp = client
+        .index_documents(tonic::Request::new(req))
+        .await
+        .map_err(SearchError::Rpc)?
+        .into_inner();
+    Ok(Json(BatchResponseBody {
+        indexed_count: resp.indexed_count,
+        skipped_count: resp.skipped_count,
+        parked_paths: resp.parked_paths,
+        error: resp.error,
+    }))
+}
+
+// ── /v2/documents/stats ──────────────────────────────────────────
+
+/// Query params for `GET /v2/documents/stats`.  GET body-less
+/// because the wire shape is a bounded scalar tuple — no room for
+/// a list / map that would justify a POST body.
+#[derive(Debug, Clone, Deserialize)]
+pub struct StatsQuery {
+    /// Zone scope; empty ⇒ ROOT_ZONE_ID.
+    #[serde(default = "default_zone")]
+    pub zone_id: String,
+    #[serde(default)]
+    pub auth_token: String,
+}
+
+/// Response body of [`stats`].  Every field mirrors the proto's
+/// `StatsResponse`; `error` follows the same absent-when-None
+/// posture as sibling handlers.  Backend-identity fields
+/// (`backend`, `embedding_model`) survive the migration from
+/// Python — pre-pivot callers scripted around them (health
+/// pollers, canaries) keep working.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct StatsResponseBody {
+    pub fts_doc_count: u32,
+    pub fts_path_count: u32,
+    pub ann_chunk_count: u32,
+    pub parked_count: u32,
+    /// Constant `"rust-plugin"` post-P12 — distinguishes this
+    /// generation from the deleted Python daemon's BM25S / pgvector
+    /// stacks.  Pollers gating on backend identity keep their
+    /// scripts.
+    pub backend: String,
+    /// Configured embedding model tag (e.g. `"mE5-small-v1"`).
+    /// Empty ⇒ keyword-only mode.
+    pub embedding_model: String,
+    /// Non-zero ⇒ query results may be served from a partially-
+    /// built index; pollers gating "healthy-empty is real"
+    /// decisions wait for 0.
+    pub indexing_in_progress: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// Handler for `GET /v2/documents/stats`.
+pub async fn stats(
+    State(state): State<AppState>,
+    Query(params): Query<StatsQuery>,
+) -> Result<Json<StatsResponseBody>, SearchError> {
+    let mut client = state.search.client().await?;
+    let req = StatsRequest {
+        zone_id: params.zone_id,
+        auth_token: params.auth_token,
+    };
+    let resp = client
+        .stats(tonic::Request::new(req))
+        .await
+        .map_err(SearchError::Rpc)?
+        .into_inner();
+    Ok(Json(StatsResponseBody {
+        fts_doc_count: resp.fts_doc_count,
+        fts_path_count: resp.fts_path_count,
+        ann_chunk_count: resp.ann_chunk_count,
+        parked_count: resp.parked_count,
+        backend: resp.backend,
+        embedding_model: resp.embedding_model,
+        indexing_in_progress: resp.indexing_in_progress,
+        error: resp.error,
+    }))
+}
+
+// ── Router ────────────────────────────────────────────────────────
+
+pub fn router() -> Router<AppState> {
+    Router::new()
+        .route("/v2/documents/index", post(index))
+        .route("/v2/documents/refresh", post(refresh))
+        .route("/v2/documents/batch", post(batch))
+        .route("/v2/documents/stats", get(stats))
+}

--- a/rust/services/http-api/src/handlers/mod.rs
+++ b/rust/services/http-api/src/handlers/mod.rs
@@ -7,5 +7,6 @@
 //! keeps `AppState` growth O(1) per new domain — a fresh domain
 //! adds a field, no handler rewire.
 
+pub mod documents;
 pub mod search;
 pub mod status;

--- a/rust/services/http-api/src/lib.rs
+++ b/rust/services/http-api/src/lib.rs
@@ -119,8 +119,8 @@ impl AppState {
 ///   (liveness probes, unauth-metadata endpoints).  Currently just
 ///   `/v2/status`.
 /// * `protected_router` — routes wrapped by
-///   [`middleware::auth::require_bearer`].  Every `/v2/search/*`
-///   handler lives here.
+///   [`middleware::auth::require_bearer`].  Every `/v2/search/*` +
+///   `/v2/documents/*` handler lives here.
 ///
 /// Both sub-routers share the same [`AppState`]; only the middleware
 /// stack differs.  A new domain lands as an additive merge on
@@ -133,6 +133,7 @@ pub fn router(state: AppState) -> Router {
         .with_state(state.clone());
     let protected_router = Router::new()
         .merge(handlers::search::router())
+        .merge(handlers::documents::router())
         .layer(from_fn_with_state(
             state.clone(),
             middleware::auth::require_bearer,

--- a/rust/services/http-api/tests/documents_e2e.rs
+++ b/rust/services/http-api/tests/documents_e2e.rs
@@ -1,0 +1,596 @@
+//! Real-chain E2E cover for `POST /v2/documents/{index,refresh,
+//! batch}` + `GET /v2/documents/stats` — same posture as
+//! `query_e2e.rs`: mock gRPC server on ephemeral port + axum
+//! listener pointed at it + reqwest hits the router.
+//!
+//! Pins the wire-shape mapping — HTTP JSON body / query params in,
+//! proto request out; proto response back, HTTP JSON body out —
+//! plus the shared error mapping table (`InvalidArgument → 400`,
+//! `Unimplemented → 501`, upstream-down → 503) inherited from
+//! `handlers::search::SearchError`.
+
+use std::sync::{Arc, Mutex};
+
+use nexus_http_api::search_proto::search_service_server::{SearchService, SearchServiceServer};
+use nexus_http_api::search_proto::{
+    AddIndexedDirectoryRequest, AddIndexedDirectoryResponse, BatchQueryRequest, BatchQueryResponse,
+    GlobRequest, GlobResponse, GrepRequest, GrepResponse, HealthRequest, HealthResponse,
+    IndexDocumentsRequest, IndexDocumentsResponse, IndexRequest, IndexResponse,
+    ListIndexedDirectoriesRequest, ListIndexedDirectoriesResponse, ListZoneIndexingModesRequest,
+    ListZoneIndexingModesResponse, LocateRequest, LocateResponse, NotifyFileChangeRequest,
+    NotifyFileChangeResponse, ParkedDiscardRequest, ParkedDiscardResponse, ParkedListRequest,
+    ParkedListResponse, ParkedRetryRequest, ParkedRetryResponse, QueryRequest, QueryResponse,
+    RefreshRequest, RefreshResponse, RemoveIndexedDirectoryRequest, RemoveIndexedDirectoryResponse,
+    SetZoneIndexingModeRequest, SetZoneIndexingModeResponse, StatsRequest, StatsResponse,
+};
+use nexus_http_api::{bind_and_serve, AppState};
+use tokio::net::TcpListener;
+use tokio_stream::wrappers::TcpListenerStream;
+use tonic::{Request, Response, Status};
+
+// ── Mock SearchService — records EVERY doc-side RPC so a test
+// can prove which one the http-api routed to.  Each `Vec<_>` in
+// the log is behind a `Mutex` so cross-thread appends stay sound
+// on tokio's multi-thread runtime.
+
+#[derive(Default, Clone)]
+struct RequestLog {
+    index: Arc<Mutex<Vec<IndexRequest>>>,
+    refresh: Arc<Mutex<Vec<RefreshRequest>>>,
+    index_documents: Arc<Mutex<Vec<IndexDocumentsRequest>>>,
+    stats: Arc<Mutex<Vec<StatsRequest>>>,
+}
+
+/// Fixed responses the mock ships back — one per RPC.  Each test
+/// picks the shape it wants; a test wanting a specific `Status`
+/// wraps in `.await.map(|_| Err(...))` at a different layer.
+#[derive(Clone)]
+struct MockConfig {
+    index_resp: IndexResponse,
+    refresh_resp: RefreshResponse,
+    index_documents_resp: IndexDocumentsResponse,
+    stats_resp: StatsResponse,
+    /// When Some, EVERY doc-side RPC returns this Status instead of
+    /// its Ok response — lets a test pin the shared status mapper
+    /// on this handler surface without a per-RPC variant.
+    rpc_err: Option<tonic::Code>,
+}
+
+impl Default for MockConfig {
+    fn default() -> Self {
+        Self {
+            index_resp: IndexResponse {
+                indexed_count: 42,
+                skipped_count: 3,
+                error: None,
+            },
+            refresh_resp: RefreshResponse {
+                reindexed_count: 5,
+                removed_count: 1,
+                unchanged_count: 100,
+                skipped_count: 2,
+                truncated: false,
+                error: None,
+            },
+            index_documents_resp: IndexDocumentsResponse {
+                indexed_count: 7,
+                skipped_count: 0,
+                parked_paths: vec![],
+                error: None,
+            },
+            stats_resp: StatsResponse {
+                fts_doc_count: 1234,
+                fts_path_count: 567,
+                ann_chunk_count: 890,
+                parked_count: 0,
+                error: None,
+                backend: "rust-plugin".into(),
+                embedding_model: "mE5-small-v1".into(),
+                indexing_in_progress: 0,
+            },
+            rpc_err: None,
+        }
+    }
+}
+
+#[derive(Clone)]
+struct MockSearchService {
+    log: RequestLog,
+    config: MockConfig,
+}
+
+macro_rules! err_or {
+    ($self:expr, $ok:expr) => {
+        if let Some(code) = $self.config.rpc_err {
+            Err(Status::new(code, "mock injected"))
+        } else {
+            Ok(Response::new($ok))
+        }
+    };
+}
+
+#[tonic::async_trait]
+impl SearchService for MockSearchService {
+    async fn index(&self, req: Request<IndexRequest>) -> Result<Response<IndexResponse>, Status> {
+        self.log.index.lock().unwrap().push(req.into_inner());
+        err_or!(self, self.config.index_resp.clone())
+    }
+
+    async fn refresh(
+        &self,
+        req: Request<RefreshRequest>,
+    ) -> Result<Response<RefreshResponse>, Status> {
+        self.log.refresh.lock().unwrap().push(req.into_inner());
+        err_or!(self, self.config.refresh_resp.clone())
+    }
+
+    async fn index_documents(
+        &self,
+        req: Request<IndexDocumentsRequest>,
+    ) -> Result<Response<IndexDocumentsResponse>, Status> {
+        self.log
+            .index_documents
+            .lock()
+            .unwrap()
+            .push(req.into_inner());
+        err_or!(self, self.config.index_documents_resp.clone())
+    }
+
+    async fn stats(&self, req: Request<StatsRequest>) -> Result<Response<StatsResponse>, Status> {
+        self.log.stats.lock().unwrap().push(req.into_inner());
+        err_or!(self, self.config.stats_resp.clone())
+    }
+
+    // Every other RPC unreachable — documents handlers never call them.
+    async fn glob(&self, _: Request<GlobRequest>) -> Result<Response<GlobResponse>, Status> {
+        unreachable!()
+    }
+    async fn grep(&self, _: Request<GrepRequest>) -> Result<Response<GrepResponse>, Status> {
+        unreachable!()
+    }
+    async fn query(&self, _: Request<QueryRequest>) -> Result<Response<QueryResponse>, Status> {
+        unreachable!()
+    }
+    async fn batch_query(
+        &self,
+        _: Request<BatchQueryRequest>,
+    ) -> Result<Response<BatchQueryResponse>, Status> {
+        unreachable!()
+    }
+    async fn notify_file_change(
+        &self,
+        _: Request<NotifyFileChangeRequest>,
+    ) -> Result<Response<NotifyFileChangeResponse>, Status> {
+        unreachable!()
+    }
+    async fn locate(&self, _: Request<LocateRequest>) -> Result<Response<LocateResponse>, Status> {
+        unreachable!()
+    }
+    async fn parked_list(
+        &self,
+        _: Request<ParkedListRequest>,
+    ) -> Result<Response<ParkedListResponse>, Status> {
+        unreachable!()
+    }
+    async fn parked_retry(
+        &self,
+        _: Request<ParkedRetryRequest>,
+    ) -> Result<Response<ParkedRetryResponse>, Status> {
+        unreachable!()
+    }
+    async fn parked_discard(
+        &self,
+        _: Request<ParkedDiscardRequest>,
+    ) -> Result<Response<ParkedDiscardResponse>, Status> {
+        unreachable!()
+    }
+    async fn add_indexed_directory(
+        &self,
+        _: Request<AddIndexedDirectoryRequest>,
+    ) -> Result<Response<AddIndexedDirectoryResponse>, Status> {
+        unreachable!()
+    }
+    async fn remove_indexed_directory(
+        &self,
+        _: Request<RemoveIndexedDirectoryRequest>,
+    ) -> Result<Response<RemoveIndexedDirectoryResponse>, Status> {
+        unreachable!()
+    }
+    async fn list_indexed_directories(
+        &self,
+        _: Request<ListIndexedDirectoriesRequest>,
+    ) -> Result<Response<ListIndexedDirectoriesResponse>, Status> {
+        unreachable!()
+    }
+    async fn set_zone_indexing_mode(
+        &self,
+        _: Request<SetZoneIndexingModeRequest>,
+    ) -> Result<Response<SetZoneIndexingModeResponse>, Status> {
+        unreachable!()
+    }
+    async fn list_zone_indexing_modes(
+        &self,
+        _: Request<ListZoneIndexingModesRequest>,
+    ) -> Result<Response<ListZoneIndexingModesResponse>, Status> {
+        unreachable!()
+    }
+    async fn health(&self, _: Request<HealthRequest>) -> Result<Response<HealthResponse>, Status> {
+        unreachable!()
+    }
+}
+
+// ── Harness ────────────────────────────────────────────────────
+
+struct Harness {
+    http_base: String,
+    log: RequestLog,
+}
+
+impl Harness {
+    async fn start(config: MockConfig) -> Self {
+        let (grpc_target, log) = spawn_mock_grpc_server(config).await;
+        let http_base = spawn_http_listener(grpc_target).await;
+        Self { http_base, log }
+    }
+
+    async fn start_pointing_at_dead_backend() -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind + release ephemeral port");
+        let dead_addr = listener.local_addr().expect("dead addr");
+        drop(listener);
+        let http_base = spawn_http_listener(format!("http://{dead_addr}")).await;
+        Self {
+            http_base,
+            log: RequestLog::default(),
+        }
+    }
+}
+
+async fn spawn_http_listener(grpc_target: String) -> String {
+    // `for_tests`: NoAuth so this file focuses on the /v2/documents/*
+    // route surface; bearer parsing / rejection has its own cover in
+    // `tests/auth_middleware_e2e.rs`.
+    let state = AppState::for_tests(grpc_target);
+    let (http_addr, fut) = bind_and_serve("127.0.0.1:0".parse().unwrap(), state)
+        .await
+        .expect("bind http listener");
+    tokio::spawn(async move {
+        fut.await.expect("axum::serve");
+    });
+    format!("http://{http_addr}")
+}
+
+async fn spawn_mock_grpc_server(config: MockConfig) -> (String, RequestLog) {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind grpc listener");
+    let addr = listener.local_addr().expect("grpc addr");
+    let log = RequestLog::default();
+    let mock = MockSearchService {
+        log: log.clone(),
+        config,
+    };
+    tokio::spawn(async move {
+        tonic::transport::Server::builder()
+            .add_service(SearchServiceServer::new(mock))
+            .serve_with_incoming(TcpListenerStream::new(listener))
+            .await
+            .expect("mock grpc serve");
+    });
+    (format!("http://{addr}"), log)
+}
+
+// ── Tests — /v2/documents/index ────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn index_happy_path_round_trips_full_chain() {
+    let h = Harness::start(MockConfig::default()).await;
+    let body = serde_json::json!({
+        "root_path": "/notes",
+        "zone_id": "root",
+        "recursive": true,
+        "max_docs": 500,
+        "auth_token": "sk-test",
+    });
+    let resp = reqwest::Client::new()
+        .post(format!("{}/v2/documents/index", h.http_base))
+        .json(&body)
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+    let parsed: serde_json::Value = resp.json().await.expect("parse json");
+    assert_eq!(parsed["indexed_count"], 42);
+    assert_eq!(parsed["skipped_count"], 3);
+    assert!(parsed.get("error").is_none() || parsed["error"].is_null());
+
+    // Handler → proto boundary — every JSON field reaches the RPC.
+    let recorded = h.log.index.lock().unwrap().clone();
+    assert_eq!(recorded.len(), 1, "exactly one upstream Index call");
+    let r = &recorded[0];
+    assert_eq!(r.root_path, "/notes");
+    assert_eq!(r.zone_id, "root");
+    assert!(r.recursive);
+    assert_eq!(r.max_docs, 500);
+    assert_eq!(r.auth_token, "sk-test");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn index_defaults_reach_backend_intact() {
+    // Absent optional fields must land at the backend as their
+    // proto defaults, not silently rewritten in the handler layer.
+    let h = Harness::start(MockConfig::default()).await;
+    let resp = reqwest::Client::new()
+        .post(format!("{}/v2/documents/index", h.http_base))
+        .json(&serde_json::json!({ "root_path": "/" }))
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+    let r = &h.log.index.lock().unwrap()[0];
+    assert_eq!(r.root_path, "/");
+    assert_eq!(r.zone_id, "");
+    assert!(!r.recursive);
+    assert_eq!(r.max_docs, 0);
+    assert_eq!(r.auth_token, "");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn index_upstream_unimplemented_maps_to_501() {
+    // Shared `grpc_status_to_http` mapper — the reason we lifted it
+    // to pub(crate).  Documents routes must speak the same wire
+    // semantics as search routes.
+    let h = Harness::start(MockConfig {
+        rpc_err: Some(tonic::Code::Unimplemented),
+        ..MockConfig::default()
+    })
+    .await;
+    let resp = reqwest::Client::new()
+        .post(format!("{}/v2/documents/index", h.http_base))
+        .json(&serde_json::json!({ "root_path": "/" }))
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(resp.status(), reqwest::StatusCode::NOT_IMPLEMENTED);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn index_upstream_down_maps_to_503() {
+    let h = Harness::start_pointing_at_dead_backend().await;
+    let resp = reqwest::Client::new()
+        .post(format!("{}/v2/documents/index", h.http_base))
+        .json(&serde_json::json!({ "root_path": "/" }))
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(resp.status(), reqwest::StatusCode::SERVICE_UNAVAILABLE);
+}
+
+// ── Tests — /v2/documents/refresh ──────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn refresh_happy_path_surfaces_full_counter_set() {
+    // Refresh's counter shape distinguishes reindexed / removed /
+    // unchanged / skipped — pin all four so a caller scripting on
+    // this endpoint locks the wire contract.
+    let h = Harness::start(MockConfig::default()).await;
+    let resp = reqwest::Client::new()
+        .post(format!("{}/v2/documents/refresh", h.http_base))
+        .json(&serde_json::json!({
+            "root_path": "/notes",
+            "zone_id": "root",
+            "recursive": false,
+            "max_docs": 100,
+        }))
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+    let parsed: serde_json::Value = resp.json().await.expect("parse json");
+    assert_eq!(parsed["reindexed_count"], 5);
+    assert_eq!(parsed["removed_count"], 1);
+    assert_eq!(parsed["unchanged_count"], 100);
+    assert_eq!(parsed["skipped_count"], 2);
+    assert_eq!(parsed["truncated"], false);
+
+    let r = &h.log.refresh.lock().unwrap()[0];
+    assert_eq!(r.root_path, "/notes");
+    assert_eq!(r.zone_id, "root");
+    assert!(!r.recursive);
+    assert_eq!(r.max_docs, 100);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn refresh_truncated_flag_rides_through_to_the_wire() {
+    // Regression pin — `truncated` was originally a Refresh-only
+    // field added late (review R4); a serde rename or accidental
+    // omission would silently drop it.
+    let h = Harness::start(MockConfig {
+        refresh_resp: RefreshResponse {
+            reindexed_count: 10,
+            removed_count: 0,
+            unchanged_count: 0,
+            skipped_count: 0,
+            truncated: true,
+            error: None,
+        },
+        ..MockConfig::default()
+    })
+    .await;
+    let resp = reqwest::Client::new()
+        .post(format!("{}/v2/documents/refresh", h.http_base))
+        .json(&serde_json::json!({ "root_path": "/" }))
+        .send()
+        .await
+        .expect("send");
+    let parsed: serde_json::Value = resp.json().await.expect("parse json");
+    assert_eq!(parsed["truncated"], true);
+    assert_eq!(parsed["reindexed_count"], 10);
+}
+
+// ── Tests — /v2/documents/batch ────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn batch_happy_path_round_trips_documents_list() {
+    // Every field on each DocumentInput reaches the corresponding
+    // proto slot — including the optional mtime_ms + per-doc
+    // zone_id override.
+    let h = Harness::start(MockConfig::default()).await;
+    let body = serde_json::json!({
+        "documents": [
+            {
+                "path": "/notes/a.md",
+                "text": "the widget hums",
+                "mtime_ms": 1_700_000_000_000_i64,
+                "zone_id": "shared",
+            },
+            {
+                "path": "/notes/b.md",
+                "text": "the beacon glows",
+            },
+        ],
+        "zone_id": "root",
+        "auth_token": "sk-test",
+    });
+    let resp = reqwest::Client::new()
+        .post(format!("{}/v2/documents/batch", h.http_base))
+        .json(&body)
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+    let parsed: serde_json::Value = resp.json().await.expect("parse json");
+    assert_eq!(parsed["indexed_count"], 7);
+    assert_eq!(parsed["skipped_count"], 0);
+    assert_eq!(parsed["parked_paths"].as_array().unwrap().len(), 0);
+
+    let r = &h.log.index_documents.lock().unwrap()[0];
+    assert_eq!(r.documents.len(), 2);
+    assert_eq!(r.documents[0].path, "/notes/a.md");
+    assert_eq!(r.documents[0].text, "the widget hums");
+    assert_eq!(r.documents[0].mtime_ms, Some(1_700_000_000_000));
+    assert_eq!(r.documents[0].zone_id, "shared");
+    assert_eq!(r.documents[1].path, "/notes/b.md");
+    assert_eq!(
+        r.documents[1].mtime_ms, None,
+        "absent optional mtime_ms must reach the backend as None, not 0",
+    );
+    assert_eq!(
+        r.documents[1].zone_id, "",
+        "absent per-doc zone_id must reach as empty (falls back at plugin layer)",
+    );
+    assert_eq!(r.zone_id, "root");
+    assert_eq!(r.auth_token, "sk-test");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn batch_parked_paths_survive_round_trip() {
+    // A partial-failure response surfaces `parked_paths` — a caller
+    // gating on retry logic reads this list to schedule follow-ups.
+    let h = Harness::start(MockConfig {
+        index_documents_resp: IndexDocumentsResponse {
+            indexed_count: 2,
+            skipped_count: 0,
+            parked_paths: vec!["/notes/a.md".into(), "/notes/c.md".into()],
+            error: None,
+        },
+        ..MockConfig::default()
+    })
+    .await;
+    let resp = reqwest::Client::new()
+        .post(format!("{}/v2/documents/batch", h.http_base))
+        .json(&serde_json::json!({
+            "documents": [{"path": "/x", "text": "x"}],
+        }))
+        .send()
+        .await
+        .expect("send");
+    let parsed: serde_json::Value = resp.json().await.expect("parse json");
+    let parked = parsed["parked_paths"].as_array().expect("parked array");
+    assert_eq!(parked.len(), 2);
+    assert_eq!(parked[0], "/notes/a.md");
+    assert_eq!(parked[1], "/notes/c.md");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn batch_missing_documents_body_returns_4xx() {
+    // POST without a body must be rejected before the RPC fires.
+    let h = Harness::start(MockConfig::default()).await;
+    let resp = reqwest::Client::new()
+        .post(format!("{}/v2/documents/batch", h.http_base))
+        .header("content-type", "application/json")
+        .body("{}")
+        .send()
+        .await
+        .expect("send");
+    assert!(
+        resp.status().is_client_error(),
+        "missing `documents` must produce a 4xx, got {}",
+        resp.status(),
+    );
+    assert!(
+        h.log.index_documents.lock().unwrap().is_empty(),
+        "upstream RPC must NOT fire on a rejected request",
+    );
+}
+
+// ── Tests — /v2/documents/stats ────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn stats_happy_path_surfaces_backend_identity_and_counters() {
+    // Backend-identity fields (`backend`, `embedding_model`) survive
+    // the pivot — health pollers scripted around them keep working.
+    let h = Harness::start(MockConfig::default()).await;
+    let resp = reqwest::Client::new()
+        .get(format!("{}/v2/documents/stats?zone_id=root", h.http_base))
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+    let parsed: serde_json::Value = resp.json().await.expect("parse json");
+    assert_eq!(parsed["fts_doc_count"], 1234);
+    assert_eq!(parsed["fts_path_count"], 567);
+    assert_eq!(parsed["ann_chunk_count"], 890);
+    assert_eq!(parsed["parked_count"], 0);
+    assert_eq!(parsed["backend"], "rust-plugin");
+    assert_eq!(parsed["embedding_model"], "mE5-small-v1");
+    assert_eq!(parsed["indexing_in_progress"], 0);
+
+    let r = &h.log.stats.lock().unwrap()[0];
+    assert_eq!(r.zone_id, "root");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn stats_query_defaults_reach_backend_intact() {
+    // `zone_id` param omitted ⇒ backend receives empty string
+    // (falls back to ROOT_ZONE_ID at the plugin layer).
+    let h = Harness::start(MockConfig::default()).await;
+    let resp = reqwest::Client::new()
+        .get(format!("{}/v2/documents/stats", h.http_base))
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+    let r = &h.log.stats.lock().unwrap()[0];
+    assert_eq!(r.zone_id, "");
+    assert_eq!(r.auth_token, "");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn stats_upstream_permission_denied_maps_to_403() {
+    // Round out the shared mapper cover — a real ApiKeyAuthProvider
+    // will emit PermissionDenied when a caller queries a zone they
+    // lack access to.  Stats is a natural surface for this.
+    let h = Harness::start(MockConfig {
+        rpc_err: Some(tonic::Code::PermissionDenied),
+        ..MockConfig::default()
+    })
+    .await;
+    let resp = reqwest::Client::new()
+        .get(format!("{}/v2/documents/stats", h.http_base))
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(resp.status(), reqwest::StatusCode::FORBIDDEN);
+}


### PR DESCRIPTION
## Summary

Next R10 route domain — port of Python `nexus-server`'s `/v2/documents/*` FastAPI router. Splits the router surface into the same two-file shape Python has (search=read, documents=write+meta) so URL namespaces stay intact for migrating callers.

## 4 new endpoints

- `POST /v2/documents/index` → `SearchService::Index` (full recursive walk)
- `POST /v2/documents/refresh` → `SearchService::Refresh` (incremental mtime-diff)
- `POST /v2/documents/batch` → `SearchService::IndexDocuments` (explicit upsert list)
- `GET /v2/documents/stats` → `SearchService::Stats` (index diagnostics)

All 4 slot under the same protected sub-router as `/v2/search/*` (bearer middleware gates access). All 4 route errors through the shared `SearchError` + `grpc_status_to_http` mapper.

## Zero AppState growth

The 4 handlers only touch `state.search`. The "AppState growth is O(1) per new domain" invariant from `handlers/mod.rs` holds — no field addition, no test-glue change.

## Test cover — 12 new real-chain tests

Mock gRPC server + axum listener + reqwest. Per-RPC `MockConfig` + `RequestLog` so every test can inject the response AND assert on which upstream RPC ran + what it received.

- **/index (4)**: happy full-round-trip, defaults intact, `Unimplemented→501`, upstream-down→503
- **/refresh (2)**: full counter set, `truncated` flag round-trip pin
- **/batch (3)**: 2-doc payload with optional `mtime_ms` pins (absent→None, not 0), parked_paths retry-callers pin, missing-body→4xx pre-RPC
- **/stats (3)**: backend-identity pins (`backend="rust-plugin"` + `embedding_model` for health pollers), query defaults, `PermissionDenied→403`

## Full suite

61 tests pass (15 lib + 5 auth-e2e + 7 glob-e2e + 5 grep-e2e + 13 query-e2e + 4 serve-e2e + 12 documents-e2e). clippy `--all-targets -D warnings` + fmt clean.

## Deferred

Extending the docker E2E (`test_http_api.py`) to also drive `/v2/documents/stats` — one PR per axis keeps blast radius small.
