### PR TITLE
chore(deps): bump nexus-vfs pin → sys_write wakes DT_STREAM tail (#258)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "a2a"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=2cc85ca7525a6a21236c189c0e173706ed03183c#2cc85ca7525a6a21236c189c0e173706ed03183c"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=dce2ba26903f730cfbdc7b5c06d1112557cb52cf#dce2ba26903f730cfbdc7b5c06d1112557cb52cf"
 dependencies = [
  "contracts",
  "kernel",
@@ -234,7 +234,7 @@ checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 [[package]]
 name = "api"
 version = "0.2.0"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=1463842f71d1518e44dbe364de2faa4b8a77adbe#1463842f71d1518e44dbe364de2faa4b8a77adbe"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=579b795e58ba708d6c26f9d0cfa89dcda18c7f13#579b795e58ba708d6c26f9d0cfa89dcda18c7f13"
 dependencies = [
  "base64 0.22.1",
  "httpdate",
@@ -327,7 +327,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 [[package]]
 name = "auth"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=2cc85ca7525a6a21236c189c0e173706ed03183c#2cc85ca7525a6a21236c189c0e173706ed03183c"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=dce2ba26903f730cfbdc7b5c06d1112557cb52cf#dce2ba26903f730cfbdc7b5c06d1112557cb52cf"
 dependencies = [
  "contracts",
  "dashmap",
@@ -430,7 +430,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=2cc85ca7525a6a21236c189c0e173706ed03183c#2cc85ca7525a6a21236c189c0e173706ed03183c"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=dce2ba26903f730cfbdc7b5c06d1112557cb52cf#dce2ba26903f730cfbdc7b5c06d1112557cb52cf"
 dependencies = [
  "ahash",
  "base64 0.22.1",
@@ -848,7 +848,7 @@ dependencies = [
 [[package]]
 name = "commands"
 version = "0.2.0"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=1463842f71d1518e44dbe364de2faa4b8a77adbe#1463842f71d1518e44dbe364de2faa4b8a77adbe"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=579b795e58ba708d6c26f9d0cfa89dcda18c7f13#579b795e58ba708d6c26f9d0cfa89dcda18c7f13"
 dependencies = [
  "plugins",
  "runtime",
@@ -917,7 +917,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=2cc85ca7525a6a21236c189c0e173706ed03183c#2cc85ca7525a6a21236c189c0e173706ed03183c"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=dce2ba26903f730cfbdc7b5c06d1112557cb52cf#dce2ba26903f730cfbdc7b5c06d1112557cb52cf"
 dependencies = [
  "parking_lot",
  "serde",
@@ -2540,7 +2540,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=2cc85ca7525a6a21236c189c0e173706ed03183c#2cc85ca7525a6a21236c189c0e173706ed03183c"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=dce2ba26903f730cfbdc7b5c06d1112557cb52cf#dce2ba26903f730cfbdc7b5c06d1112557cb52cf"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -2608,7 +2608,7 @@ checksum = "0c2cdeb66e45e9f36bfad5bbdb4d2384e70936afbee843c6f6543f0c551ebb25"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=2cc85ca7525a6a21236c189c0e173706ed03183c#2cc85ca7525a6a21236c189c0e173706ed03183c"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=dce2ba26903f730cfbdc7b5c06d1112557cb52cf#dce2ba26903f730cfbdc7b5c06d1112557cb52cf"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -2813,7 +2813,7 @@ checksum = "fc04a4c58212d57930a24bf47d3fa87485264a3a054e9c10e042eb373573ad3c"
 [[package]]
 name = "managed-agent"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=2cc85ca7525a6a21236c189c0e173706ed03183c#2cc85ca7525a6a21236c189c0e173706ed03183c"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=dce2ba26903f730cfbdc7b5c06d1112557cb52cf#dce2ba26903f730cfbdc7b5c06d1112557cb52cf"
 dependencies = [
  "a2a",
  "contracts",
@@ -3008,7 +3008,7 @@ dependencies = [
 [[package]]
 name = "nexus-cluster"
 version = "0.1.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=2cc85ca7525a6a21236c189c0e173706ed03183c#2cc85ca7525a6a21236c189c0e173706ed03183c"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=dce2ba26903f730cfbdc7b5c06d1112557cb52cf#dce2ba26903f730cfbdc7b5c06d1112557cb52cf"
 dependencies = [
  "a2a",
  "anyhow",
@@ -3086,7 +3086,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=2cc85ca7525a6a21236c189c0e173706ed03183c#2cc85ca7525a6a21236c189c0e173706ed03183c"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=dce2ba26903f730cfbdc7b5c06d1112557cb52cf#dce2ba26903f730cfbdc7b5c06d1112557cb52cf"
 
 [[package]]
 name = "nexus-rebac"
@@ -3158,7 +3158,7 @@ dependencies = [
 [[package]]
 name = "nexus-vfs-client"
 version = "0.2.0"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=1463842f71d1518e44dbe364de2faa4b8a77adbe#1463842f71d1518e44dbe364de2faa4b8a77adbe"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=579b795e58ba708d6c26f9d0cfa89dcda18c7f13#579b795e58ba708d6c26f9d0cfa89dcda18c7f13"
 dependencies = [
  "prost 0.13.5",
  "protoc-bin-vendored",
@@ -3616,7 +3616,7 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 [[package]]
 name = "plugins"
 version = "0.2.0"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=1463842f71d1518e44dbe364de2faa4b8a77adbe#1463842f71d1518e44dbe364de2faa4b8a77adbe"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=579b795e58ba708d6c26f9d0cfa89dcda18c7f13#579b795e58ba708d6c26f9d0cfa89dcda18c7f13"
 dependencies = [
  "serde",
  "serde_json",
@@ -4030,7 +4030,7 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 [[package]]
 name = "raft"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=2cc85ca7525a6a21236c189c0e173706ed03183c#2cc85ca7525a6a21236c189c0e173706ed03183c"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=dce2ba26903f730cfbdc7b5c06d1112557cb52cf#dce2ba26903f730cfbdc7b5c06d1112557cb52cf"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -4460,7 +4460,7 @@ dependencies = [
 [[package]]
 name = "runtime"
 version = "0.2.0"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=1463842f71d1518e44dbe364de2faa4b8a77adbe#1463842f71d1518e44dbe364de2faa4b8a77adbe"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=579b795e58ba708d6c26f9d0cfa89dcda18c7f13#579b795e58ba708d6c26f9d0cfa89dcda18c7f13"
 dependencies = [
  "a2a",
  "agent-client-protocol",
@@ -5160,7 +5160,7 @@ dependencies = [
 [[package]]
 name = "subprocess"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=2cc85ca7525a6a21236c189c0e173706ed03183c#2cc85ca7525a6a21236c189c0e173706ed03183c"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=dce2ba26903f730cfbdc7b5c06d1112557cb52cf#dce2ba26903f730cfbdc7b5c06d1112557cb52cf"
 dependencies = [
  "kernel",
  "libc",
@@ -5379,7 +5379,7 @@ dependencies = [
 [[package]]
 name = "telemetry"
 version = "0.2.0"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=1463842f71d1518e44dbe364de2faa4b8a77adbe#1463842f71d1518e44dbe364de2faa4b8a77adbe"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=579b795e58ba708d6c26f9d0cfa89dcda18c7f13#579b795e58ba708d6c26f9d0cfa89dcda18c7f13"
 dependencies = [
  "chrono",
  "dirs",
@@ -5771,7 +5771,7 @@ dependencies = [
 [[package]]
 name = "tools"
 version = "0.2.0"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=1463842f71d1518e44dbe364de2faa4b8a77adbe#1463842f71d1518e44dbe364de2faa4b8a77adbe"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=579b795e58ba708d6c26f9d0cfa89dcda18c7f13#579b795e58ba708d6c26f9d0cfa89dcda18c7f13"
 dependencies = [
  "api",
  "async-trait",
@@ -5916,7 +5916,7 @@ dependencies = [
 [[package]]
 name = "transport"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=2cc85ca7525a6a21236c189c0e173706ed03183c#2cc85ca7525a6a21236c189c0e173706ed03183c"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=dce2ba26903f730cfbdc7b5c06d1112557cb52cf#dce2ba26903f730cfbdc7b5c06d1112557cb52cf"
 dependencies = [
  "axum",
  "backends",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -236,30 +236,30 @@ exclude = ["nexus-fuse"]
 #
 # Bump alongside the rest of nexus-vfs updates when a downstream
 # change needs newer kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "2cc85ca7525a6a21236c189c0e173706ed03183c" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "2cc85ca7525a6a21236c189c0e173706ed03183c" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "2cc85ca7525a6a21236c189c0e173706ed03183c" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "2cc85ca7525a6a21236c189c0e173706ed03183c", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "2cc85ca7525a6a21236c189c0e173706ed03183c", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "2cc85ca7525a6a21236c189c0e173706ed03183c", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "2cc85ca7525a6a21236c189c0e173706ed03183c" }
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "dce2ba26903f730cfbdc7b5c06d1112557cb52cf" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "dce2ba26903f730cfbdc7b5c06d1112557cb52cf" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "dce2ba26903f730cfbdc7b5c06d1112557cb52cf" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "dce2ba26903f730cfbdc7b5c06d1112557cb52cf", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "dce2ba26903f730cfbdc7b5c06d1112557cb52cf", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "dce2ba26903f730cfbdc7b5c06d1112557cb52cf", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "dce2ba26903f730cfbdc7b5c06d1112557cb52cf" }
 # The cluster daemon library entry (`nexus_cluster::run_with_services`),
 # consumed by the nexus-side assembly binary (`rust/nexusd`) that composes
 # the kernel/federation boot with the nexus service set via the
 # ServiceRegistry bring-up seam.
-nexus-cluster = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "2cc85ca7525a6a21236c189c0e173706ed03183c" }
+nexus-cluster = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "dce2ba26903f730cfbdc7b5c06d1112557cb52cf" }
 # a2a messaging substrate. `default-features = false` leaves the
 # `install` feature (which pulls raft to arm the stream-wakeup observer)
 # OFF, so nexus-side consumers link only the stamp hook and stay
 # raft-free — they reach raft through kernel.sys_* (§6.1). The substrate
 # is armed in production at cluster boot in nexus-vfs, not here.
-a2a = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "2cc85ca7525a6a21236c189c0e173706ed03183c", default-features = false }
+a2a = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "dce2ba26903f730cfbdc7b5c06d1112557cb52cf", default-features = false }
 # managed-agent control plane + the shared subprocess host — RELOCATED into
 # nexus-vfs (kernel-tier) so the production nexusd-cluster carries the agent
 # control plane. `subprocess-host` enables the raw ACP-subprocess spawner (the
 # nexus-side acp path + managed-agent both use HostedSubprocess).
-managed-agent = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "2cc85ca7525a6a21236c189c0e173706ed03183c", default-features = false }
-subprocess = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "2cc85ca7525a6a21236c189c0e173706ed03183c" }
+managed-agent = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "dce2ba26903f730cfbdc7b5c06d1112557cb52cf", default-features = false }
+subprocess = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "dce2ba26903f730cfbdc7b5c06d1112557cb52cf" }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir --no-deps --prefix=/install .
 # enforces agreement) — an unpinned install tracks nexus-vfs HEAD and
 # ships an untested kernel (#4343). --locked honors the source tree's
 # Cargo.lock.
-ARG NEXUS_VFS_REV=2cc85ca7525a6a21236c189c0e173706ed03183c
+ARG NEXUS_VFS_REV=dce2ba26903f730cfbdc7b5c06d1112557cb52cf
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-cluster nexus-cluster
 
 # -- Runtime stage --

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -25,7 +25,7 @@ WORKDIR /build
 # (CI preflight enforces agreement) — an unpinned install tracks HEAD
 # and can skew the raft contract against the cluster/witness images.
 # --locked honors the source tree's Cargo.lock.
-ARG NEXUS_VFS_REV=2cc85ca7525a6a21236c189c0e173706ed03183c
+ARG NEXUS_VFS_REV=dce2ba26903f730cfbdc7b5c06d1112557cb52cf
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexus-raft-server raft
 
 # ---------- Production image ----------

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=2cc85ca7525a6a21236c189c0e173706ed03183c
+ARG NEXUS_VFS_REV=dce2ba26903f730cfbdc7b5c06d1112557cb52cf
 RUN cargo install \
     --locked \
     --git https://github.com/nexi-lab/nexus-vfs \

--- a/rust/nexusd/Cargo.toml
+++ b/rust/nexusd/Cargo.toml
@@ -67,7 +67,7 @@ anyhow = "1"
 # nexus-side co-host glue and no runtime enum to map (the adapter reports
 # `kernel::AgentState` directly). Pinned to sudocode main (spawn AgentState
 # collapse).
-sudocode-tools = { package = "tools", git = "https://github.com/sudoprivacy/sudocode", rev = "1463842f71d1518e44dbe364de2faa4b8a77adbe", optional = true }
+sudocode-tools = { package = "tools", git = "https://github.com/sudoprivacy/sudocode", rev = "579b795e58ba708d6c26f9d0cfa89dcda18c7f13", optional = true }
 # Named directly to spell `kernel::kernel::{ServiceDecl, Kernel}` — the
 # managed-agent boot decl's return type (both builds) and the co-host
 # adapter's `SpawnTask<Kernel>` (cohost build). Already present transitively


### PR DESCRIPTION
Bumps the nexus-vfs pin `2cc85ca7` → `dce2ba26`, pulling in **only** nexus-vfs #258:

- `fix(kernel): sys_write wakes DT_STREAM tail readers` — the DT_STREAM append now routes through `StreamManager::write_nowait` (SSOT push+wake) instead of an inlined bare `push`, so a same-node reader parked on `read_at_blocking` wakes on the write instead of missing it until timeout.
- `refactor(transport): gRPC StreamWriteNowait goes through the sys_write syscall` — the service no longer reaches past the syscall into a kernel-internal accessor.

This propagates the wake fix into every nexus kernel-tier build.

## Scope
Pure pin bump — `Cargo.toml` (11) + `Cargo.lock` (12) + the three `NEXUS_VFS_REV` Dockerfile ARGs (minimal / raft-server / raft-witness) bump together so all images build off the same revision. No source changes.

## Verify
- `2cc85ca7..dce2ba26` = exactly #258's three commits, nothing else (clean forward bump).
- `cargo check -p nexusd` compiles green against the new rev locally.