### PR TITLE
feat(rebac): tuple_key encoding + per-zone ReBACGraphCache (R10 — PR 3/5)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3094,6 +3094,7 @@ version = "0.1.0"
 dependencies = [
  "contracts",
  "kernel",
+ "lib",
  "parking_lot",
  "raft 0.1.0",
  "tempfile",

--- a/rust/services/rebac/Cargo.toml
+++ b/rust/services/rebac/Cargo.toml
@@ -29,6 +29,14 @@ thiserror = "1"
 raft = { workspace = true }
 contracts = { workspace = true }
 
+# `lib::rebac::ReBACGraph` + `lib::types::ReBACTuple` — the upstream
+# Zanzibar graph engine (O(1) direct-relation index + userset
+# expansion + tupleToUserset resolution) the enforcer walks.  This
+# crate builds one `ReBACGraph` per zone from a `Vec<ReBACTuple>`
+# materialised out of the store; the enforcer PR then calls
+# `lib::rebac::compute_permission` on that graph.
+lib = { workspace = true }
+
 # `tokio::runtime::Handle` — the raft store's `propose` bridge needs
 # a runtime handle to run its async futures under (matches upstream
 # `RaftAuthKeyStore::new(node, runtime)` signature). Not a workspace

--- a/rust/services/rebac/src/graph_cache.rs
+++ b/rust/services/rebac/src/graph_cache.rs
@@ -1,0 +1,458 @@
+//! Per-zone `lib::rebac::ReBACGraph` cache backed by an
+//! [`crate::store::ReBACTupleStore`].
+//!
+//! # Why a cache
+//!
+//! The Zanzibar enforcer answers `check(subject, permission, object)`
+//! by walking a `ReBACGraph` — a set of `AHashMap`s / `AHashSet`s
+//! indexing tuples for O(1) direct-relation lookups plus O(N) userset
+//! expansion.  Rebuilding the graph from `store.list()` on every
+//! check is O(N) in tuple count and pays the deserialise cost per
+//! tuple.
+//!
+//! This cache holds an `Arc<ReBACGraph>` per zone, keyed on the
+//! store's [`crate::store::ReBACTupleStore::zone_revision`] counter,
+//! so callers observe an O(1) hit under steady state.  Rebuild fires
+//! only when the revision moves — i.e. after a `put` / `delete` in
+//! that zone.
+//!
+//! # The `zone_revision == 0` fail-safe path
+//!
+//! The raft-backed store deliberately returns `zone_revision = 0` as
+//! a sentinel (see [`crate::raft_store::RaftReBACTupleStore`] module
+//! doc — a cross-node revision counter is subtle; the fail-safe is
+//! "always stale, always rebuild").  This cache treats `0` as
+//! **bypass the cache entirely**: rebuild every call, never write to
+//! the cache.  Cost: the caller pays the full `list()` + rebuild on
+//! every check.  Not a hot-path regression — enforcer checks are
+//! amortised behind `permission::PermissionLeaseCache` upstream.
+//!
+//! When a follow-up ships the raft-observer counter, this cache
+//! silently becomes fast for the raft store too — no changes here.
+//!
+//! # Concurrency
+//!
+//! Reads take a shared lock, fast-path returns the cached `Arc<
+//! ReBACGraph>` clone; writes take an exclusive lock ONLY when a
+//! rebuild is required.  A stampede (N readers all missing at once)
+//! is bounded — the first writer rebuilds, later writers observe the
+//! now-fresh entry inside the write lock and short-circuit.  No
+//! double rebuild, no lock held across the O(N) rebuild body.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use lib::rebac::ReBACGraph;
+use lib::types::ReBACTuple;
+use parking_lot::RwLock;
+
+use crate::store::{ReBACTupleStore, ReBACTupleStoreError};
+use crate::tuple_key;
+
+/// A `zone_revision` sentinel meaning "the store cannot cheaply
+/// track revisions — bypass the cache and always rebuild".  Matches
+/// [`ReBACTupleStore::zone_revision`]'s default-impl return value.
+///
+/// Named for grepability: a future reviewer scanning for the
+/// `0`-special-case sees the constant and its docstring instead of
+/// a bare literal.
+const ZONE_REV_ALWAYS_STALE: u64 = 0;
+
+/// A cached graph for one zone, keyed by the revision at which it
+/// was built.  Held as `Arc` so a reader holding an old snapshot can
+/// keep computing after a concurrent rebuild swaps in a new one.
+struct ZoneEntry {
+    revision: u64,
+    graph: Arc<ReBACGraph>,
+}
+
+/// Per-zone graph cache.
+///
+/// Clone-cheap — internal state is behind `Arc` + `RwLock`.  A
+/// single instance is composed at the composition root, cloned into
+/// the enforcer and any admin tools that also need to build the same
+/// graph (e.g. the (future) `expand` HTTP route that lists all
+/// subjects with a permission).
+///
+/// # NOT the enforcer
+///
+/// This is the *substrate* — one `Arc<ReBACGraph>` per zone.  The
+/// enforcer ([`crate::RebacPermissionProvider`] in the next PR)
+/// composes this with a namespace registry + calls `lib::rebac::
+/// compute_permission` on the returned graph.
+pub struct ReBACGraphCache {
+    store: Arc<dyn ReBACTupleStore>,
+    zones: RwLock<HashMap<String, ZoneEntry>>,
+}
+
+impl ReBACGraphCache {
+    /// Wrap a `ReBACTupleStore` with per-zone graph caching.
+    ///
+    /// A single cache instance serves many callers — the composition
+    /// root builds one, clones it (via `Arc`) into every consumer.
+    pub fn new(store: Arc<dyn ReBACTupleStore>) -> Self {
+        Self {
+            store,
+            zones: RwLock::new(HashMap::new()),
+        }
+    }
+
+    /// Return the current graph for `zone`, rebuilding if the
+    /// cached revision does not match the store's `zone_revision`.
+    ///
+    /// # The steady-state fast path
+    ///
+    /// 1. `store.zone_revision(zone)` — one branch-free counter read
+    ///    (raft returns `0`; in-memory returns the real counter).
+    /// 2. Shared-lock read the cache; if `entry.revision == current &&
+    ///    current != 0`, return `Arc::clone(&entry.graph)`.  This is
+    ///    the O(1) hot path.
+    ///
+    /// # The miss path
+    ///
+    /// Under exclusive lock: re-check the entry (a concurrent writer
+    /// may have already rebuilt), otherwise `store.list()`, filter
+    /// by `zone_of(key) == zone`, `decode()` each, hand the vec to
+    /// `ReBACGraph::from_tuples`, wrap in `Arc`, and — only if
+    /// `current != 0` — insert into the cache.  Return the fresh
+    /// `Arc`.
+    ///
+    /// # Error propagation
+    ///
+    /// Backend errors from `store.zone_revision` / `store.list`
+    /// bubble as `ReBACTupleStoreError::Backend`.  The enforcer
+    /// treats these as fail-closed (deny the permission) — the same
+    /// posture as an auth-store read failure denying auth.
+    pub fn graph_for_zone(&self, zone: &str) -> Result<Arc<ReBACGraph>, ReBACTupleStoreError> {
+        let current_rev = self.store.zone_revision(zone)?;
+
+        // Fast path: shared lock, exact revision match, non-sentinel.
+        // The `!= ZONE_REV_ALWAYS_STALE` guard is what makes the
+        // raft-backed store (which returns 0) skip this branch and
+        // fall through to a rebuild.
+        if current_rev != ZONE_REV_ALWAYS_STALE {
+            let zones = self.zones.read();
+            if let Some(entry) = zones.get(zone) {
+                if entry.revision == current_rev {
+                    return Ok(Arc::clone(&entry.graph));
+                }
+            }
+        }
+
+        // Miss / sentinel path: rebuild.  Re-check inside the write
+        // lock to collapse a rebuild stampede (N concurrent misses
+        // → one rebuild, N-1 late arrivals observe the fresh entry
+        // and short-circuit).
+        let mut zones = self.zones.write();
+        if current_rev != ZONE_REV_ALWAYS_STALE {
+            if let Some(entry) = zones.get(zone) {
+                if entry.revision == current_rev {
+                    return Ok(Arc::clone(&entry.graph));
+                }
+            }
+        }
+
+        let graph = Arc::new(build_graph_for_zone(self.store.as_ref(), zone)?);
+
+        // Skip cache-write under the sentinel — every call rebuilds,
+        // matches the raft-store fail-safe posture.
+        if current_rev != ZONE_REV_ALWAYS_STALE {
+            zones.insert(
+                zone.to_string(),
+                ZoneEntry {
+                    revision: current_rev,
+                    graph: Arc::clone(&graph),
+                },
+            );
+        }
+
+        Ok(graph)
+    }
+
+    /// Drop the cached entry for `zone`, if any.  The next
+    /// `graph_for_zone(zone)` call rebuilds unconditionally.
+    ///
+    /// Two callers today: (a) test cleanup, (b) an admin tool that
+    /// mutated tuples through a side channel and wants to force a
+    /// rebuild.  Real writes through the store's `put` / `delete`
+    /// bump `zone_revision` and are picked up naturally by the
+    /// steady-state path — this method is the escape hatch, not
+    /// the norm.
+    pub fn invalidate(&self, zone: &str) {
+        self.zones.write().remove(zone);
+    }
+}
+
+/// Walk `store.list()`, keep entries whose zone-prefix matches
+/// `zone`, decode each into a `ReBACTuple`, and build the graph.
+///
+/// Kept as a free fn so `graph_for_zone` doesn't hold the write
+/// lock across `store.list()` (which for the raft-backed store
+/// bridges an async future and can block briefly under contention).
+/// A refactor that inlines this back into `graph_for_zone` MUST
+/// preserve the "no store I/O under the write lock" property.
+fn build_graph_for_zone(
+    store: &dyn ReBACTupleStore,
+    zone: &str,
+) -> Result<ReBACGraph, ReBACTupleStoreError> {
+    let entries = store.list()?;
+    let tuples: Vec<ReBACTuple> = entries
+        .into_iter()
+        .filter_map(|(key, _value)| {
+            // `zone_of` first — cheap prefix compare avoids the
+            // full 6/7-segment split for out-of-zone keys.
+            if tuple_key::zone_of(&key) != Some(zone) {
+                return None;
+            }
+            // Soft-skip on decode failure — one malformed row does
+            // not wedge the whole zone's graph (see tuple_key::
+            // decode docstring).
+            tuple_key::decode(&key).map(|(_zone, tuple)| tuple)
+        })
+        .collect();
+    Ok(ReBACGraph::from_tuples(&tuples))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::inmem::InMemoryReBACTupleStore;
+    use crate::tuple_key;
+    use lib::types::{Entity, ReBACTuple};
+
+    fn t(obj_type: &str, obj_id: &str, rel: &str, subj_type: &str, subj_id: &str) -> ReBACTuple {
+        ReBACTuple {
+            object_type: obj_type.to_string(),
+            object_id: obj_id.to_string(),
+            relation: rel.to_string(),
+            subject_type: subj_type.to_string(),
+            subject_id: subj_id.to_string(),
+            subject_relation: None,
+        }
+    }
+
+    fn put(store: &InMemoryReBACTupleStore, zone: &str, tup: &ReBACTuple) {
+        let key = tuple_key::encode(zone, tup).expect("encode");
+        store.put(&key, b"").expect("put");
+    }
+
+    /// Fresh cache with one tuple in one zone → graph contains that
+    /// tuple as a direct relation.  End-to-end: encode → store →
+    /// list → filter → decode → build.
+    #[test]
+    fn graph_reflects_tuples_written_to_the_zone() {
+        let store = Arc::new(InMemoryReBACTupleStore::new());
+        put(&store, "root", &t("doc", "a", "reader", "user", "alice"));
+        put(&store, "root", &t("doc", "b", "writer", "user", "bob"));
+
+        let cache = ReBACGraphCache::new(store);
+        let g = cache.graph_for_zone("root").expect("graph");
+
+        assert!(g.check_direct_relation(
+            &Entity {
+                entity_type: "user".to_string(),
+                entity_id: "alice".to_string(),
+            },
+            "reader",
+            &Entity {
+                entity_type: "doc".to_string(),
+                entity_id: "a".to_string(),
+            },
+        ));
+        assert!(g.check_direct_relation(
+            &Entity {
+                entity_type: "user".to_string(),
+                entity_id: "bob".to_string(),
+            },
+            "writer",
+            &Entity {
+                entity_type: "doc".to_string(),
+                entity_id: "b".to_string(),
+            },
+        ));
+    }
+
+    /// Zone A's cache returns a graph containing only zone A's
+    /// tuples — zone B's tuples do not leak in.  Pins the
+    /// namespace-isolation invariant at the cache boundary (the
+    /// store enforces it via the key prefix, but the cache is what
+    /// actually hands a graph to the enforcer).
+    #[test]
+    fn graph_isolation_zone_a_does_not_see_zone_b_tuples() {
+        let store = Arc::new(InMemoryReBACTupleStore::new());
+        put(&store, "zone_a", &t("doc", "x", "reader", "user", "alice"));
+        put(&store, "zone_b", &t("doc", "x", "reader", "user", "alice"));
+
+        let cache = ReBACGraphCache::new(store);
+        let g_a = cache.graph_for_zone("zone_a").expect("graph a");
+        let g_b = cache.graph_for_zone("zone_b").expect("graph b");
+
+        // Same subject / relation / object on paper — but each graph
+        // sees only its own zone's tuple.  A cross-leak here would
+        // grant a user permission on the wrong tenant's data.
+        let alice = Entity {
+            entity_type: "user".to_string(),
+            entity_id: "alice".to_string(),
+        };
+        let doc = Entity {
+            entity_type: "doc".to_string(),
+            entity_id: "x".to_string(),
+        };
+        assert!(g_a.check_direct_relation(&alice, "reader", &doc));
+        assert!(g_b.check_direct_relation(&alice, "reader", &doc));
+        // Both are true because BOTH zones have the tuple; the pin
+        // is on the count / adjacency shape below.
+        let subjects_a = g_a.find_direct_subjects_for_object(&doc, "reader");
+        let subjects_b = g_b.find_direct_subjects_for_object(&doc, "reader");
+        assert_eq!(subjects_a.len(), 1, "zone A has exactly one grant");
+        assert_eq!(subjects_b.len(), 1, "zone B has exactly one grant");
+    }
+
+    /// Cache hit: two calls with no intervening write return the
+    /// same `Arc` (by pointer equality).  A future refactor that
+    /// accidentally rebuilds every call would trip this — the
+    /// pointer would move.
+    #[test]
+    fn steady_state_hit_returns_the_same_arc() {
+        let store = Arc::new(InMemoryReBACTupleStore::new());
+        put(&store, "root", &t("doc", "a", "reader", "user", "alice"));
+
+        let cache = ReBACGraphCache::new(store);
+        let g1 = cache.graph_for_zone("root").expect("g1");
+        let g2 = cache.graph_for_zone("root").expect("g2");
+        assert!(
+            Arc::ptr_eq(&g1, &g2),
+            "cache hit must return the same Arc (no rebuild on 2nd call)",
+        );
+    }
+
+    /// Cache miss after mutation: a write bumps the store's zone
+    /// revision, and the next `graph_for_zone` returns a fresh Arc
+    /// that reflects the new tuple.  Regression pin against a stale-
+    /// read bug where the cache would keep serving the old graph
+    /// after a grant lands.
+    #[test]
+    fn mutation_bumps_revision_and_next_lookup_rebuilds() {
+        let store = Arc::new(InMemoryReBACTupleStore::new());
+        put(&store, "root", &t("doc", "a", "reader", "user", "alice"));
+
+        let cache = ReBACGraphCache::new(Arc::clone(&store) as Arc<dyn ReBACTupleStore>);
+        let g1 = cache.graph_for_zone("root").expect("g1");
+        assert_eq!(
+            g1.find_direct_subjects_for_object(
+                &Entity {
+                    entity_type: "doc".to_string(),
+                    entity_id: "a".to_string()
+                },
+                "reader",
+            )
+            .len(),
+            1,
+        );
+
+        put(&store, "root", &t("doc", "a", "reader", "user", "bob"));
+        let g2 = cache.graph_for_zone("root").expect("g2");
+        assert!(!Arc::ptr_eq(&g1, &g2), "revision bump MUST force a rebuild",);
+        assert_eq!(
+            g2.find_direct_subjects_for_object(
+                &Entity {
+                    entity_type: "doc".to_string(),
+                    entity_id: "a".to_string()
+                },
+                "reader",
+            )
+            .len(),
+            2,
+            "rebuilt graph must include the new tuple",
+        );
+    }
+
+    /// The `zone_revision == 0` sentinel path (matches the raft-
+    /// backed store's fail-safe posture).  A store that always
+    /// returns 0 must never see cache hits — every call rebuilds.
+    #[test]
+    fn zone_revision_zero_sentinel_bypasses_cache() {
+        // Custom store that always returns 0 for the revision but
+        // is otherwise a real InMemory backend.
+        struct AlwaysStale(InMemoryReBACTupleStore);
+        impl ReBACTupleStore for AlwaysStale {
+            fn put(&self, key: &str, value: &[u8]) -> Result<(), ReBACTupleStoreError> {
+                self.0.put(key, value)
+            }
+            fn delete(&self, key: &str) -> Result<bool, ReBACTupleStoreError> {
+                self.0.delete(key)
+            }
+            fn get(&self, key: &str) -> Result<Option<Vec<u8>>, ReBACTupleStoreError> {
+                self.0.get(key)
+            }
+            fn list(&self) -> Result<Vec<(String, Vec<u8>)>, ReBACTupleStoreError> {
+                self.0.list()
+            }
+            // Deliberately does NOT override zone_revision — the
+            // trait default is `Ok(0)`, which is the fail-safe
+            // sentinel this test exercises.
+        }
+
+        let store = Arc::new(AlwaysStale(InMemoryReBACTupleStore::new()));
+        store.put("root|doc|a|reader|user|alice", b"").expect("put");
+
+        let cache = ReBACGraphCache::new(store);
+        let g1 = cache.graph_for_zone("root").expect("g1");
+        let g2 = cache.graph_for_zone("root").expect("g2");
+        assert!(
+            !Arc::ptr_eq(&g1, &g2),
+            "sentinel (revision=0) MUST rebuild every call — cache hit here \
+             would mean the raft-backed store silently serves stale grants",
+        );
+    }
+
+    /// A malformed key in the store (bad segment count, wrong
+    /// delimiter, empty required segment) is soft-skipped by the
+    /// rebuild — other tuples in the zone still load.  One bad row
+    /// cannot wedge the whole zone's permission plane.
+    #[test]
+    fn malformed_key_is_soft_skipped_and_zone_still_loads() {
+        let store = Arc::new(InMemoryReBACTupleStore::new());
+        // Well-formed tuple.
+        put(&store, "root", &t("doc", "a", "reader", "user", "alice"));
+        // Malformed: too few segments — decode returns None.
+        store
+            .put("root|doc|a|reader|user", b"")
+            .expect("put malformed");
+
+        let cache = ReBACGraphCache::new(store);
+        let g = cache.graph_for_zone("root").expect("graph");
+
+        // The well-formed tuple survives.
+        assert!(g.check_direct_relation(
+            &Entity {
+                entity_type: "user".to_string(),
+                entity_id: "alice".to_string()
+            },
+            "reader",
+            &Entity {
+                entity_type: "doc".to_string(),
+                entity_id: "a".to_string()
+            },
+        ));
+    }
+
+    /// `invalidate(zone)` drops the cached entry — the next lookup
+    /// rebuilds even if the store's revision has not moved.  The
+    /// escape hatch for admin tools that mutated the store via a
+    /// side channel.
+    #[test]
+    fn invalidate_forces_next_lookup_to_rebuild() {
+        let store = Arc::new(InMemoryReBACTupleStore::new());
+        put(&store, "root", &t("doc", "a", "reader", "user", "alice"));
+
+        let cache = ReBACGraphCache::new(store);
+        let g1 = cache.graph_for_zone("root").expect("g1");
+        cache.invalidate("root");
+        let g2 = cache.graph_for_zone("root").expect("g2");
+        assert!(
+            !Arc::ptr_eq(&g1, &g2),
+            "invalidate must force a rebuild — the escape hatch is a no-op otherwise",
+        );
+    }
+}

--- a/rust/services/rebac/src/lib.rs
+++ b/rust/services/rebac/src/lib.rs
@@ -44,14 +44,17 @@
 //! reusable across record kinds if a future ReBAC feature adds
 //! namespace configs / zone-revision blobs / etc.
 
+pub mod graph_cache;
 pub mod inmem;
 pub mod raft_store;
 pub mod store;
+pub mod tuple_key;
 
 // Re-export the trait + error at the crate root so callers reach
 // them at one path (`nexus_rebac::ReBACTupleStore`) instead of
 // remembering the module layout — same convention as
 // `nexus_http_api::AppState`.
+pub use graph_cache::ReBACGraphCache;
 pub use inmem::InMemoryReBACTupleStore;
 pub use raft_store::{RaftReBACTupleStore, CONTROL_NS_REBAC};
 pub use store::{NoopReBACTupleStore, ReBACTupleStore, ReBACTupleStoreError};

--- a/rust/services/rebac/src/tuple_key.rs
+++ b/rust/services/rebac/src/tuple_key.rs
@@ -1,0 +1,248 @@
+//! Encoding + decoding for the ReBAC tuple wire format persisted in
+//! the [`crate::store::ReBACTupleStore`] key space.
+//!
+//! # The key convention
+//!
+//! ```text
+//!   <zone>|<object_type>|<object_id>|<relation>|<subject_type>|<subject_id>[|<subject_relation>]
+//! ```
+//!
+//! * Pipe-delimited, 6 or 7 segments (the 7th is the optional
+//!   `subject_relation` for userset-as-subject tuples — the Zanzibar
+//!   "members of subject_type:subject_id have this relation on the
+//!   object" pattern).
+//! * The `<zone>` prefix is the tuple's scoping zone (nexus's mount-
+//!   root concept); every downstream reader filters by prefix to
+//!   materialise a per-zone graph.  Matches the convention documented
+//!   on [`crate::inmem::InMemoryReBACTupleStore`] and the raft-store
+//!   docstring.
+//!
+//! # Why a string encoding (not bincode / serde_json)
+//!
+//! The store's `list()` returns `(String, Vec<u8>)` — the KEY is what
+//! [`crate::store::ReBACTupleStore::zone_revision`] indexes by, and
+//! the graph cache rebuilds the graph by walking `list()` output.  A
+//! string key means:
+//!
+//!   * `zone_of(key)` is `str::split_once('|')` (no deserialisation)
+//!   * A raft-log dump is human-inspectable — an operator can `grep
+//!     "^root|doc:x"` an on-disk `sm_control_state` snapshot to audit
+//!     grants.  Bincode / JSON payloads would obscure this.
+//!   * The value is free for grant metadata (granter, timestamp) —
+//!     the tuple's identity lives entirely in the key.
+//!
+//! # Segment escaping — fail-loud, not silent
+//!
+//! A literal `|` in any segment would ambiguate the split.  Real
+//! ReBAC entities (users, files, groups) never carry pipes in
+//! identifiers; a caller that tries to encode one is programmer
+//! error — [`encode`] returns `Err`, not a silently-escaped key.
+//! This surfaces the mistake at the write site instead of at graph-
+//! rebuild time where a decode-fail would silently drop the tuple.
+
+use crate::store::ReBACTupleStoreError;
+use lib::types::ReBACTuple;
+
+/// Segment delimiter for the tuple key.  Kept private so callers do
+/// not build ad-hoc keys — every write and read goes through
+/// [`encode`] / [`decode`].
+const SEP: char = '|';
+
+/// Encode a `(zone, tuple)` pair into the store's key format.
+///
+/// Fails when any segment contains the delimiter [`SEP`] — see the
+/// module docstring for the fail-loud rationale.  The `subject_
+/// relation` (7th segment) is emitted only when `Some`.
+pub fn encode(zone: &str, tuple: &ReBACTuple) -> Result<String, ReBACTupleStoreError> {
+    let subject_relation_seg: Option<&str> = tuple.subject_relation.as_deref();
+    let mut segments: Vec<&str> = vec![
+        zone,
+        &tuple.object_type,
+        &tuple.object_id,
+        &tuple.relation,
+        &tuple.subject_type,
+        &tuple.subject_id,
+    ];
+    if let Some(sr) = subject_relation_seg {
+        segments.push(sr);
+    }
+    for seg in &segments {
+        if seg.contains(SEP) {
+            return Err(ReBACTupleStoreError::Backend(format!(
+                "rebac tuple segment contains reserved delimiter {SEP:?}: {seg:?}"
+            )));
+        }
+    }
+    Ok(segments.join(&SEP.to_string()))
+}
+
+/// Extract the zone from a key without a full decode.  Returns
+/// `None` for a malformed key (no `|`); callers treat that as "not
+/// in the requested zone" and skip.
+///
+/// `#[inline]` — hit per-entry during the graph-cache rebuild scan
+/// (one call per key in `store.list()`); avoiding the call cost
+/// keeps the O(N) scan tight.
+#[inline]
+pub fn zone_of(key: &str) -> Option<&str> {
+    key.split_once(SEP).map(|(z, _)| z)
+}
+
+/// Decode a key back into a `(zone, ReBACTuple)`.  Returns `None`
+/// for any malformed key — the graph-cache rebuild treats a malformed
+/// key as a soft skip (the tuple is invisible to the graph, but
+/// other tuples in the zone continue to load), NOT a hard error, so
+/// one bad row can't wedge the whole zone's permission plane.
+///
+/// Malformed = fewer than 6 or more than 7 segments.  A caller that
+/// wants to audit malformed keys should walk `store.list()`
+/// separately and check for `decode() == None` rows.
+pub fn decode(key: &str) -> Option<(String, ReBACTuple)> {
+    let parts: Vec<&str> = key.split(SEP).collect();
+    let (subject_relation, subject_id_idx) = match parts.len() {
+        6 => (None, 5),
+        7 => (Some(parts[6].to_string()), 5),
+        _ => return None,
+    };
+    // Reject empty required segments — Zanzibar entities are never
+    // "" and a "" segment nearly always means the caller mis-built
+    // the key.  Same soft-skip posture as segment-count mismatch.
+    if parts[..6].iter().any(|s| s.is_empty()) {
+        return None;
+    }
+    Some((
+        parts[0].to_string(),
+        ReBACTuple {
+            object_type: parts[1].to_string(),
+            object_id: parts[2].to_string(),
+            relation: parts[3].to_string(),
+            subject_type: parts[4].to_string(),
+            subject_id: parts[subject_id_idx].to_string(),
+            subject_relation,
+        },
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn t(
+        obj_type: &str,
+        obj_id: &str,
+        rel: &str,
+        subj_type: &str,
+        subj_id: &str,
+        subj_rel: Option<&str>,
+    ) -> ReBACTuple {
+        ReBACTuple {
+            object_type: obj_type.to_string(),
+            object_id: obj_id.to_string(),
+            relation: rel.to_string(),
+            subject_type: subj_type.to_string(),
+            subject_id: subj_id.to_string(),
+            subject_relation: subj_rel.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn encode_direct_tuple_produces_six_segment_key() {
+        let key = encode("root", &t("doc", "a", "reader", "user", "alice", None)).expect("encode");
+        assert_eq!(key, "root|doc|a|reader|user|alice");
+    }
+
+    #[test]
+    fn encode_userset_tuple_appends_subject_relation_segment() {
+        let key = encode(
+            "root",
+            &t("doc", "a", "reader", "group", "eng", Some("member")),
+        )
+        .expect("encode");
+        assert_eq!(key, "root|doc|a|reader|group|eng|member");
+    }
+
+    #[test]
+    fn encode_rejects_segment_containing_delimiter() {
+        // A pipe in any segment would ambiguate the split; a silent
+        // escape would drop the tuple at decode time.  Better to
+        // surface the bug at the write site.
+        let bad = t("doc", "a|b", "reader", "user", "alice", None);
+        assert!(encode("root", &bad).is_err(), "must reject pipe in id");
+
+        let bad_zone_result = encode("root|other", &t("doc", "a", "r", "u", "alice", None));
+        assert!(bad_zone_result.is_err(), "must reject pipe in zone");
+    }
+
+    #[test]
+    fn decode_direct_tuple_roundtrips() {
+        let original = t("doc", "a", "reader", "user", "alice", None);
+        let key = encode("root", &original).expect("encode");
+        let (zone, decoded) = decode(&key).expect("decode ok");
+        assert_eq!(zone, "root");
+        assert_eq!(decoded.object_type, original.object_type);
+        assert_eq!(decoded.object_id, original.object_id);
+        assert_eq!(decoded.relation, original.relation);
+        assert_eq!(decoded.subject_type, original.subject_type);
+        assert_eq!(decoded.subject_id, original.subject_id);
+        assert_eq!(decoded.subject_relation, original.subject_relation);
+    }
+
+    #[test]
+    fn decode_userset_tuple_roundtrips() {
+        let original = t("doc", "a", "reader", "group", "eng", Some("member"));
+        let key = encode("root", &original).expect("encode");
+        let (zone, decoded) = decode(&key).expect("decode ok");
+        assert_eq!(zone, "root");
+        assert_eq!(decoded.subject_relation.as_deref(), Some("member"));
+    }
+
+    #[test]
+    fn decode_returns_none_for_short_key() {
+        // Soft-skip posture — a malformed key is invisible to the
+        // graph rebuild, other tuples in the zone still load.
+        assert!(decode("root|doc|a|reader|user").is_none());
+    }
+
+    #[test]
+    fn decode_returns_none_for_too_many_segments() {
+        assert!(decode("root|doc|a|reader|user|alice|member|extra").is_none());
+    }
+
+    #[test]
+    fn decode_returns_none_for_empty_required_segment() {
+        // An empty segment nearly always means the caller mis-built
+        // the key; same soft-skip as segment-count mismatch.
+        assert!(decode("root||a|reader|user|alice").is_none());
+    }
+
+    #[test]
+    fn zone_of_extracts_first_segment_without_full_decode() {
+        assert_eq!(
+            zone_of("root|doc|a|reader|user|alice"),
+            Some("root"),
+            "extract zone in O(prefix) without allocating",
+        );
+        assert_eq!(
+            zone_of("shared|folder|home|writer|user|bob|member"),
+            Some("shared"),
+            "userset-tuple zone extraction is the same shape",
+        );
+    }
+
+    #[test]
+    fn zone_of_returns_none_for_key_without_delimiter() {
+        assert_eq!(zone_of("no_delimiter"), None);
+    }
+
+    #[test]
+    fn zone_of_and_decode_agree_on_the_zone() {
+        // Regression pin: a future encoding change must keep the
+        // fast-path `zone_of` in sync with the full decode.  The
+        // graph-cache rebuild walks `list()` and filters via
+        // `zone_of` — a mismatch would drop tuples silently.
+        let key =
+            encode("shared", &t("doc", "a", "reader", "user", "alice", None)).expect("encode");
+        let (decoded_zone, _) = decode(&key).expect("decode");
+        assert_eq!(zone_of(&key), Some(decoded_zone.as_str()));
+    }
+}


### PR DESCRIPTION
## Summary

**PR 3/5 of the ReBAC Rust port** (epic #4674 R10 — Python \`nexus-server\` → pure Rust).  Ships the wire format persisted in the tuple keyspace + the per-zone graph cache that materialises \`lib::rebac::ReBACGraph\` for the enforcer (PR 4/5).

- \`nexus_rebac::tuple_key::{encode, decode, zone_of}\` — the pipe-delimited \`<zone>|<obj_type>|<obj_id>|<relation>|<subj_type>|<subj_id>[|<subj_relation>]\` wire format.
- \`nexus_rebac::graph_cache::ReBACGraphCache\` — per-zone \`Arc<ReBACGraph>\` keyed on \`store.zone_revision(zone)\`.
- 18 new tests (36 total in crate, all green).

## What this PR does NOT do

- **No nexusd wire.** Crate stays \`rlib\`-only. Binary size unchanged.
- **No PermissionProvider impl.** Lands in PR 4/5 alongside the \`--features rebac\` gate + composition-root wire in nexusd (folded into \`--features http-api\` per @elfenlieds7 size-budget guidance).
- **No HTTP router.** Lands in PR 5.

## Design decisions

**String key, not bincode / JSON.** The store's \`list()\` returns \`(String, Vec<u8>)\`; the graph rebuild walks it filtered by \`zone_of(key)\` (a \`split_once('|')\`, no deserialisation). String keys also mean raft-log dumps are human-inspectable — an operator can grep an on-disk \`sm_control_state\` snapshot for grants. The value stays free for grant metadata (granter, timestamp).

**Fail-loud on \`|\` in any segment.** A pipe would ambiguate the split; a silent escape would drop the tuple at decode time. Better to surface the bug at the write site. Real ReBAC entities never carry pipes.

**Soft-skip on decode failure.** One malformed row (bad segment count, empty required segment) does NOT wedge the whole zone's permission plane — the graph rebuild filters it out, other tuples in the zone still load.

**\`zone_revision == 0\` bypasses the cache.** The raft-backed store deliberately returns \`0\` as a fail-safe sentinel (see PR #4724 module docstring). This cache treats \`0\` as \"rebuild every call, never write to the cache\" — matches the fail-safe posture. Cost: full rebuild every check, but not a hot-path regression (enforcer checks are behind \`permission::PermissionLeaseCache\` upstream). When the follow-up raft-observer counter lands, this cache silently becomes fast for the raft store too — zero changes here.

**Stampede-safe rebuild.** N concurrent misses take the write lock, but N-1 late arrivals observe the fresh entry inside the write lock and short-circuit — one rebuild, not N. No lock is held across the O(N) rebuild body (delegated to \`build_graph_for_zone\` free fn — the invariant is documented at the call site).

## Test plan

- [x] \`cargo test -p nexus-rebac\` → 36 passed (18 from PR 1/2 + 10 \`tuple_key\` + 8 \`graph_cache\`, all local)
- [x] \`cargo clippy -p nexus-rebac --all-targets -- -D warnings\` → clean
- [x] \`cargo fmt -p nexus-rebac -- --check\` → clean
- [ ] CI green

## Follow-ups (documented in \`src/lib.rs\` module doc)

- **PR 4/5** — \`RebacPermissionProvider\` impl of \`kernel::PermissionProvider\` + composition-root wire in \`nexusd\` (feature-gated behind \`--features rebac\`, folded into \`--features http-api\` so slim \`cluster\` build stays lean)
- **PR 5/5** — HTTP \`/v2/rebac/tuples\` router + delete Python \`src/nexus/bricks/rebac/\` (~37k LoC)