### PR TITLE
fix(deps): pin fastmcp<4.0.0 — 4.0 moved fastmcp.tools.tool API (rescue #4731 post-merge)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,13 @@ dependencies = [
     "markdown-it-py>=4.2.0", # CommonMark-compliant markdown AST parser (Issue #3718)
     "mdit-py-plugins>=0.6.0", # markdown-it-py plugins: front_matter (Issue #3718)
     # MCP Server (v0.7.0)
-    "fastmcp>=3.2.4", # Model Context Protocol server
+    # fastmcp<4 pinned deliberately: 4.0.0 (released 2026-08-31) moved
+    # `Tool` + `ToolResult` off `fastmcp.tools.tool` and broke every
+    # `from fastmcp.tools.tool import ...` site (nexus/nexus#4731 CI
+    # post-merge caught it — the pip resolver picks the newest match
+    # each cold install).  Bump the upper bound + migrate imports in a
+    # follow-up (search "fastmcp.tools.tool" for the 3+ call sites).
+    "fastmcp>=3.2.4,<4.0.0", # Model Context Protocol server
     # Default local PDF parser (Rust + PyO3, ~2-3 MB, zero Python deps).
     # On Python 3.14 without a cp314 wheel, pip builds from sdist and needs
     # Rust plus ``PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1`` (both present in


### PR DESCRIPTION
## Summary

Post-merge CI on develop went red after nexi-lab/nexus#4731 was merged: \`E2E Tests (Self-Contained)\` + \`Test Python 3.14\` on both ubuntu-latest + macos-latest all failed with:

\`\`\`
ModuleNotFoundError: No module named 'fastmcp.tools.tool'
\`\`\`

Root cause: **fastmcp 4.0.0 released 2026-08-31** and dropped the \`fastmcp.tools.tool\` module — \`Tool\` + \`ToolResult\` moved. Every \`from fastmcp.tools.tool import Tool, ToolResult\` site now fails to import. \`pyproject.toml\` had \`fastmcp>=3.2.4\` with no upper bound, so a fresh pip resolve during the post-merge docker rebuild picked up 4.0.0.

Pre-merge PR CI happened to hit a warmer wheel cache that still resolved fastmcp<4; the fresh post-merge docker rebuild pulled 4.0.0 for the first time — a classic dep-drift regression, not caused by the code in #4731.

## What this PR does

Pins \`fastmcp>=3.2.4,<4.0.0\` in \`pyproject.toml\` to unbreak the tree.

## Not in this PR

Migration to fastmcp 4.x API (rewrite \`src/nexus/bricks/mcp/middleware.py\`'s import + verify the tool-namespace behaviour is preserved) is a defensible follow-up. Only 1 in-tree call site to migrate.

## Test plan

- [ ] CI green (all 4 previously-red jobs on develop: E2E + Python 3.14 ubuntu/macos)