### PR TITLE
chore(nexusd): bump co-host sudocode pin to aad70dc8 (A2A reply-contract prompt)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -233,8 +233,8 @@ checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "api"
-version = "0.1.27"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=c638b5c3b646a925ade780461a662a5d92e5099b#c638b5c3b646a925ade780461a662a5d92e5099b"
+version = "0.1.28"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=aad70dc8ecf9c00744b75818170a51179baa8206#aad70dc8ecf9c00744b75818170a51179baa8206"
 dependencies = [
  "base64 0.22.1",
  "httpdate",
@@ -847,8 +847,8 @@ dependencies = [
 
 [[package]]
 name = "commands"
-version = "0.1.27"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=c638b5c3b646a925ade780461a662a5d92e5099b#c638b5c3b646a925ade780461a662a5d92e5099b"
+version = "0.1.28"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=aad70dc8ecf9c00744b75818170a51179baa8206#aad70dc8ecf9c00744b75818170a51179baa8206"
 dependencies = [
  "plugins",
  "runtime",
@@ -3151,8 +3151,8 @@ dependencies = [
 
 [[package]]
 name = "nexus-vfs-client"
-version = "0.1.27"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=c638b5c3b646a925ade780461a662a5d92e5099b#c638b5c3b646a925ade780461a662a5d92e5099b"
+version = "0.1.28"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=aad70dc8ecf9c00744b75818170a51179baa8206#aad70dc8ecf9c00744b75818170a51179baa8206"
 dependencies = [
  "prost 0.13.5",
  "protoc-bin-vendored",
@@ -3609,8 +3609,8 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plugins"
-version = "0.1.27"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=c638b5c3b646a925ade780461a662a5d92e5099b#c638b5c3b646a925ade780461a662a5d92e5099b"
+version = "0.1.28"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=aad70dc8ecf9c00744b75818170a51179baa8206#aad70dc8ecf9c00744b75818170a51179baa8206"
 dependencies = [
  "serde",
  "serde_json",
@@ -4453,8 +4453,8 @@ dependencies = [
 
 [[package]]
 name = "runtime"
-version = "0.1.27"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=c638b5c3b646a925ade780461a662a5d92e5099b#c638b5c3b646a925ade780461a662a5d92e5099b"
+version = "0.1.28"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=aad70dc8ecf9c00744b75818170a51179baa8206#aad70dc8ecf9c00744b75818170a51179baa8206"
 dependencies = [
  "a2a",
  "agent-client-protocol",
@@ -5372,8 +5372,8 @@ dependencies = [
 
 [[package]]
 name = "telemetry"
-version = "0.1.27"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=c638b5c3b646a925ade780461a662a5d92e5099b#c638b5c3b646a925ade780461a662a5d92e5099b"
+version = "0.1.28"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=aad70dc8ecf9c00744b75818170a51179baa8206#aad70dc8ecf9c00744b75818170a51179baa8206"
 dependencies = [
  "chrono",
  "dirs",
@@ -5671,6 +5671,7 @@ dependencies = [
  "prost 0.13.5",
  "socket2 0.5.10",
  "tokio",
+ "tokio-rustls",
  "tokio-stream",
  "tower",
  "tower-layer",
@@ -5763,8 +5764,8 @@ dependencies = [
 
 [[package]]
 name = "tools"
-version = "0.1.27"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=c638b5c3b646a925ade780461a662a5d92e5099b#c638b5c3b646a925ade780461a662a5d92e5099b"
+version = "0.1.28"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=aad70dc8ecf9c00744b75818170a51179baa8206#aad70dc8ecf9c00744b75818170a51179baa8206"
 dependencies = [
  "api",
  "async-trait",
@@ -5774,6 +5775,7 @@ dependencies = [
  "futures",
  "managed-agent",
  "plugins",
+ "regex",
  "reqwest 0.12.28",
  "runtime",
  "serde",

--- a/rust/nexusd/Cargo.toml
+++ b/rust/nexusd/Cargo.toml
@@ -33,7 +33,7 @@ http-api = ["dep:nexus-http-api", "dep:tracing"]
 # carries `SudoCodeSpawnAdapter` next to the loop it wraps) and injects it
 # via `install_managed_agent_with_spawn`, so a minted agent runs a real LLM
 # loop doing in-process `KernelSyscall` calls (no gRPC on its fs path).
-# The kernel rev MUST match the workspace pin (both at nexus-vfs `08460a7`)
+# The kernel rev MUST match the workspace pin (both at nexus-vfs `601c2af`)
 # so `SpawnTask<Kernel>` is one type across the seam.
 cohost-sudocode = ["dep:sudocode-tools"]
 
@@ -60,14 +60,14 @@ anyhow = "1"
 # ── Co-host (opt-in `cohost-sudocode`) ──────────────────────────────────
 # The real sudocode agent runtime, linked ONLY when co-hosting. `sudocode-
 # tools` reaches `kernel` at the SAME nexus-vfs rev the workspace pins
-# (`08460a7`), so `Kernel` / `AgentDescriptor` / `KernelSyscall` / `AgentState`
+# (`601c2af`), so `Kernel` / `AgentDescriptor` / `KernelSyscall` / `AgentState`
 # unify across the seam and `SpawnTask<Kernel>` is a single monomorphised
 # type. `sudocode-tools` carries BOTH the `spawn_managed_agent` factory and
 # the `SudoCodeSpawnAdapter` this binary injects at boot — there is no
 # nexus-side co-host glue and no runtime enum to map (the adapter reports
 # `kernel::AgentState` directly). Pinned to sudocode main (spawn AgentState
 # collapse).
-sudocode-tools = { package = "tools", git = "https://github.com/sudoprivacy/sudocode", rev = "c638b5c3b646a925ade780461a662a5d92e5099b", optional = true }
+sudocode-tools = { package = "tools", git = "https://github.com/sudoprivacy/sudocode", rev = "aad70dc8ecf9c00744b75818170a51179baa8206", optional = true }
 # Named directly to spell `kernel::kernel::{ServiceDecl, Kernel}` — the
 # managed-agent boot decl's return type (both builds) and the co-host
 # adapter's `SpawnTask<Kernel>` (cohost build). Already present transitively


### PR DESCRIPTION
## What

Bumps the optional `cohost-sudocode` dependency (`sudocode-tools`) from
`c638b5c3` → sudocode main `aad70dc8`.

That range brings two things into the co-host build:
- **#508** — standalone `scode` A2A mailbox (X).
- **#510** — the co-host **A2A reply-contract system prompt**. Without it, a
  co-hosted agent's prompt carried no A2A guidance, so the model addressed its
  reply to a word lifted from the message body instead of the sender; the reply
  landed in a nonexistent inbox and the duet stalled.

## Pin alignment

`nexus-vfs` workspace pin is **unchanged (601c2af)**. sudocode `aad70dc8` pins
the same `kernel` rev, so `SpawnTask<Kernel>` stays a single monomorphised type
across the co-host seam. Also fixes two stale `08460a7` mentions in the
pin-match comment.

## Verification (local, this exact pin)

- `cargo build -p nexusd --features cohost-sudocode` — **Finished clean**.
- Auth-on duet (native founder, mTLS operator agent cert, real LLM): standalone
  `scode` (operator) → co-host (`chatbot`) round-trips; the co-host reply lands
  in the operator inbox, node-stamped:
  ```json
  {"from":"chatbot","to":"operator","body":"PONG"}
  ```

Feature is opt-in (`cohost-sudocode`, off by default), so the slim production
`cluster` binary is unaffected.