### PR TITLE
python(agents): AwaitingInput companion (mirror nexus-vfs#260, drop Suspended)

### DIFF
--- a/docs/surface-coverage/api-rpc-surface-coverage.yaml
+++ b/docs/surface-coverage/api-rpc-surface-coverage.yaml
@@ -479,7 +479,7 @@ operations:
   transports:
     grpc_expose:
       name: agent_heartbeat
-      source: src/nexus/services/agents/agent_rpc_service.py:877
+      source: src/nexus/services/agents/agent_rpc_service.py:862
   profiles:
     lite: supported
     sandbox: supported
@@ -496,7 +496,7 @@ operations:
   transports:
     grpc_expose:
       name: agent_list_by_zone
-      source: src/nexus/services/agents/agent_rpc_service.py:885
+      source: src/nexus/services/agents/agent_rpc_service.py:870
   profiles:
     lite: supported
     sandbox: supported

--- a/src/nexus/bricks/sandbox/auth_service.py
+++ b/src/nexus/bricks/sandbox/auth_service.py
@@ -160,9 +160,7 @@ class SandboxAuthService:
         # SIGCONT "become ready" shortcut — now a direct state transition).
         from nexus.contracts.process_types import AgentState
 
-        await asyncio.to_thread(
-            self._agent_registry.update_state, agent_id, AgentState.READY.value
-        )
+        await asyncio.to_thread(self._agent_registry.update_state, agent_id, AgentState.READY.value)
         connected_record = await asyncio.to_thread(self._agent_registry.get, agent_id)
 
         # Step 4: Construct namespace from ReBAC grants

--- a/src/nexus/bricks/sandbox/auth_service.py
+++ b/src/nexus/bricks/sandbox/auth_service.py
@@ -156,12 +156,14 @@ class SandboxAuthService:
                 f"Ownership validation failed: user '{owner_id}' does not own agent '{agent_id}'"
             )
 
-        # Step 3: Signal agent SIGCONT (transition to CONNECTED)
-        from nexus.contracts.process_types import AgentSignal
+        # Step 3: Transition the agent to READY for the new session (was a
+        # SIGCONT "become ready" shortcut — now a direct state transition).
+        from nexus.contracts.process_types import AgentState
 
