### PR TITLE
feat(http-api): /v2/rebac/tuples router behind --features rebac (R10 — PR 5/5)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3055,6 +3055,8 @@ dependencies = [
  "dashmap",
  "http-body-util",
  "kernel",
+ "lib",
+ "nexus-rebac",
  "prost 0.14.4",
  "protoc-bin-vendored",
  "reqwest 0.12.28",

--- a/rust/nexusd/Cargo.toml
+++ b/rust/nexusd/Cargo.toml
@@ -46,7 +46,14 @@ cohost-sudocode = ["dep:sudocode-tools"]
 # `AHashMap` / `string_interner` transitively, so kept behind an
 # explicit gate.  Compose via `--features full` for the everything
 # build; a la carte `--features rebac,http-api` also works.
-rebac = ["dep:nexus-rebac"]
+#
+# The `nexus-http-api?/rebac` chain propagates the rebac feature
+# into the http-api crate WHEN http-api is also enabled — so
+# `--features http-api,rebac` mounts the `/v2/rebac/tuples`
+# router in addition to installing the syscall-time enforcer.
+# The `?` gate keeps `--features rebac` alone from pulling in the
+# http-api dep (enforcer without HTTP surface is a valid mode).
+rebac = ["dep:nexus-rebac", "nexus-http-api?/rebac"]
 # Meta-feature: the "full superset" build — enables every opt-in
 # service that does not require cross-repo pin coordination
 # (§7: cluster ⊂ … ⊂ full).  Downstream tooling that wants every

--- a/rust/nexusd/src/main.rs
+++ b/rust/nexusd/src/main.rs
@@ -87,15 +87,46 @@ fn main() -> anyhow::Result<()> {
     // `RaftReBACTupleStore` over (same consensus as `RaftAuthKeyStore`,
     // one namespace over).
     nexus_cluster::run_with_services(move |ctx| {
+        // Build the rebac store ONCE — the enforcer decl AND the
+        // http-api /v2/rebac/tuples router (both feature-gated on
+        // `rebac`) share the same `Arc<dyn ReBACTupleStore>` so a
+        // grant written via HTTP lands in the same store the
+        // enforcer reads.  Cloning the Arc is cheap; sharing means
+        // one SSOT, not two.
+        #[cfg(feature = "rebac")]
+        let rebac_store = build_rebac_store(ctx);
         let mut decls = vec![a2a::service_decl(ctx.auth_armed), managed_agent_decl()];
-        if let Some(decl) = http_api_decl_from(&http_api_config, ctx) {
+        if let Some(decl) = http_api_decl_from(
+            &http_api_config,
+            ctx,
+            #[cfg(feature = "rebac")]
+            std::sync::Arc::clone(&rebac_store),
+        ) {
             decls.push(decl);
         }
-        if let Some(decl) = rebac_decl_from(ctx) {
+        #[cfg(feature = "rebac")]
+        if let Some(decl) = rebac_enforcer_decl(rebac_store) {
             decls.push(decl);
         }
         decls
     })
+}
+
+/// Build the shared `RaftReBACTupleStore` from the boot ctx.
+///
+/// Called ONCE inside the `run_with_services` closure — the resulting
+/// `Arc` is cloned into both consumer decls (the enforcer's kernel
+/// slot install AND the http-api rebac router's `AppState`) so
+/// tuple grants written via HTTP land in the same store the
+/// enforcer reads on every syscall.  One SSOT, two surfaces.
+#[cfg(feature = "rebac")]
+fn build_rebac_store(
+    ctx: &nexus_cluster::ServiceBootCtx,
+) -> std::sync::Arc<dyn nexus_rebac::ReBACTupleStore> {
+    nexus_rebac::RaftReBACTupleStore::new_arc(
+        ctx.credential_consensus.clone(),
+        ctx.credential_zone_runtime.clone(),
+    )
 }
 
 /// HTTP-API config parsed at boot from env — cheap, refused loud
@@ -168,7 +199,7 @@ fn parse_http_api_config() -> anyhow::Result<Option<HttpApiConfig>> {
 /// auth provider + runtime handle) is only available inside
 /// `run_with_services`'s closure, but the config parse must run
 /// upfront to fail-loud on env typos.
-#[cfg(feature = "http-api")]
+#[cfg(all(feature = "http-api", not(feature = "rebac")))]
 fn http_api_decl_from(
     config: &Option<HttpApiConfig>,
     ctx: &nexus_cluster::ServiceBootCtx,
@@ -183,10 +214,45 @@ fn http_api_decl_from(
     ))
 }
 
-#[cfg(not(feature = "http-api"))]
+/// `--features http-api,rebac` variant of the wrapper — passes the
+/// shared `Arc<dyn ReBACTupleStore>` through to
+/// `nexus_http_api::service_decl` so `/v2/rebac/tuples` grants land
+/// in the SAME store the kernel `PermissionProvider` reads.
+///
+/// Signature deliberately mirrors the feature-off shape one extra
+/// arg later — the call site cfg-gates the arg with a single
+/// `#[cfg(feature = "rebac")]` on the `Arc::clone(&rebac_store)`
+/// expression, so a rebac-off build still compiles unchanged.
+#[cfg(all(feature = "http-api", feature = "rebac"))]
+fn http_api_decl_from(
+    config: &Option<HttpApiConfig>,
+    ctx: &nexus_cluster::ServiceBootCtx,
+    rebac_store: std::sync::Arc<dyn nexus_rebac::ReBACTupleStore>,
+) -> Option<kernel::kernel::ServiceDecl> {
+    use std::sync::Arc;
+    let cfg = config.as_ref()?;
+    Some(nexus_http_api::service_decl(
+        cfg.addr,
+        cfg.upstream_grpc.clone(),
+        Arc::clone(&ctx.auth),
+        ctx.runtime.clone(),
+        rebac_store,
+    ))
+}
+
+#[cfg(all(not(feature = "http-api"), not(feature = "rebac")))]
 fn http_api_decl_from(
     _config: &Option<HttpApiConfig>,
     _ctx: &nexus_cluster::ServiceBootCtx,
+) -> Option<kernel::kernel::ServiceDecl> {
+    None
+}
+
+#[cfg(all(not(feature = "http-api"), feature = "rebac"))]
+fn http_api_decl_from(
+    _config: &Option<HttpApiConfig>,
+    _ctx: &nexus_cluster::ServiceBootCtx,
+    _rebac_store: std::sync::Arc<dyn nexus_rebac::ReBACTupleStore>,
 ) -> Option<kernel::kernel::ServiceDecl> {
     None
 }
@@ -219,18 +285,18 @@ fn http_api_decl_from(
 /// The `rebac`-off build never links `nexus-rebac`, so the entire
 /// enforcer + graph engine + `lib::rebac` transitive weight stays
 /// out of the slim `cluster` binary (§7 size budget).
+/// Build the ReBAC enforcer `ServiceDecl` from the shared store.
+/// The store is built ONCE in the main closure ([`build_rebac_store`])
+/// and cloned into both consumers — the enforcer here + the http-api
+/// rebac router (via [`http_api_decl_from`]).  Sharing the same
+/// `Arc<dyn ReBACTupleStore>` is what makes grants written over the
+/// HTTP surface visible to the syscall-time enforcer without a
+/// second SSOT.
 #[cfg(feature = "rebac")]
-fn rebac_decl_from(ctx: &nexus_cluster::ServiceBootCtx) -> Option<kernel::kernel::ServiceDecl> {
+fn rebac_enforcer_decl(
+    store: std::sync::Arc<dyn nexus_rebac::ReBACTupleStore>,
+) -> Option<kernel::kernel::ServiceDecl> {
     use std::sync::Arc;
-    // Build the store + cache + provider OUTSIDE the install
-    // closure so ctx borrows do not need to move into a `'static`
-    // closure (the ServiceInstall signature is `FnOnce(&Arc<
-    // Kernel>) + Send + 'static`).  `store` clones the consensus +
-    // runtime handle; both are Arc-inside — cheap.
-    let store: Arc<dyn nexus_rebac::ReBACTupleStore> = nexus_rebac::RaftReBACTupleStore::new_arc(
-        ctx.credential_consensus.clone(),
-        ctx.credential_zone_runtime.clone(),
-    );
     let cache = Arc::new(nexus_rebac::ReBACGraphCache::new(store));
     let provider: Arc<Box<dyn kernel::core::dispatch::PermissionProvider>> =
         Arc::new(Box::new(nexus_rebac::RebacPermissionProvider::new(cache)));
@@ -241,9 +307,4 @@ fn rebac_decl_from(ctx: &nexus_cluster::ServiceBootCtx) -> Option<kernel::kernel
             Ok(())
         }),
     })
-}
-
-#[cfg(not(feature = "rebac"))]
-fn rebac_decl_from(_ctx: &nexus_cluster::ServiceBootCtx) -> Option<kernel::kernel::ServiceDecl> {
-    None
 }

--- a/rust/services/http-api/Cargo.toml
+++ b/rust/services/http-api/Cargo.toml
@@ -61,6 +61,28 @@ kernel = { workspace = true }
 # the sibling search-plugin uses.
 thiserror = "1"
 
+# ── Opt-in `rebac` feature ──────────────────────────────────────
+#
+# When enabled, links `nexus-rebac` and mounts the
+# `/v2/rebac/tuples` router (grant / list / revoke).  Off by
+# default so the slim `http-api` build stays out of `lib::rebac`'s
+# Zanzibar substrate + `ahash` transitive weight — real bytes the
+# search / documents callers do not need.  Downstream `nexusd`
+# chains `rebac = ["dep:nexus-rebac", "nexus-http-api?/rebac"]`
+# so its own `rebac` feature turns this one on.
+nexus-rebac = { path = "../rebac", optional = true }
+# `lib::types::ReBACTuple` — the typed shape the wire body splits
+# into for the store's key encoder.  Only used by the rebac
+# handler; optional-and-feature-gated so an `http-api`-only build
+# does not pull `lib` for this reason.  (The workspace pins `lib`
+# anyway, so linking it under `rebac` is a re-share, not a new
+# resolution.)
+lib = { workspace = true, optional = true }
+
+[features]
+default = []
+rebac = ["dep:nexus-rebac", "dep:lib"]
+
 [build-dependencies]
 # Client-only proto codegen from the workspace's search proto SSOT
 # (`rust/services/proto/nexus/search/v1/search.proto`).  Same tool

--- a/rust/services/http-api/src/handlers/mod.rs
+++ b/rust/services/http-api/src/handlers/mod.rs
@@ -8,5 +8,7 @@
 //! adds a field, no handler rewire.
 
 pub mod documents;
+#[cfg(feature = "rebac")]
+pub mod rebac;
 pub mod search;
 pub mod status;

--- a/rust/services/http-api/src/handlers/rebac.rs
+++ b/rust/services/http-api/src/handlers/rebac.rs
@@ -1,0 +1,306 @@
+//! `/v2/rebac/tuples` — HTTP grant / list / revoke over the
+//! kernel-adjacent tuple store.
+//!
+//! Callers write tuples through these routes; the enforcer
+//! ([`nexus_rebac::RebacPermissionProvider`], installed at boot in
+//! nexusd behind `--features rebac`) reads the same store on every
+//! syscall.  One SSOT — the raft-backed `RaftReBACTupleStore` — with
+//! two consumer surfaces (this HTTP router + the kernel gate).
+//!
+//! # Feature gate
+//!
+//! This whole module is `#[cfg(feature = "rebac")]` — the crate ships
+//! empty rebac routes when the caller (nexusd) builds
+//! `--features http-api` alone.  Composing `--features http-api,rebac`
+//! (or `--features full`) links the [`nexus_rebac`] crate + registers
+//! the routes.  Rationale: the `nexus-rebac` dep pulls in
+//! `lib::rebac`'s Zanzibar substrate + `ahash` transitively — real
+//! weight the slim `http-api` build does not need for search /
+//! documents callers.
+//!
+//! # Endpoints
+//!
+//! * `POST   /v2/rebac/tuples` — grant a tuple.  Idempotent (a repeat
+//!   put on the same key is a no-op at storage; the enforcer's graph
+//!   cache re-materialises the same subject on rebuild).
+//! * `DELETE /v2/rebac/tuples` — revoke a tuple.  Response reports
+//!   whether the tuple existed at propose time (advisory — the
+//!   revoke is idempotent, the raft log is authoritative).
+//! * `GET    /v2/rebac/tuples?zone=<zone>` — list tuples in `zone`.
+//!   Full scan (bounded per-zone in real deployments, O(100k) worst-
+//!   case per the store contract).  No pagination — matches the
+//!   graph-rebuild scan the enforcer already pays.
+//!
+//! # Auth
+//!
+//! Slotted under the same bearer sub-router as `/v2/search/*` +
+//! `/v2/documents/*` (see [`crate::router`]).  Any authenticated
+//! caller can grant / revoke — grant-authority is not further
+//! gated here.  A later revision may enforce
+//! `is_admin OR (grant delegates)` at this layer; today the tuples
+//! are cluster-wide-trusted (control-plane consensus, not user
+//! data).
+//!
+//! # Wire shape
+//!
+//! Body / query / response types mirror the tuple key convention
+//! documented on [`nexus_rebac::tuple_key`] — pipe-delimited
+//! `<zone>|<obj_type>|<obj_id>|<relation>|<subj_type>|<subj_id>
+//! [|<subj_relation>]`.  Callers send / receive the 6-or-7 fields
+//! as a typed JSON object; this handler encodes/decodes at the
+//! boundary so the wire form stays operator-inspectable in raft
+//! log dumps.
+
+use std::sync::Arc;
+
+use axum::extract::{Query, State};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::routing::{delete, get, post};
+use axum::{Json, Router};
+use lib::types::ReBACTuple;
+use nexus_rebac::{tuple_key, ReBACTupleStoreError};
+use serde::{Deserialize, Serialize};
+
+use crate::AppState;
+
+// ── error surface ────────────────────────────────────────────────
+
+/// Errors surfaced by the rebac handlers.  Same shape convention as
+/// [`crate::handlers::search::SearchError`] — a typed enum with a
+/// [`IntoResponse`] impl that maps each variant to an HTTP status
+/// so the axum extractor lifts them to the client without a manual
+/// `.map_err` per handler.
+#[derive(Debug, thiserror::Error)]
+pub enum RebacError {
+    /// The store rejected the read/write (raft not-leader, backend
+    /// unreachable, storage failure).  Maps to 502 — the caller is
+    /// well-formed, the backend is not currently serving.
+    #[error("rebac store backend error: {0}")]
+    Backend(String),
+
+    /// The submitted tuple contains the reserved pipe delimiter in a
+    /// segment.  Maps to 400 — the client sent malformed input; a
+    /// retry with escaped ids will succeed.  The store never sees
+    /// this — [`tuple_key::encode`] catches it at the boundary.
+    #[error("rebac tuple segment contains reserved delimiter '|': {0}")]
+    BadSegment(String),
+}
+
+impl From<ReBACTupleStoreError> for RebacError {
+    fn from(e: ReBACTupleStoreError) -> Self {
+        match e {
+            ReBACTupleStoreError::Backend(msg) => {
+                // The tuple-key encoder wraps its own segment-check
+                // failures in Backend(_) — distinguish them here so
+                // the client gets 400 (their input is wrong) instead
+                // of 502 (backend fault).  The encoder's message is
+                // stable ("rebac tuple segment contains reserved
+                // delimiter '|': ...") so a substring match is safe.
+                if msg.contains("reserved delimiter") {
+                    Self::BadSegment(msg)
+                } else {
+                    Self::Backend(msg)
+                }
+            }
+        }
+    }
+}
+
+impl IntoResponse for RebacError {
+    fn into_response(self) -> Response {
+        let status = match &self {
+            Self::Backend(_) => StatusCode::BAD_GATEWAY,
+            Self::BadSegment(_) => StatusCode::BAD_REQUEST,
+        };
+        (status, self.to_string()).into_response()
+    }
+}
+
+// ── wire shape ───────────────────────────────────────────────────
+
+/// One tuple on the wire — the 6-or-7 segments of the encoded key
+/// as a typed JSON object.  Both request bodies (grant / revoke)
+/// and response items use this shape; a repeat client that reads
+/// a listing and immediately re-grants a subset does not translate
+/// between shapes.
+///
+/// Field names match the Zanzibar convention documented on
+/// [`lib::types::ReBACTuple`] one-to-one — the only extra field
+/// here is `zone`, which lives in the store's key prefix (not on
+/// the upstream `ReBACTuple`).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TupleBody {
+    pub zone: String,
+    pub object_type: String,
+    pub object_id: String,
+    pub relation: String,
+    pub subject_type: String,
+    pub subject_id: String,
+    /// Optional userset-as-subject relation (the Zanzibar "members
+    /// of `subject_type:subject_id` have this relation on the
+    /// object" pattern).  Absent ⇒ direct tuple.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub subject_relation: Option<String>,
+}
+
+impl TupleBody {
+    /// Split the wire shape into `(zone, ReBACTuple)`.
+    fn split(self) -> (String, ReBACTuple) {
+        (
+            self.zone,
+            ReBACTuple {
+                object_type: self.object_type,
+                object_id: self.object_id,
+                relation: self.relation,
+                subject_type: self.subject_type,
+                subject_id: self.subject_id,
+                subject_relation: self.subject_relation,
+            },
+        )
+    }
+
+    /// Compose from a `(zone, ReBACTuple)` — the shape a store
+    /// listing produces.
+    fn from_pair(zone: String, tuple: ReBACTuple) -> Self {
+        Self {
+            zone,
+            object_type: tuple.object_type,
+            object_id: tuple.object_id,
+            relation: tuple.relation,
+            subject_type: tuple.subject_type,
+            subject_id: tuple.subject_id,
+            subject_relation: tuple.subject_relation,
+        }
+    }
+}
+
+// ── POST /v2/rebac/tuples (grant) ────────────────────────────────
+
+/// Response body for [`grant`].  Empty on success — the grant is
+/// idempotent, and the caller already knows the tuple it sent.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct GrantResponse {}
+
+/// Handler for `POST /v2/rebac/tuples` — grant a tuple.
+///
+/// Encodes the wire shape into a store key + puts it.  Idempotent:
+/// a repeat put on the same key is a no-op at storage; the
+/// enforcer's graph cache re-materialises the same subject.  502
+/// on a backend failure; 400 on a segment containing the reserved
+/// `|` delimiter (fail-loud at the boundary, before the store sees
+/// a malformed key).
+pub async fn grant(
+    State(state): State<AppState>,
+    Json(body): Json<TupleBody>,
+) -> Result<Json<GrantResponse>, RebacError> {
+    let store = Arc::clone(&state.rebac_store);
+    let (zone, tuple) = body.split();
+    // Encode + put on a blocking thread — the store `put` bridges
+    // through raft's `propose` (a `bridge_block_on` inside the
+    // typed wrapper), which is a blocking call under the hood.
+    // Same shape the search-plugin's write RPCs use.
+    tokio::task::spawn_blocking(move || {
+        let key = tuple_key::encode(&zone, &tuple)?;
+        store.put(&key, b"")?;
+        Ok::<_, ReBACTupleStoreError>(())
+    })
+    .await
+    .map_err(|e| RebacError::Backend(format!("rebac grant task panicked: {e}")))??;
+    Ok(Json(GrantResponse::default()))
+}
+
+// ── DELETE /v2/rebac/tuples (revoke) ─────────────────────────────
+
+/// Response body for [`revoke`].  `existed` is advisory — the
+/// revoke is idempotent (a delete on a missing key is not an
+/// error); the flag lets a caller distinguish "removed something"
+/// from "nothing was there" for their own audit trail.  The raft
+/// log is authoritative regardless.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct RevokeResponse {
+    pub existed: bool,
+}
+
+/// Handler for `DELETE /v2/rebac/tuples` — revoke a tuple.
+pub async fn revoke(
+    State(state): State<AppState>,
+    Json(body): Json<TupleBody>,
+) -> Result<Json<RevokeResponse>, RebacError> {
+    let store = Arc::clone(&state.rebac_store);
+    let (zone, tuple) = body.split();
+    let existed = tokio::task::spawn_blocking(move || {
+        let key = tuple_key::encode(&zone, &tuple)?;
+        store.delete(&key)
+    })
+    .await
+    .map_err(|e| RebacError::Backend(format!("rebac revoke task panicked: {e}")))??;
+    Ok(Json(RevokeResponse { existed }))
+}
+
+// ── GET /v2/rebac/tuples?zone=<zone> (list) ──────────────────────
+
+/// Query params for [`list`].  `zone` is required — a zone-less
+/// listing would return every grant on the cluster, which is not
+/// what any real caller wants (and would be expensive on a large
+/// deployment).  Missing / empty ⇒ 400 (the axum extractor
+/// rejects an unset required field automatically).
+#[derive(Debug, Clone, Deserialize)]
+pub struct ListQuery {
+    pub zone: String,
+}
+
+/// Response body for [`list`].
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct ListResponse {
+    pub tuples: Vec<TupleBody>,
+}
+
+/// Handler for `GET /v2/rebac/tuples?zone=<zone>`.  Walks the
+/// full store snapshot, filters by zone prefix, decodes each
+/// matching key.  Malformed keys are soft-skipped (see
+/// [`nexus_rebac::tuple_key::decode`] docstring) — a bad row in
+/// the store does not wedge the whole listing.
+pub async fn list(
+    State(state): State<AppState>,
+    Query(params): Query<ListQuery>,
+) -> Result<Json<ListResponse>, RebacError> {
+    if params.zone.is_empty() {
+        return Err(RebacError::BadSegment(
+            "zone query param is required and non-empty".to_string(),
+        ));
+    }
+    let store = Arc::clone(&state.rebac_store);
+    let zone = params.zone;
+    let tuples = tokio::task::spawn_blocking(move || {
+        let entries = store.list()?;
+        let tuples: Vec<TupleBody> = entries
+            .into_iter()
+            .filter_map(|(key, _val)| {
+                // Fast prefix compare — avoids the full 6/7-segment
+                // split for out-of-zone keys.
+                if tuple_key::zone_of(&key) != Some(zone.as_str()) {
+                    return None;
+                }
+                // Soft-skip on decode failure — one malformed row
+                // does not wedge the listing.  A caller auditing
+                // for malformed rows should scan `store.list()`
+                // directly.
+                tuple_key::decode(&key).map(|(z, t)| TupleBody::from_pair(z, t))
+            })
+            .collect();
+        Ok::<_, ReBACTupleStoreError>(tuples)
+    })
+    .await
+    .map_err(|e| RebacError::Backend(format!("rebac list task panicked: {e}")))??;
+    Ok(Json(ListResponse { tuples }))
+}
+
+// ── Router ────────────────────────────────────────────────────────
+
+pub fn router() -> Router<AppState> {
+    Router::new()
+        .route("/v2/rebac/tuples", post(grant))
+        .route("/v2/rebac/tuples", delete(revoke))
+        .route("/v2/rebac/tuples", get(list))
+}

