### PR TITLE
feat(storage): fenced projections — write-through group commit, projection_seq, /operations/wait, reconcile (#4738)

### DIFF
--- a/docs/architecture/record-store-projections.md
+++ b/docs/architecture/record-store-projections.md
@@ -1,0 +1,189 @@
+# RecordStore Projections: write-through, fence, reconcile
+
+Issue: nexi-lab/nexus#4738 (fenced projections). Companions: #4736 (write →
+searchable, `index_seq`), #4737 (read-your-writes revision token), #4741
+(conformance suite). Tenant tracking: DeepBuildAI/koodle#3079.
+
+The kernel (`nexus-vfs`, raft + CAS) is the authority for file content and
+metadata. The RecordStore (SQLite or PostgreSQL) holds **projections** of it
+that services query: `file_paths` (the search zone join, `list_versions`
+lookup), `version_history` (`list_versions`, `get_version`, rollback),
+`operation_log` (audit, `/api/v2/operations`, `/api/v2/ops/replay`, event
+delivery) and `metadata_change_log` (MCL / aspects). This document is the
+contract for how those projections follow the kernel.
+
+## 1. What changed
+
+Before #4738 the projection was fed by a 200 ms debounce over an in-memory
+`deque(maxlen=10_000)` (#809): `list_versions` right after a write could be
+empty, a burst over 10 k events silently dropped the oldest (only a counter
+moved), a crash lost everything in flight, and readers had to call the
+admin-only `flush_write_observer` RPC.
+
+Now (`src/nexus/storage/piped_record_store_write_observer.py`):
+
+| Property | Contract |
+|----------|----------|
+| Visibility | `operation_log`, `file_paths`, `version_history` rows are committed **before the write returns**. `list_versions` immediately after a write returns the new version with no flush call. |
+| Fence | Every write returns `projection_seq` — the `operation_log.sequence_number` of its row. `GET /api/v2/operations/wait?seq=N` blocks until that row is committed (200) or the timeout passes (412). |
+| Throughput | Concurrent writers share one SQL transaction (group commit); one committer thread allocates sequence numbers, so no MAX+1 retry storms. |
+| Failure | `AuditConfig.strict_mode=True` (default): commit failure after retries or no confirmation within `NEXUS_PROJECTION_TIMEOUT_S` (5 s) raises `AuditLogError` from the write. `strict_mode=False`: the write succeeds with `projection_seq: null`, the event stays queued for retry, CRITICAL log. |
+| Never silent | Both queues are bounded. The deferred queue backpressures the committer for 2 s before dropping; every drop is an ERROR log plus `nexus_projection_events_dropped_total{queue}`. |
+| Deferred | Only MCL rows and post-flush hooks (extraction, lineage) run off the write path, on a dedicated thread. |
+| Recovery | `POST /api/v2/admin/reconcile-projections` repairs the projection from the kernel after a crash, an outage or a drop. |
+
+## 2. Data flow
+
+```
+writer thread                              projection-commit thread
+─────────────                              ────────────────────────
+kernel sys_write (raft commit, durable)
+post-hook → SyncAuditWriteInterceptor
+  observer.on_write(...)
+    ticket = _submit(events)  ───────────▶ drain ≤ 100 events (all waiting tickets)
+    ticket.done.wait(timeout)              ONE transaction:
+                                             OperationLogger.log_operation → sequence_number
+                                             VersionRecorder.record_write  → file_paths, version_history
+                                           ticket.seq = sequence_number; wake writers
+    ctx.extra["projection_seq"] = seq      hand events to projection-deferred thread
+NexusFS.write returns {..., projection_seq}            │
+                                                        ▼
+                                           MCLRecorder rows, extraction + lineage hooks
+```
+
+`version_history.extra_metadata` records the kernel `gen` of the write
+(`{"gen": N}`) so reconcile can tell a lagging kernel view from a lost row.
+
+## 3. Surfaces
+
+### Writes return `projection_seq`
+
+| Surface | Field |
+|---------|-------|
+| `POST /api/v2/files/write` | `projection_seq` |
+| `POST /api/v2/files/batch/write` | `results[].projection_seq` |
+| `DELETE /api/v2/files/delete`, `POST /api/v2/files/rename`, `POST /api/v2/files/mkdir` | `projection_seq` |
+| `POST /api/v2/files/rename-batch` | `results[].projection_seq` |
+| `NexusFS.write` / `sys_write` / `write_batch` / `sys_unlink` / `rmdir` / `sys_rename` / `mkdir` / `rename_batch` | `"projection_seq"` key in the returned dict (`mkdir` used to return `None`) |
+| `POST /api/nfs/{method}` and gRPC `Call` (`write`, `delete`, `rename`, `mkdir`, `rmdir`) | `projection_seq` next to the legacy shape (`{"deleted": true, ...}`), present only when confirmed |
+
+`null` means the projection was not confirmed: the legacy synchronous
+observer is in use (`NEXUS_ENABLE_WRITE_BUFFER=false` — it commits inline but
+returns no sequence), or a non-strict observer timed out. Rename returns the
+sequence of its upsert row (the second of the two audit rows it writes).
+
+CLI: `nexus ops wait --seq N [--timeout-ms MS]` (exit 0 applied, 1 not yet)
+and `nexus admin fs reconcile-projections --prefix P [--dry-run]
+[--retire-missing] [--max-entries N]` (runs locally when the CLI holds the
+RecordStore, otherwise through the admin REST route).
+
+### `GET /api/v2/operations/wait`
+
+```
+GET /api/v2/operations/wait?seq=1234&timeout_ms=5000
+```
+
+| Outcome | Status | Body |
+|---------|--------|------|
+| Row `seq` committed in the caller's zone | 200 | `{seq, applied: true, latest_seq, zone_id, waited_ms}` |
+| Not committed before `timeout_ms` (default 5 000, max 30 000, `0` probes once) | **412** | `detail = {error: "projection_not_applied", seq, latest_seq, zone_id, waited_ms}` |
+
+Scoped to the token's zone: a sequence that belongs to another zone looks
+exactly like one that has not landed. Each probe opens a fresh RecordStore
+session so it sees rows committed by other connections (SQLite pins a read
+snapshot per transaction). `latest_seq` is the zone's newest committed
+sequence — the same number `/api/v2/ops/replay?from_sequence=` consumes.
+
+With write-through the sequence is normally committed when the write
+returns, so on the same node the wait answers immediately. It matters when
+(a) the observer runs non-strict and timed out (`projection_seq` was `null`
+— nothing to wait on; poll `latest_seq` or reconcile), (b) another node
+shares the same PostgreSQL and the caller's sequence came from elsewhere,
+and (c) as the protocol replacement for `flush_write_observer`, which is
+admin-only and now only drains deferred work.
+
+### `POST /api/v2/admin/reconcile-projections`
+
+```json
+{"prefix": "/workspace", "dry_run": false, "retire_missing": false, "max_entries": null}
+```
+
+Admin only. Walks the kernel under `prefix` (`sys_readdir` recursive with
+details, under the caller's context) and, per regular file with content:
+
+| Verdict | Condition | Action |
+|---------|-----------|--------|
+| `created` | no active `file_paths` row | `file_paths` + `version_history` v1 + `operation_log` write row, `agent_id = system:projection-reconcile` |
+| `in_sync` | head row's recorded `gen` equals the kernel's (legacy rows without a `gen`: head `content_id` equals the kernel's) | none |
+| `repaired` | kernel `gen` newer than the head row's (legacy rows: content differs) | new `version_history` row for the kernel's current content, `file_paths` updated, `operation_log` write row |
+| `stale_kernel` | head row records a `gen` newer than the kernel's | none — this node's kernel view is behind (follower lag); the projection is not the stale side |
+| `retired` (`retire_missing=true` only) | active row under `prefix` the kernel no longer lists | soft delete + `operation_log` delete row |
+
+The comparison keys on the kernel `gen` rather than `content_id` because a
+path-addressed backend (the local backend in a single-node deployment)
+reports the storage key — the path — as `content_id`, which never changes
+across writes; `gen` increments on every write everywhere. The observer
+keys `file_paths` rows by the *writer's* zone, and `list_versions` looks a
+path up by `virtual_path` alone, so reconcile matches an existing row in
+**any** zone (a root admin never duplicates rows a `research` token wrote),
+repairs in that row's zone, and uses the caller's zone only for rows that
+do not exist anywhere. Intermediate versions lost in a crash window cannot be
+recovered (the kernel keeps only current metadata); the repair records the
+current content as the next version. `retire_missing` is opt-in because a
+partial kernel listing (an unrouted mount) would otherwise retire live
+rows; it is skipped when `max_entries` truncated the walk.
+
+## 4. Operations
+
+Metrics (Prometheus, `/metrics`):
+
+| Metric | Meaning |
+|--------|---------|
+| `nexus_projection_events_dropped_total{queue="pending"\|"deferred"}` | Events shed from a bounded queue. `pending` drops lose audit/version rows → run reconcile. `deferred` drops lose MCL rows + hooks → run `POST /api/v2/admin/reindex`. Non-zero is an incident. |
+| `nexus_projection_events_failed_total` | Rows whose commit failed after retries (poison rows, #4645); their writers got `AuditLogError` in strict mode. |
+| `nexus_projection_write_through_timeouts_total` | Writes that returned before their row was confirmed (strict: as an error; non-strict: with `projection_seq: null`). |
+| `nexus_projection_pending_events{queue}` | Current queue depth. |
+
+The observer's `metrics` property carries the same counters plus
+`applied_seq` (highest sequence this process committed).
+
+Configuration:
+
+| Setting | Default | Effect |
+|---------|---------|--------|
+| `AuditConfig.strict_mode` / `audit_strict_mode` | `true` | Fail the write (`AuditLogError`) when its projection is not confirmed. |
+| `NEXUS_PROJECTION_TIMEOUT_S` | `5.0` | How long a write waits for its commit before the strict/non-strict policy applies. |
+| `NEXUS_ENABLE_WRITE_BUFFER` | `true` | `false` selects the legacy fully synchronous observer (inline MCL, `/__sys__/versioning` snapshots, no `projection_seq`). |
+
+Crash window: the kernel commit precedes the projection commit, so a
+`kill -9` between them leaves the kernel ahead by the rows in flight (at
+most one per writer thread; those writers never received a response). After
+restart, `POST /api/v2/admin/reconcile-projections` on the affected prefix
+restores `file_paths` / `version_history` from the kernel's current state;
+`dry_run: true` first shows the drift. Tenants that fenced on
+`projection_seq` are unaffected: the fence only reports sequences whose row
+is already committed.
+
+`tests/e2e/self_contained/test_projection_crash_recovery_e2e.py` is the
+acceptance test for this: a real `nexusd` + kernel, a 20 000-write burst from
+8 threads, `SIGKILL` of the whole process group at 40 %, restart on the same
+data directory, reconcile, then a path-by-path comparison of `file_paths`,
+`version_history` and `operation_log` against the kernel listing. A
+representative run: 8 000 writes acknowledged before the kill, 8 001 files in
+the kernel afterwards (one write committed by the kernel but never
+acknowledged — the crash window), reconcile `created: 1`, zero mismatches.
+
+## 5. Tenant guidance
+
+1. Keep `projection_seq` from every write next to `content_id` and the
+   `revision` token (#4737). `revision` fences kernel reads (`read`, `list`,
+   `search`); `projection_seq` fences the SQL-backed history and audit
+   surfaces (`list_versions`, `/api/v2/operations`, `/api/v2/ops/replay`).
+2. On the node that served the write no wait is needed. Across nodes sharing
+   a RecordStore, `GET /api/v2/operations/wait?seq=` before the history call.
+3. `projection_seq: null` means the deployment runs non-strict and the row is
+   pending; treat history as eventually consistent for that write and expect
+   `nexus_projection_write_through_timeouts_total` to have moved.
+4. After a server crash, ask an operator to run reconcile (or run it with an
+   admin token) before trusting `list_versions` for paths written in the last
+   seconds before the crash.

--- a/docs/guides/user-guide.md
+++ b/docs/guides/user-guide.md
@@ -1748,6 +1748,17 @@ full profile. `list_versions` and `diff_versions` are hot-path/history paths;
 `get_version` and `rollback` are content reads/writes and should be benchmarked
 when used on large files.
 
+Version history is committed before a write returns (#4738): `list_versions`
+right after `files/write` includes the new version, and every mutation
+response (write, batch write, delete, rename, mkdir) carries
+`projection_seq`. From another node sharing the RecordStore, call
+`GET /api/v2/operations/wait?seq=<projection_seq>` (200 applied, 412 not yet)
+or `nexus ops wait --seq <projection_seq>` before reading history or the
+operation log. After a server crash an admin runs
+`POST /api/v2/admin/reconcile-projections` or
+`nexus admin fs reconcile-projections --prefix /workspace` to repair history
+from the kernel. See `docs/architecture/record-store-projections.md`.
+
 ### Transactional snapshots
 
 ```bash

--- a/docs/surface-coverage/api-rpc-surface-coverage.yaml
+++ b/docs/surface-coverage/api-rpc-surface-coverage.yaml
@@ -439,13 +439,31 @@ operations:
     and covered by connector/search benchmarks when enabled.
   gap_issue: null
   owning_issue: 4136
+- id: admin.reconcile_projections
+  module: uncategorized
+  summary: Repair file_paths / version_history / operation_log from the kernel after a crash, outage or dropped projection
+    event (#4738).
+  transports:
+    http:
+      name: POST /api/v2/admin/reconcile-projections
+      source: src/nexus/server/api/v2/routers/replay.py:250
+  profiles:
+    lite: supported
+    sandbox: supported
+    full: supported
+  usage_example: null
+  correctness_test: tests/unit/server/api/v2/test_admin_reconcile_projections.py; tests/unit/storage/test_projection_reconcile.py
+  perf_class: control
+  perf_link: operator recovery surface; walks the kernel under a prefix, not on the data-plane hot path
+  gap_issue: null
+  owning_issue: 4738
 - id: admin.reindex
   module: search
   summary: ''
   transports:
     http:
       name: POST /api/v2/admin/reindex
-      source: src/nexus/server/api/v2/routers/replay.py:88
+      source: src/nexus/server/api/v2/routers/replay.py:95
   profiles:
     lite: supported
     sandbox: supported
@@ -1018,7 +1036,7 @@ operations:
   transports:
     http:
       name: POST /batch/read
-      source: src/nexus/server/api/v2/routers/async_files.py:2176
+      source: src/nexus/server/api/v2/routers/async_files.py:2206
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1037,7 +1055,7 @@ operations:
   transports:
     http:
       name: POST /batch/write
-      source: src/nexus/server/api/v2/routers/async_files.py:2091
+      source: src/nexus/server/api/v2/routers/async_files.py:2120
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1056,7 +1074,7 @@ operations:
   transports:
     http:
       name: POST /copy
-      source: src/nexus/server/api/v2/routers/async_files.py:2370
+      source: src/nexus/server/api/v2/routers/async_files.py:2401
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1075,7 +1093,7 @@ operations:
   transports:
     http:
       name: POST /copy-bulk
-      source: src/nexus/server/api/v2/routers/async_files.py:2477
+      source: src/nexus/server/api/v2/routers/async_files.py:2509
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1094,7 +1112,7 @@ operations:
   transports:
     http:
       name: DELETE /delete
-      source: src/nexus/server/api/v2/routers/async_files.py:1582
+      source: src/nexus/server/api/v2/routers/async_files.py:1606
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1112,7 +1130,7 @@ operations:
   transports:
     http:
       name: GET /exists
-      source: src/nexus/server/api/v2/routers/async_files.py:1667
+      source: src/nexus/server/api/v2/routers/async_files.py:1692
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1130,7 +1148,7 @@ operations:
   transports:
     http:
       name: GET /glob
-      source: src/nexus/server/api/v2/routers/async_files.py:2554
+      source: src/nexus/server/api/v2/routers/async_files.py:2586
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1148,7 +1166,7 @@ operations:
   transports:
     http:
       name: GET /grep
-      source: src/nexus/server/api/v2/routers/async_files.py:2613
+      source: src/nexus/server/api/v2/routers/async_files.py:2645
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1167,7 +1185,7 @@ operations:
   transports:
     http:
       name: GET /list
-      source: src/nexus/server/api/v2/routers/async_files.py:1704
+      source: src/nexus/server/api/v2/routers/async_files.py:1729
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1185,7 +1203,7 @@ operations:
   transports:
     http:
       name: GET /md-structure
-      source: src/nexus/server/api/v2/routers/async_files.py:1484
+      source: src/nexus/server/api/v2/routers/async_files.py:1508
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1203,7 +1221,7 @@ operations:
   transports:
     http:
       name: GET /metadata
-      source: src/nexus/server/api/v2/routers/async_files.py:1987
+      source: src/nexus/server/api/v2/routers/async_files.py:2016
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1221,7 +1239,7 @@ operations:
   transports:
     http:
       name: POST /mkdir
-      source: src/nexus/server/api/v2/routers/async_files.py:1949
+      source: src/nexus/server/api/v2/routers/async_files.py:1974
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1239,7 +1257,7 @@ operations:
   transports:
     http:
       name: GET /read
-      source: src/nexus/server/api/v2/routers/async_files.py:945
+      source: src/nexus/server/api/v2/routers/async_files.py:969
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1257,7 +1275,7 @@ operations:
   transports:
     http:
       name: GET /read-url
-      source: src/nexus/server/api/v2/routers/async_files.py:1320
+      source: src/nexus/server/api/v2/routers/async_files.py:1344
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1276,7 +1294,7 @@ operations:
   transports:
     http:
       name: POST /rename
-      source: src/nexus/server/api/v2/routers/async_files.py:2326
+      source: src/nexus/server/api/v2/routers/async_files.py:2356
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1294,7 +1312,7 @@ operations:
   transports:
     http:
       name: POST /rename-batch
-      source: src/nexus/server/api/v2/routers/async_files.py:2435
+      source: src/nexus/server/api/v2/routers/async_files.py:2466
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1312,7 +1330,7 @@ operations:
   transports:
     http:
       name: GET /stream
-      source: src/nexus/server/api/v2/routers/async_files.py:2255
+      source: src/nexus/server/api/v2/routers/async_files.py:2285
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1330,7 +1348,7 @@ operations:
   transports:
     http:
       name: POST /write
-      source: src/nexus/server/api/v2/routers/async_files.py:716
+      source: src/nexus/server/api/v2/routers/async_files.py:739
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1757,7 +1775,7 @@ operations:
   transports:
     grpc_expose:
       name: backfill_directory_index
-      source: src/nexus/core/nexus_fs_metadata.py:2052
+      source: src/nexus/core/nexus_fs_metadata.py:2078
     sdk:
       name: MCPClient.backfill_directory_index
       source: src/nexus/remote/domain/mcp.py:91
@@ -2507,7 +2525,7 @@ operations:
   transports:
     grpc_expose:
       name: delete_batch
-      source: src/nexus/core/nexus_fs_metadata.py:1445
+      source: src/nexus/core/nexus_fs_metadata.py:1464
   profiles:
     lite: supported
     sandbox: supported
@@ -2863,7 +2881,7 @@ operations:
   transports:
     grpc_expose:
       name: exists_batch
-      source: src/nexus/core/nexus_fs_metadata.py:1340
+      source: src/nexus/core/nexus_fs_metadata.py:1359
     sdk:
       name: KernelClient.exists_batch
       source: src/nexus/remote/kernel_client.py:815
@@ -3215,7 +3233,7 @@ operations:
       source: src/nexus/cli/commands/file_ops.py:1
     grpc_expose:
       name: append
-      source: src/nexus/core/nexus_fs_content.py:1092
+      source: src/nexus/core/nexus_fs_content.py:1096
   profiles:
     lite: supported
     sandbox: supported
@@ -3336,7 +3354,7 @@ operations:
   transports:
     grpc_expose:
       name: edit
-      source: src/nexus/core/nexus_fs_content.py:1213
+      source: src/nexus/core/nexus_fs_content.py:1217
   profiles:
     lite: supported
     sandbox: supported
@@ -3723,7 +3741,7 @@ operations:
       source: src/nexus/cli/commands/file_ops.py:1
     grpc_expose:
       name: stat
-      source: src/nexus/core/nexus_fs_metadata.py:1120
+      source: src/nexus/core/nexus_fs_metadata.py:1139
   profiles:
     lite: supported
     sandbox: supported
@@ -3850,7 +3868,7 @@ operations:
   transports:
     grpc_expose:
       name: flush_write_observer
-      source: src/nexus/core/nexus_fs_metadata.py:2082
+      source: src/nexus/core/nexus_fs_metadata.py:2108
   profiles:
     lite: supported
     sandbox: supported
@@ -5728,7 +5746,7 @@ operations:
   transports:
     grpc_expose:
       name: metadata_batch
-      source: src/nexus/core/nexus_fs_metadata.py:1350
+      source: src/nexus/core/nexus_fs_metadata.py:1369
   profiles:
     lite: supported
     sandbox: supported
@@ -6276,7 +6294,7 @@ operations:
   transports:
     http:
       name: GET /api/v2/operations/agents/{agent_id}/activity
-      source: src/nexus/server/api/v2/routers/operations.py:135
+      source: src/nexus/server/api/v2/routers/operations.py:225
   profiles:
     lite: supported
     sandbox: supported
@@ -6293,7 +6311,7 @@ operations:
   transports:
     http:
       name: GET /api/v2/operations
-      source: src/nexus/server/api/v2/routers/operations.py:58
+      source: src/nexus/server/api/v2/routers/operations.py:70
   profiles:
     lite: supported
     sandbox: supported
@@ -6304,13 +6322,30 @@ operations:
   perf_link: operator/control-plane surface; not on data-plane hot path
   gap_issue: null
   owning_issue: 4138
+- id: operations.wait
+  module: uncategorized
+  summary: Wait until a write's projection_seq (operation_log sequence) is committed; 412 on timeout (#4738).
+  transports:
+    http:
+      name: GET /api/v2/operations/wait
+      source: src/nexus/server/api/v2/routers/operations.py:147
+  profiles:
+    lite: supported
+    sandbox: supported
+    full: supported
+  usage_example: null
+  correctness_test: tests/unit/server/api/v2/test_operations_wait.py
+  perf_class: control
+  perf_link: read-your-writes fence; one indexed EXISTS probe per poll, not on the data-plane hot path
+  gap_issue: null
+  owning_issue: 4738
 - id: ops.replay
   module: uncategorized
   summary: ''
   transports:
     http:
       name: GET /api/v2/ops/replay
-      source: src/nexus/server/api/v2/routers/replay.py:30
+      source: src/nexus/server/api/v2/routers/replay.py:37
   profiles:
     lite: supported
     sandbox: supported
@@ -6914,7 +6949,7 @@ operations:
   transports:
     grpc_expose:
       name: read_batch
-      source: src/nexus/core/nexus_fs_content.py:1626
+      source: src/nexus/core/nexus_fs_content.py:1635
     sdk:
       name: KernelClient.read_batch
       source: src/nexus/remote/kernel_client.py:649
@@ -7336,7 +7371,7 @@ operations:
   transports:
     grpc_expose:
       name: rename_batch
-      source: src/nexus/core/nexus_fs_metadata.py:1584
+      source: src/nexus/core/nexus_fs_metadata.py:1603
   profiles:
     lite: supported
     sandbox: supported
@@ -8486,7 +8521,7 @@ operations:
   transports:
     grpc_expose:
       name: stat_bulk
-      source: src/nexus/core/nexus_fs_metadata.py:1208
+      source: src/nexus/core/nexus_fs_metadata.py:1227
   profiles:
     lite: supported
     sandbox: supported
@@ -9684,7 +9719,7 @@ operations:
   transports:
     grpc_expose:
       name: write_batch
-      source: src/nexus/core/nexus_fs_content.py:1463
+      source: src/nexus/core/nexus_fs_content.py:1467
     sdk:
       name: KernelClient.write_batch
       source: src/nexus/remote/kernel_client.py:1114
@@ -9877,6 +9912,14 @@ parity_warnings:
   - mcp
   - sdk
 - operation_id: access_manifests.{manifest_id}_revoke
+  has:
+  - http
+  missing:
+  - cli
+  - grpc_typed
+  - mcp
+  - sdk
+- operation_id: admin.reconcile_projections
   has:
   - http
   missing:
@@ -11805,6 +11848,14 @@ parity_warnings:
   - mcp
   - sdk
 - operation_id: operations.api_v2
+  has:
+  - http
+  missing:
+  - cli
+  - grpc_typed
+  - mcp
+  - sdk
+- operation_id: operations.wait
   has:
   - http
   missing:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -198,6 +198,7 @@ nav:
     - Backend Architecture: architecture/backend-architecture.md
     - CLI Design: architecture/cli-design.md
     - Consistency Contract: architecture/consistency-contract.md
+    - RecordStore Projections: architecture/record-store-projections.md
   - Agents:
     - Self-Observability: agents/self-observability.md
   - Research:

--- a/src/nexus/cli/commands/admin.py
+++ b/src/nexus/cli/commands/admin.py
@@ -25,6 +25,7 @@ from nexus.cli.timing import CommandTiming
 from nexus.cli.utils import (
     REMOTE_API_KEY_OPTION,
     REMOTE_URL_OPTION,
+    add_backend_options,
 )
 from nexus.contracts.constants import ROOT_ZONE_ID
 
@@ -1012,6 +1013,134 @@ def admin_fs_flush_write_observer(output_opts: OutputOptions) -> None:
                 output_opts=output_opts,
                 timing=timing,
                 human_formatter=lambda d: console.print(d),
+            )
+        except Exception as e:  # noqa: BLE001
+            console.print(f"[nexus.error]Error:[/nexus.error] {e}")
+            sys.exit(1)
+
+    asyncio.run(_impl())
+
+
+def _format_reconcile_report(data: dict[str, Any]) -> None:
+    """Human rendering for ``admin fs reconcile-projections`` (#4738)."""
+    table = Table(
+        title=f"Projection reconcile — {data.get('prefix', '/')} (zone {data.get('zone_id')})"
+    )
+    table.add_column("Verdict", style="nexus.value")
+    table.add_column("Count", style="nexus.success", justify="right")
+    for key in ("scanned", "in_sync", "created", "repaired", "retired", "stale_kernel", "errors"):
+        table.add_row(key, str(data.get(key, 0)))
+    console.print(table)
+    if data.get("dry_run"):
+        console.print("[nexus.warning]Dry run — nothing was written.[/nexus.warning]")
+    if data.get("truncated"):
+        console.print(
+            "[nexus.warning]Walk truncated by --max-entries; retire skipped.[/nexus.warning]"
+        )
+    for label, key in (
+        ("Created", "created_paths"),
+        ("Repaired", "repaired_paths"),
+        ("Retired", "retired_paths"),
+        ("Stale kernel view", "stale_kernel_paths"),
+    ):
+        paths = data.get(key) or []
+        if paths:
+            console.print(f"[bold]{label}[/bold] (first {len(paths)}):")
+            for p in paths:
+                console.print(f"  {p}")
+    for msg in data.get("error_messages") or []:
+        console.print(f"[nexus.error]error:[/nexus.error] {msg}")
+    console.print(f"[nexus.muted]{data.get('duration_ms', 0)} ms[/nexus.muted]")
+
+
+@admin_fs.command("reconcile-projections")
+@click.option("--prefix", default="/", show_default=True, help="Kernel subtree to reconcile")
+@click.option("--dry-run", is_flag=True, help="Report drift without writing")
+@click.option(
+    "--retire-missing",
+    is_flag=True,
+    help="Soft-delete file_paths rows the kernel no longer lists under PREFIX (opt-in)",
+)
+@click.option("--max-entries", type=int, default=None, help="Stop after this many kernel files")
+@add_backend_options
+@add_output_options
+def admin_fs_reconcile_projections(
+    prefix: str,
+    dry_run: bool,
+    retire_missing: bool,
+    max_entries: int | None,
+    remote_url: str | None,
+    remote_api_key: str | None,
+    output_opts: OutputOptions,
+) -> None:
+    """Repair file_paths / version_history / operation_log from the kernel (#4738).
+
+    After a server crash, a RecordStore outage or a dropped write-observer
+    event the kernel is ahead of the SQL projection.  This walks the kernel
+    under PREFIX and creates or repairs the missing rows.  Runs locally when
+    the CLI holds the RecordStore, otherwise via
+    ``POST /api/v2/admin/reconcile-projections`` (admin key required).
+
+    Examples:
+        nexus admin fs reconcile-projections --prefix /workspace --dry-run
+        nexus admin fs reconcile-projections --prefix /workspace
+    """
+    import asyncio
+
+    from nexus.cli.utils import open_filesystem
+
+    body = {
+        "prefix": prefix,
+        "dry_run": dry_run,
+        "retire_missing": retire_missing,
+        "max_entries": max_entries,
+    }
+
+    async def _impl() -> None:
+        from nexus.cli.config import resolve_connection
+
+        timing = CommandTiming()
+        try:
+            # A configured server (flag, NEXUS_URL, or active profile) means
+            # the RecordStore lives there: go straight to the admin route
+            # instead of opening a remote NexusFS (which would spawn a local
+            # kernel just to discover it has no record_store).
+            conn = resolve_connection(remote_url=remote_url, remote_api_key=remote_api_key)
+            if conn.url:
+                from nexus.cli.api_client import get_api_client_from_options
+
+                client = get_api_client_from_options(remote_url, remote_api_key)
+                with timing.phase("server"):
+                    data: dict[str, Any] = client.post(
+                        "/api/v2/admin/reconcile-projections", json_body=body
+                    )
+            else:
+                async with open_filesystem(None, None, allow_local_default=True) as nx:
+                    record_store = getattr(nx, "record_store", None)
+                    if record_store is None:
+                        raise click.ClickException(
+                            "No RecordStore on this filesystem and no server configured; "
+                            "set NEXUS_URL/--remote-url to reconcile through the admin API."
+                        )
+                    from nexus.storage.projection_reconcile import reconcile_projection
+
+                    with timing.phase("server"):
+                        report = await asyncio.to_thread(
+                            reconcile_projection,
+                            nexus_fs=nx,
+                            session_factory=record_store.session_factory,
+                            prefix=prefix,
+                            zone_id=getattr(nx, "_zone_id", None) or ROOT_ZONE_ID,
+                            dry_run=dry_run,
+                            retire_missing=retire_missing,
+                            max_entries=max_entries,
+                        )
+                    data = report.to_dict()
+            render_output(
+                data=data,
+                output_opts=output_opts,
+                timing=timing,
+                human_formatter=_format_reconcile_report,
             )
         except Exception as e:  # noqa: BLE001
             console.print(f"[nexus.error]Error:[/nexus.error] {e}")

--- a/src/nexus/cli/commands/operations.py
+++ b/src/nexus/cli/commands/operations.py
@@ -365,6 +365,70 @@ def ops_replay(
         )
 
 
+@ops_group.command(name="wait")
+@click.option("--seq", type=int, required=True, help="projection_seq returned by a write")
+@click.option(
+    "--timeout-ms",
+    type=int,
+    default=5000,
+    show_default=True,
+    help="How long the server waits for the row to be committed (0 probes once)",
+)
+@add_backend_options
+@click.pass_context
+def ops_wait(
+    ctx: click.Context,
+    seq: int,
+    timeout_ms: int,
+    remote_url: str | None,
+    remote_api_key: str | None,
+) -> None:
+    """Wait until a write's projection sequence is committed (#4738).
+
+    Every write returns ``projection_seq`` — the operation_log sequence of
+    the row that also carries its version history.  This blocks until that
+    row is committed in your zone (exit 0) or the timeout passes (exit 1),
+    so version history and the operation log can be read right after.
+
+    Examples:
+        nexus ops wait --seq 1234
+        nexus ops wait --seq 1234 --timeout-ms 0
+    """
+    import httpx
+
+    from nexus.cli.api_client import get_api_client_from_options
+
+    profile_name = (ctx.obj or {}).get("profile")
+    client = get_api_client_from_options(remote_url, remote_api_key, profile_name=profile_name)
+    try:
+        result = client.get(
+            "/api/v2/operations/wait", params={"seq": seq, "timeout_ms": timeout_ms}
+        )
+    except httpx.HTTPStatusError as e:
+        if e.response.status_code == 412:
+            try:
+                detail = e.response.json().get("detail") or {}
+            except ValueError:
+                detail = {}
+            console.print(
+                f"[nexus.warning]Not applied:[/nexus.warning] seq {seq} "
+                f"(latest_seq={detail.get('latest_seq')}, zone={detail.get('zone_id')}, "
+                f"waited {detail.get('waited_ms', timeout_ms)} ms)"
+            )
+            raise SystemExit(1) from e
+        console.print(f"[nexus.error]Error:[/nexus.error] {e}")
+        raise SystemExit(1) from e
+    except Exception as e:
+        console.print(f"[nexus.error]Error:[/nexus.error] {e}")
+        raise SystemExit(1) from e
+
+    console.print(
+        f"[nexus.success]Applied:[/nexus.success] seq {result.get('seq', seq)} "
+        f"(latest_seq={result.get('latest_seq')}, zone={result.get('zone_id')}, "
+        f"waited {result.get('waited_ms', 0)} ms)"
+    )
+
+
 @click.command(name="undo")
 @click.option("--agent", "-a", help="Filter by agent ID (undo last operation by this agent)")
 @click.option("--yes", "-y", is_flag=True, help="Skip confirmation")

--- a/src/nexus/contracts/filesystem/filesystem_abc.py
+++ b/src/nexus/contracts/filesystem/filesystem_abc.py
@@ -149,7 +149,7 @@ class NexusFilesystem(Protocol):
         exist_ok: bool = True,
         *,
         context: OperationContext | None = None,
-    ) -> None: ...
+    ) -> dict[str, Any] | None: ...
 
     def rmdir(
         self,
@@ -157,7 +157,7 @@ class NexusFilesystem(Protocol):
         recursive: bool = True,
         *,
         context: OperationContext | None = None,
-    ) -> None: ...
+    ) -> dict[str, Any] | None: ...
 
     def access(self, path: str, *, context: OperationContext | None = None) -> bool: ...
 

--- a/src/nexus/contracts/protocols/operation_log.py
+++ b/src/nexus/contracts/protocols/operation_log.py
@@ -120,6 +120,15 @@ class OperationLogProtocol(Protocol):
         """Count operations matching filters."""
         ...
 
+    def projection_state(self, seq: int, *, zone_id: str | None = None) -> tuple[bool, int | None]:
+        """Return ``(applied, latest_seq)`` for a projection sequence (#4738).
+
+        ``applied`` is True once the operation_log row with
+        ``sequence_number == seq`` is committed in ``zone_id``;
+        ``latest_seq`` is the highest committed sequence in that zone.
+        """
+        ...
+
     def get_last_operation(
         self,
         *,

--- a/src/nexus/contracts/types.py
+++ b/src/nexus/contracts/types.py
@@ -35,7 +35,7 @@ class VFSOperations(Protocol):
 
     def mkdir(
         self, path: str, parents: bool = True, exist_ok: bool = True, context: Any = None
-    ) -> None: ...
+    ) -> Any: ...
 
     def sys_write(self, path: str, buf: bytes | str, *, context: Any = None) -> int: ...
 
@@ -47,7 +47,7 @@ class VFSOperations(Protocol):
 
     def sys_readdir(self, path: str = "/", **kw: Any) -> list: ...
 
-    def sys_unlink(self, path: str, **kw: Any) -> None: ...
+    def sys_unlink(self, path: str, **kw: Any) -> Any: ...
 
 
 class Permission(IntFlag):
@@ -393,10 +393,14 @@ class AuditConfig:
     trails. ``strict_mode=True`` (default) ensures writes fail if audit
     logging fails, preventing silent audit gaps.
 
-    Note on observers: ``strict_mode`` is enforced by the synchronous
-    ``RecordStoreWriteObserver``.  The OBSERVE-phase observer receives
-    events from the Rust kernel; error handling (retry + drop) is
-    managed by the debounced flush, not by ``strict_mode``.
+    Note on observers: both observers enforce ``strict_mode`` (#4738).  The
+    synchronous ``RecordStoreWriteObserver`` raises ``AuditLogError`` when
+    its inline commit fails; the write-through group-commit observer
+    (``piped_record_store_write_observer``) raises when the commit fails
+    after retries or is not confirmed within ``NEXUS_PROJECTION_TIMEOUT_S``
+    (default 5 s).  With ``strict_mode=False`` the write succeeds, the
+    event stays queued for retry and the write reports ``projection_seq``
+    as ``None``.
     """
 
     strict_mode: bool = True

--- a/src/nexus/contracts/vfs_hooks.py
+++ b/src/nexus/contracts/vfs_hooks.py
@@ -285,6 +285,9 @@ class WriteBatchHookContext:
     zone_id: str | None = None
     agent_id: str | None = None
     warnings: list[OperationWarning] = field(default_factory=list)
+    # Hook-to-caller side channel (mirrors the single-item contexts).  The
+    # audit interceptor stores the per-item ``projection_seqs`` here (#4738).
+    extra: dict[str, Any] = field(default_factory=dict)
 
 
 @runtime_checkable

--- a/src/nexus/contracts/write_observer.py
+++ b/src/nexus/contracts/write_observer.py
@@ -11,10 +11,19 @@ derive whatever they need (e.g. snapshot_hash = metadata.content_id).
 
 Current implementations:
 - RecordStoreWriteObserver (record_store_write_observer): synchronous audit trail + versioning (strict_mode)
-- RecordStoreWriteObserver (piped_record_store_write_observer): OBSERVE-phase observer with debounced batch flush
+- RecordStoreWriteObserver (piped_record_store_write_observer): write-through group
+  commit of operation_log / file_paths / version_history; MCL + hooks deferred (#4738)
 
 The kernel is a pure caller — it never catches observer exceptions.
 Each implementation decides its own failure handling strategy.
+
+Return values (#4738): ``on_write`` / ``on_delete`` / ``on_rename`` /
+``on_mkdir`` / ``on_rmdir`` may return the ``operation_log.sequence_number``
+of the row they committed (the *projection sequence*) and ``on_write_batch``
+a list of them; ``None`` means "not confirmed" (legacy observer, or a
+non-strict observer whose commit did not complete within its timeout).
+The audit interceptor copies the value into ``ctx.extra["projection_seq"]``
+so ``NexusFS.write`` can return it to the caller.
 
 Tracked by: #55 (Move _audit_strict_mode from kernel to observer)
 Issue #900: Replaced snapshot_hash/metadata_snapshot with metadata.
@@ -47,7 +56,7 @@ class WriteObserverProtocol(Protocol):
         old_metadata: FileMetadata | None = ...,
         zone_id: str | None = ...,
         agent_id: str | None = ...,
-    ) -> None:
+    ) -> int | None:
         """Called after a single file write completes in Metastore.
 
         Args:
@@ -56,6 +65,10 @@ class WriteObserverProtocol(Protocol):
             path: Virtual path of the file.
             old_metadata: Previous metadata before write (for undo).
                           None when is_new=True.
+
+        Returns:
+            The projection sequence of the committed audit row, or None
+            when the observer does not confirm commits (#4738).
         """
         ...
 
@@ -66,11 +79,14 @@ class WriteObserverProtocol(Protocol):
         zone_id: str | None = ...,
         agent_id: str | None = ...,
         urgency: str | None = ...,
-    ) -> None:
+    ) -> list[int | None] | None:
         """Called after a batch write completes in Metastore.
 
         Args:
             items: List of (metadata, is_new) tuples.
+
+        Returns:
+            One projection sequence per item (same order), or None (#4738).
         """
         ...
 
@@ -82,7 +98,7 @@ class WriteObserverProtocol(Protocol):
         metadata: FileMetadata | None = ...,
         zone_id: str | None = ...,
         agent_id: str | None = ...,
-    ) -> None:
+    ) -> int | None:
         """Called after a file rename completes in Metastore."""
         ...
 
@@ -93,7 +109,7 @@ class WriteObserverProtocol(Protocol):
         metadata: FileMetadata | None = ...,
         zone_id: str | None = ...,
         agent_id: str | None = ...,
-    ) -> None:
+    ) -> int | None:
         """Called after a file delete completes in Metastore."""
         ...
 
@@ -103,7 +119,7 @@ class WriteObserverProtocol(Protocol):
         *,
         zone_id: str | None = ...,
         agent_id: str | None = ...,
-    ) -> None:
+    ) -> int | None:
         """Called after a directory creation completes in Metastore."""
         ...
 
@@ -114,6 +130,6 @@ class WriteObserverProtocol(Protocol):
         zone_id: str | None = ...,
         agent_id: str | None = ...,
         recursive: bool = ...,
-    ) -> None:
+    ) -> int | None:
         """Called after a directory removal completes in Metastore."""
         ...

--- a/src/nexus/core/nexus_fs_content.py
+++ b/src/nexus/core/nexus_fs_content.py
@@ -658,6 +658,7 @@ class ContentMixin:
             io_metrics.record_write_backend_rpc()
 
         # POST-INTERCEPT hooks (Rust handles backend write + metadata + OBSERVE)
+        _projection_seq: int | None = None
         if result.hit and result.post_hook_needed:
             # Rust wrote to backend (CAS or PAS) + built metadata + updated dcache.
             # old_metadata fields come from Rust (dcache/metastore snapshot taken
@@ -689,21 +690,20 @@ class ContentMixin:
                 gen=result.gen,
                 zone_id=zone_id,
             )
-            self._kernel.dispatch_post_hooks(
-                "write",
-                WriteHookContext(
-                    path=path,
-                    content=buf,
-                    context=_ctx,
-                    zone_id=zone_id,
-                    agent_id=agent_id,
-                    is_new_file=result.is_new,
-                    content_id=result.content_id or "",
-                    metadata=_meta_obj,
-                    old_metadata=_old_metadata.to_dict() if _old_metadata else None,
-                    new_version=result.version,
-                ),
+            _post_ctx = WriteHookContext(
+                path=path,
+                content=buf,
+                context=_ctx,
+                zone_id=zone_id,
+                agent_id=agent_id,
+                is_new_file=result.is_new,
+                content_id=result.content_id or "",
+                metadata=_meta_obj,
+                old_metadata=_old_metadata.to_dict() if _old_metadata else None,
+                new_version=result.version,
             )
+            self._kernel.dispatch_post_hooks("write", _post_ctx)
+            _projection_seq = _post_ctx.extra.get("projection_seq")
 
         _write_latency_ms = int((time.perf_counter() - _start) * 1000)
         if result.hit:
@@ -717,10 +717,12 @@ class ContentMixin:
             )
         # Issue #4737: revision token (``<path>@<gen>``) a reader can fence
         # on; None when the kernel reported no gen (e.g. a miss).
+        # #4738: projection sequence of the committed audit/version row.
         return {
             "path": path,
             "bytes_written": len(buf),
             "revision": revision_token(result, path=path),
+            "projection_seq": _projection_seq,
         }
 
     # @rpc_expose removed — kernel syscall, served by the thin dispatcher.
@@ -963,28 +965,26 @@ class ContentMixin:
         _cid = result.content_id or ""
         from nexus.contracts.vfs_hooks import WriteHookContext
 
-        self._kernel.dispatch_post_hooks(
-            "write",
-            WriteHookContext(
+        _post_ctx = WriteHookContext(
+            path=path,
+            content=buf,
+            context=_ctx,
+            zone_id=zone_id,
+            agent_id=agent_id,
+            is_new_file=result.is_new,
+            content_id=_cid,
+            metadata=FileMetadata(
                 path=path,
-                content=buf,
-                context=_ctx,
+                size=result.size,
+                content_id=result.content_id,
+                version=result.version,
+                gen=result.gen,
                 zone_id=zone_id,
-                agent_id=agent_id,
-                is_new_file=result.is_new,
-                content_id=_cid,
-                metadata=FileMetadata(
-                    path=path,
-                    size=result.size,
-                    content_id=result.content_id,
-                    version=result.version,
-                    gen=result.gen,
-                    zone_id=zone_id,
-                ),
-                old_metadata=_old_meta.to_dict() if _old_meta else None,
-                new_version=result.version,
             ),
+            old_metadata=_old_meta.to_dict() if _old_meta else None,
+            new_version=result.version,
         )
+        self._kernel.dispatch_post_hooks("write", _post_ctx)
 
         # Issue #4081: emit OP event for self-observability. Only on hit
         # (mirrors the io_metrics gate for sys_write — a miss is not a
@@ -1009,6 +1009,10 @@ class ContentMixin:
             # reader passes it back as X-Nexus-Min-Revision to observe this
             # write on any node. None only when the kernel reported no gen.
             "revision": revision_token(result, path=path),
+            # #4738: operation_log sequence of this write's committed
+            # projection row (the write observer stashes it on the hook
+            # context); None when unconfirmed or no projection observer.
+            "projection_seq": _post_ctx.extra.get("projection_seq"),
         }
 
     # _write_internal + _write_content deleted — Rust sys_write handles:
@@ -1607,10 +1611,15 @@ class ContentMixin:
         ]
         from nexus.contracts.vfs_hooks import WriteBatchHookContext
 
-        self._dispatch_batch_post_hook(
-            "write_batch",
-            WriteBatchHookContext(items=items, context=context, zone_id=zone_id, agent_id=agent_id),
+        _batch_ctx = WriteBatchHookContext(
+            items=items, context=context, zone_id=zone_id, agent_id=agent_id
         )
+        self._dispatch_batch_post_hook("write_batch", _batch_ctx)
+
+        # #4738: per-item projection sequence from the write observer.
+        _seqs = _batch_ctx.extra.get("projection_seqs")
+        for i, r in enumerate(results):
+            r["projection_seq"] = _seqs[i] if isinstance(_seqs, list) and i < len(_seqs) else None
 
         return results
 

--- a/src/nexus/core/nexus_fs_metadata.py
+++ b/src/nexus/core/nexus_fs_metadata.py
@@ -667,10 +667,11 @@ class MetadataMixin:
         exist_ok: bool = True,
         *,
         context: OperationContext | None = None,
-    ) -> None:
+    ) -> dict[str, Any]:
         """Create a directory (Tier 2 convenience over sys_setattr).
 
         Defaults: parents=True, exist_ok=True (mkdir -p semantics).
+        Returns ``{"path", "projection_seq"}`` (#4738).
         DT_DIR metadata creation delegated to Rust kernel sys_setattr.
         """
         self._gate_sys_namespace_mutation((path,), context)
@@ -681,18 +682,31 @@ class MetadataMixin:
         # DT_DIR metadata creation, and dcache update.
         _rust_ctx = self._build_rust_ctx(ctx, ctx.is_admin)
         _mkdir_result = self._kernel.sys_mkdir(path, _rust_ctx, parents, exist_ok)
-        if _mkdir_result.post_hook_needed:
+        _projection_seq: int | None = None
+        # The subprocess kernel cannot see Python hooks, so its
+        # ``post_hook_needed`` is False there; consult the local hook mirror
+        # like sys_rename does, otherwise mkdir never reaches the audit
+        # observer in remote mode (#4738).
+        _post_hook_needed = bool(_mkdir_result.post_hook_needed)
+        if not _post_hook_needed:
+            try:
+                _post_hook_needed = bool(self._kernel.hook_count("mkdir") > 0)
+            except Exception:
+                _post_hook_needed = False
+        if _post_hook_needed:
             from nexus.contracts.vfs_hooks import MkdirHookContext
 
-            self._kernel.dispatch_post_hooks(
-                "mkdir",
-                MkdirHookContext(
-                    path=path,
-                    context=ctx,
-                    zone_id=ctx.zone_id,
-                    agent_id=ctx.agent_id,
-                ),
+            _mkdir_ctx = MkdirHookContext(
+                path=path,
+                context=ctx,
+                zone_id=ctx.zone_id,
+                agent_id=ctx.agent_id,
             )
+            self._kernel.dispatch_post_hooks("mkdir", _mkdir_ctx)
+            _projection_seq = _mkdir_ctx.extra.get("projection_seq")
+        # #4738: operation_log sequence of the committed mkdir audit row
+        # (None when no projection observer confirmed it).
+        return {"path": path, "projection_seq": _projection_seq}
 
     # @rpc_expose removed — kernel syscall, served by the thin dispatcher.
     def rmdir(
@@ -700,13 +714,14 @@ class MetadataMixin:
         path: str,
         recursive: bool = True,
         context: OperationContext | None = None,
-    ) -> None:
+    ) -> dict[str, Any]:
         """Remove a directory with lenient defaults (Tier 2 convenience).
 
         Defaults to recursive=True (rm -rf semantics).
-        Delegates directly to sys_unlink.
+        Delegates directly to sys_unlink and returns its dict (#4738:
+        carries ``projection_seq``).
         """
-        self.sys_unlink(path, recursive=recursive, context=context)
+        return self.sys_unlink(path, recursive=recursive, context=context)
 
     # ── Tier 1 delete/rename/copy ─────────────────────────────────────
 
@@ -795,34 +810,31 @@ class MetadataMixin:
         if _unlink_result.hit:
             # Rust handled the full operation (§12e: DT_DIR handled via internal sys_rmdir).
             et = _unlink_result.entry_type
+            _post_ctx: Any
             if et == DT_DIR:
                 from nexus.contracts.vfs_hooks import RmdirHookContext
 
                 ctx = self._resolve_cred(context)
-                self._kernel.dispatch_post_hooks(
-                    "rmdir",
-                    RmdirHookContext(
-                        path=path,
-                        context=ctx,
-                        zone_id=zone_id,
-                        agent_id=agent_id,
-                        recursive=recursive,
-                        metadata=_pre_delete_meta,
-                    ),
+                _post_ctx = RmdirHookContext(
+                    path=path,
+                    context=ctx,
+                    zone_id=zone_id,
+                    agent_id=agent_id,
+                    recursive=recursive,
+                    metadata=_pre_delete_meta,
                 )
+                self._kernel.dispatch_post_hooks("rmdir", _post_ctx)
             else:
                 from nexus.contracts.vfs_hooks import DeleteHookContext
 
-                self._kernel.dispatch_post_hooks(
-                    "delete",
-                    DeleteHookContext(
-                        path=path,
-                        context=context,
-                        zone_id=zone_id,
-                        agent_id=agent_id,
-                        metadata=_pre_delete_meta,
-                    ),
+                _post_ctx = DeleteHookContext(
+                    path=path,
+                    context=context,
+                    zone_id=zone_id,
+                    agent_id=agent_id,
+                    metadata=_pre_delete_meta,
                 )
+                self._kernel.dispatch_post_hooks("delete", _post_ctx)
             if _unlink_result.entry_type == DT_MOUNT:
                 self._forget_mounted_backend_instance(path)
             emit_op_completed(
@@ -834,7 +846,11 @@ class MetadataMixin:
             )
             # Issue #4737: zone revision the delete was applied at (None
             # when the kernel did not stamp the response).
-            return {"revision": revision_token(_unlink_result)}
+            # #4738: operation_log sequence of the committed delete/rmdir row.
+            return {
+                "revision": revision_token(_unlink_result),
+                "projection_seq": _post_ctx.extra.get("projection_seq"),
+            }
 
         # ── Rust miss: only DT_EXTERNAL_STORAGE (5) or not-found ─────
         et = _unlink_result.entry_type
@@ -1010,6 +1026,7 @@ class MetadataMixin:
             except Exception:
                 post_hook_needed = False
 
+        _projection_seq: int | None = None
         if post_hook_needed:
             from nexus.contracts.metadata import FileMetadata as _FM
             from nexus.contracts.vfs_hooks import RenameHookContext
@@ -1043,10 +1060,12 @@ class MetadataMixin:
                 metadata=_old_meta,
             )
             self._kernel.dispatch_post_hooks("rename", _rename_ctx)
+            _projection_seq = _rename_ctx.extra.get("projection_seq")
 
         # Issue #4737: zone revision the rename was applied at (None when
         # the kernel did not stamp the response).
-        return {"revision": revision_token(_rename_result)}
+        # #4738: operation_log sequence of the rename's committed upsert row.
+        return {"revision": revision_token(_rename_result), "projection_seq": _projection_seq}
 
     # ------------------------------------------------------------------
     # sys_copy — Issue #3329 (Workstream 3: native copy/move)
@@ -1613,8 +1632,15 @@ class MetadataMixin:
         results = {}
         for old_path, new_path in renames:
             try:
-                self.sys_rename(old_path, new_path, context=context)
-                results[old_path] = {"success": True, "new_path": new_path}
+                _renamed = self.sys_rename(old_path, new_path, context=context)
+                results[old_path] = {
+                    "success": True,
+                    "new_path": new_path,
+                    # #4738: per-item projection sequence.
+                    "projection_seq": _renamed.get("projection_seq")
+                    if isinstance(_renamed, dict)
+                    else None,
+                }
             except Exception as e:
                 results[old_path] = {"success": False, "error": str(e)}
 
@@ -2086,13 +2112,15 @@ class MetadataMixin:
     ) -> dict[str, Any]:
         """Flush the write observer so pending version/audit records are committed.
 
-        The RecordStoreWriteObserver accumulates events dispatched by the
-        Rust kernel and flushes them to RecordStore in debounced batches.
-        This method forces an immediate flush, guaranteeing that subsequent
-        queries (e.g. list_versions) see the data.
+        Since #4738 the observer commits ``operation_log`` / ``file_paths`` /
+        ``version_history`` before a write returns and hands the caller a
+        ``projection_seq`` to fence on (``GET /api/v2/operations/wait``), so
+        ``list_versions`` right after a write no longer needs this call.
+        What remains to flush is deferred work (MCL rows, extraction and
+        lineage hooks) plus any event a non-strict timeout left queued.
 
         Returns:
-            Dict with ``flushed`` count.
+            Dict with ``flushed`` count (events committed by this call).
         """
         # Issue #1801: use service registry to find write_observer — no closure needed.
         _wo = self.service("write_observer")

--- a/src/nexus/core/protocols/vfs_core.py
+++ b/src/nexus/core/protocols/vfs_core.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 if TYPE_CHECKING:
     from nexus.contracts.types import OperationContext
 
+
 @runtime_checkable
 class VFSCoreProtocol(Protocol):
     """Core file operations — read, write, delete, stat, exists, mkdir.
@@ -85,7 +86,7 @@ class VFSCoreProtocol(Protocol):
         parents: bool = False,
         exist_ok: bool = False,
         context: "OperationContext | None" = None,
-    ) -> None:
+    ) -> Any:
         """Create directory at path.
 
         Args:

--- a/src/nexus/factory/_system.py
+++ b/src/nexus/factory/_system.py
@@ -133,9 +133,12 @@ def _boot_pre_kernel_services(
                 elif env_val in ("false", "0", "no"):
                     use_buffer = False
                 else:
-                    # Issue #3399: default to piped (async) observer for all profiles.
-                    # DFUSE principle: defer non-consistency-critical work from I/O path.
-                    # Set NEXUS_ENABLE_WRITE_BUFFER=false for strict audit compliance.
+                    # Issue #3399: default to the group-commit observer for all
+                    # profiles.  Since #4738 it is write-through for the
+                    # consistency-critical rows (operation_log, file_paths,
+                    # version_history) and defers only MCL + hooks; set
+                    # NEXUS_ENABLE_WRITE_BUFFER=false for the fully inline
+                    # observer (adds /__sys__/versioning snapshots + inline MCL).
                     use_buffer = True
 
             if use_buffer:
@@ -143,10 +146,23 @@ def _boot_pre_kernel_services(
                     RecordStoreWriteObserver as ObserverWriteObserver,
                 )
 
+                # #4738: how long a write waits for its projection row to
+                # commit before strict_mode raises AuditLogError (or, non-strict,
+                # the write returns projection_seq=None).
+                _timeout_env = os.environ.get("NEXUS_PROJECTION_TIMEOUT_S", "").strip()
+                try:
+                    _projection_timeout = float(_timeout_env) if _timeout_env else 5.0
+                except ValueError:
+                    logger.warning(
+                        "NEXUS_PROJECTION_TIMEOUT_S=%r is not a number; using 5.0", _timeout_env
+                    )
+                    _projection_timeout = 5.0
+
                 write_observer = ObserverWriteObserver(
                     ctx.record_store,
                     strict_mode=ctx.audit.strict_mode,
                     event_signal=ctx.event_signal,
+                    write_through_timeout_s=_projection_timeout,
                 )
             else:
                 from nexus.storage.record_store_write_observer import RecordStoreWriteObserver

--- a/src/nexus/lib/io_metrics.py
+++ b/src/nexus/lib/io_metrics.py
@@ -168,6 +168,45 @@ ETAG_CHECKS = Counter(
     ["result"],
 )
 
+# ---------------------------------------------------------------------------
+# RecordStore projection (write observer) — #4738
+# ---------------------------------------------------------------------------
+# ``queue`` is ``pending`` (events accepted but not yet committed to
+# operation_log / file_paths / version_history) or ``deferred`` (committed
+# events awaiting MCL + post-flush hooks).  A non-zero ``dropped`` counter
+# means projection rows were lost and ``POST /api/v2/admin/reconcile-
+# projections`` should be run.
+_PROJECTION_QUEUES = frozenset({"pending", "deferred", "other"})
+
+PROJECTION_EVENTS_DROPPED = Counter(
+    "nexus_projection_events_dropped_total",
+    "Write-observer events dropped because a bounded queue overflowed.",
+    ["queue"],
+)
+
+PROJECTION_EVENTS_FAILED = Counter(
+    "nexus_projection_events_failed_total",
+    "Write-observer events whose RecordStore commit failed after retries.",
+)
+
+PROJECTION_WRITE_THROUGH_TIMEOUTS = Counter(
+    "nexus_projection_write_through_timeouts_total",
+    "Writes that returned before their projection row was confirmed committed.",
+)
+
+PROJECTION_PENDING_EVENTS = Gauge(
+    "nexus_projection_pending_events",
+    "Write-observer events currently queued, by queue.",
+    ["queue"],
+)
+
+# Pre-register both queue series so `/metrics` exposes them at 0 from boot
+# (a labelled Counter is otherwise absent until its first increment, and an
+# absent "dropped" series is indistinguishable from an unscraped one).
+for _queue in ("pending", "deferred"):
+    PROJECTION_EVENTS_DROPPED.labels(queue=_queue)
+    PROJECTION_PENDING_EVENTS.labels(queue=_queue).set(0)
+
 
 def record_cache_request(tier: str, result: str) -> None:
     CACHE_REQUESTS.labels(
@@ -264,3 +303,23 @@ def record_write_backend_rpc() -> None:
 
 def record_generation_mismatch() -> None:
     GENERATION_MISMATCH.inc()
+
+
+def record_projection_dropped(queue: str, count: int) -> None:
+    PROJECTION_EVENTS_DROPPED.labels(queue=_bounded(queue, _PROJECTION_QUEUES)).inc(
+        _nonnegative(count)
+    )
+
+
+def record_projection_failed(count: int) -> None:
+    PROJECTION_EVENTS_FAILED.inc(_nonnegative(count))
+
+
+def record_projection_write_through_timeout() -> None:
+    PROJECTION_WRITE_THROUGH_TIMEOUTS.inc()
+
+
+def set_projection_pending(queue: str, count: int) -> None:
+    PROJECTION_PENDING_EVENTS.labels(queue=_bounded(queue, _PROJECTION_QUEUES)).set(
+        _nonnegative(count)
+    )

--- a/src/nexus/server/_kernel_syscall_dispatch.py
+++ b/src/nexus/server/_kernel_syscall_dispatch.py
@@ -151,6 +151,20 @@ def _build_kwargs(
     return kwargs
 
 
+def _with_projection_seq(wire: dict[str, Any], raw_result: Any) -> dict[str, Any]:
+    """Carry a confirmed ``projection_seq`` (#4738) into a legacy wire shape.
+
+    Legacy Tier 2 shapes (``{"deleted": True}`` …) stay byte-identical when
+    no projection observer confirmed the row; when it did, RPC / gRPC
+    callers get the same sequence the REST routes return.
+    """
+    if isinstance(raw_result, dict):
+        seq = raw_result.get("projection_seq")
+        if isinstance(seq, int) and not isinstance(seq, bool):
+            wire["projection_seq"] = seq
+    return wire
+
+
 def _apply_result_adapter(
     method: str,
     raw_result: Any,
@@ -176,13 +190,13 @@ def _apply_result_adapter(
     )
 
     if method in ("delete", "sys_unlink"):
-        return {"deleted": True}
+        return _with_projection_seq({"deleted": True}, raw_result)
     if method in ("rename", "sys_rename"):
-        return {"renamed": True}
+        return _with_projection_seq({"renamed": True}, raw_result)
     if method in ("mkdir", "sys_mkdir"):
-        return {"created": True}
+        return _with_projection_seq({"created": True}, raw_result)
     if method in ("rmdir", "sys_rmdir"):
-        return {"removed": True}
+        return _with_projection_seq({"removed": True}, raw_result)
     if method in ("write", "sys_write"):
         content = params.get("content") or params.get("buf") or b""
         content_len = len(content.encode("utf-8")) if isinstance(content, str) else len(content)

--- a/src/nexus/server/api/v2/models/__init__.py
+++ b/src/nexus/server/api/v2/models/__init__.py
@@ -38,6 +38,7 @@ from nexus.server.api.v2.models.operations import (
     AgentActivityResponse,
     OperationListResponse,
     OperationResponse,
+    ProjectionWaitResponse,
 )
 from nexus.server.api.v2.models.playbooks import (
     PlaybookCreateRequest,
@@ -118,4 +119,5 @@ __all__ = [
     "OperationResponse",
     "OperationListResponse",
     "AgentActivityResponse",
+    "ProjectionWaitResponse",
 ]

--- a/src/nexus/server/api/v2/models/aspects.py
+++ b/src/nexus/server/api/v2/models/aspects.py
@@ -78,6 +78,47 @@ class ReplayResponse(ApiModel):
     has_more: bool = False
 
 
+class ReconcileProjectionsRequest(ApiModel):
+    """Request body for POST /api/v2/admin/reconcile-projections (#4738)."""
+
+    prefix: str = "/"
+    dry_run: bool = False
+    # Soft-delete active file_paths rows the kernel no longer lists under
+    # ``prefix``.  Opt-in: a partial kernel listing would otherwise retire
+    # live rows.
+    retire_missing: bool = False
+    max_entries: int | None = Field(None, ge=1)
+
+
+class ReconcileProjectionsResponse(ApiModel):
+    """Response for POST /api/v2/admin/reconcile-projections (#4738).
+
+    Every kernel file under ``prefix`` lands in exactly one of ``in_sync``
+    / ``created`` / ``repaired`` / ``stale_kernel`` / ``errors``; path
+    samples are capped at 25 entries.  ``stale_kernel`` means the projection
+    already records a newer kernel generation than this node's kernel
+    reports (follower lag) and the path was left alone.
+    """
+
+    prefix: str
+    zone_id: str
+    dry_run: bool = False
+    scanned: int = 0
+    in_sync: int = 0
+    created: int = 0
+    repaired: int = 0
+    retired: int = 0
+    stale_kernel: int = 0
+    errors: int = 0
+    truncated: bool = False
+    duration_ms: int = 0
+    created_paths: list[str] = Field(default_factory=list)
+    repaired_paths: list[str] = Field(default_factory=list)
+    retired_paths: list[str] = Field(default_factory=list)
+    stale_kernel_paths: list[str] = Field(default_factory=list)
+    error_messages: list[str] = Field(default_factory=list)
+
+
 class ReindexRequest(ApiModel):
     """Request body for POST /api/v2/admin/reindex."""
 

--- a/src/nexus/server/api/v2/models/operations.py
+++ b/src/nexus/server/api/v2/models/operations.py
@@ -36,6 +36,23 @@ class OperationListResponse(ApiModel):
     next_cursor: str | None = None
 
 
+class ProjectionWaitResponse(ApiModel):
+    """Response for GET /api/v2/operations/wait (#4738).
+
+    ``seq`` is the ``projection_seq`` a write returned; ``applied`` is True
+    once the operation_log row with that sequence is committed in the
+    caller's zone (the endpoint answers 412 instead when the timeout
+    passes first).  ``latest_seq`` is the highest committed sequence in
+    that zone, usable as a ``/api/v2/ops/replay`` cursor.
+    """
+
+    seq: int
+    applied: bool
+    latest_seq: int | None = None
+    zone_id: str
+    waited_ms: int = 0
+
+
 class AgentActivityResponse(ApiModel):
     """Response for GET /api/v2/operations/agents/{agent_id}/activity.
 

--- a/src/nexus/server/api/v2/routers/async_files.py
+++ b/src/nexus/server/api/v2/routers/async_files.py
@@ -294,6 +294,15 @@ class WriteRequest(BaseModel):
     )
 
 
+def _projection_seq_of(result: Any) -> int | None:
+    """``projection_seq`` from a NexusFS mutation result dict (#4738), else None."""
+    if isinstance(result, dict):
+        seq = result.get("projection_seq")
+        if isinstance(seq, int) and not isinstance(seq, bool):
+            return seq
+    return None
+
+
 class WriteResponse(BaseModel):
     """Response model for write operation."""
 
@@ -312,6 +321,12 @@ class WriteResponse(BaseModel):
             "revision (#4737)."
         ),
     )
+    # #4738: operation_log sequence of this write's committed projection row
+    # (version history, operation log, file_paths). Poll
+    # GET /api/v2/operations/wait?seq=<value> from any node sharing the
+    # RecordStore to wait for it. null = not confirmed (non-strict audit
+    # mode timed out) or no projection observer.
+    projection_seq: int | None = None
 
 
 class ReadResponse(BaseModel):
@@ -337,6 +352,8 @@ class DeleteResponse(BaseModel):
             "deletes; fence on the parent listing's own writes instead."
         ),
     )
+    # #4738: projection sequence of the committed delete audit row.
+    projection_seq: int | None = None
 
 
 class ExistsResponse(BaseModel):
@@ -496,6 +513,8 @@ class BatchWriteResult(BaseModel):
     revision: str | None = Field(
         None, description="Read-your-writes token ('<path>@<gen>') for this item (#4737)."
     )
+    # #4738: projection sequence of this item's committed audit/version row.
+    projection_seq: int | None = None
 
 
 class BatchWriteResponse(BaseModel):
@@ -564,6 +583,8 @@ class RenameResponse(BaseModel):
         None,
         description="Revision token for this rename (#4737); null on kernels that do not stamp it.",
     )
+    # #4738: projection sequence of the rename's committed upsert row.
+    projection_seq: int | None = None
 
 
 class CopyRequest(BaseModel):
@@ -608,6 +629,8 @@ class BulkRenameResult(BaseModel):
     destination: str
     success: bool
     error: str | None = None
+    # #4738: projection sequence of this rename's committed upsert row.
+    projection_seq: int | None = None
 
 
 class RenameBatchResponse(BaseModel):
@@ -916,6 +939,7 @@ def create_async_files_router(
                     modified_at=str(modified),
                     index=index_result,
                     revision=result.get("revision"),
+                    projection_seq=result.get("projection_seq"),
                 )
                 write_response = Response(
                     content=response_data.model_dump_json(),
@@ -1646,6 +1670,7 @@ def create_async_files_router(
                     revision=unlink_result.get("revision")
                     if isinstance(unlink_result, dict)
                     else None,
+                    projection_seq=_projection_seq_of(unlink_result),
                 )
 
             delete_response = await _run_for_context(context, {"path": path, "zone": zone}, _work)
@@ -1962,9 +1987,13 @@ def create_async_files_router(
 
             async def _work() -> dict[str, Any]:
                 fs = await _get_fs()
-                # fs.mkdir is async — call directly
-                fs.mkdir(request.path, parents=request.parents, context=context)
-                return {"created": True, "path": request.path}
+                _made = fs.mkdir(request.path, parents=request.parents, context=context)
+                return {
+                    "created": True,
+                    "path": request.path,
+                    # #4738: projection sequence of the committed mkdir audit row.
+                    "projection_seq": _projection_seq_of(_made),
+                }
 
             return await _run_for_context(
                 context,
@@ -2139,6 +2168,7 @@ def create_async_files_router(
                         modified_at=r.get("modified_at"),
                         size=r.get("size", 0),
                         revision=r.get("revision"),
+                        projection_seq=r.get("projection_seq"),
                     )
                     for i, r in enumerate(raw_results)
                 ]
@@ -2349,6 +2379,7 @@ def create_async_files_router(
                     revision=rename_result.get("revision")
                     if isinstance(rename_result, dict)
                     else None,
+                    projection_seq=_projection_seq_of(rename_result),
                 )
 
             rename_response = await _run_for_context(context, request, _work)
@@ -2459,6 +2490,7 @@ def create_async_files_router(
                             destination=op.destination,
                             success=entry.get("success", False),
                             error=entry.get("error"),
+                            projection_seq=_projection_seq_of(entry),
                         )
                     )
 

--- a/src/nexus/server/api/v2/routers/operations.py
+++ b/src/nexus/server/api/v2/routers/operations.py
@@ -2,6 +2,7 @@
 
 Provides endpoints for querying filesystem operation history:
 - GET /api/v2/operations — List operations with offset or cursor pagination
+- GET /api/v2/operations/wait — Wait for a write's projection sequence (#4738)
 - GET /api/v2/operations/agents/{agent_id}/activity — Agent activity summary
 
 Supports filtering by agent_id, operation_type, path_pattern, status,
@@ -12,24 +13,35 @@ Issue #1197: Add Event Replay API for Agent Mesh support.
 Issue #1198: Add Agent Activity Summary endpoint.
 """
 
+import asyncio
 import json
 import logging
+import time
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Query
 
+from nexus.contracts.constants import ROOT_ZONE_ID
 from nexus.contracts.protocols.operation_log import OperationLogProtocol
-from nexus.server.api.v2.dependencies import get_operation_logger
+from nexus.server.api.v2.dependencies import get_nexus_fs, get_operation_logger
 from nexus.server.api.v2.models import (
     AgentActivityResponse,
     OperationListResponse,
     OperationResponse,
+    ProjectionWaitResponse,
 )
+from nexus.server.dependencies import get_operation_context, require_auth
 
 logger = logging.getLogger(__name__)
 
 DEFAULT_ACTIVITY_WINDOW_HOURS = 24
+
+# GET /wait polling: start fast, back off to a quarter second.
+_WAIT_POLL_INITIAL_S = 0.02
+_WAIT_POLL_MAX_S = 0.25
+_WAIT_DEFAULT_TIMEOUT_MS = 5_000
+_WAIT_MAX_TIMEOUT_MS = 30_000
 
 router = APIRouter(prefix="/api/v2/operations", tags=["operations"])
 
@@ -130,6 +142,84 @@ async def list_operations(
     except Exception as e:
         logger.error("Operations query error: %s", e, exc_info=True)
         raise HTTPException(status_code=500, detail="Failed to query operations") from e
+
+
+@router.get("/wait", response_model=ProjectionWaitResponse)
+async def wait_for_projection(
+    seq: int = Query(..., ge=1, description="projection_seq returned by a write"),
+    timeout_ms: int = Query(
+        _WAIT_DEFAULT_TIMEOUT_MS,
+        ge=0,
+        le=_WAIT_MAX_TIMEOUT_MS,
+        description="How long to wait for the sequence to be committed; 0 probes once",
+    ),
+    nexus_fs: Any = Depends(get_nexus_fs),
+    auth_result: dict[str, Any] = Depends(require_auth),
+) -> ProjectionWaitResponse:
+    """Wait until the projection row ``seq`` is committed (#4738).
+
+    Every write returns ``projection_seq`` — the ``operation_log`` sequence
+    of the row that also carries its ``version_history`` / ``file_paths``
+    update.  This endpoint polls the RecordStore until that row exists in
+    the caller's zone, so a client can fence ``list_versions``, operation
+    replay and the search zone join on it instead of calling the admin-only
+    ``flush_write_observer`` RPC.  With the write-through observer the
+    sequence is normally already committed when the write returns; the
+    wait matters for a non-strict audit mode that timed out, and for other
+    nodes sharing the same RecordStore.
+
+    * **200** — applied; ``latest_seq`` is the zone's newest sequence.
+    * **412** — not committed before ``timeout_ms`` elapsed (also the answer
+      for a sequence that belongs to another zone).
+    """
+    from nexus.storage.operation_logger import OperationLogger
+
+    context = get_operation_context(auth_result)
+    zone_id = context.zone_id or ROOT_ZONE_ID
+    record_store = getattr(nexus_fs, "record_store", None)
+    session_factory = (
+        record_store.session_factory
+        if record_store is not None
+        else getattr(nexus_fs, "SessionLocal", None)
+    )
+    if session_factory is None:
+        raise HTTPException(status_code=503, detail="RecordStore not initialized")
+
+    def _probe() -> tuple[bool, int | None]:
+        # A fresh session per probe: SQLite keeps a read snapshot for the
+        # life of a transaction, so a long-lived session would never see
+        # rows committed after its first query.
+        with session_factory() as session:
+            return OperationLogger(session).projection_state(seq, zone_id=zone_id)
+
+    started = time.monotonic()
+    deadline = started + timeout_ms / 1000.0
+    interval = _WAIT_POLL_INITIAL_S
+    while True:
+        try:
+            applied, latest = await asyncio.to_thread(_probe)
+        except Exception as e:
+            logger.error("projection wait query error: %s", e, exc_info=True)
+            raise HTTPException(status_code=500, detail="Failed to query projection state") from e
+        waited_ms = int((time.monotonic() - started) * 1000)
+        if applied:
+            return ProjectionWaitResponse(
+                seq=seq, applied=True, latest_seq=latest, zone_id=zone_id, waited_ms=waited_ms
+            )
+        now = time.monotonic()
+        if now >= deadline:
+            raise HTTPException(
+                status_code=412,
+                detail={
+                    "error": "projection_not_applied",
+                    "seq": seq,
+                    "latest_seq": latest,
+                    "zone_id": zone_id,
+                    "waited_ms": waited_ms,
+                },
+            )
+        await asyncio.sleep(min(interval, deadline - now))
+        interval = min(interval * 2, _WAIT_POLL_MAX_S)
 
 
 @router.get("/agents/{agent_id}/activity", response_model=AgentActivityResponse)

--- a/src/nexus/server/api/v2/routers/replay.py
+++ b/src/nexus/server/api/v2/routers/replay.py
@@ -3,15 +3,22 @@
 Provides endpoints for MCL replay and index rebuilding:
 - GET /api/v2/ops/replay -- Cursor-based MCL replay
 - POST /api/v2/admin/reindex -- Trigger index rebuild
+- POST /api/v2/admin/reconcile-projections -- Repair file_paths / version_history
+  / operation_log from the kernel (#4738)
 """
 
+import asyncio
 import logging
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
+from nexus.contracts.constants import ROOT_ZONE_ID
+from nexus.contracts.exceptions import NexusFileNotFoundError
 from nexus.server.api.v2.dependencies import get_auth_result, get_operation_logger
 from nexus.server.api.v2.models.aspects import (
+    ReconcileProjectionsRequest,
+    ReconcileProjectionsResponse,
     ReindexRequest,
     ReindexResponse,
     ReplayResponse,
@@ -238,3 +245,66 @@ async def trigger_reindex(
     except Exception as e:
         logger.error("reindex error: %s", e, exc_info=True)
         raise HTTPException(status_code=500, detail="Failed to run reindex") from e
+
+
+@router.post("/api/v2/admin/reconcile-projections", response_model=ReconcileProjectionsResponse)
+async def reconcile_projections(
+    request: Request,
+    body: ReconcileProjectionsRequest,
+    auth_result: dict[str, Any] = Depends(get_auth_result),
+) -> ReconcileProjectionsResponse:
+    """Repair the RecordStore projection from the kernel (#4738).
+
+    The write observer commits ``file_paths`` / ``version_history`` /
+    ``operation_log`` before a write returns, but the kernel commit lands
+    first: a crash between the two, a RecordStore outage that outlived the
+    observer's retries, or a dropped queue entry
+    (``nexus_projection_events_dropped_total``) leaves the kernel ahead of
+    the projection.  This walks the kernel under ``prefix`` and, per file,
+    creates the missing rows or appends a version for content the
+    projection does not have; paths whose projected kernel ``gen`` is
+    already newer than this node's kernel view are reported
+    ``stale_kernel`` and left alone.  Rows are keyed by the caller's zone
+    (the zone writes in that token's context were recorded under).
+    ``dry_run`` reports without writing.  Requires admin privileges.
+    """
+    if not auth_result.get("is_admin"):
+        raise HTTPException(status_code=403, detail="Admin access required for reconcile")
+
+    nexus_fs = getattr(request.app.state, "nexus_fs", None)
+    if nexus_fs is None:
+        raise HTTPException(status_code=503, detail="NexusFS not initialized")
+    record_store = getattr(nexus_fs, "record_store", None)
+    session_factory = (
+        record_store.session_factory
+        if record_store is not None
+        else getattr(nexus_fs, "SessionLocal", None)
+    )
+    if session_factory is None:
+        raise HTTPException(status_code=503, detail="RecordStore not initialized")
+
+    from nexus.server.dependencies import get_operation_context
+    from nexus.storage.projection_reconcile import reconcile_projection
+
+    context = get_operation_context(auth_result)
+    zone_id = context.zone_id or ROOT_ZONE_ID
+    try:
+        report = await asyncio.to_thread(
+            reconcile_projection,
+            nexus_fs=nexus_fs,
+            session_factory=session_factory,
+            prefix=body.prefix,
+            zone_id=zone_id,
+            context=context,
+            dry_run=body.dry_run,
+            retire_missing=body.retire_missing,
+            max_entries=body.max_entries,
+        )
+    except NexusFileNotFoundError as e:
+        raise HTTPException(
+            status_code=404, detail=f"prefix not found in the kernel: {body.prefix} ({e})"
+        ) from e
+    except Exception as e:
+        logger.error("reconcile-projections error: %s", e, exc_info=True)
+        raise HTTPException(status_code=500, detail="Failed to reconcile projections") from e
+    return ReconcileProjectionsResponse(**report.to_dict())

--- a/src/nexus/storage/operation_logger.py
+++ b/src/nexus/storage/operation_logger.py
@@ -23,6 +23,10 @@ class OperationLogger:
             session: SQLAlchemy session for database operations.
         """
         self.session = session
+        # #4738: ``sequence_number`` of the most recent row this logger
+        # inserted.  The write observer reads it after each
+        # ``log_operation`` to hand the caller a projection sequence.
+        self.last_sequence_number: int | None = None
 
     @staticmethod
     def _apply_filters(
@@ -155,6 +159,7 @@ class OperationLogger:
                 nested.commit()
                 if flush:
                     self.session.flush()
+                self.last_sequence_number = next_seq
                 return operation.operation_id
             except IntegrityError:
                 nested.rollback()
@@ -205,6 +210,31 @@ class OperationLogger:
             yield from batch
             last_seq = batch[-1].sequence_number
             current_seq = (last_seq + 1) if last_seq is not None else current_seq + batch_size
+
+    def projection_state(self, seq: int, *, zone_id: str | None = None) -> tuple[bool, int | None]:
+        """Report whether projection sequence ``seq`` is committed (#4738).
+
+        ``seq`` is the ``sequence_number`` a write returned as
+        ``projection_seq``.  Returns ``(applied, latest_seq)`` where
+        ``applied`` is True when a row with that sequence exists in the
+        caller's zone and ``latest_seq`` is the highest committed sequence
+        in that zone (``None`` when the zone has no rows yet).  Rows of
+        other zones never satisfy the check, so a foreign sequence looks
+        exactly like one that has not landed.
+
+        Callers polling this must start a fresh transaction per probe
+        (SQLite keeps a read snapshot for the life of a transaction).
+        """
+        exists_stmt = select(OperationLogModel.sequence_number).where(
+            OperationLogModel.sequence_number == seq
+        )
+        latest_stmt = select(func.max(OperationLogModel.sequence_number))
+        if zone_id is not None:
+            exists_stmt = exists_stmt.where(OperationLogModel.zone_id == zone_id)
+            latest_stmt = latest_stmt.where(OperationLogModel.zone_id == zone_id)
+        applied = self.session.execute(exists_stmt.limit(1)).scalar_one_or_none() is not None
+        latest = self.session.execute(latest_stmt).scalar_one_or_none()
+        return applied, (int(latest) if latest is not None else None)
 
     def get_operation(self, operation_id: str) -> OperationLogModel | None:
         """Get operation by ID.

--- a/src/nexus/storage/piped_record_store_write_observer.py
+++ b/src/nexus/storage/piped_record_store_write_observer.py
@@ -1,17 +1,50 @@
-"""OBSERVE-phase observer for RecordStore audit trail + versioning.
+"""Write-through RecordStore projection observer (#4738).
 
 Receives FILE_WRITE / FILE_DELETE / FILE_RENAME / DIR_CREATE / DIR_DELETE
-events from the Rust kernel and flushes them to RecordStore in debounced
-batches.
+events from the audit interceptor (Rust kernel post-hooks relayed through
+Python) and commits the *critical* projection rows — ``operation_log``,
+``file_paths``, ``version_history`` — before the mutation returns to its
+caller.  ``list_versions``, ``/api/v2/operations`` replay and the search
+zone join on ``file_paths`` therefore never lag a write on this node.
 
-Issue #809: Decouple write_observer.on_write() sync DB write from hot path.
+History.  #809 moved this work off the hot path behind a 200 ms debounce
+over an in-memory ``deque(maxlen=10_000)``: overflow dropped the oldest
+events with only a counter, a crash lost everything in flight, and readers
+had to call ``flush_write_observer``.  #4738 replaces the debounce with a
+**synchronous group commit**::
 
-Architecture:
-    Rust kernel sys_write / sys_unlink / sys_mkdir
-      -> dispatch_observers (Rust MutationObserver trait)
-        -> accumulate event in deque + reset debounce timer
-        -> threading.Timer fires _flush()
-        -> single RecordStore transaction (OperationLogger + VersionRecorder)
+    writer thread                        projection-commit thread
+    ─────────────                        ────────────────────────
+    on_write(...)                        wait for tickets
+      ticket = _submit(events) ───────▶  drain ≤ _MAX_BATCH_DRAIN events
+      ticket.done.wait(timeout)          ONE transaction: OperationLogger + VersionRecorder
+      return ticket.seq          ◀────── ticket.seq = operation_log.sequence_number
+                                         hand events to projection-deferred thread
+                                                   │
+                                                   ▼
+                                         MCL rows + post-flush hooks (extraction, lineage)
+
+* Concurrent writers share one transaction, so throughput under load matches
+  the old batch path while every writer returns only after its own row is
+  committed.  A single committer allocates ``sequence_number`` (MAX+1) — no
+  unique-constraint retry storms.
+* The sequence is the **projection sequence** a write returns as
+  ``projection_seq``; ``GET /api/v2/operations/wait?seq=`` answers from the
+  same column, so callers wait on it instead of calling
+  ``flush_write_observer``.
+* ``strict_mode=True`` (``AuditConfig`` default): a commit that fails after
+  retries, or is not confirmed within ``write_through_timeout_s``, raises
+  ``AuditLogError`` in the writer's thread — the typed error the write
+  surfaces.  ``strict_mode=False``: the write succeeds with
+  ``projection_seq=None``, the event stays queued for retry, and the gap is
+  logged at CRITICAL.
+* Nothing is dropped silently.  Both queues are bounded; the deferred queue
+  backpressures the committer first; every drop is an ERROR log plus
+  ``nexus_projection_events_dropped_total``.
+* A crash between the kernel commit and the projection commit can still lose
+  the rows in flight (the kernel is authoritative and already durable).
+  ``storage/projection_reconcile.py`` — ``POST /api/v2/admin/reconcile-
+  projections`` — repairs the projection from the kernel afterwards.
 """
 
 import logging
@@ -21,16 +54,25 @@ from collections import deque
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
+from nexus.contracts.exceptions import AuditLogError
+from nexus.lib import io_metrics
+
 if TYPE_CHECKING:
     from nexus.core.file_events import FileEvent
     from nexus.storage.record_store import RecordStoreABC
 
 logger = logging.getLogger(__name__)
 
-# Consumer batch processing
-_MAX_BATCH_DRAIN = 100  # Max events to drain per flush
+_MAX_BATCH_DRAIN = 100  # Max events per commit transaction (group size)
 _MAX_RETRIES = 3
-_DEBOUNCE_S = 0.2  # Debounce window (200ms) — same as former linger_s
+_WRITE_THROUGH_TIMEOUT_S = 5.0  # How long a writer waits for its row to commit
+_PENDING_MAX_EVENTS = 50_000  # Unconfirmed events kept for retry (non-strict mode)
+_DEFERRED_MAX_EVENTS = 10_000  # Committed events awaiting MCL + post-flush hooks
+_BACKPRESSURE_S = 2.0  # Committer blocks this long on a full deferred queue before dropping
+_DEBOUNCE_S = 0.2  # Legacy constructor default (#809); no timer is driven by it any more
+
+_RECONCILE_HINT = "run POST /api/v2/admin/reconcile-projections to repair the projection"
+_REINDEX_HINT = "run POST /api/v2/admin/reindex to rebuild aspect/MCL state"
 
 
 def _metadata_from_dict(d: dict[str, Any]) -> Any:
@@ -65,15 +107,35 @@ def _metadata_snapshot(metadata: Any | None) -> dict[str, Any] | None:
     return None
 
 
-class RecordStoreWriteObserver:
-    """OBSERVE-phase observer for RecordStore audit trail + versioning.
+class _Ticket:
+    """One intake call's events plus the writer's completion signal."""
 
-    Receives mutation events from the Rust kernel and flushes them to
-    RecordStore (OperationLogger + VersionRecorder) in debounced batches.
+    __slots__ = ("done", "error", "events", "seq")
+
+    def __init__(self, events: list[dict[str, Any]]) -> None:
+        self.events = events
+        self.done = threading.Event()
+        self.error: Exception | None = None
+        self.seq: int | None = None
+
+    def finish(self, error: Exception | None = None) -> None:
+        seqs = [e["projection_seq"] for e in self.events if e.get("projection_seq") is not None]
+        self.seq = max(seqs) if seqs else None
+        self.error = error
+        self.done.set()
+
+
+class RecordStoreWriteObserver:
+    """Write-through projection observer for RecordStore audit trail + versioning.
+
+    Receives mutation events from ``SyncAuditWriteInterceptor`` and commits
+    ``operation_log`` + ``file_paths`` + ``version_history`` in a group
+    commit before returning; MCL rows and post-flush hooks run on a
+    deferred thread.  See the module docstring for the full contract.
 
     Registration:
         Enlisted via factory orchestrator; events dispatched by the Rust
-        kernel's MutationObserver trait (not Python on_mutation).
+        kernel's post-hook path through ``SyncAuditWriteInterceptor``.
     """
 
     def __init__(
@@ -83,49 +145,58 @@ class RecordStoreWriteObserver:
         strict_mode: bool = True,
         event_signal: "Any | None" = None,
         debounce_seconds: float = _DEBOUNCE_S,
+        write_through_timeout_s: float = _WRITE_THROUGH_TIMEOUT_S,
     ) -> None:
         self._session_factory = record_store.session_factory
         self._strict_mode = strict_mode
         self._event_signal = event_signal  # Issue #3193: wake delivery worker
+        # Kept for constructor compatibility (#809 callers); the commit is
+        # driven by writers waiting on their ticket, not by a timer.
         self._debounce = debounce_seconds
+        self._timeout = write_through_timeout_s
 
-        # Debounce state — protected by _lock
-        self._pending: deque[dict[str, Any]] = deque(maxlen=10_000)
-        self._timer: threading.Timer | None = None
+        # Pending tickets (events accepted, not yet committed) — under _cond.
         self._lock = threading.Lock()
+        self._cond = threading.Condition(self._lock)
+        self._pending: deque[_Ticket] = deque()
+        self._pending_events = 0
+        # Serialises "drain + commit" between the commit thread and flush_sync().
+        self._commit_lock = threading.Lock()
+
+        # Committed events awaiting MCL + hooks — under _deferred_cond.
+        self._deferred_cond = threading.Condition()
+        self._deferred: deque[list[dict[str, Any]]] = deque()
+        self._deferred_events = 0
+
+        self._stop = False
+        self._commit_thread: threading.Thread | None = None
+        self._deferred_thread: threading.Thread | None = None
 
         # Metrics
         self._total_flushed = 0
         self._total_failed = 0
         self._total_retries = 0
         self._total_dropped = 0
+        self._total_timeouts = 0
+        self._applied_seq: int | None = None
 
         # Post-flush hooks: called after successful commit (Issue #2978)
         # Used by CatalogService for async-on-write extraction
         self._post_flush_hooks: list[Any] = []
 
     def register_post_flush_hook(self, hook: Any) -> None:
-        """Register a callback invoked after each successful flush.
+        """Register a callback invoked after each successful commit.
 
-        Hooks receive the list of flushed events. They run AFTER the
-        audit trail commit, so failures do not block the audit path.
-        Used by CatalogService for async-on-write extraction (Issue #2978).
+        Hooks receive the list of committed events.  They run on the
+        deferred thread AFTER the audit trail commit, so failures do not
+        block the audit path or the writer.  Used by CatalogService for
+        async-on-write extraction (Issue #2978).
         """
         self._post_flush_hooks.append(hook)
 
     # ------------------------------------------------------------------
     # Event intake — called by SyncAuditWriteInterceptor post-hooks
     # ------------------------------------------------------------------
-
-    def _enqueue(self, event: dict[str, Any]) -> None:
-        """Add event to pending deque and reset debounce timer."""
-        with self._lock:
-            self._pending.append(event)
-            if self._timer is not None:
-                self._timer.cancel()
-            self._timer = threading.Timer(self._debounce, self._flush)
-            self._timer.daemon = True
-            self._timer.start()
 
     def on_write(
         self,
@@ -136,8 +207,8 @@ class RecordStoreWriteObserver:
         old_metadata: Any | None = None,
         zone_id: str | None = None,
         agent_id: str | None = None,
-    ) -> None:
-        """Accept a write event from SyncAuditWriteInterceptor."""
+    ) -> int | None:
+        """Project a write; returns its projection sequence once committed."""
         if isinstance(old_metadata, dict):
             snapshot_hash = old_metadata.get("content_id")
             metadata_snapshot = old_metadata
@@ -150,18 +221,17 @@ class RecordStoreWriteObserver:
             snapshot_hash = None
             metadata_snapshot = None
 
-        self._enqueue(
-            {
-                "op": "write",
-                "path": path,
-                "is_new": is_new,
-                "zone_id": zone_id,
-                "agent_id": agent_id,
-                "snapshot_hash": snapshot_hash,
-                "metadata_snapshot": metadata_snapshot,
-                "metadata": metadata.to_dict() if hasattr(metadata, "to_dict") else metadata,
-            }
-        )
+        event = {
+            "op": "write",
+            "path": path,
+            "is_new": is_new,
+            "zone_id": zone_id,
+            "agent_id": agent_id,
+            "snapshot_hash": snapshot_hash,
+            "metadata_snapshot": metadata_snapshot,
+            "metadata": metadata.to_dict() if hasattr(metadata, "to_dict") else metadata,
+        }
+        return self._write_through([event], operation="write", path=path)
 
     def on_write_batch(
         self,
@@ -170,21 +240,27 @@ class RecordStoreWriteObserver:
         zone_id: str | None = None,
         agent_id: str | None = None,
         urgency: str | None = None,  # noqa: ARG002
-    ) -> None:
-        """Accept a batch write event from SyncAuditWriteInterceptor."""
-        for metadata, is_new in items:
-            self._enqueue(
-                {
-                    "op": "write",
-                    "path": metadata.path,
-                    "is_new": is_new,
-                    "zone_id": zone_id,
-                    "agent_id": agent_id,
-                    "snapshot_hash": None,
-                    "metadata_snapshot": None,
-                    "metadata": metadata.to_dict() if hasattr(metadata, "to_dict") else metadata,
-                }
-            )
+    ) -> list[int | None]:
+        """Project a batch write in one transaction; one sequence per item."""
+        events = [
+            {
+                "op": "write",
+                "path": metadata.path,
+                "is_new": is_new,
+                "zone_id": zone_id,
+                "agent_id": agent_id,
+                "snapshot_hash": None,
+                "metadata_snapshot": None,
+                "metadata": metadata.to_dict() if hasattr(metadata, "to_dict") else metadata,
+            }
+            for metadata, is_new in items
+        ]
+        if not events:
+            return []
+        confirmed = self._write_through(events, operation="write_batch", path=events[0]["path"])
+        if confirmed is None:
+            return [None] * len(events)
+        return [e.get("projection_seq") for e in events]
 
     def on_delete(
         self,
@@ -193,18 +269,17 @@ class RecordStoreWriteObserver:
         metadata: Any | None = None,
         zone_id: str | None = None,
         agent_id: str | None = None,
-    ) -> None:
-        """Accept a delete event from SyncAuditWriteInterceptor."""
-        self._enqueue(
-            {
-                "op": "delete",
-                "path": path,
-                "zone_id": zone_id,
-                "agent_id": agent_id,
-                "snapshot_hash": _metadata_content_id(metadata),
-                "metadata_snapshot": _metadata_snapshot(metadata),
-            }
-        )
+    ) -> int | None:
+        """Project a delete; returns its projection sequence once committed."""
+        event = {
+            "op": "delete",
+            "path": path,
+            "zone_id": zone_id,
+            "agent_id": agent_id,
+            "snapshot_hash": _metadata_content_id(metadata),
+            "metadata_snapshot": _metadata_snapshot(metadata),
+        }
+        return self._write_through([event], operation="delete", path=path)
 
     def on_rename(
         self,
@@ -214,19 +289,18 @@ class RecordStoreWriteObserver:
         metadata: Any | None = None,
         zone_id: str | None = None,
         agent_id: str | None = None,
-    ) -> None:
-        """Accept a rename event from SyncAuditWriteInterceptor."""
-        self._enqueue(
-            {
-                "op": "rename",
-                "path": old_path,
-                "new_path": new_path,
-                "zone_id": zone_id,
-                "agent_id": agent_id,
-                "snapshot_hash": _metadata_content_id(metadata),
-                "metadata_snapshot": _metadata_snapshot(metadata),
-            }
-        )
+    ) -> int | None:
+        """Project a rename; returns the sequence of its upsert row once committed."""
+        event = {
+            "op": "rename",
+            "path": old_path,
+            "new_path": new_path,
+            "zone_id": zone_id,
+            "agent_id": agent_id,
+            "snapshot_hash": _metadata_content_id(metadata),
+            "metadata_snapshot": _metadata_snapshot(metadata),
+        }
+        return self._write_through([event], operation="rename", path=old_path)
 
     def on_mkdir(
         self,
@@ -234,16 +308,10 @@ class RecordStoreWriteObserver:
         path: str,
         zone_id: str | None = None,
         agent_id: str | None = None,
-    ) -> None:
-        """Accept a mkdir event from SyncAuditWriteInterceptor."""
-        self._enqueue(
-            {
-                "op": "mkdir",
-                "path": path,
-                "zone_id": zone_id,
-                "agent_id": agent_id,
-            }
-        )
+    ) -> int | None:
+        """Project a mkdir; returns its projection sequence once committed."""
+        event = {"op": "mkdir", "path": path, "zone_id": zone_id, "agent_id": agent_id}
+        return self._write_through([event], operation="mkdir", path=path)
 
     def on_rmdir(
         self,
@@ -252,162 +320,356 @@ class RecordStoreWriteObserver:
         zone_id: str | None = None,
         agent_id: str | None = None,
         recursive: bool = False,
-    ) -> None:
-        """Accept an rmdir event from SyncAuditWriteInterceptor."""
-        self._enqueue(
-            {
-                "op": "rmdir",
-                "path": path,
-                "zone_id": zone_id,
-                "agent_id": agent_id,
-                "recursive": recursive,
-            }
-        )
+    ) -> int | None:
+        """Project an rmdir; returns its projection sequence once committed."""
+        event = {
+            "op": "rmdir",
+            "path": path,
+            "zone_id": zone_id,
+            "agent_id": agent_id,
+            "recursive": recursive,
+        }
+        return self._write_through([event], operation="rmdir", path=path)
 
     # ------------------------------------------------------------------
-    # Debounce flush
+    # Write-through: submit, wait, apply the strict_mode policy
     # ------------------------------------------------------------------
 
-    def _flush(self) -> None:
-        """Fire after debounce window -- flush events to RecordStore."""
-        with self._lock:
-            events = list(self._pending)
-            self._pending.clear()
-            self._timer = None
+    def _write_through(
+        self, events: list[dict[str, Any]], *, operation: str, path: str
+    ) -> int | None:
+        """Queue ``events`` for the group commit and wait for the row(s) to land.
 
-        if not events:
-            return
-
-        # Batch: take up to _MAX_BATCH_DRAIN at a time, retry remainder
-        self._flush_batch(events)
-
-    def _flush_batch(self, events: list[dict[str, Any]], attempt: int = 0) -> None:
-        """Flush a batch of events to RecordStore in a single transaction."""
-        t0 = time.monotonic()
-        try:
-            self._flush_batch_sync(events)
-
-            duration = time.monotonic() - t0
-            self._total_flushed += len(events)
-
-            # Issue #3193: signal delivery worker immediately after commit
-            if self._event_signal is not None:
-                self._event_signal.set()
-
-            logger.info(
-                "[OBSERVE] Flushed %d audit events in %.3fs",
-                len(events),
-                duration,
+        Returns the ticket's projection sequence (highest
+        ``operation_log.sequence_number`` among its events) or ``None`` when
+        the commit is not confirmed and ``strict_mode`` is off.  Raises
+        ``AuditLogError`` in strict mode when the commit failed or timed out.
+        """
+        ticket = self._submit(events)
+        if not ticket.done.wait(self._timeout):
+            self._total_timeouts += 1
+            io_metrics.record_projection_write_through_timeout()
+            detail = (
+                f"projection of {operation} on '{path}' not confirmed within "
+                f"{self._timeout:.1f}s (still queued for retry)"
             )
-
-            # Post-flush hooks: extraction, etc. (Issue #2978)
-            # Runs AFTER commit — failures do not block audit trail.
-            for hook in self._post_flush_hooks:
-                try:
-                    hook(events)
-                except Exception as hook_err:
-                    logger.debug(
-                        "Post-flush hook %s failed (non-critical): %s",
-                        getattr(hook, "__name__", hook),
-                        hook_err,
-                    )
-
-        except Exception as e:
-            if attempt < _MAX_RETRIES:
-                self._total_retries += 1
-                wait = 0.1 * (2**attempt)  # 100ms, 200ms, 400ms
-                logger.warning(
-                    "RecordStoreWriteObserver flush failed (attempt %d/%d, retry in %.1fs): %s",
-                    attempt + 1,
-                    _MAX_RETRIES,
-                    wait,
-                    e,
-                )
-                threading.Timer(wait, self._flush_batch, args=(events, attempt + 1)).start()
-            else:
-                # #4645: a single poison event (e.g. an INSERT the
-                # schema rejects) must not take the whole batch's
-                # audit trail down with it — salvage per event and
-                # drop only the rows that individually fail.
+            if self._strict_mode:
                 logger.error(
-                    "RecordStoreWriteObserver flush FAILED after %d retries, "
+                    "AUDIT LOG FAILURE: %s on '%s' ABORTED. %s. "
+                    "Set audit_strict_mode=False to allow writes without a confirmed audit row.",
+                    operation,
+                    path,
+                    detail,
+                )
+                raise AuditLogError(f"Operation aborted: {detail}", path=path)
+            logger.critical(
+                "AUDIT LOG FAILURE: %s on '%s' SUCCEEDED but %s. "
+                "Callers that fence on projection_seq see None for this write.",
+                operation,
+                path,
+                detail,
+            )
+            return None
+        if ticket.error is not None:
+            if self._strict_mode:
+                logger.error(
+                    "AUDIT LOG FAILURE: %s on '%s' ABORTED. Error: %s. "
+                    "Set audit_strict_mode=False to allow writes without audit logs.",
+                    operation,
+                    path,
+                    ticket.error,
+                )
+                raise AuditLogError(
+                    f"Operation aborted: audit logging failed for {operation}: {ticket.error}",
+                    path=path,
+                    original_error=ticket.error,
+                ) from ticket.error
+            # Non-strict: the salvage path already logged the lost row at ERROR.
+            return None
+        return ticket.seq
+
+    def _submit(self, events: list[dict[str, Any]]) -> _Ticket:
+        ticket = _Ticket(events)
+        with self._cond:
+            self._ensure_threads_locked()
+            self._pending.append(ticket)
+            self._pending_events += len(events)
+            self._enforce_pending_bound_locked()
+            pending = self._pending_events
+            self._cond.notify()
+        io_metrics.set_projection_pending("pending", pending)
+        return ticket
+
+    def _enqueue(self, event: dict[str, Any]) -> _Ticket:
+        """Queue one event without waiting for it (shutdown / test helper)."""
+        return self._submit([event])
+
+    def _enforce_pending_bound_locked(self) -> None:
+        """Drop the oldest unconfirmed tickets once the pending queue overflows.
+
+        Only reachable in non-strict mode while the RecordStore has been
+        unavailable long enough to accumulate ``_PENDING_MAX_EVENTS``
+        (strict mode raises at the writer instead of orphaning tickets).
+        Never silent: ERROR log + ``nexus_projection_events_dropped_total``.
+        """
+        while self._pending_events > _PENDING_MAX_EVENTS and len(self._pending) > 1:
+            victim = self._pending.popleft()
+            n = len(victim.events)
+            self._pending_events -= n
+            self._total_dropped += n
+            io_metrics.record_projection_dropped("pending", n)
+            first = victim.events[0]
+            logger.error(
+                "RecordStoreWriteObserver dropped %d unconfirmed event(s) (pending queue over "
+                "%d): op=%s path=%s — their version/audit rows are LOST; %s",
+                n,
+                _PENDING_MAX_EVENTS,
+                first.get("op"),
+                first.get("path"),
+                _RECONCILE_HINT,
+            )
+            victim.finish(RuntimeError("projection pending queue overflow"))
+
+    def _ensure_threads_locked(self) -> None:
+        """Start the commit + deferred threads lazily (caller holds ``_cond``)."""
+        if self._commit_thread is not None and self._commit_thread.is_alive():
+            return
+        self._stop = False
+        self._commit_thread = threading.Thread(
+            target=self._commit_loop, name="projection-commit", daemon=True
+        )
+        self._commit_thread.start()
+        if self._deferred_thread is None or not self._deferred_thread.is_alive():
+            self._deferred_thread = threading.Thread(
+                target=self._deferred_loop, name="projection-deferred", daemon=True
+            )
+            self._deferred_thread.start()
+
+    # ------------------------------------------------------------------
+    # Commit thread: group commit of the critical rows
+    # ------------------------------------------------------------------
+
+    def _drain_locked(self, max_events: int | None) -> list[_Ticket]:
+        """Pop tickets up to ``max_events`` (at least one; caller holds ``_cond``)."""
+        tickets: list[_Ticket] = []
+        total = 0
+        while self._pending:
+            nxt = self._pending[0]
+            if tickets and max_events is not None and total + len(nxt.events) > max_events:
+                break
+            self._pending.popleft()
+            tickets.append(nxt)
+            total += len(nxt.events)
+        self._pending_events -= total
+        return tickets
+
+    def _commit_loop(self) -> None:
+        while True:
+            with self._cond:
+                while not self._pending and not self._stop:
+                    self._cond.wait()
+                if self._stop and not self._pending:
+                    return
+            with self._commit_lock:
+                with self._cond:
+                    tickets = self._drain_locked(_MAX_BATCH_DRAIN)
+                    pending = self._pending_events
+                io_metrics.set_projection_pending("pending", pending)
+                if tickets:
+                    self._commit_tickets(tickets)
+
+    def _commit_tickets(self, tickets: list[_Ticket]) -> int:
+        """Commit the tickets' events in one transaction; returns rows committed.
+
+        Retries the whole batch with backoff, then salvages per event so a
+        single poison row (#4645) cannot take the batch's audit trail down.
+        Caller holds ``_commit_lock``.
+        """
+        events = [e for t in tickets for e in t.events]
+        attempt = 0
+        while True:
+            try:
+                self._flush_batch_sync(events)
+                break
+            except Exception as exc:
+                if attempt < _MAX_RETRIES:
+                    self._total_retries += 1
+                    wait = 0.1 * (2**attempt)  # 100ms, 200ms, 400ms
+                    logger.warning(
+                        "RecordStoreWriteObserver commit failed (attempt %d/%d, retry in %.1fs): %s",
+                        attempt + 1,
+                        _MAX_RETRIES,
+                        wait,
+                        exc,
+                    )
+                    attempt += 1
+                    time.sleep(wait)
+                    continue
+                logger.error(
+                    "RecordStoreWriteObserver commit FAILED after %d retries, "
                     "salvaging %d events individually: %s",
                     _MAX_RETRIES,
                     len(events),
-                    e,
+                    exc,
                 )
-                salvaged = self._salvage_events_individually(events)
-                if salvaged:
-                    if self._event_signal is not None:
-                        self._event_signal.set()
-                    for hook in self._post_flush_hooks:
-                        try:
-                            hook(salvaged)
-                        except Exception as hook_err:
-                            logger.debug(
-                                "Post-flush hook %s failed (non-critical): %s",
-                                getattr(hook, "__name__", hook),
-                                hook_err,
-                            )
+                return self._salvage_tickets(tickets)
 
-    def _salvage_events_individually(self, events: list[dict[str, Any]]) -> list[dict[str, Any]]:
-        """Last-resort per-event flush after a batch repeatedly failed (#4645).
+        for ticket in tickets:
+            ticket.finish()
+        self._after_commit(events)
+        return len(events)
 
-        Each event gets its own transaction; only the rows that
-        individually fail are dropped, and every drop is logged loudly
-        with the op + path whose audit row it loses.  Returns the
-        events that made it to the store.
+    def _salvage_tickets(self, tickets: list[_Ticket]) -> int:
+        """Last-resort per-event commit after a batch repeatedly failed (#4645).
+
+        Each event gets its own transaction; only the rows that individually
+        fail are lost, every loss is logged at ERROR with op + path, and the
+        ticket carries the first failure so a strict-mode writer raises.
         """
         salvaged: list[dict[str, Any]] = []
-        for event in events:
-            try:
-                self._flush_batch_sync([event])
-                salvaged.append(event)
-            except Exception as event_err:
-                self._total_failed += 1
-                logger.error(
-                    "RecordStoreWriteObserver dropping audit event: op=%s path=%s error=%s",
-                    event.get("op"),
-                    event.get("path"),
-                    event_err,
-                )
-        self._total_flushed += len(salvaged)
-        return salvaged
+        for ticket in tickets:
+            first_error: Exception | None = None
+            for event in ticket.events:
+                try:
+                    self._flush_batch_sync([event])
+                    salvaged.append(event)
+                except Exception as event_err:
+                    self._total_failed += 1
+                    io_metrics.record_projection_failed(1)
+                    first_error = first_error or event_err
+                    logger.error(
+                        "RecordStoreWriteObserver dropping audit event: op=%s path=%s error=%s — %s",
+                        event.get("op"),
+                        event.get("path"),
+                        event_err,
+                        _RECONCILE_HINT,
+                    )
+            ticket.finish(first_error)
+        if salvaged:
+            self._after_commit(salvaged)
+        return len(salvaged)
+
+    def _after_commit(self, events: list[dict[str, Any]]) -> None:
+        """Bookkeeping after critical rows committed: metrics, signal, deferred work."""
+        self._total_flushed += len(events)
+        seqs = [e["projection_seq"] for e in events if e.get("projection_seq") is not None]
+        if seqs:
+            top = max(seqs)
+            if self._applied_seq is None or top > self._applied_seq:
+                self._applied_seq = top
+        # Issue #3193: signal delivery worker immediately after commit
+        if self._event_signal is not None:
+            self._event_signal.set()
+        self._enqueue_deferred(events)
 
     # ------------------------------------------------------------------
-    # Flush sync (for CLI shutdown / close callbacks)
+    # Deferred thread: MCL rows + post-flush hooks (off the writer's path)
+    # ------------------------------------------------------------------
+
+    def _enqueue_deferred(self, events: list[dict[str, Any]]) -> None:
+        """Hand committed events to the deferred thread, with backpressure.
+
+        A full queue first blocks the committer (and therefore the writers)
+        for ``_BACKPRESSURE_S``; only then are the oldest batches dropped,
+        loudly.  Dropping here loses MCL rows + hooks, never audit/version
+        rows — those are already committed.
+        """
+        with self._deferred_cond:
+            deadline = time.monotonic() + _BACKPRESSURE_S
+            while (
+                self._deferred_events + len(events) > _DEFERRED_MAX_EVENTS
+                and self._deferred
+                and not self._stop
+            ):
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    break
+                self._deferred_cond.wait(remaining)
+            while self._deferred_events + len(events) > _DEFERRED_MAX_EVENTS and self._deferred:
+                dropped = self._deferred.popleft()
+                n = len(dropped)
+                self._deferred_events -= n
+                self._total_dropped += n
+                io_metrics.record_projection_dropped("deferred", n)
+                logger.error(
+                    "RecordStoreWriteObserver dropped %d committed event(s) from the deferred "
+                    "queue (over %d after %.1fs of backpressure): first op=%s path=%s — their "
+                    "MCL rows and post-flush hooks will not run; %s",
+                    n,
+                    _DEFERRED_MAX_EVENTS,
+                    _BACKPRESSURE_S,
+                    dropped[0].get("op"),
+                    dropped[0].get("path"),
+                    _REINDEX_HINT,
+                )
+            self._deferred.append(events)
+            self._deferred_events += len(events)
+            depth = self._deferred_events
+            self._deferred_cond.notify_all()
+        io_metrics.set_projection_pending("deferred", depth)
+
+    def _deferred_loop(self) -> None:
+        while True:
+            with self._deferred_cond:
+                while not self._deferred and not self._stop:
+                    self._deferred_cond.wait()
+                if not self._deferred:
+                    return
+                batch = self._deferred.popleft()
+                self._deferred_events -= len(batch)
+                depth = self._deferred_events
+                self._deferred_cond.notify_all()
+            io_metrics.set_projection_pending("deferred", depth)
+            self._run_deferred(batch)
+
+    def _run_deferred(self, events: list[dict[str, Any]]) -> None:
+        """Phase 2 for committed events: MCL rows, then post-flush hooks."""
+        self._record_mcl_batch(events)
+        for hook in self._post_flush_hooks:
+            try:
+                hook(events)
+            except Exception as hook_err:
+                logger.debug(
+                    "Post-flush hook %s failed (non-critical): %s",
+                    getattr(hook, "__name__", hook),
+                    hook_err,
+                )
+
+    def _drain_deferred_inline(self) -> None:
+        """Run all queued deferred work on the calling thread (shutdown)."""
+        while True:
+            with self._deferred_cond:
+                if not self._deferred:
+                    return
+                batch = self._deferred.popleft()
+                self._deferred_events -= len(batch)
+                self._deferred_cond.notify_all()
+            self._run_deferred(batch)
+
+    # ------------------------------------------------------------------
+    # Flush (CLI shutdown / close callbacks / flush_write_observer RPC)
     # ------------------------------------------------------------------
 
     def flush_sync(self) -> int:
-        """Synchronously flush all pending events to the DB.
+        """Commit every pending event and run all deferred work, inline.
 
-        Used by CLI shutdown path (NexusFS.close) where no asyncio loop
-        is running. Returns count of flushed events.
+        Returns the number of events committed by this call.  With
+        write-through the pending queue is normally empty (each writer has
+        already waited for its own row); this drains whatever a non-strict
+        timeout or a shutdown left behind.
         """
-        with self._lock:
-            events = list(self._pending)
-            self._pending.clear()
-            if self._timer is not None:
-                self._timer.cancel()
-                self._timer = None
-
-        if not events:
-            return 0
-
-        try:
-            self._flush_batch_sync(events)
-            count = len(events)
-            self._total_flushed += count
-            logger.debug("flush_sync: flushed %d events", count)
-            return count
-        except Exception as e:
-            # #4645: salvage per event instead of losing the batch.
-            logger.error(
-                "flush_sync batch failed, salvaging %d events individually: %s",
-                len(events),
-                e,
-            )
-            return len(self._salvage_events_individually(events))
+        committed = 0
+        with self._commit_lock:
+            with self._cond:
+                tickets = self._drain_locked(None)
+            io_metrics.set_projection_pending("pending", 0)
+            if tickets:
+                committed = self._commit_tickets(tickets)
+        self._drain_deferred_inline()
+        io_metrics.set_projection_pending("deferred", 0)
+        if committed:
+            logger.debug("flush_sync: committed %d events", committed)
+        return committed
 
     async def flush(self, timeout: float = 5.0) -> int:  # noqa: ARG002
         """Flush pending events. Async signature for protocol compat.
@@ -476,7 +738,7 @@ class RecordStoreWriteObserver:
             return None  # Unsupported event type — ignore
 
     # ------------------------------------------------------------------
-    # DB flush logic (shared by _flush_batch and flush_sync)
+    # DB logic
     # ------------------------------------------------------------------
 
     @staticmethod
@@ -551,11 +813,29 @@ class RecordStoreWriteObserver:
                 "MCL recording failed for %s:%s (non-critical)", event.get("op"), event.get("path")
             )
 
+    def _record_mcl_batch(self, events: list[dict[str, Any]]) -> None:
+        """Record MCL rows for committed events in their own session (non-critical)."""
+        mcl_session = None
+        try:
+            mcl_session = self._session_factory()
+            for event in events:
+                if event.get("op") in ("write", "delete", "rename"):
+                    self._record_mcl_for_event(mcl_session, event)
+            mcl_session.commit()
+        except Exception as mcl_err:
+            if mcl_session is not None:
+                mcl_session.rollback()
+            logger.debug("MCL batch recording failed (non-critical): %s", mcl_err)
+        finally:
+            if mcl_session is not None:
+                mcl_session.close()
+
     def _process_events_in_session(self, session: Any, events: list[dict[str, Any]]) -> None:
         """Dispatch events to OperationLogger + VersionRecorder within a session.
 
-        Shared by ``_flush_batch()`` and ``flush_sync()``.
-        Caller is responsible for ``session.commit()``.
+        Stamps every event with ``projection_seq`` — the
+        ``operation_log.sequence_number`` of its (last) audit row.  Caller
+        is responsible for ``session.commit()``.
         """
         from nexus.storage.operation_logger import OperationLogger
         from nexus.storage.version_recorder import VersionRecorder
@@ -654,14 +934,15 @@ class RecordStoreWriteObserver:
                     status="success",
                 )
 
-    def _flush_batch_sync(self, events: list[dict[str, Any]]) -> None:
-        """Synchronous flush: critical writes first, MCL second.
+            event["projection_seq"] = op_logger.last_sequence_number
 
-        Phase 1 commits operation_log + file_paths + version_history.
-        Phase 2 records MCL entries in a separate session so failures
-        cannot corrupt the critical writes.
+    def _flush_batch_sync(self, events: list[dict[str, Any]]) -> None:
+        """Commit the critical rows for ``events`` in ONE transaction.
+
+        operation_log + file_paths + version_history only.  MCL rows and
+        post-flush hooks are deferred work (``_run_deferred``) so a slow
+        extraction never sits on a writer's critical path.
         """
-        # Phase 1: Critical writes (operation_log + version_history)
         session = self._session_factory()
         try:
             self._process_events_in_session(session, events)
@@ -672,46 +953,50 @@ class RecordStoreWriteObserver:
         finally:
             session.close()
 
-        # Phase 2: MCL recording (non-critical, separate session)
-        mcl_session = None
-        try:
-            mcl_session = self._session_factory()
-            for event in events:
-                if event.get("op") in ("write", "delete", "rename"):
-                    self._record_mcl_for_event(mcl_session, event)
-            mcl_session.commit()
-        except Exception as mcl_err:
-            if mcl_session is not None:
-                mcl_session.rollback()
-            logger.debug("MCL batch recording failed (non-critical): %s", mcl_err)
-        finally:
-            if mcl_session is not None:
-                mcl_session.close()
-
     # ------------------------------------------------------------------
     # Cleanup
     # ------------------------------------------------------------------
 
     def cancel(self) -> None:
-        """Cancel any pending debounce timer (for clean shutdown)."""
-        with self._lock:
-            if self._timer is not None:
-                self._timer.cancel()
-                self._timer = None
+        """Stop the commit + deferred threads (for clean shutdown).
+
+        Pending events are committed before the commit thread exits; call
+        ``flush_sync()`` first when deferred work (MCL, hooks) must also
+        complete synchronously.
+        """
+        with self._cond:
+            self._stop = True
+            self._cond.notify_all()
+        with self._deferred_cond:
+            self._deferred_cond.notify_all()
+        for thread in (self._commit_thread, self._deferred_thread):
+            if (
+                thread is not None
+                and thread.is_alive()
+                and thread is not threading.current_thread()
+            ):
+                thread.join(timeout=2.0)
 
     # ------------------------------------------------------------------
     # Observability
     # ------------------------------------------------------------------
 
     @property
-    def metrics(self) -> dict[str, int]:
+    def metrics(self) -> dict[str, int | None]:
         """Return observer metrics."""
+        with self._cond:
+            pending = self._pending_events
+        with self._deferred_cond:
+            deferred = self._deferred_events
         return {
             "total_flushed": self._total_flushed,
             "total_failed": self._total_failed,
             "total_retries": self._total_retries,
             "total_dropped": self._total_dropped,
-            "pending_events": len(self._pending),
+            "total_timeouts": self._total_timeouts,
+            "pending_events": pending,
+            "deferred_events": deferred,
+            "applied_seq": self._applied_seq,
         }
 
 

--- a/src/nexus/storage/projection_reconcile.py
+++ b/src/nexus/storage/projection_reconcile.py
@@ -1,0 +1,374 @@
+"""Repair the RecordStore projection from the kernel (#4738).
+
+The write observer commits ``file_paths`` / ``version_history`` /
+``operation_log`` rows before a mutation returns, but the kernel commit
+happens first: a ``kill -9`` between the two, a RecordStore outage that
+outlived the observer's retry budget, or a dropped queue entry leaves the
+kernel (authoritative, durable) ahead of the projection.  This module
+walks the kernel under a prefix and brings the projection back in line:
+
+* path in the kernel, no active ``file_paths`` row → ``created`` (a
+  ``file_paths`` row + ``version_history`` v1 from the kernel's current
+  metadata, plus an ``operation_log`` write row attributed to
+  ``system:projection-reconcile``);
+* row present and the head ``version_history`` row records a kernel
+  ``gen``: kernel ``gen`` newer → ``repaired`` (a new version row for the
+  kernel's current content); equal → ``in_sync``; older → ``stale_kernel``
+  (this node's kernel view is the lagging one — a follower — and the path
+  is left alone);
+* row present, legacy head row without a ``gen``: fall back to comparing
+  ``content_id`` (differs → ``repaired``, same → ``in_sync``);
+* with ``retire_missing=True``, active rows under the prefix the kernel no
+  longer has → ``retired`` (soft delete).
+
+``gen`` is the primary key of the comparison because a path-addressed
+backend (the local backend in a single-node deployment) reports the
+storage key — the path — as ``content_id``, which never changes across
+writes; ``gen`` increments on every write everywhere.
+
+Intermediate versions lost in the crash window cannot be recovered — the
+kernel keeps only the current metadata — so the repair records the
+current content as the next version.  Exposed as
+``POST /api/v2/admin/reconcile-projections``.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass, field, replace
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import select
+
+from nexus.contracts.constants import ROOT_ZONE_ID, SYSTEM_PATH_PREFIX
+from nexus.contracts.metadata import DT_REG, FileMetadata
+from nexus.storage.models import FilePathModel, VersionHistoryModel
+from nexus.storage.version_recorder import VersionRecorder, version_gen
+
+logger = logging.getLogger(__name__)
+
+RECONCILE_ACTOR = "system:projection-reconcile"
+_INTERNAL_PIPE_PREFIX = "/nexus/pipes/"
+_SAMPLE_CAP = 25
+
+
+@dataclass
+class ReconcileReport:
+    """Outcome of one reconcile pass; every scanned path lands in one bucket."""
+
+    prefix: str
+    zone_id: str
+    dry_run: bool
+    scanned: int = 0
+    in_sync: int = 0
+    created: int = 0
+    repaired: int = 0
+    retired: int = 0
+    stale_kernel: int = 0
+    errors: int = 0
+    truncated: bool = False
+    duration_ms: int = 0
+    created_paths: list[str] = field(default_factory=list)
+    repaired_paths: list[str] = field(default_factory=list)
+    retired_paths: list[str] = field(default_factory=list)
+    stale_kernel_paths: list[str] = field(default_factory=list)
+    error_messages: list[str] = field(default_factory=list)
+
+    def _note(self, bucket: list[str], value: str) -> None:
+        if len(bucket) < _SAMPLE_CAP:
+            bucket.append(value)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "prefix": self.prefix,
+            "zone_id": self.zone_id,
+            "dry_run": self.dry_run,
+            "scanned": self.scanned,
+            "in_sync": self.in_sync,
+            "created": self.created,
+            "repaired": self.repaired,
+            "retired": self.retired,
+            "stale_kernel": self.stale_kernel,
+            "errors": self.errors,
+            "truncated": self.truncated,
+            "duration_ms": self.duration_ms,
+            "created_paths": list(self.created_paths),
+            "repaired_paths": list(self.repaired_paths),
+            "retired_paths": list(self.retired_paths),
+            "stale_kernel_paths": list(self.stale_kernel_paths),
+            "error_messages": list(self.error_messages),
+        }
+
+
+def _parse_ts(value: Any) -> datetime | None:
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, str) and value:
+        try:
+            return datetime.fromisoformat(value)
+        except ValueError:
+            return None
+    return None
+
+
+def _is_projected_file(entry: Any) -> bool:
+    """Regular files with content, outside the kernel-internal namespaces."""
+    if not isinstance(entry, dict):
+        return False
+    path = entry.get("path")
+    if not isinstance(path, str) or not path.startswith("/"):
+        return False
+    if path.startswith(SYSTEM_PATH_PREFIX) or path.startswith(_INTERNAL_PIPE_PREFIX):
+        return False
+    if entry.get("is_directory"):
+        return False
+    entry_type = entry.get("entry_type", DT_REG)
+    if entry_type not in (DT_REG, None):
+        return False
+    return bool(entry.get("content_id"))
+
+
+def _entry_metadata(entry: dict[str, Any], zone_id: str) -> FileMetadata:
+    """Kernel listing entry → FileMetadata keyed by the caller's zone.
+
+    The observer keys ``file_paths`` rows by the *writer's* zone (the
+    context's ``zone_id``), not the mount's, so the repair uses the token
+    zone the admin is reconciling for and ignores ``entry["zone_id"]``.
+    """
+    return FileMetadata(
+        path=entry["path"],
+        size=int(entry.get("size") or 0),
+        content_id=entry.get("content_id"),
+        mime_type=entry.get("mime_type"),
+        created_at=_parse_ts(entry.get("created_at")),
+        modified_at=_parse_ts(entry.get("modified_at")),
+        version=int(entry.get("version") or 1),
+        zone_id=zone_id,
+        owner_id=entry.get("owner_id"),
+        gen=int(entry.get("gen") or 0),
+    )
+
+
+def list_kernel_files(nexus_fs: Any, prefix: str, *, context: Any = None) -> list[dict[str, Any]]:
+    """Recursive kernel listing under ``prefix`` filtered to projected files."""
+    raw = nexus_fs.sys_readdir(prefix, recursive=True, details=True, context=context)
+    entries: list[Any]
+    if isinstance(raw, dict):
+        entries = list(raw.get("entries") or raw.get("items") or [])
+    else:
+        entries = list(raw or [])
+    return [e for e in entries if _is_projected_file(e)]
+
+
+def _head_version(session: Any, path_id: str) -> VersionHistoryModel | None:
+    head: VersionHistoryModel | None = session.execute(
+        select(VersionHistoryModel)
+        .where(
+            VersionHistoryModel.resource_type == "file",
+            VersionHistoryModel.resource_id == path_id,
+        )
+        .order_by(VersionHistoryModel.version_number.desc())
+        .limit(1)
+    ).scalar_one_or_none()
+    return head
+
+
+def _log_row(op_logger: Any, md: FileMetadata, *, zone_id: str, operation: str) -> None:
+    from nexus.contracts.urn import NexusURN
+
+    op_logger.log_operation(
+        operation_type=operation,
+        path=md.path,
+        zone_id=zone_id,
+        agent_id=RECONCILE_ACTOR,
+        metadata_snapshot=md.to_dict() if operation == "write" else None,
+        status="success",
+        entity_urn=str(NexusURN.for_file(zone_id, md.path)),
+        aspect_name="file_metadata",
+        change_type="upsert" if operation == "write" else "delete",
+    )
+
+
+def reconcile_entry(
+    session: Any,
+    md: FileMetadata,
+    *,
+    zone_id: str,
+    dry_run: bool = False,
+) -> str:
+    """Reconcile one kernel entry; returns ``in_sync|created|repaired|stale_kernel``.
+
+    Rows are matched by ``virtual_path`` across zones: the observer keys
+    ``file_paths`` by the *writer's* zone (a ``research`` token's writes sit
+    under ``research``) while ``list_versions`` looks a path up by
+    ``virtual_path`` alone, so a root-zone reconcile must adopt those rows,
+    not duplicate them.  ``zone_id`` (the caller's) is used only for rows
+    that exist in no zone; repairs stay in the matched row's zone.
+    """
+    from nexus.storage.operation_logger import OperationLogger
+
+    rows = list(
+        session.execute(
+            select(FilePathModel)
+            .where(
+                FilePathModel.virtual_path == md.path,
+                FilePathModel.deleted_at.is_(None),
+            )
+            .order_by(FilePathModel.current_version.desc(), FilePathModel.updated_at.desc())
+        ).scalars()
+    )
+    # Prefer the caller's zone when the path was projected under several.
+    row = next((r for r in rows if r.zone_id == zone_id), rows[0] if rows else None)
+
+    if row is None:
+        if not dry_run:
+            VersionRecorder(session).record_write(md, is_new=True, created_by=RECONCILE_ACTOR)
+            _log_row(OperationLogger(session), md, zone_id=zone_id, operation="write")
+        return "created"
+
+    if row.zone_id != zone_id:
+        # Repair against the zone the projection already uses for this path.
+        zone_id = row.zone_id
+        md = replace(md, zone_id=zone_id)
+
+    head = _head_version(session, row.path_id)
+    head_gen = version_gen(head) if head is not None else None
+    if head_gen is not None and md.gen:
+        # Both sides know the kernel generation: it, not content_id, decides
+        # (path-addressed backends report the same content_id for every write).
+        if md.gen == head_gen:
+            return "in_sync"
+        if md.gen < head_gen:
+            # The projection already holds a newer kernel generation: this
+            # node's kernel view is behind (follower lag), not the projection.
+            return "stale_kernel"
+    else:
+        head_content_id = head.content_id if head is not None else row.content_id
+        if head_content_id == md.content_id:
+            return "in_sync"
+
+    if not dry_run:
+        VersionRecorder(session).record_write(md, is_new=False, created_by=RECONCILE_ACTOR)
+        _log_row(OperationLogger(session), md, zone_id=zone_id, operation="write")
+    return "repaired"
+
+
+def reconcile_projection(
+    *,
+    nexus_fs: Any,
+    session_factory: Any,
+    prefix: str = "/",
+    zone_id: str | None = None,
+    context: Any = None,
+    dry_run: bool = False,
+    retire_missing: bool = False,
+    max_entries: int | None = None,
+    batch_size: int = 200,
+) -> ReconcileReport:
+    """Bring the projection under ``prefix`` in line with the kernel.
+
+    ``retire_missing`` soft-deletes active rows the kernel no longer lists;
+    it is opt-in because a partial kernel listing (an unrouted mount) would
+    otherwise retire live rows.  It is skipped when the walk was truncated
+    by ``max_entries``.
+    """
+    from nexus.storage.operation_logger import OperationLogger
+
+    started = time.monotonic()
+    zone = zone_id or ROOT_ZONE_ID
+    report = ReconcileReport(prefix=prefix, zone_id=zone, dry_run=dry_run)
+
+    entries = list_kernel_files(nexus_fs, prefix, context=context)
+    if max_entries is not None and len(entries) > max_entries:
+        entries = entries[:max_entries]
+        report.truncated = True
+
+    kernel_paths: set[str] = set()
+    for start in range(0, len(entries), max(1, batch_size)):
+        chunk = entries[start : start + max(1, batch_size)]
+        with session_factory() as session:
+            for entry in chunk:
+                report.scanned += 1
+                md = _entry_metadata(entry, zone)
+                kernel_paths.add(md.path)
+                try:
+                    with session.begin_nested():
+                        verdict = reconcile_entry(session, md, zone_id=zone, dry_run=dry_run)
+                except Exception as exc:
+                    report.errors += 1
+                    report._note(report.error_messages, f"{md.path}: {exc}")
+                    logger.warning("projection reconcile failed for %s: %s", md.path, exc)
+                    continue
+                if verdict == "created":
+                    report.created += 1
+                    report._note(report.created_paths, md.path)
+                elif verdict == "repaired":
+                    report.repaired += 1
+                    report._note(report.repaired_paths, md.path)
+                elif verdict == "stale_kernel":
+                    report.stale_kernel += 1
+                    report._note(report.stale_kernel_paths, md.path)
+                else:
+                    report.in_sync += 1
+            if dry_run:
+                session.rollback()
+            else:
+                session.commit()
+
+    if retire_missing and not report.truncated:
+        like = "%" if prefix in ("", "/") else prefix.rstrip("/") + "/%"
+        with session_factory() as session:
+            rows = list(
+                session.execute(
+                    select(FilePathModel).where(
+                        FilePathModel.zone_id == zone,
+                        FilePathModel.deleted_at.is_(None),
+                        FilePathModel.virtual_path.like(like),
+                    )
+                ).scalars()
+            )
+            recorder = VersionRecorder(session)
+            op_logger = OperationLogger(session)
+            for row in rows:
+                path = row.virtual_path
+                if path in kernel_paths or path.startswith(SYSTEM_PATH_PREFIX):
+                    continue
+                report.retired += 1
+                report._note(report.retired_paths, path)
+                if dry_run:
+                    continue
+                try:
+                    with session.begin_nested():
+                        recorder.record_delete(path)
+                        _log_row(
+                            op_logger,
+                            FileMetadata(path=path, size=0, zone_id=zone),
+                            zone_id=zone,
+                            operation="delete",
+                        )
+                except Exception as exc:
+                    report.errors += 1
+                    report._note(report.error_messages, f"{path}: {exc}")
+            if dry_run:
+                session.rollback()
+            else:
+                session.commit()
+
+    report.duration_ms = int((time.monotonic() - started) * 1000)
+    if report.created or report.repaired or report.retired:
+        logger.warning(
+            "projection reconcile under %s (zone %s%s): scanned=%d created=%d repaired=%d "
+            "retired=%d stale_kernel=%d errors=%d",
+            prefix,
+            zone,
+            ", dry run" if dry_run else "",
+            report.scanned,
+            report.created,
+            report.repaired,
+            report.retired,
+            report.stale_kernel,
+            report.errors,
+        )
+    return report

--- a/src/nexus/storage/version_recorder.py
+++ b/src/nexus/storage/version_recorder.py
@@ -9,9 +9,16 @@ Populates FilePathModel and VersionHistoryModel so Services
 Architecture:
     Metastore (sled) = SSOT for FileMetadata
     RecordStore (SQL) = supplemental for version history + search indexing
-    If sync fails, the write still succeeds (sled is authoritative).
+    The kernel is authoritative; whether a projection failure fails the
+    write is the observer's ``strict_mode`` policy (#4738).
+
+Each ``version_history`` row stores the kernel ``gen`` of the write it
+records in ``extra_metadata`` (``{"gen": N}``) so
+``storage/projection_reconcile.py`` can tell "kernel is ahead of the
+projection" from "this node's kernel view is stale" (#4738).
 """
 
+import json
 import uuid
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
@@ -29,6 +36,24 @@ if TYPE_CHECKING:
 def _utcnow_naive() -> datetime:
     """Return current UTC time as naive datetime (for SQLite compat)."""
     return datetime.now(UTC).replace(tzinfo=None)
+
+
+def _version_extra(metadata: "FileMetadata") -> str | None:
+    """``extra_metadata`` JSON carrying the kernel ``gen`` (None when unknown)."""
+    gen = getattr(metadata, "gen", 0) or 0
+    return json.dumps({"gen": int(gen)}) if gen > 0 else None
+
+
+def version_gen(row: "VersionHistoryModel") -> int | None:
+    """Kernel ``gen`` recorded on a version row, or None for legacy rows."""
+    raw = row.extra_metadata
+    if not raw:
+        return None
+    try:
+        value = json.loads(raw).get("gen")
+    except (ValueError, AttributeError):
+        return None
+    return int(value) if isinstance(value, int) and value > 0 else None
 
 
 class VersionRecorder:
@@ -185,6 +210,7 @@ class VersionRecorder:
                 source_type="original",
                 created_at=file_path.created_at,
                 created_by=created_by,
+                extra_metadata=_version_extra(metadata),
             )
             self.session.add(version_entry)
 
@@ -243,6 +269,7 @@ class VersionRecorder:
                 source_type="original",
                 created_at=_utcnow_naive(),
                 created_by=created_by,
+                extra_metadata=_version_extra(metadata),
             )
             self.session.add(version_entry)
         else:

--- a/src/nexus/storage/write_observer_hooks.py
+++ b/src/nexus/storage/write_observer_hooks.py
@@ -74,17 +74,26 @@ class SyncAuditWriteInterceptor:
         self._strict_mode = strict_mode
 
     # ── Sync POST hooks (called by KernelDispatch serial path) ─────────
+    #
+    # #4738: the write-through observer returns the projection sequence
+    # (``operation_log.sequence_number``) of the row it committed.  It is
+    # stashed in ``ctx.extra["projection_seq"]`` (``projection_seqs`` per
+    # item for batches) so ``NexusFS.write`` can return it to the caller;
+    # the legacy synchronous observer returns None and stashes nothing.
 
     def on_post_write(self, ctx: "WriteHookContext") -> None:
         if ctx.path.startswith(_INTERNAL_PIPE_PREFIX):
             return
-        self._observer.on_write(
-            ctx.metadata,
-            is_new=ctx.is_new_file,
-            path=ctx.path,
-            old_metadata=ctx.old_metadata,
-            zone_id=ctx.zone_id,
-            agent_id=ctx.agent_id,
+        _stash_projection_seq(
+            ctx,
+            self._observer.on_write(
+                ctx.metadata,
+                is_new=ctx.is_new_file,
+                path=ctx.path,
+                old_metadata=ctx.old_metadata,
+                zone_id=ctx.zone_id,
+                agent_id=ctx.agent_id,
+            ),
         )
 
     def on_post_write_batch(self, ctx: "WriteBatchHookContext") -> None:
@@ -95,20 +104,29 @@ class SyncAuditWriteInterceptor:
         ]
         if not filtered_items:
             return
-        self._observer.on_write_batch(
+        seqs = self._observer.on_write_batch(
             filtered_items,
             zone_id=ctx.zone_id,
             agent_id=ctx.agent_id,
         )
+        if isinstance(seqs, list) and len(seqs) == len(filtered_items):
+            by_path = {
+                metadata.path: seq
+                for (metadata, _is_new), seq in zip(filtered_items, seqs, strict=True)
+            }
+            ctx.extra["projection_seqs"] = [by_path.get(metadata.path) for metadata, _ in ctx.items]
 
     def on_post_delete(self, ctx: "DeleteHookContext") -> None:
         if ctx.path.startswith(_INTERNAL_PIPE_PREFIX):
             return
-        self._observer.on_delete(
-            path=ctx.path,
-            metadata=ctx.metadata,
-            zone_id=ctx.zone_id,
-            agent_id=ctx.agent_id,
+        _stash_projection_seq(
+            ctx,
+            self._observer.on_delete(
+                path=ctx.path,
+                metadata=ctx.metadata,
+                zone_id=ctx.zone_id,
+                agent_id=ctx.agent_id,
+            ),
         )
 
     def on_post_rename(self, ctx: "RenameHookContext") -> None:
@@ -116,32 +134,49 @@ class SyncAuditWriteInterceptor:
             _INTERNAL_PIPE_PREFIX
         ):
             return
-        self._observer.on_rename(
-            old_path=ctx.old_path,
-            new_path=ctx.new_path,
-            metadata=ctx.metadata,
-            zone_id=ctx.zone_id,
-            agent_id=ctx.agent_id,
+        _stash_projection_seq(
+            ctx,
+            self._observer.on_rename(
+                old_path=ctx.old_path,
+                new_path=ctx.new_path,
+                metadata=ctx.metadata,
+                zone_id=ctx.zone_id,
+                agent_id=ctx.agent_id,
+            ),
         )
 
     def on_post_mkdir(self, ctx: "MkdirHookContext") -> None:
         if ctx.path.startswith(_INTERNAL_PIPE_PREFIX):
             return
-        self._observer.on_mkdir(
-            path=ctx.path,
-            zone_id=ctx.zone_id,
-            agent_id=ctx.agent_id,
+        _stash_projection_seq(
+            ctx,
+            self._observer.on_mkdir(
+                path=ctx.path,
+                zone_id=ctx.zone_id,
+                agent_id=ctx.agent_id,
+            ),
         )
 
     def on_post_rmdir(self, ctx: "RmdirHookContext") -> None:
         if ctx.path.startswith(_INTERNAL_PIPE_PREFIX):
             return
-        self._observer.on_rmdir(
-            path=ctx.path,
-            zone_id=ctx.zone_id,
-            agent_id=ctx.agent_id,
-            recursive=ctx.recursive,
+        _stash_projection_seq(
+            ctx,
+            self._observer.on_rmdir(
+                path=ctx.path,
+                zone_id=ctx.zone_id,
+                agent_id=ctx.agent_id,
+                recursive=ctx.recursive,
+            ),
         )
+
+
+def _stash_projection_seq(ctx: Any, seq: Any) -> None:
+    """Record an observer's projection sequence on the hook context (#4738)."""
+    if isinstance(seq, int) and not isinstance(seq, bool):
+        extra = getattr(ctx, "extra", None)
+        if isinstance(extra, dict):
+            extra["projection_seq"] = seq
 
 
 class AuditWriteInterceptor:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,13 +38,15 @@ if os.environ.get("NEXUS_RUST_EDITABLE") == "1":
         pass  # maturin-import-hook not installed — skip (warn below)
 
 # ---------------------------------------------------------------------------
-# Issue #3399: default to sync write observer in tests.
-# The piped observer spawns a background consumer task per NexusFS instance;
-# with 10K+ tests this adds significant startup/shutdown overhead and can
-# cause CI timeouts.  Tests that specifically need the piped observer create
-# it directly (e.g. test_piped_write_observer_flush.py).
+# #4738: run the suite against the production-default write observer.
+# Issue #3399 forced the synchronous observer here because the debounced
+# piped observer spawned a background consumer per NexusFS instance and made
+# projection rows visible only after a timer.  The write-through observer
+# commits before a write returns and starts its two daemon threads lazily,
+# so tests see the same observer production runs.  Set
+# NEXUS_ENABLE_WRITE_BUFFER=false to exercise the legacy synchronous one.
 # ---------------------------------------------------------------------------
-os.environ.setdefault("NEXUS_ENABLE_WRITE_BUFFER", "false")
+os.environ.setdefault("NEXUS_ENABLE_WRITE_BUFFER", "true")
 
 # ---------------------------------------------------------------------------
 # OAuthCrypto: allow ephemeral keys in the test suite.

--- a/tests/e2e/self_contained/test_projection_crash_recovery_e2e.py
+++ b/tests/e2e/self_contained/test_projection_crash_recovery_e2e.py
@@ -1,0 +1,394 @@
+"""#4738 acceptance: ``kill -9`` during a write burst loses zero version rows.
+
+Boots a real ``nexusd`` (Rust kernel subprocess + SQLite RecordStore), fires
+a burst of ``files/write`` calls from several threads, SIGKILLs the whole
+server process group mid-burst, restarts ``nexusd`` on the same data
+directory, runs ``POST /api/v2/admin/reconcile-projections`` and then
+compares the projection against the kernel path by path:
+
+* every file the kernel has under the burst prefix has an active
+  ``file_paths`` row whose ``current_version`` equals the kernel ``version``,
+  exactly that many ``version_history`` rows, and at least that many
+  ``operation_log`` write rows;
+* nothing the kernel does not have is projected.
+
+The burst size defaults to the issue's 20 000 writes; set
+``NEXUS_CRASH_BURST`` to shrink it locally.  Skips without a cluster
+binary (``NEXUS_KERNEL_BINARY`` or a worktree ``target/`` build).
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import socket
+import subprocess
+import sys
+import threading
+import time
+from collections.abc import Generator
+from contextlib import closing
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+from sqlalchemy import func, select
+
+pytestmark = [pytest.mark.e2e, pytest.mark.slow]
+
+_BURST = int(os.environ.get("NEXUS_CRASH_BURST", "20000"))
+_THREADS = 8
+_KILL_AT_FRACTION = 0.4
+_API_KEY = "crash-e2e-admin-key"
+_PREFIX = "/burst"
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[3]
+
+
+def _resolve_cluster_binary() -> Path | None:
+    explicit = os.environ.get("NEXUS_KERNEL_BINARY")
+    if explicit:
+        candidate = Path(explicit)
+        if candidate.exists() and os.access(candidate, os.X_OK):
+            return candidate
+    root = _repo_root()
+    for directory in (
+        root / "rust" / "target" / "release",
+        root / "rust" / "target" / "debug",
+        root / "target" / "release",
+        root / "target" / "debug",
+    ):
+        for name in ("nexusd-cluster", "nexus-cluster"):
+            candidate = directory / name
+            if candidate.exists() and os.access(candidate, os.X_OK):
+                return candidate
+    return None
+
+
+def _free_port() -> int:
+    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
+        s.bind(("127.0.0.1", 0))
+        return int(s.getsockname()[1])
+
+
+@dataclass
+class _Server:
+    env: dict[str, str]
+    data_dir: Path
+    port: int = 0
+    pgid: int = 0
+    process: subprocess.Popen[bytes] | None = None
+    lines: list[str] = field(default_factory=list)
+
+    @property
+    def base_url(self) -> str:
+        return f"http://127.0.0.1:{self.port}"
+
+    def start(self, timeout: float = 180.0) -> None:
+        self.port = _free_port()
+        nexusd_bin = str(Path(sys.executable).parent / "nexusd")
+        self.lines = []
+        self.process = subprocess.Popen(
+            [
+                nexusd_bin,
+                "--host",
+                "127.0.0.1",
+                "--port",
+                str(self.port),
+                "--data-dir",
+                str(self.data_dir),
+                "--api-key",
+                _API_KEY,
+                "--auth-type",
+                "static",
+                "--log-level",
+                "info",
+            ],
+            env=self.env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            # Own process group: nexusd's kernel child inherits it, so one
+            # SIGKILL to the group is the whole-node crash we want.
+            preexec_fn=os.setsid,
+        )
+        self.pgid = os.getpgid(self.process.pid)
+
+        def _drain(pipe: Any) -> None:
+            try:
+                for raw in iter(pipe.readline, b""):
+                    self.lines.append(raw.decode(errors="replace"))
+            except ValueError:
+                pass
+
+        threading.Thread(target=_drain, args=(self.process.stdout,), daemon=True).start()
+
+        # Readiness = the HTTP health route answers; log markers depend on
+        # the log level and uvicorn's formatter.
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if self.process.poll() is not None:
+                pytest.fail(
+                    f"nexusd exited with {self.process.returncode} before ready:\n"
+                    + "".join(self.lines[-60:])
+                )
+            try:
+                r = httpx.get(f"{self.base_url}/health", timeout=2.0)
+                if r.status_code < 500:
+                    return
+            except httpx.HTTPError:
+                pass
+            time.sleep(0.25)
+        self.stop()
+        pytest.fail("nexusd did not become ready:\n" + "".join(self.lines[-60:]))
+
+    def _killpg(self, sig: int) -> None:
+        try:
+            os.killpg(self.pgid, sig)
+        except ProcessLookupError:
+            pass
+
+    def kill9(self) -> None:
+        """The crash: SIGKILL the server AND its kernel child, no shutdown hooks."""
+        assert self.process is not None
+        self._killpg(signal.SIGKILL)
+        self.process.wait(timeout=30)
+        time.sleep(0.5)
+        self._killpg(signal.SIGKILL)  # anything the group still holds
+
+    def stop(self) -> None:
+        if self.process is None:
+            return
+        if self.process.poll() is None:
+            self._killpg(signal.SIGTERM)
+            try:
+                self.process.wait(timeout=20)
+            except subprocess.TimeoutExpired:
+                pass
+        # The kernel child does not always honour SIGTERM promptly; never
+        # leave it orphaned behind the test.
+        time.sleep(0.5)
+        self._killpg(signal.SIGKILL)
+        try:
+            self.process.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            pass
+
+
+@pytest.fixture()
+def crash_server(tmp_path: Path) -> Generator[_Server, None, None]:
+    cluster = _resolve_cluster_binary()
+    if cluster is None:
+        pytest.skip("crash-recovery E2E requires a cluster binary (NEXUS_KERNEL_BINARY)")
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    (bin_dir / "nexus-cluster").symlink_to(cluster)
+    (bin_dir / "nexusd-cluster").symlink_to(cluster)
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{bin_dir}{os.pathsep}{env.get('PATH', '')}",
+            "NEXUS_KERNEL_BINARY": str(cluster),
+            "NEXUS_DATA_DIR": str(data_dir),
+            "NEXUS_DATABASE_URL": f"sqlite:///{tmp_path / 'records.db'}",
+            "NEXUS_API_KEY": _API_KEY,
+            # The observer under test; the pytest process env forces the
+            # legacy one for the in-process suite.
+            "NEXUS_ENABLE_WRITE_BUFFER": "true",
+            "NEXUS_ENFORCE_PERMISSIONS": "false",
+            "NEXUS_SEARCH_DAEMON": "false",
+            "NEXUS_ACTIVITY_ENABLED": "0",
+            "NEXUS_ACTIVITY_DB_PATH": str(tmp_path / "activity.db"),
+        }
+    )
+    for noisy in ("OPENAI_API_KEY", "OPENROUTER_API_KEY"):
+        env.pop(noisy, None)
+    server = _Server(env=env, data_dir=data_dir)
+    try:
+        yield server
+    finally:
+        server.stop()
+
+
+def _headers() -> dict[str, str]:
+    return {"Authorization": f"Bearer {_API_KEY}"}
+
+
+def _kernel_files(base_url: str, *, settle_s: float = 60.0) -> dict[str, dict[str, Any]]:
+    """Recursive kernel listing under the burst prefix (files with content).
+
+    Polls for up to ``settle_s`` after a restart: the kernel answers health
+    before the zone's raft log has finished replaying.
+    """
+    deadline = time.monotonic() + settle_s
+    last_body: Any = None
+    while True:
+        resp = httpx.post(
+            f"{base_url}/api/nfs/sys_readdir",
+            headers=_headers(),
+            json={
+                "method": "sys_readdir",
+                "params": {"path": _PREFIX, "recursive": True, "details": True},
+            },
+            timeout=120.0,
+        )
+        assert resp.status_code == 200, resp.text
+        last_body = resp.json()
+        entries = last_body.get("result", last_body) if isinstance(last_body, dict) else last_body
+        if isinstance(entries, dict):  # sys_readdir wire shape: {"files": [...], ...}
+            entries = entries.get("files") or []
+        files = {
+            e["path"]: e
+            for e in (entries or [])
+            if isinstance(e, dict) and e.get("content_id") and not e.get("is_directory")
+        }
+        if files or time.monotonic() >= deadline:
+            if not files:
+                print(f"\nsys_readdir({_PREFIX}) after restart: {str(last_body)[:800]}")
+            return files
+        time.sleep(1.0)
+
+
+def test_kill_9_during_burst_loses_zero_version_rows(crash_server: _Server, tmp_path: Path) -> None:
+    server = crash_server
+    server.start()
+    with httpx.Client(base_url=server.base_url, headers=_headers(), timeout=30.0) as c:
+        assert c.post("/api/v2/files/mkdir", json={"path": _PREFIX}).status_code == 200
+
+    acked: set[str] = set()
+    acked_lock = threading.Lock()
+    attempted = 0
+    attempted_lock = threading.Lock()
+    stop = threading.Event()
+    per_thread = _BURST // _THREADS
+
+    def worker(t: int) -> None:
+        nonlocal attempted
+        with httpx.Client(base_url=server.base_url, headers=_headers(), timeout=30.0) as c:
+            for i in range(per_thread):
+                if stop.is_set():
+                    return
+                path = f"{_PREFIX}/t{t}/f{i:05d}.txt"
+                with attempted_lock:
+                    attempted += 1
+                try:
+                    r = c.post("/api/v2/files/write", json={"path": path, "content": f"{t}:{i}"})
+                except httpx.HTTPError:
+                    return  # the crash happened under us
+                if r.status_code == 200 and isinstance(r.json().get("projection_seq"), int):
+                    with acked_lock:
+                        acked.add(path)
+
+    threads = [threading.Thread(target=worker, args=(t,), daemon=True) for t in range(_THREADS)]
+    started = time.monotonic()
+    for th in threads:
+        th.start()
+    kill_at = int(_BURST * _KILL_AT_FRACTION)
+    while time.monotonic() - started < 600:
+        with acked_lock:
+            done = len(acked)
+        if done >= kill_at or all(not th.is_alive() for th in threads):
+            break
+        time.sleep(0.02)
+
+    # ── The crash ────────────────────────────────────────────────────
+    server.kill9()
+    stop.set()
+    for th in threads:
+        th.join(timeout=60)
+    acked_before_crash = set(acked)
+    assert acked_before_crash, "no write was acknowledged before the crash"
+
+    # ── Restart on the same data dir + RecordStore, then reconcile ───
+    server.start()
+    kernel = _kernel_files(server.base_url)
+    assert kernel, "kernel lost every write under the burst prefix"
+    kernel_missing_acked = sorted(acked_before_crash - set(kernel))
+
+    reconcile = httpx.post(
+        f"{server.base_url}/api/v2/admin/reconcile-projections",
+        headers=_headers(),
+        json={"prefix": _PREFIX},
+        timeout=600.0,
+    )
+    assert reconcile.status_code == 200, reconcile.text
+    report = reconcile.json()
+    assert report["errors"] == 0, report
+
+    # ── Compare projection against kernel, path by path ──────────────
+    from nexus.storage.models import FilePathModel, OperationLogModel, VersionHistoryModel
+    from nexus.storage.record_store import SQLAlchemyRecordStore
+
+    rs = SQLAlchemyRecordStore(db_path=tmp_path / "records.db")
+    try:
+        with rs.session_factory() as session:
+            rows = (
+                session.execute(
+                    select(FilePathModel).where(
+                        FilePathModel.virtual_path.like(f"{_PREFIX}/%"),
+                        FilePathModel.deleted_at.is_(None),
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            projected = {r.virtual_path: r for r in rows}
+            version_counts = dict(
+                session.execute(
+                    select(VersionHistoryModel.resource_id, func.count())
+                    .where(VersionHistoryModel.resource_type == "file")
+                    .group_by(VersionHistoryModel.resource_id)
+                ).all()
+            )
+            write_rows = dict(
+                session.execute(
+                    select(OperationLogModel.path, func.count())
+                    .where(
+                        OperationLogModel.operation_type == "write",
+                        OperationLogModel.path.like(f"{_PREFIX}/%"),
+                    )
+                    .group_by(OperationLogModel.path)
+                ).all()
+            )
+    finally:
+        rs.close()
+
+    summary = {
+        "burst": _BURST,
+        "attempted": attempted,
+        "acked_before_crash": len(acked_before_crash),
+        "kernel_files": len(kernel),
+        "acked_but_missing_in_kernel": len(kernel_missing_acked),
+        "reconcile": {k: report[k] for k in ("scanned", "in_sync", "created", "repaired")},
+        "elapsed_s": round(time.monotonic() - started, 1),
+    }
+    print(f"\ncrash-recovery summary: {summary}")
+
+    mismatches: list[str] = []
+    for path, entry in kernel.items():
+        row = projected.get(path)
+        if row is None:
+            mismatches.append(f"{path}: no file_paths row")
+            continue
+        kernel_version = int(entry.get("version") or 1)
+        if row.current_version != kernel_version:
+            mismatches.append(
+                f"{path}: current_version {row.current_version} != kernel {kernel_version}"
+            )
+        if version_counts.get(row.path_id, 0) != kernel_version:
+            mismatches.append(
+                f"{path}: {version_counts.get(row.path_id, 0)} version rows != {kernel_version}"
+            )
+        if write_rows.get(path, 0) < kernel_version:
+            mismatches.append(f"{path}: {write_rows.get(path, 0)} operation_log rows")
+    extra = sorted(set(projected) - set(kernel))
+    assert not mismatches, mismatches[:20]
+    assert not extra, extra[:20]
+    # The kernel is authoritative; an acknowledged write it does not hold
+    # after the crash would be a kernel durability bug, not a projection one.
+    assert not kernel_missing_acked, kernel_missing_acked[:20]

--- a/tests/e2e/self_contained/test_projection_fence_live_e2e.py
+++ b/tests/e2e/self_contained/test_projection_fence_live_e2e.py
@@ -1,0 +1,308 @@
+"""Live E2E for fenced projections (#4738) against the real Rust kernel.
+
+Boots a kernel-backed NexusFS with the write-through observer
+(``NEXUS_ENABLE_WRITE_BUFFER=true``), the FastAPI app and a SQLite
+RecordStore, then checks the issue's acceptance criteria end to end:
+
+* ``list_versions`` immediately after ``files/write`` returns the new
+  version — no ``flush_write_observer`` call;
+* the write response carries ``projection_seq`` and
+  ``GET /api/v2/operations/wait?seq=`` answers 200 for it;
+* the crash window (kernel committed, projection not) is repaired by
+  ``POST /api/v2/admin/reconcile-projections`` — simulated by writing
+  through the kernel with the Python post-hooks bypassed.
+
+Skips unless a cluster binary is available (``NEXUS_KERNEL_BINARY`` or a
+worktree ``target/`` build).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import os
+import time
+from collections.abc import Generator
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+pytestmark = pytest.mark.e2e
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[3]
+
+
+def _resolve_cluster_binary() -> Path | None:
+    explicit = os.environ.get("NEXUS_KERNEL_BINARY")
+    if explicit:
+        candidate = Path(explicit)
+        if candidate.exists() and os.access(candidate, os.X_OK):
+            return candidate
+    root = _repo_root()
+    for directory in (
+        root / "rust" / "target" / "release",
+        root / "rust" / "target" / "debug",
+        root / "target" / "release",
+        root / "target" / "debug",
+    ):
+        for name in ("nexusd-cluster", "nexus-cluster"):
+            candidate = directory / name
+            if candidate.exists() and os.access(candidate, os.X_OK):
+                return candidate
+    return None
+
+
+@dataclass
+class LiveApp:
+    client: TestClient
+    nx: Any
+    headers: dict[str, str]
+
+
+@pytest.fixture()
+def live_app(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Generator[LiveApp, None, None]:
+    cluster = _resolve_cluster_binary()
+    if cluster is None:
+        pytest.skip("projection fence E2E requires a cluster binary (NEXUS_KERNEL_BINARY)")
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    (bin_dir / "nexus-cluster").symlink_to(cluster)
+    (bin_dir / "nexusd-cluster").symlink_to(cluster)
+    monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}")
+    monkeypatch.setenv("NEXUS_KERNEL_BINARY", str(cluster))
+    monkeypatch.setenv("NEXUS_ENFORCE_PERMISSIONS", "false")
+    monkeypatch.setenv("NEXUS_SEARCH_DAEMON", "false")
+    # The write-through group-commit observer is what this suite tests.
+    monkeypatch.setenv("NEXUS_ENABLE_WRITE_BUFFER", "true")
+    monkeypatch.setenv("NEXUS_ACTIVITY_ENABLED", "0")
+    monkeypatch.setenv("NEXUS_ACTIVITY_DB_PATH", str(tmp_path / "activity.db"))
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+
+    import nexus
+    from nexus.server.fastapi_server import create_app
+
+    database_url = f"sqlite:///{tmp_path / 'records.db'}"
+    nx = nexus.connect(
+        config={
+            "data_dir": str(tmp_path / "data"),
+            "profile": "full",
+            "database_url": database_url,
+            "enforce_permissions": False,
+        }
+    )
+    app = create_app(
+        nexus_fs=nx,
+        api_key="live-projection-secret",
+        database_url=database_url,
+        data_dir=str(tmp_path),
+    )
+    headers = {"Authorization": "Bearer live-projection-secret"}
+    try:
+        with TestClient(app, raise_server_exceptions=False) as client:
+            yield LiveApp(client=client, nx=nx, headers=headers)
+    finally:
+        close = getattr(nx, "close", None)
+        if callable(close):
+            close()
+
+
+def _list_versions(nx: Any, path: str) -> list[dict[str, Any]]:
+    """The consumer named in #4738: VersionService.list_versions, no flush first."""
+    service = nx.service("version_service")
+    return asyncio.run(service.list_versions(path))
+
+
+def _write(live: LiveApp, path: str, content: str) -> dict[str, Any]:
+    resp = live.client.post(
+        "/api/v2/files/write", headers=live.headers, json={"path": path, "content": content}
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+def test_list_versions_immediately_after_write_without_flush(live_app: LiveApp) -> None:
+    live = live_app
+    live.nx.mkdir("/ws", exist_ok=True)
+
+    first = _write(live, "/ws/a.txt", "v1")
+    assert isinstance(first["projection_seq"], int) and first["projection_seq"] >= 1
+    versions = _list_versions(live.nx, "/ws/a.txt")
+    assert [v["content_id"] for v in versions] == [first["content_id"]]
+
+    second = _write(live, "/ws/a.txt", "v2")
+    assert second["projection_seq"] > first["projection_seq"]
+    versions = _list_versions(live.nx, "/ws/a.txt")
+    assert [v["content_id"] for v in versions] == [second["content_id"], first["content_id"]]
+    assert [v["version"] for v in versions] == [2, 1]
+
+    # The fence answers immediately for a sequence the write already committed.
+    started = time.perf_counter()
+    wait = live.client.get(
+        f"/api/v2/operations/wait?seq={second['projection_seq']}", headers=live.headers
+    )
+    assert wait.status_code == 200, wait.text
+    body = wait.json()
+    assert body["applied"] is True and body["latest_seq"] >= second["projection_seq"]
+    assert (time.perf_counter() - started) < 2.0
+
+    # A sequence nobody has committed yet is an honest 412, not an empty answer.
+    missing = live.client.get(
+        f"/api/v2/operations/wait?seq={second['projection_seq'] + 1000}&timeout_ms=0",
+        headers=live.headers,
+    )
+    assert missing.status_code == 412, missing.text
+    assert missing.json()["detail"]["error"] == "projection_not_applied"
+
+    # The operation log carries the same sequence numbers.
+    ops = live.client.get(
+        "/api/v2/operations?path_pattern=/ws/a.txt&limit=10", headers=live.headers
+    )
+    assert ops.status_code == 200, ops.text
+    assert len(ops.json()["operations"]) == 2
+
+
+def test_batch_write_returns_per_item_projection_seq(live_app: LiveApp) -> None:
+    live = live_app
+    live.nx.mkdir("/batch", exist_ok=True)
+    files = [
+        {"path": f"/batch/f{i}.txt", "content_base64": base64.b64encode(f"c{i}".encode()).decode()}
+        for i in range(3)
+    ]
+    resp = live.client.post(
+        "/api/v2/files/batch/write", headers=live.headers, json={"files": files}
+    )
+    assert resp.status_code == 200, resp.text
+    seqs = [r["projection_seq"] for r in resp.json()["results"]]
+    assert all(isinstance(s, int) for s in seqs)
+    assert seqs == sorted(seqs) and len(set(seqs)) == 3
+    for i in range(3):
+        assert len(_list_versions(live.nx, f"/batch/f{i}.txt")) == 1
+
+
+def test_mkdir_rename_delete_return_projection_seq(live_app: LiveApp) -> None:
+    live = live_app
+    made = live.client.post("/api/v2/files/mkdir", headers=live.headers, json={"path": "/mut"})
+    assert made.status_code == 200, made.text
+    mkdir_seq = made.json()["projection_seq"]
+    assert isinstance(mkdir_seq, int)
+
+    written = _write(live, "/mut/a.txt", "x")
+    renamed = live.client.post(
+        "/api/v2/files/rename",
+        headers=live.headers,
+        json={"source": "/mut/a.txt", "destination": "/mut/b.txt"},
+    )
+    assert renamed.status_code == 200, renamed.text
+    rename_seq = renamed.json()["projection_seq"]
+    assert isinstance(rename_seq, int) and rename_seq > written["projection_seq"]
+
+    deleted = live.client.delete("/api/v2/files/delete?path=/mut/b.txt", headers=live.headers)
+    assert deleted.status_code == 200, deleted.text
+    delete_seq = deleted.json()["projection_seq"]
+    assert isinstance(delete_seq, int) and delete_seq > rename_seq
+
+    # Each sequence is a committed operation_log row the fence answers for.
+    for seq in (mkdir_seq, rename_seq, delete_seq):
+        wait = live.client.get(
+            f"/api/v2/operations/wait?seq={seq}&timeout_ms=0", headers=live.headers
+        )
+        assert wait.status_code == 200, wait.text
+
+    # Python API shapes: dicts carrying the sequence (mkdir used to return None).
+    assert live.nx.mkdir("/mut2", exist_ok=True)["projection_seq"] is not None
+    assert live.nx.sys_rename("/mut2", "/mut3")["projection_seq"] is not None
+    assert live.nx.rmdir("/mut3")["projection_seq"] is not None
+
+    # The deprecated JSON-RPC route carries it on the legacy wire shapes too.
+    rpc = live.client.post(
+        "/api/nfs/mkdir", headers=live.headers, json={"method": "mkdir", "params": {"path": "/rpc"}}
+    )
+    assert rpc.status_code == 200, rpc.text
+    result = rpc.json().get("result", rpc.json())
+    assert result.get("created") is True and isinstance(result.get("projection_seq"), int)
+
+
+def test_reconcile_repairs_a_kernel_write_the_projection_never_saw(live_app: LiveApp) -> None:
+    """Crash-window simulation: the kernel committed, the projection did not."""
+    live = live_app
+    live.nx.mkdir("/crash", exist_ok=True)
+    seen = _write(live, "/crash/a.txt", "seen")
+    _write(live, "/crash/b.txt", "b")
+    assert [v["content_id"] for v in _list_versions(live.nx, "/crash/a.txt")] == [
+        seen["content_id"]
+    ]
+
+    # Write straight through the kernel, bypassing the Python post-hooks that
+    # feed the observer — the state a kill -9 between the two commits leaves.
+    rust_ctx = live.nx._build_rust_ctx(None, True)
+    live.nx._kernel.sys_write("/crash/a.txt", rust_ctx, b"lost", 0)
+    live.nx._kernel.sys_write("/crash/new.txt", rust_ctx, b"never projected", 0)
+    kernel_a = live.nx.sys_stat("/crash/a.txt")
+    kernel_new = live.nx.sys_stat("/crash/new.txt")
+    # Kernel is ahead of the projection: version 2 in the kernel, one row in
+    # history.  (Compare versions, not content_id — a path-addressed local
+    # backend reports the path as content_id for every write.)
+    assert kernel_a["version"] == 2 and kernel_a["gen"] >= 2
+    stale = _list_versions(live.nx, "/crash/a.txt")
+    assert [v["version"] for v in stale] == [1] and stale[0]["content_id"] == seen["content_id"]
+    assert _list_versions(live.nx, "/crash/new.txt") == []
+
+    dry = live.client.post(
+        "/api/v2/admin/reconcile-projections",
+        headers=live.headers,
+        json={"prefix": "/crash", "dry_run": True},
+    )
+    assert dry.status_code == 200, dry.text
+    assert dry.json()["repaired"] == 1 and dry.json()["created"] == 1 and dry.json()["in_sync"] == 1
+    assert _list_versions(live.nx, "/crash/new.txt") == [], "dry run writes nothing"
+
+    fix = live.client.post(
+        "/api/v2/admin/reconcile-projections", headers=live.headers, json={"prefix": "/crash"}
+    )
+    assert fix.status_code == 200, fix.text
+    body = fix.json()
+    assert (
+        body["scanned"],
+        body["in_sync"],
+        body["created"],
+        body["repaired"],
+        body["errors"],
+    ) == (
+        3,
+        1,
+        1,
+        1,
+        0,
+    )
+    assert body["repaired_paths"] == ["/crash/a.txt"] and body["created_paths"] == [
+        "/crash/new.txt"
+    ]
+
+    # Projection now matches the kernel: newest version first, one per kernel version.
+    a_versions = _list_versions(live.nx, "/crash/a.txt")
+    assert [v["content_id"] for v in a_versions] == [kernel_a["content_id"], seen["content_id"]]
+    assert a_versions[0]["version"] == kernel_a["version"] == 2
+    new_versions = _list_versions(live.nx, "/crash/new.txt")
+    assert [v["content_id"] for v in new_versions] == [kernel_new["content_id"]]
+
+    # Idempotent: a second pass finds everything in sync.
+    again = live.client.post(
+        "/api/v2/admin/reconcile-projections", headers=live.headers, json={"prefix": "/crash"}
+    )
+    assert again.json()["in_sync"] == 3 and again.json()["repaired"] == 0
+
+
+def test_reconcile_requires_admin(live_app: LiveApp) -> None:
+    resp = live_app.client.post(
+        "/api/v2/admin/reconcile-projections",
+        headers={"Authorization": "Bearer not-the-admin-key"},
+        json={"prefix": "/"},
+    )
+    assert resp.status_code in (401, 403), resp.text

--- a/tests/integration/storage/test_piped_write_observer_flush.py
+++ b/tests/integration/storage/test_piped_write_observer_flush.py
@@ -1,10 +1,10 @@
-"""Tests for RecordStoreWriteObserver (OBSERVE-phase) flush behavior.
+"""Integration tests for the write-through RecordStoreWriteObserver (#4738).
 
-Ensures that flush_sync() drains pending events and commits them to the
-database before returning, so that subsequent queries (e.g. list_versions)
-see version history created by immediately preceding writes.
-
-Also tests the debounce → flush path for the OBSERVE-phase observer.
+Against a real SQLite RecordStore: ``on_write`` / ``on_delete`` / ``on_rename``
+commit operation_log + file_paths + version_history before returning and
+hand back the operation_log ``sequence_number`` (the projection sequence);
+``flush_sync()`` drains whatever was queued without waiting and runs the
+deferred MCL work inline; the deferred phase records MCL rows.
 """
 
 from __future__ import annotations
@@ -15,6 +15,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
+from sqlalchemy import select
 
 from nexus.contracts.constants import ROOT_ZONE_ID
 from nexus.contracts.metadata import FileMetadata
@@ -24,11 +25,13 @@ from nexus.storage.models import (
     OperationLogModel,
     VersionHistoryModel,
 )
+from nexus.storage.operation_logger import OperationLogger
 from nexus.storage.piped_record_store_write_observer import (
     RecordStoreWriteObserver as ObserverWriteObserver,
 )
 from nexus.storage.record_store import SQLAlchemyRecordStore
 from nexus.storage.record_store_write_observer import RecordStoreWriteObserver
+from nexus.storage.version_recorder import version_gen
 
 
 @pytest.fixture
@@ -44,12 +47,21 @@ def record_store(temp_dir: Path) -> Generator[SQLAlchemyRecordStore, None, None]
     rs.close()
 
 
+@pytest.fixture
+def observer(record_store: SQLAlchemyRecordStore) -> Generator[ObserverWriteObserver, None, None]:
+    obs = ObserverWriteObserver(record_store)
+    yield obs
+    obs.flush_sync()
+    obs.cancel()
+
+
 def _make_metadata(
     path: str = "/test.txt",
     *,
     content_id: str = "abc123",
     size: int = 100,
     version: int = 1,
+    gen: int = 1,
 ) -> FileMetadata:
     return FileMetadata(
         path=path,
@@ -59,6 +71,7 @@ def _make_metadata(
         created_at=datetime.now(UTC),
         modified_at=datetime.now(UTC),
         version=version,
+        gen=gen,
         zone_id=ROOT_ZONE_ID,
         owner_id="user1",
     )
@@ -74,298 +87,178 @@ class TestSyncObserverFlush:
         assert result == 0
 
 
-class TestObserverFlushSync:
-    """flush_sync() on the OBSERVE-phase observer drains pending events."""
+class TestWriteThrough:
+    """Critical rows are committed when the intake call returns."""
 
-    @pytest.mark.anyio
-    async def test_flush_sync_commits_to_db(self, record_store: SQLAlchemyRecordStore) -> None:
-        observer = ObserverWriteObserver(record_store, debounce_seconds=10.0)
+    def test_on_write_is_visible_immediately_and_returns_op_log_seq(
+        self, record_store: SQLAlchemyRecordStore, observer: ObserverWriteObserver
+    ) -> None:
+        seq = observer.on_write(
+            _make_metadata("/prebuf.txt", content_id="h1"),
+            is_new=True,
+            path="/prebuf.txt",
+            zone_id="root",
+            agent_id="agent-1",
+        )
+        assert isinstance(seq, int)
 
-        # Manually populate pending events (simulating on_mutation path)
-        metadata = _make_metadata("/prebuf.txt", content_id="h1")
-        event = {
-            "op": "write",
-            "path": "/prebuf.txt",
-            "is_new": True,
-            "zone_id": "root",
-            "agent_id": None,
-            "snapshot_hash": None,
-            "metadata_snapshot": None,
-            "metadata": metadata.to_dict(),
-        }
-        observer._pending.append(event)
-
-        assert len(observer._pending) == 1
-
-        # flush_sync should commit directly to DB
-        flushed = observer.flush_sync()
-        assert flushed == 1
-        assert len(observer._pending) == 0
-
-        # Verify data is in the database
+        # No flush call in between — the rows are already there (acceptance #2).
         with record_store.session_factory() as session:
             ops = session.query(OperationLogModel).all()
             assert len(ops) == 1
             assert ops[0].path == "/prebuf.txt"
+            assert ops[0].sequence_number == seq
+            assert ops[0].agent_id == "agent-1"
+            assert ops[0].delivered is False
 
             fps = session.query(FilePathModel).filter(FilePathModel.deleted_at.is_(None)).all()
-            assert len(fps) == 1
-            assert fps[0].virtual_path == "/prebuf.txt"
+            assert len(fps) == 1 and fps[0].virtual_path == "/prebuf.txt"
 
             vhs = session.query(VersionHistoryModel).all()
             assert len(vhs) == 1
+            assert version_gen(vhs[0]) == 1, "kernel gen recorded for reconcile"
 
-        observer.cancel()
+            applied, latest = OperationLogger(session).projection_state(seq, zone_id="root")
+            assert applied is True and latest == seq
+
+        assert observer.metrics["applied_seq"] == seq
+        assert observer.metrics["pending_events"] == 0
+
+    def test_sequences_increase_across_writes_and_versions_accumulate(
+        self, record_store: SQLAlchemyRecordStore, observer: ObserverWriteObserver
+    ) -> None:
+        s1 = observer.on_write(
+            _make_metadata("/multi.txt", content_id="v1"),
+            is_new=True,
+            path="/multi.txt",
+            zone_id="root",
+        )
+        s2 = observer.on_write(
+            _make_metadata("/multi.txt", content_id="v2", version=2, gen=2),
+            is_new=False,
+            path="/multi.txt",
+            zone_id="root",
+        )
+        assert s1 is not None and s2 is not None and s2 > s1
+        with record_store.session_factory() as session:
+            vhs = (
+                session.execute(
+                    select(VersionHistoryModel).order_by(VersionHistoryModel.version_number)
+                )
+                .scalars()
+                .all()
+            )
+            assert [v.content_id for v in vhs] == ["v1", "v2"]
+            assert [version_gen(v) for v in vhs] == [1, 2]
+
+    def test_delete_event_produces_correct_records(
+        self, record_store: SQLAlchemyRecordStore, observer: ObserverWriteObserver
+    ) -> None:
+        metadata = _make_metadata("/del_test.txt", content_id="d1")
+        observer.on_write(metadata, is_new=True, path="/del_test.txt", zone_id="root")
+        seq = observer.on_delete(path="/del_test.txt", metadata=metadata, zone_id="root")
+        assert isinstance(seq, int)
+
+        with record_store.session_factory() as session:
+            ops = session.query(OperationLogModel).order_by(OperationLogModel.sequence_number).all()
+            assert [o.operation_type for o in ops] == ["write", "delete"]
+            assert ops[0].change_type == "upsert"
+            assert ops[1].change_type == "delete" and ops[1].entity_urn is not None
+            assert ops[1].sequence_number == seq
+            active = session.query(FilePathModel).filter(FilePathModel.deleted_at.is_(None)).all()
+            assert active == []
+
+    def test_rename_produces_two_operation_log_rows_and_returns_upsert_seq(
+        self, record_store: SQLAlchemyRecordStore, observer: ObserverWriteObserver
+    ) -> None:
+        metadata = _make_metadata("/old_name.txt", content_id="r1")
+        observer.on_write(metadata, is_new=True, path="/old_name.txt", zone_id="root")
+        seq = observer.on_rename(
+            old_path="/old_name.txt", new_path="/new_name.txt", metadata=metadata, zone_id="root"
+        )
+
+        with record_store.session_factory() as session:
+            ops = session.query(OperationLogModel).order_by(OperationLogModel.sequence_number).all()
+            # Write (1 row) + Rename (2 rows: delete old + upsert new)
+            assert len(ops) == 3
+            rename_ops = [o for o in ops if o.operation_type == "rename"]
+            assert {o.change_type for o in rename_ops} == {"delete", "upsert"}
+            assert seq == max(o.sequence_number for o in rename_ops)
+            fp = session.query(FilePathModel).filter(FilePathModel.deleted_at.is_(None)).one()
+            assert fp.virtual_path == "/new_name.txt"
+
+    def test_mkdir_and_rmdir_events(
+        self, record_store: SQLAlchemyRecordStore, observer: ObserverWriteObserver
+    ) -> None:
+        s1 = observer.on_mkdir(path="/test_dir", zone_id="root")
+        s2 = observer.on_rmdir(path="/test_dir", zone_id="root", recursive=True)
+        assert s1 is not None and s2 is not None and s2 > s1
+        with record_store.session_factory() as session:
+            ops = session.query(OperationLogModel).order_by(OperationLogModel.sequence_number).all()
+            assert [o.operation_type for o in ops] == ["mkdir", "rmdir_recursive"]
+
+    def test_write_event_has_entity_urn(
+        self, record_store: SQLAlchemyRecordStore, observer: ObserverWriteObserver
+    ) -> None:
+        observer.on_write(
+            _make_metadata("/urn_test.txt", content_id="u1"),
+            is_new=True,
+            path="/urn_test.txt",
+            zone_id="root",
+            agent_id="agent-1",
+        )
+        with record_store.session_factory() as session:
+            ops = session.query(OperationLogModel).all()
+            assert len(ops) == 1
+            assert ops[0].entity_urn is not None and "root" in ops[0].entity_urn
+            assert ops[0].aspect_name == "file_metadata"
+            assert ops[0].change_type == "upsert"
+
+
+class TestFlushSync:
+    """flush_sync() drains queued events and deferred work inline."""
+
+    def test_flush_sync_commits_queued_events(
+        self,
+        record_store: SQLAlchemyRecordStore,
+        observer: ObserverWriteObserver,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Queue without waiting (what a non-strict timeout leaves behind),
+        # with the commit thread disabled so flush_sync does the work.
+        monkeypatch.setattr(observer, "_ensure_threads_locked", lambda: None)
+        observer._enqueue(
+            {
+                "op": "write",
+                "path": "/queued.txt",
+                "is_new": True,
+                "zone_id": "root",
+                "agent_id": None,
+                "snapshot_hash": None,
+                "metadata_snapshot": None,
+                "metadata": _make_metadata("/queued.txt", content_id="q1").to_dict(),
+            }
+        )
+        assert observer.metrics["pending_events"] == 1
+        assert observer.flush_sync() == 1
+        assert observer.metrics["pending_events"] == 0
+        assert observer.metrics["total_flushed"] == 1
+        with record_store.session_factory() as session:
+            assert session.query(VersionHistoryModel).count() == 1
 
     @pytest.mark.anyio
     async def test_flush_empty_returns_zero(self, record_store: SQLAlchemyRecordStore) -> None:
         observer = ObserverWriteObserver(record_store)
-        flushed = await observer.flush()
-        assert flushed == 0
-        observer.cancel()
-
-    @pytest.mark.anyio
-    async def test_flush_handles_multiple_ops(self, record_store: SQLAlchemyRecordStore) -> None:
-        observer = ObserverWriteObserver(record_store, debounce_seconds=10.0)
-
-        # Write, then update — populate pending directly
-        m1 = _make_metadata("/multi.txt", content_id="v1")
-        e1 = {
-            "op": "write",
-            "path": "/multi.txt",
-            "is_new": True,
-            "zone_id": "root",
-            "agent_id": None,
-            "snapshot_hash": None,
-            "metadata_snapshot": None,
-            "metadata": m1.to_dict(),
-        }
-        observer._pending.append(e1)
-
-        m2 = _make_metadata("/multi.txt", content_id="v2", version=2)
-        e2 = {
-            "op": "write",
-            "path": "/multi.txt",
-            "is_new": False,
-            "zone_id": "root",
-            "agent_id": None,
-            "snapshot_hash": None,
-            "metadata_snapshot": None,
-            "metadata": m2.to_dict(),
-        }
-        observer._pending.append(e2)
-
-        assert len(observer._pending) == 2
-
-        flushed = observer.flush_sync()
-        assert flushed == 2
-
-        with record_store.session_factory() as session:
-            vhs = session.query(VersionHistoryModel).all()
-            assert len(vhs) == 2
-
+        assert await observer.flush() == 0
         observer.cancel()
 
 
-class TestObserverFlushMetrics:
-    """flush_sync() updates observer metrics correctly."""
+class TestDeferredPhase:
+    """MCL rows are recorded by the deferred phase, after the critical commit."""
 
-    @pytest.mark.anyio
-    async def test_flush_increments_total_flushed(
-        self, record_store: SQLAlchemyRecordStore
+    def test_flush_batch_sync_then_run_deferred_records_mcl(
+        self, record_store: SQLAlchemyRecordStore, observer: ObserverWriteObserver
     ) -> None:
-        observer = ObserverWriteObserver(record_store, debounce_seconds=10.0)
-        metadata = _make_metadata("/metrics.txt", content_id="mh1")
-        event = {
-            "op": "write",
-            "path": "/metrics.txt",
-            "is_new": True,
-            "zone_id": "root",
-            "agent_id": None,
-            "snapshot_hash": None,
-            "metadata_snapshot": None,
-            "metadata": metadata.to_dict(),
-        }
-        observer._pending.append(event)
-
-        assert observer.metrics["total_flushed"] == 0
-
-        observer.flush_sync()
-
-        assert observer.metrics["total_flushed"] == 1
-        observer.cancel()
-
-
-class TestObserverSQLiteIntegration:
-    """Verify OBSERVE-phase observer produces correct records on SQLite.
-
-    _process_events_in_session() must produce complete records:
-    entity_urn, aspect_name, change_type, rename two-URN pattern,
-    delete soft-delete.
-    """
-
-    @pytest.mark.anyio
-    async def test_write_event_has_entity_urn(self, record_store: SQLAlchemyRecordStore) -> None:
-        """Write event must populate entity_urn, aspect_name, change_type."""
-        observer = ObserverWriteObserver(record_store, debounce_seconds=10.0)
-        metadata = _make_metadata("/urn_test.txt", content_id="u1")
-        event = {
-            "op": "write",
-            "path": "/urn_test.txt",
-            "is_new": True,
-            "zone_id": "root",
-            "agent_id": "agent-1",
-            "snapshot_hash": None,
-            "metadata_snapshot": None,
-            "metadata": metadata.to_dict(),
-        }
-        observer._pending.append(event)
-
-        flushed = observer.flush_sync()
-        assert flushed == 1
-
-        with record_store.session_factory() as session:
-            ops = session.query(OperationLogModel).all()
-            assert len(ops) == 1
-            assert ops[0].entity_urn is not None
-            assert "root" in ops[0].entity_urn
-            assert ops[0].aspect_name == "file_metadata"
-            assert ops[0].change_type == "upsert"
-            assert ops[0].agent_id == "agent-1"
-            assert ops[0].delivered is False
-
-        observer.cancel()
-
-    @pytest.mark.anyio
-    async def test_delete_event_produces_correct_records(
-        self, record_store: SQLAlchemyRecordStore
-    ) -> None:
-        """Delete event must have entity_urn, change_type='delete'."""
-        observer = ObserverWriteObserver(record_store, debounce_seconds=10.0)
-        metadata = _make_metadata("/del_test.txt", content_id="d1")
-
-        # First write the file so there's something to delete
-        write_event = {
-            "op": "write",
-            "path": "/del_test.txt",
-            "is_new": True,
-            "zone_id": "root",
-            "agent_id": None,
-            "snapshot_hash": None,
-            "metadata_snapshot": None,
-            "metadata": metadata.to_dict(),
-        }
-        observer._pending.append(write_event)
-
-        delete_event = {
-            "op": "delete",
-            "path": "/del_test.txt",
-            "zone_id": "root",
-            "agent_id": None,
-            "snapshot_hash": "d1",
-            "metadata_snapshot": metadata.to_dict(),
-        }
-        observer._pending.append(delete_event)
-
-        flushed = observer.flush_sync()
-        assert flushed == 2
-
-        with record_store.session_factory() as session:
-            ops = session.query(OperationLogModel).order_by(OperationLogModel.created_at).all()
-            assert len(ops) == 2
-            # Write op
-            assert ops[0].operation_type == "write"
-            assert ops[0].change_type == "upsert"
-            # Delete op
-            assert ops[1].operation_type == "delete"
-            assert ops[1].entity_urn is not None
-            assert ops[1].change_type == "delete"
-
-        observer.cancel()
-
-    @pytest.mark.anyio
-    async def test_rename_produces_two_operation_log_rows(
-        self, record_store: SQLAlchemyRecordStore
-    ) -> None:
-        """Rename must produce two operation_log rows: DELETE old + UPSERT new."""
-        observer = ObserverWriteObserver(record_store, debounce_seconds=10.0)
-        metadata = _make_metadata("/old_name.txt", content_id="r1")
-
-        # Write the file first
-        write_event = {
-            "op": "write",
-            "path": "/old_name.txt",
-            "is_new": True,
-            "zone_id": "root",
-            "agent_id": None,
-            "snapshot_hash": None,
-            "metadata_snapshot": None,
-            "metadata": metadata.to_dict(),
-        }
-        observer._pending.append(write_event)
-
-        rename_event = {
-            "op": "rename",
-            "path": "/old_name.txt",
-            "new_path": "/new_name.txt",
-            "zone_id": "root",
-            "agent_id": None,
-            "snapshot_hash": "r1",
-            "metadata_snapshot": metadata.to_dict(),
-        }
-        observer._pending.append(rename_event)
-
-        flushed = observer.flush_sync()
-        assert flushed == 2
-
-        with record_store.session_factory() as session:
-            ops = session.query(OperationLogModel).order_by(OperationLogModel.created_at).all()
-            # Write (1 row) + Rename (2 rows: delete old + upsert new)
-            assert len(ops) == 3
-            rename_ops = [o for o in ops if o.operation_type == "rename"]
-            assert len(rename_ops) == 2
-            change_types = {o.change_type for o in rename_ops}
-            assert change_types == {"delete", "upsert"}
-
-        observer.cancel()
-
-    @pytest.mark.anyio
-    async def test_mkdir_and_rmdir_events(self, record_store: SQLAlchemyRecordStore) -> None:
-        """mkdir and rmdir events should be recorded without entity_urn."""
-        observer = ObserverWriteObserver(record_store, debounce_seconds=10.0)
-
-        mkdir_event = {
-            "op": "mkdir",
-            "path": "/test_dir",
-            "zone_id": "root",
-            "agent_id": None,
-        }
-        rmdir_event = {
-            "op": "rmdir",
-            "path": "/test_dir",
-            "zone_id": "root",
-            "agent_id": None,
-            "recursive": True,
-        }
-        observer._pending.append(mkdir_event)
-        observer._pending.append(rmdir_event)
-
-        flushed = observer.flush_sync()
-        assert flushed == 2
-
-        with record_store.session_factory() as session:
-            ops = session.query(OperationLogModel).order_by(OperationLogModel.created_at).all()
-            assert len(ops) == 2
-            assert ops[0].operation_type == "mkdir"
-            assert ops[1].operation_type == "rmdir_recursive"
-
-        observer.cancel()
-
-    @pytest.mark.anyio
-    async def test_batch_flush_records_mcl(self, record_store: SQLAlchemyRecordStore) -> None:
-        """Batch flush path (via _flush_batch_sync) should record MCL entries."""
-        observer = ObserverWriteObserver(record_store)
-        metadata = _make_metadata("/mcl_test.txt", content_id="m1")
         event = {
             "op": "write",
             "path": "/mcl_test.txt",
@@ -374,39 +267,37 @@ class TestObserverSQLiteIntegration:
             "agent_id": None,
             "snapshot_hash": None,
             "metadata_snapshot": None,
-            "metadata": metadata.to_dict(),
+            "metadata": _make_metadata("/mcl_test.txt", content_id="m1").to_dict(),
         }
-
-        # Use _flush_batch_sync directly (the flush path)
         observer._flush_batch_sync([event])
-
+        assert event["projection_seq"] is not None, "critical commit stamps the sequence"
         with record_store.session_factory() as session:
-            # Phase 1: operation_log + version_history
-            ops = session.query(OperationLogModel).all()
-            assert len(ops) == 1
-            assert ops[0].entity_urn is not None
-            assert ops[0].aspect_name == "file_metadata"
+            assert session.query(OperationLogModel).count() == 1
+            assert session.query(MetadataChangeLogModel).count() == 0, "MCL is deferred"
 
-            # Phase 2: MCL recording
+        observer._run_deferred([event])
+        with record_store.session_factory() as session:
             mcl = session.query(MetadataChangeLogModel).all()
             assert len(mcl) == 1
-            assert mcl[0].change_type == "upsert"
-            assert "root" in mcl[0].entity_urn
+            assert mcl[0].change_type == "upsert" and "root" in mcl[0].entity_urn
 
-        observer.cancel()
+    def test_on_write_then_flush_sync_lands_mcl(
+        self, record_store: SQLAlchemyRecordStore, observer: ObserverWriteObserver
+    ) -> None:
+        observer.on_write(
+            _make_metadata("/deferred.txt", content_id="dd"),
+            is_new=True,
+            path="/deferred.txt",
+            zone_id="root",
+        )
+        observer.flush_sync()  # drains the deferred queue inline
+        with record_store.session_factory() as session:
+            assert session.query(MetadataChangeLogModel).count() == 1
 
-    @pytest.mark.anyio
-    async def test_debounce_parameter_defaults(self, record_store: SQLAlchemyRecordStore) -> None:
-        """Verify debounce_seconds parameter is configurable and has correct default."""
+    def test_debounce_parameter_kept_for_compat(self, record_store: SQLAlchemyRecordStore) -> None:
         observer_default = ObserverWriteObserver(record_store)
         assert observer_default._debounce == 0.2
-
         observer_custom = ObserverWriteObserver(record_store, debounce_seconds=0.5)
         assert observer_custom._debounce == 0.5
-
-        observer_zero = ObserverWriteObserver(record_store, debounce_seconds=0)
-        assert observer_zero._debounce == 0
-
         observer_default.cancel()
         observer_custom.cancel()
-        observer_zero.cancel()

--- a/tests/unit/cli/test_projection_cli.py
+++ b/tests/unit/cli/test_projection_cli.py
@@ -1,0 +1,200 @@
+"""CLI surfaces for fenced projections (#4738).
+
+``nexus ops wait --seq N`` fences on a write's projection sequence over REST;
+``nexus admin fs reconcile-projections`` repairs the projection — locally when
+the CLI holds the RecordStore, otherwise through the admin REST route.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import tempfile
+from collections.abc import AsyncIterator, Generator
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+from click.testing import CliRunner
+
+from nexus.cli.commands.admin import admin
+from nexus.cli.commands.operations import ops_group
+from nexus.storage.record_store import SQLAlchemyRecordStore
+
+MOCK_URL = "http://localhost:2026"
+_ENV = {"NEXUS_NO_AUTO_JSON": "1", "NEXUS_URL": MOCK_URL}
+
+
+def _client(**method_returns: Any) -> MagicMock:
+    client = MagicMock()
+    for name, value in method_returns.items():
+        setattr(client, name, MagicMock(return_value=value))
+    return client
+
+
+@pytest.fixture
+def record_store() -> Generator[SQLAlchemyRecordStore, None, None]:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        rs = SQLAlchemyRecordStore(db_path=Path(tmpdir) / "metadata.db")
+        yield rs
+        rs.close()
+
+
+# ── nexus ops wait ────────────────────────────────────────────────────
+
+
+def test_ops_wait_applied_exits_zero() -> None:
+    fake = _client(
+        get={"seq": 42, "applied": True, "latest_seq": 45, "zone_id": "eng", "waited_ms": 3}
+    )
+    with patch("nexus.cli.api_client.get_api_client_from_options", return_value=fake):
+        result = CliRunner(env=_ENV).invoke(
+            ops_group, ["wait", "--seq", "42", "--remote-url", MOCK_URL]
+        )
+    assert result.exit_code == 0, result.output
+    fake.get.assert_called_once_with(
+        "/api/v2/operations/wait", params={"seq": 42, "timeout_ms": 5000}
+    )
+    assert "Applied" in result.output and "42" in result.output and "latest_seq=45" in result.output
+
+
+def test_ops_wait_412_exits_one_with_latest_seq() -> None:
+    request = httpx.Request("GET", f"{MOCK_URL}/api/v2/operations/wait")
+    response = httpx.Response(
+        412,
+        request=request,
+        json={
+            "detail": {
+                "error": "projection_not_applied",
+                "seq": 99,
+                "latest_seq": 40,
+                "zone_id": "eng",
+                "waited_ms": 250,
+            }
+        },
+    )
+    fake = MagicMock()
+    fake.get = MagicMock(
+        side_effect=httpx.HTTPStatusError("412", request=request, response=response)
+    )
+    with patch("nexus.cli.api_client.get_api_client_from_options", return_value=fake):
+        result = CliRunner(env=_ENV).invoke(
+            ops_group,
+            ["wait", "--seq", "99", "--timeout-ms", "250", "--remote-url", MOCK_URL],
+        )
+    assert result.exit_code == 1
+    assert "Not applied" in result.output and "latest_seq=40" in result.output
+
+
+def test_ops_wait_requires_seq() -> None:
+    result = CliRunner(env=_ENV).invoke(ops_group, ["wait", "--remote-url", MOCK_URL])
+    assert result.exit_code == 2
+
+
+# ── nexus admin fs reconcile-projections ──────────────────────────────
+
+
+def _open_filesystem_yielding(nx: Any) -> Any:
+    @contextlib.asynccontextmanager
+    async def _cm(*_a: Any, **_k: Any) -> AsyncIterator[Any]:
+        yield nx
+
+    return _cm
+
+
+def test_reconcile_uses_rest_when_the_cli_has_no_record_store() -> None:
+    report = {
+        "prefix": "/ws",
+        "zone_id": "eng",
+        "dry_run": True,
+        "scanned": 3,
+        "in_sync": 1,
+        "created": 1,
+        "repaired": 1,
+        "retired": 0,
+        "stale_kernel": 0,
+        "errors": 0,
+        "truncated": False,
+        "duration_ms": 12,
+        "created_paths": ["/ws/new.txt"],
+        "repaired_paths": ["/ws/lost.txt"],
+        "retired_paths": [],
+        "stale_kernel_paths": [],
+        "error_messages": [],
+    }
+    fake = _client(post=report)
+    opened: list[Any] = []
+
+    @contextlib.asynccontextmanager
+    async def _must_not_open(*a: Any, **k: Any) -> AsyncIterator[Any]:
+        opened.append((a, k))
+        yield SimpleNamespace(record_store=None)
+
+    with (
+        patch("nexus.cli.utils.open_filesystem", _must_not_open),
+        patch("nexus.cli.api_client.get_api_client_from_options", return_value=fake),
+    ):
+        result = CliRunner(env=_ENV).invoke(
+            admin,
+            [
+                "fs",
+                "reconcile-projections",
+                "--prefix",
+                "/ws",
+                "--dry-run",
+                "--remote-url",
+                MOCK_URL,
+            ],
+        )
+    assert result.exit_code == 0, result.output
+    fake.post.assert_called_once_with(
+        "/api/v2/admin/reconcile-projections",
+        json_body={"prefix": "/ws", "dry_run": True, "retire_missing": False, "max_entries": None},
+    )
+    assert opened == [], "a configured server must not spawn a local filesystem/kernel"
+    assert "/ws/new.txt" in result.output and "/ws/lost.txt" in result.output
+    assert "Dry run" in result.output
+
+
+def test_reconcile_runs_locally_when_the_cli_holds_the_record_store(
+    record_store: SQLAlchemyRecordStore,
+) -> None:
+    entries = [
+        {
+            "path": "/ws/a.txt",
+            "size": 1,
+            "content_id": "ca",
+            "mime_type": "text/plain",
+            "version": 1,
+            "gen": 1,
+            "entry_type": 0,
+        }
+    ]
+    local_nx = SimpleNamespace(
+        record_store=record_store,
+        _zone_id="root",
+        sys_readdir=lambda path, **kw: list(entries),
+    )
+    rest = MagicMock()
+    no_server = SimpleNamespace(url=None, api_key=None)
+    with (
+        patch("nexus.cli.config.resolve_connection", return_value=no_server),
+        patch("nexus.cli.utils.open_filesystem", _open_filesystem_yielding(local_nx)),
+        patch("nexus.cli.api_client.get_api_client_from_options", return_value=rest),
+    ):
+        result = CliRunner(env={"NEXUS_NO_AUTO_JSON": "1"}).invoke(
+            admin, ["fs", "reconcile-projections", "--prefix", "/ws"]
+        )
+    assert result.exit_code == 0, result.output
+    rest.post.assert_not_called()
+    assert "created" in result.output and "/ws/a.txt" in result.output
+
+    from sqlalchemy import select
+
+    from nexus.storage.models import FilePathModel
+
+    with record_store.session_factory() as session:
+        rows = session.execute(select(FilePathModel.virtual_path)).scalars().all()
+    assert rows == ["/ws/a.txt"]

--- a/tests/unit/core/test_write_projection_seq.py
+++ b/tests/unit/core/test_write_projection_seq.py
@@ -1,0 +1,132 @@
+"""NexusFS.write / sys_write / write_batch return the projection sequence (#4738).
+
+The write observer stashes ``projection_seq`` on the post-hook context; the
+write paths must read it back and return it next to content_id / version.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+from nexus.core.nexus_fs_content import ContentMixin
+
+
+class _Kernel:
+    """Kernel stub whose post-hook dispatch behaves like the audit interceptor."""
+
+    def __init__(self, *, seq: int | None = 11, post_hook_needed: bool = True) -> None:
+        self.seq = seq
+        self.post_hook_needed = post_hook_needed
+        self.dispatched: list[str] = []
+
+    def sys_write(self, path: str, _ctx: object, content: bytes, _offset: int = 0) -> Any:
+        return SimpleNamespace(
+            hit=True,
+            content_id="cid",
+            post_hook_needed=self.post_hook_needed,
+            version=2,
+            gen=2,
+            size=len(content),
+            is_new=False,
+            old_content_id="old",
+            old_size=1,
+            old_version=1,
+            old_modified_at_ms=None,
+        )
+
+    def write_batch(self, files: list[tuple[str, bytes]], _ctx: object) -> list[Any]:
+        return [
+            SimpleNamespace(hit=True, content_id=f"cid-{i}", version=1, gen=1, size=len(c))
+            for i, (_p, c) in enumerate(files)
+        ]
+
+    def stat_batch(self, paths: list[str], zone_id: str = "root") -> list[Any]:
+        return [None for _ in paths]
+
+    def dispatch_pre_hooks(self, _name: str, _ctx: object) -> None:
+        return None
+
+    def hook_count(self, _name: str) -> int:
+        return 1
+
+    def dispatch_post_hooks(self, name: str, ctx: Any) -> None:
+        self.dispatched.append(name)
+        if self.seq is None:
+            return
+        if name == "write_batch":
+            ctx.extra["projection_seqs"] = [self.seq + i for i, _ in enumerate(ctx.items)]
+        else:
+            ctx.extra["projection_seq"] = self.seq
+
+
+class _Harness(ContentMixin):
+    def __init__(self, kernel: _Kernel) -> None:
+        self._kernel = kernel
+        self._zone_id = "root"
+        self.metadata = SimpleNamespace()
+        self._driver_coordinator = SimpleNamespace()
+
+    def _parse_context(self, context: object | None) -> object | None:
+        return context
+
+    def resolve_write(
+        self, path: str, content: bytes, *, context: object | None = None
+    ) -> tuple[bool, dict[str, object] | None]:
+        return (False, None)
+
+    def _build_rust_ctx(self, context: object | None, is_admin: bool) -> object:
+        return object()
+
+    def _get_context_identity(self, context: object | None) -> tuple[str, str | None, bool]:
+        return ("root", None, False)
+
+    def _prepare_rust_ctx(
+        self, context: object | None = None
+    ) -> tuple[str | None, str | None, bool, object]:
+        zone_id, agent_id, is_admin = self._get_context_identity(context)
+        return zone_id, agent_id, is_admin, self._build_rust_ctx(context, is_admin)
+
+    def _validate_path(self, path: str) -> str:
+        return path
+
+    def _batch_permission_check(self, paths: list[str], context: object | None) -> set[str]:
+        return set(paths)
+
+    def _dispatch_batch_post_hook(self, name: str, ctx: object) -> None:
+        self._kernel.dispatch_post_hooks(name, ctx)
+
+
+def test_write_returns_projection_seq_from_post_hook_context() -> None:
+    kernel = _Kernel(seq=11)
+    result = _Harness(kernel).write("/file.txt", b"abc")
+    assert result["projection_seq"] == 11
+    assert result["content_id"] == "cid" and result["version"] == 2 and result["gen"] == 2
+    assert kernel.dispatched == ["write"]
+
+
+def test_write_projection_seq_is_none_when_no_observer_confirms() -> None:
+    result = _Harness(_Kernel(seq=None)).write("/file.txt", b"abc")
+    assert "projection_seq" in result and result["projection_seq"] is None
+
+
+def test_sys_write_returns_projection_seq_when_hooks_run() -> None:
+    result = _Harness(_Kernel(seq=5)).sys_write("/file.txt", b"abc")
+    assert result["projection_seq"] == 5 and result["bytes_written"] == 3 and "revision" in result
+
+
+def test_sys_write_projection_seq_none_when_kernel_skips_post_hooks() -> None:
+    kernel = _Kernel(seq=5, post_hook_needed=False)
+    result = _Harness(kernel).sys_write("/file.txt", b"abc")
+    assert result["projection_seq"] is None and kernel.dispatched == []
+
+
+def test_write_batch_returns_per_item_projection_seq() -> None:
+    results = _Harness(_Kernel(seq=20)).write_batch([("/a", b"1"), ("/b", b"22")])
+    assert [r["projection_seq"] for r in results] == [20, 21]
+    assert [r["content_id"] for r in results] == ["cid-0", "cid-1"]
+
+
+def test_write_batch_projection_seq_none_without_observer() -> None:
+    results = _Harness(_Kernel(seq=None)).write_batch([("/a", b"1")])
+    assert results[0]["projection_seq"] is None

--- a/tests/unit/server/api/v2/routers/test_files_revision.py
+++ b/tests/unit/server/api/v2/routers/test_files_revision.py
@@ -121,7 +121,12 @@ def test_delete_without_kernel_stamp_reports_null(client: TestClient) -> None:
     resp = client.delete("/delete", params={"path": "/a.txt"})
 
     assert resp.status_code == 200, resp.text
-    assert resp.json() == {"deleted": True, "path": "/a.txt", "revision": None}
+    assert resp.json() == {
+        "deleted": True,
+        "path": "/a.txt",
+        "revision": None,
+        "projection_seq": None,
+    }
     assert REVISION_HEADER not in resp.headers
 
 

--- a/tests/unit/server/api/v2/routers/test_files_write_projection_seq.py
+++ b/tests/unit/server/api/v2/routers/test_files_write_projection_seq.py
@@ -1,0 +1,162 @@
+"""POST /files/write and /files/batch/write return ``projection_seq`` (#4738)."""
+
+from __future__ import annotations
+
+import base64
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+
+try:
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    _HAS_FASTAPI = True
+except ImportError:
+    _HAS_FASTAPI = False
+
+pytestmark = pytest.mark.skipif(not _HAS_FASTAPI, reason="fastapi test client unavailable")
+
+_AUTH = {
+    "authenticated": True,
+    "subject_type": "user",
+    "subject_id": "alice",
+    "zone_id": "eng",
+    "zone_perms": [["eng", "rw"]],
+    "is_admin": True,
+}
+_MODIFIED = datetime(2026, 9, 3, 12, 0, tzinfo=UTC)
+
+
+class _FakeFS:
+    def __init__(self, *, seq: int | None = 42) -> None:
+        self.seq = seq
+
+    def sys_unlink(self, path: str, **_: Any) -> dict[str, Any]:
+        return {"projection_seq": self.seq}
+
+    def sys_rename(self, source: str, destination: str, **_: Any) -> dict[str, Any]:
+        return {"projection_seq": self.seq}
+
+    def mkdir(self, path: str, **_: Any) -> dict[str, Any]:
+        return {"path": path, "projection_seq": self.seq}
+
+    def rename_batch(self, renames: list[tuple[str, str]], **_: Any) -> dict[str, Any]:
+        return {
+            src: {
+                "success": True,
+                "new_path": dst,
+                "projection_seq": (self.seq + i) if self.seq is not None else None,
+            }
+            for i, (src, dst) in enumerate(renames)
+        }
+
+    def write(self, *, path: str, buf: bytes, **_: Any) -> dict[str, Any]:
+        return {
+            "content_id": "cid-1",
+            "version": 3,
+            "size": len(buf),
+            "modified_at": _MODIFIED,
+            "projection_seq": self.seq,
+        }
+
+    def write_batch(self, files: list[tuple[str, bytes]], **_: Any) -> list[dict[str, Any]]:
+        return [
+            {
+                "path": path,
+                "content_id": f"cid-{i}",
+                "version": 1,
+                "size": len(buf),
+                "modified_at": _MODIFIED,
+                "projection_seq": (self.seq + i) if self.seq is not None else None,
+            }
+            for i, (path, buf) in enumerate(files)
+        ]
+
+
+def _client(fs: _FakeFS) -> TestClient:
+    from nexus.server.api.v2.routers.async_files import create_async_files_router
+    from nexus.server.dependencies import get_auth_result, require_auth
+
+    app = FastAPI()
+    app.state.search_daemon = None
+    app.dependency_overrides[get_auth_result] = lambda: _AUTH
+    app.dependency_overrides[require_auth] = lambda: _AUTH
+    app.include_router(create_async_files_router(nexus_fs=fs), prefix="/api/v2/files")
+    return TestClient(app)
+
+
+def test_write_response_carries_projection_seq() -> None:
+    resp = _client(_FakeFS(seq=42)).post(
+        "/api/v2/files/write", json={"path": "/docs/a.md", "content": "hello"}
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["projection_seq"] == 42
+    assert body["content_id"] == "cid-1"
+
+
+def test_write_response_projection_seq_is_null_when_unconfirmed() -> None:
+    resp = _client(_FakeFS(seq=None)).post(
+        "/api/v2/files/write", json={"path": "/docs/a.md", "content": "hello"}
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["projection_seq"] is None
+
+
+def test_batch_write_results_carry_per_item_projection_seq() -> None:
+    files = [
+        {"path": "/docs/a.md", "content_base64": base64.b64encode(b"a").decode()},
+        {"path": "/docs/b.md", "content_base64": base64.b64encode(b"b").decode()},
+    ]
+    resp = _client(_FakeFS(seq=10)).post("/api/v2/files/batch/write", json={"files": files})
+    assert resp.status_code == 200, resp.text
+    assert [r["projection_seq"] for r in resp.json()["results"]] == [10, 11]
+
+
+def test_delete_response_carries_projection_seq() -> None:
+    resp = _client(_FakeFS(seq=7)).delete("/api/v2/files/delete?path=/docs/a.md")
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {
+        "deleted": True,
+        "path": "/docs/a.md",
+        "revision": None,
+        "projection_seq": 7,
+    }
+
+
+def test_rename_response_carries_projection_seq() -> None:
+    resp = _client(_FakeFS(seq=8)).post(
+        "/api/v2/files/rename", json={"source": "/docs/a.md", "destination": "/docs/b.md"}
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["projection_seq"] == 8 and resp.json()["success"] is True
+
+
+def test_mkdir_response_carries_projection_seq() -> None:
+    resp = _client(_FakeFS(seq=9)).post("/api/v2/files/mkdir", json={"path": "/docs/new"})
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {"created": True, "path": "/docs/new", "projection_seq": 9}
+
+
+def test_rename_batch_results_carry_per_item_projection_seq() -> None:
+    resp = _client(_FakeFS(seq=20)).post(
+        "/api/v2/files/rename-batch",
+        json={
+            "operations": [
+                {"source": "/a", "destination": "/b"},
+                {"source": "/c", "destination": "/d"},
+            ]
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    assert [r["projection_seq"] for r in resp.json()["results"]] == [20, 21]
+
+
+def test_mutation_responses_report_null_when_unconfirmed() -> None:
+    client = _client(_FakeFS(seq=None))
+    assert client.delete("/api/v2/files/delete?path=/x").json()["projection_seq"] is None
+    assert client.post("/api/v2/files/mkdir", json={"path": "/d"}).json()["projection_seq"] is None
+    body = client.post("/api/v2/files/rename", json={"source": "/a", "destination": "/b"}).json()
+    assert body["projection_seq"] is None

--- a/tests/unit/server/api/v2/test_admin_reconcile_projections.py
+++ b/tests/unit/server/api/v2/test_admin_reconcile_projections.py
@@ -1,0 +1,139 @@
+"""POST /api/v2/admin/reconcile-projections repairs the projection from the kernel (#4738)."""
+
+from __future__ import annotations
+
+import tempfile
+from collections.abc import Generator
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+try:
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    _HAS_FASTAPI = True
+except ImportError:
+    _HAS_FASTAPI = False
+
+from nexus.contracts.metadata import DT_REG
+from nexus.storage.record_store import SQLAlchemyRecordStore
+
+pytestmark = pytest.mark.skipif(not _HAS_FASTAPI, reason="fastapi test client unavailable")
+
+_ADMIN = {
+    "authenticated": True,
+    "subject_type": "user",
+    "subject_id": "root",
+    "zone_id": "eng",
+    "zone_perms": [["eng", "rw"]],
+    "is_admin": True,
+}
+_USER = {**_ADMIN, "subject_id": "alice", "is_admin": False}
+
+
+@pytest.fixture
+def record_store() -> Generator[SQLAlchemyRecordStore, None, None]:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        rs = SQLAlchemyRecordStore(db_path=Path(tmpdir) / "metadata.db")
+        yield rs
+        rs.close()
+
+
+class _FakeFS:
+    def __init__(self, record_store: SQLAlchemyRecordStore, entries: list[dict[str, Any]]) -> None:
+        self.record_store = record_store
+        self.entries = entries
+        self.readdir_calls: list[tuple[str, dict[str, Any]]] = []
+
+    def sys_readdir(self, path: str, **kwargs: Any) -> list[dict[str, Any]]:
+        self.readdir_calls.append((path, kwargs))
+        return list(self.entries)
+
+
+def _client(fs: Any, auth: dict[str, Any]) -> TestClient:
+    from nexus.server.api.v2.dependencies import get_auth_result
+    from nexus.server.api.v2.routers.replay import router
+
+    app = FastAPI()
+    app.state.nexus_fs = fs
+    app.dependency_overrides[get_auth_result] = lambda: auth
+    app.include_router(router)
+    return TestClient(app)
+
+
+def _entry(path: str, content_id: str) -> dict[str, Any]:
+    return {
+        "path": path,
+        "size": 3,
+        "content_id": content_id,
+        "mime_type": "text/plain",
+        "version": 1,
+        "gen": 1,
+        "entry_type": DT_REG,
+        "zone_id": "root",
+    }
+
+
+def test_requires_admin(record_store: SQLAlchemyRecordStore) -> None:
+    fs = _FakeFS(record_store, [])
+    resp = _client(fs, _USER).post("/api/v2/admin/reconcile-projections", json={})
+    assert resp.status_code == 403
+    assert fs.readdir_calls == []
+
+
+def test_reconcile_creates_missing_rows_in_the_token_zone(
+    record_store: SQLAlchemyRecordStore,
+) -> None:
+    fs = _FakeFS(record_store, [_entry("/ws/a.txt", "ca"), _entry("/ws/b.txt", "cb")])
+    resp = _client(fs, _ADMIN).post("/api/v2/admin/reconcile-projections", json={"prefix": "/ws"})
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["zone_id"] == "eng" and body["prefix"] == "/ws"
+    assert body["scanned"] == 2 and body["created"] == 2 and body["errors"] == 0
+    assert body["created_paths"] == ["/ws/a.txt", "/ws/b.txt"]
+    assert body["dry_run"] is False and body["truncated"] is False
+    # The kernel walk ran under the caller's context, recursively with details.
+    path, kwargs = fs.readdir_calls[0]
+    assert path == "/ws" and kwargs["recursive"] is True and kwargs["details"] is True
+    assert kwargs["context"] is not None
+
+    # Now in sync.
+    again = _client(fs, _ADMIN).post(
+        "/api/v2/admin/reconcile-projections", json={"prefix": "/ws", "dry_run": True}
+    )
+    assert again.json()["in_sync"] == 2 and again.json()["dry_run"] is True
+
+
+def test_missing_prefix_is_404_not_500(record_store: SQLAlchemyRecordStore) -> None:
+    from nexus.contracts.exceptions import NexusFileNotFoundError
+
+    class _MissingFS(_FakeFS):
+        def sys_readdir(self, path: str, **kwargs: Any) -> list[dict[str, Any]]:
+            raise NexusFileNotFoundError(path)
+
+    resp = _client(_MissingFS(record_store, []), _ADMIN).post(
+        "/api/v2/admin/reconcile-projections", json={"prefix": "/nope"}
+    )
+    assert resp.status_code == 404, resp.text
+    assert "/nope" in resp.json()["detail"]
+
+
+def test_503_without_nexus_fs() -> None:
+    from nexus.server.api.v2.dependencies import get_auth_result
+    from nexus.server.api.v2.routers.replay import router
+
+    app = FastAPI()
+    app.state.nexus_fs = None
+    app.dependency_overrides[get_auth_result] = lambda: _ADMIN
+    app.include_router(router)
+    resp = TestClient(app).post("/api/v2/admin/reconcile-projections", json={})
+    assert resp.status_code == 503
+
+
+def test_503_without_record_store() -> None:
+    fs = SimpleNamespace(record_store=None)
+    resp = _client(fs, _ADMIN).post("/api/v2/admin/reconcile-projections", json={})
+    assert resp.status_code == 503

--- a/tests/unit/server/api/v2/test_operations_wait.py
+++ b/tests/unit/server/api/v2/test_operations_wait.py
@@ -1,0 +1,128 @@
+"""GET /api/v2/operations/wait — fence on a write's projection sequence (#4738).
+
+Runs against a real SQLite RecordStore so the probe sees rows committed
+from another connection while it polls (the reason each probe opens a
+fresh session).
+"""
+
+from __future__ import annotations
+
+import tempfile
+import threading
+import time
+from collections.abc import Generator
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+try:
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    _HAS_FASTAPI = True
+except ImportError:
+    _HAS_FASTAPI = False
+
+from nexus.storage.operation_logger import OperationLogger
+from nexus.storage.record_store import SQLAlchemyRecordStore
+
+pytestmark = pytest.mark.skipif(not _HAS_FASTAPI, reason="fastapi test client unavailable")
+
+_AUTH = {
+    "authenticated": True,
+    "subject_type": "user",
+    "subject_id": "alice",
+    "zone_id": "eng",
+    "zone_perms": [["eng", "rw"]],
+    "is_admin": False,
+}
+
+
+@pytest.fixture
+def record_store() -> Generator[SQLAlchemyRecordStore, None, None]:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        rs = SQLAlchemyRecordStore(db_path=Path(tmpdir) / "metadata.db")
+        yield rs
+        rs.close()
+
+
+def _log(record_store: SQLAlchemyRecordStore, path: str, *, zone_id: str = "eng") -> int:
+    with record_store.session_factory() as session:
+        op_logger = OperationLogger(session)
+        op_logger.log_operation(operation_type="write", path=path, zone_id=zone_id)
+        session.commit()
+        assert op_logger.last_sequence_number is not None
+        return op_logger.last_sequence_number
+
+
+def _client(record_store: SQLAlchemyRecordStore) -> TestClient:
+    from nexus.server.api.v2.dependencies import get_nexus_fs
+    from nexus.server.api.v2.routers.operations import router
+    from nexus.server.dependencies import require_auth
+
+    fake_fs = SimpleNamespace(record_store=record_store)
+    app = FastAPI()
+    app.state.nexus_fs = fake_fs
+    app.dependency_overrides[get_nexus_fs] = lambda: fake_fs
+    app.dependency_overrides[require_auth] = lambda: _AUTH
+    app.include_router(router)
+    return TestClient(app)
+
+
+def test_committed_sequence_is_applied_immediately(record_store: SQLAlchemyRecordStore) -> None:
+    seq = _log(record_store, "/a")
+    later = _log(record_store, "/b")
+    resp = _client(record_store).get(f"/api/v2/operations/wait?seq={seq}")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["applied"] is True
+    assert body["seq"] == seq
+    assert body["latest_seq"] == later
+    assert body["zone_id"] == "eng"
+
+
+def test_unknown_sequence_is_412_with_latest_after_timeout(
+    record_store: SQLAlchemyRecordStore,
+) -> None:
+    latest = _log(record_store, "/a")
+    resp = _client(record_store).get(f"/api/v2/operations/wait?seq={latest + 5}&timeout_ms=0")
+    assert resp.status_code == 412, resp.text
+    detail = resp.json()["detail"]
+    assert detail["error"] == "projection_not_applied"
+    assert detail["seq"] == latest + 5
+    assert detail["latest_seq"] == latest
+    assert detail["zone_id"] == "eng"
+
+
+def test_other_zones_sequence_looks_unapplied(record_store: SQLAlchemyRecordStore) -> None:
+    foreign = _log(record_store, "/secret", zone_id="finance")
+    resp = _client(record_store).get(f"/api/v2/operations/wait?seq={foreign}&timeout_ms=0")
+    assert resp.status_code == 412
+    assert resp.json()["detail"]["latest_seq"] is None, "no rows in the caller's zone"
+
+
+def test_wait_returns_once_the_row_lands_from_another_connection(
+    record_store: SQLAlchemyRecordStore,
+) -> None:
+    first = _log(record_store, "/a")
+    target = first + 1
+    client = _client(record_store)  # build the app before starting the clock
+
+    def _late_commit() -> None:
+        time.sleep(0.15)
+        _log(record_store, "/b")
+
+    threading.Thread(target=_late_commit, daemon=True).start()
+    resp = client.get(f"/api/v2/operations/wait?seq={target}&timeout_ms=3000")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["applied"] is True and body["latest_seq"] == target
+    assert body["waited_ms"] >= 100
+
+
+def test_invalid_parameters_are_400(record_store: SQLAlchemyRecordStore) -> None:
+    client = _client(record_store)
+    assert client.get("/api/v2/operations/wait?seq=0").status_code == 422
+    assert client.get("/api/v2/operations/wait?seq=1&timeout_ms=60000").status_code == 422
+    assert client.get("/api/v2/operations/wait").status_code == 422

--- a/tests/unit/server/test_kernel_syscall_projection_seq.py
+++ b/tests/unit/server/test_kernel_syscall_projection_seq.py
@@ -1,0 +1,49 @@
+"""The thin syscall dispatcher carries ``projection_seq`` over RPC / gRPC (#4738).
+
+``/api/nfs/{method}`` and the gRPC ``Call`` servicer both encode whatever
+``_apply_result_adapter`` returns.  Legacy Tier 2 shapes stay byte-identical
+when no observer confirmed a row; a confirmed sequence rides along.
+"""
+
+from __future__ import annotations
+
+from nexus.server._kernel_syscall_dispatch import _apply_result_adapter
+
+
+def test_legacy_shapes_unchanged_without_projection_seq() -> None:
+    assert _apply_result_adapter("delete", {}, {}) == {"deleted": True}
+    assert _apply_result_adapter("sys_unlink", {"projection_seq": None}, {}) == {"deleted": True}
+    assert _apply_result_adapter("rename", None, {}) == {"renamed": True}
+    assert _apply_result_adapter("mkdir", None, {}) == {"created": True}
+    assert _apply_result_adapter("rmdir", {}, {}) == {"removed": True}
+
+
+def test_confirmed_projection_seq_rides_along_on_legacy_shapes() -> None:
+    assert _apply_result_adapter("delete", {"projection_seq": 5}, {}) == {
+        "deleted": True,
+        "projection_seq": 5,
+    }
+    assert _apply_result_adapter("sys_rename", {"projection_seq": 6}, {}) == {
+        "renamed": True,
+        "projection_seq": 6,
+    }
+    assert _apply_result_adapter("mkdir", {"path": "/d", "projection_seq": 7}, {}) == {
+        "created": True,
+        "projection_seq": 7,
+    }
+    assert _apply_result_adapter("rmdir", {"projection_seq": 8}, {}) == {
+        "removed": True,
+        "projection_seq": 8,
+    }
+    # A bool is not a sequence.
+    assert _apply_result_adapter("delete", {"projection_seq": True}, {}) == {"deleted": True}
+
+
+def test_write_result_dict_passes_projection_seq_through() -> None:
+    wire = _apply_result_adapter(
+        "write",
+        {"content_id": "c", "version": 1, "gen": 1, "size": 3, "projection_seq": 11},
+        {"content": "abc"},
+    )
+    assert wire["bytes_written"] == 3
+    assert wire["projection_seq"] == 11

--- a/tests/unit/storage/test_piped_record_store_write_observer.py
+++ b/tests/unit/storage/test_piped_record_store_write_observer.py
@@ -1,7 +1,23 @@
+"""Unit tests for the write-through group-commit observer (#4738).
+
+The observer commits operation_log / file_paths / version_history before
+``on_write`` returns and hands back the projection sequence; MCL rows and
+post-flush hooks run on the deferred thread.  These tests stub the commit
+(``_flush_batch_sync``) so they exercise the queueing, grouping, strict-mode
+and never-drop-silently policies without a database.
+"""
+
 from __future__ import annotations
+
+import logging
+import threading
+import time
+from typing import Any
 
 import pytest
 
+from nexus.contracts.exceptions import AuditLogError
+from nexus.storage import piped_record_store_write_observer as mod
 from nexus.storage.piped_record_store_write_observer import RecordStoreWriteObserver
 
 
@@ -9,10 +25,66 @@ class FakeRecordStore:
     session_factory = object()
 
 
-def test_on_write_accepts_dict_old_metadata_contract_shape() -> None:
-    observer = RecordStoreWriteObserver(FakeRecordStore(), debounce_seconds=60)
+class _StubCommit:
+    """Replaces ``_flush_batch_sync``: records batches, stamps sequences."""
+
+    def __init__(self, *, poison: set[str] | None = None, block: threading.Event | None = None):
+        self.batches: list[list[dict[str, Any]]] = []
+        self.poison = poison or set()
+        self.block = block
+        self._seq = 0
+        self._lock = threading.Lock()
+
+    def __call__(self, events: list[dict[str, Any]]) -> None:
+        if self.block is not None:
+            self.block.wait()
+        for event in events:
+            if event.get("path") in self.poison:
+                raise RuntimeError(f"value too long for {event['path']}")
+        with self._lock:
+            for event in events:
+                self._seq += 1
+                event["projection_seq"] = self._seq
+            self.batches.append(list(events))
+
+
+def _observer(
+    monkeypatch: pytest.MonkeyPatch,
+    stub: _StubCommit,
+    *,
+    strict: bool = True,
+    timeout: float = 5.0,
+) -> RecordStoreWriteObserver:
+    observer = RecordStoreWriteObserver(
+        FakeRecordStore(), strict_mode=strict, write_through_timeout_s=timeout
+    )
+    monkeypatch.setattr(observer, "_flush_batch_sync", stub)
+    # MCL recording needs a real session factory; not under test here.
+    monkeypatch.setattr(observer, "_record_mcl_batch", lambda events: None)
+    # Retries sleep with exponential backoff; keep the poison tests fast.
+    monkeypatch.setattr(mod.time, "sleep", lambda _s: None)
+    return observer
+
+
+def _write(observer: RecordStoreWriteObserver, path: str, **kw: Any) -> int | None:
+    return observer.on_write(
+        {"content_id": "new", "path": path},
+        is_new=kw.pop("is_new", True),
+        path=path,
+        **kw,
+    )
+
+
+# ── intake contract ───────────────────────────────────────────────────
+
+
+def test_on_write_commits_before_returning_and_returns_projection_seq(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stub = _StubCommit()
+    observer = _observer(monkeypatch, stub)
     try:
-        observer.on_write(
+        seq = observer.on_write(
             {"content_id": "new", "path": "/workspace/report.csv"},
             is_new=False,
             path="/workspace/report.csv",
@@ -20,90 +92,308 @@ def test_on_write_accepts_dict_old_metadata_contract_shape() -> None:
             zone_id="zone-a",
             agent_id="agent-a",
         )
-
-        with observer._lock:
-            event = observer._pending[-1]
-
+        assert seq == 1
+        assert len(stub.batches) == 1
+        event = stub.batches[0][0]
+        assert event["op"] == "write"
         assert event["snapshot_hash"] == "old"
         assert event["metadata_snapshot"] == {
             "content_id": "old",
             "path": "/workspace/report.csv",
         }
+        assert event["zone_id"] == "zone-a" and event["agent_id"] == "agent-a"
+        assert observer.metrics["total_flushed"] == 1
+        assert observer.metrics["applied_seq"] == 1
+        assert observer.metrics["pending_events"] == 0
     finally:
-        if observer._timer is not None:
-            observer._timer.cancel()
+        observer.cancel()
 
 
-def test_flush_batch_salvages_per_event_after_final_retry(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """#4645: one poison event must not drop the whole batch's audit rows."""
-    from nexus.storage.piped_record_store_write_observer import _MAX_RETRIES
-
-    observer = RecordStoreWriteObserver(FakeRecordStore(), debounce_seconds=60)
-    poison = {"op": "rename", "path": "/deep/" + "x" * 100, "new_path": "/y"}
-    good_a = {"op": "write", "path": "/a", "is_new": True, "metadata": {}}
-    good_b = {"op": "delete", "path": "/b"}
-    events = [good_a, poison, good_b]
-
-    flushed_batches: list[list[dict]] = []
-
-    def fake_flush(batch: list[dict]) -> None:
-        if poison in batch:
-            raise RuntimeError("value too long for type character varying(64)")
-        flushed_batches.append(batch)
-
-    monkeypatch.setattr(observer, "_flush_batch_sync", fake_flush)
-    hook_calls: list[list[dict]] = []
-    observer._post_flush_hooks = [hook_calls.append]
-
-    # attempt == _MAX_RETRIES lands in the salvage branch directly.
-    observer._flush_batch(events, attempt=_MAX_RETRIES)
-
-    assert flushed_batches == [[good_a], [good_b]]
-    assert observer._total_flushed == 2
-    assert observer._total_failed == 1
-    # Post-flush hooks still fire for the salvaged subset.
-    assert hook_calls == [[good_a, good_b]]
-
-
-def test_flush_sync_salvages_per_event(monkeypatch: pytest.MonkeyPatch) -> None:
-    """#4645: shutdown flush drops only the individually failing rows."""
-    observer = RecordStoreWriteObserver(FakeRecordStore(), debounce_seconds=60)
-    poison = {"op": "rename", "path": "/p", "new_path": "/q"}
-    good = {"op": "write", "path": "/a", "is_new": True, "metadata": {}}
-
-    def fake_flush(batch: list[dict]) -> None:
-        if poison in batch:
-            raise RuntimeError("boom")
-
-    monkeypatch.setattr(observer, "_flush_batch_sync", fake_flush)
-    with observer._lock:
-        observer._pending.extend([good, poison])
-
-    assert observer.flush_sync() == 1
-    assert observer._total_flushed == 1
-    assert observer._total_failed == 1
-
-
-def test_on_delete_accepts_dict_metadata_contract_shape() -> None:
-    observer = RecordStoreWriteObserver(FakeRecordStore(), debounce_seconds=60)
+def test_on_delete_accepts_dict_metadata_contract_shape(monkeypatch: pytest.MonkeyPatch) -> None:
+    stub = _StubCommit()
+    observer = _observer(monkeypatch, stub)
     try:
-        observer.on_delete(
+        seq = observer.on_delete(
             path="/workspace/report.csv",
             metadata={"content_id": "old", "path": "/workspace/report.csv"},
             zone_id="zone-a",
             agent_id="agent-a",
         )
-
-        with observer._lock:
-            event = observer._pending[-1]
-
+        assert seq == 1
+        event = stub.batches[0][0]
+        assert event["op"] == "delete"
         assert event["snapshot_hash"] == "old"
         assert event["metadata_snapshot"] == {
             "content_id": "old",
             "path": "/workspace/report.csv",
         }
     finally:
-        if observer._timer is not None:
-            observer._timer.cancel()
+        observer.cancel()
+
+
+def test_on_write_batch_returns_one_seq_per_item_in_order(monkeypatch: pytest.MonkeyPatch) -> None:
+    from nexus.contracts.metadata import FileMetadata
+
+    stub = _StubCommit()
+    observer = _observer(monkeypatch, stub)
+    try:
+        items = [
+            (FileMetadata(path="/a", size=1, content_id="ca"), True),
+            (FileMetadata(path="/b", size=1, content_id="cb"), False),
+        ]
+        seqs = observer.on_write_batch(items, zone_id="z", agent_id="ag")
+        assert seqs == [1, 2]
+        assert len(stub.batches) == 1, "one transaction for the whole batch"
+        assert [e["path"] for e in stub.batches[0]] == ["/a", "/b"]
+        assert observer.on_write_batch([], zone_id="z") == []
+    finally:
+        observer.cancel()
+
+
+# ── group commit ──────────────────────────────────────────────────────
+
+
+def test_concurrent_writers_share_one_transaction(monkeypatch: pytest.MonkeyPatch) -> None:
+    gate = threading.Event()
+    stub = _StubCommit(block=gate)
+    observer = _observer(monkeypatch, stub)
+    results: dict[str, int | None] = {}
+
+    def writer(path: str) -> None:
+        results[path] = _write(observer, path)
+
+    try:
+        # First writer opens a commit that blocks on the gate...
+        first = threading.Thread(target=writer, args=("/first",))
+        first.start()
+        deadline = time.monotonic() + 2
+        while observer.metrics["pending_events"] != 0 and time.monotonic() < deadline:
+            time.sleep(0.005)
+        # ...meanwhile eight more writers queue up behind it.
+        rest = [threading.Thread(target=writer, args=(f"/p{i}",)) for i in range(8)]
+        for t in rest:
+            t.start()
+        deadline = time.monotonic() + 2
+        while observer.metrics["pending_events"] < 8 and time.monotonic() < deadline:
+            time.sleep(0.005)
+        assert observer.metrics["pending_events"] == 8
+        gate.set()
+        for t in [first, *rest]:
+            t.join(timeout=5)
+
+        assert len(stub.batches) == 2, "first alone, then the eight queued writers together"
+        assert len(stub.batches[1]) == 8
+        # Every writer got the sequence of its own row.
+        assert sorted(results.values()) == list(range(1, 10))
+        for batch in stub.batches:
+            for event in batch:
+                assert results[event["path"]] == event["projection_seq"]
+    finally:
+        gate.set()
+        observer.cancel()
+
+
+# ── failure policy ────────────────────────────────────────────────────
+
+
+def test_poison_event_is_salvaged_per_event_and_strict_writer_raises(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """#4645 + #4738: one poison row loses only itself; its writer gets the typed error."""
+    gate = threading.Event()
+    stub = _StubCommit(poison={"/deep/poison"}, block=gate)
+    observer = _observer(monkeypatch, stub)
+    hook_calls: list[list[dict[str, Any]]] = []
+    observer.register_post_flush_hook(hook_calls.append)
+    outcome: dict[str, Any] = {}
+
+    def good(path: str) -> None:
+        outcome[path] = _write(observer, path)
+
+    def bad() -> None:
+        try:
+            _write(observer, "/deep/poison")
+        except AuditLogError as exc:
+            outcome["/deep/poison"] = exc
+
+    try:
+        threads = [threading.Thread(target=good, args=("/a",))]
+        threads[0].start()
+        deadline = time.monotonic() + 2
+        while observer.metrics["pending_events"] != 0 and time.monotonic() < deadline:
+            time.sleep(0.005)
+        threads += [threading.Thread(target=bad), threading.Thread(target=good, args=("/b",))]
+        for t in threads[1:]:
+            t.start()
+        deadline = time.monotonic() + 2
+        while observer.metrics["pending_events"] < 2 and time.monotonic() < deadline:
+            time.sleep(0.005)
+        with caplog.at_level(logging.ERROR, logger=mod.__name__):
+            gate.set()
+            for t in threads:
+                t.join(timeout=5)
+            observer.flush_sync()  # run deferred hooks inline
+
+        assert isinstance(outcome["/deep/poison"], AuditLogError)
+        assert outcome["/a"] == 1 and outcome["/b"] == 2
+        assert observer.metrics["total_flushed"] == 2
+        assert observer.metrics["total_failed"] == 1
+        assert observer.metrics["total_retries"] == mod._MAX_RETRIES
+        assert any(
+            "dropping audit event" in r.message and "/deep/poison" in r.message
+            for r in caplog.records
+        )
+        # Hooks fire for the salvaged subset only.
+        assert [sorted(e["path"] for e in call) for call in hook_calls] == [["/a"], ["/b"]]
+    finally:
+        gate.set()
+        observer.cancel()
+
+
+def test_non_strict_failure_returns_none_instead_of_raising(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stub = _StubCommit(poison={"/poison"})
+    observer = _observer(monkeypatch, stub, strict=False)
+    try:
+        assert _write(observer, "/poison") is None
+        assert observer.metrics["total_failed"] == 1
+    finally:
+        observer.cancel()
+
+
+def test_timeout_strict_raises_and_non_strict_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    gate = threading.Event()
+    stub = _StubCommit(block=gate)
+
+    strict = _observer(monkeypatch, stub, strict=True, timeout=0.05)
+    try:
+        with pytest.raises(AuditLogError, match="not confirmed within"):
+            _write(strict, "/slow")
+        assert strict.metrics["total_timeouts"] == 1
+    finally:
+        gate.set()
+        strict.cancel()
+
+    gate.clear()
+    stub2 = _StubCommit(block=gate)
+    lenient = _observer(monkeypatch, stub2, strict=False, timeout=0.05)
+    try:
+        assert _write(lenient, "/slow") is None
+        assert lenient.metrics["total_timeouts"] == 1
+        # The event was NOT lost: it commits once the store answers.
+        gate.set()
+        deadline = time.monotonic() + 2
+        while lenient.metrics["total_flushed"] < 1 and time.monotonic() < deadline:
+            time.sleep(0.005)
+        assert lenient.metrics["total_flushed"] == 1
+    finally:
+        gate.set()
+        lenient.cancel()
+
+
+# ── never drop silently ───────────────────────────────────────────────
+
+
+def test_deferred_queue_overflow_drops_loudly_with_metric(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    monkeypatch.setattr(mod, "_DEFERRED_MAX_EVENTS", 2)
+    monkeypatch.setattr(mod, "_BACKPRESSURE_S", 0.01)
+    stub = _StubCommit()
+    observer = _observer(monkeypatch, stub)
+    # Stall the deferred worker so batches pile up.
+    stall = threading.Event()
+    monkeypatch.setattr(observer, "_run_deferred", lambda events: stall.wait())
+    dropped_metric: list[tuple[str, int]] = []
+    monkeypatch.setattr(
+        mod.io_metrics, "record_projection_dropped", lambda q, n: dropped_metric.append((q, n))
+    )
+    try:
+        with caplog.at_level(logging.ERROR, logger=mod.__name__):
+            for i in range(5):
+                assert _write(observer, f"/f{i}") == i + 1
+        # Critical rows all committed — only deferred work was shed.
+        assert observer.metrics["total_flushed"] == 5
+        assert observer.metrics["total_dropped"] >= 1
+        assert dropped_metric and all(q == "deferred" for q, _ in dropped_metric)
+        assert any("dropped" in r.message and "deferred queue" in r.message for r in caplog.records)
+    finally:
+        stall.set()
+        observer.cancel()
+
+
+def test_pending_queue_overflow_releases_oldest_ticket_with_error(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    monkeypatch.setattr(mod, "_PENDING_MAX_EVENTS", 2)
+    gate = threading.Event()
+    stub = _StubCommit(block=gate)
+    observer = _observer(monkeypatch, stub, strict=False, timeout=0.02)
+    dropped_metric: list[tuple[str, int]] = []
+    monkeypatch.setattr(
+        mod.io_metrics, "record_projection_dropped", lambda q, n: dropped_metric.append((q, n))
+    )
+    try:
+        with caplog.at_level(logging.ERROR, logger=mod.__name__):
+            # Commit thread is stuck on the first event; the rest time out
+            # (non-strict → None) and stay queued until the bound trips.
+            for i in range(5):
+                assert _write(observer, f"/p{i}") is None
+        assert observer.metrics["total_dropped"] >= 1
+        assert dropped_metric and all(q == "pending" for q, _ in dropped_metric)
+        assert any("unconfirmed event" in r.message for r in caplog.records)
+    finally:
+        gate.set()
+        observer.cancel()
+
+
+# ── flush / shutdown ──────────────────────────────────────────────────
+
+
+def test_flush_sync_commits_queued_events_inline(monkeypatch: pytest.MonkeyPatch) -> None:
+    stub = _StubCommit()
+    observer = _observer(monkeypatch, stub)
+    # Bypass the commit thread entirely: queue without waiting, then flush.
+    monkeypatch.setattr(observer, "_ensure_threads_locked", lambda: None)
+    try:
+        observer._enqueue({"op": "write", "path": "/a", "is_new": True, "metadata": {}})
+        observer._enqueue({"op": "delete", "path": "/b"})
+        assert observer.metrics["pending_events"] == 2
+        assert observer.flush_sync() == 2
+        assert observer.metrics["pending_events"] == 0
+        assert observer.metrics["total_flushed"] == 2
+        assert observer.flush_sync() == 0
+    finally:
+        observer.cancel()
+
+
+def test_flush_sync_salvages_per_event(monkeypatch: pytest.MonkeyPatch) -> None:
+    """#4645: shutdown flush drops only the individually failing rows."""
+    stub = _StubCommit(poison={"/p"})
+    observer = _observer(monkeypatch, stub)
+    monkeypatch.setattr(observer, "_ensure_threads_locked", lambda: None)
+    try:
+        observer._enqueue({"op": "write", "path": "/a", "is_new": True, "metadata": {}})
+        observer._enqueue({"op": "rename", "path": "/p", "new_path": "/q"})
+        assert observer.flush_sync() == 1
+        assert observer.metrics["total_flushed"] == 1
+        assert observer.metrics["total_failed"] == 1
+    finally:
+        observer.cancel()
+
+
+def test_metrics_keys_and_legacy_debounce_attribute() -> None:
+    observer = RecordStoreWriteObserver(FakeRecordStore(), debounce_seconds=60)
+    assert observer._debounce == 60
+    assert set(observer.metrics) == {
+        "total_flushed",
+        "total_failed",
+        "total_retries",
+        "total_dropped",
+        "total_timeouts",
+        "pending_events",
+        "deferred_events",
+        "applied_seq",
+    }
+    observer.cancel()  # no threads started — must be a no-op

--- a/tests/unit/storage/test_projection_reconcile.py
+++ b/tests/unit/storage/test_projection_reconcile.py
@@ -1,0 +1,349 @@
+"""storage.projection_reconcile — repair file_paths / version_history from the kernel (#4738).
+
+The kernel listing is a fake ``sys_readdir(details=True)``; the RecordStore
+is a real SQLite file.  Rows the observer would have written are seeded
+through ``VersionRecorder`` so the tests exercise the same schema the
+observer commits.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from collections.abc import Generator
+from pathlib import Path
+from typing import Any
+
+import pytest
+from sqlalchemy import select
+
+from nexus.contracts.metadata import DT_DIR, DT_REG, FileMetadata
+from nexus.storage.models import FilePathModel, OperationLogModel, VersionHistoryModel
+from nexus.storage.projection_reconcile import (
+    RECONCILE_ACTOR,
+    list_kernel_files,
+    reconcile_projection,
+)
+from nexus.storage.record_store import SQLAlchemyRecordStore
+from nexus.storage.version_recorder import VersionRecorder, version_gen
+
+
+@pytest.fixture
+def record_store() -> Generator[SQLAlchemyRecordStore, None, None]:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        rs = SQLAlchemyRecordStore(db_path=Path(tmpdir) / "metadata.db")
+        yield rs
+        rs.close()
+
+
+class _FakeFS:
+    """``sys_readdir(prefix, recursive=True, details=True)`` over a dict of entries."""
+
+    def __init__(self, entries: list[dict[str, Any]]) -> None:
+        self.entries = entries
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    def sys_readdir(self, path: str, **kwargs: Any) -> list[dict[str, Any]]:
+        self.calls.append((path, kwargs))
+        return [
+            e for e in self.entries if e["path"].startswith(path.rstrip("/") + "/") or path == "/"
+        ]
+
+
+def _entry(
+    path: str, content_id: str, *, gen: int = 1, version: int = 1, **extra: Any
+) -> dict[str, Any]:
+    base = {
+        "path": path,
+        "size": 5,
+        "content_id": content_id,
+        "mime_type": "text/plain",
+        "created_at": "2026-09-03T00:00:00+00:00",
+        "modified_at": "2026-09-03T00:00:01+00:00",
+        "version": version,
+        "zone_id": "root",
+        "owner_id": "alice",
+        "entry_type": DT_REG,
+        "gen": gen,
+    }
+    base.update(extra)
+    return base
+
+
+def _seed(
+    record_store: SQLAlchemyRecordStore,
+    path: str,
+    content_id: str,
+    *,
+    gen: int,
+    is_new: bool = True,
+) -> None:
+    with record_store.session_factory() as session:
+        VersionRecorder(session).record_write(
+            FileMetadata(path=path, size=5, content_id=content_id, zone_id="eng", gen=gen),
+            is_new=is_new,
+        )
+        session.commit()
+
+
+def _versions(record_store: SQLAlchemyRecordStore, path: str) -> list[VersionHistoryModel]:
+    with record_store.session_factory() as session:
+        fp = session.execute(
+            select(FilePathModel).where(
+                FilePathModel.virtual_path == path, FilePathModel.deleted_at.is_(None)
+            )
+        ).scalar_one_or_none()
+        if fp is None:
+            return []
+        return list(
+            session.execute(
+                select(VersionHistoryModel)
+                .where(VersionHistoryModel.resource_id == fp.path_id)
+                .order_by(VersionHistoryModel.version_number)
+            ).scalars()
+        )
+
+
+def test_list_kernel_files_filters_dirs_system_paths_and_empty_content() -> None:
+    fs = _FakeFS(
+        [
+            _entry("/ws/a.txt", "ca"),
+            _entry("/ws/dir", "", entry_type=DT_DIR, is_directory=True),
+            _entry("/__sys__/audit/traces/", "x"),
+            _entry("/nexus/pipes/audit", "x"),
+            _entry("/ws/empty", None),
+        ]
+    )
+    assert [e["path"] for e in list_kernel_files(fs, "/ws")] == ["/ws/a.txt"]
+    assert fs.calls[0][1] == {"recursive": True, "details": True, "context": None}
+
+
+def test_missing_and_drifted_rows_are_created_and_repaired(
+    record_store: SQLAlchemyRecordStore,
+) -> None:
+    # /ws/in-sync: projection matches kernel.  /ws/lost: kernel has a newer
+    # content (the write whose projection commit the crash ate).
+    # /ws/never: kernel has it, projection never saw it.
+    _seed(record_store, "/ws/in-sync", "c-same", gen=3)
+    _seed(record_store, "/ws/lost", "c-old", gen=1)
+    fs = _FakeFS(
+        [
+            _entry("/ws/in-sync", "c-same", gen=3),
+            _entry("/ws/lost", "c-new", gen=2, version=2),
+            _entry("/ws/never", "c-never", gen=1),
+        ]
+    )
+
+    report = reconcile_projection(
+        nexus_fs=fs, session_factory=record_store.session_factory, prefix="/ws", zone_id="eng"
+    )
+
+    assert (report.scanned, report.in_sync, report.created, report.repaired) == (3, 1, 1, 1)
+    assert report.errors == 0 and report.stale_kernel == 0 and report.retired == 0
+    assert report.created_paths == ["/ws/never"] and report.repaired_paths == ["/ws/lost"]
+
+    lost = _versions(record_store, "/ws/lost")
+    assert [v.content_id for v in lost] == ["c-old", "c-new"]
+    assert [version_gen(v) for v in lost] == [1, 2]
+    assert lost[-1].created_by == RECONCILE_ACTOR
+    never = _versions(record_store, "/ws/never")
+    assert [v.content_id for v in never] == ["c-never"]
+
+    with record_store.session_factory() as session:
+        ops = (
+            session.execute(select(OperationLogModel).order_by(OperationLogModel.sequence_number))
+            .scalars()
+            .all()
+        )
+        assert [(o.path, o.agent_id, o.change_type) for o in ops] == [
+            ("/ws/lost", RECONCILE_ACTOR, "upsert"),
+            ("/ws/never", RECONCILE_ACTOR, "upsert"),
+        ]
+        assert all(o.zone_id == "eng" for o in ops)
+
+    # Second pass is a no-op: everything in sync.
+    again = reconcile_projection(
+        nexus_fs=fs, session_factory=record_store.session_factory, prefix="/ws", zone_id="eng"
+    )
+    assert (again.in_sync, again.created, again.repaired) == (3, 0, 0)
+
+
+def test_stale_kernel_view_is_not_written_back(record_store: SQLAlchemyRecordStore) -> None:
+    """A lagging follower's older content must not become a 'new' version."""
+    _seed(record_store, "/ws/f", "c-v1", gen=1)
+    _seed(record_store, "/ws/f", "c-v2", gen=2, is_new=False)
+    fs = _FakeFS([_entry("/ws/f", "c-v1", gen=1)])
+
+    report = reconcile_projection(
+        nexus_fs=fs, session_factory=record_store.session_factory, prefix="/ws", zone_id="eng"
+    )
+
+    assert report.stale_kernel == 1 and report.repaired == 0
+    assert report.stale_kernel_paths == ["/ws/f"]
+    assert [v.content_id for v in _versions(record_store, "/ws/f")] == ["c-v1", "c-v2"]
+
+
+def test_path_addressed_backend_same_content_id_is_repaired_by_gen(
+    record_store: SQLAlchemyRecordStore,
+) -> None:
+    """A path-addressed backend reports the path as content_id for every write."""
+    _seed(record_store, "/ws/p.txt", "ws/p.txt", gen=1)
+    fs = _FakeFS([_entry("/ws/p.txt", "ws/p.txt", gen=2, version=2)])
+
+    report = reconcile_projection(
+        nexus_fs=fs, session_factory=record_store.session_factory, prefix="/ws", zone_id="eng"
+    )
+    assert report.repaired == 1 and report.in_sync == 0
+    versions = _versions(record_store, "/ws/p.txt")
+    assert [version_gen(v) for v in versions] == [1, 2]
+    assert [v.version_number for v in versions] == [1, 2]
+
+
+def test_equal_gen_is_in_sync_even_when_content_id_differs(
+    record_store: SQLAlchemyRecordStore,
+) -> None:
+    _seed(record_store, "/ws/g.txt", "c-a", gen=4)
+    fs = _FakeFS([_entry("/ws/g.txt", "c-b", gen=4)])
+    report = reconcile_projection(
+        nexus_fs=fs, session_factory=record_store.session_factory, prefix="/ws", zone_id="eng"
+    )
+    assert report.in_sync == 1 and report.repaired == 0
+    assert [v.content_id for v in _versions(record_store, "/ws/g.txt")] == ["c-a"]
+
+
+def test_legacy_rows_without_gen_fall_back_to_content_comparison(
+    record_store: SQLAlchemyRecordStore,
+) -> None:
+    _seed(record_store, "/ws/legacy", "c-old", gen=0)  # gen 0 → no extra_metadata
+    assert version_gen(_versions(record_store, "/ws/legacy")[0]) is None
+    fs = _FakeFS([_entry("/ws/legacy", "c-new", gen=5)])
+
+    report = reconcile_projection(
+        nexus_fs=fs, session_factory=record_store.session_factory, prefix="/ws", zone_id="eng"
+    )
+    assert report.repaired == 1
+    assert [v.content_id for v in _versions(record_store, "/ws/legacy")] == ["c-old", "c-new"]
+
+
+def test_rows_projected_under_another_zone_are_matched_not_duplicated(
+    record_store: SQLAlchemyRecordStore,
+) -> None:
+    """The observer keys rows by the writer's zone; a root reconcile must not
+    create root-zone duplicates for paths a 'research' token wrote (seen live
+    with `nexus demo init`: 6 'created' for rows that existed under zone
+    research). Matching is zone-agnostic; repairs stay in the row's zone."""
+    with record_store.session_factory() as session:
+        VersionRecorder(session).record_write(
+            FileMetadata(path="/ws/r.md", size=5, content_id="c1", zone_id="research", gen=1),
+            is_new=True,
+        )
+        session.commit()
+
+    fs = _FakeFS([_entry("/ws/r.md", "c1", gen=1)])
+    report = reconcile_projection(
+        nexus_fs=fs, session_factory=record_store.session_factory, prefix="/ws", zone_id="root"
+    )
+    assert (report.in_sync, report.created, report.repaired) == (1, 0, 0)
+
+    # Kernel moved on: the repair lands on the research-zone row, no root row appears.
+    fs = _FakeFS([_entry("/ws/r.md", "c2", gen=2, version=2)])
+    report = reconcile_projection(
+        nexus_fs=fs, session_factory=record_store.session_factory, prefix="/ws", zone_id="root"
+    )
+    assert report.repaired == 1 and report.created == 0
+    with record_store.session_factory() as session:
+        rows = (
+            session.execute(
+                select(FilePathModel).where(
+                    FilePathModel.virtual_path == "/ws/r.md", FilePathModel.deleted_at.is_(None)
+                )
+            )
+            .scalars()
+            .all()
+        )
+    assert [(r.zone_id, r.current_version) for r in rows] == [("research", 2)]
+    assert [version_gen(v) for v in _versions(record_store, "/ws/r.md")] == [1, 2]
+
+
+def test_dry_run_reports_without_writing(record_store: SQLAlchemyRecordStore) -> None:
+    fs = _FakeFS([_entry("/ws/never", "c")])
+    report = reconcile_projection(
+        nexus_fs=fs,
+        session_factory=record_store.session_factory,
+        prefix="/ws",
+        zone_id="eng",
+        dry_run=True,
+    )
+    assert report.dry_run is True and report.created == 1
+    assert _versions(record_store, "/ws/never") == []
+
+
+def test_retire_missing_is_opt_in_and_skipped_when_truncated(
+    record_store: SQLAlchemyRecordStore,
+) -> None:
+    _seed(record_store, "/ws/gone", "c-gone", gen=1)
+    _seed(record_store, "/ws/keep", "c-keep", gen=1)
+    _seed(record_store, "/other/untouched", "c-o", gen=1)
+    fs = _FakeFS([_entry("/ws/keep", "c-keep", gen=1)])
+    kwargs: dict[str, Any] = {
+        "nexus_fs": fs,
+        "session_factory": record_store.session_factory,
+        "prefix": "/ws",
+        "zone_id": "eng",
+    }
+
+    # Default: nothing retired.
+    assert reconcile_projection(**kwargs).retired == 0
+    assert _versions(record_store, "/ws/gone")
+
+    # Truncated walk: retire is skipped even when requested.
+    truncated = reconcile_projection(**kwargs, retire_missing=True, max_entries=0)
+    assert truncated.truncated is False or truncated.retired == 0
+
+    # Full walk with retire_missing: /ws/gone soft-deleted, /other untouched.
+    report = reconcile_projection(**kwargs, retire_missing=True)
+    assert report.retired == 1 and report.retired_paths == ["/ws/gone"]
+    assert _versions(record_store, "/ws/gone") == []
+    assert _versions(record_store, "/other/untouched")
+    with record_store.session_factory() as session:
+        delete_rows = (
+            session.execute(
+                select(OperationLogModel).where(OperationLogModel.operation_type == "delete")
+            )
+            .scalars()
+            .all()
+        )
+        assert [(o.path, o.agent_id) for o in delete_rows] == [("/ws/gone", RECONCILE_ACTOR)]
+
+
+def test_max_entries_truncates_and_reports(record_store: SQLAlchemyRecordStore) -> None:
+    fs = _FakeFS([_entry(f"/ws/f{i}", f"c{i}") for i in range(5)])
+    report = reconcile_projection(
+        nexus_fs=fs,
+        session_factory=record_store.session_factory,
+        prefix="/ws",
+        zone_id="eng",
+        max_entries=2,
+    )
+    assert report.truncated is True and report.scanned == 2 and report.created == 2
+
+
+def test_per_entry_failure_is_counted_and_does_not_abort_the_pass(
+    record_store: SQLAlchemyRecordStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import nexus.storage.projection_reconcile as mod
+
+    real = mod.reconcile_entry
+
+    def flaky(session: Any, md: FileMetadata, **kw: Any) -> str:
+        if md.path == "/ws/bad":
+            raise RuntimeError("boom")
+        return real(session, md, **kw)
+
+    monkeypatch.setattr(mod, "reconcile_entry", flaky)
+    fs = _FakeFS([_entry("/ws/bad", "cb"), _entry("/ws/good", "cg")])
+    report = reconcile_projection(
+        nexus_fs=fs, session_factory=record_store.session_factory, prefix="/ws", zone_id="eng"
+    )
+    assert report.errors == 1 and report.created == 1
+    assert report.error_messages == ["/ws/bad: boom"]
+    assert _versions(record_store, "/ws/good")

--- a/tests/unit/storage/test_write_observer_hooks_projection_seq.py
+++ b/tests/unit/storage/test_write_observer_hooks_projection_seq.py
@@ -1,0 +1,81 @@
+"""SyncAuditWriteInterceptor relays the observer's projection sequence (#4738)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from nexus.contracts.metadata import FileMetadata
+from nexus.contracts.vfs_hooks import (
+    DeleteHookContext,
+    RenameHookContext,
+    WriteBatchHookContext,
+    WriteHookContext,
+)
+from nexus.storage.write_observer_hooks import SyncAuditWriteInterceptor
+
+
+class _SeqObserver:
+    def __init__(self, seq: Any = 7) -> None:
+        self.seq = seq
+        self.calls: list[str] = []
+
+    def on_write(self, *_a: Any, **_k: Any) -> Any:
+        self.calls.append("write")
+        return self.seq
+
+    def on_delete(self, **_k: Any) -> Any:
+        self.calls.append("delete")
+        return self.seq
+
+    def on_rename(self, **_k: Any) -> Any:
+        self.calls.append("rename")
+        return self.seq
+
+    def on_write_batch(self, items: list[tuple[Any, bool]], **_k: Any) -> Any:
+        self.calls.append("write_batch")
+        return [100 + i for i, _ in enumerate(items)]
+
+
+def test_write_seq_is_stashed_on_ctx_extra() -> None:
+    hook = SyncAuditWriteInterceptor(_SeqObserver(seq=7))
+    ctx = WriteHookContext(path="/a", content=b"x", context=None)
+    hook.on_post_write(ctx)
+    assert ctx.extra["projection_seq"] == 7
+
+
+def test_none_seq_from_legacy_observer_leaves_extra_alone() -> None:
+    hook = SyncAuditWriteInterceptor(_SeqObserver(seq=None))
+    ctx = WriteHookContext(path="/a", content=b"x", context=None)
+    hook.on_post_write(ctx)
+    assert "projection_seq" not in ctx.extra
+
+
+def test_internal_pipe_paths_are_skipped() -> None:
+    obs = _SeqObserver()
+    hook = SyncAuditWriteInterceptor(obs)
+    ctx = WriteHookContext(path="/nexus/pipes/audit", content=b"x", context=None)
+    hook.on_post_write(ctx)
+    assert obs.calls == [] and ctx.extra == {}
+
+
+def test_delete_and_rename_seqs_are_stashed() -> None:
+    hook = SyncAuditWriteInterceptor(_SeqObserver(seq=9))
+    d = DeleteHookContext(path="/a", context=None)
+    hook.on_post_delete(d)
+    r = RenameHookContext(old_path="/a", new_path="/b", context=None)
+    hook.on_post_rename(r)
+    assert d.extra["projection_seq"] == 9 and r.extra["projection_seq"] == 9
+
+
+def test_batch_seqs_map_back_to_every_item_including_filtered_pipes() -> None:
+    hook = SyncAuditWriteInterceptor(_SeqObserver())
+    items = [
+        (FileMetadata(path="/a", size=1, content_id="ca"), True),
+        (FileMetadata(path="/nexus/pipes/p", size=1, content_id="cp"), True),
+        (FileMetadata(path="/b", size=1, content_id="cb"), False),
+    ]
+    ctx = WriteBatchHookContext(items=items, context=None, zone_id="z")
+    hook.on_post_write_batch(ctx)
+    # Pipe item is filtered before the observer sees the batch: it gets None
+    # and the others keep their observer-assigned sequences in order.
+    assert ctx.extra["projection_seqs"] == [100, None, 101]


### PR DESCRIPTION
## Summary

Closes #4738.

The RecordStore projections (`file_paths`, `version_history`, `operation_log`) rode a lossy 200 ms debounce over an in-memory `deque(maxlen=10_000)`: `list_versions` right after a write could be empty, bursts over 10k events silently dropped the oldest, a crash lost everything in flight, and readers had to call the admin-only `flush_write_observer`. This PR replaces that with a write-through contract plus a fence and a repair path.

- **Write-through group commit** (`storage/piped_record_store_write_observer.py`): a writer blocks until one committer thread has committed `operation_log` + `file_paths` + `version_history` for all waiting writers in a single transaction; only MCL rows and extraction/lineage hooks run deferred. `list_versions` immediately after a write returns the new version with no flush. One committer allocates `sequence_number`, so no MAX+1 retry storms.
- **Fence**: every mutation returns `projection_seq` (the row's `operation_log.sequence_number`) — `files/write`, `batch/write`, `delete`, `rename`, `rename-batch`, `mkdir`, the Python API (`write`/`sys_write`/`write_batch`/`sys_unlink`/`rmdir`/`sys_rename`/`mkdir`; `mkdir` used to return `None`), and the legacy `/api/nfs` + gRPC `Call` shapes. New `GET /api/v2/operations/wait?seq=N&timeout_ms=` answers 200 once committed in the caller's zone, 412 on timeout. CLI: `nexus ops wait --seq N`.
- **Never silent**: both queues are bounded; the deferred queue backpressures the committer for 2 s before shedding; every drop is an ERROR log plus `nexus_projection_events_dropped_total{queue}` (also `_failed_total`, `_write_through_timeouts_total`, `nexus_projection_pending_events{queue}`). `AuditConfig.strict_mode` (default on) is enforced again for this observer: a commit that fails after retries or is not confirmed within `NEXUS_PROJECTION_TIMEOUT_S` (5 s) raises `AuditLogError`; non-strict returns `projection_seq: null` and keeps the event queued.
- **Recovery**: `storage/projection_reconcile.py` + admin `POST /api/v2/admin/reconcile-projections` (`nexus admin fs reconcile-projections`) walks the kernel under a prefix and creates/repairs rows the projection lacks, keyed on the kernel `gen` now stored in `version_history.extra_metadata` (`content_id` is the path on path-addressed backends and never changes). Rows are matched by `virtual_path` across zones so a root admin never duplicates rows another zone's token wrote; `stale_kernel` reports a lagging follower instead of writing older content back; `retire_missing` is opt-in.
- Also fixed along the way: `mkdir` never dispatched its post-hook in remote mode (the subprocess kernel's `post_hook_needed` is always False there), so mkdir audit rows were never written — it now uses the same hook-count fallback `sys_rename` had.
- `tests/conftest.py` now defaults `NEXUS_ENABLE_WRITE_BUFFER=true` so the suite runs the production observer (the #3399 reason for forcing the synchronous one — a debounced observer with a background consumer per instance — no longer applies).
- Docs: `docs/architecture/record-store-projections.md` (contract, surfaces, verdict table, metrics, crash window), user-guide row, mkdocs nav, surface-coverage yaml.

## Acceptance (from the issue)

- **`kill -9` during a 20k-write burst loses zero `version_history` rows**: `tests/e2e/self_contained/test_projection_crash_recovery_e2e.py` boots a real `nexusd` + kernel, fires 20k writes from 8 threads, SIGKILLs the process group at 40%, restarts on the same data dir, reconciles, and compares path by path — 8,000 acked, 8,001 in the kernel (the one in-flight write), reconcile `created: 1`, zero mismatches. Repeated against the Docker stack (`docker kill -s KILL` on the nexus container mid-burst, `docker start`, reconcile): 8,017 acked / 8,018 in kernel / created 1 / second pass all in sync / 0 mismatches.
- **`list_versions` immediately after write returns the new version without `flush_write_observer`**: `tests/e2e/self_contained/test_projection_fence_live_e2e.py` (5 tests, real kernel) and the stack checks below.

## Test plan

- [x] Unit/integration: `tests/unit/storage/test_piped_record_store_write_observer.py` (rewritten: group commit, poison salvage, strict/non-strict timeout, bounded-queue drops), `tests/integration/storage/test_piped_write_observer_flush.py` (rewritten), new `test_projection_reconcile.py`, `test_write_observer_hooks_projection_seq.py`, `tests/unit/core/test_write_projection_seq.py`, `tests/unit/server/api/v2/test_operations_wait.py`, `test_admin_reconcile_projections.py`, `routers/test_files_write_projection_seq.py`, `tests/unit/server/test_kernel_syscall_projection_seq.py`, `tests/unit/cli/test_projection_cli.py`. Full `tests/unit` green under the new default (only the kernel-spawning parity tests error without a kernel binary on PATH). `tests/integration` failures are identical on develop's own code (verified via a temporary WIP commit + `git checkout develop -- src tests`), so none are introduced here.
- [x] Live against the real kernel: fence e2e 5/5, crash-recovery e2e 1/1 at 20k.
- [x] `nexus up --build` (Postgres, native search plugin host + mE5 embedder): `permissions_demo_enhanced.sh` all green; `scripts/test_build_perf_e2e.py` 30/30 with HERB 8/8; 23/23 #4738 surface checks (write/batch/delete/rename/mkdir seqs, wait 200/412, `list_versions` with no flush, legacy RPC shapes, reconcile dry-run over `/workspace` all in sync, `/metrics`); both new CLI commands from the host; container `kill -9` burst as above. Sequential write latency through the stack p50 25 ms / p95 64 ms.
- [x] ruff check / ruff format / mypy clean on every changed file; pre-commit hooks pass; surface-coverage yaml validates.

## Notes

- `strict_mode` was effectively dead for the default observer and is live again: a RecordStore outage now fails writes with `AuditLogError` instead of silently losing rows.
- Kernel subprocesses spawned by `create_nexus_fs` tests ignore SIGTERM and pile up as orphans; the crash harness SIGKILLs its process group on teardown (pre-existing test-hygiene issue elsewhere, not addressed here).
- `develop` moved by PR #4742 (search plugin) after this branch's base; no overlapping files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
