### PR TITLE
chore(deps): adopt AwaitingInput kernel (nexus-vfs b5b969a0 + sudocode 69328d3e)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "a2a"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c#326d2b78115419d68689a0584d066372431b632c"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=b5b969a060c322835be67ff9b1e6e02f7c97abd1#b5b969a060c322835be67ff9b1e6e02f7c97abd1"
 dependencies = [
  "contracts",
  "kernel",
@@ -234,7 +234,7 @@ checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 [[package]]
 name = "api"
 version = "0.2.0"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=874d76fa2fb2211cefa4114bd99d57831188fdbe#874d76fa2fb2211cefa4114bd99d57831188fdbe"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=69328d3e081e23801a85d022b292c01fe6f184c5#69328d3e081e23801a85d022b292c01fe6f184c5"
 dependencies = [
  "base64 0.22.1",
  "httpdate",
@@ -327,7 +327,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 [[package]]
 name = "auth"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c#326d2b78115419d68689a0584d066372431b632c"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=b5b969a060c322835be67ff9b1e6e02f7c97abd1#b5b969a060c322835be67ff9b1e6e02f7c97abd1"
 dependencies = [
  "contracts",
  "dashmap",
@@ -430,7 +430,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c#326d2b78115419d68689a0584d066372431b632c"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=b5b969a060c322835be67ff9b1e6e02f7c97abd1#b5b969a060c322835be67ff9b1e6e02f7c97abd1"
 dependencies = [
  "ahash",
  "base64 0.22.1",
@@ -848,7 +848,7 @@ dependencies = [
 [[package]]
 name = "commands"
 version = "0.2.0"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=874d76fa2fb2211cefa4114bd99d57831188fdbe#874d76fa2fb2211cefa4114bd99d57831188fdbe"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=69328d3e081e23801a85d022b292c01fe6f184c5#69328d3e081e23801a85d022b292c01fe6f184c5"
 dependencies = [
  "plugins",
  "runtime",
@@ -917,7 +917,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c#326d2b78115419d68689a0584d066372431b632c"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=b5b969a060c322835be67ff9b1e6e02f7c97abd1#b5b969a060c322835be67ff9b1e6e02f7c97abd1"
 dependencies = [
  "parking_lot",
  "serde",
@@ -2540,7 +2540,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c#326d2b78115419d68689a0584d066372431b632c"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=b5b969a060c322835be67ff9b1e6e02f7c97abd1#b5b969a060c322835be67ff9b1e6e02f7c97abd1"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -2608,7 +2608,7 @@ checksum = "0c2cdeb66e45e9f36bfad5bbdb4d2384e70936afbee843c6f6543f0c551ebb25"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c#326d2b78115419d68689a0584d066372431b632c"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=b5b969a060c322835be67ff9b1e6e02f7c97abd1#b5b969a060c322835be67ff9b1e6e02f7c97abd1"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -2813,7 +2813,7 @@ checksum = "fc04a4c58212d57930a24bf47d3fa87485264a3a054e9c10e042eb373573ad3c"
 [[package]]
 name = "managed-agent"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c#326d2b78115419d68689a0584d066372431b632c"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=b5b969a060c322835be67ff9b1e6e02f7c97abd1#b5b969a060c322835be67ff9b1e6e02f7c97abd1"
 dependencies = [
  "a2a",
  "contracts",
@@ -3008,7 +3008,7 @@ dependencies = [
 [[package]]
 name = "nexus-cluster"
 version = "0.1.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c#326d2b78115419d68689a0584d066372431b632c"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=b5b969a060c322835be67ff9b1e6e02f7c97abd1#b5b969a060c322835be67ff9b1e6e02f7c97abd1"
 dependencies = [
  "a2a",
  "anyhow",
@@ -3086,7 +3086,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c#326d2b78115419d68689a0584d066372431b632c"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=b5b969a060c322835be67ff9b1e6e02f7c97abd1#b5b969a060c322835be67ff9b1e6e02f7c97abd1"
 
 [[package]]
 name = "nexus-rebac"
@@ -3159,7 +3159,7 @@ dependencies = [
 [[package]]
 name = "nexus-vfs-client"
 version = "0.2.0"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=874d76fa2fb2211cefa4114bd99d57831188fdbe#874d76fa2fb2211cefa4114bd99d57831188fdbe"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=69328d3e081e23801a85d022b292c01fe6f184c5#69328d3e081e23801a85d022b292c01fe6f184c5"
 dependencies = [
  "prost 0.13.5",
  "protoc-bin-vendored",
@@ -3618,7 +3618,7 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 [[package]]
 name = "plugins"
 version = "0.2.0"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=874d76fa2fb2211cefa4114bd99d57831188fdbe#874d76fa2fb2211cefa4114bd99d57831188fdbe"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=69328d3e081e23801a85d022b292c01fe6f184c5#69328d3e081e23801a85d022b292c01fe6f184c5"
 dependencies = [
  "serde",
  "serde_json",
@@ -4032,7 +4032,7 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 [[package]]
 name = "raft"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c#326d2b78115419d68689a0584d066372431b632c"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=b5b969a060c322835be67ff9b1e6e02f7c97abd1#b5b969a060c322835be67ff9b1e6e02f7c97abd1"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -4462,7 +4462,7 @@ dependencies = [
 [[package]]
 name = "runtime"
 version = "0.2.0"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=874d76fa2fb2211cefa4114bd99d57831188fdbe#874d76fa2fb2211cefa4114bd99d57831188fdbe"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=69328d3e081e23801a85d022b292c01fe6f184c5#69328d3e081e23801a85d022b292c01fe6f184c5"
 dependencies = [
  "a2a",
  "agent-client-protocol",
@@ -5162,7 +5162,7 @@ dependencies = [
 [[package]]
 name = "subprocess"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c#326d2b78115419d68689a0584d066372431b632c"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=b5b969a060c322835be67ff9b1e6e02f7c97abd1#b5b969a060c322835be67ff9b1e6e02f7c97abd1"
 dependencies = [
  "kernel",
  "libc",
@@ -5381,7 +5381,7 @@ dependencies = [
 [[package]]
 name = "telemetry"
 version = "0.2.0"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=874d76fa2fb2211cefa4114bd99d57831188fdbe#874d76fa2fb2211cefa4114bd99d57831188fdbe"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=69328d3e081e23801a85d022b292c01fe6f184c5#69328d3e081e23801a85d022b292c01fe6f184c5"
 dependencies = [
  "chrono",
  "dirs",
@@ -5773,7 +5773,7 @@ dependencies = [
 [[package]]
 name = "tools"
 version = "0.2.0"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=874d76fa2fb2211cefa4114bd99d57831188fdbe#874d76fa2fb2211cefa4114bd99d57831188fdbe"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=69328d3e081e23801a85d022b292c01fe6f184c5#69328d3e081e23801a85d022b292c01fe6f184c5"
 dependencies = [
  "api",
  "async-trait",
@@ -5918,7 +5918,7 @@ dependencies = [
 [[package]]
 name = "transport"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=326d2b78115419d68689a0584d066372431b632c#326d2b78115419d68689a0584d066372431b632c"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=b5b969a060c322835be67ff9b1e6e02f7c97abd1#b5b969a060c322835be67ff9b1e6e02f7c97abd1"
 dependencies = [
  "axum",
  "backends",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -236,30 +236,30 @@ exclude = ["nexus-fuse"]
 #
 # Bump alongside the rest of nexus-vfs updates when a downstream
 # change needs newer kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "326d2b78115419d68689a0584d066372431b632c" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "326d2b78115419d68689a0584d066372431b632c" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "326d2b78115419d68689a0584d066372431b632c" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "326d2b78115419d68689a0584d066372431b632c", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "326d2b78115419d68689a0584d066372431b632c", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "326d2b78115419d68689a0584d066372431b632c", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "326d2b78115419d68689a0584d066372431b632c" }
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "b5b969a060c322835be67ff9b1e6e02f7c97abd1" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "b5b969a060c322835be67ff9b1e6e02f7c97abd1" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "b5b969a060c322835be67ff9b1e6e02f7c97abd1" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "b5b969a060c322835be67ff9b1e6e02f7c97abd1", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "b5b969a060c322835be67ff9b1e6e02f7c97abd1", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "b5b969a060c322835be67ff9b1e6e02f7c97abd1", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "b5b969a060c322835be67ff9b1e6e02f7c97abd1" }
 # The cluster daemon library entry (`nexus_cluster::run_with_services`),
 # consumed by the nexus-side assembly binary (`rust/nexusd`) that composes
 # the kernel/federation boot with the nexus service set via the
 # ServiceRegistry bring-up seam.
-nexus-cluster = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "326d2b78115419d68689a0584d066372431b632c" }
+nexus-cluster = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "b5b969a060c322835be67ff9b1e6e02f7c97abd1" }
 # a2a messaging substrate. `default-features = false` leaves the
 # `install` feature (which pulls raft to arm the stream-wakeup observer)
 # OFF, so nexus-side consumers link only the stamp hook and stay
 # raft-free — they reach raft through kernel.sys_* (§6.1). The substrate
 # is armed in production at cluster boot in nexus-vfs, not here.
-a2a = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "326d2b78115419d68689a0584d066372431b632c", default-features = false }
+a2a = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "b5b969a060c322835be67ff9b1e6e02f7c97abd1", default-features = false }
 # managed-agent control plane + the shared subprocess host — RELOCATED into
 # nexus-vfs (kernel-tier) so the production nexusd-cluster carries the agent
 # control plane. `subprocess-host` enables the raw ACP-subprocess spawner (the
 # nexus-side acp path + managed-agent both use HostedSubprocess).
-managed-agent = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "326d2b78115419d68689a0584d066372431b632c", default-features = false }
-subprocess = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "326d2b78115419d68689a0584d066372431b632c" }
+managed-agent = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "b5b969a060c322835be67ff9b1e6e02f7c97abd1", default-features = false }
+subprocess = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "b5b969a060c322835be67ff9b1e6e02f7c97abd1" }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir --no-deps --prefix=/install .
 # enforces agreement) — an unpinned install tracks nexus-vfs HEAD and
 # ships an untested kernel (#4343). --locked honors the source tree's
 # Cargo.lock.
-ARG NEXUS_VFS_REV=326d2b78115419d68689a0584d066372431b632c
+ARG NEXUS_VFS_REV=b5b969a060c322835be67ff9b1e6e02f7c97abd1
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-cluster nexus-cluster
 
 # -- Runtime stage --

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -25,7 +25,7 @@ WORKDIR /build
 # (CI preflight enforces agreement) — an unpinned install tracks HEAD
 # and can skew the raft contract against the cluster/witness images.
 # --locked honors the source tree's Cargo.lock.
-ARG NEXUS_VFS_REV=326d2b78115419d68689a0584d066372431b632c
+ARG NEXUS_VFS_REV=b5b969a060c322835be67ff9b1e6e02f7c97abd1
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexus-raft-server raft
 
 # ---------- Production image ----------

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=326d2b78115419d68689a0584d066372431b632c
+ARG NEXUS_VFS_REV=b5b969a060c322835be67ff9b1e6e02f7c97abd1
 RUN cargo install \
     --locked \
     --git https://github.com/nexi-lab/nexus-vfs \

--- a/rust/nexusd/Cargo.toml
+++ b/rust/nexusd/Cargo.toml
@@ -94,7 +94,7 @@ anyhow = "1"
 # nexus-side co-host glue and no runtime enum to map (the adapter reports
 # `kernel::AgentState` directly). Pinned to sudocode main (spawn AgentState
 # collapse).
-sudocode-tools = { package = "tools", git = "https://github.com/sudoprivacy/sudocode", rev = "874d76fa2fb2211cefa4114bd99d57831188fdbe", optional = true }
+sudocode-tools = { package = "tools", git = "https://github.com/sudoprivacy/sudocode", rev = "69328d3e081e23801a85d022b292c01fe6f184c5", optional = true }
 # Named directly to spell `kernel::kernel::{ServiceDecl, Kernel}` — the
 # managed-agent boot decl's return type (both builds) and the co-host
 # adapter's `SpawnTask<Kernel>` (cohost build). Already present transitively


### PR DESCRIPTION
Final cascade step — nexus adopts the merged AwaitingInput kernel.

- nexus-vfs `326d2b78 → b5b969a0` (#260 merged): AgentState `AwaitingInput` replaces `Suspended`, agent-reported `reason`, cross-machine `/agents/<name>/state`.
- sudocode-tools `874d76fa → 69328d3e` (#531 merged): new `Fn(AgentState, Option<String>)` observer. Its transitive nexus-vfs pin is the same `b5b969a0`, so the pin-divergence gate sees a single rev.

Python companion (nexus#4733) already on develop mirrors the new states. Pure pin bump — Cargo.toml + Cargo.lock + 3 `NEXUS_VFS_REV` Dockerfile ARGs + nexusd sudocode-tools. `cargo check -p nexusd --features cohost-sudocode` green; gate extraction = 1 rev locally.