### PR TITLE
chore: bump nexus-vfs → ec149759 + sudocode → 37321ed9 (auth-on cross-machine federation)

### DIFF
--- a/.github/workflows/mtls-federation-e2e.yml
+++ b/.github/workflows/mtls-federation-e2e.yml
@@ -131,8 +131,11 @@ jobs:
               echo "OK: federation converged over mTLS — voters=[1, 2], joiner caught up"
               # The founder actually served mTLS, the joiner actually reached it
               # over https, and the founder dialed the joiner back over https
-              # (not a plaintext fallback in either direction).
-              echo "$flog" | grep -q 'TLS mode: mTLS' \
+              # (not a plaintext fallback in either direction). The founder's
+              # ZoneManager boot line reports `tls=true` when TLS is armed (the
+              # former `TLS mode: mTLS` log was retired); the https dial-back
+              # assertion below is what proves it is *mutual* TLS, not one-way.
+              echo "$flog" | grep -q 'started (bind=[^)]*tls=true)' \
                 || { echo '::error::founder did not enable mTLS'; exit 1; }
               echo "$jlog" | grep -q 'DiscoverZones: peer reported federation zones' \
                 || { echo '::error::joiner did not discover over mTLS'; exit 1; }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "a2a"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=ec1497591e44fc573585ff6910a011658d5cce50#ec1497591e44fc573585ff6910a011658d5cce50"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=2cc85ca7525a6a21236c189c0e173706ed03183c#2cc85ca7525a6a21236c189c0e173706ed03183c"
 dependencies = [
  "contracts",
  "kernel",
@@ -233,8 +233,8 @@ checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "api"
-version = "0.1.29"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=37321ed958c82fa61fbdb3f65a5fd76e792a9afd#37321ed958c82fa61fbdb3f65a5fd76e792a9afd"
+version = "0.2.0"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=1463842f71d1518e44dbe364de2faa4b8a77adbe#1463842f71d1518e44dbe364de2faa4b8a77adbe"
 dependencies = [
  "base64 0.22.1",
  "httpdate",
@@ -327,7 +327,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 [[package]]
 name = "auth"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=ec1497591e44fc573585ff6910a011658d5cce50#ec1497591e44fc573585ff6910a011658d5cce50"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=2cc85ca7525a6a21236c189c0e173706ed03183c#2cc85ca7525a6a21236c189c0e173706ed03183c"
 dependencies = [
  "contracts",
  "dashmap",
@@ -430,7 +430,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=ec1497591e44fc573585ff6910a011658d5cce50#ec1497591e44fc573585ff6910a011658d5cce50"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=2cc85ca7525a6a21236c189c0e173706ed03183c#2cc85ca7525a6a21236c189c0e173706ed03183c"
 dependencies = [
  "ahash",
  "base64 0.22.1",
@@ -847,8 +847,8 @@ dependencies = [
 
 [[package]]
 name = "commands"
-version = "0.1.29"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=37321ed958c82fa61fbdb3f65a5fd76e792a9afd#37321ed958c82fa61fbdb3f65a5fd76e792a9afd"
+version = "0.2.0"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=1463842f71d1518e44dbe364de2faa4b8a77adbe#1463842f71d1518e44dbe364de2faa4b8a77adbe"
 dependencies = [
  "plugins",
  "runtime",
@@ -917,7 +917,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=ec1497591e44fc573585ff6910a011658d5cce50#ec1497591e44fc573585ff6910a011658d5cce50"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=2cc85ca7525a6a21236c189c0e173706ed03183c#2cc85ca7525a6a21236c189c0e173706ed03183c"
 dependencies = [
  "parking_lot",
  "serde",
@@ -2540,7 +2540,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=ec1497591e44fc573585ff6910a011658d5cce50#ec1497591e44fc573585ff6910a011658d5cce50"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=2cc85ca7525a6a21236c189c0e173706ed03183c#2cc85ca7525a6a21236c189c0e173706ed03183c"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -2608,7 +2608,7 @@ checksum = "0c2cdeb66e45e9f36bfad5bbdb4d2384e70936afbee843c6f6543f0c551ebb25"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=ec1497591e44fc573585ff6910a011658d5cce50#ec1497591e44fc573585ff6910a011658d5cce50"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=2cc85ca7525a6a21236c189c0e173706ed03183c#2cc85ca7525a6a21236c189c0e173706ed03183c"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -2813,7 +2813,7 @@ checksum = "fc04a4c58212d57930a24bf47d3fa87485264a3a054e9c10e042eb373573ad3c"
 [[package]]
 name = "managed-agent"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=ec1497591e44fc573585ff6910a011658d5cce50#ec1497591e44fc573585ff6910a011658d5cce50"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=2cc85ca7525a6a21236c189c0e173706ed03183c#2cc85ca7525a6a21236c189c0e173706ed03183c"
 dependencies = [
  "a2a",
  "contracts",
@@ -3008,7 +3008,7 @@ dependencies = [
 [[package]]
 name = "nexus-cluster"
 version = "0.1.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=ec1497591e44fc573585ff6910a011658d5cce50#ec1497591e44fc573585ff6910a011658d5cce50"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=2cc85ca7525a6a21236c189c0e173706ed03183c#2cc85ca7525a6a21236c189c0e173706ed03183c"
 dependencies = [
  "a2a",
  "anyhow",
@@ -3086,7 +3086,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=ec1497591e44fc573585ff6910a011658d5cce50#ec1497591e44fc573585ff6910a011658d5cce50"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=2cc85ca7525a6a21236c189c0e173706ed03183c#2cc85ca7525a6a21236c189c0e173706ed03183c"
 
 [[package]]
 name = "nexus-rebac"
@@ -3157,8 +3157,8 @@ dependencies = [
 
 [[package]]
 name = "nexus-vfs-client"
-version = "0.1.29"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=37321ed958c82fa61fbdb3f65a5fd76e792a9afd#37321ed958c82fa61fbdb3f65a5fd76e792a9afd"
+version = "0.2.0"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=1463842f71d1518e44dbe364de2faa4b8a77adbe#1463842f71d1518e44dbe364de2faa4b8a77adbe"
 dependencies = [
  "prost 0.13.5",
  "protoc-bin-vendored",
@@ -3615,8 +3615,8 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plugins"
-version = "0.1.29"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=37321ed958c82fa61fbdb3f65a5fd76e792a9afd#37321ed958c82fa61fbdb3f65a5fd76e792a9afd"
+version = "0.2.0"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=1463842f71d1518e44dbe364de2faa4b8a77adbe#1463842f71d1518e44dbe364de2faa4b8a77adbe"
 dependencies = [
  "serde",
  "serde_json",
@@ -4030,7 +4030,7 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 [[package]]
 name = "raft"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=ec1497591e44fc573585ff6910a011658d5cce50#ec1497591e44fc573585ff6910a011658d5cce50"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=2cc85ca7525a6a21236c189c0e173706ed03183c#2cc85ca7525a6a21236c189c0e173706ed03183c"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -4459,8 +4459,8 @@ dependencies = [
 
 [[package]]
 name = "runtime"
-version = "0.1.29"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=37321ed958c82fa61fbdb3f65a5fd76e792a9afd#37321ed958c82fa61fbdb3f65a5fd76e792a9afd"
+version = "0.2.0"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=1463842f71d1518e44dbe364de2faa4b8a77adbe#1463842f71d1518e44dbe364de2faa4b8a77adbe"
 dependencies = [
  "a2a",
  "agent-client-protocol",
@@ -5160,7 +5160,7 @@ dependencies = [
 [[package]]
 name = "subprocess"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=ec1497591e44fc573585ff6910a011658d5cce50#ec1497591e44fc573585ff6910a011658d5cce50"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=2cc85ca7525a6a21236c189c0e173706ed03183c#2cc85ca7525a6a21236c189c0e173706ed03183c"
 dependencies = [
  "kernel",
  "libc",
@@ -5378,8 +5378,8 @@ dependencies = [
 
 [[package]]
 name = "telemetry"
-version = "0.1.29"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=37321ed958c82fa61fbdb3f65a5fd76e792a9afd#37321ed958c82fa61fbdb3f65a5fd76e792a9afd"
+version = "0.2.0"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=1463842f71d1518e44dbe364de2faa4b8a77adbe#1463842f71d1518e44dbe364de2faa4b8a77adbe"
 dependencies = [
  "chrono",
  "dirs",
@@ -5770,8 +5770,8 @@ dependencies = [
 
 [[package]]
 name = "tools"
-version = "0.1.29"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=37321ed958c82fa61fbdb3f65a5fd76e792a9afd#37321ed958c82fa61fbdb3f65a5fd76e792a9afd"
+version = "0.2.0"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=1463842f71d1518e44dbe364de2faa4b8a77adbe#1463842f71d1518e44dbe364de2faa4b8a77adbe"
 dependencies = [
  "api",
  "async-trait",
@@ -5916,7 +5916,7 @@ dependencies = [
 [[package]]
 name = "transport"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=ec1497591e44fc573585ff6910a011658d5cce50#ec1497591e44fc573585ff6910a011658d5cce50"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=2cc85ca7525a6a21236c189c0e173706ed03183c#2cc85ca7525a6a21236c189c0e173706ed03183c"
 dependencies = [
  "axum",
  "backends",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "a2a"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b#601c2af20b85a324496a7c95b8aba5cb20848e3b"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=ec1497591e44fc573585ff6910a011658d5cce50#ec1497591e44fc573585ff6910a011658d5cce50"
 dependencies = [
  "contracts",
  "kernel",
@@ -233,8 +233,8 @@ checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "api"
-version = "0.1.28"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=aad70dc8ecf9c00744b75818170a51179baa8206#aad70dc8ecf9c00744b75818170a51179baa8206"
+version = "0.1.29"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=37321ed958c82fa61fbdb3f65a5fd76e792a9afd#37321ed958c82fa61fbdb3f65a5fd76e792a9afd"
 dependencies = [
  "base64 0.22.1",
  "httpdate",
@@ -327,7 +327,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 [[package]]
 name = "auth"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b#601c2af20b85a324496a7c95b8aba5cb20848e3b"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=ec1497591e44fc573585ff6910a011658d5cce50#ec1497591e44fc573585ff6910a011658d5cce50"
 dependencies = [
  "contracts",
  "dashmap",
@@ -430,7 +430,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b#601c2af20b85a324496a7c95b8aba5cb20848e3b"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=ec1497591e44fc573585ff6910a011658d5cce50#ec1497591e44fc573585ff6910a011658d5cce50"
 dependencies = [
  "ahash",
  "base64 0.22.1",
@@ -847,8 +847,8 @@ dependencies = [
 
 [[package]]
 name = "commands"
-version = "0.1.28"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=aad70dc8ecf9c00744b75818170a51179baa8206#aad70dc8ecf9c00744b75818170a51179baa8206"
+version = "0.1.29"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=37321ed958c82fa61fbdb3f65a5fd76e792a9afd#37321ed958c82fa61fbdb3f65a5fd76e792a9afd"
 dependencies = [
  "plugins",
  "runtime",
@@ -917,7 +917,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b#601c2af20b85a324496a7c95b8aba5cb20848e3b"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=ec1497591e44fc573585ff6910a011658d5cce50#ec1497591e44fc573585ff6910a011658d5cce50"
 dependencies = [
  "parking_lot",
  "serde",
@@ -2540,7 +2540,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b#601c2af20b85a324496a7c95b8aba5cb20848e3b"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=ec1497591e44fc573585ff6910a011658d5cce50#ec1497591e44fc573585ff6910a011658d5cce50"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -2608,7 +2608,7 @@ checksum = "0c2cdeb66e45e9f36bfad5bbdb4d2384e70936afbee843c6f6543f0c551ebb25"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b#601c2af20b85a324496a7c95b8aba5cb20848e3b"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=ec1497591e44fc573585ff6910a011658d5cce50#ec1497591e44fc573585ff6910a011658d5cce50"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -2813,7 +2813,7 @@ checksum = "fc04a4c58212d57930a24bf47d3fa87485264a3a054e9c10e042eb373573ad3c"
 [[package]]
 name = "managed-agent"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b#601c2af20b85a324496a7c95b8aba5cb20848e3b"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=ec1497591e44fc573585ff6910a011658d5cce50#ec1497591e44fc573585ff6910a011658d5cce50"
 dependencies = [
  "a2a",
  "contracts",
@@ -3008,7 +3008,7 @@ dependencies = [
 [[package]]
 name = "nexus-cluster"
 version = "0.1.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b#601c2af20b85a324496a7c95b8aba5cb20848e3b"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=ec1497591e44fc573585ff6910a011658d5cce50#ec1497591e44fc573585ff6910a011658d5cce50"
 dependencies = [
  "a2a",
  "anyhow",
@@ -3086,7 +3086,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b#601c2af20b85a324496a7c95b8aba5cb20848e3b"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=ec1497591e44fc573585ff6910a011658d5cce50#ec1497591e44fc573585ff6910a011658d5cce50"
 
 [[package]]
 name = "nexus-rebac"
@@ -3157,8 +3157,8 @@ dependencies = [
 
 [[package]]
 name = "nexus-vfs-client"
-version = "0.1.28"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=aad70dc8ecf9c00744b75818170a51179baa8206#aad70dc8ecf9c00744b75818170a51179baa8206"
+version = "0.1.29"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=37321ed958c82fa61fbdb3f65a5fd76e792a9afd#37321ed958c82fa61fbdb3f65a5fd76e792a9afd"
 dependencies = [
  "prost 0.13.5",
  "protoc-bin-vendored",
@@ -3615,8 +3615,8 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plugins"
-version = "0.1.28"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=aad70dc8ecf9c00744b75818170a51179baa8206#aad70dc8ecf9c00744b75818170a51179baa8206"
+version = "0.1.29"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=37321ed958c82fa61fbdb3f65a5fd76e792a9afd#37321ed958c82fa61fbdb3f65a5fd76e792a9afd"
 dependencies = [
  "serde",
  "serde_json",
@@ -4030,7 +4030,7 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 [[package]]
 name = "raft"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b#601c2af20b85a324496a7c95b8aba5cb20848e3b"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=ec1497591e44fc573585ff6910a011658d5cce50#ec1497591e44fc573585ff6910a011658d5cce50"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -4459,8 +4459,8 @@ dependencies = [
 
 [[package]]
 name = "runtime"
-version = "0.1.28"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=aad70dc8ecf9c00744b75818170a51179baa8206#aad70dc8ecf9c00744b75818170a51179baa8206"
+version = "0.1.29"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=37321ed958c82fa61fbdb3f65a5fd76e792a9afd#37321ed958c82fa61fbdb3f65a5fd76e792a9afd"
 dependencies = [
  "a2a",
  "agent-client-protocol",
@@ -5160,7 +5160,7 @@ dependencies = [
 [[package]]
 name = "subprocess"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b#601c2af20b85a324496a7c95b8aba5cb20848e3b"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=ec1497591e44fc573585ff6910a011658d5cce50#ec1497591e44fc573585ff6910a011658d5cce50"
 dependencies = [
  "kernel",
  "libc",
@@ -5378,8 +5378,8 @@ dependencies = [
 
 [[package]]
 name = "telemetry"
-version = "0.1.28"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=aad70dc8ecf9c00744b75818170a51179baa8206#aad70dc8ecf9c00744b75818170a51179baa8206"
+version = "0.1.29"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=37321ed958c82fa61fbdb3f65a5fd76e792a9afd#37321ed958c82fa61fbdb3f65a5fd76e792a9afd"
 dependencies = [
  "chrono",
  "dirs",
@@ -5770,8 +5770,8 @@ dependencies = [
 
 [[package]]
 name = "tools"
-version = "0.1.28"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=aad70dc8ecf9c00744b75818170a51179baa8206#aad70dc8ecf9c00744b75818170a51179baa8206"
+version = "0.1.29"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=37321ed958c82fa61fbdb3f65a5fd76e792a9afd#37321ed958c82fa61fbdb3f65a5fd76e792a9afd"
 dependencies = [
  "api",
  "async-trait",
@@ -5916,7 +5916,7 @@ dependencies = [
 [[package]]
 name = "transport"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=601c2af20b85a324496a7c95b8aba5cb20848e3b#601c2af20b85a324496a7c95b8aba5cb20848e3b"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=ec1497591e44fc573585ff6910a011658d5cce50#ec1497591e44fc573585ff6910a011658d5cce50"
 dependencies = [
  "axum",
  "backends",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -236,30 +236,30 @@ exclude = ["nexus-fuse"]
 #
 # Bump alongside the rest of nexus-vfs updates when a downstream
 # change needs newer kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "601c2af20b85a324496a7c95b8aba5cb20848e3b" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "601c2af20b85a324496a7c95b8aba5cb20848e3b" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "601c2af20b85a324496a7c95b8aba5cb20848e3b" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "601c2af20b85a324496a7c95b8aba5cb20848e3b", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "601c2af20b85a324496a7c95b8aba5cb20848e3b", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "601c2af20b85a324496a7c95b8aba5cb20848e3b", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "601c2af20b85a324496a7c95b8aba5cb20848e3b" }
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ec1497591e44fc573585ff6910a011658d5cce50" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ec1497591e44fc573585ff6910a011658d5cce50" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ec1497591e44fc573585ff6910a011658d5cce50" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ec1497591e44fc573585ff6910a011658d5cce50", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ec1497591e44fc573585ff6910a011658d5cce50", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ec1497591e44fc573585ff6910a011658d5cce50", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ec1497591e44fc573585ff6910a011658d5cce50" }
 # The cluster daemon library entry (`nexus_cluster::run_with_services`),
 # consumed by the nexus-side assembly binary (`rust/nexusd`) that composes
 # the kernel/federation boot with the nexus service set via the
 # ServiceRegistry bring-up seam.
-nexus-cluster = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "601c2af20b85a324496a7c95b8aba5cb20848e3b" }
+nexus-cluster = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ec1497591e44fc573585ff6910a011658d5cce50" }
 # a2a messaging substrate. `default-features = false` leaves the
 # `install` feature (which pulls raft to arm the stream-wakeup observer)
 # OFF, so nexus-side consumers link only the stamp hook and stay
 # raft-free — they reach raft through kernel.sys_* (§6.1). The substrate
 # is armed in production at cluster boot in nexus-vfs, not here.
-a2a = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "601c2af20b85a324496a7c95b8aba5cb20848e3b", default-features = false }
+a2a = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ec1497591e44fc573585ff6910a011658d5cce50", default-features = false }
 # managed-agent control plane + the shared subprocess host — RELOCATED into
 # nexus-vfs (kernel-tier) so the production nexusd-cluster carries the agent
 # control plane. `subprocess-host` enables the raw ACP-subprocess spawner (the
 # nexus-side acp path + managed-agent both use HostedSubprocess).
-managed-agent = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "601c2af20b85a324496a7c95b8aba5cb20848e3b", default-features = false }
-subprocess = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "601c2af20b85a324496a7c95b8aba5cb20848e3b" }
+managed-agent = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ec1497591e44fc573585ff6910a011658d5cce50", default-features = false }
+subprocess = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ec1497591e44fc573585ff6910a011658d5cce50" }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -236,30 +236,30 @@ exclude = ["nexus-fuse"]
 #
 # Bump alongside the rest of nexus-vfs updates when a downstream
 # change needs newer kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ec1497591e44fc573585ff6910a011658d5cce50" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ec1497591e44fc573585ff6910a011658d5cce50" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ec1497591e44fc573585ff6910a011658d5cce50" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ec1497591e44fc573585ff6910a011658d5cce50", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ec1497591e44fc573585ff6910a011658d5cce50", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ec1497591e44fc573585ff6910a011658d5cce50", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ec1497591e44fc573585ff6910a011658d5cce50" }
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "2cc85ca7525a6a21236c189c0e173706ed03183c" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "2cc85ca7525a6a21236c189c0e173706ed03183c" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "2cc85ca7525a6a21236c189c0e173706ed03183c" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "2cc85ca7525a6a21236c189c0e173706ed03183c", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "2cc85ca7525a6a21236c189c0e173706ed03183c", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "2cc85ca7525a6a21236c189c0e173706ed03183c", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "2cc85ca7525a6a21236c189c0e173706ed03183c" }
 # The cluster daemon library entry (`nexus_cluster::run_with_services`),
 # consumed by the nexus-side assembly binary (`rust/nexusd`) that composes
 # the kernel/federation boot with the nexus service set via the
 # ServiceRegistry bring-up seam.
-nexus-cluster = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ec1497591e44fc573585ff6910a011658d5cce50" }
+nexus-cluster = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "2cc85ca7525a6a21236c189c0e173706ed03183c" }
 # a2a messaging substrate. `default-features = false` leaves the
 # `install` feature (which pulls raft to arm the stream-wakeup observer)
 # OFF, so nexus-side consumers link only the stamp hook and stay
 # raft-free — they reach raft through kernel.sys_* (§6.1). The substrate
 # is armed in production at cluster boot in nexus-vfs, not here.
-a2a = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ec1497591e44fc573585ff6910a011658d5cce50", default-features = false }
+a2a = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "2cc85ca7525a6a21236c189c0e173706ed03183c", default-features = false }
 # managed-agent control plane + the shared subprocess host — RELOCATED into
 # nexus-vfs (kernel-tier) so the production nexusd-cluster carries the agent
 # control plane. `subprocess-host` enables the raw ACP-subprocess spawner (the
 # nexus-side acp path + managed-agent both use HostedSubprocess).
-managed-agent = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ec1497591e44fc573585ff6910a011658d5cce50", default-features = false }
-subprocess = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "ec1497591e44fc573585ff6910a011658d5cce50" }
+managed-agent = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "2cc85ca7525a6a21236c189c0e173706ed03183c", default-features = false }
+subprocess = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "2cc85ca7525a6a21236c189c0e173706ed03183c" }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir --no-deps --prefix=/install .
 # enforces agreement) — an unpinned install tracks nexus-vfs HEAD and
 # ships an untested kernel (#4343). --locked honors the source tree's
 # Cargo.lock.
-ARG NEXUS_VFS_REV=ec1497591e44fc573585ff6910a011658d5cce50
+ARG NEXUS_VFS_REV=2cc85ca7525a6a21236c189c0e173706ed03183c
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-cluster nexus-cluster
 
 # -- Runtime stage --

--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir --no-deps --prefix=/install .
 # enforces agreement) — an unpinned install tracks nexus-vfs HEAD and
 # ships an untested kernel (#4343). --locked honors the source tree's
 # Cargo.lock.
-ARG NEXUS_VFS_REV=601c2af20b85a324496a7c95b8aba5cb20848e3b
+ARG NEXUS_VFS_REV=ec1497591e44fc573585ff6910a011658d5cce50
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-cluster nexus-cluster
 
 # -- Runtime stage --

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -25,7 +25,7 @@ WORKDIR /build
 # (CI preflight enforces agreement) — an unpinned install tracks HEAD
 # and can skew the raft contract against the cluster/witness images.
 # --locked honors the source tree's Cargo.lock.
-ARG NEXUS_VFS_REV=ec1497591e44fc573585ff6910a011658d5cce50
+ARG NEXUS_VFS_REV=2cc85ca7525a6a21236c189c0e173706ed03183c
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexus-raft-server raft
 
 # ---------- Production image ----------

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -25,7 +25,7 @@ WORKDIR /build
 # (CI preflight enforces agreement) — an unpinned install tracks HEAD
 # and can skew the raft contract against the cluster/witness images.
 # --locked honors the source tree's Cargo.lock.
-ARG NEXUS_VFS_REV=601c2af20b85a324496a7c95b8aba5cb20848e3b
+ARG NEXUS_VFS_REV=ec1497591e44fc573585ff6910a011658d5cce50
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexus-raft-server raft
 
 # ---------- Production image ----------

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=601c2af20b85a324496a7c95b8aba5cb20848e3b
+ARG NEXUS_VFS_REV=ec1497591e44fc573585ff6910a011658d5cce50
 RUN cargo install \
     --locked \
     --git https://github.com/nexi-lab/nexus-vfs \

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=ec1497591e44fc573585ff6910a011658d5cce50
+ARG NEXUS_VFS_REV=2cc85ca7525a6a21236c189c0e173706ed03183c
 RUN cargo install \
     --locked \
     --git https://github.com/nexi-lab/nexus-vfs \

--- a/dockerfiles/docker-compose.cc-tasks-peer-shared.yml
+++ b/dockerfiles/docker-compose.cc-tasks-peer-shared.yml
@@ -43,13 +43,6 @@ x-bootstrap-entrypoint: &bootstrap-entrypoint
     - |
       set -e
       DATA_DIR="${NEXUS_DATA_DIR:-/app/data}"
-      # Advertise this container's routable IP, not the bare compose service name:
-      # the federation fail-loud check refuses bare hostnames (they do not resolve
-      # across an overlay). Peers still resolve each other via NEXUS_PEERS (compose
-      # DNS) for the initial dial, then learn the advertised IP.
-      if [ -n "$${NEXUS_ADVERTISE_ADDR}" ]; then
-        export NEXUS_ADVERTISE_ADDR="$$(hostname -i | awk '{print $$1}'):$${NEXUS_ADVERTISE_ADDR##*:}"
-      fi
       # Reachable 0.0.0.0 bind + --no-tls trips the loopback auth invariant;
       # this is a trusted CI/compose cluster, so take the sanctioned escape.
       exec nexusd-cluster \
@@ -76,6 +69,7 @@ services:
       NEXUS_HOSTNAME: founder
       NEXUS_BIND_ADDR: 0.0.0.0:2126
       NEXUS_ADVERTISE_ADDR: founder:2126
+      NEXUS_ALLOW_HOSTNAME_ADVERTISE: "1"
       NEXUS_DATA_DIR: /app/data
       NEXUS_NO_TLS: "true"
       NEXUS_CLUSTER_INIT: sharedzone
@@ -113,6 +107,7 @@ services:
       NEXUS_HOSTNAME: joiner
       NEXUS_BIND_ADDR: 0.0.0.0:2126
       NEXUS_ADVERTISE_ADDR: joiner:2126
+      NEXUS_ALLOW_HOSTNAME_ADVERTISE: "1"
       NEXUS_DATA_DIR: /app/data
       NEXUS_IDENTITY_DIR: /app/identity
       NEXUS_NO_TLS: "true"

--- a/dockerfiles/docker-compose.cc-tasks-peer-shared.yml
+++ b/dockerfiles/docker-compose.cc-tasks-peer-shared.yml
@@ -43,6 +43,13 @@ x-bootstrap-entrypoint: &bootstrap-entrypoint
     - |
       set -e
       DATA_DIR="${NEXUS_DATA_DIR:-/app/data}"
+      # Advertise this container's routable IP, not the bare compose service name:
+      # the federation fail-loud check refuses bare hostnames (they do not resolve
+      # across an overlay). Peers still resolve each other via NEXUS_PEERS (compose
+      # DNS) for the initial dial, then learn the advertised IP.
+      if [ -n "$${NEXUS_ADVERTISE_ADDR}" ]; then
+        export NEXUS_ADVERTISE_ADDR="$$(hostname -i | awk '{print $$1}'):$${NEXUS_ADVERTISE_ADDR##*:}"
+      fi
       # Reachable 0.0.0.0 bind + --no-tls trips the loopback auth invariant;
       # this is a trusted CI/compose cluster, so take the sanctioned escape.
       exec nexusd-cluster \

--- a/dockerfiles/docker-compose.cc-tasks-share.yml
+++ b/dockerfiles/docker-compose.cc-tasks-share.yml
@@ -86,13 +86,6 @@ x-bootstrap-entrypoint: &bootstrap-entrypoint
     - |
       set -e
       DATA_DIR="${NEXUS_DATA_DIR:-/app/data}"
-      # Advertise this container's routable IP, not the bare compose service name:
-      # the federation fail-loud check refuses bare hostnames (they do not resolve
-      # across an overlay). Peers still resolve each other via NEXUS_PEERS (compose
-      # DNS) for the initial dial, then learn the advertised IP.
-      if [ -n "$${NEXUS_ADVERTISE_ADDR}" ]; then
-        export NEXUS_ADVERTISE_ADDR="$$(hostname -i | awk '{print $$1}'):$${NEXUS_ADVERTISE_ADDR##*:}"
-      fi
       # Reachable 0.0.0.0 bind + --no-tls trips the loopback auth invariant;
       # this is a trusted CI/compose cluster, so take the sanctioned escape.
       exec nexusd-cluster \
@@ -123,6 +116,7 @@ services:
       NEXUS_HOSTNAME: founder
       NEXUS_BIND_ADDR: 0.0.0.0:2126
       NEXUS_ADVERTISE_ADDR: founder:2126
+      NEXUS_ALLOW_HOSTNAME_ADVERTISE: "1"
       NEXUS_DATA_DIR: /app/data
       NEXUS_NO_TLS: "true"
       # First boot only — auto-detect entrypoint strips on restart.
@@ -168,6 +162,7 @@ services:
       NEXUS_HOSTNAME: joiner
       NEXUS_BIND_ADDR: 0.0.0.0:2126
       NEXUS_ADVERTISE_ADDR: joiner:2126
+      NEXUS_ALLOW_HOSTNAME_ADVERTISE: "1"
       NEXUS_DATA_DIR: /app/data
       # `identity.json` (nexus-vfs PR #106) — node-bound peer address
       # book that survives `<NEXUS_DATA_DIR>` cleanup.  Volume-mounted

--- a/dockerfiles/docker-compose.cc-tasks-share.yml
+++ b/dockerfiles/docker-compose.cc-tasks-share.yml
@@ -86,6 +86,13 @@ x-bootstrap-entrypoint: &bootstrap-entrypoint
     - |
       set -e
       DATA_DIR="${NEXUS_DATA_DIR:-/app/data}"
+      # Advertise this container's routable IP, not the bare compose service name:
+      # the federation fail-loud check refuses bare hostnames (they do not resolve
+      # across an overlay). Peers still resolve each other via NEXUS_PEERS (compose
+      # DNS) for the initial dial, then learn the advertised IP.
+      if [ -n "$${NEXUS_ADVERTISE_ADDR}" ]; then
+        export NEXUS_ADVERTISE_ADDR="$$(hostname -i | awk '{print $$1}'):$${NEXUS_ADVERTISE_ADDR##*:}"
+      fi
       # Reachable 0.0.0.0 bind + --no-tls trips the loopback auth invariant;
       # this is a trusted CI/compose cluster, so take the sanctioned escape.
       exec nexusd-cluster \

--- a/dockerfiles/docker-compose.federation-runbook.yml
+++ b/dockerfiles/docker-compose.federation-runbook.yml
@@ -51,6 +51,14 @@ x-runbook-entrypoint: &runbook-entrypoint
     - |
       set -e
       DATA_DIR="${NEXUS_DATA_DIR:-/app/data}"
+      # Advertise this container's routable IP, not the bare compose service
+      # name: the federation fail-loud check refuses bare hostnames (they do not
+      # resolve across an overlay). Models a real overlay deployment, which
+      # advertises its routable IP; peers still resolve each other via NEXUS_PEERS
+      # (compose DNS) for the initial dial, then learn the advertised IP.
+      if [ -n "$${NEXUS_ADVERTISE_ADDR}" ]; then
+        export NEXUS_ADVERTISE_ADDR="$$(hostname -i | awk '{print $$1}'):$${NEXUS_ADVERTISE_ADDR##*:}"
+      fi
       # Reachable 0.0.0.0 bind + --no-tls trips the loopback auth invariant;
       # this is a trusted CI/compose cluster, so take the sanctioned escape.
       exec nexusd-cluster \

--- a/dockerfiles/docker-compose.federation-runbook.yml
+++ b/dockerfiles/docker-compose.federation-runbook.yml
@@ -51,14 +51,6 @@ x-runbook-entrypoint: &runbook-entrypoint
     - |
       set -e
       DATA_DIR="${NEXUS_DATA_DIR:-/app/data}"
-      # Advertise this container's routable IP, not the bare compose service
-      # name: the federation fail-loud check refuses bare hostnames (they do not
-      # resolve across an overlay). Models a real overlay deployment, which
-      # advertises its routable IP; peers still resolve each other via NEXUS_PEERS
-      # (compose DNS) for the initial dial, then learn the advertised IP.
-      if [ -n "$${NEXUS_ADVERTISE_ADDR}" ]; then
-        export NEXUS_ADVERTISE_ADDR="$$(hostname -i | awk '{print $$1}'):$${NEXUS_ADVERTISE_ADDR##*:}"
-      fi
       # Reachable 0.0.0.0 bind + --no-tls trips the loopback auth invariant;
       # this is a trusted CI/compose cluster, so take the sanctioned escape.
       exec nexusd-cluster \
@@ -81,6 +73,7 @@ services:
       NEXUS_HOSTNAME: founder
       NEXUS_BIND_ADDR: 0.0.0.0:2126
       NEXUS_ADVERTISE_ADDR: founder:2126
+      NEXUS_ALLOW_HOSTNAME_ADVERTISE: "1"
       NEXUS_DATA_DIR: /app/data
       NEXUS_NO_TLS: "true"
       # First boot only — auto-detect entrypoint strips these on restart.
@@ -107,6 +100,7 @@ services:
       NEXUS_HOSTNAME: joiner
       NEXUS_BIND_ADDR: 0.0.0.0:2126
       NEXUS_ADVERTISE_ADDR: joiner:2126
+      NEXUS_ALLOW_HOSTNAME_ADVERTISE: "1"
       NEXUS_DATA_DIR: /app/data
       NEXUS_NO_TLS: "true"
       RUST_LOG: info,nexus_raft=debug

--- a/dockerfiles/docker-compose.mtls-federation-test.yml
+++ b/dockerfiles/docker-compose.mtls-federation-test.yml
@@ -35,6 +35,12 @@ x-mtls-node: &mtls-node
     - |
       set -e
       cp -r /certs/. /app/data/
+      # Advertise this container's routable IP, not the bare compose service name:
+      # the federation fail-loud check refuses bare hostnames (they do not resolve
+      # across an overlay). Peers still resolve via NEXUS_PEERS (compose DNS).
+      if [ -n "$${NEXUS_ADVERTISE_ADDR}" ]; then
+        export NEXUS_ADVERTISE_ADDR="$$(hostname -i | awk '{print $$1}'):$${NEXUS_ADVERTISE_ADDR##*:}"
+      fi
       exec nexusd-cluster --bind-addr 0.0.0.0:2126 --data-dir /app/data
   command: []
   networks:

--- a/dockerfiles/docker-compose.mtls-federation-test.yml
+++ b/dockerfiles/docker-compose.mtls-federation-test.yml
@@ -35,12 +35,6 @@ x-mtls-node: &mtls-node
     - |
       set -e
       cp -r /certs/. /app/data/
-      # Advertise this container's routable IP, not the bare compose service name:
-      # the federation fail-loud check refuses bare hostnames (they do not resolve
-      # across an overlay). Peers still resolve via NEXUS_PEERS (compose DNS).
-      if [ -n "$${NEXUS_ADVERTISE_ADDR}" ]; then
-        export NEXUS_ADVERTISE_ADDR="$$(hostname -i | awk '{print $$1}'):$${NEXUS_ADVERTISE_ADDR##*:}"
-      fi
       exec nexusd-cluster --bind-addr 0.0.0.0:2126 --data-dir /app/data
   command: []
   networks:
@@ -54,6 +48,7 @@ services:
     environment:
       NEXUS_HOSTNAME: founder
       NEXUS_ADVERTISE_ADDR: founder:2126
+      NEXUS_ALLOW_HOSTNAME_ADVERTISE: "1"
       # Static topology: create `sharedzone` and mount it at /shared. The
       # joiner discovers this over mTLS and auto-joins.
       NEXUS_CLUSTER_INIT: sharedzone
@@ -85,6 +80,7 @@ services:
     environment:
       NEXUS_HOSTNAME: joiner
       NEXUS_ADVERTISE_ADDR: joiner:2126
+      NEXUS_ALLOW_HOSTNAME_ADVERTISE: "1"
       # No zones of its own — discover + auto-join the founder's over mTLS.
       NEXUS_PEERS: founder:2126
       RUST_LOG: info,nexus_raft=info

--- a/rust/nexusd/Cargo.toml
+++ b/rust/nexusd/Cargo.toml
@@ -67,7 +67,7 @@ anyhow = "1"
 # nexus-side co-host glue and no runtime enum to map (the adapter reports
 # `kernel::AgentState` directly). Pinned to sudocode main (spawn AgentState
 # collapse).
-sudocode-tools = { package = "tools", git = "https://github.com/sudoprivacy/sudocode", rev = "37321ed958c82fa61fbdb3f65a5fd76e792a9afd", optional = true }
+sudocode-tools = { package = "tools", git = "https://github.com/sudoprivacy/sudocode", rev = "1463842f71d1518e44dbe364de2faa4b8a77adbe", optional = true }
 # Named directly to spell `kernel::kernel::{ServiceDecl, Kernel}` — the
 # managed-agent boot decl's return type (both builds) and the co-host
 # adapter's `SpawnTask<Kernel>` (cohost build). Already present transitively

--- a/rust/nexusd/Cargo.toml
+++ b/rust/nexusd/Cargo.toml
@@ -67,7 +67,7 @@ anyhow = "1"
 # nexus-side co-host glue and no runtime enum to map (the adapter reports
 # `kernel::AgentState` directly). Pinned to sudocode main (spawn AgentState
 # collapse).
-sudocode-tools = { package = "tools", git = "https://github.com/sudoprivacy/sudocode", rev = "aad70dc8ecf9c00744b75818170a51179baa8206", optional = true }
+sudocode-tools = { package = "tools", git = "https://github.com/sudoprivacy/sudocode", rev = "37321ed958c82fa61fbdb3f65a5fd76e792a9afd", optional = true }
 # Named directly to spell `kernel::kernel::{ServiceDecl, Kernel}` — the
 # managed-agent boot decl's return type (both builds) and the co-host
 # adapter's `SpawnTask<Kernel>` (cohost build). Already present transitively


### PR DESCRIPTION
## What
Completes the **nexus-vfs → sudocode → nexus** pin cascade for the auth-on cross-machine federation fixes.

- **nexus-vfs** `601c2af2` → `ec149759` (nexus-vfs #256):
  - `enroll-token` reads the accepted-hash set **live** (a token minted against a running founder works without a restart; mirrors the revoked-serials live-read).
  - the founder's self-signed node cert now carries its `--advertise-addr` IP in the **SAN**, so a cross-machine joiner can validate its server cert over Tailscale (mTLS handshake was failing before).
- **sudocode** `aad70dc8` → `37321ed9` (sudocode #513): re-pins the co-host `kernel` to the same `ec149759`, so `SpawnTask<Kernel>` stays one monomorphised type across the co-host seam.

## Alignment / verification
`kernel` (nexus) and `kernel` (sudocode co-host) now resolve to the same `ec149759`. `cargo build -p nexusd --features cohost-sudocode` **Finished clean**.

Both fixes were **proven live**: a joiner dialing the founder's Tailscale IP formed a 2-voter cluster, and a **Win↔Mac co-host↔co-host A2A duet** ran end-to-end under mTLS (multi-turn, node-stamped, no infinite ping-pong).

The `cohost-sudocode` feature is opt-in (off by default), so the slim production `cluster` binary is unaffected.