### PR TITLE
feat(rebac): crate skeleton + ReBACTupleStore trait + inmem impl (R10 — PR 1/5)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3089,6 +3089,14 @@ version = "0.1.0"
 source = "git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b#601c2af20b85a324496a7c95b8aba5cb20848e3b"
 
 [[package]]
+name = "nexus-rebac"
+version = "0.1.0"
+dependencies = [
+ "parking_lot",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "nexus-search-plugin"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,13 @@ members = [
     # `GET /v2/status` so the axum + JSON + test-harness pattern
     # is proven before the search/documents/auth routes land.
     "rust/services/http-api",
+    # nexus-rebac — Rust replacement for `src/nexus/bricks/rebac/`
+    # (Zanzibar-shaped relationship-based access control).  Part
+    # of R10 epic #4674.  PR-1 ships the ReBACTupleStore HAL trait
+    # + noop + in-memory impls; the raft-backed impl, graph cache,
+    # enforcer, HTTP router, and kernel `PermissionProvider` impl
+    # land in follow-up PRs.
+    "rust/services/rebac",
     # nexusd — the nexus cluster-profile daemon assembly binary
     # (`nexusd-cluster`). Composes the nexus-vfs cluster boot
     # (`nexus_cluster::run_with_services`) with the managed_agent control

--- a/rust/services/rebac/Cargo.toml
+++ b/rust/services/rebac/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "nexus-rebac"
+version = "0.1.0"
+edition = "2021"
+description = "Relationship-based access control (Zanzibar-shaped) for nexus — the Rust replacement for `src/nexus/bricks/rebac/`.  Owns the tuple store trait + in-memory impl + (in later PRs) the raft-backed impl, the per-zone graph cache, and the enforcer facade the /v2/search/* + /v2/documents/* handlers call as a post-filter.  Kernel `PermissionProvider` impl for syscall-tier gating lands here too."
+authors = ["Nexus Team"]
+publish = false
+
+[lib]
+name = "nexus_rebac"
+crate-type = ["rlib"]
+
+[dependencies]
+# `parking_lot::RwLock` for the in-memory tuple store — matches every
+# other sync-lock in the workspace (kernel + search-plugin) and is
+# ~2x faster than std::sync under low contention (the read-heavy
+# ReBAC hot path).
+parking_lot = "0.12"
+
+# `thiserror` for the store-error enum — matches the shape every
+# other nexus service uses so downstream `?` propagation stays
+# uniform.
+thiserror = "1"
+
+[dev-dependencies]
+# The in-memory impl needs to be exercised from multiple threads to
+# prove its `Send + Sync` bounds hold under real racing — no
+# additional deps required, but keeping this section explicit for
+# a future test that wants tokio-based concurrency stress.

--- a/rust/services/rebac/src/inmem.rs
+++ b/rust/services/rebac/src/inmem.rs
@@ -1,0 +1,272 @@
+//! `InMemoryReBACTupleStore` — the real (non-noop) impl backed by a
+//! `parking_lot::RwLock<HashMap>`.
+//!
+//! # When to use
+//!
+//! * **Tests** — the enforcer + graph cache + HTTP handler tests
+//!   all build their fixture graph through this.  Same shape
+//!   real callers use, no boot-order dance.
+//! * **Dev / single-node** — a nexusd built without the raft
+//!   feature (a future opt-out) can install this at the
+//!   composition root.  Grants persist for the process lifetime
+//!   and vanish on restart — CORRECT for dev; NEVER production.
+//!
+//! # Cross-thread safety
+//!
+//! `RwLock<HashMap>`: unbounded readers, at-most-one writer.
+//! Every method takes the lock briefly and returns owned data —
+//! no lock is held across the caller's compute.  The `list()`
+//! call clones the whole map; this is O(N) where N is the tuple
+//! count — the same "one full scan per graph rebuild" cost
+//! model the real raft-backed impl carries.
+//!
+//! # Zone revision tracking
+//!
+//! An in-memory `HashMap<String, u64>` bumps on every `put` /
+//! `delete` for the zone extracted from the tuple key's first
+//! `|`-delimited segment (the tuple key convention this crate
+//! adopts — documented on [`InMemoryReBACTupleStore`]).  A key
+//! that does not encode a zone bumps a `""` global counter — safe
+//! (over-invalidates the enforcer's cache) but the tuple-key
+//! convention is stable enough this branch is never taken in
+//! production.
+
+use std::collections::HashMap;
+
+use parking_lot::RwLock;
+
+use crate::store::{ReBACTupleStore, ReBACTupleStoreError};
+
+/// In-memory tuple store.  Wraps a `RwLock<HashMap>`; every method
+/// takes the lock briefly and returns owned data (no borrow-across-
+/// caller).
+///
+/// # Tuple key convention
+///
+/// Keys are expected to be pipe-delimited `<zone>|<rest>` — the
+/// zone-revision tracker keys off the first segment.  Any key
+/// without a `|` bumps the empty-string revision counter, which
+/// the enforcer treats as a global cache bust (safe over-
+/// invalidate, no correctness impact).  The full production key
+/// shape lands in the enforcer PR: `<zone>|<object_type>|
+/// <object_id>|<relation>|<subject_type>|<subject_id>[|<subject_
+/// relation>]`.
+#[derive(Debug, Default)]
+pub struct InMemoryReBACTupleStore {
+    entries: RwLock<HashMap<String, Vec<u8>>>,
+    zone_revs: RwLock<HashMap<String, u64>>,
+}
+
+impl InMemoryReBACTupleStore {
+    /// Fresh empty store.  Equivalent to `Default::default()` but
+    /// spelled out for readable call-sites.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Extract the zone from a tuple key (first `|`-delimited
+    /// segment).  Returns `""` for a key with no `|` — see the
+    /// struct doc for the safe-over-invalidate rationale.
+    fn zone_of(key: &str) -> &str {
+        key.split_once('|').map(|(z, _)| z).unwrap_or("")
+    }
+
+    fn bump_zone_rev(&self, zone: &str) {
+        let mut revs = self.zone_revs.write();
+        let entry = revs.entry(zone.to_string()).or_insert(0);
+        *entry = entry.saturating_add(1);
+    }
+}
+
+impl ReBACTupleStore for InMemoryReBACTupleStore {
+    fn put(&self, key: &str, value: &[u8]) -> Result<(), ReBACTupleStoreError> {
+        // Bump the zone revision on EVERY put — even a same-value
+        // write, matching the `RaftReBACTupleStore` posture (a
+        // raft propose commits regardless of value equality).
+        // Cheap: one lock + one hash insert.
+        self.entries.write().insert(key.to_string(), value.to_vec());
+        self.bump_zone_rev(Self::zone_of(key));
+        Ok(())
+    }
+
+    fn delete(&self, key: &str) -> Result<bool, ReBACTupleStoreError> {
+        let existed = self.entries.write().remove(key).is_some();
+        // Bump the revision only when the delete actually removed
+        // something — a delete-on-missing does not change graph
+        // state, so the enforcer cache stays fresh.  Matches the
+        // idempotent-delete contract.
+        if existed {
+            self.bump_zone_rev(Self::zone_of(key));
+        }
+        Ok(existed)
+    }
+
+    fn get(&self, key: &str) -> Result<Option<Vec<u8>>, ReBACTupleStoreError> {
+        Ok(self.entries.read().get(key).cloned())
+    }
+
+    fn list(&self) -> Result<Vec<(String, Vec<u8>)>, ReBACTupleStoreError> {
+        Ok(self
+            .entries
+            .read()
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect())
+    }
+
+    fn zone_revision(&self, zone: &str) -> Result<u64, ReBACTupleStoreError> {
+        Ok(self.zone_revs.read().get(zone).copied().unwrap_or(0))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn put_then_get_returns_the_written_value() {
+        let s = InMemoryReBACTupleStore::new();
+        s.put("root|doc:a|reader|user|alice", b"grant")
+            .expect("put");
+        assert_eq!(
+            s.get("root|doc:a|reader|user|alice").expect("get"),
+            Some(b"grant".to_vec()),
+        );
+    }
+
+    #[test]
+    fn get_absent_key_returns_none() {
+        let s = InMemoryReBACTupleStore::new();
+        assert_eq!(s.get("root|missing|reader|user|alice").expect("get"), None);
+    }
+
+    #[test]
+    fn delete_returns_true_when_key_existed() {
+        let s = InMemoryReBACTupleStore::new();
+        s.put("root|doc:a|reader|user|alice", b"grant")
+            .expect("put");
+        assert!(s.delete("root|doc:a|reader|user|alice").expect("delete"));
+        assert!(!s
+            .delete("root|doc:a|reader|user|alice")
+            .expect("delete idempotent"));
+    }
+
+    #[test]
+    fn list_returns_snapshot_of_all_entries() {
+        let s = InMemoryReBACTupleStore::new();
+        s.put("root|doc:a|reader|user|alice", b"1").expect("put a");
+        s.put("shared|doc:b|writer|user|bob", b"2").expect("put b");
+        let mut got = s.list().expect("list");
+        got.sort();
+        assert_eq!(
+            got,
+            vec![
+                ("root|doc:a|reader|user|alice".to_string(), b"1".to_vec()),
+                ("shared|doc:b|writer|user|bob".to_string(), b"2".to_vec()),
+            ],
+        );
+    }
+
+    #[test]
+    fn put_bumps_zone_revision_for_the_written_zone() {
+        // The enforcer keys its per-zone graph cache on this
+        // counter — a bump on write is what makes a stale cache
+        // notice it needs to rebuild.  Regression pin: a delete
+        // must also bump so a revoke invalidates every reader.
+        let s = InMemoryReBACTupleStore::new();
+        assert_eq!(s.zone_revision("root").expect("rev0"), 0);
+
+        s.put("root|doc:a|reader|user|alice", b"g").expect("put");
+        let rev1 = s.zone_revision("root").expect("rev1");
+        assert!(rev1 > 0);
+
+        s.put("root|doc:b|reader|user|alice", b"g")
+            .expect("put again");
+        let rev2 = s.zone_revision("root").expect("rev2");
+        assert!(rev2 > rev1);
+
+        s.delete("root|doc:a|reader|user|alice").expect("del");
+        let rev3 = s.zone_revision("root").expect("rev3");
+        assert!(rev3 > rev2);
+    }
+
+    #[test]
+    fn delete_on_missing_key_does_not_bump_zone_revision() {
+        // Idempotent delete + no-op cache bust — a caller that
+        // retries a delete does not spuriously invalidate every
+        // reader's cache in the zone.
+        let s = InMemoryReBACTupleStore::new();
+        assert_eq!(s.zone_revision("root").expect("rev0"), 0);
+        assert!(!s.delete("root|missing|reader|user|alice").expect("delete"));
+        assert_eq!(
+            s.zone_revision("root").expect("rev unchanged"),
+            0,
+            "delete on missing key must NOT bump the revision — a retry \
+             storm would otherwise invalidate every reader's cache in the zone",
+        );
+    }
+
+    #[test]
+    fn zone_revisions_are_independent_across_zones() {
+        // Writing to zone A must not bust zone B's cache.
+        let s = InMemoryReBACTupleStore::new();
+        s.put("A|doc:x|reader|user|alice", b"g").expect("put A");
+        let rev_a_1 = s.zone_revision("A").expect("A rev1");
+        let rev_b_1 = s.zone_revision("B").expect("B rev1");
+
+        s.put("A|doc:y|reader|user|alice", b"g")
+            .expect("put A again");
+        assert!(s.zone_revision("A").expect("A rev2") > rev_a_1);
+        assert_eq!(
+            s.zone_revision("B").expect("B unchanged"),
+            rev_b_1,
+            "write to zone A must not bump zone B's revision",
+        );
+    }
+
+    #[test]
+    fn key_without_zone_prefix_bumps_empty_string_revision() {
+        // Safe over-invalidate posture — a malformed key (no `|`)
+        // is treated as a global cache bust rather than silently
+        // dropped.  Real callers use the documented key shape;
+        // this branch is a safety net.
+        let s = InMemoryReBACTupleStore::new();
+        s.put("legacy_no_zone_prefix", b"g").expect("put");
+        assert_eq!(
+            s.zone_revision("").expect("empty-zone rev"),
+            1,
+            "key without `|` must bump the empty-zone counter, not silently drop",
+        );
+    }
+
+    #[test]
+    fn concurrent_writes_from_multiple_threads_all_land() {
+        // parking_lot RwLock serializes writers — every put lands.
+        // Regression pin against a future refactor that
+        // accidentally introduces a lock-free path with lost
+        // updates.
+        use std::sync::Arc;
+        use std::thread;
+
+        let s = Arc::new(InMemoryReBACTupleStore::new());
+        let handles: Vec<_> = (0..8)
+            .map(|w| {
+                let s = Arc::clone(&s);
+                thread::spawn(move || {
+                    for i in 0..100 {
+                        let key = format!("root|doc:{w}-{i}|reader|user|alice");
+                        s.put(&key, b"g").expect("put");
+                    }
+                })
+            })
+            .collect();
+        for h in handles {
+            h.join().expect("thread joined");
+        }
+        assert_eq!(
+            s.list().expect("list").len(),
+            8 * 100,
+            "all 800 concurrent writes must land — no lost updates",
+        );
+    }
+}

--- a/rust/services/rebac/src/lib.rs
+++ b/rust/services/rebac/src/lib.rs
@@ -1,0 +1,51 @@
+//! `nexus-rebac` — the Rust replacement for `src/nexus/bricks/
+//! rebac/` (relationship-based access control, Zanzibar-shaped).
+//!
+//! Part of the R10 pure-Rust `nexus-server` migration (epic
+//! #4674).  Ships in phases:
+//!
+//!   * **PR-1 (this crate skeleton)** — [`store::ReBACTupleStore`]
+//!     HAL trait + [`store::NoopReBACTupleStore`] fail-closed
+//!     default + [`inmem::InMemoryReBACTupleStore`] real impl.
+//!     No enforcer, no graph cache, no HTTP wire, no kernel hook.
+//!     Sets the seam other crates code against.
+//!   * PR-2 — `RaftReBACTupleStore` (a `raft::ControlStateStore`
+//!     wrapper with namespace `"rebac"`) + graph cache built on
+//!     `lib::rebac::ReBACGraph`.
+//!   * PR-3 — `RebacPermissionProvider` impl of
+//!     `kernel::PermissionProvider` + composition-root wire in
+//!     `nexusd`.
+//!   * PR-4 — HTTP `/v2/rebac/tuples` router (grant / list /
+//!     revoke) + post-filter wire in `handlers::search` +
+//!     `handlers::documents`.
+//!   * PR-5 — Delete `src/nexus/bricks/rebac/` (~37k LoC Python).
+//!
+//! # SSOT — kernel metastore, not Postgres
+//!
+//! Deliberately NOT the Python side's Postgres schema.  Nexus's
+//! Rust `ApiKeyAuthProvider` already migrated OFF Postgres onto
+//! `KernelSlotStore` (raft-replicated); ReBAC follows the same
+//! posture.  Rationale:
+//!
+//!   * Rust binary stays self-contained (no PG deploy dep).
+//!   * Cross-node consistency is raft's problem, not the caller's
+//!     (matches the standing `feedback_distributed_ssot` rule).
+//!   * One SSOT shape across auth + rebac control-plane state.
+//!
+//! # Values are opaque bytes
+//!
+//! The store is a generic key/value primitive; the enforcer (PR-3)
+//! owns the tuple encoding.  Same "the store never interprets the
+//! value" contract as upstream `AuthKeyStore`.  Keeps the store
+//! reusable across record kinds if a future ReBAC feature adds
+//! namespace configs / zone-revision blobs / etc.
+
+pub mod inmem;
+pub mod store;
+
+// Re-export the trait + error at the crate root so callers reach
+// them at one path (`nexus_rebac::ReBACTupleStore`) instead of
+// remembering the module layout — same convention as
+// `nexus_http_api::AppState`.
+pub use inmem::InMemoryReBACTupleStore;
+pub use store::{NoopReBACTupleStore, ReBACTupleStore, ReBACTupleStoreError};

--- a/rust/services/rebac/src/store.rs
+++ b/rust/services/rebac/src/store.rs
@@ -1,0 +1,223 @@
+//! The `ReBACTupleStore` HAL trait — the seam every callable ReBAC
+//! surface (enforcer, HTTP grant router, kernel `PermissionProvider`
+//! impl) reads from.
+//!
+//! # Why a trait, not a concrete
+//!
+//! Three impls at different tiers:
+//!
+//!   * [`NoopReBACTupleStore`] — the fail-closed default installed at
+//!     boot, before the raft-backed store exists (matches the
+//!     `NoopAuthKeyStore` posture upstream).
+//!   * [`crate::inmem::InMemoryReBACTupleStore`] — test double + dev
+//!     backend when no cluster is configured.
+//!   * `RaftReBACTupleStore` (PR-2, not in this crate yet) — the
+//!     production impl, a thin wrapper over
+//!     `raft::ControlStateStore` with namespace `"rebac"`.
+//!
+//! Callers hold `Arc<dyn ReBACTupleStore>` and never name a concrete —
+//! same DI shape as `kernel::hal::auth_key_store::AuthKeyStore`
+//! upstream.
+//!
+//! # Values are opaque bytes
+//!
+//! The store never interprets the value; the enforcer owns the
+//! schema (Zanzibar tuple bytes today; a namespace-config blob or
+//! zone-revision counter tomorrow — one store surface, many
+//! callers).  Matches the `AuthKeyStore` "values are opaque"
+//! rationale — keeps the store generic across ReBAC record kinds.
+//!
+//! # Sync by design
+//!
+//! Every caller (the enforcer running in the kernel `PermissionProvider`
+//! slot; the http-api handlers under `axum::extract::State`) reaches
+//! this on the syscall / request hot path.  Async would force a
+//! `runtime.spawn` on every check — the impl bridges to any async
+//! backend internally (raft's `propose` becomes a `block_on_via`
+//! inside `RaftReBACTupleStore`).
+
+use std::error::Error;
+use std::fmt;
+
+/// Failure to reach the tuple store, or to commit a write to it.
+///
+/// One variant on purpose: every caller treats an error the same
+/// way — **fail closed**.  A check that cannot read the store must
+/// deny the permission rather than guess, and a grant tool that
+/// cannot commit a `put` / `delete` must report the write as not
+/// durable.
+#[derive(Debug, thiserror::Error)]
+pub enum ReBACTupleStoreError {
+    /// The store could not be read, or the write was not committed
+    /// (consensus rejected the proposal, this node is not the
+    /// leader, or the underlying storage failed).  Carries the
+    /// backend's message for the operator log.
+    #[error("rebac tuple store backend error: {0}")]
+    Backend(String),
+}
+
+/// Distinct owned-error type for cross-crate propagation — same
+/// shape as `AuthKeyStore`'s `Box<dyn Error + Send + Sync>` bound
+/// for the underlying source. Kept simple (one variant) so callers
+/// do not need a match.
+impl ReBACTupleStoreError {
+    /// Wrap any error into the single `Backend` variant.  Used by
+    /// impls that adapt a foreign error type (raft errors, redb
+    /// errors, sqlx errors in the deprecated PG path).
+    pub fn backend<E: Error + Send + Sync + 'static>(err: E) -> Self {
+        ReBACTupleStoreError::Backend(err.to_string())
+    }
+}
+
+/// The kernel-adjacent store of Zanzibar tuples.
+///
+/// # Contract
+///
+/// * `put` is idempotent — writing the same `(key, value)` twice
+///   MUST NOT double-count.  Impls that back a log-ordered raft
+///   proposal accept this by convention (a repeated put commits
+///   as a single revision bump; see [`Self::zone_revision`]).
+///
+/// * `delete` is idempotent — deleting a missing key returns
+///   `Ok(false)`, not an error.  Callers `assert!(returned || not_
+///   present)`, they don't retry on false.
+///
+/// * `list` returns the FULL snapshot for the current namespace —
+///   there is no pagination.  Real deployments cap ReBAC tuples at
+///   O(100k) per zone (matches the Python Tiger/Leopard-cached
+///   design point); a full-scan is O(ms) and rebuilds the
+///   in-memory graph cache in one shot.
+///
+/// * `zone_revision(zone)` is a monotonic counter the enforcer
+///   uses as a cache-freshness key: on `put`/`delete` for a given
+///   zone the counter bumps; readers that saw revision N can skip
+///   the full-scan rebuild as long as the current revision is
+///   still N.  A store that cannot cheaply track this returns
+///   `0` (equivalent to "always stale — always rebuild") — safe,
+///   just slower.
+pub trait ReBACTupleStore: Send + Sync {
+    /// Write `value` at `key`.  Idempotent — same-value writes
+    /// are no-ops at the storage layer, though they may bump the
+    /// zone revision.  Returns Err only on storage failure, never
+    /// on "already exists."
+    fn put(&self, key: &str, value: &[u8]) -> Result<(), ReBACTupleStoreError>;
+
+    /// Delete `key`.  Returns `Ok(true)` when the key existed,
+    /// `Ok(false)` when it did not — idempotent; a delete on a
+    /// missing key is not an error.
+    fn delete(&self, key: &str) -> Result<bool, ReBACTupleStoreError>;
+
+    /// Read the value at `key`, or `Ok(None)` when the key is
+    /// absent.
+    fn get(&self, key: &str) -> Result<Option<Vec<u8>>, ReBACTupleStoreError>;
+
+    /// Full snapshot of the store's contents.  Callers rebuild the
+    /// per-zone `lib::rebac::ReBACGraph` from this on cache miss;
+    /// see the trait doc for the size-budget rationale.
+    fn list(&self) -> Result<Vec<(String, Vec<u8>)>, ReBACTupleStoreError>;
+
+    /// Monotonic per-zone revision counter — the cache-freshness
+    /// key the enforcer's graph cache reads to decide whether it
+    /// can skip the full-scan rebuild.
+    ///
+    /// An impl that cannot cheaply track this returns `0` (always-
+    /// stale — safe but slower).  The default here is `0`, so a
+    /// minimal impl only needs to implement the 4 CRUD methods.
+    fn zone_revision(&self, _zone: &str) -> Result<u64, ReBACTupleStoreError> {
+        Ok(0)
+    }
+}
+
+/// Fail-closed default installed at boot before the real store
+/// exists.  Every method is a no-op: `list` returns empty (so the
+/// enforcer's graph is empty ⇒ no permissions granted ⇒ every
+/// check denies), `put`/`delete` succeed silently (so a grant
+/// tool that fires before the raft store is up records the write
+/// but does not error — the write is lost, matching the "boot
+/// order safety, real store swaps in when ready" pattern of
+/// upstream `NoopAuthKeyStore`).
+///
+/// **NEVER install this in a real deployment** — the enforcer
+/// backed by this will deny every permission check.  Compose the
+/// real backend before the http-api service starts serving.
+///
+/// The one-shot `list` returning empty is the SAFE fail-closed
+/// posture: a live enforcer reading an empty graph denies every
+/// non-admin request, which surfaces the mis-wiring loudly (403 /
+/// 401 chain) rather than silently admitting requests under a
+/// missing store.
+pub struct NoopReBACTupleStore;
+
+impl ReBACTupleStore for NoopReBACTupleStore {
+    fn put(&self, _key: &str, _value: &[u8]) -> Result<(), ReBACTupleStoreError> {
+        Ok(())
+    }
+
+    fn delete(&self, _key: &str) -> Result<bool, ReBACTupleStoreError> {
+        Ok(false)
+    }
+
+    fn get(&self, _key: &str) -> Result<Option<Vec<u8>>, ReBACTupleStoreError> {
+        Ok(None)
+    }
+
+    fn list(&self) -> Result<Vec<(String, Vec<u8>)>, ReBACTupleStoreError> {
+        Ok(Vec::new())
+    }
+}
+
+/// Diagnostic Debug impl — `Arc<dyn ReBACTupleStore>` shows up in
+/// service-state Debug output; a bare "NoopReBACTupleStore" tells
+/// an operator immediately why every check denies.
+impl fmt::Debug for NoopReBACTupleStore {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "NoopReBACTupleStore")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn noop_put_get_returns_none() {
+        let s = NoopReBACTupleStore;
+        s.put("k", b"v").expect("put ok");
+        assert_eq!(s.get("k").expect("get ok"), None);
+    }
+
+    #[test]
+    fn noop_delete_returns_false_on_missing_key() {
+        // Idempotent delete — a caller that retries a delete never
+        // sees Err on the "already gone" branch.
+        let s = NoopReBACTupleStore;
+        assert!(!s.delete("k").expect("delete ok"));
+    }
+
+    #[test]
+    fn noop_list_returns_empty_vec() {
+        // The fail-closed posture — enforcer builds an empty graph,
+        // every non-admin check denies.  A test asserting >0 here
+        // would surface a regression that made Noop silently admit
+        // wrong tuples.
+        let s = NoopReBACTupleStore;
+        assert!(s.list().expect("list ok").is_empty());
+    }
+
+    #[test]
+    fn noop_zone_revision_defaults_to_zero() {
+        // 0 = "always stale" = safe fail-closed default for the
+        // freshness key.  Real impls override.
+        let s = NoopReBACTupleStore;
+        assert_eq!(s.zone_revision("root").expect("revision ok"), 0);
+    }
+
+    #[test]
+    fn error_backend_wraps_arbitrary_source() {
+        // Impls adapting foreign error types use `backend()` to
+        // preserve the source's Display in the operator log.
+        let src = std::io::Error::new(std::io::ErrorKind::PermissionDenied, "eaccess");
+        let e = ReBACTupleStoreError::backend(src);
+        assert!(e.to_string().contains("eaccess"));
+    }
+}


### PR DESCRIPTION
## Summary

**PR 1/5 of the ReBAC Rust port** (epic #4674 R10). Sets the seam downstream PRs code against; ships nothing wire-visible yet.

## What lands

New `rust/services/rebac/` crate with:
- `ReBACTupleStore` HAL trait — sync CRUD + optional `zone_revision(zone)` freshness counter. Same shape as upstream `AuthKeyStore`; opaque byte values.
- `ReBACTupleStoreError::Backend(String)` — one variant on purpose; every caller treats a store error the same way (**fail closed**).
- `NoopReBACTupleStore` — fail-closed default for boot-order safety.
- `InMemoryReBACTupleStore` — real impl backed by `parking_lot::RwLock<HashMap>`. Test fixture backend + dev single-node.

## SSOT decision — kernel metastore, not Postgres

Deliberately NOT Python's Postgres schema. Rust `ApiKeyAuthProvider` already migrated OFF Postgres onto `KernelSlotStore` (raft-replicated); ReBAC follows the same posture:
- Rust binary stays self-contained (no PG deploy dep)
- Cross-node consistency = raft (matches `feedback_distributed_ssot`)
- One SSOT shape across auth + rebac control-plane state

PR-2 lands `RaftReBACTupleStore` as a `raft::ControlStateStore` wrapper with namespace `"rebac"` — a 60-line typed shim exactly like upstream `RaftAuthKeyStore`. This crate is unchanged for that PR.

## Roadmap

- **PR 1 (this)** — trait + noop + inmem
- PR 2 — `RaftReBACTupleStore` + graph cache built on `lib::rebac::ReBACGraph`
- PR 3 — `RebacPermissionProvider` + composition-root wire in `nexusd`
- PR 4 — HTTP `/v2/rebac/tuples` + post-filter wire in search/documents handlers
- PR 5 — Delete `src/nexus/bricks/rebac/` (~37k LoC Python)

## Test cover — 14 tests

- `noop_{put,delete,get,list,zone_revision}` — fail-closed posture pins
- `error_backend_wraps_arbitrary_source` — cross-crate error propagation
- InMemory: put/get roundtrip, absent-none, idempotent delete, list snapshot, zone-rev bumps on write, no-bump on delete-missing, per-zone independence, malformed-key over-invalidate, 8-thread × 100-write concurrent stress

All 14 pass; clippy + fmt clean.
