### PR TITLE
feat(consistency): read-your-writes revision token for reads, lists and search (#4737)

### DIFF
--- a/docs/architecture/consistency-contract.md
+++ b/docs/architecture/consistency-contract.md
@@ -1,0 +1,272 @@
+# Consistency Contract: kernel, server, tenant
+
+Issue: nexi-lab/nexus#4737 (read-your-writes revision token). Companions:
+`mount-routing-ssot-gap.md` (mount table vs metastore), #4736 (write → searchable,
+`index_seq`), #4741 (conformance suite).
+
+This document is the published consistency contract for a Nexus deployment.
+Section 2 records what the pinned kernel (`nexus-vfs` at the rev in
+`Cargo.lock`) guarantees today, with file pointers so the claims can be
+re-verified. Section 3 defines the **revision token** the server exposes,
+which needs nothing beyond that kernel. Section 5 lists optional kernel
+work that would extend the token. Cross-node read fixes that were previously
+narrated only in `Cargo.toml` comments (PR #108 `try_remote_fetch` for
+`sys_readdir`, PR #138 "read ⊥ cache ⊥ materialize", content_id stamping)
+are summarised in §2.3 and §2.4; the `Cargo.toml` comments remain a
+changelog, not a contract.
+
+## 1. Vocabulary
+
+| Term | Meaning |
+|------|---------|
+| zone | One raft group with its own log and state machine (`root`, `corp-eng`, …). A zone is mounted into the global VFS at one or more paths (`DT_MOUNT` rows). |
+| `gen` | Per-path content generation stored in the file's metadata row; increments on every write to that path and is returned by `write` and `stat`. |
+| `commit_index` | Highest log index a quorum has durably accepted. May run ahead of the state machine (`raft/src/raft/node.rs`, `commit_index()` doc: "Do not gate reads on this value"). |
+| `applied_index` | Highest log index the **local** state machine has applied. "A reader that sees `applied_index >= N` is guaranteed to also see every state-machine effect of log entries with `index <= N`" (`node.rs`, `applied_index()`). |
+| revision token | `<anchor>@<index>`: `/ws/a.txt@7` (path + gen, what writes return) or `root@1234` (zone + applied_index, optional). §3. |
+| mount table | `MountTable::entries` (Rust, in-memory, per kernel) that `route()` consults to pick the metastore for a path. |
+| dcache | Kernel dentry/metadata cache in front of the per-zone state machine. |
+
+## 2. What the kernel guarantees today
+
+### 2.1 Mutations are strongly consistent on the leader
+
+`sys_write`, `sys_unlink`, `sys_rename`, `sys_mkdir`, `sys_setattr` on a
+federation mount go through `ZoneMetaStore` → `ZoneConsensus::propose`
+(`raft/src/zone_meta_store.rs`, "Write consistency": put / delete / CAS /
+`append_stream_entry` are SC; the EC plane is opt-in for metadata registers
+only). A proposal's completion is signalled from `apply_entries`
+(`node.rs`, `proposal.tx.send(Ok(result))` inside `apply_entries`), so:
+
+* When a mutation RPC returns on the **leader**, the leader's state machine
+  has applied it.
+* When the mutation was issued on a **follower**, the proposal is forwarded
+  (`forward_to_leader`) and the reply comes from the leader. The follower's
+  own state machine may still be behind when the RPC returns. Writing on a
+  follower and immediately reading on the same follower is therefore *not*
+  read-your-writes without the fence in §3.
+* Raft applies committed entries **in log order** on every node. This is
+  what makes a per-path fence sufficient for whole-zone visibility (§3.4).
+
+### 2.2 Metadata reads are local (sequentially consistent)
+
+`sys_stat`, `sys_readdir`, `exists`, list and every other metadata lookup
+read the **local** state machine (`node.rs`, `with_state_machine`: "on a
+follower may be behind the leader by up to the replication lag,
+ZooKeeper-default style"). Only `get_lock` / `list_locks` use the ReadIndex
+protocol (`read_linearizable`). A follower can legitimately return
+`found=false` / `metadata: None` for a path the leader has already applied.
+That is the gap the revision token closes.
+
+### 2.3 Content reads: local backend, then origin fetch, no cache-back
+
+`sys_read` resolves metadata locally, then reads content from the mount's
+backend by `content_id` (`kernel/src/kernel/syscall_impl.rs`, step 5/7). On a
+backend miss with metadata present it calls `try_remote_fetch`: the
+*virtual path* is sent to the node named in `last_writer_address` via the
+`ReadBlob` RPC and that peer self-routes through its own `VFSRouter`. The
+fetch is a pure read — **no local cache-back** (nexus-vfs PR #138) — and
+returns `FileNotFound` when `last_writer_address` is unset, equals this
+node, or the remote call fails. `sys_readdir` has the same
+"sender dispatches, remote handles" peer path (PR #108). A writer-side node
+reading its own placeholder entry serves bytes from the federation cache
+(`federation_cache_substitution_read`).
+
+Consequence: once metadata is applied locally (§3 fence satisfied), a read
+on any node either returns the bytes or fails loudly; it does not return
+stale bytes for the new `content_id`.
+
+### 2.4 dcache invalidation is apply-side
+
+Each zone installs an apply-side invalidation callback
+(`Kernel::install_zone_apply_invalidator`, wired from
+`ZoneMetaStore::new`; `raft/src/raft/state_machine.rs`
+"Apply-side invalidation callback — fires once per committed metadata
+mutation"). The callback fans out to every mount point that shares the
+zone's `coherence_key` (`kernel/src/core/vfs_router.rs`,
+`mount_points_for_coherence_key`), so crosslink mounts of one zone are
+invalidated together. A dcache entry therefore cannot outlive the apply of
+the mutation that changed it, and a `sys_stat` that shows the new `gen`
+is not a cache artefact.
+
+### 2.5 Mount table can lag the metastore
+
+Mount topology lives in two stores (raft `DT_MOUNT` rows and
+`MountTable::entries`) joined by a Rust → Python → Rust callback chain. Until
+the chain has run on a freshly (re)started follower, `route()` misroutes and
+`sys_stat` returns `metadata: None` **even when the raft log has caught
+up**. Full analysis and the kernel-side fix are in
+`mount-routing-ssot-gap.md`. Under the §3 fence this window is *visible*
+rather than silent: the anchor path stats as absent, so the fenced read
+waits and then answers 412 instead of an empty result.
+
+### 2.6 What the pinned kernel does *not* expose
+
+* No gRPC response carries `applied_index`. `WriteResponse` is
+  `{content_id, size, gen}`; `StatResponse` has `gen` but no zone revision.
+* `Call("federation_cluster_info")` is **not** served by `nexusd-cluster`
+  (`rust/transport/src/call_dispatch.rs` only dispatches agent / mount-point
+  / service ops; anything else is `unknown Call method`). The Python
+  `FederationRPCService.federation_cluster_info` therefore returns the
+  standalone stub with `applied_index: 0`.
+* `stat("/__sys__/zones/<id>")` is a placeholder (`version: 0`, `gen: 0`).
+* `_nexus_raft.pyi` (`is_committed`, `set_metadata(consistency=…)`)
+  describes the retired PyO3 module. Python talks to the kernel over gRPC
+  (`KernelClient`), so `is_committed` is unreachable from Python by
+  construction — the "zero callers" observation in #4737 is structural.
+
+None of this blocks the token: the per-path `gen` that `write` and `stat`
+already return is enough (§3).
+
+## 3. Revision token (server ↔ tenant)
+
+Implemented in `nexus` (`src/nexus/lib/zone_revision.py`,
+`src/nexus/server/api/v2/_revision_fence.py`). Works on the pinned kernel.
+
+### 3.1 Token
+
+```
+revision = "<path>@<gen>"          e.g. /ws/a.txt@7      (returned by writes)
+revision = "<zone_id>@<index>"     e.g. root@1234        (optional, kernel-stamped)
+```
+
+The anchor is everything before the **last** `@`, so paths containing `@`
+are fine. An anchor starting with `/` is a path; anything else is a zone
+id; a bare integer is a zone token for `root`. Only the path form is
+emitted today; the zone form is accepted so a kernel that later stamps
+`zone_id` / `applied_index` on mutation responses (§5) needs no server
+change.
+
+### 3.2 Where mutations return it
+
+| Surface | Field | Header |
+|---------|-------|--------|
+| `POST /api/v2/files/write` | `revision` | `X-Nexus-Revision` |
+| `POST /api/v2/files/batch/write` | `results[].revision` | — |
+| `POST /api/v2/files/copy` | `revision` (destination write) | `X-Nexus-Revision` |
+| `DELETE /api/v2/files/delete`, `POST /api/v2/files/rename` | `revision` | `X-Nexus-Revision` |
+| `NexusFS.write / sys_write / write_batch` | `"revision"` key in the returned dict | — |
+
+Writes always carry `/path@gen`. Delete and rename have no gen to anchor on
+and return `null` unless the kernel stamps a zone revision; a tenant that
+needs to fence a delete waits for the parent listing to drop the entry, or
+fences on the next write it makes. `mkdir` returns `None` on the Python API
+and is a follow-up.
+
+### 3.3 How reads consume it
+
+Request (either form; header wins):
+
+```
+X-Nexus-Min-Revision: /ws/a.txt@7      ?min_revision=/ws/a.txt@7
+X-Nexus-Revision-Timeout-Ms: 5000      ?revision_timeout_ms=5000
+```
+
+Default timeout 5 000 ms, maximum 30 000 ms, `0` probes once. Applied to:
+
+* files: `read`, `metadata`, `exists`, `list`, `glob`, `grep`, `stream`,
+  `batch-read`, `batch/read`
+* search: `query`, `query/batch`, `grep` (GET and POST), `glob` (GET and POST)
+
+The fence runs `sys_stat(anchor)` on the serving node **under the caller's
+OperationContext** (permission hooks apply, so it is not an existence
+oracle for paths the caller cannot read) and compares `gen`:
+
+| Outcome | Status | Body / headers |
+|---------|--------|----------------|
+| `stat(anchor).gen >= index` within the timeout | 200 (normal response) | `X-Nexus-Revision: <anchor>@<observed gen>` |
+| Not reached before the timeout (path absent counts as gen 0) | **412 Precondition Failed** | `detail.error = revision_not_applied`, `detail.min_revision`, `detail.current_revision`, `detail.waited_ms`; header `X-Nexus-Revision: <anchor>@<current>` |
+| Zone token on a kernel that cannot report `applied_index` | **501 Not Implemented** | `detail.error = zone_revision_unavailable` |
+| Zone token, kernel probe failed (transport) | 503 | `detail.error = zone_revision_probe_failed` |
+| Malformed token / timeout | 400 | — |
+
+A fenced read never answers with `metadata: None` or an empty listing
+because the node is behind: it waits, then either serves state that
+includes the write or says 412 with the revision it *does* have. Unfenced
+reads are unchanged (no header, no extra round-trip).
+
+### 3.4 What the fence guarantees
+
+* **Same path**: `read`, `metadata`, `exists`, `stream` of the anchor see
+  the write's metadata and `content_id` (§2.2, §2.4).
+* **Same zone**: because raft applies in order (§2.1), a node whose stat
+  shows the anchor at `gen >= G` has applied every earlier entry of that
+  zone. `list`, `glob`, `grep` and `search` over that zone therefore
+  include the write and everything the same client wrote before it.
+* **Content**: `sys_read` may still fetch bytes from the origin node
+  (§2.3). It returns the written bytes or fails; never older bytes.
+* **Search**: `min_revision` on `/search/*` fences the VFS state the search
+  plugin reads from. Whether the write is *indexed* is the `index_seq`
+  contract of #4736 (`/search/stats.last_index_seq >= index_seq` returned by
+  index-on-write). A tenant that needs "written and searchable" checks both.
+* **Other zones**: a token fences only the zone that owns its anchor. A
+  listing that spans mounts of several zones is fenced for the anchor's
+  zone only.
+
+Known edge: a path that is deleted and re-created starts a new `gen`
+sequence, so a token from the old life may never be satisfied and yields
+412 after the timeout. Use the token from the latest write.
+
+### 3.5 Tenant guidance
+
+1. Keep `revision` from every write response next to the `content_id`.
+2. Send it as `X-Nexus-Min-Revision` on the read, list or search that must
+   observe the write (any node behind the same load balancer).
+3. `412` means "this node has not applied it yet": retry after the returned
+   `current_revision` advances, or route to another node.
+4. Batches: fence on the token of the item you are about to read, or on
+   the last item's token to cover the whole batch.
+
+Example:
+
+```bash
+curl -s -X POST "$NEXUS/api/v2/files/write" -H "Authorization: Bearer $KEY" \
+  -d '{"path":"/ws/a.txt","content":"hello"}'
+# {"content_id":"…","version":3,"size":5,"modified_at":"…","revision":"/ws/a.txt@3"}
+
+curl -s -D - "$NEXUS/api/v2/files/list?path=/ws" -H "Authorization: Bearer $KEY" \
+  -H "X-Nexus-Min-Revision: /ws/a.txt@3"
+# HTTP/1.1 200 OK            (or 412 with current_revision)
+# X-Nexus-Revision: /ws/a.txt@3
+```
+
+## 4. Readiness
+
+`/healthz/ready` is unchanged by #4737. While a freshly restarted follower's
+mount table lags the metastore (§2.5) fenced reads on that node answer 412,
+so the window is observable and retryable rather than silent. Gating
+readiness on mount-table convergence needs a kernel signal (§5 item 3) and
+stays with `mount-routing-ssot-gap.md`.
+
+## 5. Optional kernel work (nexus-vfs)
+
+Nothing here is required for §3. Each item widens the token and is
+consumed by the server already, tolerant of absence:
+
+1. **Stamp mutations with a zone revision.** Add `string zone_id` and
+   `uint64 applied_index` to `WriteResponse`, `BatchWriteItemResponse`,
+   `DeleteResponse`, `RenameResponse`, `MkdirResponse`, `CopyResponse`
+   (`proto/nexus/grpc/vfs/vfs.proto`). Gives delete and rename a token and
+   lets a client fence "everything so far" with one number instead of a
+   path. `KernelClient` reads the fields via `revision_fields()` and
+   `revision_from_result()` prefers them over the path form.
+2. **Serve `Call("federation_cluster_info", {"zone_id"})`** from
+   `call_dispatch.rs` → `DistributedCoordinator::cluster_info` as JSON
+   (`zone_id, node_id, has_store, is_leader, leader_id, term, commit_index,
+   applied_index, voter_count, witness_count, links_count`). This is what
+   `read_zone_revision` polls for zone tokens; without it they answer 501.
+3. **Mount convergence signal** (`Call("federation_mount_convergence")` or
+   a `/__sys__/mounts` view) plus the apply-side `add_mount` callback from
+   `mount-routing-ssot-gap.md`, so readiness can gate on it.
+4. **Retire `_nexus_raft.pyi`** or mark it as the description of an
+   internal Rust API; nothing in `src/` can import it.
+
+## 6. Acceptance (tracked in #4741)
+
+* Embedded, remote and 2-node federated: write returns `revision = R`;
+  `read`, `list`, `glob`, `grep` and `search/query` with `min_revision = R`
+  observe the write, on the leader and on the follower.
+* A follower asked for a revision it has not applied within the timeout
+  returns 412 with `current_revision`, never `metadata: None`.
+* A zone token on a kernel without §5 items 1–2 is 501; no test may pass by
+  treating that as success.

--- a/docs/architecture/mount-routing-ssot-gap.md
+++ b/docs/architecture/mount-routing-ssot-gap.md
@@ -134,3 +134,8 @@ and the test hits it deterministically.
 - Workaround for PR #3765: the `applied_index` gate + tight raft
   transport keepalive shrinks the window enough that most runs pass,
   but the test remains flaky on slow hosts.
+- nexi-lab/nexus#4737: a read fenced with `X-Nexus-Min-Revision`
+  (`consistency-contract.md` §3) stats the written path first, so in the
+  window above it answers 412 with the revision this node has instead of
+  `metadata: None`. Readiness still does not gate on convergence; that
+  needs the kernel signal listed in `consistency-contract.md` §5.

--- a/docs/guides/user-guide.md
+++ b/docs/guides/user-guide.md
@@ -1045,6 +1045,38 @@ A second acquirer of a held lock is refused/blocked; release frees it.
   migration-only**, sunset **2026-06-25** (Issue #1133). Use gRPC `Call` or
   the typed `Read`/`Write`/`Delete` RPCs (what the CLI uses).
 
+### Read-your-writes across nodes (revision token)
+
+In a multi-node deployment a read can land on a follower that has not yet
+applied your write. Every write returns a **revision token** you can fence a
+later read on (Issue #4737):
+
+```bash
+curl -s -X POST "$NEXUS/api/v2/files/write" -H "Authorization: Bearer $KEY" \
+  -H 'Content-Type: application/json' -d '{"path":"/w/a.txt","content":"hello"}'
+# {"content_id":"…","version":3,"size":5,"modified_at":"…","revision":"/w/a.txt@3"}
+
+curl -s -D - "$NEXUS/api/v2/files/list?path=/w" -H "Authorization: Bearer $KEY" \
+  -H "X-Nexus-Min-Revision: /w/a.txt@3" -H "X-Nexus-Revision-Timeout-Ms: 5000"
+# 200 + X-Nexus-Revision: /w/a.txt@3   — this node has applied the write
+# 412 + current_revision in the body    — this node is still behind
+```
+
+- `revision` (also the `X-Nexus-Revision` header) is `"<path>@<gen>"` on
+  `files/write`, `files/batch/write` (per item) and `files/copy`. Because
+  raft applies entries in order, a node that shows the path at that gen has
+  applied every earlier write in the zone, so listings, glob, grep and
+  search include it too.
+- `X-Nexus-Min-Revision` (or `?min_revision=`) is honoured by `files/read`,
+  `metadata`, `exists`, `list`, `glob`, `grep`, `stream`, `batch-read`,
+  `batch/read` and `search/query`, `search/query/batch`, `search/grep`,
+  `search/glob`. Timeout via `X-Nexus-Revision-Timeout-Ms` /
+  `?revision_timeout_ms=` (default 5000, max 30000, 0 = probe once).
+- Search visibility is a separate contract: `min_revision` fences the files
+  the search plugin can see, `index_seq` (§5) tells you the write is indexed.
+
+Full semantics: [Consistency Contract](../architecture/consistency-contract.md).
+
 ### Performance (guidance, not CI gates)
 
 Hot paths benchmarked in `tests/benchmarks/bench_read_write_overhead.py`

--- a/docs/surface-coverage/api-rpc-surface-coverage.yaml
+++ b/docs/surface-coverage/api-rpc-surface-coverage.yaml
@@ -513,7 +513,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.agent_registry
-      source: src/nexus/remote/kernel_client.py:1133
+      source: src/nexus/remote/kernel_client.py:1140
   profiles:
     lite: supported
     sandbox: supported
@@ -1018,7 +1018,7 @@ operations:
   transports:
     http:
       name: POST /batch/read
-      source: src/nexus/server/api/v2/routers/async_files.py:2094
+      source: src/nexus/server/api/v2/routers/async_files.py:2176
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1037,7 +1037,7 @@ operations:
   transports:
     http:
       name: POST /batch/write
-      source: src/nexus/server/api/v2/routers/async_files.py:2010
+      source: src/nexus/server/api/v2/routers/async_files.py:2091
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1056,7 +1056,7 @@ operations:
   transports:
     http:
       name: POST /copy
-      source: src/nexus/server/api/v2/routers/async_files.py:2270
+      source: src/nexus/server/api/v2/routers/async_files.py:2370
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1075,7 +1075,7 @@ operations:
   transports:
     http:
       name: POST /copy-bulk
-      source: src/nexus/server/api/v2/routers/async_files.py:2369
+      source: src/nexus/server/api/v2/routers/async_files.py:2477
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1094,7 +1094,7 @@ operations:
   transports:
     http:
       name: DELETE /delete
-      source: src/nexus/server/api/v2/routers/async_files.py:1541
+      source: src/nexus/server/api/v2/routers/async_files.py:1582
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1112,7 +1112,7 @@ operations:
   transports:
     http:
       name: GET /exists
-      source: src/nexus/server/api/v2/routers/async_files.py:1617
+      source: src/nexus/server/api/v2/routers/async_files.py:1667
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1130,7 +1130,7 @@ operations:
   transports:
     http:
       name: GET /glob
-      source: src/nexus/server/api/v2/routers/async_files.py:2446
+      source: src/nexus/server/api/v2/routers/async_files.py:2554
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1148,7 +1148,7 @@ operations:
   transports:
     http:
       name: GET /grep
-      source: src/nexus/server/api/v2/routers/async_files.py:2497
+      source: src/nexus/server/api/v2/routers/async_files.py:2613
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1167,7 +1167,7 @@ operations:
   transports:
     http:
       name: GET /list
-      source: src/nexus/server/api/v2/routers/async_files.py:1646
+      source: src/nexus/server/api/v2/routers/async_files.py:1704
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1185,7 +1185,7 @@ operations:
   transports:
     http:
       name: GET /md-structure
-      source: src/nexus/server/api/v2/routers/async_files.py:1443
+      source: src/nexus/server/api/v2/routers/async_files.py:1484
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1203,7 +1203,7 @@ operations:
   transports:
     http:
       name: GET /metadata
-      source: src/nexus/server/api/v2/routers/async_files.py:1922
+      source: src/nexus/server/api/v2/routers/async_files.py:1987
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1221,7 +1221,7 @@ operations:
   transports:
     http:
       name: POST /mkdir
-      source: src/nexus/server/api/v2/routers/async_files.py:1884
+      source: src/nexus/server/api/v2/routers/async_files.py:1949
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1239,7 +1239,7 @@ operations:
   transports:
     http:
       name: GET /read
-      source: src/nexus/server/api/v2/routers/async_files.py:910
+      source: src/nexus/server/api/v2/routers/async_files.py:945
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1257,7 +1257,7 @@ operations:
   transports:
     http:
       name: GET /read-url
-      source: src/nexus/server/api/v2/routers/async_files.py:1279
+      source: src/nexus/server/api/v2/routers/async_files.py:1320
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1276,7 +1276,7 @@ operations:
   transports:
     http:
       name: POST /rename
-      source: src/nexus/server/api/v2/routers/async_files.py:2232
+      source: src/nexus/server/api/v2/routers/async_files.py:2326
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1294,7 +1294,7 @@ operations:
   transports:
     http:
       name: POST /rename-batch
-      source: src/nexus/server/api/v2/routers/async_files.py:2327
+      source: src/nexus/server/api/v2/routers/async_files.py:2435
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1312,7 +1312,7 @@ operations:
   transports:
     http:
       name: GET /stream
-      source: src/nexus/server/api/v2/routers/async_files.py:2168
+      source: src/nexus/server/api/v2/routers/async_files.py:2255
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1330,7 +1330,7 @@ operations:
   transports:
     http:
       name: POST /write
-      source: src/nexus/server/api/v2/routers/async_files.py:684
+      source: src/nexus/server/api/v2/routers/async_files.py:716
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1757,7 +1757,7 @@ operations:
   transports:
     grpc_expose:
       name: backfill_directory_index
-      source: src/nexus/core/nexus_fs_metadata.py:2047
+      source: src/nexus/core/nexus_fs_metadata.py:2052
     sdk:
       name: MCPClient.backfill_directory_index
       source: src/nexus/remote/domain/mcp.py:91
@@ -1930,7 +1930,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.close_all_pipes
-      source: src/nexus/remote/kernel_client.py:1012
+      source: src/nexus/remote/kernel_client.py:1018
   profiles:
     lite: supported
     sandbox: supported
@@ -1947,7 +1947,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.close_all_streams
-      source: src/nexus/remote/kernel_client.py:1065
+      source: src/nexus/remote/kernel_client.py:1071
   profiles:
     lite: supported
     sandbox: supported
@@ -1964,7 +1964,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.close_pipe
-      source: src/nexus/remote/kernel_client.py:1002
+      source: src/nexus/remote/kernel_client.py:1008
   profiles:
     lite: supported
     sandbox: supported
@@ -1981,7 +1981,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.close_stream
-      source: src/nexus/remote/kernel_client.py:1056
+      source: src/nexus/remote/kernel_client.py:1062
   profiles:
     lite: supported
     sandbox: supported
@@ -2199,7 +2199,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.count_by_state
-      source: src/nexus/remote/kernel_client.py:1608
+      source: src/nexus/remote/kernel_client.py:1660
   profiles:
     lite: supported
     sandbox: supported
@@ -2233,7 +2233,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.create_pipe
-      source: src/nexus/remote/kernel_client.py:994
+      source: src/nexus/remote/kernel_client.py:1000
   profiles:
     lite: supported
     sandbox: supported
@@ -2267,7 +2267,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.create_stream
-      source: src/nexus/remote/kernel_client.py:1019
+      source: src/nexus/remote/kernel_client.py:1025
   profiles:
     lite: supported
     sandbox: supported
@@ -2507,7 +2507,7 @@ operations:
   transports:
     grpc_expose:
       name: delete_batch
-      source: src/nexus/core/nexus_fs_metadata.py:1440
+      source: src/nexus/core/nexus_fs_metadata.py:1445
   profiles:
     lite: supported
     sandbox: supported
@@ -2580,7 +2580,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.destroy_pipe
-      source: src/nexus/remote/kernel_client.py:998
+      source: src/nexus/remote/kernel_client.py:1004
   profiles:
     lite: supported
     sandbox: supported
@@ -2597,7 +2597,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.destroy_stream
-      source: src/nexus/remote/kernel_client.py:1061
+      source: src/nexus/remote/kernel_client.py:1067
   profiles:
     lite: supported
     sandbox: supported
@@ -2703,7 +2703,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.dispatch_post_hooks
-      source: src/nexus/remote/kernel_client.py:748
+      source: src/nexus/remote/kernel_client.py:754
   profiles:
     lite: supported
     sandbox: supported
@@ -2720,7 +2720,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.dispatch_pre_hooks
-      source: src/nexus/remote/kernel_client.py:755
+      source: src/nexus/remote/kernel_client.py:761
   profiles:
     lite: supported
     sandbox: supported
@@ -2737,7 +2737,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.dispatch_pre_hooks_batch_stat
-      source: src/nexus/remote/kernel_client.py:783
+      source: src/nexus/remote/kernel_client.py:789
   profiles:
     lite: supported
     sandbox: supported
@@ -2863,10 +2863,10 @@ operations:
   transports:
     grpc_expose:
       name: exists_batch
-      source: src/nexus/core/nexus_fs_metadata.py:1335
+      source: src/nexus/core/nexus_fs_metadata.py:1340
     sdk:
       name: KernelClient.exists_batch
-      source: src/nexus/remote/kernel_client.py:809
+      source: src/nexus/remote/kernel_client.py:815
   profiles:
     lite: supported
     sandbox: supported
@@ -3215,7 +3215,7 @@ operations:
       source: src/nexus/cli/commands/file_ops.py:1
     grpc_expose:
       name: append
-      source: src/nexus/core/nexus_fs_content.py:1080
+      source: src/nexus/core/nexus_fs_content.py:1092
   profiles:
     lite: supported
     sandbox: supported
@@ -3336,7 +3336,7 @@ operations:
   transports:
     grpc_expose:
       name: edit
-      source: src/nexus/core/nexus_fs_content.py:1201
+      source: src/nexus/core/nexus_fs_content.py:1213
   profiles:
     lite: supported
     sandbox: supported
@@ -3723,7 +3723,7 @@ operations:
       source: src/nexus/cli/commands/file_ops.py:1
     grpc_expose:
       name: stat
-      source: src/nexus/core/nexus_fs_metadata.py:1115
+      source: src/nexus/core/nexus_fs_metadata.py:1120
   profiles:
     lite: supported
     sandbox: supported
@@ -3758,7 +3758,7 @@ operations:
   transports:
     grpc_expose:
       name: stream
-      source: src/nexus/core/nexus_fs_content.py:479
+      source: src/nexus/core/nexus_fs_content.py:480
   profiles:
     lite: supported
     sandbox: supported
@@ -3850,7 +3850,7 @@ operations:
   transports:
     grpc_expose:
       name: flush_write_observer
-      source: src/nexus/core/nexus_fs_metadata.py:2077
+      source: src/nexus/core/nexus_fs_metadata.py:2082
   profiles:
     lite: supported
     sandbox: supported
@@ -3952,7 +3952,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.get
-      source: src/nexus/remote/kernel_client.py:1555
+      source: src/nexus/remote/kernel_client.py:1607
   profiles:
     lite: supported
     sandbox: supported
@@ -3969,7 +3969,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.heartbeat
-      source: src/nexus/remote/kernel_client.py:1581
+      source: src/nexus/remote/kernel_client.py:1633
   profiles:
     lite: supported
     sandbox: supported
@@ -4020,7 +4020,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.open
-      source: src/nexus/remote/kernel_client.py:306
+      source: src/nexus/remote/kernel_client.py:307
   profiles:
     lite: supported
     sandbox: supported
@@ -4054,7 +4054,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.register
-      source: src/nexus/remote/kernel_client.py:1516
+      source: src/nexus/remote/kernel_client.py:1568
   profiles:
     lite: supported
     sandbox: supported
@@ -4122,7 +4122,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.signal
-      source: src/nexus/remote/kernel_client.py:1558
+      source: src/nexus/remote/kernel_client.py:1610
   profiles:
     lite: supported
     sandbox: supported
@@ -4207,7 +4207,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.unregister
-      source: src/nexus/remote/kernel_client.py:1549
+      source: src/nexus/remote/kernel_client.py:1601
   profiles:
     lite: supported
     sandbox: supported
@@ -4321,10 +4321,10 @@ operations:
   transports:
     grpc_expose:
       name: get_content_id
-      source: src/nexus/core/nexus_fs_metadata.py:627
+      source: src/nexus/core/nexus_fs_metadata.py:628
     sdk:
       name: KernelClient.get_content_id
-      source: src/nexus/remote/kernel_client.py:800
+      source: src/nexus/remote/kernel_client.py:806
   profiles:
     lite: supported
     sandbox: supported
@@ -4392,7 +4392,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.get_mount_points
-      source: src/nexus/remote/kernel_client.py:814
+      source: src/nexus/remote/kernel_client.py:820
   profiles:
     lite: supported
     sandbox: supported
@@ -4511,10 +4511,10 @@ operations:
   transports:
     grpc_expose:
       name: get_top_level_mounts
-      source: src/nexus/core/nexus_fs_metadata.py:268
+      source: src/nexus/core/nexus_fs_metadata.py:269
     sdk:
       name: KernelClient.get_top_level_mounts
-      source: src/nexus/remote/kernel_client.py:821
+      source: src/nexus/remote/kernel_client.py:827
   profiles:
     lite: supported
     sandbox: supported
@@ -4549,7 +4549,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.get_xattr
-      source: src/nexus/remote/kernel_client.py:959
+      source: src/nexus/remote/kernel_client.py:965
   profiles:
     lite: supported
     sandbox: supported
@@ -4566,7 +4566,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.get_xattr_bulk
-      source: src/nexus/remote/kernel_client.py:980
+      source: src/nexus/remote/kernel_client.py:986
   profiles:
     lite: supported
     sandbox: supported
@@ -4771,7 +4771,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.has_pipe
-      source: src/nexus/remote/kernel_client.py:1007
+      source: src/nexus/remote/kernel_client.py:1013
   profiles:
     lite: supported
     sandbox: supported
@@ -4788,7 +4788,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.has_stream
-      source: src/nexus/remote/kernel_client.py:1023
+      source: src/nexus/remote/kernel_client.py:1029
   profiles:
     lite: supported
     sandbox: supported
@@ -4857,7 +4857,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.hook_count
-      source: src/nexus/remote/kernel_client.py:745
+      source: src/nexus/remote/kernel_client.py:751
   profiles:
     lite: supported
     sandbox: supported
@@ -5012,7 +5012,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.is_directory
-      source: src/nexus/remote/kernel_client.py:791
+      source: src/nexus/remote/kernel_client.py:797
   profiles:
     lite: supported
     sandbox: supported
@@ -5151,7 +5151,7 @@ operations:
       source: src/nexus/services/agents/agent_rpc_service.py:584
     sdk:
       name: _AgentRegistryProxy.list_agents
-      source: src/nexus/remote/kernel_client.py:1584
+      source: src/nexus/remote/kernel_client.py:1636
   profiles:
     lite: supported
     sandbox: supported
@@ -5169,7 +5169,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.list_by_priority
-      source: src/nexus/remote/kernel_client.py:1612
+      source: src/nexus/remote/kernel_client.py:1664
   profiles:
     lite: supported
     sandbox: supported
@@ -5314,7 +5314,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.list_processes
-      source: src/nexus/remote/kernel_client.py:1587
+      source: src/nexus/remote/kernel_client.py:1639
   profiles:
     lite: supported
     sandbox: supported
@@ -5728,7 +5728,7 @@ operations:
   transports:
     grpc_expose:
       name: metadata_batch
-      source: src/nexus/core/nexus_fs_metadata.py:1345
+      source: src/nexus/core/nexus_fs_metadata.py:1350
   profiles:
     lite: supported
     sandbox: supported
@@ -5745,7 +5745,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.metastore_list_paginated
-      source: src/nexus/remote/kernel_client.py:829
+      source: src/nexus/remote/kernel_client.py:835
   profiles:
     lite: supported
     sandbox: supported
@@ -6914,10 +6914,10 @@ operations:
   transports:
     grpc_expose:
       name: read_batch
-      source: src/nexus/core/nexus_fs_content.py:1613
+      source: src/nexus/core/nexus_fs_content.py:1626
     sdk:
       name: KernelClient.read_batch
-      source: src/nexus/remote/kernel_client.py:643
+      source: src/nexus/remote/kernel_client.py:649
   profiles:
     lite: supported
     sandbox: supported
@@ -6936,7 +6936,7 @@ operations:
   transports:
     grpc_expose:
       name: read_bulk
-      source: src/nexus/core/nexus_fs_content.py:241
+      source: src/nexus/core/nexus_fs_content.py:242
   profiles:
     lite: supported
     sandbox: supported
@@ -6972,7 +6972,7 @@ operations:
   transports:
     grpc_expose:
       name: read_range
-      source: src/nexus/core/nexus_fs_content.py:414
+      source: src/nexus/core/nexus_fs_content.py:415
   profiles:
     lite: supported
     sandbox: supported
@@ -7248,7 +7248,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.register_external
-      source: src/nexus/remote/kernel_client.py:1519
+      source: src/nexus/remote/kernel_client.py:1571
   profiles:
     lite: supported
     sandbox: supported
@@ -7265,7 +7265,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.register_hook
-      source: src/nexus/remote/kernel_client.py:762
+      source: src/nexus/remote/kernel_client.py:768
   profiles:
     lite: supported
     sandbox: supported
@@ -7299,7 +7299,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.register_native_hook
-      source: src/nexus/remote/kernel_client.py:1100
+      source: src/nexus/remote/kernel_client.py:1106
   profiles:
     lite: supported
     sandbox: supported
@@ -7336,7 +7336,7 @@ operations:
   transports:
     grpc_expose:
       name: rename_batch
-      source: src/nexus/core/nexus_fs_metadata.py:1579
+      source: src/nexus/core/nexus_fs_metadata.py:1584
   profiles:
     lite: supported
     sandbox: supported
@@ -7715,7 +7715,7 @@ operations:
       source: src/nexus/bricks/search/search_service.py:1808
     http:
       name: POST /api/v2/search/glob
-      source: src/nexus/server/api/v2/routers/search.py:1648
+      source: src/nexus/server/api/v2/routers/search.py:1694
     mcp:
       name: nexus_glob
       source: src/nexus/config/tool_profiles.yaml:1
@@ -7742,7 +7742,7 @@ operations:
       source: src/nexus/bricks/search/search_service.py:2118
     http:
       name: POST /api/v2/search/grep
-      source: src/nexus/server/api/v2/routers/search.py:1525
+      source: src/nexus/server/api/v2/routers/search.py:1555
     mcp:
       name: nexus_grep
       source: src/nexus/config/tool_profiles.yaml:1
@@ -7778,7 +7778,7 @@ operations:
   transports:
     http:
       name: GET /api/v2/search/health
-      source: src/nexus/server/api/v2/routers/search.py:170
+      source: src/nexus/server/api/v2/routers/search.py:171
   profiles:
     lite: supported
     sandbox: supported
@@ -7795,7 +7795,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/index
-      source: src/nexus/server/api/v2/routers/search.py:1710
+      source: src/nexus/server/api/v2/routers/search.py:1764
   profiles:
     lite: supported
     sandbox: supported
@@ -7812,7 +7812,7 @@ operations:
   transports:
     http:
       name: GET /api/v2/search/query
-      source: src/nexus/server/api/v2/routers/search.py:249
+      source: src/nexus/server/api/v2/routers/search.py:250
   profiles:
     lite: supported
     sandbox: supported
@@ -7830,7 +7830,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/query/batch
-      source: src/nexus/server/api/v2/routers/search.py:897
+      source: src/nexus/server/api/v2/routers/search.py:910
   profiles:
     lite: supported
     sandbox: supported
@@ -7847,7 +7847,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/refresh
-      source: src/nexus/server/api/v2/routers/search.py:1825
+      source: src/nexus/server/api/v2/routers/search.py:1879
   profiles:
     lite: supported
     sandbox: supported
@@ -7881,7 +7881,7 @@ operations:
   transports:
     http:
       name: GET /api/v2/search/stats
-      source: src/nexus/server/api/v2/routers/search.py:220
+      source: src/nexus/server/api/v2/routers/search.py:221
   profiles:
     lite: supported
     sandbox: supported
@@ -7988,7 +7988,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.service_close_all
-      source: src/nexus/remote/kernel_client.py:737
+      source: src/nexus/remote/kernel_client.py:743
   profiles:
     lite: supported
     sandbox: supported
@@ -8005,7 +8005,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.service_enlist
-      source: src/nexus/remote/kernel_client.py:724
+      source: src/nexus/remote/kernel_client.py:730
   profiles:
     lite: supported
     sandbox: supported
@@ -8022,7 +8022,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.service_lookup
-      source: src/nexus/remote/kernel_client.py:712
+      source: src/nexus/remote/kernel_client.py:718
   profiles:
     lite: supported
     sandbox: supported
@@ -8039,7 +8039,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.service_mark_bootstrapped
-      source: src/nexus/remote/kernel_client.py:709
+      source: src/nexus/remote/kernel_client.py:715
   profiles:
     lite: supported
     sandbox: supported
@@ -8056,7 +8056,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.service_start_all
-      source: src/nexus/remote/kernel_client.py:706
+      source: src/nexus/remote/kernel_client.py:712
   profiles:
     lite: supported
     sandbox: supported
@@ -8073,7 +8073,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.service_stop_all
-      source: src/nexus/remote/kernel_client.py:734
+      source: src/nexus/remote/kernel_client.py:740
   profiles:
     lite: supported
     sandbox: supported
@@ -8090,7 +8090,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.service_swap
-      source: src/nexus/remote/kernel_client.py:716
+      source: src/nexus/remote/kernel_client.py:722
   profiles:
     lite: supported
     sandbox: supported
@@ -8107,7 +8107,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.service_unregister
-      source: src/nexus/remote/kernel_client.py:940
+      source: src/nexus/remote/kernel_client.py:946
   profiles:
     lite: supported
     sandbox: supported
@@ -8124,7 +8124,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.set_hook_count
-      source: src/nexus/remote/kernel_client.py:779
+      source: src/nexus/remote/kernel_client.py:785
   profiles:
     lite: supported
     sandbox: supported
@@ -8141,7 +8141,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.set_metastore_path
-      source: src/nexus/remote/kernel_client.py:1072
+      source: src/nexus/remote/kernel_client.py:1078
   profiles:
     lite: supported
     sandbox: supported
@@ -8158,7 +8158,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.set_permission_provider
-      source: src/nexus/remote/kernel_client.py:1104
+      source: src/nexus/remote/kernel_client.py:1110
   profiles:
     lite: supported
     sandbox: supported
@@ -8192,7 +8192,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.set_vfs_lock
-      source: src/nexus/remote/kernel_client.py:1096
+      source: src/nexus/remote/kernel_client.py:1102
   profiles:
     lite: supported
     sandbox: supported
@@ -8209,7 +8209,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.set_xattr
-      source: src/nexus/remote/kernel_client.py:972
+      source: src/nexus/remote/kernel_client.py:978
   profiles:
     lite: supported
     sandbox: supported
@@ -8469,7 +8469,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.stat_batch
-      source: src/nexus/remote/kernel_client.py:677
+      source: src/nexus/remote/kernel_client.py:683
   profiles:
     lite: supported
     sandbox: supported
@@ -8486,7 +8486,7 @@ operations:
   transports:
     grpc_expose:
       name: stat_bulk
-      source: src/nexus/core/nexus_fs_metadata.py:1203
+      source: src/nexus/core/nexus_fs_metadata.py:1208
   profiles:
     lite: supported
     sandbox: supported
@@ -8503,7 +8503,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.stream_collect_all
-      source: src/nexus/remote/kernel_client.py:1052
+      source: src/nexus/remote/kernel_client.py:1058
   profiles:
     lite: supported
     sandbox: supported
@@ -8520,7 +8520,7 @@ operations:
   transports:
     grpc_expose:
       name: stream_range
-      source: src/nexus/core/nexus_fs_content.py:527
+      source: src/nexus/core/nexus_fs_content.py:528
   profiles:
     lite: supported
     sandbox: supported
@@ -8537,7 +8537,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.stream_read_at
-      source: src/nexus/remote/kernel_client.py:1040
+      source: src/nexus/remote/kernel_client.py:1046
   profiles:
     lite: supported
     sandbox: supported
@@ -8554,7 +8554,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.stream_read_at_blocking
-      source: src/nexus/remote/kernel_client.py:1027
+      source: src/nexus/remote/kernel_client.py:1033
   profiles:
     lite: supported
     sandbox: supported
@@ -8571,7 +8571,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.stream_write_nowait
-      source: src/nexus/remote/kernel_client.py:1035
+      source: src/nexus/remote/kernel_client.py:1041
   profiles:
     lite: supported
     sandbox: supported
@@ -8656,7 +8656,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.sys_copy
-      source: src/nexus/remote/kernel_client.py:578
+      source: src/nexus/remote/kernel_client.py:583
   profiles:
     lite: supported
     sandbox: supported
@@ -8673,7 +8673,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.sys_lock
-      source: src/nexus/remote/kernel_client.py:614
+      source: src/nexus/remote/kernel_client.py:620
   profiles:
     lite: supported
     sandbox: supported
@@ -8690,7 +8690,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.sys_mkdir
-      source: src/nexus/remote/kernel_client.py:547
+      source: src/nexus/remote/kernel_client.py:551
   profiles:
     lite: supported
     sandbox: supported
@@ -8707,7 +8707,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.sys_read
-      source: src/nexus/remote/kernel_client.py:444
+      source: src/nexus/remote/kernel_client.py:445
   profiles:
     lite: supported
     sandbox: supported
@@ -8724,7 +8724,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.sys_read_raw
-      source: src/nexus/remote/kernel_client.py:476
+      source: src/nexus/remote/kernel_client.py:477
   profiles:
     lite: supported
     sandbox: supported
@@ -8741,7 +8741,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.sys_readdir
-      source: src/nexus/remote/kernel_client.py:598
+      source: src/nexus/remote/kernel_client.py:604
   profiles:
     lite: supported
     sandbox: supported
@@ -8758,7 +8758,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.sys_rename
-      source: src/nexus/remote/kernel_client.py:555
+      source: src/nexus/remote/kernel_client.py:559
   profiles:
     lite: supported
     sandbox: supported
@@ -8775,7 +8775,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.sys_setattr
-      source: src/nexus/remote/kernel_client.py:514
+      source: src/nexus/remote/kernel_client.py:517
   profiles:
     lite: supported
     sandbox: supported
@@ -8792,7 +8792,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.sys_stat
-      source: src/nexus/remote/kernel_client.py:497
+      source: src/nexus/remote/kernel_client.py:500
   profiles:
     lite: supported
     sandbox: supported
@@ -8809,7 +8809,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.sys_unlink
-      source: src/nexus/remote/kernel_client.py:533
+      source: src/nexus/remote/kernel_client.py:536
   profiles:
     lite: supported
     sandbox: supported
@@ -8826,7 +8826,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.sys_unlock
-      source: src/nexus/remote/kernel_client.py:637
+      source: src/nexus/remote/kernel_client.py:643
   profiles:
     lite: supported
     sandbox: supported
@@ -8846,7 +8846,7 @@ operations:
       source: src/nexus/core/nexus_fs_watch.py:26
     sdk:
       name: KernelClient.sys_watch
-      source: src/nexus/remote/kernel_client.py:692
+      source: src/nexus/remote/kernel_client.py:698
   profiles:
     lite: supported
     sandbox: supported
@@ -8863,7 +8863,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.sys_write
-      source: src/nexus/remote/kernel_client.py:481
+      source: src/nexus/remote/kernel_client.py:482
   profiles:
     lite: supported
     sandbox: supported
@@ -8948,7 +8948,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.trie_lookup
-      source: src/nexus/remote/kernel_client.py:951
+      source: src/nexus/remote/kernel_client.py:957
   profiles:
     lite: supported
     sandbox: supported
@@ -8965,7 +8965,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.trie_register
-      source: src/nexus/remote/kernel_client.py:948
+      source: src/nexus/remote/kernel_client.py:954
   profiles:
     lite: supported
     sandbox: supported
@@ -8982,7 +8982,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.trie_unregister
-      source: src/nexus/remote/kernel_client.py:954
+      source: src/nexus/remote/kernel_client.py:960
   profiles:
     lite: supported
     sandbox: supported
@@ -9358,7 +9358,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.unregister_external
-      source: src/nexus/remote/kernel_client.py:1552
+      source: src/nexus/remote/kernel_client.py:1604
   profiles:
     lite: supported
     sandbox: supported
@@ -9375,7 +9375,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.unregister_hook
-      source: src/nexus/remote/kernel_client.py:767
+      source: src/nexus/remote/kernel_client.py:773
   profiles:
     lite: supported
     sandbox: supported
@@ -9447,7 +9447,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.update_state
-      source: src/nexus/remote/kernel_client.py:1570
+      source: src/nexus/remote/kernel_client.py:1622
   profiles:
     lite: supported
     sandbox: supported
@@ -9684,10 +9684,10 @@ operations:
   transports:
     grpc_expose:
       name: write_batch
-      source: src/nexus/core/nexus_fs_content.py:1451
+      source: src/nexus/core/nexus_fs_content.py:1463
     sdk:
       name: KernelClient.write_batch
-      source: src/nexus/remote/kernel_client.py:1108
+      source: src/nexus/remote/kernel_client.py:1114
   profiles:
     lite: supported
     sandbox: supported
@@ -9723,7 +9723,7 @@ operations:
   transports:
     grpc_expose:
       name: write_stream
-      source: src/nexus/core/nexus_fs_content.py:569
+      source: src/nexus/core/nexus_fs_content.py:570
   profiles:
     lite: supported
     sandbox: supported

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -197,6 +197,7 @@ nav:
     # - Kernel Architecture: architecture/KERNEL-ARCHITECTURE.md  # moved to nexus-vfs
     - Backend Architecture: architecture/backend-architecture.md
     - CLI Design: architecture/cli-design.md
+    - Consistency Contract: architecture/consistency-contract.md
   - Agents:
     - Self-Observability: agents/self-observability.md
   - Research:

--- a/src/nexus/core/nexus_fs_content.py
+++ b/src/nexus/core/nexus_fs_content.py
@@ -29,6 +29,7 @@ from nexus.contracts.metadata import FileMetadata
 from nexus.contracts.types import OperationContext
 from nexus.lib import io_metrics
 from nexus.lib.rpc_decorator import rpc_expose
+from nexus.lib.zone_revision import revision_token
 
 if TYPE_CHECKING:
     pass
@@ -714,7 +715,13 @@ class ContentMixin:
                 bytes_count=len(buf),
                 latency_ms=_write_latency_ms,
             )
-        return {"path": path, "bytes_written": len(buf)}
+        # Issue #4737: revision token (``<path>@<gen>``) a reader can fence
+        # on; None when the kernel reported no gen (e.g. a miss).
+        return {
+            "path": path,
+            "bytes_written": len(buf),
+            "revision": revision_token(result, path=path),
+        }
 
     # @rpc_expose removed — kernel syscall, served by the thin dispatcher.
     def read(
@@ -997,6 +1004,11 @@ class ContentMixin:
             "gen": result.gen,
             "modified_at": None,
             "size": result.size,
+            # Issue #4737: read-your-writes token — ``<path>@<gen>`` (or a
+            # kernel-stamped ``zone@applied_index`` when available). A
+            # reader passes it back as X-Nexus-Min-Revision to observe this
+            # write on any node. None only when the kernel reported no gen.
+            "revision": revision_token(result, path=path),
         }
 
     # _write_internal + _write_content deleted — Rust sys_write handles:
@@ -1575,6 +1587,7 @@ class ContentMixin:
                     "gen": r.gen,
                     "modified_at": now,
                     "size": r.size,
+                    "revision": revision_token(r, path=path),
                 }
             )
             metadata_list.append(

--- a/src/nexus/core/nexus_fs_metadata.py
+++ b/src/nexus/core/nexus_fs_metadata.py
@@ -30,6 +30,7 @@ from nexus.contracts.types import OperationContext
 from nexus.core.nexus_fs_content import emit_op_completed
 from nexus.kernel_helpers import metastore_list_iter
 from nexus.lib.rpc_decorator import rpc_expose
+from nexus.lib.zone_revision import revision_token
 
 if TYPE_CHECKING:
     pass
@@ -831,7 +832,9 @@ class MetadataMixin:
                 bytes_count=0,
                 latency_ms=int((time.perf_counter() - _unlink_start) * 1000),
             )
-            return {}
+            # Issue #4737: zone revision the delete was applied at (None
+            # when the kernel did not stamp the response).
+            return {"revision": revision_token(_unlink_result)}
 
         # ── Rust miss: only DT_EXTERNAL_STORAGE (5) or not-found ─────
         et = _unlink_result.entry_type
@@ -1041,7 +1044,9 @@ class MetadataMixin:
             )
             self._kernel.dispatch_post_hooks("rename", _rename_ctx)
 
-        return {}
+        # Issue #4737: zone revision the rename was applied at (None when
+        # the kernel did not stamp the response).
+        return {"revision": revision_token(_rename_result)}
 
     # ------------------------------------------------------------------
     # sys_copy — Issue #3329 (Workstream 3: native copy/move)

--- a/src/nexus/lib/zone_revision.py
+++ b/src/nexus/lib/zone_revision.py
@@ -1,0 +1,375 @@
+"""Revision token — read-your-writes fence across nodes (Issue #4737).
+
+A mutation returns a *revision token* a later read can wait on::
+
+    <anchor>@<index>
+
+* **Path-anchored** (what writes return today): the anchor is the written
+  path and the index is its ``gen`` after the write, e.g.
+  ``/ws/a.txt@7``. Raft applies log entries strictly in order, so a node
+  whose ``sys_stat`` shows the path at ``gen >= 7`` has applied every
+  earlier entry of that zone as well. Fencing on the path therefore also
+  fences directory listings, glob, grep and search for that zone — no
+  kernel change and no zone-wide counter needed.
+* **Zone-anchored** (optional, kernel-stamped): ``root@1234`` where the
+  index is the zone's raft ``applied_index`` on the serving node. Emitted
+  only when the kernel stamps ``zone_id`` / ``applied_index`` on the
+  mutation response; honoured only when the kernel serves the
+  ``federation_cluster_info`` Call. A bare integer is a zone token for
+  ``root``.
+
+This module is tier-neutral (``lib/``): ``kernel`` arguments are
+duck-typed to ``KernelClient`` (``_call``) and ``fs`` arguments to
+``NexusFS`` (``sys_stat``). Contract:
+``docs/architecture/consistency-contract.md``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import inspect
+import logging
+import time
+import weakref
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from nexus.contracts.constants import ROOT_ZONE_ID
+
+logger = logging.getLogger(__name__)
+
+REVISION_HEADER = "X-Nexus-Revision"
+MIN_REVISION_HEADER = "X-Nexus-Min-Revision"
+REVISION_TIMEOUT_HEADER = "X-Nexus-Revision-Timeout-Ms"
+MIN_REVISION_PARAM = "min_revision"
+REVISION_TIMEOUT_PARAM = "revision_timeout_ms"
+
+DEFAULT_REVISION_TIMEOUT_MS = 5_000
+MAX_REVISION_TIMEOUT_MS = 30_000
+
+CLUSTER_INFO_METHOD = "federation_cluster_info"
+
+# Poll cadence for the wait loops (exponential backoff between the bounds).
+_INITIAL_POLL_S = 0.02
+_MAX_POLL_S = 0.25
+
+_UNAVAILABLE_MARKERS = (
+    "unknown call method",
+    "method not found",
+    "not available in subprocess mode",
+    "federation not active",
+)
+
+
+class ZoneRevisionUnavailable(RuntimeError):
+    """The serving kernel cannot report ``applied_index`` for a zone."""
+
+
+@dataclass(frozen=True, slots=True)
+class RevisionToken:
+    """``<anchor>@<index>``: a path + gen, or a zone + applied_index."""
+
+    anchor: str
+    index: int
+
+    @property
+    def is_path(self) -> bool:
+        return self.anchor.startswith("/")
+
+    def __str__(self) -> str:
+        return f"{self.anchor}@{self.index}"
+
+    @classmethod
+    def parse(cls, raw: str, *, default_zone: str = ROOT_ZONE_ID) -> RevisionToken:
+        """Parse ``anchor@index`` or a bare ``index`` (zone token for ``default_zone``).
+
+        Splits on the *last* ``@`` so path anchors may themselves contain
+        ``@``. Raises ``ValueError`` on malformed input.
+        """
+        text = (raw or "").strip()
+        if not text:
+            raise ValueError("revision token is empty")
+        anchor, sep, index_text = text.rpartition("@")
+        if not sep:
+            anchor, index_text = default_zone, text
+        anchor = anchor.strip()
+        if not anchor:
+            raise ValueError(f"revision token has an empty anchor: {raw!r}")
+        if not anchor.startswith("/") and any(c.isspace() for c in anchor):
+            raise ValueError(f"revision token has an invalid zone id: {raw!r}")
+        if not index_text.strip().isdigit():
+            raise ValueError(f"revision token index must be a non-negative integer: {raw!r}")
+        return cls(anchor=anchor, index=int(index_text))
+
+
+def _field(result: Any, name: str) -> Any:
+    if isinstance(result, dict):
+        return result.get(name)
+    return getattr(result, name, None)
+
+
+def _positive_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        number = int(value)
+    except (TypeError, ValueError):
+        return None
+    return number if number > 0 else None
+
+
+def revision_from_result(result: Any, *, path: str | None = None) -> RevisionToken | None:
+    """Build the token a kernel mutation result should return.
+
+    Prefers a kernel-stamped zone revision (``zone_id`` + ``applied_index``
+    on the result). Otherwise, when ``path`` is given and the result
+    carries a positive ``gen``, returns the path-anchored token. ``None``
+    when neither is available — callers surface ``revision: null`` rather
+    than guess.
+    """
+    if result is None:
+        return None
+    zone_id = _field(result, "zone_id")
+    applied_index = _positive_int(_field(result, "applied_index"))
+    if zone_id and applied_index is not None:
+        return RevisionToken(anchor=str(zone_id), index=applied_index)
+    if path and path.startswith("/"):
+        gen = _positive_int(_field(result, "gen"))
+        if gen is not None:
+            return RevisionToken(anchor=path, index=gen)
+    return None
+
+
+def revision_token(result: Any, *, path: str | None = None) -> str | None:
+    """``str(revision_from_result(...))`` or ``None``."""
+    rev = revision_from_result(result, path=path)
+    return str(rev) if rev is not None else None
+
+
+def revision_fields(response: Any) -> dict[str, Any]:
+    """Normalise the optional kernel-stamped revision fields on a typed response.
+
+    ``zone_id`` / ``applied_index`` are additive proto fields a kernel may
+    stamp on mutating responses. Absent (or zero) on the pinned kernel,
+    in which case both come back as ``None``.
+    """
+    zone_id = getattr(response, "zone_id", "") or None
+    try:
+        applied_index = int(getattr(response, "applied_index", 0) or 0)
+    except (TypeError, ValueError):
+        applied_index = 0
+    return {"zone_id": zone_id, "applied_index": applied_index or None}
+
+
+# ---------------------------------------------------------------------------
+# Path-anchored fence: sys_stat gen on the serving node
+# ---------------------------------------------------------------------------
+
+
+def read_path_gen(fs: Any, path: str, context: Any = None) -> int:
+    """Return the ``gen`` of ``path`` as this node currently sees it (0 if absent).
+
+    Goes through ``fs.sys_stat`` so permission hooks apply — the fence must
+    not become an existence oracle for paths the caller cannot read.
+    """
+    meta = fs.sys_stat(path, context=context)
+    if inspect.isawaitable(meta):  # pragma: no cover — sync NexusFS in production
+        raise TypeError("read_path_gen requires a synchronous sys_stat; use await_path_gen")
+    return _gen_of(meta)
+
+
+async def _stat_async(fs: Any, path: str, context: Any) -> Any:
+    meta = await asyncio.to_thread(fs.sys_stat, path, context=context)
+    if inspect.isawaitable(meta):
+        meta = await meta
+    return meta
+
+
+def _gen_of(meta: Any) -> int:
+    if not meta:
+        return 0
+    gen = _field(meta, "gen")
+    if gen is None:
+        gen = _field(meta, "version")
+    try:
+        return max(int(gen or 0), 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+async def await_path_gen(
+    fs: Any,
+    path: str,
+    min_gen: int,
+    *,
+    timeout_s: float,
+    context: Any = None,
+) -> tuple[bool, int]:
+    """Wait until this node's ``sys_stat(path).gen >= min_gen``.
+
+    Returns ``(satisfied, current_gen)``; ``current_gen`` is 0 while the
+    path is not visible here. ``timeout_s <= 0`` probes once.
+    """
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + max(float(timeout_s), 0.0)
+    interval = _INITIAL_POLL_S
+    while True:
+        current = _gen_of(await _stat_async(fs, path, context))
+        if current >= min_gen:
+            return True, current
+        now = loop.time()
+        if now >= deadline:
+            return False, current
+        await asyncio.sleep(min(interval, deadline - now))
+        interval = min(interval * 2, _MAX_POLL_S)
+
+
+# ---------------------------------------------------------------------------
+# Zone-anchored fence: kernel applied_index (optional, kernel-stamped)
+# ---------------------------------------------------------------------------
+
+# Kernels that answered "unknown method" for the cluster-info Call. The
+# answer is fixed for the lifetime of a kernel binary, so remember it and
+# stop paying a round-trip per fenced read. Keyed weakly so a dropped
+# KernelClient does not pin the entry.
+_unavailable_kernels: weakref.WeakKeyDictionary[Any, str] = weakref.WeakKeyDictionary()
+
+
+def reset_zone_revision_cache() -> None:
+    """Forget cached "kernel lacks cluster-info" verdicts (tests)."""
+    _unavailable_kernels.clear()
+
+
+def _remember_unavailable(kernel: Any, reason: str) -> None:
+    # Not weak-referenceable → skip the cache and re-probe next time.
+    with contextlib.suppress(TypeError):
+        _unavailable_kernels[kernel] = reason
+
+
+def _cached_unavailable(kernel: Any) -> str | None:
+    try:
+        return _unavailable_kernels.get(kernel)
+    except TypeError:
+        return None
+
+
+def _looks_unavailable(exc: BaseException) -> bool:
+    text = str(exc).lower()
+    return any(marker in text for marker in _UNAVAILABLE_MARKERS)
+
+
+def read_zone_revision(kernel: Any, zone_id: str) -> int:
+    """Return the serving node's ``applied_index`` for ``zone_id``.
+
+    Raises :class:`ZoneRevisionUnavailable` when the kernel does not
+    expose ``federation_cluster_info`` (the pinned nexusd-cluster does
+    not) or does not host the zone. Transport errors propagate unchanged.
+    """
+    if kernel is None:
+        raise ZoneRevisionUnavailable("no kernel attached to this NexusFS")
+    cached = _cached_unavailable(kernel)
+    if cached is not None:
+        raise ZoneRevisionUnavailable(cached)
+    try:
+        info = kernel._call(CLUSTER_INFO_METHOD, {"zone_id": zone_id})
+    except ZoneRevisionUnavailable:
+        raise
+    except Exception as exc:
+        if _looks_unavailable(exc):
+            reason = f"kernel does not expose {CLUSTER_INFO_METHOD}: {exc}"
+            _remember_unavailable(kernel, reason)
+            logger.info("zone revision unavailable — %s", reason)
+            raise ZoneRevisionUnavailable(reason) from exc
+        raise
+    if not isinstance(info, dict):
+        raise ZoneRevisionUnavailable(
+            f"{CLUSTER_INFO_METHOD} returned {type(info).__name__}, expected an object"
+        )
+    if info.get("available") is False:
+        # Python-side standalone stub shape (federation_rpc.py) — not a
+        # kernel verdict, so do not cache it.
+        raise ZoneRevisionUnavailable(
+            str(info.get("reason") or f"{CLUSTER_INFO_METHOD} reports federation unavailable")
+        )
+    if info.get("has_store") is False:
+        raise ZoneRevisionUnavailable(f"zone {zone_id!r} is not hosted by this node")
+    try:
+        return int(info.get("applied_index", 0))
+    except (TypeError, ValueError) as exc:
+        raise ZoneRevisionUnavailable(
+            f"{CLUSTER_INFO_METHOD} returned a non-integer applied_index"
+        ) from exc
+
+
+def wait_for_zone_revision(
+    kernel: Any,
+    zone_id: str,
+    min_index: int,
+    *,
+    timeout_s: float,
+    sleep: Callable[[float], None] = time.sleep,
+    clock: Callable[[], float] = time.monotonic,
+) -> tuple[bool, int]:
+    """Block until the node's ``applied_index`` for ``zone_id`` reaches ``min_index``.
+
+    Returns ``(satisfied, current_index)``. ``timeout_s <= 0`` probes once.
+    Propagates :class:`ZoneRevisionUnavailable` from the first probe.
+    """
+    deadline = clock() + max(float(timeout_s), 0.0)
+    interval = _INITIAL_POLL_S
+    while True:
+        current = read_zone_revision(kernel, zone_id)
+        if current >= min_index:
+            return True, current
+        now = clock()
+        if now >= deadline:
+            return False, current
+        sleep(min(interval, deadline - now))
+        interval = min(interval * 2, _MAX_POLL_S)
+
+
+async def await_zone_revision(
+    kernel: Any,
+    zone_id: str,
+    min_index: int,
+    *,
+    timeout_s: float,
+) -> tuple[bool, int]:
+    """Async twin of :func:`wait_for_zone_revision` (probes on a worker thread)."""
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + max(float(timeout_s), 0.0)
+    interval = _INITIAL_POLL_S
+    while True:
+        current = await asyncio.to_thread(read_zone_revision, kernel, zone_id)
+        if current >= min_index:
+            return True, current
+        now = loop.time()
+        if now >= deadline:
+            return False, current
+        await asyncio.sleep(min(interval, deadline - now))
+        interval = min(interval * 2, _MAX_POLL_S)
+
+
+__all__ = [
+    "CLUSTER_INFO_METHOD",
+    "DEFAULT_REVISION_TIMEOUT_MS",
+    "MAX_REVISION_TIMEOUT_MS",
+    "MIN_REVISION_HEADER",
+    "MIN_REVISION_PARAM",
+    "REVISION_HEADER",
+    "REVISION_TIMEOUT_HEADER",
+    "REVISION_TIMEOUT_PARAM",
+    "RevisionToken",
+    "ZoneRevisionUnavailable",
+    "await_path_gen",
+    "await_zone_revision",
+    "read_path_gen",
+    "read_zone_revision",
+    "reset_zone_revision_cache",
+    "revision_fields",
+    "revision_from_result",
+    "revision_token",
+    "wait_for_zone_revision",
+]

--- a/src/nexus/remote/kernel_client.py
+++ b/src/nexus/remote/kernel_client.py
@@ -29,6 +29,7 @@ from typing import IO, Any
 from nexus.contracts.constants import ROOT_ZONE_ID
 from nexus.contracts.rpc_types import RPCErrorCode
 from nexus.lib.rpc_codec import decode_rpc_message
+from nexus.lib.zone_revision import revision_fields as _revision_fields
 from nexus.remote.rpc_transport import RPCTransport
 
 logger = logging.getLogger(__name__)
@@ -492,6 +493,8 @@ class KernelClient:
             content_id=result.get("content_id"),
             size=result.get("size", 0),
             gen=result.get("gen", 0),
+            zone_id=result.get("zone_id") or None,
+            applied_index=int(result.get("applied_index") or 0) or None,
         )
 
     def sys_stat(self, path: str, zone_id: str = ROOT_ZONE_ID) -> Any:
@@ -541,6 +544,7 @@ class KernelClient:
                 "path": r.path,
                 "content_id": r.content_id or None,
                 "size": r.size,
+                **_revision_fields(r),
             }
         )
 
@@ -550,7 +554,7 @@ class KernelClient:
         """Create a directory via the typed Mkdir RPC."""
         assert self._transport is not None
         r = self._transport.mkdir(path, parents=parents, exist_ok=exist_ok)
-        return _SysMkdirResult({"hit": r.hit})
+        return _SysMkdirResult({"hit": r.hit, **_revision_fields(r)})
 
     def sys_rename(
         self,
@@ -572,6 +576,7 @@ class KernelClient:
                 "old_modified_at_ms": r.old_modified_at_ms
                 if r.HasField("old_modified_at_ms")
                 else None,
+                **_revision_fields(r),
             }
         )
 
@@ -592,6 +597,7 @@ class KernelClient:
                 "size": r.size,
                 "version": r.version,
                 "gen": r.gen,
+                **_revision_fields(r),
             }
         )
 
@@ -1124,6 +1130,7 @@ class KernelClient:
                     "size": item.size,
                     "gen": item.gen,
                     "version": item.version,
+                    **_revision_fields(item),
                 }
             )
             for item in self._transport.batch_write(files)
@@ -1251,9 +1258,18 @@ class _SysWriteResult:
         "old_size",
         "old_version",
         "old_modified_at_ms",
+        "zone_id",
+        "applied_index",
     )
 
-    def __init__(self, content_id: str | None = None, size: int = 0, gen: int = 0) -> None:
+    def __init__(
+        self,
+        content_id: str | None = None,
+        size: int = 0,
+        gen: int = 0,
+        zone_id: str | None = None,
+        applied_index: int | None = None,
+    ) -> None:
         self.hit = True
         self.content_id = content_id
         self.post_hook_needed = True
@@ -1265,23 +1281,39 @@ class _SysWriteResult:
         self.old_size: int | None = None
         self.old_version: int | None = None
         self.old_modified_at_ms: int | None = None
+        # Zone revision (#4737): raft zone the write landed in + the
+        # serving node's applied_index after the apply. None when the
+        # kernel did not stamp the response.
+        self.zone_id: str | None = zone_id
+        self.applied_index: int | None = applied_index
 
 
 class _SysMkdirResult:
     """Result wrapper for sys_mkdir Call RPC response."""
 
-    __slots__ = ("hit", "post_hook_needed")
+    __slots__ = ("hit", "post_hook_needed", "zone_id", "applied_index")
 
     def __init__(self, d: dict[str, Any] | None = None) -> None:
         d = d or {}
         self.hit = d.get("hit", True)
         self.post_hook_needed = d.get("post_hook_needed", False)
+        self.zone_id = d.get("zone_id")
+        self.applied_index = d.get("applied_index")
 
 
 class _SysUnlinkResult:
     """Result wrapper for sys_unlink Call RPC response."""
 
-    __slots__ = ("hit", "post_hook_needed", "entry_type", "path", "content_id", "size")
+    __slots__ = (
+        "hit",
+        "post_hook_needed",
+        "entry_type",
+        "path",
+        "content_id",
+        "size",
+        "zone_id",
+        "applied_index",
+    )
 
     def __init__(self, d: dict[str, Any] | None = None) -> None:
         d = d or {}
@@ -1291,6 +1323,8 @@ class _SysUnlinkResult:
         self.path = d.get("path", "")
         self.content_id = d.get("content_id")
         self.size = d.get("size", 0)
+        self.zone_id = d.get("zone_id")
+        self.applied_index = d.get("applied_index")
 
 
 class _SysRenameResult:
@@ -1305,6 +1339,8 @@ class _SysRenameResult:
         "old_size",
         "old_version",
         "old_modified_at_ms",
+        "zone_id",
+        "applied_index",
     )
 
     def __init__(self, d: dict[str, Any] | None = None) -> None:
@@ -1317,12 +1353,24 @@ class _SysRenameResult:
         self.old_size = d.get("old_size")
         self.old_version = d.get("old_version")
         self.old_modified_at_ms = d.get("old_modified_at_ms")
+        self.zone_id = d.get("zone_id")
+        self.applied_index = d.get("applied_index")
 
 
 class _SysCopyResult:
     """Result wrapper for sys_copy Call RPC response."""
 
-    __slots__ = ("hit", "post_hook_needed", "dst_path", "content_id", "size", "version", "gen")
+    __slots__ = (
+        "hit",
+        "post_hook_needed",
+        "dst_path",
+        "content_id",
+        "size",
+        "version",
+        "gen",
+        "zone_id",
+        "applied_index",
+    )
 
     def __init__(self, d: dict[str, Any] | None = None) -> None:
         d = d or {}
@@ -1333,6 +1381,8 @@ class _SysCopyResult:
         self.size = d.get("size", 0)
         self.version = d.get("version", 1)
         self.gen = d.get("gen", 0)
+        self.zone_id = d.get("zone_id")
+        self.applied_index = d.get("applied_index")
 
 
 class _SysSetAttrResult:
@@ -1350,7 +1400,7 @@ class _SysSetAttrResult:
 class _BatchWriteItemResult:
     """Result wrapper for individual write_batch item."""
 
-    __slots__ = ("content_id", "size", "gen", "version")
+    __slots__ = ("content_id", "size", "gen", "version", "zone_id", "applied_index")
 
     def __init__(self, d: dict[str, Any] | None = None) -> None:
         d = d or {}
@@ -1358,6 +1408,8 @@ class _BatchWriteItemResult:
         self.size = d.get("size", 0)
         self.gen = d.get("gen", 0)
         self.version = d.get("version", 1)
+        self.zone_id = d.get("zone_id")
+        self.applied_index = d.get("applied_index")
 
 
 class _AttrDict(dict):

--- a/src/nexus/remote/rpc_transport.py
+++ b/src/nexus/remote/rpc_transport.py
@@ -38,6 +38,7 @@ from nexus.contracts.exceptions import (
 from nexus.grpc.defaults import build_channel_options
 from nexus.grpc.vfs import vfs_pb2, vfs_pb2_grpc
 from nexus.lib.rpc_codec import decode_rpc_message, encode_rpc_message
+from nexus.lib.zone_revision import revision_fields as _revision_fields
 from nexus.remote.base_client import BaseRemoteNexusFS
 
 if TYPE_CHECKING:
@@ -358,7 +359,9 @@ class RPCTransport:
         """Write file content via typed Write RPC — no JSON/base64 overhead.
 
         Returns:
-            Dict with ``content_id``, ``size``, and ``gen``.
+            Dict with ``content_id``, ``size``, ``gen``, plus the zone
+            revision fields ``zone_id`` / ``applied_index`` when the kernel
+            stamps them (#4737; empty / 0 on kernels that do not).
         """
         request = vfs_pb2.WriteRequest(
             path=path,
@@ -373,7 +376,12 @@ class RPCTransport:
             self._raise_transport_error(exc, timeout, "Write")
         if response.is_error:
             self._handle_typed_error(response.error_payload)
-        return {"content_id": response.content_id, "size": response.size, "gen": response.gen}
+        return {
+            "content_id": response.content_id,
+            "size": response.size,
+            "gen": response.gen,
+            **_revision_fields(response),
+        }
 
     @retry(
         stop=stop_after_attempt(3),

--- a/src/nexus/server/api/v2/_revision_fence.py
+++ b/src/nexus/server/api/v2/_revision_fence.py
@@ -1,0 +1,233 @@
+"""Read-your-writes fence for HTTP reads (Issue #4737).
+
+A caller that holds the ``revision`` a mutation returned (``/ws/a.txt@7``)
+can ask any read — ``/files/read``, ``/files/metadata``, ``/files/list``,
+``/files/glob``, ``/search/query``, ``/search/grep``, … — to observe at
+least that revision by sending::
+
+    X-Nexus-Min-Revision: /ws/a.txt@7        (or ?min_revision=/ws/a.txt@7)
+    X-Nexus-Revision-Timeout-Ms: 5000        (or ?revision_timeout_ms=5000)
+
+The fence waits until the serving node's ``sys_stat`` of the anchor path
+shows ``gen >= 7`` (bounded by the timeout, default 5 s, max 30 s), then
+lets the read run and stamps ``X-Nexus-Revision`` with what it observed.
+Because raft applies entries in order, a node that shows the path at that
+gen has applied every earlier entry of the zone, so listings, glob, grep
+and search for that zone include the write too. If the deadline passes
+first the request fails with ``412 Precondition Failed`` carrying the
+current revision — never a stale or ``metadata: None`` answer dressed up
+as success.
+
+Zone-anchored tokens (``root@1234``, kernel ``applied_index``) are
+accepted for kernels that stamp them; on the pinned kernel they answer
+``501 Not Implemented`` so the caller learns the guarantee is absent.
+Unfenced reads are untouched: no header, no extra round-trip.
+
+Contract: ``docs/architecture/consistency-contract.md``.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+from typing import Any
+
+from fastapi import Header, HTTPException, Query
+from fastapi.responses import Response
+
+from nexus.contracts.constants import ROOT_ZONE_ID
+from nexus.lib.zone_revision import (
+    DEFAULT_REVISION_TIMEOUT_MS,
+    MAX_REVISION_TIMEOUT_MS,
+    MIN_REVISION_HEADER,
+    MIN_REVISION_PARAM,
+    REVISION_HEADER,
+    REVISION_TIMEOUT_HEADER,
+    REVISION_TIMEOUT_PARAM,
+    RevisionToken,
+    ZoneRevisionUnavailable,
+    await_path_gen,
+    await_zone_revision,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class RevisionFence:
+    """Per-request fence state — built by :func:`get_revision_fence`."""
+
+    required: RevisionToken | None = None
+    timeout_ms: int = DEFAULT_REVISION_TIMEOUT_MS
+    #: Revision observed on the serving node once :meth:`enforce` ran.
+    observed: RevisionToken | None = None
+
+    @property
+    def active(self) -> bool:
+        return self.required is not None
+
+    async def enforce(self, fs: Any, context: Any = None) -> None:
+        """Wait for the required revision or fail with 412 / 501 / 503.
+
+        No-op when the request did not ask for a fence. Call it inside the
+        route's work function *before* the read so the read observes the
+        applied state. ``context`` is the caller's ``OperationContext``;
+        path-anchored fences stat through it so permission hooks apply.
+        """
+        required = self.required
+        if required is None:
+            return
+        if fs is None:
+            raise HTTPException(status_code=503, detail="NexusFS not initialized")
+        started = time.monotonic()
+        timeout_s = self.timeout_ms / 1000.0
+        if required.is_path:
+            satisfied, current = await await_path_gen(
+                fs, required.anchor, required.index, timeout_s=timeout_s, context=context
+            )
+        else:
+            satisfied, current = await self._await_zone(fs, required, timeout_s)
+
+        self.observed = RevisionToken(anchor=required.anchor, index=current)
+        if not satisfied:
+            waited_ms = int((time.monotonic() - started) * 1000)
+            what = "path" if required.is_path else "zone"
+            raise HTTPException(
+                status_code=412,
+                detail={
+                    "error": "revision_not_applied",
+                    "message": (
+                        f"This node sees {what} {required.anchor!r} at revision {current}; "
+                        f"{required.index} was required. Waited {waited_ms} ms."
+                    ),
+                    "min_revision": str(required),
+                    "current_revision": str(self.observed),
+                    "waited_ms": waited_ms,
+                },
+                headers={REVISION_HEADER: str(self.observed)},
+            )
+
+    @staticmethod
+    async def _await_zone(fs: Any, required: RevisionToken, timeout_s: float) -> tuple[bool, int]:
+        kernel = getattr(fs, "_kernel", None)
+        try:
+            return await await_zone_revision(
+                kernel, required.anchor, required.index, timeout_s=timeout_s
+            )
+        except ZoneRevisionUnavailable as exc:
+            raise HTTPException(
+                status_code=501,
+                detail={
+                    "error": "zone_revision_unavailable",
+                    "message": (
+                        "This server cannot fence reads on a zone revision: "
+                        f"{exc}. Use the path-anchored revision a write returns."
+                    ),
+                    "min_revision": str(required),
+                },
+            ) from exc
+        except HTTPException:
+            raise
+        except Exception as exc:
+            logger.warning("zone revision probe failed for %s: %s", required, exc)
+            raise HTTPException(
+                status_code=503,
+                detail={
+                    "error": "zone_revision_probe_failed",
+                    "message": f"Could not read the zone revision from the kernel: {exc}",
+                    "min_revision": str(required),
+                },
+            ) from exc
+
+    def stamp(self, response: Response | None) -> None:
+        """Set ``X-Nexus-Revision`` on ``response`` if a fence ran."""
+        if response is None or self.observed is None:
+            return
+        response.headers[REVISION_HEADER] = str(self.observed)
+
+
+def _parse_min_revision(raw: str | None, source: str) -> RevisionToken | None:
+    if raw is None or not raw.strip():
+        return None
+    try:
+        return RevisionToken.parse(raw, default_zone=ROOT_ZONE_ID)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid {source}: {exc}. Expected '<path>@<gen>' as returned by a write.",
+        ) from exc
+
+
+def _parse_timeout(raw: str | None, source: str) -> int | None:
+    if raw is None or not raw.strip():
+        return None
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=400, detail=f"Invalid {source}: must be an integer number of ms"
+        ) from exc
+    if value < 0 or value > MAX_REVISION_TIMEOUT_MS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid {source}: must be between 0 and {MAX_REVISION_TIMEOUT_MS} ms",
+        )
+    return value
+
+
+def get_revision_fence(
+    min_revision: str | None = Query(
+        None,
+        alias=MIN_REVISION_PARAM,
+        description=(
+            "Read-your-writes fence: wait until this node has applied the given "
+            "revision ('<path>@<gen>', as returned in the 'revision' field / "
+            "X-Nexus-Revision header of a mutation) before serving the read. "
+            "412 with the current revision if it is not applied within the timeout."
+        ),
+    ),
+    min_revision_header: str | None = Header(
+        None,
+        alias=MIN_REVISION_HEADER,
+        description="Header form of min_revision (takes precedence).",
+    ),
+    revision_timeout_ms: str | None = Query(
+        None,
+        alias=REVISION_TIMEOUT_PARAM,
+        description=(
+            f"How long to wait for min_revision (default {DEFAULT_REVISION_TIMEOUT_MS}, "
+            f"max {MAX_REVISION_TIMEOUT_MS} ms; 0 probes once)."
+        ),
+    ),
+    revision_timeout_header: str | None = Header(
+        None,
+        alias=REVISION_TIMEOUT_HEADER,
+        description="Header form of revision_timeout_ms (takes precedence).",
+    ),
+) -> RevisionFence:
+    """FastAPI dependency: parse the fence headers / query params."""
+    required = _parse_min_revision(min_revision_header, MIN_REVISION_HEADER)
+    if required is None:
+        required = _parse_min_revision(min_revision, MIN_REVISION_PARAM)
+    timeout = _parse_timeout(revision_timeout_header, REVISION_TIMEOUT_HEADER)
+    if timeout is None:
+        timeout = _parse_timeout(revision_timeout_ms, REVISION_TIMEOUT_PARAM)
+    return RevisionFence(
+        required=required,
+        timeout_ms=DEFAULT_REVISION_TIMEOUT_MS if timeout is None else timeout,
+    )
+
+
+def stamp_revision(response: Response, token: str | None) -> None:
+    """Set ``X-Nexus-Revision: <token>`` on a mutation response, if known."""
+    if token:
+        response.headers[REVISION_HEADER] = token
+
+
+__all__ = [
+    "REVISION_HEADER",
+    "RevisionFence",
+    "get_revision_fence",
+    "stamp_revision",
+]

--- a/src/nexus/server/api/v2/routers/async_files.py
+++ b/src/nexus/server/api/v2/routers/async_files.py
@@ -35,6 +35,11 @@ from nexus.runtime.zone_resolution import (
     zone_from_path,
     zones_from_params,
 )
+from nexus.server.api.v2._revision_fence import (
+    RevisionFence,
+    get_revision_fence,
+    stamp_revision,
+)
 from nexus.server.api.v2.routers._index_on_write import (
     IndexOnWrite,
     WriteIndexResult,
@@ -298,6 +303,15 @@ class WriteResponse(BaseModel):
     modified_at: str
     # Present when `index` was requested: indexed | skipped | error (#4736).
     index: WriteIndexResult | None = None
+    revision: str | None = Field(
+        None,
+        description=(
+            "Read-your-writes token ('<path>@<gen>') for this write. Pass it back as "
+            "X-Nexus-Min-Revision / ?min_revision= on a later read, list, glob, grep or "
+            "search to observe the write on any node, or get 412 with the node's current "
+            "revision (#4737)."
+        ),
+    )
 
 
 class ReadResponse(BaseModel):
@@ -316,6 +330,13 @@ class DeleteResponse(BaseModel):
 
     deleted: bool
     path: str
+    revision: str | None = Field(
+        None,
+        description=(
+            "Revision token for this delete (#4737). null on kernels that do not stamp "
+            "deletes; fence on the parent listing's own writes instead."
+        ),
+    )
 
 
 class ExistsResponse(BaseModel):
@@ -472,6 +493,9 @@ class BatchWriteResult(BaseModel):
     size: int
     # Present when indexing was requested for this file (#4736).
     index: WriteIndexResult | None = None
+    revision: str | None = Field(
+        None, description="Read-your-writes token ('<path>@<gen>') for this item (#4737)."
+    )
 
 
 class BatchWriteResponse(BaseModel):
@@ -536,6 +560,10 @@ class RenameResponse(BaseModel):
     success: bool
     source: str
     destination: str
+    revision: str | None = Field(
+        None,
+        description="Revision token for this rename (#4737); null on kernels that do not stamp it.",
+    )
 
 
 class CopyRequest(BaseModel):
@@ -552,6 +580,10 @@ class CopyResponse(BaseModel):
     source: str
     destination: str
     bytes_copied: int
+    revision: str | None = Field(
+        None,
+        description="Read-your-writes token ('<destination>@<gen>') for the copied file (#4737).",
+    )
 
 
 class RenameOperation(BaseModel):
@@ -883,11 +915,14 @@ def create_async_files_router(
                     size=result["size"],
                     modified_at=str(modified),
                     index=index_result,
+                    revision=result.get("revision"),
                 )
-                return Response(
+                write_response = Response(
                     content=response_data.model_dump_json(),
                     media_type="application/json",
                 )
+                stamp_revision(write_response, response_data.revision)
+                return write_response
 
             return await _run_for_context(context, {"path": request.path, "zone": zone}, _work)
 
@@ -941,6 +976,7 @@ def create_async_files_router(
         ),
         context: Any = Depends(get_context),
         auth_result: dict[str, Any] = Depends(require_auth),
+        revision_fence: RevisionFence = Depends(get_revision_fence),
     ) -> Response:
         """
         Read file content.
@@ -968,6 +1004,7 @@ def create_async_files_router(
 
             async def _work() -> Any:
                 fs = await _get_fs()
+                await revision_fence.enforce(fs, context=context)
 
                 # Fast path: content-hash (content_id) lookup — used by the diff viewer
                 # to retrieve a historical snapshot stored in CAS.
@@ -1256,7 +1293,11 @@ def create_async_files_router(
                         media_type="application/json",
                     )
 
-            return await _run_for_context(context, {"path": path, "zone": zone}, _work)
+            read_response: Response = await _run_for_context(
+                context, {"path": path, "zone": zone}, _work
+            )
+            revision_fence.stamp(read_response)
+            return read_response
 
         except HTTPException:
             # Preserve explicit HTTP status codes (e.g., 400 transaction_id
@@ -1540,6 +1581,7 @@ def create_async_files_router(
 
     @router.delete("/delete", response_model=DeleteResponse)
     async def delete_file(
+        response: Response,
         path: str = Query(..., description="Path to delete"),
         transaction_id: str | None = Query(
             None,
@@ -1581,7 +1623,7 @@ def create_async_files_router(
                         except Exception:
                             _original_hash = None
 
-                fs.sys_unlink(path, context=context)
+                unlink_result = fs.sys_unlink(path, context=context)
 
                 if (
                     _ss is not None
@@ -1598,9 +1640,17 @@ def create_async_files_router(
                     except Exception as _track_err:
                         logger.warning("txn track delete failed: %s", _track_err)
 
-                return DeleteResponse(deleted=True, path=path)
+                return DeleteResponse(
+                    deleted=True,
+                    path=path,
+                    revision=unlink_result.get("revision")
+                    if isinstance(unlink_result, dict)
+                    else None,
+                )
 
-            return await _run_for_context(context, {"path": path, "zone": zone}, _work)
+            delete_response = await _run_for_context(context, {"path": path, "zone": zone}, _work)
+            stamp_revision(response, delete_response.revision)
+            return delete_response
 
         except _PERMISSION_ERRORS as e:
             raise HTTPException(status_code=403, detail=str(e)) from e
@@ -1616,6 +1666,7 @@ def create_async_files_router(
 
     @router.get("/exists", response_model=ExistsResponse)
     async def file_exists(
+        response: Response,
         path: str = Query(..., description="Path to check"),
         zone: str | None = Query(
             None,
@@ -1623,6 +1674,7 @@ def create_async_files_router(
         ),
         context: Any = Depends(get_context),
         auth_result: dict[str, Any] = Depends(require_auth),
+        revision_fence: RevisionFence = Depends(get_revision_fence),
     ) -> ExistsResponse:
         """Check if a file or directory exists."""
         context = _apply_zone_override(context, zone, auth_result)
@@ -1630,11 +1682,17 @@ def create_async_files_router(
 
             async def _work() -> ExistsResponse:
                 fs = await _get_fs()
+                await revision_fence.enforce(fs, context=context)
                 exists = fs.access(path, context=context)
                 return ExistsResponse(exists=exists)
 
-            return await _run_for_context(context, {"path": path, "zone": zone}, _work)
+            exists_response = await _run_for_context(context, {"path": path, "zone": zone}, _work)
+            revision_fence.stamp(response)
+            return exists_response
 
+        except HTTPException:
+            # Preserve explicit statuses (412/501 from the revision fence).
+            raise
         except _PERMISSION_ERRORS as e:
             raise HTTPException(status_code=403, detail=str(e)) from e
         except InvalidPathError as e:
@@ -1645,6 +1703,7 @@ def create_async_files_router(
 
     @router.get("/list", response_model=ListResponse, response_model_by_alias=True)
     async def list_directory(
+        response: Response,
         path: str = Query(..., description="Directory path to list"),
         limit: int | None = Query(
             None, ge=1, le=1000, description="Max items per page (default: all)"
@@ -1658,6 +1717,7 @@ def create_async_files_router(
         ),
         context: Any = Depends(get_context),
         auth_result: dict[str, Any] = Depends(require_auth),
+        revision_fence: RevisionFence = Depends(get_revision_fence),
     ) -> ListResponse:
         """List directory contents with optional cursor pagination.
 
@@ -1673,6 +1733,7 @@ def create_async_files_router(
 
             async def _work() -> Any:
                 fs = await _get_fs()
+                await revision_fence.enforce(fs, context=context)
 
                 # Decode opaque cursor (base64-encoded path)
                 cursor_path: str | None = None
@@ -1860,7 +1921,11 @@ def create_async_files_router(
                 ]
                 return ListResponse(items=file_items, has_more=False)
 
-            return await _run_for_context(context, {"path": path, "zone": zone}, _work)
+            list_response: ListResponse = await _run_for_context(
+                context, {"path": path, "zone": zone}, _work
+            )
+            revision_fence.stamp(response)
+            return list_response
 
         except HTTPException:
             raise
@@ -1921,6 +1986,7 @@ def create_async_files_router(
 
     @router.get("/metadata", response_model=MetadataResponse)
     async def get_file_metadata(
+        response: Response,
         path: str = Query(..., description="Path to get metadata for"),
         zone: str | None = Query(
             None,
@@ -1928,6 +1994,7 @@ def create_async_files_router(
         ),
         context: Any = Depends(get_context),
         auth_result: dict[str, Any] = Depends(require_auth),
+        revision_fence: RevisionFence = Depends(get_revision_fence),
     ) -> MetadataResponse:
         """Get file or directory metadata."""
         context = _apply_zone_override(context, zone, auth_result)
@@ -1935,14 +2002,20 @@ def create_async_files_router(
 
             async def _work() -> MetadataResponse:
                 fs = await _get_fs()
+                await revision_fence.enforce(fs, context=context)
                 meta = fs.sys_stat(path, context=context)
                 if meta is None:
                     raise NexusFileNotFoundError(path=path)
 
                 return _to_metadata_response(meta, fallback_path=path)
 
-            return await _run_for_context(context, {"path": path, "zone": zone}, _work)
+            metadata_response = await _run_for_context(context, {"path": path, "zone": zone}, _work)
+            revision_fence.stamp(response)
+            return metadata_response
 
+        except HTTPException:
+            # Preserve explicit statuses (412/501 from the revision fence).
+            raise
         except AuthenticationError:
             # Preserve structured re-auth signal (see /list and /read handlers).
             raise
@@ -1958,6 +2031,7 @@ def create_async_files_router(
 
     @router.post("/batch-read")
     async def batch_read_files(
+        response: Response,
         request: BatchReadRequest,
         zone: str | None = Query(
             None,
@@ -1965,6 +2039,7 @@ def create_async_files_router(
         ),
         context: Any = Depends(get_context),
         auth_result: dict[str, Any] = Depends(require_auth),
+        revision_fence: RevisionFence = Depends(get_revision_fence),
     ) -> dict[str, Any]:
         """
         Read multiple files in a single request.
@@ -1977,6 +2052,7 @@ def create_async_files_router(
 
             async def _work() -> dict[str, Any]:
                 fs = await _get_fs()
+                await revision_fence.enforce(fs, context=context)
                 results = await asyncio.to_thread(fs.read_bulk, request.paths, context=context)
 
                 # Convert bytes to string for JSON response
@@ -1993,12 +2069,17 @@ def create_async_files_router(
 
                 return response
 
-            return await _run_for_context(
+            bulk_response = await _run_for_context(
                 context,
                 {"paths": request.paths, "zone": zone},
                 _work,
             )
+            revision_fence.stamp(response)
+            return bulk_response
 
+        except HTTPException:
+            # Preserve explicit statuses (412/501 from the revision fence).
+            raise
         except _PERMISSION_ERRORS as e:
             raise HTTPException(status_code=403, detail=str(e)) from e
         except InvalidPathError as e:
@@ -2057,6 +2138,7 @@ def create_async_files_router(
                         version=r.get("version", 0),
                         modified_at=r.get("modified_at"),
                         size=r.get("size", 0),
+                        revision=r.get("revision"),
                     )
                     for i, r in enumerate(raw_results)
                 ]
@@ -2093,8 +2175,10 @@ def create_async_files_router(
 
     @router.post("/batch/read", response_model=BatchReadResponse)
     async def batch_read_files_v2(
+        response: Response,
         request: BatchReadAtomicRequest,
         context: Any = Depends(get_context),
+        revision_fence: RevisionFence = Depends(get_revision_fence),
     ) -> BatchReadResponse:
         """
         Read multiple files in a single atomic round-trip.
@@ -2110,6 +2194,7 @@ def create_async_files_router(
 
             async def _work() -> BatchReadResponse:
                 fs = await _get_fs()
+                await revision_fence.enforce(fs, context=context)
                 raw_results = await _maybe_await(
                     fs.read_batch(request.paths, partial=request.partial, context=context)
                 )
@@ -2146,7 +2231,9 @@ def create_async_files_router(
                         )
                 return BatchReadResponse(results=items)
 
-            return await _run_for_context(context, request, _work)
+            batch_response = await _run_for_context(context, request, _work)
+            revision_fence.stamp(response)
+            return batch_response
         except NexusFileNotFoundError as e:
             raise HTTPException(status_code=404, detail=str(e)) from e
         except _PERMISSION_ERRORS as e:
@@ -2171,6 +2258,7 @@ def create_async_files_router(
         path: str = Query(..., description="Path to stream"),
         chunk_size: int = Query(65536, description="Chunk size in bytes"),
         context: Any = Depends(get_context),
+        revision_fence: RevisionFence = Depends(get_revision_fence),
     ) -> Response | StreamingResponse:
         """
         Stream file content in chunks with HTTP Range support (RFC 9110).
@@ -2185,6 +2273,7 @@ def create_async_files_router(
 
             async def _work() -> Response | StreamingResponse:
                 fs = await _get_fs()
+                await revision_fence.enforce(fs, context=context)
                 meta = fs.sys_stat(path, context=context)
                 if meta is None:
                     raise NexusFileNotFoundError(path=path)
@@ -2215,8 +2304,13 @@ def create_async_files_router(
                     filename=path.split("/")[-1],
                 )
 
-            return await _run_for_context(context, {"path": path}, _work)
+            stream_response = await _run_for_context(context, {"path": path}, _work)
+            revision_fence.stamp(stream_response)
+            return stream_response
 
+        except HTTPException:
+            # Preserve explicit statuses (412/501 from the revision fence).
+            raise
         except _PERMISSION_ERRORS as e:
             raise HTTPException(status_code=403, detail=str(e)) from e
         except NexusFileNotFoundError as e:
@@ -2231,6 +2325,7 @@ def create_async_files_router(
 
     @router.post("/rename", response_model=RenameResponse)
     async def rename_file(
+        response: Response,
         request: RenameRequest,
         context: Any = Depends(get_context),
     ) -> RenameResponse:
@@ -2244,16 +2339,21 @@ def create_async_files_router(
 
             async def _work() -> RenameResponse:
                 fs = await _get_fs()
-                await _maybe_await(
+                rename_result = await _maybe_await(
                     fs.sys_rename(request.source, request.destination, context=context)
                 )
                 return RenameResponse(
                     success=True,
                     source=request.source,
                     destination=request.destination,
+                    revision=rename_result.get("revision")
+                    if isinstance(rename_result, dict)
+                    else None,
                 )
 
-            return await _run_for_context(context, request, _work)
+            rename_response = await _run_for_context(context, request, _work)
+            stamp_revision(response, rename_response.revision)
+            return rename_response
 
         except _PERMISSION_ERRORS as e:
             raise HTTPException(status_code=403, detail=str(e)) from e
@@ -2269,6 +2369,7 @@ def create_async_files_router(
 
     @router.post("/copy", response_model=CopyResponse)
     async def copy_file(
+        response: Response,
         request: CopyRequest,
         context: Any = Depends(get_context),
     ) -> CopyResponse:
@@ -2293,24 +2394,31 @@ def create_async_files_router(
                 if file_size < STREAMING_COPY_THRESHOLD:
                     # Small file: read all then write all
                     content = await _maybe_await(fs.sys_read(request.source, context=context))
-                    await _maybe_await(fs.write(request.destination, buf=content, context=context))
+                    write_result = await _maybe_await(
+                        fs.write(request.destination, buf=content, context=context)
+                    )
                     bytes_copied = len(content)
                 else:
                     # Large file: streaming copy
                     chunks = await asyncio.to_thread(fs.stream, request.source, context=context)
-                    result = await asyncio.to_thread(
+                    write_result = await asyncio.to_thread(
                         fs.write_stream, request.destination, chunks, context=context
                     )
-                    bytes_copied = result.get("size", file_size)
+                    bytes_copied = write_result.get("size", file_size)
 
                 return CopyResponse(
                     success=True,
                     source=request.source,
                     destination=request.destination,
                     bytes_copied=bytes_copied,
+                    revision=write_result.get("revision")
+                    if isinstance(write_result, dict)
+                    else None,
                 )
 
-            return await _run_for_context(context, request, _work)
+            copy_response = await _run_for_context(context, request, _work)
+            stamp_revision(response, copy_response.revision)
+            return copy_response
 
         except _PERMISSION_ERRORS as e:
             raise HTTPException(status_code=403, detail=str(e)) from e
@@ -2445,10 +2553,12 @@ def create_async_files_router(
 
     @router.get("/glob", response_model=GlobResponse)
     async def glob_search(
+        response: Response,
         pattern: str = Query(..., description="Glob pattern to match (e.g. '**/*.py')"),
         path: str = Query("/", description="Base path to search under"),
         limit: int = Query(100, description="Maximum number of results", ge=1, le=1000),
         context: Any = Depends(get_context),
+        revision_fence: RevisionFence = Depends(get_revision_fence),
     ) -> GlobResponse:
         """
         Search for files matching a glob pattern.
@@ -2460,6 +2570,7 @@ def create_async_files_router(
 
             async def _work() -> GlobResponse:
                 fs = await _get_fs()
+                await revision_fence.enforce(fs, context=context)
 
                 # List all files without blocking the zone runner when a
                 # synchronous NexusFS implementation performs recursive I/O.
@@ -2484,8 +2595,13 @@ def create_async_files_router(
                     base_path=path,
                 )
 
-            return await _run_for_context(context, {"path": path}, _work)
+            glob_response = await _run_for_context(context, {"path": path}, _work)
+            revision_fence.stamp(response)
+            return glob_response
 
+        except HTTPException:
+            # Preserve explicit statuses (412/501 from the revision fence).
+            raise
         except _PERMISSION_ERRORS as e:
             raise HTTPException(status_code=403, detail=str(e)) from e
         except InvalidPathError as e:
@@ -2496,11 +2612,13 @@ def create_async_files_router(
 
     @router.get("/grep", response_model=GrepResponse)
     async def grep_search(
+        response: Response,
         pattern: str = Query(..., description="Regex pattern to search for"),
         path: str = Query("/", description="Base path to search under"),
         ignore_case: bool = Query(False, description="Case-insensitive matching"),
         limit: int = Query(100, description="Maximum number of results", ge=1, le=1000),
         context: Any = Depends(get_context),
+        revision_fence: RevisionFence = Depends(get_revision_fence),
     ) -> GrepResponse:
         """
         Search for content matching a regex pattern within files.
@@ -2514,6 +2632,7 @@ def create_async_files_router(
 
             async def _work() -> GrepResponse:
                 fs = await _get_fs()
+                await revision_fence.enforce(fs, context=context)
 
                 flags = re.IGNORECASE if ignore_case else 0
                 try:
@@ -2632,7 +2751,9 @@ def create_async_files_router(
                     base_path=path,
                 )
 
-            return await _run_for_context(context, {"path": path}, _work)
+            grep_response = await _run_for_context(context, {"path": path}, _work)
+            revision_fence.stamp(response)
+            return grep_response
 
         except HTTPException:
             raise

--- a/src/nexus/server/api/v2/routers/search.py
+++ b/src/nexus/server/api/v2/routers/search.py
@@ -35,7 +35,7 @@ import time
 from typing import Any
 
 import structlog
-from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
 
 from nexus.bricks.search.results import BACKEND_LEG_TIMING_KEYS as _BACKEND_LEG_TIMING_KEYS
 from nexus.contracts.search_types import BatchQueryFailure, SearchRequest
@@ -44,6 +44,7 @@ from nexus.lib.rebac_filter import apply_rebac_filter as _apply_rebac_filter
 from nexus.lib.rebac_filter import compute_rebac_fetch_limit as _compute_rebac_fetch_limit
 from nexus.lib.rebac_filter import rebac_denial_stats as _rebac_denial_stats
 from nexus.runtime.zone_resolution import target_zone_for_context
+from nexus.server.api.v2._revision_fence import RevisionFence, get_revision_fence
 from nexus.server.api.v2.routers._index_on_write import (
     REASON_EMPTY,
     REASON_NON_TEXT,
@@ -249,6 +250,7 @@ async def search_daemon_stats(
 @router.get("/query")
 async def search_query(
     request: Request,
+    response: Response,
     q: str = Query(..., description="Search query text", min_length=1),
     type: str = Query("hybrid", description="Search type: keyword, semantic, or hybrid"),
     limit: int = Query(10, description="Maximum number of results", ge=1, le=100),
@@ -285,6 +287,7 @@ async def search_query(
     search_daemon: Any = Depends(_get_search_daemon),
     async_session_factory: Any = Depends(_get_async_read_session_factory),
     record_store: Any = Depends(_get_record_store),
+    revision_fence: RevisionFence = Depends(get_revision_fence),
 ) -> dict[str, Any]:
     """Execute a fast search query using the search daemon."""
     from nexus.contracts.constants import ROOT_ZONE_ID
@@ -318,6 +321,16 @@ async def search_query(
 
     if not search_daemon.is_initialized:
         raise HTTPException(status_code=503, detail="Search daemon is still initializing")
+
+    # Issue #4737: read-your-writes fence — wait until this node has applied
+    # the caller's zone revision before the query runs. This fences the VFS
+    # state the plugin reads from; whether the write is *indexed* is the
+    # separate index_seq contract (#4736).
+    await revision_fence.enforce(
+        getattr(request.app.state, "nexus_fs", None),
+        context=get_operation_context(auth_result),
+    )
+    revision_fence.stamp(response)
 
     if type not in ("keyword", "semantic", "hybrid"):
         raise HTTPException(
@@ -897,8 +910,10 @@ async def _handle_federated_search(
 @router.post("/query/batch")
 async def search_query_batch(
     request: Request,
+    response: Response,
     auth_result: dict[str, Any] = Depends(require_auth),
     search_daemon: Any = Depends(_get_search_daemon),
+    revision_fence: RevisionFence = Depends(get_revision_fence),
 ) -> dict[str, Any]:
     """Batch search: run N queries through the full hybrid pipeline.
 
@@ -969,6 +984,13 @@ async def search_query_batch(
 
     if not search_daemon.is_initialized:
         raise HTTPException(status_code=503, detail="Search daemon is still initializing")
+
+    # Issue #4737: read-your-writes fence (see /query).
+    await revision_fence.enforce(
+        getattr(request.app.state, "nexus_fs", None),
+        context=get_operation_context(auth_result),
+    )
+    revision_fence.stamp(response)
 
     # Same ReBAC hook the single-query endpoint uses.
     permission_enforcer = getattr(request.app.state, "permission_enforcer", None)
@@ -1451,6 +1473,7 @@ def _resolve_section_filter(section: str | None, in_section: str | None) -> str 
 @router.get("/grep")
 async def search_grep(
     request: Request,
+    response: Response,
     pattern: str = Query(..., description="Regex pattern to search for", min_length=1),
     path: str = Query("/", description="Base path to search from"),
     ignore_case: bool = Query(False, description="Case-insensitive match"),
@@ -1487,6 +1510,7 @@ async def search_grep(
         description="Alias for section, matching the CLI --in-section flag (#4186).",
     ),
     auth_result: dict[str, Any] = Depends(require_auth),
+    revision_fence: RevisionFence = Depends(get_revision_fence),
 ) -> dict[str, Any]:
     """Search file contents via regex (#3701 Issue 1A).
 
@@ -1505,6 +1529,12 @@ async def search_grep(
     those, use ``POST /api/v2/search/grep`` which accepts the same fields
     as a JSON body — no URL length constraint.
     """
+    # Issue #4737: read-your-writes fence (see /query).
+    await revision_fence.enforce(
+        getattr(request.app.state, "nexus_fs", None),
+        context=get_operation_context(auth_result),
+    )
+    revision_fence.stamp(response)
     return await _do_grep_operation(
         request,
         auth_result,
@@ -1525,7 +1555,9 @@ async def search_grep(
 @router.post("/grep")
 async def search_grep_post(
     request: Request,
+    response: Response,
     auth_result: dict[str, Any] = Depends(require_auth),
+    revision_fence: RevisionFence = Depends(get_revision_fence),
 ) -> dict[str, Any]:
     """POST variant of ``/api/v2/search/grep`` accepting a JSON body.
 
@@ -1592,6 +1624,12 @@ async def search_grep_post(
         raise HTTPException(status_code=400, detail="Field 'block_type' must be a string")
     section = _resolve_section_filter(body.get("section"), body.get("in_section"))
 
+    # Issue #4737: read-your-writes fence (see /query).
+    await revision_fence.enforce(
+        getattr(request.app.state, "nexus_fs", None),
+        context=get_operation_context(auth_result),
+    )
+    revision_fence.stamp(response)
     return await _do_grep_operation(
         request,
         auth_result,
@@ -1612,6 +1650,7 @@ async def search_grep_post(
 @router.get("/glob")
 async def search_glob(
     request: Request,
+    response: Response,
     pattern: str = Query(..., description="Glob pattern (e.g. '**/*.py')", min_length=1),
     path: str = Query("/", description="Base path to search from"),
     limit: int = Query(100, ge=1, le=10000, description="Max results to return"),
@@ -1624,6 +1663,7 @@ async def search_glob(
         ),
     ),
     auth_result: dict[str, Any] = Depends(require_auth),
+    revision_fence: RevisionFence = Depends(get_revision_fence),
 ) -> dict[str, Any]:
     """Search file paths via glob pattern (#3701 Issue 1A).
 
@@ -1634,6 +1674,12 @@ async def search_glob(
     length limit of your HTTP client (typically >500–2000 paths), use
     ``POST /api/v2/search/glob`` with a JSON body.
     """
+    # Issue #4737: read-your-writes fence (see /query).
+    await revision_fence.enforce(
+        getattr(request.app.state, "nexus_fs", None),
+        context=get_operation_context(auth_result),
+    )
+    revision_fence.stamp(response)
     return await _do_glob_operation(
         request,
         auth_result,
@@ -1648,7 +1694,9 @@ async def search_glob(
 @router.post("/glob")
 async def search_glob_post(
     request: Request,
+    response: Response,
     auth_result: dict[str, Any] = Depends(require_auth),
+    revision_fence: RevisionFence = Depends(get_revision_fence),
 ) -> dict[str, Any]:
     """POST variant of ``/api/v2/search/glob`` accepting a JSON body.
 
@@ -1696,6 +1744,12 @@ async def search_glob_post(
     offset = _body_get_int(body, "offset", 0, ge=0)
     files = _body_get_files(body)
 
+    # Issue #4737: read-your-writes fence (see /query).
+    await revision_fence.enforce(
+        getattr(request.app.state, "nexus_fs", None),
+        context=get_operation_context(auth_result),
+    )
+    revision_fence.stamp(response)
     return await _do_glob_operation(
         request,
         auth_result,

--- a/tests/unit/core/test_write_revision_token.py
+++ b/tests/unit/core/test_write_revision_token.py
@@ -1,0 +1,115 @@
+"""NexusFS write paths return the path-anchored revision token (Issue #4737)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+from nexus.core.nexus_fs_content import ContentMixin
+
+
+class _Kernel:
+    """Minimal kernel stand-in: every write lands at gen 3, batch items at gen i+1."""
+
+    def sys_write(self, path: str, _ctx: object, content: bytes, _offset: int = 0) -> Any:
+        return SimpleNamespace(
+            hit=True,
+            content_id="cid",
+            post_hook_needed=False,
+            version=1,
+            gen=3,
+            size=len(content),
+            is_new=True,
+            old_content_id=None,
+            old_size=None,
+            old_version=None,
+            old_modified_at_ms=None,
+        )
+
+    def write_batch(self, files: list[tuple[str, bytes]], _ctx: object) -> list[Any]:
+        return [
+            SimpleNamespace(hit=True, content_id=f"cid-{i}", version=1, gen=i + 1, size=len(c))
+            for i, (_p, c) in enumerate(files)
+        ]
+
+    def stat_batch(self, paths: list[str], zone_id: str = "root") -> list[Any]:
+        return [None for _ in paths]
+
+    def dispatch_pre_hooks(self, _name: str, _ctx: object) -> None:
+        return None
+
+    def dispatch_post_hooks(self, _name: str, _ctx: object) -> None:
+        return None
+
+    def hook_count(self, _name: str) -> int:
+        return 0
+
+
+class _StampingKernel(_Kernel):
+    """A future kernel that stamps zone revisions on the response."""
+
+    def sys_write(self, path: str, _ctx: object, content: bytes, _offset: int = 0) -> Any:
+        result = super().sys_write(path, _ctx, content, _offset)
+        result.zone_id = "root"
+        result.applied_index = 1234
+        return result
+
+
+class _Harness(ContentMixin):
+    def __init__(self, kernel: _Kernel | None = None) -> None:
+        self._kernel = kernel or _Kernel()
+        self._zone_id = "root"
+        self.metadata = SimpleNamespace()
+        self._driver_coordinator = SimpleNamespace()
+
+    def _parse_context(self, context: object | None) -> object | None:
+        return context
+
+    def resolve_write(
+        self, path: str, content: bytes, *, context: object | None = None
+    ) -> tuple[bool, dict[str, object] | None]:
+        return (False, None)
+
+    def _build_rust_ctx(self, context: object | None, is_admin: bool) -> object:
+        return object()
+
+    def _get_context_identity(self, context: object | None) -> tuple[str, str | None, bool]:
+        return ("root", None, False)
+
+    def _prepare_rust_ctx(
+        self, context: object | None = None
+    ) -> tuple[str | None, str | None, bool, object]:
+        zone_id, agent_id, is_admin = self._get_context_identity(context)
+        return zone_id, agent_id, is_admin, self._build_rust_ctx(context, is_admin)
+
+    def _validate_path(self, path: str) -> str:
+        return path
+
+    def _dispatch_batch_post_hook(self, _name: str, _ctx: object) -> None:
+        return None
+
+
+def test_write_returns_path_anchored_revision() -> None:
+    result = _Harness().write("/ws/a.txt", b"abc")
+
+    assert result["gen"] == 3
+    assert result["revision"] == "/ws/a.txt@3"
+
+
+def test_sys_write_returns_path_anchored_revision() -> None:
+    result = _Harness().sys_write("/ws/a.txt", b"abc")
+
+    assert result["bytes_written"] == 3
+    assert result["revision"] == "/ws/a.txt@3"
+
+
+def test_write_batch_returns_per_item_revision() -> None:
+    results = _Harness().write_batch([("/ws/a.txt", b"abc"), ("/ws/b.txt", b"defg")])
+
+    assert [r["revision"] for r in results] == ["/ws/a.txt@1", "/ws/b.txt@2"]
+
+
+def test_kernel_stamped_zone_revision_is_preferred() -> None:
+    result = _Harness(_StampingKernel()).write("/ws/a.txt", b"abc")
+
+    assert result["revision"] == "root@1234"

--- a/tests/unit/lib/test_zone_revision.py
+++ b/tests/unit/lib/test_zone_revision.py
@@ -1,0 +1,284 @@
+"""Unit tests for the revision token (Issue #4737)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from nexus.contracts.exceptions import NexusError
+from nexus.lib.zone_revision import (
+    CLUSTER_INFO_METHOD,
+    RevisionToken,
+    ZoneRevisionUnavailable,
+    await_path_gen,
+    await_zone_revision,
+    read_path_gen,
+    read_zone_revision,
+    reset_zone_revision_cache,
+    revision_fields,
+    revision_from_result,
+    revision_token,
+    wait_for_zone_revision,
+)
+
+
+@pytest.fixture(autouse=True)
+def _fresh_cache() -> None:
+    reset_zone_revision_cache()
+
+
+# ---------------------------------------------------------------------------
+# Token parsing / formatting
+# ---------------------------------------------------------------------------
+
+
+class TestRevisionTokenParse:
+    def test_path_token_round_trips(self) -> None:
+        tok = RevisionToken.parse("/ws/a.txt@7")
+        assert tok == RevisionToken(anchor="/ws/a.txt", index=7)
+        assert tok.is_path
+        assert str(tok) == "/ws/a.txt@7"
+
+    def test_path_anchor_may_contain_at_and_spaces(self) -> None:
+        tok = RevisionToken.parse("/inbox/me@example.com/my file.txt@3")
+        assert tok.anchor == "/inbox/me@example.com/my file.txt"
+        assert tok.index == 3
+
+    def test_zone_token_round_trips(self) -> None:
+        tok = RevisionToken.parse("corp-eng@1234")
+        assert tok == RevisionToken(anchor="corp-eng", index=1234)
+        assert not tok.is_path
+
+    def test_bare_index_is_a_root_zone_token(self) -> None:
+        assert RevisionToken.parse("42") == RevisionToken(anchor="root", index=42)
+        assert RevisionToken.parse(" 7 ", default_zone="eng") == RevisionToken("eng", 7)
+
+    @pytest.mark.parametrize(
+        "raw",
+        ["", "   ", "root@", "@5", "/ws/a.txt@", "root@x", "root@-1", "ro ot@5", "root@1.5"],
+    )
+    def test_malformed_tokens_raise(self, raw: str) -> None:
+        with pytest.raises(ValueError):
+            RevisionToken.parse(raw)
+
+
+class TestRevisionFromResult:
+    def test_path_anchored_from_gen(self) -> None:
+        result = SimpleNamespace(content_id="abc", gen=7)
+        assert revision_token(result, path="/ws/a.txt") == "/ws/a.txt@7"
+
+    def test_kernel_stamped_zone_revision_wins_over_path(self) -> None:
+        result = SimpleNamespace(gen=7, zone_id="root", applied_index=1234)
+        assert revision_token(result, path="/ws/a.txt") == "root@1234"
+
+    def test_dict_results(self) -> None:
+        assert revision_token({"gen": "9"}, path="/a") == "/a@9"
+        assert revision_token({"zone_id": "eng", "applied_index": "5"}) == "eng@5"
+
+    @pytest.mark.parametrize(
+        ("result", "path"),
+        [
+            (None, "/a"),
+            ({}, "/a"),
+            ({"gen": 0}, "/a"),
+            ({"gen": None}, "/a"),
+            ({"gen": "nope"}, "/a"),
+            ({"gen": 3}, None),
+            ({"gen": 3}, "relative/path"),
+            ({"zone_id": "root", "applied_index": 0}, None),
+            ({"zone_id": "", "applied_index": 5}, None),
+            (SimpleNamespace(content_id="abc"), "/a"),
+        ],
+    )
+    def test_no_token_when_nothing_to_anchor_on(self, result: Any, path: str | None) -> None:
+        assert revision_from_result(result, path=path) is None
+        assert revision_token(result, path=path) is None
+
+
+class TestRevisionFields:
+    def test_stamped_response(self) -> None:
+        resp = SimpleNamespace(zone_id="root", applied_index=31)
+        assert revision_fields(resp) == {"zone_id": "root", "applied_index": 31}
+
+    def test_pinned_kernel_response_without_fields(self) -> None:
+        resp = SimpleNamespace(content_id="x", gen=3)
+        assert revision_fields(resp) == {"zone_id": None, "applied_index": None}
+
+    def test_zero_values_normalise_to_none(self) -> None:
+        resp = SimpleNamespace(zone_id="", applied_index=0)
+        assert revision_fields(resp) == {"zone_id": None, "applied_index": None}
+
+
+# ---------------------------------------------------------------------------
+# Path-anchored fence (sys_stat gen)
+# ---------------------------------------------------------------------------
+
+
+class FakeFS:
+    """Duck-typed NexusFS: sys_stat answers from a script of gens (None = absent)."""
+
+    def __init__(self, gens: list[int | None]) -> None:
+        self._gens = list(gens)
+        self.calls: list[tuple[str, Any]] = []
+
+    def sys_stat(self, path: str, context: Any = None) -> dict[str, Any] | None:
+        self.calls.append((path, context))
+        gen = self._gens[0] if len(self._gens) == 1 else self._gens.pop(0)
+        if gen is None:
+            return None
+        return {"path": path, "gen": gen, "content_id": "abc"}
+
+
+class TestPathGen:
+    def test_read_path_gen_goes_through_permission_checked_stat(self) -> None:
+        fs = FakeFS([4])
+        ctx = object()
+        assert read_path_gen(fs, "/a", ctx) == 4
+        assert fs.calls == [("/a", ctx)]
+
+    def test_absent_path_is_gen_zero(self) -> None:
+        assert read_path_gen(FakeFS([None]), "/a") == 0
+
+    def test_falls_back_to_version_when_gen_missing(self) -> None:
+        class VersionOnlyFS:
+            def sys_stat(self, path: str, context: Any = None) -> dict[str, Any]:
+                return {"path": path, "version": 3}
+
+        assert read_path_gen(VersionOnlyFS(), "/a") == 3
+
+    async def test_await_satisfied_after_replication(self) -> None:
+        fs = FakeFS([None, 2, 7])
+        ok, current = await await_path_gen(fs, "/a", 7, timeout_s=2.0)
+        assert (ok, current) == (True, 7)
+        assert len(fs.calls) == 3
+
+    async def test_await_times_out_with_current_gen(self) -> None:
+        ok, current = await await_path_gen(FakeFS([3]), "/a", 9, timeout_s=0.05)
+        assert (ok, current) == (False, 3)
+
+    async def test_zero_timeout_probes_once(self) -> None:
+        fs = FakeFS([None])
+        ok, current = await await_path_gen(fs, "/a", 1, timeout_s=0)
+        assert (ok, current) == (False, 0)
+        assert len(fs.calls) == 1
+
+    async def test_async_sys_stat_is_awaited(self) -> None:
+        class AsyncFS:
+            async def sys_stat(self, path: str, context: Any = None) -> dict[str, Any]:
+                return {"gen": 5}
+
+        assert await await_path_gen(AsyncFS(), "/a", 5, timeout_s=0) == (True, 5)
+
+
+# ---------------------------------------------------------------------------
+# Zone-anchored fence (kernel applied_index) — optional, kernel-stamped
+# ---------------------------------------------------------------------------
+
+
+class FakeKernel:
+    def __init__(self, applied: list[int] | int) -> None:
+        self._applied = list(applied) if isinstance(applied, list) else [applied]
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    def _call(self, method: str, params: dict[str, Any]) -> Any:
+        self.calls.append((method, params))
+        assert method == CLUSTER_INFO_METHOD
+        current = self._applied[0] if len(self._applied) == 1 else self._applied.pop(0)
+        return {"zone_id": params["zone_id"], "has_store": True, "applied_index": current}
+
+
+class FailingKernel:
+    def __init__(self, exc: Exception) -> None:
+        self.exc = exc
+        self.calls = 0
+
+    def _call(self, method: str, params: dict[str, Any]) -> Any:
+        self.calls += 1
+        raise self.exc
+
+
+class TestReadZoneRevision:
+    def test_returns_applied_index(self) -> None:
+        kernel = FakeKernel(42)
+        assert read_zone_revision(kernel, "root") == 42
+        assert kernel.calls == [(CLUSTER_INFO_METHOD, {"zone_id": "root"})]
+
+    def test_none_kernel_is_unavailable(self) -> None:
+        with pytest.raises(ZoneRevisionUnavailable):
+            read_zone_revision(None, "root")
+
+    def test_unknown_call_method_is_unavailable_and_cached(self) -> None:
+        kernel = FailingKernel(
+            NexusError("RPC error [-32603]: unknown Call method: federation_cluster_info")
+        )
+        for _ in range(2):
+            with pytest.raises(ZoneRevisionUnavailable):
+                read_zone_revision(kernel, "root")
+        assert kernel.calls == 1  # second probe answered from the cache
+
+    def test_transport_errors_propagate_and_are_not_cached(self) -> None:
+        kernel = FailingKernel(RuntimeError("connection refused"))
+        for _ in range(2):
+            with pytest.raises(RuntimeError):
+                read_zone_revision(kernel, "root")
+        assert kernel.calls == 2
+
+    def test_python_standalone_stub_is_unavailable_but_not_cached(self) -> None:
+        class StubKernel:
+            calls = 0
+
+            def _call(self, method: str, params: dict[str, Any]) -> Any:
+                self.calls += 1
+                return {"zone_id": "root", "applied_index": 0, "available": False}
+
+        kernel = StubKernel()
+        for _ in range(2):
+            with pytest.raises(ZoneRevisionUnavailable):
+                read_zone_revision(kernel, "root")
+        assert kernel.calls == 2
+
+    def test_zone_not_hosted_is_unavailable(self) -> None:
+        class NoStoreKernel:
+            def _call(self, method: str, params: dict[str, Any]) -> Any:
+                return {"zone_id": params["zone_id"], "has_store": False, "applied_index": 0}
+
+        with pytest.raises(ZoneRevisionUnavailable, match="not hosted"):
+            read_zone_revision(NoStoreKernel(), "ghost")
+
+
+class _Clock:
+    def __init__(self) -> None:
+        self.now = 0.0
+        self.sleeps: list[float] = []
+
+    def __call__(self) -> float:
+        return self.now
+
+    def sleep(self, seconds: float) -> None:
+        self.sleeps.append(seconds)
+        self.now += seconds
+
+
+class TestWaitForZoneRevision:
+    def test_satisfied_after_polls_with_backoff(self) -> None:
+        clock = _Clock()
+        kernel = FakeKernel([1, 3, 7])
+        ok, current = wait_for_zone_revision(
+            kernel, "root", 7, timeout_s=5.0, sleep=clock.sleep, clock=clock
+        )
+        assert (ok, current) == (True, 7)
+        assert clock.sleeps == [0.02, 0.04]
+
+    def test_timeout_returns_current_index(self) -> None:
+        clock = _Clock()
+        ok, current = wait_for_zone_revision(
+            FakeKernel(3), "root", 99, timeout_s=0.5, sleep=clock.sleep, clock=clock
+        )
+        assert (ok, current) == (False, 3)
+        assert all(s <= 0.25 for s in clock.sleeps)
+
+    async def test_async_twin(self) -> None:
+        ok, current = await await_zone_revision(FakeKernel([0, 5]), "root", 5, timeout_s=2.0)
+        assert (ok, current) == (True, 5)

--- a/tests/unit/remote/test_kernel_client_revision.py
+++ b/tests/unit/remote/test_kernel_client_revision.py
@@ -1,0 +1,114 @@
+"""KernelClient passes the kernel's zone revision fields through (Issue #4737)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+from nexus.lib.zone_revision import revision_token
+from nexus.remote.kernel_client import KernelClient
+
+
+class _ProtoLike(SimpleNamespace):
+    """Stands in for a generated protobuf message (HasField + attributes)."""
+
+    def HasField(self, name: str) -> bool:  # noqa: N802 — protobuf API name
+        return getattr(self, name, None) is not None
+
+
+def _client(transport: Any) -> KernelClient:
+    client = KernelClient(server_address="127.0.0.1:1")
+    client._transport = transport
+    return client
+
+
+def test_sys_write_carries_zone_revision_when_kernel_stamps_it() -> None:
+    class Transport:
+        def write_file(self, path: str, data: bytes, **_: Any) -> dict[str, Any]:
+            return {
+                "content_id": "abc",
+                "size": 3,
+                "gen": 4,
+                "zone_id": "corp-eng",
+                "applied_index": 57,
+            }
+
+    result = _client(Transport()).sys_write("/corp/eng/a.txt", None, b"abc")
+
+    assert result.zone_id == "corp-eng"
+    assert result.applied_index == 57
+    assert revision_token(result) == "corp-eng@57"
+
+
+def test_sys_write_without_stamp_yields_no_revision() -> None:
+    class Transport:
+        def write_file(self, path: str, data: bytes, **_: Any) -> dict[str, Any]:
+            return {"content_id": "abc", "size": 3, "gen": 4}
+
+    result = _client(Transport()).sys_write("/a.txt", None, b"abc")
+
+    assert result.zone_id is None
+    assert result.applied_index is None
+    assert revision_token(result) is None
+
+
+def test_sys_unlink_and_rename_pass_revision_fields_through() -> None:
+    class Transport:
+        def delete(self, path: str, recursive: bool) -> _ProtoLike:
+            return _ProtoLike(
+                success=True,
+                entry_type=1,
+                path=path,
+                content_id="abc",
+                size=3,
+                zone_id="root",
+                applied_index=12,
+            )
+
+        def rename(self, path: str, new_path: str) -> _ProtoLike:
+            return _ProtoLike(
+                hit=True,
+                success=True,
+                is_directory=False,
+                old_content_id=None,
+                old_size=None,
+                old_version=None,
+                old_modified_at_ms=None,
+                zone_id="root",
+                applied_index=13,
+            )
+
+    client = _client(Transport())
+
+    assert revision_token(client.sys_unlink("/a.txt")) == "root@12"
+    assert revision_token(client.sys_rename("/a.txt", "/b.txt")) == "root@13"
+
+
+def test_pre_contract_typed_responses_yield_no_revision() -> None:
+    class Transport:
+        def delete(self, path: str, recursive: bool) -> _ProtoLike:
+            return _ProtoLike(success=True, entry_type=1, path=path, content_id="", size=0)
+
+        def batch_write(self, files: list[tuple[str, bytes]]) -> list[_ProtoLike]:
+            return [_ProtoLike(content_id="abc", size=1, gen=1, version=1) for _ in files]
+
+    client = _client(Transport())
+
+    assert revision_token(client.sys_unlink("/a.txt")) is None
+    items = client.write_batch([("/a", b"x")])
+    assert items[0].zone_id is None and items[0].applied_index is None
+
+
+def test_write_batch_carries_per_item_revision() -> None:
+    class Transport:
+        def batch_write(self, files: list[tuple[str, bytes]]) -> list[_ProtoLike]:
+            return [
+                _ProtoLike(
+                    content_id="abc", size=1, gen=1, version=1, zone_id="root", applied_index=i + 1
+                )
+                for i, _ in enumerate(files)
+            ]
+
+    items = _client(Transport()).write_batch([("/a", b"x"), ("/b", b"y")])
+
+    assert [revision_token(i) for i in items] == ["root@1", "root@2"]

--- a/tests/unit/server/api/v2/routers/test_files_revision.py
+++ b/tests/unit/server/api/v2/routers/test_files_revision.py
@@ -1,0 +1,256 @@
+"""v2 files router: revision on mutations, X-Nexus-Min-Revision on reads (#4737)."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from nexus.lib.zone_revision import (
+    MIN_REVISION_HEADER,
+    REVISION_HEADER,
+    REVISION_TIMEOUT_HEADER,
+    reset_zone_revision_cache,
+)
+from nexus.server.api.v2.routers.async_files import create_async_files_router
+from nexus.server.dependencies import get_auth_result
+
+# What this node's sys_stat currently sees for the anchor path.
+_LOCAL_GEN = 10
+
+
+@pytest.fixture(autouse=True)
+def _fresh_cache() -> None:
+    reset_zone_revision_cache()
+
+
+@pytest.fixture()
+def mock_fs() -> MagicMock:
+    fs = MagicMock()
+    fs.write.return_value = {
+        "content_id": "abc",
+        "version": 2,
+        "gen": 2,
+        "size": 5,
+        "modified_at": None,
+        "revision": "/a.txt@2",
+    }
+    fs.write_batch.return_value = [
+        {
+            "content_id": "abc",
+            "version": 1,
+            "gen": 1,
+            "size": 1,
+            "modified_at": None,
+            "revision": "/a.txt@1",
+        },
+    ]
+    fs.sys_unlink.return_value = {"revision": None}
+    fs.sys_rename = AsyncMock(return_value={"revision": "root@11"})
+    fs.read.return_value = b"hello"
+    fs.sys_stat.return_value = {
+        "path": "/a.txt",
+        "size": 5,
+        "content_id": "abc",
+        "version": 2,
+        "gen": _LOCAL_GEN,
+        "is_directory": False,
+    }
+    fs.sys_readdir.return_value = []
+    fs.access.return_value = True
+    return fs
+
+
+@pytest.fixture()
+def client(mock_fs: MagicMock) -> TestClient:
+    app = FastAPI()
+    app.include_router(create_async_files_router(nexus_fs=mock_fs))
+    app.dependency_overrides[get_auth_result] = lambda: {
+        "authenticated": True,
+        "user_id": "test-user",
+        "groups": [],
+        "zone_id": "root",
+        "is_admin": False,
+    }
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# Mutations carry the revision
+# ---------------------------------------------------------------------------
+
+
+def test_write_returns_revision_in_body_and_header(client: TestClient) -> None:
+    resp = client.post("/write", json={"path": "/a.txt", "content": "hello"})
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["revision"] == "/a.txt@2"
+    assert resp.headers[REVISION_HEADER] == "/a.txt@2"
+
+
+def test_write_without_revision_reports_null(client: TestClient, mock_fs: MagicMock) -> None:
+    mock_fs.write.return_value = {
+        "content_id": "abc",
+        "version": 1,
+        "gen": 1,
+        "size": 5,
+        "modified_at": None,
+    }
+
+    resp = client.post("/write", json={"path": "/a.txt", "content": "hello"})
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["revision"] is None
+    assert REVISION_HEADER not in resp.headers
+
+
+def test_batch_write_returns_per_item_revision(client: TestClient) -> None:
+    resp = client.post(
+        "/batch/write",
+        json={"files": [{"path": "/a.txt", "content_base64": "aGk="}]},
+    )
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["results"][0]["revision"] == "/a.txt@1"
+
+
+def test_delete_without_kernel_stamp_reports_null(client: TestClient) -> None:
+    resp = client.delete("/delete", params={"path": "/a.txt"})
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {"deleted": True, "path": "/a.txt", "revision": None}
+    assert REVISION_HEADER not in resp.headers
+
+
+def test_rename_passes_kernel_stamped_revision_through(client: TestClient) -> None:
+    resp = client.post("/rename", json={"source": "/a.txt", "destination": "/b.txt"})
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["revision"] == "root@11"
+    assert resp.headers[REVISION_HEADER] == "root@11"
+
+
+# ---------------------------------------------------------------------------
+# Reads honour the fence
+# ---------------------------------------------------------------------------
+
+
+def test_read_without_fence_does_not_stat(client: TestClient, mock_fs: MagicMock) -> None:
+    resp = client.get("/read", params={"path": "/a.txt"})
+
+    assert resp.status_code == 200, resp.text
+    assert REVISION_HEADER not in resp.headers
+    mock_fs.sys_stat.assert_not_called()
+
+
+def test_read_with_satisfied_fence_stamps_observed_revision(
+    client: TestClient, mock_fs: MagicMock
+) -> None:
+    resp = client.get("/read", params={"path": "/a.txt"}, headers={MIN_REVISION_HEADER: "/a.txt@7"})
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["content"] == "hello"
+    assert resp.headers[REVISION_HEADER] == f"/a.txt@{_LOCAL_GEN}"
+    # The fence stat carried the caller's context (permission hooks apply).
+    _path, kwargs = mock_fs.sys_stat.call_args.args[0], mock_fs.sys_stat.call_args.kwargs
+    assert _path == "/a.txt" and kwargs["context"] is not None
+
+
+def test_read_behind_follower_returns_412_not_stale_data(
+    client: TestClient, mock_fs: MagicMock
+) -> None:
+    resp = client.get(
+        "/read",
+        params={"path": "/a.txt"},
+        headers={MIN_REVISION_HEADER: "/a.txt@50", REVISION_TIMEOUT_HEADER: "0"},
+    )
+
+    assert resp.status_code == 412, resp.text
+    detail = resp.json()["detail"]
+    assert detail["error"] == "revision_not_applied"
+    assert detail["current_revision"] == f"/a.txt@{_LOCAL_GEN}"
+    assert resp.headers[REVISION_HEADER] == f"/a.txt@{_LOCAL_GEN}"
+    mock_fs.read.assert_not_called()
+
+
+def test_read_of_path_this_node_has_not_seen_is_412(client: TestClient, mock_fs: MagicMock) -> None:
+    mock_fs.sys_stat.return_value = None
+
+    resp = client.get(
+        "/read",
+        params={"path": "/new.txt"},
+        headers={MIN_REVISION_HEADER: "/new.txt@1", REVISION_TIMEOUT_HEADER: "0"},
+    )
+
+    assert resp.status_code == 412, resp.text
+    assert resp.json()["detail"]["current_revision"] == "/new.txt@0"
+    mock_fs.read.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("method", "route", "params"),
+    [
+        ("get", "/metadata", {"path": "/a.txt"}),
+        ("get", "/exists", {"path": "/a.txt"}),
+        ("get", "/list", {"path": "/"}),
+        ("get", "/glob", {"pattern": "*.txt", "path": "/"}),
+        ("get", "/grep", {"pattern": "hello", "path": "/"}),
+    ],
+)
+def test_metadata_listing_routes_stamp_and_fence(
+    client: TestClient, method: str, route: str, params: dict[str, str]
+) -> None:
+    ok = client.request(method, route, params=params, headers={MIN_REVISION_HEADER: "/a.txt@3"})
+    assert ok.status_code == 200, ok.text
+    assert ok.headers[REVISION_HEADER] == f"/a.txt@{_LOCAL_GEN}"
+
+    behind = client.request(
+        method,
+        route,
+        params={**params, "min_revision": "/a.txt@99", "revision_timeout_ms": "0"},
+    )
+    assert behind.status_code == 412, behind.text
+    assert behind.json()["detail"]["current_revision"] == f"/a.txt@{_LOCAL_GEN}"
+
+
+def test_batch_read_routes_honour_fence(client: TestClient, mock_fs: MagicMock) -> None:
+    mock_fs.read_bulk.return_value = {"/a.txt": b"hello"}
+    mock_fs.read_batch.return_value = [
+        {"path": "/a.txt", "content": b"hello", "content_id": "abc", "version": 1, "size": 5}
+    ]
+
+    ok = client.post(
+        "/batch-read", json={"paths": ["/a.txt"]}, headers={MIN_REVISION_HEADER: "/a.txt@1"}
+    )
+    assert ok.status_code == 200, ok.text
+    assert ok.headers[REVISION_HEADER] == f"/a.txt@{_LOCAL_GEN}"
+
+    ok_v2 = client.post(
+        "/batch/read", json={"paths": ["/a.txt"]}, headers={MIN_REVISION_HEADER: "/a.txt@1"}
+    )
+    assert ok_v2.status_code == 200, ok_v2.text
+    assert ok_v2.headers[REVISION_HEADER] == f"/a.txt@{_LOCAL_GEN}"
+
+    behind = client.post(
+        "/batch/read",
+        json={"paths": ["/a.txt"]},
+        headers={MIN_REVISION_HEADER: "/a.txt@99", REVISION_TIMEOUT_HEADER: "0"},
+    )
+    assert behind.status_code == 412, behind.text
+
+
+def test_zone_token_on_pinned_kernel_is_501(client: TestClient, mock_fs: MagicMock) -> None:
+    class PinnedKernel:
+        def _call(self, method: str, params: dict[str, Any]) -> Any:
+            raise RuntimeError(f"RPC error [-32603]: unknown Call method: {method}")
+
+    mock_fs._kernel = PinnedKernel()
+
+    resp = client.get("/read", params={"path": "/a.txt"}, headers={MIN_REVISION_HEADER: "root@1"})
+
+    assert resp.status_code == 501, resp.text
+    assert resp.json()["detail"]["error"] == "zone_revision_unavailable"
+    mock_fs.read.assert_not_called()

--- a/tests/unit/server/api/v2/test_revision_fence.py
+++ b/tests/unit/server/api/v2/test_revision_fence.py
@@ -1,0 +1,269 @@
+"""Unit tests for the read-your-writes fence dependency (Issue #4737)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from fastapi import Depends, FastAPI, Response
+from fastapi.testclient import TestClient
+
+from nexus.contracts.exceptions import NexusError
+from nexus.lib.zone_revision import (
+    MAX_REVISION_TIMEOUT_MS,
+    MIN_REVISION_HEADER,
+    REVISION_HEADER,
+    REVISION_TIMEOUT_HEADER,
+    reset_zone_revision_cache,
+)
+from nexus.server.api.v2._revision_fence import (
+    RevisionFence,
+    get_revision_fence,
+    stamp_revision,
+)
+
+
+class FakeFS:
+    """NexusFS stand-in: ``gens`` maps path → gen this node currently sees."""
+
+    def __init__(self, gens: dict[str, int] | None = None, kernel: Any = None) -> None:
+        self.gens = dict(gens or {})
+        self._kernel = kernel
+        self.stat_calls: list[tuple[str, Any]] = []
+
+    def sys_stat(self, path: str, context: Any = None) -> dict[str, Any] | None:
+        self.stat_calls.append((path, context))
+        gen = self.gens.get(path)
+        return None if gen is None else {"path": path, "gen": gen}
+
+
+class FakeKernel:
+    def __init__(self, applied: int = 0, *, exc: Exception | None = None) -> None:
+        self.applied = applied
+        self.exc = exc
+        self.calls = 0
+
+    def _call(self, method: str, params: dict[str, Any]) -> Any:
+        self.calls += 1
+        if self.exc is not None:
+            raise self.exc
+        return {"zone_id": params["zone_id"], "has_store": True, "applied_index": self.applied}
+
+
+_CTX = SimpleNamespace(user_id="alice")
+
+
+def _make_app(fs: Any) -> FastAPI:
+    app = FastAPI()
+    app.state.fs = fs
+
+    @app.get("/probe")
+    async def probe(
+        response: Response, fence: RevisionFence = Depends(get_revision_fence)
+    ) -> dict[str, Any]:
+        await fence.enforce(app.state.fs, context=_CTX)
+        fence.stamp(response)
+        return {"ok": True, "fenced": fence.active}
+
+    return app
+
+
+@pytest.fixture(autouse=True)
+def _fresh_cache() -> None:
+    reset_zone_revision_cache()
+
+
+# ---------------------------------------------------------------------------
+# Path-anchored tokens (what writes return)
+# ---------------------------------------------------------------------------
+
+
+def test_unfenced_request_is_untouched() -> None:
+    fs = FakeFS({"/a.txt": 10})
+    client = TestClient(_make_app(fs))
+
+    resp = client.get("/probe")
+
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True, "fenced": False}
+    assert REVISION_HEADER not in resp.headers
+    assert fs.stat_calls == []
+
+
+def test_path_fence_satisfied_stamps_observed_gen() -> None:
+    fs = FakeFS({"/a.txt": 10})
+    client = TestClient(_make_app(fs))
+
+    resp = client.get("/probe", headers={MIN_REVISION_HEADER: "/a.txt@7"})
+
+    assert resp.status_code == 200
+    assert resp.json()["fenced"] is True
+    assert resp.headers[REVISION_HEADER] == "/a.txt@10"
+    # Stat went through the caller's context so permission hooks applied.
+    assert fs.stat_calls == [("/a.txt", _CTX)]
+
+
+def test_path_fence_via_query_param() -> None:
+    client = TestClient(_make_app(FakeFS({"/a.txt": 10})))
+
+    resp = client.get("/probe", params={"min_revision": "/a.txt@10"})
+
+    assert resp.status_code == 200
+    assert resp.headers[REVISION_HEADER] == "/a.txt@10"
+
+
+def test_header_takes_precedence_over_query_param() -> None:
+    client = TestClient(_make_app(FakeFS({"/a.txt": 10})))
+
+    resp = client.get(
+        "/probe",
+        params={"min_revision": "/a.txt@99", "revision_timeout_ms": "0"},
+        headers={MIN_REVISION_HEADER: "/a.txt@3"},
+    )
+
+    assert resp.status_code == 200
+
+
+def test_path_not_yet_applied_returns_412_with_current_gen() -> None:
+    fs = FakeFS({"/a.txt": 5})
+    client = TestClient(_make_app(fs))
+
+    resp = client.get(
+        "/probe",
+        headers={MIN_REVISION_HEADER: "/a.txt@9", REVISION_TIMEOUT_HEADER: "0"},
+    )
+
+    assert resp.status_code == 412
+    detail = resp.json()["detail"]
+    assert detail["error"] == "revision_not_applied"
+    assert detail["min_revision"] == "/a.txt@9"
+    assert detail["current_revision"] == "/a.txt@5"
+    assert resp.headers[REVISION_HEADER] == "/a.txt@5"
+    assert len(fs.stat_calls) == 1  # timeout 0 → single probe
+
+
+def test_path_absent_on_this_node_is_412_not_metadata_none() -> None:
+    client = TestClient(_make_app(FakeFS({})))
+
+    resp = client.get(
+        "/probe",
+        headers={MIN_REVISION_HEADER: "/new.txt@1", REVISION_TIMEOUT_HEADER: "0"},
+    )
+
+    assert resp.status_code == 412
+    assert resp.json()["detail"]["current_revision"] == "/new.txt@0"
+
+
+def test_path_fence_waits_for_replication() -> None:
+    class LaggingFS(FakeFS):
+        def sys_stat(self, path: str, context: Any = None) -> dict[str, Any] | None:
+            # Absent on the first two probes, then applied.
+            self.stat_calls.append((path, context))
+            return {"path": path, "gen": 4} if len(self.stat_calls) >= 3 else None
+
+    fs = LaggingFS()
+    client = TestClient(_make_app(fs))
+
+    resp = client.get("/probe", headers={MIN_REVISION_HEADER: "/a.txt@4"})
+
+    assert resp.status_code == 200
+    assert resp.headers[REVISION_HEADER] == "/a.txt@4"
+    assert len(fs.stat_calls) == 3
+
+
+def test_missing_fs_returns_503() -> None:
+    client = TestClient(_make_app(None))
+
+    resp = client.get("/probe", headers={MIN_REVISION_HEADER: "/a.txt@1"})
+
+    assert resp.status_code == 503
+
+
+@pytest.mark.parametrize("raw", ["/a.txt@", "@5", "abc", "/a.txt@1.5", "root@-1"])
+def test_malformed_min_revision_is_400(raw: str) -> None:
+    client = TestClient(_make_app(FakeFS({"/a.txt": 1})))
+
+    resp = client.get("/probe", headers={MIN_REVISION_HEADER: raw})
+
+    assert resp.status_code == 400
+    assert "Invalid X-Nexus-Min-Revision" in resp.json()["detail"]
+
+
+@pytest.mark.parametrize("raw", ["-1", "abc", str(MAX_REVISION_TIMEOUT_MS + 1)])
+def test_invalid_timeout_is_400(raw: str) -> None:
+    client = TestClient(_make_app(FakeFS({"/a.txt": 1})))
+
+    resp = client.get(
+        "/probe", headers={MIN_REVISION_HEADER: "/a.txt@1", REVISION_TIMEOUT_HEADER: raw}
+    )
+
+    assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Zone-anchored tokens (optional; kernel-stamped)
+# ---------------------------------------------------------------------------
+
+
+def test_zone_fence_satisfied_when_kernel_reports_applied_index() -> None:
+    kernel = FakeKernel(applied=10)
+    client = TestClient(_make_app(FakeFS(kernel=kernel)))
+
+    resp = client.get("/probe", headers={MIN_REVISION_HEADER: "root@5"})
+
+    assert resp.status_code == 200
+    assert resp.headers[REVISION_HEADER] == "root@10"
+    assert kernel.calls == 1
+
+
+def test_bare_index_is_a_root_zone_token() -> None:
+    kernel = FakeKernel(applied=10)
+    client = TestClient(_make_app(FakeFS(kernel=kernel)))
+
+    resp = client.get("/probe", headers={MIN_REVISION_HEADER: "99", REVISION_TIMEOUT_HEADER: "0"})
+
+    assert resp.status_code == 412
+    assert resp.json()["detail"]["current_revision"] == "root@10"
+
+
+def test_zone_fence_on_pinned_kernel_returns_501() -> None:
+    kernel = FakeKernel(exc=NexusError("unknown Call method: federation_cluster_info"))
+    client = TestClient(_make_app(FakeFS(kernel=kernel)))
+
+    resp = client.get("/probe", headers={MIN_REVISION_HEADER: "root@1"})
+
+    assert resp.status_code == 501
+    detail = resp.json()["detail"]
+    assert detail["error"] == "zone_revision_unavailable"
+    assert "path-anchored" in detail["message"]
+    assert REVISION_HEADER not in resp.headers
+
+
+def test_zone_probe_transport_error_returns_503() -> None:
+    kernel = FakeKernel(exc=RuntimeError("connection refused"))
+    client = TestClient(_make_app(FakeFS(kernel=kernel)))
+
+    resp = client.get("/probe", headers={MIN_REVISION_HEADER: "root@1"})
+
+    assert resp.status_code == 503
+    assert resp.json()["detail"]["error"] == "zone_revision_probe_failed"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def test_stamp_revision_sets_header_only_when_known() -> None:
+    response = Response()
+    stamp_revision(response, None)
+    assert REVISION_HEADER not in response.headers
+    stamp_revision(response, "/a.txt@3")
+    assert response.headers[REVISION_HEADER] == "/a.txt@3"
+
+
+def test_fence_stamp_is_noop_before_enforce() -> None:
+    response = Response()
+    RevisionFence().stamp(response)
+    assert REVISION_HEADER not in response.headers

--- a/tests/unit/server/api/v2/test_search_revision_fence.py
+++ b/tests/unit/server/api/v2/test_search_revision_fence.py
@@ -1,0 +1,160 @@
+"""Search routes honour X-Nexus-Min-Revision before querying (Issue #4737)."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from nexus.lib.zone_revision import (
+    MIN_REVISION_HEADER,
+    REVISION_HEADER,
+    REVISION_TIMEOUT_HEADER,
+    reset_zone_revision_cache,
+)
+
+_AUTH = {
+    "authenticated": True,
+    "subject_type": "user",
+    "subject_id": "alice",
+    "zone_id": "eng",
+    "zone_perms": [["eng", "r"]],
+    "is_admin": False,
+}
+
+_LOCAL_GEN = 10
+
+
+class FakeFS:
+    def __init__(self) -> None:
+        self.stat_calls: list[tuple[str, Any]] = []
+
+    def sys_stat(self, path: str, context: Any = None) -> dict[str, Any]:
+        self.stat_calls.append((path, context))
+        return {"path": path, "gen": _LOCAL_GEN}
+
+    def service(self, name: str) -> Any:
+        return None
+
+
+class _Runner:
+    async def call(self, work: Any) -> Any:
+        return await work()
+
+
+class _Registry:
+    def runner_for(self, zone_id: str) -> _Runner:
+        return _Runner()
+
+
+def _make_daemon() -> MagicMock:
+    daemon = MagicMock()
+    daemon.is_initialized = True
+    daemon.config = MagicMock()
+    daemon.config.txtai_graph = False
+
+    async def fake_search(*args: Any, **kwargs: Any) -> list[Any]:
+        return []
+
+    daemon.search = AsyncMock(side_effect=fake_search)
+    return daemon
+
+
+def _build_app(fs: FakeFS) -> tuple[FastAPI, MagicMock]:
+    from nexus.server.api.v2.routers.search import router
+    from nexus.server.dependencies import require_auth
+
+    daemon = _make_daemon()
+    app = FastAPI()
+    app.state.search_daemon = daemon
+    app.state.record_store = object()
+    app.state.async_read_session_factory = object()
+    app.state.permission_enforcer = None
+    app.state.zone_registry = _Registry()
+    app.state.nexus_fs = fs
+    app.dependency_overrides[require_auth] = lambda: _AUTH
+    app.include_router(router)
+    return app, daemon
+
+
+@pytest.fixture(autouse=True)
+def _fresh_cache() -> None:
+    reset_zone_revision_cache()
+
+
+def test_query_without_fence_does_not_stat() -> None:
+    fs = FakeFS()
+    app, daemon = _build_app(fs)
+
+    with TestClient(app) as client:
+        resp = client.get("/api/v2/search/query", params={"q": "hello"})
+
+    assert resp.status_code == 200, resp.text
+    assert REVISION_HEADER not in resp.headers
+    assert fs.stat_calls == []
+    daemon.search.assert_called_once()
+
+
+def test_query_with_satisfied_fence_runs_and_stamps_revision() -> None:
+    fs = FakeFS()
+    app, daemon = _build_app(fs)
+
+    with TestClient(app) as client:
+        resp = client.get(
+            "/api/v2/search/query",
+            params={"q": "hello"},
+            headers={MIN_REVISION_HEADER: "/ws/a.txt@4"},
+        )
+
+    assert resp.status_code == 200, resp.text
+    assert resp.headers[REVISION_HEADER] == f"/ws/a.txt@{_LOCAL_GEN}"
+    # Fence stat ran under the caller's OperationContext (eng zone).
+    assert fs.stat_calls[0][0] == "/ws/a.txt"
+    assert getattr(fs.stat_calls[0][1], "zone_id", None) == "eng"
+    daemon.search.assert_called_once()
+
+
+def test_query_behind_revision_is_412_and_never_queries() -> None:
+    app, daemon = _build_app(FakeFS())
+
+    with TestClient(app) as client:
+        resp = client.get(
+            "/api/v2/search/query",
+            params={"q": "hello"},
+            headers={MIN_REVISION_HEADER: "/ws/a.txt@40", REVISION_TIMEOUT_HEADER: "0"},
+        )
+
+    assert resp.status_code == 412, resp.text
+    assert resp.json()["detail"]["current_revision"] == f"/ws/a.txt@{_LOCAL_GEN}"
+    assert resp.headers[REVISION_HEADER] == f"/ws/a.txt@{_LOCAL_GEN}"
+    daemon.search.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("method", "route", "kwargs"),
+    [
+        ("post", "/api/v2/search/query/batch", {"json": {"queries": [{"q": "hello"}]}}),
+        ("get", "/api/v2/search/glob", {"params": {"pattern": "*.py"}}),
+        ("post", "/api/v2/search/glob", {"json": {"pattern": "*.py"}}),
+        ("get", "/api/v2/search/grep", {"params": {"pattern": "TODO"}}),
+        ("post", "/api/v2/search/grep", {"json": {"pattern": "TODO"}}),
+    ],
+)
+def test_other_search_routes_fence_before_work(method: str, route: str, kwargs: dict) -> None:
+    app, daemon = _build_app(FakeFS())
+
+    with TestClient(app) as client:
+        resp = client.request(
+            method,
+            route,
+            headers={MIN_REVISION_HEADER: "/ws/a.txt@99", REVISION_TIMEOUT_HEADER: "0"},
+            **kwargs,
+        )
+
+    assert resp.status_code == 412, resp.text
+    assert resp.json()["detail"]["error"] == "revision_not_applied"
+    daemon.search.assert_not_called()
+    daemon.batch_search.assert_not_called()


### PR DESCRIPTION
## Summary

Closes #4737.

Every write returns a **revision token** a later read can wait on, so a tenant no longer has to re-read and byte-compare to know its write is visible on another node.

- **Token**: `"<path>@<gen>"` (e.g. `/ws/a.txt@7`). Returned as `revision` plus `X-Nexus-Revision` on `files/write`, `files/batch/write` (per item), `files/copy`, and as a `"revision"` key from `NexusFS.write` / `sys_write` / `write_batch` (so the legacy `/api/nfs/write` route carries it too).
- **Fence**: `X-Nexus-Min-Revision: /ws/a.txt@7` (or `?min_revision=`) on `files/read|metadata|exists|list|glob|grep|stream|batch-read|batch/read` and `search/query|query/batch|grep|glob`. The server polls `sys_stat(anchor)` **under the caller's context** until `gen >= 7` (bounded by `X-Nexus-Revision-Timeout-Ms`, default 5 s, max 30 s), then serves and stamps `X-Nexus-Revision` with what it observed. Otherwise **412** with `detail.current_revision` — never `metadata: None` or an empty listing because the node is behind.
- **Why a per-path gen is enough**: raft applies entries in log order, so a node whose stat shows the anchor at `gen >= G` has applied every earlier entry of that zone. Listings, glob, grep and search for that zone therefore include the write. No `applied_index`, no kernel change.
- **Zone tokens** (`zone@applied_index`) are accepted as an optional future format for a kernel that stamps `zone_id` / `applied_index` on mutation responses and serves `federation_cluster_info`; on the pinned kernel they answer **501**. Delete and rename return `revision: null` (nothing to anchor a gen on).
- **Docs**: `docs/architecture/consistency-contract.md` publishes the kernel consistency semantics with file pointers (SC proposals resolve after leader apply, local sequential metadata reads, ReadIndex only for locks, `try_remote_fetch` without cache-back, apply-side dcache invalidation, mount-table gap) plus the token protocol; optional kernel work is listed in §5. User guide gets a short section; the SSOT gap doc gets a status note.

Note on the issue text: the shipped token is the per-path `gen`, not a zone-wide `applied_index`. The acceptance criteria hold without a zone-wide sequence, and the pinned `nexusd-cluster` exposes no `applied_index` over gRPC (`federation_cluster_info` is `unknown Call method`; `_nexus_raft.pyi` describes the retired PyO3 module, which is why `is_committed` has no callers).

## Test plan

- [x] Unit: `tests/unit/lib/test_zone_revision.py`, `tests/unit/server/api/v2/test_revision_fence.py`, `tests/unit/server/api/v2/routers/test_files_revision.py`, `tests/unit/server/api/v2/test_search_revision_fence.py`, `tests/unit/core/test_write_revision_token.py`, `tests/unit/remote/test_kernel_client_revision.py` (209 targeted tests incl. adjacent existing suites; `tests/unit/{server,remote,lib,core}` green).
- [x] ruff check / ruff format / mypy clean on changed files.
- [x] Live on `nexus up --build` + native search-plugin host (`backend=rust-plugin`): 41/41 HTTP checks — write returns `/path@gen` (body + header), second write bumps gen, fenced read/metadata/exists/list/glob/grep and search glob/query return 200 with the observed revision, fenced read returns latest content, 412 with `current_revision` for an unapplied revision, 412 `@0` for a path this node has never seen, 300 ms timeout honoured, 400 malformed, 501 zone token, batch per-item revisions, unfenced reads carry no header, copy anchored on destination, delete/rename null.
- [x] `permissions_demo_enhanced.sh` inside the container: all green.
- [x] `scripts/test_build_perf_e2e.py` inside the container: 30 passed, 0 failed, HERB 8/8.

Not covered here: a live 2-node follower (the conformance suite is #4741).

## Follow-ups (not in this PR)

- `mkdir` returns `None` on the Python API, so it carries no token.
- The deprecated `/api/nfs/{method}` route and the gRPC `Call` servicer are not fenced (they do return `revision` on write).
- Delete + recreate resets `gen`, so a token from the old life times out to 412.
- Optional kernel work (zone-wide token, revision on delete/rename, mount-convergence readiness) is listed in `docs/architecture/consistency-contract.md` §5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