-        connected_record = await asyncio.to_thread(
-            self._agent_registry.signal, agent_id, AgentSignal.SIGCONT
+        await asyncio.to_thread(
+            self._agent_registry.update_state, agent_id, AgentState.READY.value
         )
+        connected_record = await asyncio.to_thread(self._agent_registry.get, agent_id)
 
         # Step 4: Construct namespace from ReBAC grants
         # (best-effort — failure doesn't block sandbox)
@@ -244,14 +246,18 @@ class SandboxAuthService:
         # Stop the sandbox
         result = await self._sandbox_manager.stop_sandbox(sandbox_id)
 
-        # Signal agent SIGSTOP (transition to IDLE — best-effort)
+        # Return the agent to READY after its sandbox stops — best-effort.
+        # (Was a SIGSTOP "→ IDLE" suspend; SUSPENDED is gone, so the agent simply
+        # goes idle-ready. Stopping the sandbox does not terminate the agent.)
         try:
-            from nexus.contracts.process_types import AgentSignal
+            from nexus.contracts.process_types import AgentState
 
-            await asyncio.to_thread(self._agent_registry.signal, agent_id, AgentSignal.SIGSTOP)
+            await asyncio.to_thread(
+                self._agent_registry.update_state, agent_id, AgentState.READY.value
+            )
         except Exception:
             logger.warning(
-                "[SANDBOX-AUTH] Failed to transition agent %s to IDLE after stop",
+                "[SANDBOX-AUTH] Failed to return agent %s to READY after stop",
                 agent_id,
                 exc_info=True,
             )

--- a/src/nexus/cli/commands/agent.py
+++ b/src/nexus/cli/commands/agent.py
@@ -347,7 +347,7 @@ def delete_cmd(
 @click.argument("agent_id", type=str)
 @click.argument(
     "target_state",
-    type=click.Choice(["CONNECTED", "IDLE", "SUSPENDED"], case_sensitive=False),
+    type=click.Choice(["CONNECTED", "IDLE"], case_sensitive=False),
 )
 @click.option(
     "--expected-generation",

--- a/src/nexus/contracts/agent_types.py
+++ b/src/nexus/contracts/agent_types.py
@@ -138,7 +138,7 @@ class AgentPhase(StrEnum):
     ACTIVE = "active"
     THINKING = "thinking"
     IDLE = "idle"
-    SUSPENDED = "suspended"
+    AWAITING_INPUT = "awaiting_input"
     EVICTED = "evicted"
 
 
@@ -148,7 +148,7 @@ AGENT_STATE_TO_PHASE: dict[AgentState, AgentPhase] = {
     AgentState.WARMING_UP: AgentPhase.WARMING,
     AgentState.READY: AgentPhase.READY,
     AgentState.BUSY: AgentPhase.ACTIVE,
-    AgentState.SUSPENDED: AgentPhase.SUSPENDED,
+    AgentState.AWAITING_INPUT: AgentPhase.AWAITING_INPUT,
     AgentState.TERMINATED: AgentPhase.EVICTED,
 }
 

--- a/src/nexus/contracts/process_types.py
+++ b/src/nexus/contracts/process_types.py
@@ -7,7 +7,7 @@ on other layers — only stdlib + contracts.
 
 Defines:
     AgentState       — finite state machine (REGISTERED → WARMING_UP → READY ↔ BUSY → TERMINATED)
-    AgentSignal      — POSIX-like signals (SIGTERM, SIGSTOP, SIGCONT, SIGKILL, SIGUSR1)
+    AgentSignal      — POSIX-like signals (SIGTERM, SIGKILL, SIGUSR1)
     AgentKind        — MANAGED (nexusd-spawned) vs UNMANAGED (self-managed via gRPC)
     AgentDescriptor  — frozen PCB (Process Control Block)
     ExternalProcessInfo — connection metadata for external agents

--- a/src/nexus/contracts/process_types.py
+++ b/src/nexus/contracts/process_types.py
@@ -31,44 +31,53 @@ from typing import Any
 
 
 class AgentState(StrEnum):
-    """Unified agent lifecycle states (Issue #1798, #1800).
+    """Unified agent lifecycle states — MIRRORS the Rust kernel SSOT
+    (nexus-vfs ``kernel/src/core/agents/registry.rs::AgentState``).
 
-    Single source of truth — replaces the dual ProcessState/AgentState
-    state machines that were out of sync.
+    Single-axis lifecycle::
 
-    Lifecycle::
+        REGISTERED → WARMING_UP → READY ⇄ BUSY ⇄ AWAITING_INPUT → TERMINATED
 
-        REGISTERED → WARMING_UP → READY → BUSY → READY (loop)
-                                    ↓       ↓
-                                SUSPENDED ← ─┘
-                                    ↓
-                               TERMINATED
+    ``AWAITING_INPUT`` = alive, in an in-flight turn, blocked awaiting a reply
+    the agent requested (permission / question / plan approval); reachable only
+    from BUSY, resumes to BUSY when answered or READY if abandoned.
+
+    (The former ``SUSPENDED`` was removed: it modelled a half-built eviction
+    pause with no resume path — eviction now terminates. See the Rust docstring
+    for the full rationale.)
     """
 
     REGISTERED = "registered"  # Agent registered, not yet started
     WARMING_UP = "warming_up"  # Initializing (load credentials, mount namespace)
     READY = "ready"  # Idle, waiting for next prompt
     BUSY = "busy"  # Actively processing a prompt / tool call
-    SUSPENDED = "suspended"  # Paused (admin / resource pressure eviction)
+    AWAITING_INPUT = "awaiting_input"  # In a turn, blocked awaiting a requested reply
     TERMINATED = "terminated"  # Finished, pending cleanup
 
 
 VALID_AGENT_TRANSITIONS: dict[AgentState, frozenset[AgentState]] = {
     AgentState.REGISTERED: frozenset({AgentState.WARMING_UP, AgentState.TERMINATED}),
     AgentState.WARMING_UP: frozenset({AgentState.READY, AgentState.TERMINATED}),
-    AgentState.READY: frozenset({AgentState.BUSY, AgentState.SUSPENDED, AgentState.TERMINATED}),
-    AgentState.BUSY: frozenset({AgentState.READY, AgentState.SUSPENDED, AgentState.TERMINATED}),
-    AgentState.SUSPENDED: frozenset({AgentState.READY, AgentState.TERMINATED}),
+    AgentState.READY: frozenset({AgentState.BUSY, AgentState.TERMINATED}),
+    AgentState.BUSY: frozenset(
+        {AgentState.READY, AgentState.AWAITING_INPUT, AgentState.TERMINATED}
+    ),
+    # Reachable only from BUSY: resume to BUSY when answered, drop to READY if abandoned.
+    AgentState.AWAITING_INPUT: frozenset(
+        {AgentState.BUSY, AgentState.READY, AgentState.TERMINATED}
+    ),
     AgentState.TERMINATED: frozenset(),  # terminal
 }
 
 
 class AgentSignal(StrEnum):
-    """POSIX-like agent signals."""
+    """POSIX-like agent signals.
+
+    ``SIGSTOP``/``SIGCONT`` were removed with the ``SUSPENDED`` state — no
+    feature paused agents; eviction terminates and warmup transitions directly.
+    """
 
     SIGTERM = "SIGTERM"  # Graceful shutdown → TERMINATED
-    SIGSTOP = "SIGSTOP"  # Suspend → SUSPENDED
-    SIGCONT = "SIGCONT"  # Resume/connect → READY
     SIGKILL = "SIGKILL"  # Immediate kill + reap
     SIGUSR1 = "SIGUSR1"  # User-defined (agent steering)
 

--- a/src/nexus/services/agents/agent_rpc_service.py
+++ b/src/nexus/services/agents/agent_rpc_service.py
@@ -819,55 +819,40 @@ class AgentRPCService:
         """Transition an agent's lifecycle state with optimistic locking."""
         if not self._agent_registry:
             raise ValueError("AgentRegistry not available")
-        from nexus.contracts.process_types import (
-            AgentSignal,
-            AgentState,
-            InvalidTransitionError,
-        )
+        from nexus.contracts.process_types import AgentState, InvalidTransitionError
 
-        # Map legacy state names to signals
-        _STATE_TO_SIGNAL = {
-            "CONNECTED": AgentSignal.SIGCONT,
-            "IDLE": AgentSignal.SIGSTOP,
-            "SUSPENDED": AgentSignal.SIGSTOP,
+        # Legacy phase-named targets map onto real AgentState values. (SUSPENDED
+        # and the SIGSTOP/SIGCONT signal path were removed with the state; a
+        # transition is now a direct AgentRegistry.update_state.)
+        _TARGET_TO_STATE = {
+            "CONNECTED": AgentState.READY,
+            "IDLE": AgentState.READY,
         }
-        sig = _STATE_TO_SIGNAL.get(target_state.upper())
-        if sig is None:
-            raise ValueError(
-                f"Invalid target state '{target_state}'. Valid: CONNECTED, IDLE, SUSPENDED"
+        new_state = _TARGET_TO_STATE.get(target_state.upper())
+        if new_state is None:
+            raise ValueError(f"Invalid target state '{target_state}'. Valid: CONNECTED, IDLE")
+
+        current = self._agent_registry.get(agent_id)
+        if current is None:
+            raise ValueError(f"Agent '{agent_id}' not found")
+        if expected_generation is not None and current.generation != expected_generation:
+            raise InvalidTransitionError(
+                f"stale generation for {agent_id}: expected {expected_generation}, got {current.generation}"
             )
 
-        current = None
-        if expected_generation is not None:
-            current = self._agent_registry.get(agent_id)
-            if current is None:
-                raise ValueError(f"Agent '{agent_id}' not found")
-            if current.generation != expected_generation:
-                raise InvalidTransitionError(
-                    f"stale generation for {agent_id}: expected {expected_generation}, got {current.generation}"
-                )
-        elif target_state.upper() == "CONNECTED":
-            current = self._agent_registry.get(agent_id)
-            if current is None:
-                raise ValueError(f"Agent '{agent_id}' not found")
-
-        if (
-            target_state.upper() == "CONNECTED"
-            and current is not None
-            and current.state == AgentState.REGISTERED
-        ):
+        # A freshly-REGISTERED agent must warm up first (REGISTERED cannot jump
+        # straight to READY); an already-live agent transitions directly.
+        if target_state.upper() == "CONNECTED" and current.state == AgentState.REGISTERED:
             if self._agent_warmup_service is None:
                 raise ValueError("AgentWarmupService not available")
-
             result = await self._agent_warmup_service.warmup(agent_id)
             if not result.success:
                 raise InvalidTransitionError(result.error or f"warmup failed for {agent_id}")
-
-            desc = self._agent_registry.get(agent_id)
-            if desc is None:
-                raise ValueError(f"Agent '{agent_id}' not found")
         else:
-            desc = self._agent_registry.signal(agent_id, sig)
+            self._agent_registry.update_state(agent_id, new_state.value)
+        desc = self._agent_registry.get(agent_id)
+        if desc is None:
+            raise ValueError(f"Agent '{agent_id}' not found")
         return {
             "agent_id": desc.pid,
             "state": str(desc.state),
@@ -901,7 +886,6 @@ class AgentRPCService:
             _STATE_MAP = {
                 "CONNECTED": AgentState.BUSY,
                 "IDLE": AgentState.READY,
-                "SUSPENDED": AgentState.SUSPENDED,
             }
             state_enum = _STATE_MAP.get(state.upper())
             if state_enum is None:

--- a/src/nexus/services/agents/agent_warmup.py
+++ b/src/nexus/services/agents/agent_warmup.py
@@ -34,7 +34,6 @@ from nexus.contracts.agent_warmup_types import (
 )
 from nexus.contracts.process_types import (
     AgentError,
-    AgentSignal,
     AgentState,
     InvalidTransitionError,
 )
@@ -280,9 +279,13 @@ class AgentWarmupService:
                 raise InvalidTransitionError(
                     f"stale generation for {agent_id}: expected {expected_generation}, got {current.generation}"
                 )
-            self._agent_registry.signal(agent_id, AgentSignal.SIGCONT)
+            # Warmup completes by transitioning the agent to READY directly.
+            # (SIGCONT — the old "resume from SUSPENDED" signal — was only ever
+            # abused here as a "become ready" shortcut; it never resumed a
+            # suspended agent, and SUSPENDED is gone.)
+            self._agent_registry.update_state(agent_id, AgentState.READY.value)
         except (ValueError, InvalidTransitionError, AgentError) as exc:
-            logger.warning("[WARMUP] Failed to transition agent %s to CONNECTED: %s", agent_id, exc)
+            logger.warning("[WARMUP] Failed to transition agent %s to READY: %s", agent_id, exc)
             return WarmupResult(
                 success=False,
                 agent_id=agent_id,

--- a/src/nexus/services/agents/eviction_manager.py
+++ b/src/nexus/services/agents/eviction_manager.py
@@ -214,9 +214,13 @@ class EvictionManager:
                     current = self._agent_registry.get(agent.pid)
                     if current is None or current.generation != agent.generation:
                         raise InvalidTransitionError(f"stale generation for {agent.pid}")
-                    self._agent_registry.signal(agent.pid, AgentSignal.SIGSTOP)
+                    # Eviction reclaims the slot by TERMINATING the agent —
+                    # SUSPENDED (pause) was a dead-end with no resume path, so a
+                    # frozen agent never freed anything. SIGTERM actually
+                    # releases the slot.
+                    self._agent_registry.signal(agent.pid, AgentSignal.SIGTERM)
                     logger.debug(
-                        "[EVICTION] Sent SIGSTOP to process %s (gen=%d)",
+                        "[EVICTION] Terminated process %s (gen=%d)",
                         agent.pid,
                         agent.generation,
                     )
@@ -289,7 +293,7 @@ class EvictionManager:
             current = self._agent_registry.get(agent_id)
             if current is None or current.generation != record.generation:
                 raise InvalidTransitionError(f"stale generation for {agent_id}")
-            self._agent_registry.signal(agent_id, AgentSignal.SIGSTOP)
+            self._agent_registry.signal(agent_id, AgentSignal.SIGTERM)
         except (InvalidTransitionError, AgentError) as exc:
             logger.info("[EVICTION] Manual eviction skipped for %s: %s", agent_id, exc)
             return EvictionResult(evicted=0, reason=EvictionReason.MANUAL, skipped=1)

--- a/src/nexus/services/agents/warmup_steps.py
+++ b/src/nexus/services/agents/warmup_steps.py
@@ -25,7 +25,7 @@ async def load_credentials(ctx: "WarmupContext") -> bool:
     """Verify agent has valid credentials in the registry.
 
     Checks that the agent record has a non-empty owner_id and is in a
-    state eligible for connection (UNKNOWN, IDLE, or SUSPENDED).
+    state eligible for warmup (REGISTERED, WARMING_UP, or READY).
     """
     record = ctx.agent_record
     if not record.owner_id:
@@ -38,7 +38,6 @@ async def load_credentials(ctx: "WarmupContext") -> bool:
         AgentState.REGISTERED,
         AgentState.WARMING_UP,
         AgentState.READY,
-        AgentState.SUSPENDED,
     }
     if record.state not in eligible:
         logger.warning(

--- a/src/nexus/services/scheduler/dispatcher.py
+++ b/src/nexus/services/scheduler/dispatcher.py
@@ -494,7 +494,9 @@ class TaskDispatcher:
         if event.new_state in ("CONNECTED", "IDLE"):
             if self._running:
                 self._spawn_cursor(executor_id)
-        elif event.new_state == "SUSPENDED":
+        elif event.new_state == "TERMINATED":
+            # Eviction now terminates (SUSPENDED/pause was removed) — cancel the
+            # cursor when the executor goes away.
             self._cancel_cursor(executor_id)
 
     # =========================================================================

--- a/src/nexus/services/scheduler/queue.py
+++ b/src/nexus/services/scheduler/queue.py
@@ -436,7 +436,7 @@ class TaskQueue:
         """Dequeue using HRRN scoring within priority classes (Astraea).
 
         Orders by: priority_class DESC, HRRN score DESC, enqueued_at ASC.
-        Filters out tasks whose executor is SUSPENDED.
+        Filters out tasks whose executor is no longer live (TERMINATED).
 
         Args:
             conn: Database connection.

--- a/tests/unit/core/test_agent_record.py
+++ b/tests/unit/core/test_agent_record.py
@@ -38,7 +38,7 @@ class TestAgentState:
         assert AgentState.WARMING_UP.value == "warming_up"
         assert AgentState.READY.value == "ready"
         assert AgentState.BUSY.value == "busy"
-        assert AgentState.SUSPENDED.value == "suspended"
+        assert AgentState.AWAITING_INPUT.value == "awaiting_input"
         assert AgentState.TERMINATED.value == "terminated"
 
     def test_states_are_distinct(self):
@@ -51,7 +51,7 @@ class TestAgentState:
         assert AgentState("registered") is AgentState.REGISTERED
         assert AgentState("ready") is AgentState.READY
         assert AgentState("busy") is AgentState.BUSY
-        assert AgentState("suspended") is AgentState.SUSPENDED
+        assert AgentState("awaiting_input") is AgentState.AWAITING_INPUT
 
     def test_invalid_string_raises(self):
         """Invalid string raises ValueError."""

--- a/tests/unit/remote/test_kernel_client_hooks.py
+++ b/tests/unit/remote/test_kernel_client_hooks.py
@@ -139,7 +139,7 @@ def test_kernel_client_agent_registry_proxy_wraps_external_lifecycle_calls() -> 
                     "kind": "UNMANAGED",
                     "owner_id": "admin",
                     "zone_id": "root",
-                    "state": "SUSPENDED",
+                    "state": "TERMINATED",
                     "generation": 1,
                     "created_at_ms": 1_700_000_000_000,
                     "updated_at_ms": 1_700_000_000_001,
@@ -174,14 +174,16 @@ def test_kernel_client_agent_registry_proxy_wraps_external_lifecycle_calls() -> 
         zone_id="root",
         connection_id="admin,agent",
     )
-    transitioned = client.agent_registry.signal("admin,agent", AgentSignal.SIGSTOP)
+    transitioned = client.agent_registry.signal("admin,agent", AgentSignal.SIGTERM)
     warming = client.agent_registry.update_state("admin,agent", AgentState.WARMING_UP.value)
-    listed = client.agent_registry.list_processes(zone_id="root", state=AgentState.SUSPENDED)
+    listed = client.agent_registry.list_processes(
+        zone_id="root", state=AgentState.AWAITING_INPUT
+    )
 
     assert desc.pid == "admin,agent"
     assert desc.state == AgentState.REGISTERED
     assert desc.capabilities == ["search", "cache"]
-    assert transitioned.state == AgentState.SUSPENDED
+    assert transitioned.state == AgentState.TERMINATED
     assert warming.state == AgentState.WARMING_UP
     assert listed == []
     assert transport.calls == [
@@ -199,11 +201,11 @@ def test_kernel_client_agent_registry_proxy_wraps_external_lifecycle_calls() -> 
                 "labels": {},
             },
         ),
-        ("agent_signal", {"pid": "admin,agent", "sig": "SIGSTOP", "payload": {}}),
+        ("agent_signal", {"pid": "admin,agent", "sig": "SIGTERM", "payload": {}}),
         ("agent_update_state", {"pid": "admin,agent", "state": "warming_up"}),
         (
             "agent_list",
-            {"zone_id": "root", "owner_id": None, "kind": None, "state": "suspended"},
+            {"zone_id": "root", "owner_id": None, "kind": None, "state": "awaiting_input"},
         ),
     ]
 

--- a/tests/unit/remote/test_kernel_client_hooks.py
+++ b/tests/unit/remote/test_kernel_client_hooks.py
@@ -176,9 +176,7 @@ def test_kernel_client_agent_registry_proxy_wraps_external_lifecycle_calls() -> 
     )
     transitioned = client.agent_registry.signal("admin,agent", AgentSignal.SIGTERM)
     warming = client.agent_registry.update_state("admin,agent", AgentState.WARMING_UP.value)
-    listed = client.agent_registry.list_processes(
-        zone_id="root", state=AgentState.AWAITING_INPUT
-    )
+    listed = client.agent_registry.list_processes(zone_id="root", state=AgentState.AWAITING_INPUT)
 
     assert desc.pid == "admin,agent"
     assert desc.state == AgentState.REGISTERED

--- a/tests/unit/services/test_agent_rpc_service_lifecycle.py
+++ b/tests/unit/services/test_agent_rpc_service_lifecycle.py
@@ -11,7 +11,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from nexus.contracts.exceptions import NexusFileNotFoundError
-from nexus.contracts.process_types import AgentSignal, AgentState, InvalidTransitionError
+from nexus.contracts.process_types import AgentState, InvalidTransitionError
 from nexus.services.agents.agent_rpc_service import AgentRPCService
 
 
@@ -26,7 +26,7 @@ class _Registry:
     def __init__(self, desc: _Descriptor | None = None) -> None:
         self.desc = desc or _Descriptor()
         self.heartbeats: list[str] = []
-        self.signals: list[tuple[str, AgentSignal]] = []
+        self.state_updates: list[tuple[str, str]] = []
 
     def heartbeat(self, agent_id: str) -> None:
         self.heartbeats.append(agent_id)
@@ -36,14 +36,10 @@ class _Registry:
             return self.desc
         return None
 
-    def signal(self, agent_id: str, signal: AgentSignal) -> _Descriptor:
-        self.signals.append((agent_id, signal))
+    def update_state(self, agent_id: str, state: str) -> None:
+        self.state_updates.append((agent_id, state))
         self.desc.generation += 1
-        if signal == AgentSignal.SIGCONT:
-            self.desc.state = AgentState.BUSY
-        elif signal == AgentSignal.SIGSTOP:
-            self.desc.state = AgentState.SUSPENDED
-        return self.desc
+        self.desc.state = AgentState(state)
 
 
 @pytest.fixture()
@@ -114,14 +110,15 @@ async def test_agent_transition_rejects_stale_generation(
 
 
 @pytest.mark.asyncio()
-async def test_agent_transition_signals_target_state(
+async def test_agent_transition_updates_target_state(
     rpc: tuple[AgentRPCService, _Registry],
 ) -> None:
     service, registry = rpc
 
+    # Legacy "IDLE" target now maps to a direct update_state(READY) — no signal.
     result = await service.agent_transition("alice", "IDLE", expected_generation=7)
 
-    assert registry.signals == [("alice", AgentSignal.SIGSTOP)]
+    assert registry.state_updates == [("alice", AgentState.READY.value)]
     assert result["agent_id"] == "alice"
     assert result["generation"] == 8
 


### PR DESCRIPTION
Python companion to the merged kernel change (nexus-vfs#260): `AgentState` gains `AWAITING_INPUT`, drops `SUSPENDED`; `SIGSTOP`/`SIGCONT` are gone.

**Forward-compatible — lands independently of the re-pin.** Every replacement (SIGTERM, `update_state`) exists in both the old and new kernel, and the daemon-state decode already suppresses unknown values, so this works against the current daemon AND the new one.

## Changes
- `process_types.py` / `agent_types.py`: SSOT sync (AWAITING_INPUT in, SUSPENDED out; single-axis transitions; AgentPhase mapping).
- **eviction** `SIGSTOP → SIGTERM`: eviction TERMINATES to reclaim the slot (SUSPENDED was a dead-end pause with no resume — it froze agents without freeing anything).
- **warmup / sandbox** `SIGCONT/SIGSTOP → update_state(READY)`: they only ever abused the signals as become-ready/return-to-ready shortcuts.
- **agent_transition RPC + CLI**: legacy CONNECTED/IDLE → `update_state` (keeps CONNECTED→warmup); dropped SUSPENDED.
- dispatcher cancels the cursor on TERMINATED (eviction's new end-state); state-filter / warmup eligibility / CLI Choice drop SUSPENDED.
- Tests updated (agent_transition, kernel_client proxy, agent_record enum).

## Verify
All changed modules import; the affected unit tests pass locally (eviction / agent_rpc lifecycle / kernel_client hooks / agent_record / eviction_policy).

## Follow-up (separate)
Re-pin nexus's nexus-vfs → #260 merge + sudocode → #531, to actually adopt the new kernel (the cascade 'adopt' step).