### PR TITLE
feat(nexusd): wire nexus-rebac PermissionProvider behind --features {rebac,full}

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,10 +5,21 @@ version = 4
 [[package]]
 name = "a2a"
 version = "0.1.0"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c#326d2b78115419d68689a0584d066372431b632c"
+dependencies = [
+ "contracts 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
+ "kernel 0.10.1 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "a2a"
+version = "0.1.0"
 source = "git+https://github.com/nexi-lab/nexus-vfs?rev=dce2ba26903f730cfbdc7b5c06d1112557cb52cf#dce2ba26903f730cfbdc7b5c06d1112557cb52cf"
 dependencies = [
- "contracts",
- "kernel",
+ "contracts 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=dce2ba26903f730cfbdc7b5c06d1112557cb52cf)",
+ "kernel 0.10.1 (git+https://github.com/nexi-lab/nexus-vfs?rev=dce2ba26903f730cfbdc7b5c06d1112557cb52cf)",
  "serde",
  "serde_json",
 ]
@@ -327,12 +338,12 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 [[package]]
 name = "auth"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=dce2ba26903f730cfbdc7b5c06d1112557cb52cf#dce2ba26903f730cfbdc7b5c06d1112557cb52cf"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c#326d2b78115419d68689a0584d066372431b632c"
 dependencies = [
- "contracts",
+ "contracts 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
  "dashmap",
  "hmac 0.13.0",
- "kernel",
+ "kernel 0.10.1 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
  "parking_lot",
  "rand 0.10.2",
  "serde",
@@ -430,13 +441,13 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=dce2ba26903f730cfbdc7b5c06d1112557cb52cf#dce2ba26903f730cfbdc7b5c06d1112557cb52cf"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c#326d2b78115419d68689a0584d066372431b632c"
 dependencies = [
  "ahash",
  "base64 0.22.1",
  "blake3",
  "chrono",
- "contracts",
+ "contracts 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
  "crc32fast",
  "dashmap",
  "encoding_rs",
@@ -444,8 +455,8 @@ dependencies = [
  "futures",
  "globset",
  "hmac 0.13.0",
- "kernel",
- "lib",
+ "kernel 0.10.1 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
+ "lib 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
  "libc",
  "lru 0.18.1",
  "memchr",
@@ -913,6 +924,15 @@ name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
+name = "contracts"
+version = "0.1.0"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c#326d2b78115419d68689a0584d066372431b632c"
+dependencies = [
+ "parking_lot",
+ "serde",
+]
 
 [[package]]
 name = "contracts"
@@ -2540,6 +2560,52 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c#326d2b78115419d68689a0584d066372431b632c"
+dependencies = [
+ "ahash",
+ "arc-swap",
+ "base64 0.22.1",
+ "blake3",
+ "bloomfilter",
+ "bytes",
+ "chrono",
+ "contracts 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
+ "crc32fast",
+ "dashmap",
+ "ed25519-dalek",
+ "fastcdc",
+ "futures",
+ "globset",
+ "lib 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
+ "libc",
+ "libloading 0.8.9",
+ "lru 0.18.1",
+ "memchr",
+ "memmap2",
+ "nexus-plugin-abi 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
+ "parking_lot",
+ "prost 0.14.4",
+ "protoc-bin-vendored",
+ "rayon",
+ "redb",
+ "regex",
+ "roaring",
+ "serde",
+ "serde_json",
+ "smallvec",
+ "string-interner",
+ "tempfile",
+ "tokio",
+ "tonic 0.14.6",
+ "tonic-prost",
+ "tonic-prost-build",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "kernel"
+version = "0.10.1"
 source = "git+https://github.com/nexi-lab/nexus-vfs?rev=dce2ba26903f730cfbdc7b5c06d1112557cb52cf#dce2ba26903f730cfbdc7b5c06d1112557cb52cf"
 dependencies = [
  "ahash",
@@ -2549,20 +2615,20 @@ dependencies = [
  "bloomfilter",
  "bytes",
  "chrono",
- "contracts",
+ "contracts 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=dce2ba26903f730cfbdc7b5c06d1112557cb52cf)",
  "crc32fast",
  "dashmap",
  "ed25519-dalek",
  "fastcdc",
  "futures",
  "globset",
- "lib",
+ "lib 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=dce2ba26903f730cfbdc7b5c06d1112557cb52cf)",
  "libc",
  "libloading 0.8.9",
  "lru 0.18.1",
  "memchr",
  "memmap2",
- "nexus-plugin-abi",
+ "nexus-plugin-abi 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=dce2ba26903f730cfbdc7b5c06d1112557cb52cf)",
  "parking_lot",
  "prost 0.14.4",
  "protoc-bin-vendored",
@@ -2608,13 +2674,49 @@ checksum = "0c2cdeb66e45e9f36bfad5bbdb4d2384e70936afbee843c6f6543f0c551ebb25"
 [[package]]
 name = "lib"
 version = "0.1.0"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c#326d2b78115419d68689a0584d066372431b632c"
+dependencies = [
+ "ahash",
+ "arc-swap",
+ "base64 0.22.1",
+ "blake3",
+ "contracts 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
+ "crc32fast",
+ "dashmap",
+ "getrandom 0.4.3",
+ "globset",
+ "memchr",
+ "parking_lot",
+ "pem",
+ "regex",
+ "regex-syntax",
+ "ring",
+ "roaring",
+ "rustls",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "string-interner",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "tokio-rustls",
+ "tokio-stream",
+ "tonic 0.14.6",
+ "tracing",
+ "x509-parser",
+]
+
+[[package]]
+name = "lib"
+version = "0.1.0"
 source = "git+https://github.com/nexi-lab/nexus-vfs?rev=dce2ba26903f730cfbdc7b5c06d1112557cb52cf#dce2ba26903f730cfbdc7b5c06d1112557cb52cf"
 dependencies = [
  "ahash",
  "arc-swap",
  "base64 0.22.1",
  "blake3",
- "contracts",
+ "contracts 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=dce2ba26903f730cfbdc7b5c06d1112557cb52cf)",
  "crc32fast",
  "dashmap",
  "getrandom 0.4.3",
@@ -2813,16 +2915,33 @@ checksum = "fc04a4c58212d57930a24bf47d3fa87485264a3a054e9c10e042eb373573ad3c"
 [[package]]
 name = "managed-agent"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=dce2ba26903f730cfbdc7b5c06d1112557cb52cf#dce2ba26903f730cfbdc7b5c06d1112557cb52cf"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c#326d2b78115419d68689a0584d066372431b632c"
 dependencies = [
- "a2a",
- "contracts",
+ "a2a 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
+ "contracts 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
  "dashmap",
- "kernel",
+ "kernel 0.10.1 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
  "parking_lot",
  "serde",
  "serde_json",
  "subprocess",
+ "tokio",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "managed-agent"
+version = "0.1.0"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=dce2ba26903f730cfbdc7b5c06d1112557cb52cf#dce2ba26903f730cfbdc7b5c06d1112557cb52cf"
+dependencies = [
+ "a2a 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=dce2ba26903f730cfbdc7b5c06d1112557cb52cf)",
+ "contracts 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=dce2ba26903f730cfbdc7b5c06d1112557cb52cf)",
+ "dashmap",
+ "kernel 0.10.1 (git+https://github.com/nexi-lab/nexus-vfs?rev=dce2ba26903f730cfbdc7b5c06d1112557cb52cf)",
+ "parking_lot",
+ "serde",
+ "serde_json",
  "tokio",
  "tracing",
  "uuid",
@@ -3008,17 +3127,17 @@ dependencies = [
 [[package]]
 name = "nexus-cluster"
 version = "0.1.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=dce2ba26903f730cfbdc7b5c06d1112557cb52cf#dce2ba26903f730cfbdc7b5c06d1112557cb52cf"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c#326d2b78115419d68689a0584d066372431b632c"
 dependencies = [
- "a2a",
+ "a2a 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
  "anyhow",
  "auth",
  "backends",
  "clap",
- "contracts",
+ "contracts 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
  "gethostname",
- "kernel",
- "managed-agent",
+ "kernel 0.10.1 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
+ "managed-agent 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
  "raft 0.1.0",
  "rand 0.10.2",
  "tokio",
@@ -3036,7 +3155,7 @@ dependencies = [
  "async-trait",
  "fuser",
  "libc",
- "nexus-plugin-abi",
+ "nexus-plugin-abi 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
  "nfsserve",
  "tempfile",
  "tokio",
@@ -3051,10 +3170,10 @@ name = "nexus-http-api"
 version = "0.1.0"
 dependencies = [
  "axum",
- "contracts",
+ "contracts 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
  "dashmap",
  "http-body-util",
- "kernel",
+ "kernel 0.10.1 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
  "prost 0.14.4",
  "protoc-bin-vendored",
  "reqwest 0.12.28",
@@ -3076,12 +3195,17 @@ name = "nexus-local-connector"
 version = "0.1.1"
 dependencies = [
  "backends",
- "kernel",
- "nexus-plugin-abi",
+ "kernel 0.10.1 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
+ "nexus-plugin-abi 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
  "serde_json",
  "tempfile",
  "tracing",
 ]
+
+[[package]]
+name = "nexus-plugin-abi"
+version = "0.1.0"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c#326d2b78115419d68689a0584d066372431b632c"
 
 [[package]]
 name = "nexus-plugin-abi"
@@ -3093,9 +3217,9 @@ name = "nexus-rebac"
 version = "0.1.0"
 dependencies = [
  "ahash",
- "contracts",
- "kernel",
- "lib",
+ "contracts 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
+ "kernel 0.10.1 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
+ "lib 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
  "parking_lot",
  "raft 0.1.0",
  "tempfile",
@@ -3116,7 +3240,7 @@ dependencies = [
  "hnsw_rs",
  "libloading 0.8.9",
  "mimalloc",
- "nexus-plugin-abi",
+ "nexus-plugin-abi 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
  "ort",
  "parking_lot",
  "prost 0.14.4",
@@ -3142,9 +3266,9 @@ version = "0.1.4"
 dependencies = [
  "backends",
  "clap",
- "kernel",
+ "kernel 0.10.1 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
  "libloading 0.8.9",
- "nexus-plugin-abi",
+ "nexus-plugin-abi 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
  "prost 0.14.4",
  "services",
  "tempfile",
@@ -3173,13 +3297,14 @@ dependencies = [
 name = "nexusd"
 version = "0.1.0"
 dependencies = [
- "a2a",
+ "a2a 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
  "anyhow",
  "backends",
- "kernel",
- "managed-agent",
+ "kernel 0.10.1 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
+ "managed-agent 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
  "nexus-cluster",
  "nexus-http-api",
+ "nexus-rebac",
  "tools",
  "tracing",
 ]
@@ -4031,16 +4156,16 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 [[package]]
 name = "raft"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=dce2ba26903f730cfbdc7b5c06d1112557cb52cf#dce2ba26903f730cfbdc7b5c06d1112557cb52cf"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c#326d2b78115419d68689a0584d066372431b632c"
 dependencies = [
  "base64 0.22.1",
  "bincode",
  "bytes",
- "contracts",
+ "contracts 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
  "dashmap",
  "gethostname",
- "kernel",
- "lib",
+ "kernel 0.10.1 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
+ "lib 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
  "parking_lot",
  "pem",
  "prost 0.14.4",
@@ -4463,7 +4588,7 @@ name = "runtime"
 version = "0.2.0"
 source = "git+https://github.com/sudoprivacy/sudocode?rev=579b795e58ba708d6c26f9d0cfa89dcda18c7f13#579b795e58ba708d6c26f9d0cfa89dcda18c7f13"
 dependencies = [
- "a2a",
+ "a2a 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=dce2ba26903f730cfbdc7b5c06d1112557cb52cf)",
  "agent-client-protocol",
  "agent-client-protocol-schema",
  "agent-client-protocol-tokio",
@@ -4477,9 +4602,9 @@ dependencies = [
  "getrandom 0.2.17",
  "glob",
  "image",
- "kernel",
+ "kernel 0.10.1 (git+https://github.com/nexi-lab/nexus-vfs?rev=dce2ba26903f730cfbdc7b5c06d1112557cb52cf)",
  "keyring",
- "lib",
+ "lib 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=dce2ba26903f730cfbdc7b5c06d1112557cb52cf)",
  "nexus-vfs-client",
  "nix 0.29.0",
  "plugins",
@@ -4874,19 +4999,19 @@ dependencies = [
 name = "services"
 version = "0.1.0"
 dependencies = [
- "a2a",
+ "a2a 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
  "aes-gcm",
  "async-trait",
  "axum",
  "base32",
  "bincode",
  "chrono",
- "contracts",
+ "contracts 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
  "dashmap",
  "fjall",
  "futures",
  "hmac 0.12.1",
- "kernel",
+ "kernel 0.10.1 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
  "libc",
  "parking_lot",
  "prost 0.14.4",
@@ -5161,9 +5286,9 @@ dependencies = [
 [[package]]
 name = "subprocess"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=dce2ba26903f730cfbdc7b5c06d1112557cb52cf#dce2ba26903f730cfbdc7b5c06d1112557cb52cf"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c#326d2b78115419d68689a0584d066372431b632c"
 dependencies = [
- "kernel",
+ "kernel 0.10.1 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
  "libc",
  "tokio",
 ]
@@ -5780,7 +5905,7 @@ dependencies = [
  "commands",
  "flate2",
  "futures",
- "managed-agent",
+ "managed-agent 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=dce2ba26903f730cfbdc7b5c06d1112557cb52cf)",
  "plugins",
  "regex",
  "reqwest 0.12.28",
@@ -5917,21 +6042,21 @@ dependencies = [
 [[package]]
 name = "transport"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=dce2ba26903f730cfbdc7b5c06d1112557cb52cf#dce2ba26903f730cfbdc7b5c06d1112557cb52cf"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c#326d2b78115419d68689a0584d066372431b632c"
 dependencies = [
  "axum",
  "backends",
  "base64 0.22.1",
  "bytes",
  "chrono",
- "contracts",
+ "contracts 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
  "dashmap",
  "futures",
  "http",
  "http-body",
  "http-body-util",
- "kernel",
- "lib",
+ "kernel 0.10.1 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
+ "lib 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
  "parking_lot",
  "pem",
  "prost 0.14.4",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,19 +7,8 @@ name = "a2a"
 version = "0.1.0"
 source = "git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c#326d2b78115419d68689a0584d066372431b632c"
 dependencies = [
- "contracts 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
- "kernel 0.10.1 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "a2a"
-version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=dce2ba26903f730cfbdc7b5c06d1112557cb52cf#dce2ba26903f730cfbdc7b5c06d1112557cb52cf"
-dependencies = [
- "contracts 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=dce2ba26903f730cfbdc7b5c06d1112557cb52cf)",
- "kernel 0.10.1 (git+https://github.com/nexi-lab/nexus-vfs?rev=dce2ba26903f730cfbdc7b5c06d1112557cb52cf)",
+ "contracts",
+ "kernel",
  "serde",
  "serde_json",
 ]
@@ -245,7 +234,7 @@ checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 [[package]]
 name = "api"
 version = "0.2.0"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=579b795e58ba708d6c26f9d0cfa89dcda18c7f13#579b795e58ba708d6c26f9d0cfa89dcda18c7f13"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=874d76fa2fb2211cefa4114bd99d57831188fdbe#874d76fa2fb2211cefa4114bd99d57831188fdbe"
 dependencies = [
  "base64 0.22.1",
  "httpdate",
@@ -340,10 +329,10 @@ name = "auth"
 version = "0.1.0"
 source = "git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c#326d2b78115419d68689a0584d066372431b632c"
 dependencies = [
- "contracts 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
+ "contracts",
  "dashmap",
  "hmac 0.13.0",
- "kernel 0.10.1 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
+ "kernel",
  "parking_lot",
  "rand 0.10.2",
  "serde",
@@ -447,7 +436,7 @@ dependencies = [
  "base64 0.22.1",
  "blake3",
  "chrono",
- "contracts 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
+ "contracts",
  "crc32fast",
  "dashmap",
  "encoding_rs",
@@ -455,8 +444,8 @@ dependencies = [
  "futures",
  "globset",
  "hmac 0.13.0",
- "kernel 0.10.1 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
- "lib 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
+ "kernel",
+ "lib",
  "libc",
  "lru 0.18.1",
  "memchr",
@@ -859,7 +848,7 @@ dependencies = [
 [[package]]
 name = "commands"
 version = "0.2.0"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=579b795e58ba708d6c26f9d0cfa89dcda18c7f13#579b795e58ba708d6c26f9d0cfa89dcda18c7f13"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=874d76fa2fb2211cefa4114bd99d57831188fdbe#874d76fa2fb2211cefa4114bd99d57831188fdbe"
 dependencies = [
  "plugins",
  "runtime",
@@ -929,15 +918,6 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 name = "contracts"
 version = "0.1.0"
 source = "git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c#326d2b78115419d68689a0584d066372431b632c"
-dependencies = [
- "parking_lot",
- "serde",
-]
-
-[[package]]
-name = "contracts"
-version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=dce2ba26903f730cfbdc7b5c06d1112557cb52cf#dce2ba26903f730cfbdc7b5c06d1112557cb52cf"
 dependencies = [
  "parking_lot",
  "serde",
@@ -2569,66 +2549,20 @@ dependencies = [
  "bloomfilter",
  "bytes",
  "chrono",
- "contracts 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
+ "contracts",
  "crc32fast",
  "dashmap",
  "ed25519-dalek",
  "fastcdc",
  "futures",
  "globset",
- "lib 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
+ "lib",
  "libc",
  "libloading 0.8.9",
  "lru 0.18.1",
  "memchr",
  "memmap2",
- "nexus-plugin-abi 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
- "parking_lot",
- "prost 0.14.4",
- "protoc-bin-vendored",
- "rayon",
- "redb",
- "regex",
- "roaring",
- "serde",
- "serde_json",
- "smallvec",
- "string-interner",
- "tempfile",
- "tokio",
- "tonic 0.14.6",
- "tonic-prost",
- "tonic-prost-build",
- "tracing",
- "uuid",
-]
-
-[[package]]
-name = "kernel"
-version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=dce2ba26903f730cfbdc7b5c06d1112557cb52cf#dce2ba26903f730cfbdc7b5c06d1112557cb52cf"
-dependencies = [
- "ahash",
- "arc-swap",
- "base64 0.22.1",
- "blake3",
- "bloomfilter",
- "bytes",
- "chrono",
- "contracts 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=dce2ba26903f730cfbdc7b5c06d1112557cb52cf)",
- "crc32fast",
- "dashmap",
- "ed25519-dalek",
- "fastcdc",
- "futures",
- "globset",
- "lib 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=dce2ba26903f730cfbdc7b5c06d1112557cb52cf)",
- "libc",
- "libloading 0.8.9",
- "lru 0.18.1",
- "memchr",
- "memmap2",
- "nexus-plugin-abi 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=dce2ba26903f730cfbdc7b5c06d1112557cb52cf)",
+ "nexus-plugin-abi",
  "parking_lot",
  "prost 0.14.4",
  "protoc-bin-vendored",
@@ -2680,43 +2614,7 @@ dependencies = [
  "arc-swap",
  "base64 0.22.1",
  "blake3",
- "contracts 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
- "crc32fast",
- "dashmap",
- "getrandom 0.4.3",
- "globset",
- "memchr",
- "parking_lot",
- "pem",
- "regex",
- "regex-syntax",
- "ring",
- "roaring",
- "rustls",
- "serde",
- "serde_json",
- "sha2 0.11.0",
- "string-interner",
- "thiserror 2.0.18",
- "time",
- "tokio",
- "tokio-rustls",
- "tokio-stream",
- "tonic 0.14.6",
- "tracing",
- "x509-parser",
-]
-
-[[package]]
-name = "lib"
-version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=dce2ba26903f730cfbdc7b5c06d1112557cb52cf#dce2ba26903f730cfbdc7b5c06d1112557cb52cf"
-dependencies = [
- "ahash",
- "arc-swap",
- "base64 0.22.1",
- "blake3",
- "contracts 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=dce2ba26903f730cfbdc7b5c06d1112557cb52cf)",
+ "contracts",
  "crc32fast",
  "dashmap",
  "getrandom 0.4.3",
@@ -2917,31 +2815,14 @@ name = "managed-agent"
 version = "0.1.0"
 source = "git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c#326d2b78115419d68689a0584d066372431b632c"
 dependencies = [
- "a2a 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
- "contracts 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
+ "a2a",
+ "contracts",
  "dashmap",
- "kernel 0.10.1 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
+ "kernel",
  "parking_lot",
  "serde",
  "serde_json",
  "subprocess",
- "tokio",
- "tracing",
- "uuid",
-]
-
-[[package]]
-name = "managed-agent"
-version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=dce2ba26903f730cfbdc7b5c06d1112557cb52cf#dce2ba26903f730cfbdc7b5c06d1112557cb52cf"
-dependencies = [
- "a2a 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=dce2ba26903f730cfbdc7b5c06d1112557cb52cf)",
- "contracts 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=dce2ba26903f730cfbdc7b5c06d1112557cb52cf)",
- "dashmap",
- "kernel 0.10.1 (git+https://github.com/nexi-lab/nexus-vfs?rev=dce2ba26903f730cfbdc7b5c06d1112557cb52cf)",
- "parking_lot",
- "serde",
- "serde_json",
  "tokio",
  "tracing",
  "uuid",
@@ -3129,15 +3010,15 @@ name = "nexus-cluster"
 version = "0.1.1"
 source = "git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c#326d2b78115419d68689a0584d066372431b632c"
 dependencies = [
- "a2a 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
+ "a2a",
  "anyhow",
  "auth",
  "backends",
  "clap",
- "contracts 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
+ "contracts",
  "gethostname",
- "kernel 0.10.1 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
- "managed-agent 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
+ "kernel",
+ "managed-agent",
  "raft 0.1.0",
  "rand 0.10.2",
  "tokio",
@@ -3155,7 +3036,7 @@ dependencies = [
  "async-trait",
  "fuser",
  "libc",
- "nexus-plugin-abi 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
+ "nexus-plugin-abi",
  "nfsserve",
  "tempfile",
  "tokio",
@@ -3170,10 +3051,10 @@ name = "nexus-http-api"
 version = "0.1.0"
 dependencies = [
  "axum",
- "contracts 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
+ "contracts",
  "dashmap",
  "http-body-util",
- "kernel 0.10.1 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
+ "kernel",
  "prost 0.14.4",
  "protoc-bin-vendored",
  "reqwest 0.12.28",
@@ -3195,8 +3076,8 @@ name = "nexus-local-connector"
 version = "0.1.1"
 dependencies = [
  "backends",
- "kernel 0.10.1 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
- "nexus-plugin-abi 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
+ "kernel",
+ "nexus-plugin-abi",
  "serde_json",
  "tempfile",
  "tracing",
@@ -3208,18 +3089,13 @@ version = "0.1.0"
 source = "git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c#326d2b78115419d68689a0584d066372431b632c"
 
 [[package]]
-name = "nexus-plugin-abi"
-version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=dce2ba26903f730cfbdc7b5c06d1112557cb52cf#dce2ba26903f730cfbdc7b5c06d1112557cb52cf"
-
-[[package]]
 name = "nexus-rebac"
 version = "0.1.0"
 dependencies = [
  "ahash",
- "contracts 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
- "kernel 0.10.1 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
- "lib 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
+ "contracts",
+ "kernel",
+ "lib",
  "parking_lot",
  "raft 0.1.0",
  "tempfile",
@@ -3240,7 +3116,7 @@ dependencies = [
  "hnsw_rs",
  "libloading 0.8.9",
  "mimalloc",
- "nexus-plugin-abi 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
+ "nexus-plugin-abi",
  "ort",
  "parking_lot",
  "prost 0.14.4",
@@ -3266,9 +3142,9 @@ version = "0.1.4"
 dependencies = [
  "backends",
  "clap",
- "kernel 0.10.1 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
+ "kernel",
  "libloading 0.8.9",
- "nexus-plugin-abi 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
+ "nexus-plugin-abi",
  "prost 0.14.4",
  "services",
  "tempfile",
@@ -3283,7 +3159,7 @@ dependencies = [
 [[package]]
 name = "nexus-vfs-client"
 version = "0.2.0"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=579b795e58ba708d6c26f9d0cfa89dcda18c7f13#579b795e58ba708d6c26f9d0cfa89dcda18c7f13"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=874d76fa2fb2211cefa4114bd99d57831188fdbe#874d76fa2fb2211cefa4114bd99d57831188fdbe"
 dependencies = [
  "prost 0.13.5",
  "protoc-bin-vendored",
@@ -3297,11 +3173,11 @@ dependencies = [
 name = "nexusd"
 version = "0.1.0"
 dependencies = [
- "a2a 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
+ "a2a",
  "anyhow",
  "backends",
- "kernel 0.10.1 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
- "managed-agent 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
+ "kernel",
+ "managed-agent",
  "nexus-cluster",
  "nexus-http-api",
  "nexus-rebac",
@@ -3742,7 +3618,7 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 [[package]]
 name = "plugins"
 version = "0.2.0"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=579b795e58ba708d6c26f9d0cfa89dcda18c7f13#579b795e58ba708d6c26f9d0cfa89dcda18c7f13"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=874d76fa2fb2211cefa4114bd99d57831188fdbe#874d76fa2fb2211cefa4114bd99d57831188fdbe"
 dependencies = [
  "serde",
  "serde_json",
@@ -4161,11 +4037,11 @@ dependencies = [
  "base64 0.22.1",
  "bincode",
  "bytes",
- "contracts 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
+ "contracts",
  "dashmap",
  "gethostname",
- "kernel 0.10.1 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
- "lib 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
+ "kernel",
+ "lib",
  "parking_lot",
  "pem",
  "prost 0.14.4",
@@ -4586,9 +4462,9 @@ dependencies = [
 [[package]]
 name = "runtime"
 version = "0.2.0"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=579b795e58ba708d6c26f9d0cfa89dcda18c7f13#579b795e58ba708d6c26f9d0cfa89dcda18c7f13"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=874d76fa2fb2211cefa4114bd99d57831188fdbe#874d76fa2fb2211cefa4114bd99d57831188fdbe"
 dependencies = [
- "a2a 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=dce2ba26903f730cfbdc7b5c06d1112557cb52cf)",
+ "a2a",
  "agent-client-protocol",
  "agent-client-protocol-schema",
  "agent-client-protocol-tokio",
@@ -4602,9 +4478,9 @@ dependencies = [
  "getrandom 0.2.17",
  "glob",
  "image",
- "kernel 0.10.1 (git+https://github.com/nexi-lab/nexus-vfs?rev=dce2ba26903f730cfbdc7b5c06d1112557cb52cf)",
+ "kernel",
  "keyring",
- "lib 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=dce2ba26903f730cfbdc7b5c06d1112557cb52cf)",
+ "lib",
  "nexus-vfs-client",
  "nix 0.29.0",
  "plugins",
@@ -4999,19 +4875,19 @@ dependencies = [
 name = "services"
 version = "0.1.0"
 dependencies = [
- "a2a 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
+ "a2a",
  "aes-gcm",
  "async-trait",
  "axum",
  "base32",
  "bincode",
  "chrono",
- "contracts 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
+ "contracts",
  "dashmap",
  "fjall",
  "futures",
  "hmac 0.12.1",
- "kernel 0.10.1 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
+ "kernel",
  "libc",
  "parking_lot",
  "prost 0.14.4",
@@ -5288,7 +5164,7 @@ name = "subprocess"
 version = "0.1.0"
 source = "git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c#326d2b78115419d68689a0584d066372431b632c"
 dependencies = [
- "kernel 0.10.1 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
+ "kernel",
  "libc",
  "tokio",
 ]
@@ -5505,7 +5381,7 @@ dependencies = [
 [[package]]
 name = "telemetry"
 version = "0.2.0"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=579b795e58ba708d6c26f9d0cfa89dcda18c7f13#579b795e58ba708d6c26f9d0cfa89dcda18c7f13"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=874d76fa2fb2211cefa4114bd99d57831188fdbe#874d76fa2fb2211cefa4114bd99d57831188fdbe"
 dependencies = [
  "chrono",
  "dirs",
@@ -5897,7 +5773,7 @@ dependencies = [
 [[package]]
 name = "tools"
 version = "0.2.0"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=579b795e58ba708d6c26f9d0cfa89dcda18c7f13#579b795e58ba708d6c26f9d0cfa89dcda18c7f13"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=874d76fa2fb2211cefa4114bd99d57831188fdbe#874d76fa2fb2211cefa4114bd99d57831188fdbe"
 dependencies = [
  "api",
  "async-trait",
@@ -5905,7 +5781,7 @@ dependencies = [
  "commands",
  "flate2",
  "futures",
- "managed-agent 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=dce2ba26903f730cfbdc7b5c06d1112557cb52cf)",
+ "managed-agent",
  "plugins",
  "regex",
  "reqwest 0.12.28",
@@ -6049,14 +5925,14 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "chrono",
- "contracts 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
+ "contracts",
  "dashmap",
  "futures",
  "http",
  "http-body",
  "http-body-util",
- "kernel 0.10.1 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
- "lib 0.1.0 (git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c)",
+ "kernel",
+ "lib",
  "parking_lot",
  "pem",
  "prost 0.14.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -236,30 +236,30 @@ exclude = ["nexus-fuse"]
 #
 # Bump alongside the rest of nexus-vfs updates when a downstream
 # change needs newer kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "dce2ba26903f730cfbdc7b5c06d1112557cb52cf" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "dce2ba26903f730cfbdc7b5c06d1112557cb52cf" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "dce2ba26903f730cfbdc7b5c06d1112557cb52cf" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "dce2ba26903f730cfbdc7b5c06d1112557cb52cf", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "dce2ba26903f730cfbdc7b5c06d1112557cb52cf", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "dce2ba26903f730cfbdc7b5c06d1112557cb52cf", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "dce2ba26903f730cfbdc7b5c06d1112557cb52cf" }
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "326d2b78115419d68689a0584d066372431b632c" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "326d2b78115419d68689a0584d066372431b632c" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "326d2b78115419d68689a0584d066372431b632c" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "326d2b78115419d68689a0584d066372431b632c", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "326d2b78115419d68689a0584d066372431b632c", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "326d2b78115419d68689a0584d066372431b632c", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "326d2b78115419d68689a0584d066372431b632c" }
 # The cluster daemon library entry (`nexus_cluster::run_with_services`),
 # consumed by the nexus-side assembly binary (`rust/nexusd`) that composes
 # the kernel/federation boot with the nexus service set via the
 # ServiceRegistry bring-up seam.
-nexus-cluster = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "dce2ba26903f730cfbdc7b5c06d1112557cb52cf" }
+nexus-cluster = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "326d2b78115419d68689a0584d066372431b632c" }
 # a2a messaging substrate. `default-features = false` leaves the
 # `install` feature (which pulls raft to arm the stream-wakeup observer)
 # OFF, so nexus-side consumers link only the stamp hook and stay
 # raft-free — they reach raft through kernel.sys_* (§6.1). The substrate
 # is armed in production at cluster boot in nexus-vfs, not here.
-a2a = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "dce2ba26903f730cfbdc7b5c06d1112557cb52cf", default-features = false }
+a2a = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "326d2b78115419d68689a0584d066372431b632c", default-features = false }
 # managed-agent control plane + the shared subprocess host — RELOCATED into
 # nexus-vfs (kernel-tier) so the production nexusd-cluster carries the agent
 # control plane. `subprocess-host` enables the raw ACP-subprocess spawner (the
 # nexus-side acp path + managed-agent both use HostedSubprocess).
-managed-agent = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "dce2ba26903f730cfbdc7b5c06d1112557cb52cf", default-features = false }
-subprocess = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "dce2ba26903f730cfbdc7b5c06d1112557cb52cf" }
+managed-agent = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "326d2b78115419d68689a0584d066372431b632c", default-features = false }
+subprocess = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "326d2b78115419d68689a0584d066372431b632c" }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir --no-deps --prefix=/install .
 # enforces agreement) — an unpinned install tracks nexus-vfs HEAD and
 # ships an untested kernel (#4343). --locked honors the source tree's
 # Cargo.lock.
-ARG NEXUS_VFS_REV=dce2ba26903f730cfbdc7b5c06d1112557cb52cf
+ARG NEXUS_VFS_REV=326d2b78115419d68689a0584d066372431b632c
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-cluster nexus-cluster
 
 # -- Runtime stage --

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -25,7 +25,7 @@ WORKDIR /build
 # (CI preflight enforces agreement) — an unpinned install tracks HEAD
 # and can skew the raft contract against the cluster/witness images.
 # --locked honors the source tree's Cargo.lock.
-ARG NEXUS_VFS_REV=dce2ba26903f730cfbdc7b5c06d1112557cb52cf
+ARG NEXUS_VFS_REV=326d2b78115419d68689a0584d066372431b632c
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexus-raft-server raft
 
 # ---------- Production image ----------

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=dce2ba26903f730cfbdc7b5c06d1112557cb52cf
+ARG NEXUS_VFS_REV=326d2b78115419d68689a0584d066372431b632c
 RUN cargo install \
     --locked \
     --git https://github.com/nexi-lab/nexus-vfs \

--- a/rust/nexusd/Cargo.toml
+++ b/rust/nexusd/Cargo.toml
@@ -94,7 +94,7 @@ anyhow = "1"
 # nexus-side co-host glue and no runtime enum to map (the adapter reports
 # `kernel::AgentState` directly). Pinned to sudocode main (spawn AgentState
 # collapse).
-sudocode-tools = { package = "tools", git = "https://github.com/sudoprivacy/sudocode", rev = "579b795e58ba708d6c26f9d0cfa89dcda18c7f13", optional = true }
+sudocode-tools = { package = "tools", git = "https://github.com/sudoprivacy/sudocode", rev = "874d76fa2fb2211cefa4114bd99d57831188fdbe", optional = true }
 # Named directly to spell `kernel::kernel::{ServiceDecl, Kernel}` — the
 # managed-agent boot decl's return type (both builds) and the co-host
 # adapter's `SpawnTask<Kernel>` (cohost build). Already present transitively

--- a/rust/nexusd/Cargo.toml
+++ b/rust/nexusd/Cargo.toml
@@ -36,6 +36,33 @@ http-api = ["dep:nexus-http-api", "dep:tracing"]
 # The kernel rev MUST match the workspace pin (both at nexus-vfs `601c2af`)
 # so `SpawnTask<Kernel>` is one type across the seam.
 cohost-sudocode = ["dep:sudocode-tools"]
+# Opt-in ReBAC enforcer — Rust replacement for the Python
+# `bricks/rebac/` (part of the R10 pure-Rust `nexus-server`
+# migration; epic #4674).  Links `nexus-rebac` (the Zanzibar-shaped
+# graph engine + raft-backed tuple store + `PermissionProvider`
+# impl) and wires it into the kernel's ONE permission-provider slot
+# at boot.  OFF in the default slim `cluster` build AND in
+# `--features http-api` — pulls in the `lib::rebac` graph engine +
+# `AHashMap` / `string_interner` transitively, so kept behind an
+# explicit gate.  Compose via `--features full` for the everything
+# build; a la carte `--features rebac,http-api` also works.
+rebac = ["dep:nexus-rebac"]
+# Meta-feature: the "full superset" build — enables every opt-in
+# service that does not require cross-repo pin coordination
+# (§7: cluster ⊂ … ⊂ full).  Downstream tooling that wants every
+# in-house capability without spelling each feature builds
+# `--features full`.  The slim `cluster` production binary stays
+# the default (this meta ONLY pulls features UP, never restricts
+# the slim path).
+#
+# **`cohost-sudocode` NOT included** — it links `sudocode-tools`
+# from a pinned rev in a separate repo (sudoprivacy/sudocode) that
+# must match the workspace's `nexus-vfs` pin for `SpawnTask<Kernel>`
+# to unify.  Bumping either half out of sync fails the build.
+# Operators who want the true everything-build spell it explicitly
+# as `--features full,cohost-sudocode` (which fails LOUD until the
+# sudocode pin is refreshed).
+full = ["driver-s3", "http-api", "rebac"]
 
 [dependencies]
 # Cluster library entry — `nexus_cluster::run_with_services` owns clap
@@ -87,3 +114,12 @@ nexus-http-api = { path = "../services/http-api", optional = true }
 # the rest of nexusd inherits tracing via `nexus-cluster`'s
 # `install_tracing` (which itself pulls tracing in unconditionally).
 tracing = { version = "0.1", optional = true }
+
+# ReBAC enforcer (opt-in `rebac` feature; folded into `full`). Links
+# only when the feature is on — zero cost in the default slim
+# `cluster` build and in the `--features http-api` build.  Ships
+# `RaftReBACTupleStore` (over the same credential-zone consensus as
+# `RaftAuthKeyStore`, one namespace over), `ReBACGraphCache`, and
+# `RebacPermissionProvider` — the kernel's ONE `PermissionProvider`
+# slot receives an `Arc<Box<Self>>` at boot.
+nexus-rebac = { path = "../services/rebac", optional = true }

--- a/rust/nexusd/src/main.rs
+++ b/rust/nexusd/src/main.rs
@@ -18,6 +18,25 @@
 //! the default. managed_agent is the one control-plane service cluster
 //! adds; supersets inherit it. `acp` (nexus-drives-ACP one-shot) is NOT a
 //! cluster service.
+//!
+//! Opt-in features (each linked ONLY when named on the cargo cmdline):
+//!
+//!   * `driver-s3` — adds the S3 / R2 object-store driver.
+//!   * `http-api` — adds the axum HTTP shim over the search-plugin gRPC
+//!     surface (part of R10 epic #4674). Runtime bring-up ALSO needs
+//!     `NEXUS_HTTP_ADDR` set.
+//!   * `cohost-sudocode` — links the sudocode agent runtime IN-PROCESS
+//!     (cross-repo pin coordination required).
+//!   * `rebac` — links `nexus-rebac` (the ReBAC enforcer) and installs
+//!     its `PermissionProvider` in the kernel's ONE slot. Backed by
+//!     `RaftReBACTupleStore` over the SAME credential-zone consensus
+//!     that already backs `RaftAuthKeyStore` (one namespace over —
+//!     `CONTROL_NS_REBAC = "rebac"`).  Rust replacement for the Python
+//!     `bricks/rebac/` (R10 epic #4674).
+//!   * `full` — meta-feature = `driver-s3 + http-api + rebac`. Does NOT
+//!     include `cohost-sudocode` (that one needs cross-repo pin
+//!     coordination; operators wanting the true everything-build spell
+//!     `--features full,cohost-sudocode`).
 
 /// The `managed_agent` boot declaration. In the default slim cluster build
 /// this is the procfs-only variant (`service_decl`) — no runtime body. In a
@@ -58,14 +77,21 @@ fn main() -> anyhow::Result<()> {
     // The daemon's service set — the SSOT for "which services this daemon
     // runs", ordered. a2a is installed first (its from-stamp hook must be
     // armed before agents write mailboxes); managed_agent follows; the
-    // optional HTTP-API listener (feature-gated `http-api`) slots in last.
+    // optional HTTP-API listener (feature-gated `http-api`) slots in last;
+    // the optional ReBAC enforcer (feature-gated `rebac`) installs its
+    // `PermissionProvider` at the same tier as the HTTP-API decl.
     // `ctx.auth_armed` is boot-derived (true iff sk- auth is armed) and
-    // sets a2a's fail-closed posture; `ctx.auth` + `ctx.runtime` are
-    // live handles that http-api needs to inject into its bearer
-    // middleware + spawn its axum listener on the daemon runtime.
+    // sets a2a's fail-closed posture; `ctx.auth` + `ctx.runtime` are live
+    // handles that http-api needs; `ctx.credential_consensus` +
+    // `ctx.credential_zone_runtime` are what the rebac decl binds its
+    // `RaftReBACTupleStore` over (same consensus as `RaftAuthKeyStore`,
+    // one namespace over).
     nexus_cluster::run_with_services(move |ctx| {
         let mut decls = vec![a2a::service_decl(ctx.auth_armed), managed_agent_decl()];
         if let Some(decl) = http_api_decl_from(&http_api_config, ctx) {
+            decls.push(decl);
+        }
+        if let Some(decl) = rebac_decl_from(ctx) {
             decls.push(decl);
         }
         decls
@@ -162,5 +188,62 @@ fn http_api_decl_from(
     _config: &Option<HttpApiConfig>,
     _ctx: &nexus_cluster::ServiceBootCtx,
 ) -> Option<kernel::kernel::ServiceDecl> {
+    None
+}
+
+/// Build the ReBAC enforcer `ServiceDecl` from the boot ctx.
+///
+/// # What it does
+///
+/// * Constructs a `RaftReBACTupleStore` over `ctx.credential_
+///   consensus` — the SAME consensus that already backs
+///   `RaftAuthKeyStore`, one namespace over (`CONTROL_NS_REBAC =
+///   "rebac"`).  Grants + revokes therefore replicate through the
+///   same raft log a key mint does — one cluster-wide plane, no
+///   split-brain between auth and access.
+/// * Wraps in `ReBACGraphCache` for the per-zone `Arc<ReBACGraph>`
+///   cache the enforcer's check hot path reads.
+/// * Wraps in `RebacPermissionProvider` and hands it to
+///   `kernel.set_permission_provider(...)` in the install closure.
+///
+/// # Why a `ServiceDecl` (not a direct call at ctx-build time)
+///
+/// The kernel's `Arc<Kernel>` handle is only available inside a
+/// `ServiceDecl::install` closure — the ServiceRegistry is the single
+/// authority for services (`feedback_sr_uniform_service_registration`).
+/// Even for a wiring-only "service" that installs no RPC surface, going
+/// through the decl keeps the composition-root uniform + boot-ordered.
+///
+/// # Feature-off build stubs to `None`
+///
+/// The `rebac`-off build never links `nexus-rebac`, so the entire
+/// enforcer + graph engine + `lib::rebac` transitive weight stays
+/// out of the slim `cluster` binary (§7 size budget).
+#[cfg(feature = "rebac")]
+fn rebac_decl_from(ctx: &nexus_cluster::ServiceBootCtx) -> Option<kernel::kernel::ServiceDecl> {
+    use std::sync::Arc;
+    // Build the store + cache + provider OUTSIDE the install
+    // closure so ctx borrows do not need to move into a `'static`
+    // closure (the ServiceInstall signature is `FnOnce(&Arc<
+    // Kernel>) + Send + 'static`).  `store` clones the consensus +
+    // runtime handle; both are Arc-inside — cheap.
+    let store: Arc<dyn nexus_rebac::ReBACTupleStore> = nexus_rebac::RaftReBACTupleStore::new_arc(
+        ctx.credential_consensus.clone(),
+        ctx.credential_zone_runtime.clone(),
+    );
+    let cache = Arc::new(nexus_rebac::ReBACGraphCache::new(store));
+    let provider: Arc<Box<dyn kernel::core::dispatch::PermissionProvider>> =
+        Arc::new(Box::new(nexus_rebac::RebacPermissionProvider::new(cache)));
+    Some(kernel::kernel::ServiceDecl {
+        name: "rebac".to_string(),
+        install: Box::new(move |kernel| {
+            kernel.set_permission_provider(provider);
+            Ok(())
+        }),
+    })
+}
+
+#[cfg(not(feature = "rebac"))]
+fn rebac_decl_from(_ctx: &nexus_cluster::ServiceBootCtx) -> Option<kernel::kernel::ServiceDecl> {
     None
 }


### PR DESCRIPTION
## Summary

**PR 4b/5 of the ReBAC Rust port** (epic #4674 R10). Composition-root wire for the enforcer shipped in PR 4a (#4730). Behind a two-tier feature gate — the default slim \`cluster\` build stays rebac-free (size-budget preserved).

- \`rebac\` feature = a la carte opt-in (\`--features rebac\`)
- \`full\` feature = meta = \`driver-s3 + http-api + rebac\`
- Neither the default nor \`--features http-api\` links nexus-rebac
- \`--features full\` OR \`--features rebac\` builds the enforcer into \`nexusd-cluster\` and wires \`kernel.set_permission_provider(RebacPermissionProvider)\` at boot

## Cross-repo pin bump

Bumps nexus-vfs pin from \`dce2ba26\` → \`326d2b78\` (nexi-lab/nexus-vfs#259 — \`feat(cluster): expose credential ZoneConsensus + runtime on ServiceBootCtx\` — precondition for this PR). Consistent across workspace \`Cargo.toml\` (10 lines) + all 3 docker ARGs.

## Why the \`full\` meta-feature doesn't include \`cohost-sudocode\`

\`cohost-sudocode\` links \`sudocode-tools\` from a pinned rev in a separate repo (sudoprivacy/sudocode) that MUST match the workspace's \`nexus-vfs\` pin for \`SpawnTask<Kernel>\` to unify. Bumping either half out of sync fails the build. Operators wanting the true everything-build spell it explicitly as \`--features full,cohost-sudocode\` (which fails LOUD until the sudocode pin is refreshed).

## What this PR does NOT do

- **No HTTP router.** \`/v2/rebac/tuples\` grant/list/revoke lands in PR 5.
- **No Python delete.** \`src/nexus/bricks/rebac/\` (~37k LoC) removed in PR 5.
- **No Docker E2E test.** The full build path is validated by \`cargo build -p nexusd --features full\` locally + CI; an \`e2e/rebac-full/\` docker-compose harness is a defensible follow-up.

## Test plan

- [x] \`cargo build -p nexusd\` → clean (slim; no rebac link)
- [x] \`cargo build -p nexusd --features rebac\` → clean (a la carte)
- [x] \`cargo build -p nexusd --features full\` → clean (meta = s3 + http + rebac)
- [x] \`cargo clippy -p nexusd -- -D warnings\` → clean (slim)
- [x] \`cargo clippy -p nexusd --features full -- -D warnings\` → clean
- [x] \`cargo fmt -p nexusd -- --check\` → clean
- [ ] CI green

## Follow-ups

- **PR 5/5** — HTTP \`/v2/rebac/tuples\` router (grant/list/revoke) + delete Python \`src/nexus/bricks/rebac/\` (~37k LoC)