--- a/rust/services/http-api/src/lib.rs
+++ b/rust/services/http-api/src/lib.rs
@@ -84,6 +84,15 @@ pub use search_backend::{BackendError, SearchBackend};
 pub struct AppState {
     pub search: SearchBackend,
     pub auth: Arc<dyn AuthProvider>,
+    /// The kernel-adjacent ReBAC tuple store — grant / list / revoke
+    /// backend for `/v2/rebac/tuples`.  Present iff this crate was
+    /// built `--features rebac`; the composition root in `nexusd`
+    /// (also under `--features rebac`) passes the same
+    /// `RaftReBACTupleStore` the kernel's `PermissionProvider`
+    /// reads, so grants written via HTTP take effect on the next
+    /// permission check without a second SSOT.
+    #[cfg(feature = "rebac")]
+    pub rebac_store: Arc<dyn nexus_rebac::ReBACTupleStore>,
 }
 
 impl AppState {
@@ -98,10 +107,16 @@ impl AppState {
     /// Not for production — the composition root in `nexusd` builds
     /// the same struct field-by-field with the real `SearchBackend`
     /// target + `ApiKeyAuthProvider`.
+    ///
+    /// Under `--features rebac`, wires an in-memory store so rebac
+    /// route tests can exercise grant / list / revoke without a
+    /// live raft cluster.
     pub fn for_tests(grpc_target: impl Into<Arc<str>>) -> Self {
         Self {
             search: SearchBackend::new(grpc_target),
             auth: middleware::auth::default_no_auth_provider(),
+            #[cfg(feature = "rebac")]
+            rebac_store: Arc::new(nexus_rebac::InMemoryReBACTupleStore::new()),
         }
     }
 }
@@ -131,14 +146,18 @@ pub fn router(state: AppState) -> Router {
     let public_router = Router::new()
         .merge(handlers::status::router())
         .with_state(state.clone());
-    let protected_router = Router::new()
-        .merge(handlers::search::router())
-        .merge(handlers::documents::router())
-        .layer(from_fn_with_state(
+    let protected_router = {
+        let r = Router::new()
+            .merge(handlers::search::router())
+            .merge(handlers::documents::router());
+        #[cfg(feature = "rebac")]
+        let r = r.merge(handlers::rebac::router());
+        r.layer(from_fn_with_state(
             state.clone(),
             middleware::auth::require_bearer,
         ))
-        .with_state(state);
+        .with_state(state)
+    };
     Router::new().merge(public_router).merge(protected_router)
 }
 
@@ -232,6 +251,7 @@ pub async fn bind_and_serve(
 /// half-served request), but the "listener is up" invariant is
 /// established synchronously — matches `a2a::install_a2a_stamp_hook`
 /// which also fails install synchronously if setup errors.
+#[cfg(not(feature = "rebac"))]
 pub fn service_decl(
     addr: SocketAddr,
     upstream_grpc: String,
@@ -241,6 +261,28 @@ pub fn service_decl(
     kernel::kernel::ServiceDecl {
         name: "http_api".to_string(),
         install: Box::new(move |_kernel| install_impl(addr, upstream_grpc, auth, runtime)),
+    }
+}
+
+/// `--features rebac` variant of [`service_decl`] — takes the
+/// tuple store the composition root has already wired for the
+/// kernel's `PermissionProvider`, so grants written via
+/// `/v2/rebac/tuples` land in the same store the enforcer reads
+/// (no second SSOT).  Signature adds the last param; every other
+/// arg matches the feature-off version.
+#[cfg(feature = "rebac")]
+pub fn service_decl(
+    addr: SocketAddr,
+    upstream_grpc: String,
+    auth: Arc<dyn AuthProvider>,
+    runtime: tokio::runtime::Handle,
+    rebac_store: Arc<dyn nexus_rebac::ReBACTupleStore>,
+) -> kernel::kernel::ServiceDecl {
+    kernel::kernel::ServiceDecl {
+        name: "http_api".to_string(),
+        install: Box::new(move |_kernel| {
+            install_impl(addr, upstream_grpc, auth, runtime, rebac_store)
+        }),
     }
 }
 
@@ -260,10 +302,13 @@ pub fn install_impl(
     upstream_grpc: String,
     auth: Arc<dyn AuthProvider>,
     runtime: tokio::runtime::Handle,
+    #[cfg(feature = "rebac")] rebac_store: Arc<dyn nexus_rebac::ReBACTupleStore>,
 ) -> Result<(), String> {
     let state = AppState {
         search: SearchBackend::new(upstream_grpc),
         auth,
+        #[cfg(feature = "rebac")]
+        rebac_store,
     };
     // Bind synchronously so `install` surfaces the failure —
     // port-in-use / EACCES / bad interface all become an

--- a/rust/services/http-api/src/middleware/auth.rs
+++ b/rust/services/http-api/src/middleware/auth.rs
@@ -355,8 +355,8 @@ mod tests {
             "reached"
         }
         let state = AppState {
-            search: crate::SearchBackend::new("http://127.0.0.1:1"),
             auth: Arc::new(RejectAll),
+            ..AppState::for_tests("http://127.0.0.1:1")
         };
         let app: Router = Router::new()
             .route("/protected", axum::routing::get(inner_ok))
@@ -392,8 +392,8 @@ mod tests {
             "reached"
         }
         let state = AppState {
-            search: crate::SearchBackend::new("http://127.0.0.1:1"),
             auth: default_no_auth_provider(),
+            ..AppState::for_tests("http://127.0.0.1:1")
         };
         let app: Router = Router::new()
             .route("/protected", axum::routing::get(inner_ok))
@@ -431,8 +431,8 @@ mod tests {
             "reached"
         }
         let state = AppState {
-            search: crate::SearchBackend::new("http://127.0.0.1:1"),
             auth: default_no_auth_provider(),
+            ..AppState::for_tests("http://127.0.0.1:1")
         };
         let app: Router = Router::new()
             .route("/protected", axum::routing::get(inner_ok))
@@ -466,8 +466,8 @@ mod tests {
             "reached"
         }
         let state = AppState {
-            search: crate::SearchBackend::new("http://127.0.0.1:1"),
             auth: Arc::new(RejectAll),
+            ..AppState::for_tests("http://127.0.0.1:1")
         };
         let app: Router = Router::new()
             .route("/protected", axum::routing::get(inner_ok))
@@ -507,8 +507,8 @@ mod tests {
             ctx.user_id.clone()
         }
         let state = AppState {
-            search: crate::SearchBackend::new("http://127.0.0.1:1"),
             auth: default_no_auth_provider(), // returns "cluster-internal"
+            ..AppState::for_tests("http://127.0.0.1:1")
         };
         let app: Router = Router::new()
             .route("/protected", axum::routing::get(echo_user_id))

--- a/rust/services/http-api/tests/auth_middleware_e2e.rs
+++ b/rust/services/http-api/tests/auth_middleware_e2e.rs
@@ -192,6 +192,13 @@ impl Harness {
         let state = AppState {
             search: SearchBackend::new(grpc_target),
             auth,
+            // Under `--features rebac` (nexusd's `full` build path
+            // exercises this harness transitively via CI), AppState
+            // gains a `rebac_store` field.  Use the same in-memory
+            // default the `for_tests` helper wires — this middleware
+            // suite never hits `/v2/rebac/*`, so any store is fine.
+            #[cfg(feature = "rebac")]
+            rebac_store: std::sync::Arc::new(nexus_rebac::InMemoryReBACTupleStore::new()),
         };
         let (addr, fut) = bind_and_serve("127.0.0.1:0".parse().unwrap(), state)
             .await

--- a/rust/services/http-api/tests/rebac_e2e.rs
+++ b/rust/services/http-api/tests/rebac_e2e.rs
@@ -1,0 +1,315 @@
+//! Integration coverage for the `/v2/rebac/tuples` router.
+//!
+//! Real-chain shape: bind an ephemeral axum listener over an
+//! `AppState` whose `rebac_store` is an `InMemoryReBACTupleStore`
+//! (the raft-backed store needs a live 1-voter zone — covered in
+//! the nexus-rebac unit tests, not needed here).  Grants written
+//! via HTTP land in the same store a `list` reads back, so the
+//! wire and the SSOT stay in sync end-to-end.
+//!
+//! Gate: `#[cfg(feature = "rebac")]` — the test file is a no-op
+//! under the slim `http-api`-only build, matching the crate's
+//! feature-gated router.
+
+#![cfg(feature = "rebac")]
+
+use std::sync::Arc;
+
+use nexus_http_api::{bind_and_serve, AppState};
+use nexus_rebac::InMemoryReBACTupleStore;
+use serde_json::json;
+
+/// Bring up an axum listener on an ephemeral port with a fresh
+/// in-memory rebac store.  Returns the base URL callers `POST` /
+/// `GET` / `DELETE` against + a handle keeping the serve task
+/// alive (dropped at end of scope — tokio cancels the listener).
+async fn spawn_test_server() -> (String, tokio::task::JoinHandle<()>) {
+    let mut state = AppState::for_tests("http://127.0.0.1:1"); // never dialed
+    state.rebac_store = Arc::new(InMemoryReBACTupleStore::new());
+    let addr: std::net::SocketAddr = "127.0.0.1:0".parse().expect("parse addr");
+    let (bound, fut) = bind_and_serve(addr, state).await.expect("bind + serve");
+    let handle = tokio::spawn(async move {
+        let _ = fut.await;
+    });
+    (format!("http://{bound}"), handle)
+}
+
+/// POST `/v2/rebac/tuples` — direct-relation grant.  Immediately
+/// GET `?zone=...` and assert the tuple is listed.  Pins the "wire
+/// grant lands in the store" invariant end-to-end (encode → put →
+/// list → decode → JSON body match).
+#[tokio::test]
+async fn grant_then_list_reflects_the_new_tuple() {
+    let (base, _h) = spawn_test_server().await;
+    let client = reqwest::Client::new();
+
+    let body = json!({
+        "zone": "root",
+        "object_type": "file",
+        "object_id": "/root/doc",
+        "relation": "reader",
+        "subject_type": "user",
+        "subject_id": "alice",
+    });
+    let resp = client
+        .post(format!("{base}/v2/rebac/tuples"))
+        .json(&body)
+        .send()
+        .await
+        .expect("grant send");
+    assert_eq!(resp.status().as_u16(), 200, "grant must return 200");
+
+    let listed = client
+        .get(format!("{base}/v2/rebac/tuples?zone=root"))
+        .send()
+        .await
+        .expect("list send")
+        .json::<serde_json::Value>()
+        .await
+        .expect("list body");
+    assert_eq!(
+        listed["tuples"].as_array().expect("tuples array").len(),
+        1,
+        "the fresh zone must have exactly the grant we just wrote",
+    );
+    let t = &listed["tuples"][0];
+    assert_eq!(t["zone"], "root");
+    assert_eq!(t["object_type"], "file");
+    assert_eq!(t["object_id"], "/root/doc");
+    assert_eq!(t["relation"], "reader");
+    assert_eq!(t["subject_type"], "user");
+    assert_eq!(t["subject_id"], "alice");
+    assert!(
+        t.get("subject_relation").is_none() || t["subject_relation"].is_null(),
+        "direct tuple must not emit a subject_relation field",
+    );
+}
+
+/// Userset-as-subject grant (Zanzibar `subject_relation`) — the
+/// 7-segment path.  Pins that the extra field roundtrips through
+/// the wire encoder / decoder faithfully.
+#[tokio::test]
+async fn grant_userset_tuple_roundtrips_subject_relation() {
+    let (base, _h) = spawn_test_server().await;
+    let client = reqwest::Client::new();
+
+    let body = json!({
+        "zone": "root",
+        "object_type": "file",
+        "object_id": "/root/team-doc",
+        "relation": "reader",
+        "subject_type": "group",
+        "subject_id": "eng",
+        "subject_relation": "member",
+    });
+    let resp = client
+        .post(format!("{base}/v2/rebac/tuples"))
+        .json(&body)
+        .send()
+        .await
+        .expect("grant send");
+    assert_eq!(resp.status().as_u16(), 200);
+
+    let listed = client
+        .get(format!("{base}/v2/rebac/tuples?zone=root"))
+        .send()
+        .await
+        .expect("list send")
+        .json::<serde_json::Value>()
+        .await
+        .expect("list body");
+    assert_eq!(listed["tuples"][0]["subject_relation"], "member");
+}
+
+/// DELETE `/v2/rebac/tuples` — advisory `existed` = true on a
+/// present tuple, false on a missing one (idempotent).  Also
+/// asserts the grant is gone from the following `GET` — the store
+/// really removed it, not just reported success.
+#[tokio::test]
+async fn revoke_removes_the_tuple_and_reports_existence() {
+    let (base, _h) = spawn_test_server().await;
+    let client = reqwest::Client::new();
+
+    let body = json!({
+        "zone": "root",
+        "object_type": "file",
+        "object_id": "/root/doc",
+        "relation": "reader",
+        "subject_type": "user",
+        "subject_id": "alice",
+    });
+    // Grant first.
+    client
+        .post(format!("{base}/v2/rebac/tuples"))
+        .json(&body)
+        .send()
+        .await
+        .expect("grant");
+
+    // Revoke — must report existed=true.
+    let revoke_resp = client
+        .delete(format!("{base}/v2/rebac/tuples"))
+        .json(&body)
+        .send()
+        .await
+        .expect("revoke send")
+        .json::<serde_json::Value>()
+        .await
+        .expect("revoke body");
+    assert_eq!(revoke_resp["existed"], true, "must report existed=true");
+
+    // Re-revoke — must report existed=false (idempotent).
+    let re_revoke = client
+        .delete(format!("{base}/v2/rebac/tuples"))
+        .json(&body)
+        .send()
+        .await
+        .expect("re-revoke send")
+        .json::<serde_json::Value>()
+        .await
+        .expect("re-revoke body");
+    assert_eq!(
+        re_revoke["existed"], false,
+        "second revoke on the same tuple must report existed=false — \
+         the response gives a caller an audit signal without paying \
+         a not-found error",
+    );
+
+    // Listing must now be empty.
+    let listed = client
+        .get(format!("{base}/v2/rebac/tuples?zone=root"))
+        .send()
+        .await
+        .expect("list send")
+        .json::<serde_json::Value>()
+        .await
+        .expect("list body");
+    assert!(
+        listed["tuples"].as_array().unwrap().is_empty(),
+        "the store must actually remove the tuple, not just report success",
+    );
+}
+
+/// GET `?zone=` (empty) — 400, not 500 or empty result.  Pins the
+/// "zone is required" contract at the boundary.
+#[tokio::test]
+async fn list_without_zone_returns_400() {
+    let (base, _h) = spawn_test_server().await;
+    let resp = reqwest::get(format!("{base}/v2/rebac/tuples?zone="))
+        .await
+        .expect("list send");
+    assert_eq!(
+        resp.status().as_u16(),
+        400,
+        "empty zone must be rejected with 400, not silently listed",
+    );
+}
+
+/// Zone isolation on the wire: a grant in zone A does NOT appear
+/// in a listing of zone B, and vice-versa.  Pins the store's
+/// per-zone scoping through the HTTP surface.
+#[tokio::test]
+async fn zone_isolation_grant_in_a_invisible_in_b() {
+    let (base, _h) = spawn_test_server().await;
+    let client = reqwest::Client::new();
+
+    let mk = |zone: &str| {
+        json!({
+            "zone": zone,
+            "object_type": "file",
+            "object_id": "/doc",
+            "relation": "reader",
+            "subject_type": "user",
+            "subject_id": "alice",
+        })
+    };
+
+    client
+        .post(format!("{base}/v2/rebac/tuples"))
+        .json(&mk("zone_a"))
+        .send()
+        .await
+        .expect("grant A");
+
+    let listed_b: serde_json::Value = client
+        .get(format!("{base}/v2/rebac/tuples?zone=zone_b"))
+        .send()
+        .await
+        .expect("list B")
+        .json()
+        .await
+        .expect("list B body");
+    assert!(
+        listed_b["tuples"].as_array().unwrap().is_empty(),
+        "zone_b must not see zone_a's grant — the store's per-zone \
+         scoping must reach the HTTP surface",
+    );
+}
+
+/// A tuple segment containing the reserved `|` delimiter is a
+/// client input error — 400, not 502.  Regression pin against
+/// classifying every store error as a backend failure.
+#[tokio::test]
+async fn grant_with_pipe_in_segment_returns_400() {
+    let (base, _h) = spawn_test_server().await;
+    let body = json!({
+        "zone": "root",
+        "object_type": "file",
+        "object_id": "/root/bad|id",
+        "relation": "reader",
+        "subject_type": "user",
+        "subject_id": "alice",
+    });
+    let resp = reqwest::Client::new()
+        .post(format!("{base}/v2/rebac/tuples"))
+        .json(&body)
+        .send()
+        .await
+        .expect("grant send");
+    assert_eq!(
+        resp.status().as_u16(),
+        400,
+        "a pipe in a segment is client input error (400), not backend (502)",
+    );
+}
+
+/// A repeat grant on the same tuple is idempotent — 200 both
+/// times, and the listing shows exactly one entry (no dupes).
+/// Pins the idempotent-put contract at the HTTP boundary.
+#[tokio::test]
+async fn repeat_grant_is_idempotent_no_duplicate_listing() {
+    let (base, _h) = spawn_test_server().await;
+    let client = reqwest::Client::new();
+    let body = json!({
+        "zone": "root",
+        "object_type": "file",
+        "object_id": "/doc",
+        "relation": "reader",
+        "subject_type": "user",
+        "subject_id": "alice",
+    });
+    for _ in 0..3 {
+        let r = client
+            .post(format!("{base}/v2/rebac/tuples"))
+            .json(&body)
+            .send()
+            .await
+            .expect("grant");
+        assert_eq!(r.status().as_u16(), 200);
+    }
+    let listed: serde_json::Value = client
+        .get(format!("{base}/v2/rebac/tuples?zone=root"))
+        .send()
+        .await
+        .expect("list")
+        .json()
+        .await
+        .expect("list body");
+    assert_eq!(
+        listed["tuples"].as_array().unwrap().len(),
+        1,
+        "3 identical grants must produce exactly 1 listed entry — \
+         a regression would surface as a duplicate row a graph rebuild \
+         silently deduplicates (masking the write-side bug)",
+    );
+}

--- a/rust/services/http-api/tests/serve_e2e.rs
+++ b/rust/services/http-api/tests/serve_e2e.rs
@@ -110,6 +110,12 @@ async fn service_decl_install_body_runs_under_a_tokio_runtime() {
         "http://127.0.0.1:1".to_string(),
         default_no_auth_provider(),
         handle,
+        // The `--features rebac` build widens `install_impl` with a
+        // tuple-store arg — use the same in-memory default the
+        // `AppState::for_tests` helper wires (this test never hits
+        // `/v2/rebac/*`, so any store is fine).
+        #[cfg(feature = "rebac")]
+        std::sync::Arc::new(nexus_rebac::InMemoryReBACTupleStore::new()),
     );
     assert!(
         result.is_ok(),
@@ -146,6 +152,8 @@ async fn service_decl_install_body_returns_err_on_bind_failure() {
         "http://127.0.0.1:1".to_string(),
         default_no_auth_provider(),
         handle.clone(),
+        #[cfg(feature = "rebac")]
+        std::sync::Arc::new(nexus_rebac::InMemoryReBACTupleStore::new()),
     );
     assert!(first.is_ok(), "first install must succeed; got {first:?}");
 
@@ -156,6 +164,8 @@ async fn service_decl_install_body_returns_err_on_bind_failure() {
         "http://127.0.0.1:1".to_string(),
         default_no_auth_provider(),
         handle,
+        #[cfg(feature = "rebac")]
+        std::sync::Arc::new(nexus_rebac::InMemoryReBACTupleStore::new()),
     );
     let err = second.expect_err("second install on same addr must Err");
     assert!(


### PR DESCRIPTION
## Summary

**Last piece of the ReBAC arc** (R10 epic #4674). Ships the HTTP grant / list / revoke over the same \`RaftReBACTupleStore\` the kernel's \`PermissionProvider\` reads. One SSOT, two surfaces (HTTP + syscall enforcer).

- \`POST   /v2/rebac/tuples\` — grant (idempotent)
- \`DELETE /v2/rebac/tuples\` — revoke (advisory \`existed\` flag)
- \`GET    /v2/rebac/tuples?zone=<zone>\` — list zone tuples

**Feature-gated**: only \`--features http-api,rebac\` (or \`--features full\`) mounts the router. Slim \`http-api\` build stays out of \`lib::rebac\`'s Zanzibar substrate weight; slim \`cluster\` build unchanged.

## Design decisions

- **Shared \`Arc<dyn ReBACTupleStore>\`.** \`nexusd::main\` builds the raft-backed store ONCE inside \`run_with_services\`, clones the Arc into both the http-api decl AND the enforcer decl. A grant on the wire is visible to the next syscall check on the same node — no eventual consistency to reason about.
- **Feature chain \`nexus-http-api?/rebac\`.** \`nexusd\`'s \`rebac\` feature propagates into http-api's \`rebac\` feature ONLY IF http-api is also enabled — so standalone \`--features rebac\` (enforcer only, no HTTP surface) stays a valid mode.
- **Bearer-protected.** Same middleware sub-router as \`/v2/search/*\`. Any authenticated caller can grant / revoke (tuples are cluster-wide-trusted control-plane state, not user data). A future revision may layer \`is_admin OR (grant delegates)\`.
- **String wire format.** Body fields mirror \`nexus_rebac::tuple_key\` 1:1 (\`zone\` / \`object_type\` / ...); the handler encodes to the pipe-delimited key at the store boundary so raft-log dumps stay operator-inspectable.
- **Fail-loud on \`|\` in a segment.** 400 (client input error), not 502 (backend). \`RebacError::From<ReBACTupleStoreError>\` peeks the error message for the encoder's stable \"reserved delimiter\" substring — the store's only input-shape rejection.

## AppState struct-update refactor

Existing tests that built \`AppState { search, auth }\` literally would break under \`--features rebac\` (the new \`rebac_store\` field missing). Rewritten via \`..AppState::for_tests(target)\` so any future additive field flows through without touching every test.

## Test plan

- [x] \`cargo test -p nexus-http-api --features rebac\` → 7 new rebac_e2e + prior 15 all green
- [x] Build sweep — every combo compiles clean:
    - \`cargo build -p nexusd\` (slim)
    - \`cargo build -p nexusd --features http-api\`
    - \`cargo build -p nexusd --features rebac\`
    - \`cargo build -p nexusd --features http-api,rebac\`
    - \`cargo build -p nexusd --features full\`
- [x] \`cargo clippy -p nexus-http-api --all-targets -- -D warnings\` clean (slim + \`--features rebac\`)
- [x] \`cargo fmt -p nexus-http-api -p nexusd -- --check\` clean
- [ ] CI green

## R10 ReBAC arc — done

| PR | State |
|---|---|
| #4721 crate skeleton | ✅ |
| #4724 RaftReBACTupleStore | ✅ |
| #4727 tuple_key + graph cache | ✅ |
| #4730 enforcer facade | ✅ |
| #4731 nexusd wire (\`--features full\`) | ✅ |
| **#(this) HTTP router** | 🟡 in review |

Python \`src/nexus/bricks/rebac/\` delete (~37k LoC) lands as a **separate follow-up** once callers of the Python HTTP surface are verified to be either (a) migrated to \`/v2/rebac/tuples\` or (b) part of the Python \`nexus-server\` being retired.