### PR TITLE
feat(rebac): sync owner grant, consistency=strong, targeted Tiger revocation, ReBAC-filtered readdir (#4739)

### DIFF
--- a/docs/architecture/rebac.md
+++ b/docs/architecture/rebac.md
@@ -246,3 +246,112 @@ self.rebac = EnhancedReBACManager(engine)
 | **Our changes apply to** | ✅ | ✅ (inherited) | ✅ (inherited) |
 
 **Bottom line:** Our changes to `ReBACManager` automatically improve all three classes! 🎉
+
+---
+
+## Permission caches, TTLs and consistency (Issue #4739)
+
+A permission decision (`check`, and the `filter_list` pass behind `list`,
+`glob`, `grep` and search) can be answered by several caches before the tuple
+store is consulted. Each cache has its own TTL and its own invalidation
+trigger, so the window between a tuple change and every surface reflecting it
+is the *longest* of the rows below unless the caller opts into
+`consistency=strong`.
+
+### Cache matrix
+
+| Layer | What it caches | Default TTL (env) | Written by | Invalidated by | Bypassed by `consistency=strong` |
+|---|---|---|---|---|---|
+| **Owner fast-path** (`PermissionEnforcer.check_owner`) | Nothing cached — compares `metadata.owner_id` to the subject on single-path `read`/`write`/`delete` | n/a | Kernel stamps `owner_id` on create | n/a | No (authoritative) |
+| **Permission lease** (`PermissionLeaseTable`) | A successful single-path check for `(path, agent_id)`; only agents (`context.agent_id`) get leases | 30 s | `RebacPermissionCheckHook` after a full check | `rebac_delete` → `CacheCoordinator.invalidate_for_write` (path-targeted for direct grants, zone-wide for group/inherited); agent termination | Yes |
+| **L1 result cache** (`ReBACPermissionCache`) | `(subject, permission, object, zone) → bool` | grants 300 s `NEXUS_CACHE_PERMISSION_TTL`; denials 60 s `NEXUS_CACHE_DENIAL_TTL`; tiered: owner 3600 s, editor/viewer 600 s, inherited 300 s | `rebac_check` (base path), `rebac_check_bulk`, eager recompute | Every `rebac_write` / `rebac_delete` for the touched subject and object (plus object prefix for file relations) | Yes |
+| **Boundary cache** (`PermissionBoundaryCache`) | Nearest ancestor that granted `permission` on a file path | process lifetime, revalidated against a direct-grant lookup on hit | `_check_rebac_*` when a parent granted | `rebac_write` / `rebac_delete` via boundary invalidators | Yes |
+| **Tiger bitmap** (`TigerCache`, PostgreSQL only) | Per `(subject, permission, resource_type)` roaring bitmap of accessible resources; L1 in-process, L2 Dragonfly, L3 table | 3600 s `NEXUS_CACHE_TIGER_TTL` (Dragonfly key TTL; L3 rows have none) | Write-through on `rebac_write` (`persist_single_grant`, Leopard-style directory expansion to descendants), background updater | `rebac_delete`: `persist_single_revoke` for the exact object; for a **directory** grant also `remove_directory_grant` + `tiger_invalidate_cache(subject, permission)` (drops L1+L2+L3); `invalidate_for_write` evicts L1/L2 for the subject in every process | Yes (`check`, `filter_list`, search predicate pushdown, directory visibility) |
+| **Bitmap completeness / Leopard dir index** (`PermissionCacheCoordinator`) | "This subject's bitmap is complete" and accessible-directory sets used by `filter_list` | 3600 s | `BulkReBACStrategy`, `HierarchyPreFilterStrategy` | `PermissionCacheCoordinator.invalidate` | Yes (strong chain skips both strategies) |
+| **Zone graph cache** | Tuple graph snapshot per zone for the Rust evaluator | until next write | graph loader | Every `rebac_write` / `rebac_delete` in the zone | n/a (always refreshed on write) |
+| **Deferred permission buffer** (`DeferredPermissionBuffer`) | Not a cache: hierarchy (`parent`) tuples waiting to be written | flushed every `PermissionConfig.deferred_flush_interval` (50 ms) or at 1000 items | `DeferredPermissionHook` on write/mkdir/write_batch | n/a | n/a — see "sync owner grant" |
+
+### Sync owner grant (read-your-writes for the creator)
+
+With `PermissionConfig.enable_deferred=True` (default) the hierarchy tuples for
+a new file are still batched, but since #4739 the creating subject's
+`direct_owner` tuple is written **synchronously** by `DeferredPermissionHook`
+(`rebac_write`, or `rebac_write_batch` for `write_batch`). The writer's own
+`check`, `list`, `glob`, `grep` and search therefore see the file as soon as
+the write returns; no flush or cache expiry is involved. If the synchronous
+write fails, the grant falls back to the deferred queue and the write result
+carries a `degraded` warning (`component=deferred_permission`).
+
+`PermissionConfig.sync_owner_grant=False` restores the pre-#4739 behaviour
+(owner grant deferred with the hierarchy tuples, up to `deferred_flush_interval`
+plus a possible 60 s cached denial before the writer's `list`/`search` see the
+file).
+
+The hook keys the grant on `WriteHookContext.is_new_file`. Over the kernel
+RPC the `WriteResponse` proto carries no `is_new`, so the Python kernel client
+derives it from the kernel's generation counter (`gen == 1` on the first write
+to a path, see `rust/kernel/src/kernel/io.rs`). Before #4739 the client
+hard-coded `is_new=False`, which silently disabled every creator grant in the
+subprocess-kernel deployment. The kernel also does not stamp
+`FileMetadata.owner_id` on write, so the O(1) owner fast-path never applies
+there; the creator's access comes from this tuple.
+
+### `consistency=strong`
+
+`strong` is the SpiceDB `fully_consistent` analog: for that one call no cached
+*allow* or *deny* may answer; the decision is resolved from the tuple store and
+the fresh result is written back to the caches (so a strong read also repairs a
+stale entry). `eventual` (the default) keeps today's cached behaviour.
+
+| Surface | How to request strong |
+|---|---|
+| HTTP (every route that builds an `OperationContext`: files, list/glob/grep, search, RPC) | `X-Nexus-Consistency: strong` header. Invalid values → `400`. |
+| `rebac_check` RPC / `ReBACService.rebac_check` / `rebac_check_sync` | `consistency="strong"` parameter (defaults to `context.consistency` for an `OperationContext`) |
+| `rebac_check_batch` RPC / `ReBACService.rebac_check_batch` / `rebac_check_batch_sync` | `consistency="strong"` parameter (applies to every check in the batch) |
+| `ReBACManager.rebac_check` / `rebac_check_bulk` / `rebac_check_batch` / `rebac_check_batch_fast` | `consistency="strong"` keyword |
+| `NexusFS.sys_readdir` (behind `/v2/files/list`) | `OperationContext.consistency = "strong"` (non-admin callers; see "Listing surfaces") |
+| `PermissionEnforcer.check` / `filter_list` / `has_accessible_descendants*` | `OperationContext.consistency = "strong"` |
+| `PermissionEnforcer.filter_search_results` | `consistency="strong"` keyword |
+| `SearchService.list` | `OperationContext.consistency = "strong"` (skips Tiger predicate pushdown) |
+
+Cost: a strong `check` is one graph evaluation (Rust) instead of a cache hit;
+a strong `list` of N paths is one `rebac_check_bulk` over N paths plus
+ancestors instead of a bitmap scan. Use it for read-after-write and
+post-revocation verification, not for hot paths.
+
+### Revocation bound
+
+`rebac_delete` invalidates, in this order: zone graph → `CacheCoordinator.invalidate_for_write`
+(L1, Tiger L1/L2 eviction, permission leases, boundary and directory-visibility
+caches, iterator cache, DT_STREAM / Pub/Sub / durable-stream hints for other
+processes and zones) → Tiger write-through revoke (and bitmap drop for
+directory grants) → Leopard closure → L1 subject/object. A revoked subject is
+therefore denied on the next `check`, and excluded from the next `list` /
+`search`, as soon as the delete returns in the deleting process; other
+processes converge when they consume the stream/Pub/Sub hint (or, without a
+Dragonfly/NATS bus, on the L1/Tiger TTLs above). `rebac_write` does not run the
+coordinator path: a new tuple cannot make a cached allow wrong, so grants keep
+the cheap write-through path.
+
+The server-side distributed lease invalidator (`DistributedLeaseManager`,
+registered in `server/lifespan/permissions.py`) is one of those lease
+callbacks: on every revoke it schedules a zone-wide sweep of `lease:<zone>:*`
+keys in Dragonfly. Before #4739 its callback took a single argument and raised
+on every notification, so it never actually ran.
+
+### Listing surfaces
+
+`sys_readdir` (the kernel syscall behind `/v2/files/list`, the CLI listing and
+`NexusFS.sys_readdir`) applied zone filtering only until #4739, so a non-admin
+key could enumerate the names of files it cannot read. It now runs the same
+ReBAC post-filter as the search service for non-admin, non-system callers:
+files through `PermissionEnforcer.filter_list` (which honours
+`OperationContext.consistency`), directories through
+`has_accessible_descendants_batch` (visible when the caller can reach a
+descendant; indeterminate directories stay visible, matching `SearchService`).
+Admin and system listings are unchanged here; admin zone scoping is #4740. If
+enforcement is on but the permission enforcer is unavailable the listing is
+empty (fail-closed), mirroring the read path.
+
+The data-visibility side of read-after-write (the raft `gen` revision token,
+`X-Nexus-Min-Revision`) is a separate contract tracked in #4737.

--- a/docs/surface-coverage/api-rpc-surface-coverage.yaml
+++ b/docs/surface-coverage/api-rpc-surface-coverage.yaml
@@ -1775,7 +1775,7 @@ operations:
   transports:
     grpc_expose:
       name: backfill_directory_index
-      source: src/nexus/core/nexus_fs_metadata.py:2078
+      source: src/nexus/core/nexus_fs_metadata.py:2109
     sdk:
       name: MCPClient.backfill_directory_index
       source: src/nexus/remote/domain/mcp.py:91
@@ -2217,7 +2217,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.count_by_state
-      source: src/nexus/remote/kernel_client.py:1660
+      source: src/nexus/remote/kernel_client.py:1667
   profiles:
     lite: supported
     sandbox: supported
@@ -2525,7 +2525,7 @@ operations:
   transports:
     grpc_expose:
       name: delete_batch
-      source: src/nexus/core/nexus_fs_metadata.py:1464
+      source: src/nexus/core/nexus_fs_metadata.py:1465
   profiles:
     lite: supported
     sandbox: supported
@@ -2881,7 +2881,7 @@ operations:
   transports:
     grpc_expose:
       name: exists_batch
-      source: src/nexus/core/nexus_fs_metadata.py:1359
+      source: src/nexus/core/nexus_fs_metadata.py:1360
     sdk:
       name: KernelClient.exists_batch
       source: src/nexus/remote/kernel_client.py:815
@@ -3412,7 +3412,7 @@ operations:
       source: src/nexus/server/_kernel_syscall_dispatch.py:52
     grpc_expose:
       name: list
-      source: src/nexus/bricks/search/search_service.py:480
+      source: src/nexus/bricks/search/search_service.py:481
   profiles:
     lite: supported
     sandbox: supported
@@ -3741,7 +3741,7 @@ operations:
       source: src/nexus/cli/commands/file_ops.py:1
     grpc_expose:
       name: stat
-      source: src/nexus/core/nexus_fs_metadata.py:1139
+      source: src/nexus/core/nexus_fs_metadata.py:1140
   profiles:
     lite: supported
     sandbox: supported
@@ -3868,7 +3868,7 @@ operations:
   transports:
     grpc_expose:
       name: flush_write_observer
-      source: src/nexus/core/nexus_fs_metadata.py:2108
+      source: src/nexus/core/nexus_fs_metadata.py:2139
   profiles:
     lite: supported
     sandbox: supported
@@ -3970,7 +3970,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.get
-      source: src/nexus/remote/kernel_client.py:1607
+      source: src/nexus/remote/kernel_client.py:1614
   profiles:
     lite: supported
     sandbox: supported
@@ -3987,7 +3987,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.heartbeat
-      source: src/nexus/remote/kernel_client.py:1633
+      source: src/nexus/remote/kernel_client.py:1640
   profiles:
     lite: supported
     sandbox: supported
@@ -4072,7 +4072,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.register
-      source: src/nexus/remote/kernel_client.py:1568
+      source: src/nexus/remote/kernel_client.py:1575
   profiles:
     lite: supported
     sandbox: supported
@@ -4140,7 +4140,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.signal
-      source: src/nexus/remote/kernel_client.py:1610
+      source: src/nexus/remote/kernel_client.py:1617
   profiles:
     lite: supported
     sandbox: supported
@@ -4225,7 +4225,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.unregister
-      source: src/nexus/remote/kernel_client.py:1601
+      source: src/nexus/remote/kernel_client.py:1608
   profiles:
     lite: supported
     sandbox: supported
@@ -4339,7 +4339,7 @@ operations:
   transports:
     grpc_expose:
       name: get_content_id
-      source: src/nexus/core/nexus_fs_metadata.py:628
+      source: src/nexus/core/nexus_fs_metadata.py:629
     sdk:
       name: KernelClient.get_content_id
       source: src/nexus/remote/kernel_client.py:806
@@ -4359,7 +4359,7 @@ operations:
   transports:
     grpc_expose:
       name: get_dynamic_viewer_config
-      source: src/nexus/bricks/rebac/rebac_service.py:1597
+      source: src/nexus/bricks/rebac/rebac_service.py:1607
   profiles:
     lite: supported
     sandbox: supported
@@ -4427,7 +4427,7 @@ operations:
   transports:
     grpc_expose:
       name: get_namespace
-      source: src/nexus/bricks/rebac/rebac_service.py:1083
+      source: src/nexus/bricks/rebac/rebac_service.py:1093
   profiles:
     lite: supported
     sandbox: supported
@@ -4478,7 +4478,7 @@ operations:
   transports:
     grpc_expose:
       name: get_rebac_option
-      source: src/nexus/bricks/rebac/rebac_service.py:991
+      source: src/nexus/bricks/rebac/rebac_service.py:1001
   profiles:
     lite: supported
     sandbox: supported
@@ -4529,7 +4529,7 @@ operations:
   transports:
     grpc_expose:
       name: get_top_level_mounts
-      source: src/nexus/core/nexus_fs_metadata.py:269
+      source: src/nexus/core/nexus_fs_metadata.py:270
     sdk:
       name: KernelClient.get_top_level_mounts
       source: src/nexus/remote/kernel_client.py:827
@@ -4601,7 +4601,7 @@ operations:
   transports:
     grpc_expose:
       name: glob_batch
-      source: src/nexus/bricks/search/search_service.py:2061
+      source: src/nexus/bricks/search/search_service.py:2076
   profiles:
     lite: supported
     sandbox: supported
@@ -4687,7 +4687,7 @@ operations:
   transports:
     grpc_expose:
       name: grant_consent
-      source: src/nexus/bricks/rebac/rebac_service.py:1210
+      source: src/nexus/bricks/rebac/rebac_service.py:1220
   profiles:
     lite: supported
     sandbox: supported
@@ -5012,7 +5012,7 @@ operations:
   transports:
     grpc_expose:
       name: initialize_semantic_search
-      source: src/nexus/bricks/search/search_service.py:4942
+      source: src/nexus/bricks/search/search_service.py:4957
   profiles:
     lite: supported
     sandbox: supported
@@ -5169,7 +5169,7 @@ operations:
       source: src/nexus/services/agents/agent_rpc_service.py:584
     sdk:
       name: _AgentRegistryProxy.list_agents
-      source: src/nexus/remote/kernel_client.py:1636
+      source: src/nexus/remote/kernel_client.py:1643
   profiles:
     lite: supported
     sandbox: supported
@@ -5187,7 +5187,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.list_by_priority
-      source: src/nexus/remote/kernel_client.py:1664
+      source: src/nexus/remote/kernel_client.py:1671
   profiles:
     lite: supported
     sandbox: supported
@@ -5260,7 +5260,7 @@ operations:
   transports:
     grpc_expose:
       name: list_incoming_shares
-      source: src/nexus/bricks/rebac/rebac_service.py:1539
+      source: src/nexus/bricks/rebac/rebac_service.py:1549
   profiles:
     lite: supported
     sandbox: supported
@@ -5315,7 +5315,7 @@ operations:
   transports:
     grpc_expose:
       name: list_outgoing_shares
-      source: src/nexus/bricks/rebac/rebac_service.py:1489
+      source: src/nexus/bricks/rebac/rebac_service.py:1499
   profiles:
     lite: supported
     sandbox: supported
@@ -5332,7 +5332,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.list_processes
-      source: src/nexus/remote/kernel_client.py:1639
+      source: src/nexus/remote/kernel_client.py:1646
   profiles:
     lite: supported
     sandbox: supported
@@ -5523,7 +5523,7 @@ operations:
   transports:
     grpc_expose:
       name: make_private
-      source: src/nexus/bricks/rebac/rebac_service.py:1292
+      source: src/nexus/bricks/rebac/rebac_service.py:1302
   profiles:
     lite: supported
     sandbox: supported
@@ -5540,7 +5540,7 @@ operations:
   transports:
     grpc_expose:
       name: make_public
-      source: src/nexus/bricks/rebac/rebac_service.py:1273
+      source: src/nexus/bricks/rebac/rebac_service.py:1283
   profiles:
     lite: supported
     sandbox: supported
@@ -5746,7 +5746,7 @@ operations:
   transports:
     grpc_expose:
       name: metadata_batch
-      source: src/nexus/core/nexus_fs_metadata.py:1369
+      source: src/nexus/core/nexus_fs_metadata.py:1370
   profiles:
     lite: supported
     sandbox: supported
@@ -5940,7 +5940,7 @@ operations:
   transports:
     grpc_expose:
       name: namespace_delete
-      source: src/nexus/bricks/rebac/rebac_service.py:1128
+      source: src/nexus/bricks/rebac/rebac_service.py:1138
   profiles:
     lite: supported
     sandbox: supported
@@ -5957,7 +5957,7 @@ operations:
   transports:
     grpc_expose:
       name: namespace_list
-      source: src/nexus/bricks/rebac/rebac_service.py:1104
+      source: src/nexus/bricks/rebac/rebac_service.py:1114
   profiles:
     lite: supported
     sandbox: supported
@@ -7024,7 +7024,7 @@ operations:
   transports:
     grpc_expose:
       name: read_with_dynamic_viewer
-      source: src/nexus/bricks/rebac/rebac_service.py:1688
+      source: src/nexus/bricks/rebac/rebac_service.py:1698
   profiles:
     lite: supported
     sandbox: supported
@@ -7077,7 +7077,7 @@ operations:
   transports:
     grpc_expose:
       name: rebac_check
-      source: src/nexus/bricks/rebac/rebac_service.py:427
+      source: src/nexus/bricks/rebac/rebac_service.py:428
   profiles:
     lite: supported
     sandbox: supported
@@ -7094,7 +7094,7 @@ operations:
   transports:
     grpc_expose:
       name: rebac_check_batch
-      source: src/nexus/bricks/rebac/rebac_service.py:650
+      source: src/nexus/bricks/rebac/rebac_service.py:655
   profiles:
     lite: supported
     sandbox: supported
@@ -7128,7 +7128,7 @@ operations:
   transports:
     grpc_expose:
       name: rebac_create
-      source: src/nexus/bricks/rebac/rebac_service.py:212
+      source: src/nexus/bricks/rebac/rebac_service.py:213
   profiles:
     lite: supported
     sandbox: supported
@@ -7145,7 +7145,7 @@ operations:
   transports:
     grpc_expose:
       name: rebac_delete
-      source: src/nexus/bricks/rebac/rebac_service.py:756
+      source: src/nexus/bricks/rebac/rebac_service.py:766
   profiles:
     lite: supported
     sandbox: supported
@@ -7162,7 +7162,7 @@ operations:
   transports:
     grpc_expose:
       name: rebac_expand
-      source: src/nexus/bricks/rebac/rebac_service.py:514
+      source: src/nexus/bricks/rebac/rebac_service.py:519
   profiles:
     lite: supported
     sandbox: supported
@@ -7179,7 +7179,7 @@ operations:
   transports:
     grpc_expose:
       name: rebac_expand_with_privacy
-      source: src/nexus/bricks/rebac/rebac_service.py:1163
+      source: src/nexus/bricks/rebac/rebac_service.py:1173
   profiles:
     lite: supported
     sandbox: supported
@@ -7197,7 +7197,7 @@ operations:
   transports:
     grpc_expose:
       name: rebac_explain
-      source: src/nexus/bricks/rebac/rebac_service.py:570
+      source: src/nexus/bricks/rebac/rebac_service.py:575
   profiles:
     lite: supported
     sandbox: supported
@@ -7214,7 +7214,7 @@ operations:
   transports:
     grpc_expose:
       name: rebac_list_objects
-      source: src/nexus/bricks/rebac/rebac_service.py:899
+      source: src/nexus/bricks/rebac/rebac_service.py:909
   profiles:
     lite: supported
     sandbox: supported
@@ -7231,7 +7231,7 @@ operations:
   transports:
     grpc_expose:
       name: rebac_list_tuples
-      source: src/nexus/bricks/rebac/rebac_service.py:798
+      source: src/nexus/bricks/rebac/rebac_service.py:808
   profiles:
     lite: supported
     sandbox: supported
@@ -7283,7 +7283,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.register_external
-      source: src/nexus/remote/kernel_client.py:1571
+      source: src/nexus/remote/kernel_client.py:1578
   profiles:
     lite: supported
     sandbox: supported
@@ -7317,7 +7317,7 @@ operations:
   transports:
     grpc_expose:
       name: register_namespace
-      source: src/nexus/bricks/rebac/rebac_service.py:1022
+      source: src/nexus/bricks/rebac/rebac_service.py:1032
   profiles:
     lite: supported
     sandbox: supported
@@ -7371,7 +7371,7 @@ operations:
   transports:
     grpc_expose:
       name: rename_batch
-      source: src/nexus/core/nexus_fs_metadata.py:1603
+      source: src/nexus/core/nexus_fs_metadata.py:1604
   profiles:
     lite: supported
     sandbox: supported
@@ -7408,7 +7408,7 @@ operations:
   transports:
     grpc_expose:
       name: revoke_consent
-      source: src/nexus/bricks/rebac/rebac_service.py:1238
+      source: src/nexus/bricks/rebac/rebac_service.py:1248
   profiles:
     lite: supported
     sandbox: supported
@@ -7459,7 +7459,7 @@ operations:
   transports:
     grpc_expose:
       name: revoke_share
-      source: src/nexus/bricks/rebac/rebac_service.py:1401
+      source: src/nexus/bricks/rebac/rebac_service.py:1411
   profiles:
     lite: supported
     sandbox: supported
@@ -7476,7 +7476,7 @@ operations:
   transports:
     grpc_expose:
       name: revoke_share_by_id
-      source: src/nexus/bricks/rebac/rebac_service.py:1465
+      source: src/nexus/bricks/rebac/rebac_service.py:1475
   profiles:
     lite: supported
     sandbox: supported
@@ -7747,7 +7747,7 @@ operations:
       source: src/nexus/cli/commands/search.py:1
     grpc_expose:
       name: glob
-      source: src/nexus/bricks/search/search_service.py:1808
+      source: src/nexus/bricks/search/search_service.py:1823
     http:
       name: POST /api/v2/search/glob
       source: src/nexus/server/api/v2/routers/search.py:1694
@@ -7774,7 +7774,7 @@ operations:
       source: src/nexus/cli/commands/search.py:1
     grpc_expose:
       name: grep
-      source: src/nexus/bricks/search/search_service.py:2118
+      source: src/nexus/bricks/search/search_service.py:2133
     http:
       name: POST /api/v2/search/grep
       source: src/nexus/server/api/v2/routers/search.py:1555
@@ -7968,7 +7968,7 @@ operations:
   transports:
     grpc_expose:
       name: semantic_search
-      source: src/nexus/bricks/search/search_service.py:4449
+      source: src/nexus/bricks/search/search_service.py:4464
     mcp:
       name: nexus_semantic_search
       source: src/nexus/config/tool_profiles.yaml:1
@@ -7989,7 +7989,7 @@ operations:
   transports:
     grpc_expose:
       name: semantic_search_index
-      source: src/nexus/bricks/search/search_service.py:4800
+      source: src/nexus/bricks/search/search_service.py:4815
   profiles:
     lite: supported
     sandbox: supported
@@ -8006,7 +8006,7 @@ operations:
   transports:
     grpc_expose:
       name: semantic_search_stats
-      source: src/nexus/bricks/search/search_service.py:4894
+      source: src/nexus/bricks/search/search_service.py:4909
   profiles:
     lite: supported
     sandbox: supported
@@ -8210,7 +8210,7 @@ operations:
   transports:
     grpc_expose:
       name: set_rebac_option
-      source: src/nexus/bricks/rebac/rebac_service.py:954
+      source: src/nexus/bricks/rebac/rebac_service.py:964
   profiles:
     lite: supported
     sandbox: supported
@@ -8261,7 +8261,7 @@ operations:
   transports:
     grpc_expose:
       name: share_with_group
-      source: src/nexus/bricks/rebac/rebac_service.py:1364
+      source: src/nexus/bricks/rebac/rebac_service.py:1374
   profiles:
     lite: supported
     sandbox: supported
@@ -8278,7 +8278,7 @@ operations:
   transports:
     grpc_expose:
       name: share_with_user
-      source: src/nexus/bricks/rebac/rebac_service.py:1327
+      source: src/nexus/bricks/rebac/rebac_service.py:1337
   profiles:
     lite: supported
     sandbox: supported
@@ -8521,7 +8521,7 @@ operations:
   transports:
     grpc_expose:
       name: stat_bulk
-      source: src/nexus/core/nexus_fs_metadata.py:1227
+      source: src/nexus/core/nexus_fs_metadata.py:1228
   profiles:
     lite: supported
     sandbox: supported
@@ -9393,7 +9393,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.unregister_external
-      source: src/nexus/remote/kernel_client.py:1604
+      source: src/nexus/remote/kernel_client.py:1611
   profiles:
     lite: supported
     sandbox: supported
@@ -9482,7 +9482,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.update_state
-      source: src/nexus/remote/kernel_client.py:1622
+      source: src/nexus/remote/kernel_client.py:1629
   profiles:
     lite: supported
     sandbox: supported

--- a/src/nexus/bricks/rebac/batch/bulk_checker.py
+++ b/src/nexus/bricks/rebac/batch/bulk_checker.py
@@ -25,7 +25,7 @@ from nexus.bricks.rebac.domain import WILDCARD_SUBJECT, Entity
 from nexus.bricks.rebac.graph._operators import parent_path_of
 from nexus.bricks.rebac.path_patterns import is_path_pattern, path_pattern_candidates
 from nexus.contracts.constants import ROOT_ZONE_ID
-from nexus.contracts.rebac_types import CROSS_ZONE_ALLOWED_RELATIONS
+from nexus.contracts.rebac_types import CROSS_ZONE_ALLOWED_RELATIONS, is_strong_consistency
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -107,6 +107,7 @@ class BulkPermissionChecker:
         self,
         checks: list[tuple[tuple[str, str], str, tuple[str, str]]],
         zone_id: str,
+        consistency: Any = None,
     ) -> dict[tuple[tuple[str, str], str, tuple[str, str]], bool]:
         """Check permissions for multiple (subject, permission, object) tuples in batch.
 
@@ -118,11 +119,14 @@ class BulkPermissionChecker:
         3. Runs permission checks against the cached graph
         4. Returns all results in a single call
 
-        Always uses cached (eventual) consistency.
+        Uses cached (eventual) consistency by default.  ``consistency="strong"``
+        (Issue #4739) skips Phase 0 (L1) and Phase 0.5 (Tiger) so every check
+        is resolved from the tuple store; results are still written to L1.
 
         Args:
             checks: List of (subject, permission, object) tuples to check
             zone_id: Zone ID to scope all checks
+            consistency: ``None`` / ``"eventual"`` (cached) or ``"strong"``
 
         Returns:
             Dict mapping each check tuple to its result (True/False)
@@ -158,15 +162,20 @@ class BulkPermissionChecker:
         results: dict[tuple[tuple[str, str], str, tuple[str, str]], bool] = {}
         cache_misses: list[tuple[tuple[str, str], str, tuple[str, str]]] = []
 
-        # PHASE 0: L1 in-memory cache
-        cache_misses = self._phase_l1_cache(checks, zone_id, results, bulk_start)
-        if not cache_misses:
-            return results
+        if is_strong_consistency(consistency):
+            # Issue #4739: strong consistency — no cached allow/deny may answer.
+            logger.debug("[BULK] strong consistency: skipping L1 and Tiger phases")
+            cache_misses = list(checks)
+        else:
+            # PHASE 0: L1 in-memory cache
+            cache_misses = self._phase_l1_cache(checks, zone_id, results, bulk_start)
+            if not cache_misses:
+                return results
 
-        # PHASE 0.5: Tiger Cache
-        cache_misses = self._phase_tiger_cache(cache_misses, zone_id, results, bulk_start)
-        if not cache_misses:
-            return results
+            # PHASE 0.5: Tiger Cache
+            cache_misses = self._phase_tiger_cache(cache_misses, zone_id, results, bulk_start)
+            if not cache_misses:
+                return results
 
         logger.debug(f"Cache misses: {len(cache_misses)}, fetching tuples in bulk")
 

--- a/src/nexus/bricks/rebac/cache/result_cache.py
+++ b/src/nexus/bricks/rebac/cache/result_cache.py
@@ -906,12 +906,17 @@ class ReBACPermissionCache:
             self._entry_metadata[key] = (time.time(), jittered_ttl, delta, current_revision)
 
             # Route to appropriate cache based on result (Issue #877)
-            # Grants get longer TTL, denials get shorter TTL for security
+            # Grants get longer TTL, denials get shorter TTL for security.
+            # Issue #4739: a fresh result must supersede a stale entry of the
+            # opposite polarity — get() consults the grant cache first, so a
+            # stale True would otherwise outlive a freshly computed False.
             if result:
+                self._denial_cache.pop(key, None)
                 self._grant_cache[key] = result
                 if self._enable_metrics:
                     self._grant_sets += 1
             else:
+                self._grant_cache.pop(key, None)
                 self._denial_cache[key] = result
                 if self._enable_metrics:
                     self._denial_sets += 1

--- a/src/nexus/bricks/rebac/deferred_permission_hook.py
+++ b/src/nexus/bricks/rebac/deferred_permission_hook.py
@@ -1,14 +1,28 @@
-"""VFS hooks for deferred permission buffer (Issue #1773, #1682).
+"""VFS hooks for deferred permission buffer (Issue #1773, #1682, #4739).
 
-Wraps ``DeferredPermissionBuffer.queue_hierarchy()`` /
-``queue_owner_grant()`` as proper KernelDispatch hooks, eliminating
-direct kernel coupling to the deferred permission buffer.
+Wraps ``DeferredPermissionBuffer.queue_hierarchy()`` as a proper
+KernelDispatch hook, eliminating direct kernel coupling to the deferred
+permission buffer.
+
+Issue #4739 — sync owner grant:
+    The creating subject's ``direct_owner`` grant is written **synchronously**
+    through ``rebac_manager.rebac_write()`` (``rebac_write_batch()`` for
+    ``write_batch``) so the writer's own ``list`` / ``search`` / ``check`` see
+    the new file immediately.  Only the hierarchy (``parent``) tuples stay
+    deferred: they serve sharing and inheritance, which carry no
+    read-your-writes expectation.  If the synchronous write fails, the grant
+    falls back to the deferred queue and the operation carries a ``degraded``
+    warning instead of failing the write.
+
+    ``sync_owner_grant=False`` restores the pre-#4739 behaviour (owner grant
+    queued alongside the hierarchy tuples, flushed every
+    ``deferred_flush_interval`` seconds).
 
 Data mapping:
     ctx.path          → path
     ctx.zone_id       → zone_id (default "root")
     ctx.context       → OperationContext (user_id, is_system)
-    ctx.is_new_file   → only queue_owner_grant for new files
+    ctx.is_new_file   → only grant ownership for new files
 
 For rename, we call ``rebac_manager.update_object_path()`` directly
 (not via the deferred buffer) because path updates must be immediate.
@@ -35,10 +49,10 @@ logger = logging.getLogger(__name__)
 
 
 class DeferredPermissionHook:
-    """Post-write/mkdir/write_batch/rename hook that queues hierarchy + owner grants."""
+    """Post-write/mkdir/write_batch/rename hook: deferred hierarchy + sync owner grant."""
 
     name = "deferred_permission"
-    __slots__ = ("_buf", "_rebac")
+    __slots__ = ("_buf", "_rebac", "_sync_owner_grant")
 
     # ── Hook spec (duck-typed) (Issue #1773) ──────────────────────────
 
@@ -52,63 +66,133 @@ class DeferredPermissionHook:
             rename_hooks=(self,),
         )
 
-    def __init__(self, deferred_buffer: Any, rebac_manager: Any | None = None) -> None:
+    def __init__(
+        self,
+        deferred_buffer: Any,
+        rebac_manager: Any | None = None,
+        *,
+        sync_owner_grant: bool = True,
+    ) -> None:
         self._buf = deferred_buffer
         self._rebac = rebac_manager
+        # Issue #4739: write the creator's owner grant synchronously.  Only
+        # possible when a rebac_manager is wired; otherwise fall back to queue.
+        self._sync_owner_grant = sync_owner_grant
+
+    # ── Shared helpers ────────────────────────────────────────────────
+
+    @staticmethod
+    def _warn(warnings: list[OperationWarning], message: str) -> None:
+        warnings.append(
+            OperationWarning(
+                severity="degraded",
+                component="deferred_permission",
+                message=message,
+            )
+        )
+
+    @staticmethod
+    def _grant_user(context: Any) -> str | None:
+        """Return the user to grant ownership to, or ``None`` for system/anonymous."""
+        if context is None:
+            return None
+        user = getattr(context, "user_id", None)
+        if user and not getattr(context, "is_system", False):
+            return str(user)
+        return None
+
+    def _queue_hierarchy(self, path: str, zone: str, warnings: list[OperationWarning]) -> None:
+        try:
+            self._buf.queue_hierarchy(path, zone)
+        except Exception as e:
+            self._warn(warnings, f"queue failed: {e}")
+
+    def _queue_owner_grant(
+        self, user: str, path: str, zone: str, warnings: list[OperationWarning]
+    ) -> None:
+        try:
+            self._buf.queue_owner_grant(user, path, zone)
+        except Exception as e:
+            self._warn(warnings, f"queue failed: {e}")
+
+    def _owner_grant(
+        self, user: str, path: str, zone: str, warnings: list[OperationWarning]
+    ) -> None:
+        """Grant ``direct_owner`` to *user* on *path* — sync first, queue as fallback."""
+        if self._sync_owner_grant and self._rebac is not None:
+            try:
+                self._rebac.rebac_write(
+                    subject=("user", user),
+                    relation="direct_owner",
+                    object=("file", path),
+                    zone_id=zone,
+                )
+                return
+            except Exception as e:
+                logger.warning("[deferred_permission] sync owner grant failed for %s: %s", path, e)
+                self._warn(warnings, f"sync owner grant failed, queued: {e}")
+        self._queue_owner_grant(user, path, zone, warnings)
+
+    def _owner_grants_batch(
+        self, user: str, paths: list[str], zone: str, warnings: list[OperationWarning]
+    ) -> None:
+        """Batch variant of :meth:`_owner_grant` for ``write_batch``."""
+        if not paths:
+            return
+        if self._sync_owner_grant and self._rebac is not None:
+            grants = [
+                {
+                    "subject": ("user", user),
+                    "relation": "direct_owner",
+                    "object": ("file", path),
+                    "zone_id": zone,
+                }
+                for path in paths
+            ]
+            try:
+                if hasattr(self._rebac, "rebac_write_batch"):
+                    self._rebac.rebac_write_batch(grants)
+                else:
+                    for grant in grants:
+                        self._rebac.rebac_write(**grant)
+                return
+            except Exception as e:
+                logger.warning(
+                    "[deferred_permission] sync owner grant batch failed (%d paths): %s",
+                    len(paths),
+                    e,
+                )
+                self._warn(warnings, f"sync owner grant batch failed, queued: {e}")
+        for path in paths:
+            self._queue_owner_grant(user, path, zone, warnings)
 
     # ── Hook callbacks ────────────────────────────────────────────────
 
     def on_post_write(self, ctx: WriteHookContext) -> None:
         zone = ctx.zone_id or ROOT_ZONE_ID
-        try:
-            self._buf.queue_hierarchy(ctx.path, zone)
-            if ctx.is_new_file and ctx.context:
-                user = ctx.context.user_id
-                if user and not ctx.context.is_system:
-                    self._buf.queue_owner_grant(user, ctx.path, zone)
-        except Exception as e:
-            ctx.warnings.append(
-                OperationWarning(
-                    severity="degraded",
-                    component="deferred_permission",
-                    message=f"queue failed: {e}",
-                )
-            )
+        self._queue_hierarchy(ctx.path, zone, ctx.warnings)
+        if ctx.is_new_file:
+            user = self._grant_user(ctx.context)
+            if user:
+                self._owner_grant(user, ctx.path, zone, ctx.warnings)
 
     def on_post_mkdir(self, ctx: MkdirHookContext) -> None:
         zone = ctx.zone_id or ROOT_ZONE_ID
-        try:
-            self._buf.queue_hierarchy(ctx.path, zone)
-            if ctx.context:
-                user = ctx.context.user_id
-                if user and not ctx.context.is_system:
-                    self._buf.queue_owner_grant(user, ctx.path, zone)
-        except Exception as e:
-            ctx.warnings.append(
-                OperationWarning(
-                    severity="degraded",
-                    component="deferred_permission",
-                    message=f"queue failed: {e}",
-                )
-            )
+        self._queue_hierarchy(ctx.path, zone, ctx.warnings)
+        user = self._grant_user(ctx.context)
+        if user:
+            self._owner_grant(user, ctx.path, zone, ctx.warnings)
 
     def on_post_write_batch(self, ctx: WriteBatchHookContext) -> None:
         zone = ctx.zone_id or ROOT_ZONE_ID
-        try:
-            for meta, is_new in ctx.items:
-                self._buf.queue_hierarchy(meta.path, zone)
-                if is_new and ctx.context:
-                    user = ctx.context.user_id
-                    if user and not ctx.context.is_system:
-                        self._buf.queue_owner_grant(user, meta.path, zone)
-        except Exception as e:
-            ctx.warnings.append(
-                OperationWarning(
-                    severity="degraded",
-                    component="deferred_permission",
-                    message=f"queue failed: {e}",
-                )
-            )
+        new_paths: list[str] = []
+        for meta, is_new in ctx.items:
+            self._queue_hierarchy(meta.path, zone, ctx.warnings)
+            if is_new:
+                new_paths.append(meta.path)
+        user = self._grant_user(ctx.context)
+        if user and new_paths:
+            self._owner_grants_batch(user, new_paths, zone, ctx.warnings)
 
     def on_post_rename(self, ctx: RenameHookContext) -> None:
         if self._rebac is None:

--- a/src/nexus/bricks/rebac/enforcer.py
+++ b/src/nexus/bricks/rebac/enforcer.py
@@ -13,6 +13,7 @@ from sqlalchemy.exc import OperationalError
 
 from nexus.contracts.constants import ROOT_ZONE_ID, SYSTEM_PATH_PREFIX
 from nexus.contracts.protocols.activity import EventKind, Result, emit
+from nexus.contracts.rebac_types import is_strong_consistency
 from nexus.contracts.types import OperationContext, Permission
 
 
@@ -293,6 +294,9 @@ class PermissionEnforcer:
             return {}
 
         start = time.time()
+        # Issue #4739: under strong consistency a Tiger miss is "unknown", not
+        # "denied" — misses are confirmed from the tuple store below.
+        strong = is_strong_consistency(getattr(context, "consistency", None))
         tiger_cache = getattr(self.rebac_manager, "_tiger_cache", None)
         if tiger_cache is None:
             logger.debug("[BATCH-OPT] No Tiger cache, returning all True (fallback)")
@@ -339,12 +343,16 @@ class PermissionEnforcer:
                     f"[BATCH-OPT] No bitmap for {subject_type}:{subject_id}, "
                     f"returning all False for {len(prefixes)} prefixes (fail-closed)"
                 )
+                if strong:
+                    return self._authoritative_prefix_visibility(prefixes, context)
                 return dict.fromkeys(prefixes, False)
 
             if not accessible_paths:
                 if fully_resolved:
                     if logger.isEnabledFor(logging.DEBUG):
                         logger.debug(f"[BATCH-OPT] Empty paths for {subject_type}:{subject_id}")
+                    if strong:
+                        return self._authoritative_prefix_visibility(prefixes, context)
                     return dict.fromkeys(prefixes, False)
                 # All-orphan: indeterminate. Drop False entries so the
                 # caller (search_service uses dict.get(prefix, True)) falls
@@ -370,6 +378,18 @@ class PermissionEnforcer:
                 # to "include" (matches search_service.py:1027 semantics).
                 results = {k: v for k, v in results.items() if v}
 
+            if strong:
+                # Issue #4739: a bitmap miss may be stale-negative (directory
+                # created moments ago, grant not yet materialised).  Confirm the
+                # misses from the tuple store; Tiger's True answers are kept.
+                unresolved = [p for p in prefixes if not results.get(p, False)]
+                if unresolved:
+                    for prefix, visible in self._authoritative_prefix_visibility(
+                        unresolved, context
+                    ).items():
+                        if visible:
+                            results[prefix] = True
+
             elapsed = (time.time() - start) * 1000
             found_count = sum(1 for v in results.values() if v)
             logger.debug(
@@ -391,6 +411,50 @@ class PermissionEnforcer:
             )
             # Fail-closed: deny access on error (security-critical)
             return dict.fromkeys(prefixes, False)
+
+    def _authoritative_prefix_visibility(
+        self,
+        prefixes: list[str],
+        context: OperationContext,
+    ) -> dict[str, bool]:
+        """Resolve directory visibility from the tuple store (Issue #4739).
+
+        A prefix is visible when the subject can READ the directory itself or
+        one of its ancestors — the same checks ``filter_list`` runs for a
+        file, issued with ``consistency="strong"``.  Grants that exist only on
+        deeper descendants are not discovered here (that remains Tiger's job),
+        so callers use this to confirm a Tiger *miss*, never to override a hit.
+        Fails closed on error.
+        """
+        if not prefixes:
+            return {}
+        if self.rebac_manager is None:
+            return dict.fromkeys(prefixes, False)
+
+        from nexus.bricks.rebac.permission_filter_chain import _dedupe_checks_by_path
+
+        subject = context.get_subject()
+        zone_id = context.zone_id or ROOT_ZONE_ID
+        dir_paths = [p.rstrip("/") or "/" for p in prefixes]
+        checks_by_path, checks = _dedupe_checks_by_path(subject, dir_paths)
+        try:
+            results = self.rebac_manager.rebac_check_bulk(
+                checks, zone_id=zone_id, consistency="strong"
+            )
+        except Exception:
+            logger.warning(
+                "[BATCH-OPT] authoritative prefix visibility failed for zone=%s subject=%s; "
+                "returning all False (fail-closed)",
+                zone_id,
+                subject,
+                exc_info=True,
+            )
+            return dict.fromkeys(prefixes, False)
+
+        return {
+            prefix: any(results.get(check, False) for check in checks_by_path[dir_path])
+            for prefix, dir_path in zip(prefixes, dir_paths, strict=True)
+        }
 
     def _effective_zone_perms(self, context: OperationContext) -> tuple:
         """Return the request's effective zone_perms from context directly.
@@ -689,16 +753,30 @@ class PermissionEnforcer:
         # Threshold 3 avoids rebac_check_bulk SQLite race on some platforms.
         depth = object_id.count("/") if object_id else 0
 
+        # Issue #4739: honour the caller's consistency level (OperationContext).
+        consistency = getattr(context, "consistency", None)
+
         if depth <= SEQUENTIAL_DEPTH_THRESHOLD or permission_name not in (
             "read",
             "write",
             "traverse",
         ):
             return self._check_rebac_sequential(
-                subject, permission_name, object_type, object_id, zone_id
+                subject, permission_name, object_type, object_id, zone_id, consistency=consistency
             )
 
-        return self._check_rebac_batched(subject, permission_name, object_type, object_id, zone_id)
+        return self._check_rebac_batched(
+            subject, permission_name, object_type, object_id, zone_id, consistency=consistency
+        )
+
+    @staticmethod
+    def _check_kwargs(consistency: Any) -> dict[str, Any]:
+        """Extra kwargs for ``rebac_check`` / ``rebac_check_bulk`` (Issue #4739).
+
+        ``consistency`` is forwarded only when strong so managers and test
+        doubles without the parameter keep working for cached calls.
+        """
+        return {"consistency": consistency} if is_strong_consistency(consistency) else {}
 
     def _check_rebac_sequential(
         self,
@@ -707,13 +785,18 @@ class PermissionEnforcer:
         object_type: str,
         object_id: str,
         zone_id: str,
+        consistency: Any = None,
     ) -> bool:
         """Sequential permission check for shallow paths (depth <= 3).
 
         Performs direct check, TRAVERSE implication, boundary cache lookup,
         and parent walk one level at a time. Efficient when only 1-2 parents.
+        ``consistency="strong"`` (Issue #4739) skips the boundary cache and
+        is forwarded to every ``rebac_check`` so the manager skips its caches.
         """
         assert self.rebac_manager is not None  # guaranteed by _check_rebac guard
+        strong = is_strong_consistency(consistency)
+        check_kwargs = self._check_kwargs(consistency)
 
         # 1. Direct permission check
         result = self.rebac_manager.rebac_check(
@@ -721,6 +804,7 @@ class PermissionEnforcer:
             permission=permission_name,
             object=(object_type, object_id),
             zone_id=zone_id,
+            **check_kwargs,
         )
         if result:
             return True
@@ -733,6 +817,7 @@ class PermissionEnforcer:
                     permission=implied_perm,
                     object=(object_type, object_id),
                     zone_id=zone_id,
+                    **check_kwargs,
                 ):
                     logger.debug(
                         f"[_check_rebac] ALLOW TRAVERSE (has {implied_perm.upper()} permission)"
@@ -743,8 +828,8 @@ class PermissionEnforcer:
         if permission_name in ("read", "write", "traverse") and object_id:
             subject_type, subject_id = subject
 
-            # FAST PATH: Boundary cache (Issue #922)
-            if self._boundary_cache:
+            # FAST PATH: Boundary cache (Issue #922) — skipped under strong (#4739)
+            if self._boundary_cache and not strong:
                 boundary = self._boundary_cache.get_boundary(
                     zone_id, subject_type, subject_id, permission_name, object_id
                 )
@@ -776,6 +861,7 @@ class PermissionEnforcer:
                     permission=permission_name,
                     object=(object_type, parent_path),
                     zone_id=zone_id,
+                    **check_kwargs,
                 )
                 if parent_result:
                     if logger.isEnabledFor(logging.DEBUG):
@@ -803,19 +889,22 @@ class PermissionEnforcer:
         object_type: str,
         object_id: str,
         zone_id: str,
+        consistency: Any = None,
     ) -> bool:
         """Batch permission check for deep paths (depth > 2) (Issue #899).
 
         Collects all check variants (direct, implied TRAVERSE, all ancestors)
         and resolves them in a single rebac_check_bulk() call instead of O(D)
-        sequential queries.
+        sequential queries.  ``consistency="strong"`` (Issue #4739) skips the
+        boundary cache and is forwarded to ``rebac_check_bulk``.
         """
         assert self.rebac_manager is not None  # guaranteed by _check_rebac guard
 
         subject_type, subject_id = subject
+        strong = is_strong_consistency(consistency)
 
-        # FAST PATH: Boundary cache (Issue #922)
-        if self._boundary_cache:
+        # FAST PATH: Boundary cache (Issue #922) — skipped under strong (#4739)
+        if self._boundary_cache and not strong:
             boundary = self._boundary_cache.get_boundary(
                 zone_id, subject_type, subject_id, permission_name, object_id
             )
@@ -861,7 +950,9 @@ class PermissionEnforcer:
                     checks.append((subject, "write", (object_type, ancestor)))
 
         # ONE bulk call instead of O(D) sequential calls
-        results = self.rebac_manager.rebac_check_bulk(checks, zone_id=zone_id)
+        results = self.rebac_manager.rebac_check_bulk(
+            checks, zone_id=zone_id, **self._check_kwargs(consistency)
+        )
 
         # Process results: direct > implied > inherited (priority order)
         for check in checks:
@@ -1148,6 +1239,10 @@ class PermissionEnforcer:
         4. Zone pre-filter (cross-zone elimination)
         5. Bulk ReBAC (final fallback)
 
+        When ``context.consistency == "strong"`` (Issue #4739) only steps 4
+        and 5 run, with ``consistency="strong"`` forwarded to the bulk check,
+        so no Tiger / Leopard / L1 entry can answer for this call.
+
         Args:
             paths: List of paths to filter
             context: Operation context
@@ -1206,6 +1301,7 @@ class PermissionEnforcer:
                 cache=self._cache,
                 rebac_manager=self.rebac_manager,
                 dlc=self.dlc,
+                consistency=getattr(context, "consistency", None),
             )
 
             filtered = run_filter_chain(filter_ctx)
@@ -1232,6 +1328,7 @@ class PermissionEnforcer:
         user_id: str,
         zone_id: str,
         is_admin: bool = False,
+        consistency: str | None = None,
     ) -> list[str]:
         """Filter search result paths by read permission via bulk check.
 
@@ -1247,6 +1344,7 @@ class PermissionEnforcer:
             user_id: The authenticated user's ID
             zone_id: Zone ID for isolation
             is_admin: Whether the user is an admin (bypasses checks)
+            consistency: ``None`` / ``"eventual"`` or ``"strong"`` (Issue #4739)
 
         Returns:
             Filtered list of paths the user can read
@@ -1262,7 +1360,9 @@ class PermissionEnforcer:
             return []  # fail-closed: no manager = no access
 
         try:
-            return self._filter_search_bulk(paths, user_id=user_id, zone_id=zone_id)
+            return self._filter_search_bulk(
+                paths, user_id=user_id, zone_id=zone_id, consistency=consistency
+            )
         except Exception:
             logger.warning(
                 "filter_search_results failed, denying all (fail-closed)",
@@ -1276,6 +1376,7 @@ class PermissionEnforcer:
         *,
         user_id: str,
         zone_id: str,
+        consistency: str | None = None,
     ) -> list[str]:
         """Check only the given paths via the authoritative ReBAC bulk path."""
         from nexus.bricks.rebac.permission_filter_chain import _dedupe_checks_by_path
@@ -1288,7 +1389,10 @@ class PermissionEnforcer:
         # forces a fresh Rust graph per call (tuple_version = time_ns()), so
         # the process-global GRAPH_CACHE cannot leak stale results across call
         # sites. A separate freshness workaround here would be redundant.
-        results = self.rebac_manager.rebac_check_bulk(checks, zone_id=zone_id)
+        # Issue #4739: consistency="strong" additionally skips its L1/Tiger phases.
+        results = self.rebac_manager.rebac_check_bulk(
+            checks, zone_id=zone_id, **self._check_kwargs(consistency)
+        )
 
         return [
             path

--- a/src/nexus/bricks/rebac/filter_chain.py
+++ b/src/nexus/bricks/rebac/filter_chain.py
@@ -7,6 +7,7 @@ duplicate implementation.
 
 from nexus.bricks.rebac.permission_filter_chain import (
     DEFAULT_FILTER_CHAIN,
+    STRONG_FILTER_CHAIN,
     BulkReBACStrategy,
     FilterContext,
     FilterResult,
@@ -20,6 +21,7 @@ from nexus.bricks.rebac.permission_filter_chain import (
 
 __all__ = [
     "DEFAULT_FILTER_CHAIN",
+    "STRONG_FILTER_CHAIN",
     "BulkReBACStrategy",
     "FilterContext",
     "FilterResult",

--- a/src/nexus/bricks/rebac/manager.py
+++ b/src/nexus/bricks/rebac/manager.py
@@ -85,6 +85,7 @@ from nexus.contracts.rebac_types import (
     GraphLimits,
     TraversalStats,
     WriteResult,
+    is_strong_consistency,
 )
 from nexus.lib.zone import normalize_zone_id
 
@@ -498,8 +499,16 @@ class ReBACManager:
         object: tuple[str, str],
         context: dict[str, Any] | None = None,
         zone_id: str | None = None,  # Issue #773: Defaults to "root" internally
+        consistency: Any = None,
     ) -> bool:
-        """Check permission (always uses cached/eventual consistency).
+        """Check permission.
+
+        Uses cached (eventual) consistency by default: the boundary cache,
+        Tiger bitmaps and L1 result cache may answer the check.  Pass
+        ``consistency="strong"`` (Issue #4739, SpiceDB ``fully_consistent``
+        analog) to bypass every cached allow/deny for this one call and
+        resolve from the tuple store; the fresh result is still written back
+        to the caches.
 
         Args:
             subject: (subject_type, subject_id) tuple
@@ -507,6 +516,7 @@ class ReBACManager:
             object: (object_type, object_id) tuple
             context: Optional ABAC context for condition evaluation
             zone_id: Zone ID to scope check
+            consistency: ``None`` / ``"eventual"`` (cached) or ``"strong"``
 
         Returns:
             True if permission is granted, False otherwise
@@ -516,10 +526,12 @@ class ReBACManager:
 
         Example:
             result = manager.rebac_check(subject, permission, object)
+            fresh = manager.rebac_check(subject, permission, object, consistency="strong")
         """
         logger.debug(
             f"ReBACManager.rebac_check called: enforce_zone_isolation={self.enforce_zone_isolation}, MAX_DEPTH={GraphLimits.MAX_DEPTH}"
         )
+        strong = is_strong_consistency(consistency)
 
         # Issue #702: OTel tracing — wrap the entire check in a root span
         check_start = time.perf_counter()
@@ -528,7 +540,7 @@ class ReBACManager:
             permission=permission,
             obj=object,
             zone_id=zone_id,
-            consistency="cached",
+            consistency="strong" if strong else "cached",
         ) as _check_span:
             result = self._rebac_check_inner(
                 subject,
@@ -536,6 +548,7 @@ class ReBACManager:
                 object,
                 context,
                 zone_id,
+                consistency=consistency,
             )
             decision_ms = (time.perf_counter() - check_start) * 1000
             record_check_result(_check_span, allowed=result, decision_time_ms=decision_ms)
@@ -548,11 +561,15 @@ class ReBACManager:
         object: tuple[str, str],
         context: dict[str, Any] | None,
         zone_id: str | None,
+        consistency: Any = None,
     ) -> bool:
         """Inner body of rebac_check, extracted for clean span wrapping (Issue #702)."""
         object_type, object_id = object
         subject_type, subject_id = subject
         effective_zone = normalize_zone_id(zone_id)
+        # Issue #4739: strong consistency skips every cached allow (boundary,
+        # Tiger, L1) and goes straight to the tuple store.
+        strong = is_strong_consistency(consistency)
 
         # OPTIMIZATION 1: Boundary Cache (Issue #922) - O(1) inheritance shortcut
         # For file permissions, check if we have a cached boundary (nearest ancestor with grant)
@@ -561,6 +578,7 @@ class ReBACManager:
             and permission in ("read", "write", "execute")
             and self._boundary_cache
             and context is None
+            and not strong
         ):
             boundary = self._boundary_cache.get_boundary(
                 effective_zone, subject_type, subject_id, permission, object_id
@@ -585,7 +603,7 @@ class ReBACManager:
 
         # OPTIMIZATION 2: Try Tiger Cache (O(1) bitmap lookup)
         # Tiger Cache stores pre-materialized permissions as Roaring Bitmaps
-        if self._tiger_cache and zone_id and context is None:
+        if self._tiger_cache and zone_id and context is None and not strong:
             tiger_result = self.tiger_check_access(
                 subject=subject,
                 permission=permission,
@@ -604,7 +622,9 @@ class ReBACManager:
         if not self.enforce_zone_isolation:
             if logger.isEnabledFor(logging.DEBUG):
                 logger.debug(f"  -> Falling back to base check path, max_depth={self.max_depth}")
-            result = self._rebac_check_base(subject, permission, object, context, zone_id)
+            result = self._rebac_check_base(
+                subject, permission, object, context, zone_id, consistency=consistency
+            )
 
             # Write-through to Tiger Cache (Issue #935)
             if result and self._tiger_cache and zone_id and context is None:
@@ -617,7 +637,9 @@ class ReBACManager:
             return result
 
         logger.debug("  -> Using rebac_check_detailed")
-        detailed_result = self.rebac_check_detailed(subject, permission, object, context, zone_id)
+        detailed_result = self.rebac_check_detailed(
+            subject, permission, object, context, zone_id, consistency=consistency
+        )
         logger.debug(
             f"  -> rebac_check_detailed result: allowed={detailed_result.allowed}, indeterminate={detailed_result.indeterminate}"
         )
@@ -817,10 +839,12 @@ class ReBACManager:
         object: tuple[str, str],
         context: dict[str, Any] | None = None,
         zone_id: str | None = None,  # Issue #773: Defaults to "root" internally
+        consistency: Any = None,
     ) -> CheckResult:
         """Check permission with detailed result metadata.
 
-        Always uses cached (eventual) consistency.
+        Uses cached (eventual) consistency unless ``consistency="strong"``
+        (Issue #4739), which skips the cache lookup and computes from tuples.
 
         Args:
             subject: (subject_type, subject_id) tuple
@@ -828,6 +852,7 @@ class ReBACManager:
             object: (object_type, object_id) tuple
             context: Optional ABAC context for condition evaluation
             zone_id: Zone ID to scope check
+            consistency: ``None`` / ``"eventual"`` (cached) or ``"strong"``
 
         Returns:
             CheckResult with consistency metadata and traversal stats
@@ -871,8 +896,9 @@ class ReBACManager:
         self._cleanup_expired_tuples_if_needed()
 
         # Context-sensitive ABAC checks cannot use the context-free cache key.
-        if context is None:
-            # Always use cached (eventual) consistency: Use cache (up to cache_ttl_seconds staleness)
+        # Issue #4739: strong consistency never serves a cached decision.
+        if context is None and not is_strong_consistency(consistency):
+            # Cached (eventual) consistency: Use cache (up to cache_ttl_seconds staleness)
             cached = self._get_cached_check_zone_aware(
                 subject_entity, permission, object_entity, zone_id
             )
@@ -1746,40 +1772,91 @@ class ReBACManager:
             if zone_id:
                 self.invalidate_zone_graph_cache(zone_id)
 
+            subject_type = tuple_info["subject_type"]
+            subject_id = tuple_info["subject_id"]
+            relation = tuple_info["relation"]
+            object_type = tuple_info["object_type"]
+            object_id = tuple_info["object_id"]
+            effective_zone = normalize_zone_id(zone_id)
+            has_full_tuple = bool(subject_type and subject_id and object_type and object_id)
+
+            # Issue #4739: a revocation must reach every cache that can hold a
+            # stale *allow*, not only the L1 / boundary / visibility caches
+            # handled further down.  CacheCoordinator.invalidate_for_write() is
+            # the single entry point: it also clears permission leases, evicts
+            # the Tiger L1/L2 bitmaps (this process and — via DT_STREAM,
+            # Pub/Sub and the durable stream — other processes and zones) and
+            # the iterator cache.  Grants keep their write-through path: adding
+            # a tuple cannot make a cached allow wrong, so rebac_write does not
+            # need this and stays cheap.
+            if has_full_tuple:
+                try:
+                    self._cache_coordinator.invalidate_for_write(
+                        zone_id=effective_zone,
+                        subject=(subject_type, subject_id),
+                        relation=relation,
+                        object=(object_type, object_id),
+                    )
+                except Exception:
+                    logger.warning(
+                        "[ReBACManager] coordinator invalidation failed for deleted tuple %s",
+                        tuple_id,
+                        exc_info=True,
+                    )
+
             # Tiger Cache: Write-through revocation
-            if self._tiger_cache:
-                subject_type = tuple_info["subject_type"]
-                subject_id = tuple_info["subject_id"]
-                relation = tuple_info["relation"]
-                object_type = tuple_info["object_type"]
-                object_id = tuple_info["object_id"]
+            if self._tiger_cache and has_full_tuple:
+                permissions = RELATION_TO_PERMISSIONS.get(relation, [])
+                object_is_pattern = is_path_pattern(object_type, object_id)
+                # Issue #4739: rebac_write expanded a directory grant to every
+                # descendant (Leopard-style).  persist_revoke only drops the
+                # directory's own bit, so a revoked viewer would keep seeing the
+                # files until the Tiger TTL (3600 s).  Drop the directory-grant
+                # record (stops future files being added to the bitmap) and the
+                # subject's bitmap for that permission (L1 + L2 + L3) so the next
+                # access recomputes from tuples — targeted to subject+permission,
+                # not zone-wide.
+                is_directory_grant = (
+                    object_type == "file"
+                    and not object_is_pattern
+                    and self._is_directory_path(object_id)
+                )
 
-                if subject_type and subject_id and object_type and object_id:
-                    permissions = RELATION_TO_PERMISSIONS.get(relation, [])
-
-                    effective_zone = normalize_zone_id(zone_id)
-
-                    # Revoke each permission immediately
-                    for permission in permissions:
-                        try:
-                            if is_path_pattern(object_type, object_id):
-                                self.tiger_invalidate_cache(
-                                    (subject_type, subject_id),
-                                    permission,
-                                    object_type,
-                                    effective_zone,
-                                )
-                            else:
-                                self.tiger_persist_revoke(
-                                    subject=(subject_type, subject_id),
-                                    permission=permission,
-                                    resource_type=object_type,
-                                    resource_id=object_id,
-                                    zone_id=effective_zone,
-                                )
-                        except (OperationalError, ProgrammingError) as e:
-                            if logger.isEnabledFor(logging.DEBUG):
-                                logger.debug(f"[TIGER] Revoke failed: {e}")
+                # Revoke each permission immediately
+                for permission in permissions:
+                    try:
+                        if object_is_pattern:
+                            self.tiger_invalidate_cache(
+                                (subject_type, subject_id),
+                                permission,
+                                object_type,
+                                effective_zone,
+                            )
+                            continue
+                        self.tiger_persist_revoke(
+                            subject=(subject_type, subject_id),
+                            permission=permission,
+                            resource_type=object_type,
+                            resource_id=object_id,
+                            zone_id=effective_zone,
+                        )
+                        if is_directory_grant:
+                            self._tiger_cache.remove_directory_grant(
+                                subject_type=subject_type,
+                                subject_id=subject_id,
+                                permission=permission,
+                                directory_path=object_id,
+                                zone_id=effective_zone,
+                            )
+                            self.tiger_invalidate_cache(
+                                (subject_type, subject_id),
+                                permission,
+                                object_type,
+                                effective_zone,
+                            )
+                    except (OperationalError, ProgrammingError) as e:
+                        if logger.isEnabledFor(logging.DEBUG):
+                            logger.debug(f"[TIGER] Revoke failed: {e}")
 
             # Leopard: Update transitive closure for membership relations
             if tuple_info["relation"] in self.MEMBERSHIP_RELATIONS:
@@ -2206,6 +2283,7 @@ class ReBACManager:
         self,
         checks: list[tuple[tuple[str, str], str, tuple[str, str]]],
         zone_id: str,
+        consistency: Any = None,
     ) -> dict[tuple[tuple[str, str], str, tuple[str, str]], bool]:
         """Check permissions for multiple (subject, permission, object) tuples in batch.
 
@@ -2214,6 +2292,9 @@ class ReBACManager:
         Performance impact: 100x reduction in database queries for N=20 objects.
         - Before: 20 files * 15 queries/file = 300 queries
         - After: 1-2 queries to fetch all tuples + in-memory computation
+
+        ``consistency="strong"`` (Issue #4739) skips the L1 and Tiger phases
+        so every check is resolved from the tuple store.
         """
         # Keep mutable refs in sync before delegating
         self._bulk_checker.update_refs(
@@ -2221,7 +2302,7 @@ class ReBACManager:
             tiger_cache=self._tiger_cache,
             tuple_version=getattr(self, "_tuple_version", 0),
         )
-        return self._bulk_checker.check_bulk(checks, zone_id)
+        return self._bulk_checker.check_bulk(checks, zone_id, consistency=consistency)
 
     def rebac_list_objects(
         self,
@@ -3392,11 +3473,14 @@ class ReBACManager:
         object: tuple[str, str],
         context: dict[str, Any] | None = None,
         zone_id: str | None = None,
+        consistency: Any = None,
     ) -> bool:
         """Check if subject has permission on object.
 
         Uses caching and recursive graph traversal to compute permissions.
         Supports ABAC-style contextual conditions (time, location, device, etc.).
+        ``consistency="strong"`` (Issue #4739) skips the L1 lookup and
+        stampede wait; the fresh result is still cached.
 
         Args:
             subject: (subject_type, subject_id) tuple
@@ -3446,8 +3530,10 @@ class ReBACManager:
         self._cleanup_expired_tuples_if_needed()
 
         # Check cache first with refresh-ahead (Issue #932)
-        # Only if no context, since context makes checks dynamic
-        if context is None:
+        # Only if no context, since context makes checks dynamic.
+        # Issue #4739: strong consistency bypasses the L1 lookup (and the
+        # stampede wait, which would hand back another caller's cached result).
+        if context is None and not is_strong_consistency(consistency):
             # Use refresh-ahead pattern to proactively refresh cache before expiry
             if self._l1_cache:
                 cached, needs_refresh, cache_key = self._l1_cache.get_with_refresh_check(
@@ -3570,14 +3656,18 @@ class ReBACManager:
     def rebac_check_batch(
         self,
         checks: list[tuple[tuple[str, str], str, tuple[str, str]]],
+        consistency: Any = None,
     ) -> list[bool]:
         """Batch permission checks for efficiency.
 
         Checks cache first for each check, then computes uncached checks.
         More efficient than individual checks when checking multiple permissions.
+        ``consistency="strong"`` (Issue #4739) skips the cache lookup; results
+        are still written back.
 
         Args:
             checks: List of (subject, permission, object) tuples to check
+            consistency: ``None`` / ``"eventual"`` (cached) or ``"strong"``
 
         Returns:
             List of boolean results in the same order as input
@@ -3599,13 +3689,18 @@ class ReBACManager:
         # Map to track results by index
         results: dict[int, bool] = {}
         uncached_checks: list[tuple[int, Entity, str, Entity]] = []
+        strong = is_strong_consistency(consistency)
 
-        # Phase 1: Check cache for all checks
+        # Phase 1: Check cache for all checks (skipped under strong, #4739)
         for i, (subject, permission, obj) in enumerate(checks):
             subject_entity = Entity(subject[0], subject[1])
             object_entity = Entity(obj[0], obj[1])
 
-            cached = self._get_cached_check(subject_entity, permission, object_entity)
+            cached = (
+                None
+                if strong
+                else self._get_cached_check(subject_entity, permission, object_entity)
+            )
             if cached is not None:
                 results[i] = cached
             else:
@@ -3630,15 +3725,19 @@ class ReBACManager:
         self,
         checks: list[tuple[tuple[str, str], str, tuple[str, str]]],
         use_rust: bool = True,
+        consistency: Any = None,
     ) -> list[bool]:
         """Batch permission checks with optional Rust acceleration.
 
         This method is identical to rebac_check_batch but uses Rust for bulk
         computation of uncached checks, providing 50-85x speedup for large batches.
+        ``consistency="strong"`` (Issue #4739) skips the cache lookup; results
+        are still written back.
 
         Args:
             checks: List of (subject, permission, object) tuples to check
             use_rust: Use Rust acceleration if available (default: True)
+            consistency: ``None`` / ``"eventual"`` (cached) or ``"strong"``
 
         Returns:
             List of boolean results in the same order as input
@@ -3667,13 +3766,18 @@ class ReBACManager:
         # Map to track results by index
         results: dict[int, bool] = {}
         uncached_checks: list[tuple[int, tuple[tuple[str, str], str, tuple[str, str]]]] = []
+        strong = is_strong_consistency(consistency)
 
-        # Phase 1: Check cache for all checks
+        # Phase 1: Check cache for all checks (skipped under strong, #4739)
         for i, (subject, permission, obj) in enumerate(checks):
             subject_entity = Entity(subject[0], subject[1])
             object_entity = Entity(obj[0], obj[1])
 
-            cached = self._get_cached_check(subject_entity, permission, object_entity)
+            cached = (
+                None
+                if strong
+                else self._get_cached_check(subject_entity, permission, object_entity)
+            )
             if cached is not None:
                 results[i] = cached
             else:

--- a/src/nexus/bricks/rebac/permission_filter_chain.py
+++ b/src/nexus/bricks/rebac/permission_filter_chain.py
@@ -9,6 +9,11 @@ Decomposes the ~450-line filter_list() into a chain of composable strategies:
 
 Each strategy receives remaining paths and returns (allowed, remaining).
 The chain short-circuits once all paths are resolved.
+
+Issue #4739: when ``FilterContext.consistency`` is ``"strong"`` the chain is
+``STRONG_FILTER_CHAIN`` — zone pre-filter plus the authoritative bulk ReBAC
+pass with ``consistency="strong"`` — so no Tiger bitmap, Leopard index or L1
+entry can answer for the call.
 """
 
 import logging
@@ -18,6 +23,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Protocol
 
 from nexus.bricks.rebac._path_utils import get_ancestors
+from nexus.contracts.rebac_types import is_strong_consistency
 from nexus.core.path_utils import unscope_internal_path
 
 if TYPE_CHECKING:
@@ -39,6 +45,19 @@ class FilterContext:
     cache: "PermissionCacheCoordinator"
     rebac_manager: "ReBACManager"
     dlc: Any = None
+    # Issue #4739: None / "eventual" (cached) or "strong" (bypass caches).
+    consistency: str | None = None
+
+    def bulk_kwargs(self) -> dict[str, Any]:
+        """Keyword arguments for ``rebac_manager.rebac_check_bulk``.
+
+        ``consistency`` is only forwarded when strong so managers (and test
+        doubles) that predate the parameter keep working for cached calls.
+        """
+        kwargs: dict[str, Any] = {"zone_id": self.zone_id}
+        if is_strong_consistency(self.consistency):
+            kwargs["consistency"] = self.consistency
+        return kwargs
 
 
 @dataclass
@@ -166,7 +185,7 @@ class HierarchyPreFilterStrategy:
         subject = ctx.subject
 
         checks_by_parent, parent_checks = _dedupe_checks_by_path(subject, unique_parents)
-        parent_results = ctx.rebac_manager.rebac_check_bulk(parent_checks, zone_id=ctx.zone_id)
+        parent_results = ctx.rebac_manager.rebac_check_bulk(parent_checks, **ctx.bulk_kwargs())
 
         accessible_parents = {
             parent
@@ -258,12 +277,13 @@ class BulkReBACStrategy:
         checks_by_path, checks = _dedupe_checks_by_path(subject, remaining)
 
         # Retry-once on transient I/O failures only
+        bulk_kwargs = ctx.bulk_kwargs()
         try:
-            results = ctx.rebac_manager.rebac_check_bulk(checks, zone_id=ctx.zone_id)
+            results = ctx.rebac_manager.rebac_check_bulk(checks, **bulk_kwargs)
         except (OSError, ConnectionError, TimeoutError) as e:
             logger.warning(f"[BULK-REBAC] Bulk check failed, retrying once: {e}")
             try:
-                results = ctx.rebac_manager.rebac_check_bulk(checks, zone_id=ctx.zone_id)
+                results = ctx.rebac_manager.rebac_check_bulk(checks, **bulk_kwargs)
             except Exception as e2:  # fail-safe: second failure → deny all (fail-closed)
                 logger.error(f"[BULK-REBAC] Bulk check failed twice: {e2}")
                 return FilterResult(allowed=[], remaining=[], short_circuit=True)
@@ -309,6 +329,14 @@ DEFAULT_FILTER_CHAIN: list[FilterStrategy] = [
     BulkReBACStrategy(),
 ]
 
+# Issue #4739: strong consistency — only non-cache strategies.  The zone
+# pre-filter is pure path arithmetic; BulkReBACStrategy forwards
+# consistency="strong" so the manager skips its own L1 / Tiger phases.
+STRONG_FILTER_CHAIN: list[FilterStrategy] = [
+    ZonePreFilterStrategy(),
+    BulkReBACStrategy(),
+]
+
 
 def run_filter_chain(
     ctx: FilterContext,
@@ -323,12 +351,18 @@ def run_filter_chain(
 
     Args:
         ctx: Filter context with paths, subject, caches, etc.
-        chain: Optional custom strategy chain (defaults to DEFAULT_FILTER_CHAIN)
+        chain: Optional custom strategy chain (defaults to DEFAULT_FILTER_CHAIN,
+            or STRONG_FILTER_CHAIN when ``ctx.consistency`` is ``"strong"``)
 
     Returns:
         List of allowed paths.
     """
-    strategies = chain if chain is not None else DEFAULT_FILTER_CHAIN
+    if chain is not None:
+        strategies = chain
+    elif is_strong_consistency(ctx.consistency):
+        strategies = STRONG_FILTER_CHAIN
+    else:
+        strategies = DEFAULT_FILTER_CHAIN
     allowed: list[str] = []
     remaining = list(ctx.paths)
 

--- a/src/nexus/bricks/rebac/permission_hook.py
+++ b/src/nexus/bricks/rebac/permission_hook.py
@@ -19,6 +19,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from nexus.contracts.constants import ROOT_ZONE_ID, SYSTEM_PATH_PREFIX
+from nexus.contracts.rebac_types import is_strong_consistency
 from nexus.contracts.types import Permission
 from nexus.core.path_utils import parent_path
 
@@ -114,6 +115,15 @@ class RebacPermissionCheckHook:
         """Extract agent_id from context, or None if unavailable."""
         return getattr(context, "agent_id", None) if context else None
 
+    @staticmethod
+    def _is_strong(context: Any) -> bool:
+        """``True`` when the caller asked for strong consistency (Issue #4739).
+
+        A permission lease is a cached *allow*, so the lease fast path is
+        skipped for that call; the full check then re-stamps the lease.
+        """
+        return is_strong_consistency(getattr(context, "consistency", None)) if context else False
+
     # ------------------------------------------------------------------
     # Rust PermissionProvider entry point
     # ------------------------------------------------------------------
@@ -167,7 +177,7 @@ class RebacPermissionCheckHook:
         agent_id = self._extract_agent_id(context)
 
         # Fast path: check permission lease
-        if self._lease_check(ctx.path, agent_id):
+        if not self._is_strong(context) and self._lease_check(ctx.path, agent_id):
             return
 
         # Slow path: full ReBAC check
@@ -204,8 +214,8 @@ class RebacPermissionCheckHook:
 
         agent_id = self._extract_agent_id(context)
 
-        # Fast path: check permission lease (~100-200ns)
-        if self._lease_check(checked_path, agent_id):
+        # Fast path: check permission lease (~100-200ns); skipped under strong (#4739)
+        if not self._is_strong(context) and self._lease_check(checked_path, agent_id):
             return  # lease valid — skip full ReBAC check
 
         # Slow path: full ReBAC check (raises PermissionError on denial)
@@ -230,7 +240,7 @@ class RebacPermissionCheckHook:
         context = ctx.context or self._default_context
         agent_id = self._extract_agent_id(context)
 
-        if self._lease_check(ctx.path, agent_id):
+        if not self._is_strong(context) and self._lease_check(ctx.path, agent_id):
             return
 
         self._checker.check(ctx.path, Permission.WRITE, context)
@@ -293,7 +303,7 @@ class RebacPermissionCheckHook:
         context = ctx.context or self._default_context
         agent_id = self._extract_agent_id(context)
 
-        if self._lease_check(ctx.path, agent_id):
+        if not self._is_strong(context) and self._lease_check(ctx.path, agent_id):
             return
 
         self._checker.check(ctx.path, Permission.WRITE, context)

--- a/src/nexus/bricks/rebac/rebac_service.py
+++ b/src/nexus/bricks/rebac/rebac_service.py
@@ -27,8 +27,9 @@ from nexus.bricks.rebac.dynamic_viewer import (
 )
 from nexus.bricks.rebac.share_mixin import ReBACShareMixin
 from nexus.contracts.exceptions import CircuitOpenError
+from nexus.contracts.rebac_types import is_strong_consistency
 from nexus.contracts.types import OperationContext
-from nexus.lib.context_utils import get_subject_from_context
+from nexus.lib.context_utils import get_consistency, get_subject_from_context
 from nexus.lib.rpc_decorator import rpc_expose
 
 logger = logging.getLogger(__name__)
@@ -432,12 +433,13 @@ class ReBACService(ReBACShareMixin):
         object: tuple[str, str],
         context: Any = None,
         zone_id: str | None = None,
+        consistency: str | None = None,
     ) -> bool:
         """Check if subject has permission on object.
 
         Uses relationship graph traversal to determine access, supporting both
         direct relationships and inherited permissions through group membership.
-        Always uses cached (eventual) consistency.
+        Cached (eventual) consistency; ``consistency="strong"`` bypasses caches (#4739).
 
         Args:
             subject: Subject tuple e.g., ("user", "alice")
@@ -445,6 +447,7 @@ class ReBACService(ReBACShareMixin):
             object: Object tuple e.g., ("file", "/doc.txt")
             context: Optional ABAC context for condition evaluation (time, ip, device, attributes)
             zone_id: Zone ID for multi-zone isolation
+            consistency: ``None``/``"eventual"`` or ``"strong"``; defaults to ``context.consistency``
 
         Returns:
             True if permission granted, False otherwise
@@ -460,6 +463,7 @@ class ReBACService(ReBACShareMixin):
                 object=("file", "/doc.txt")
             )
         """
+        effective_consistency = get_consistency(context, consistency)
 
         def _check_sync() -> bool:
             """Synchronous implementation for thread pool execution."""
@@ -480,7 +484,7 @@ class ReBACService(ReBACShareMixin):
 
             manager_context = None if isinstance(context, OperationContext) else context
 
-            # Check permission with optional ABAC context (always cached consistency)
+            # Check permission with optional ABAC context
             # Manager guaranteed by _run_in_thread
             assert self._rebac_manager is not None
             result: bool = self._rebac_manager.rebac_check(
@@ -489,15 +493,16 @@ class ReBACService(ReBACShareMixin):
                 object=object,
                 context=manager_context,
                 zone_id=effective_zone_id,
+                consistency=effective_consistency,
             )
 
             return result
 
-        # Read operation — supports L1 cache fallback (Decision 3A)
+        # Read operation — L1 cache fallback (Decision 3A); never for a strong check (#4739)
         try:
             return await self._run_in_thread(_check_sync)
         except CircuitOpenError:
-            if self._rebac_manager:
+            if self._rebac_manager and not is_strong_consistency(effective_consistency):
                 cached: bool | None = self._rebac_manager.get_cached_permission(
                     subject=subject, permission=permission, object=object, zone_id=zone_id
                 )
@@ -652,6 +657,7 @@ class ReBACService(ReBACShareMixin):
         self,
         checks: list[tuple[tuple[str, str], str, tuple[str, str]]],
         zone_id: str | None = None,
+        consistency: str | None = None,
     ) -> list[bool]:
         """Check multiple permissions in a single call for efficiency.
 
@@ -661,6 +667,7 @@ class ReBACService(ReBACShareMixin):
         Args:
             checks: List of (subject, permission, object) tuples
             zone_id: Zone ID (currently unused by manager)
+            consistency: ``None``/``"eventual"`` or ``"strong"`` for every check in the batch (#4739)
 
         Returns:
             List of boolean results (same order as input)
@@ -702,12 +709,15 @@ class ReBACService(ReBACShareMixin):
                         permission=perm,
                         object=obj,
                         zone_id=zone_id,
+                        consistency=consistency,
                     )
                     batch_results.append(result)
                 return batch_results
 
             # No zone_id: use optimized batch path (Rust acceleration)
-            return self._rebac_manager.rebac_check_batch_fast(checks=normalized_checks)
+            return self._rebac_manager.rebac_check_batch_fast(
+                checks=normalized_checks, consistency=consistency
+            )
 
         # Issue #702: Wrap batch check in a summary span
         import time as _time
@@ -732,7 +742,7 @@ class ReBACService(ReBACShareMixin):
                 )
                 return batch_results
             except CircuitOpenError:
-                if self._rebac_manager:
+                if self._rebac_manager and not is_strong_consistency(consistency):
                     results: list[bool] = []
                     all_cached = True
                     for check in checks:
@@ -2105,8 +2115,9 @@ class ReBACService(ReBACShareMixin):
         object: tuple[str, str],
         context: Any = None,
         zone_id: str | None = None,
+        consistency: str | None = None,
     ) -> bool:
-        """Synchronous rebac_check — full business logic with traverse fallback."""
+        """Synchronous rebac_check — traverse fallback; ``consistency="strong"`` bypasses caches."""
         mgr = self._require_manager()
 
         if not isinstance(subject, tuple) or len(subject) != 2:
@@ -2127,6 +2138,7 @@ class ReBACService(ReBACShareMixin):
             object=object,
             context=context,
             zone_id=effective_zone_id,
+            consistency=get_consistency(context, consistency),
         )
 
         # Unix-like TRAVERSE fallback
@@ -2185,11 +2197,12 @@ class ReBACService(ReBACShareMixin):
     def rebac_check_batch_sync(
         self,
         checks: list[tuple[tuple[str, str], str, tuple[str, str]]],
+        consistency: str | None = None,
     ) -> list[bool]:
-        """Synchronous rebac_check_batch."""
+        """Synchronous rebac_check_batch (``consistency="strong"`` bypasses caches, #4739)."""
         mgr = self._require_manager()
         normalized_checks = [_coerce_check_tuple(check, i) for i, check in enumerate(checks)]
-        results: list[bool] = mgr.rebac_check_batch_fast(checks=normalized_checks)
+        results: list[bool] = mgr.rebac_check_batch_fast(normalized_checks, consistency=consistency)
         return results
 
     def rebac_delete_sync(self, tuple_id: str) -> bool:

--- a/src/nexus/bricks/search/search_service.py
+++ b/src/nexus/bricks/search/search_service.py
@@ -28,6 +28,7 @@ from nexus.bricks.search.primitives import glob_helpers, trigram_fast
 from nexus.contracts.constants import ROOT_ZONE_ID
 from nexus.contracts.exceptions import PermissionDeniedError
 from nexus.contracts.protocols.activity import EventKind, Result, emit
+from nexus.contracts.rebac_types import is_strong_consistency
 from nexus.contracts.search_types import (
     GLOB_RUST_THRESHOLD,
     GREP_CACHED_TEXT_RATIO,
@@ -622,6 +623,9 @@ class SearchService:
                 subject_id,
                 _revision_before,
                 _rebac_manager,
+                # Issue #4739: strong consistency must not pre-filter by the
+                # Tiger bitmap; fall through to filter_list (strong chain).
+                use_tiger_pushdown=not is_strong_consistency(getattr(context, "consistency", None)),
             )
             sample_paths = [m["path"] for m in all_files[:5]]
             logger.info(f"[LIST-DEBUG] FALLBACK all_files sample: {sample_paths}")
@@ -1229,8 +1233,13 @@ class SearchService:
         subject_id: str | None,
         _revision_before: int | None,
         _rebac_manager: Any,
+        use_tiger_pushdown: bool = True,
     ) -> tuple[builtins.list[Any], set[int] | None]:
-        """Full recursive metadata scan with predicate pushdown optimization."""
+        """Full recursive metadata scan with predicate pushdown optimization.
+
+        ``use_tiger_pushdown=False`` (Issue #4739, strong consistency) skips
+        the Tiger bitmap pre-filter so every candidate reaches ``filter_list``.
+        """
         import os as _os
         import time as _time
 
@@ -1240,7 +1249,13 @@ class SearchService:
             "true",
         )
 
-        if self._enforce_permissions and subject_type and subject_id and not _pushdown_disabled:
+        if (
+            self._enforce_permissions
+            and subject_type
+            and subject_id
+            and not _pushdown_disabled
+            and use_tiger_pushdown
+        ):
             _pushdown_start = _time.time()
             tiger_cache = getattr(_rebac_manager, "_tiger_cache", None) if _rebac_manager else None
             if tiger_cache is not None:

--- a/src/nexus/contracts/protocols/permission.py
+++ b/src/nexus/contracts/protocols/permission.py
@@ -38,12 +38,14 @@ class PermissionProtocol(Protocol):
         object: tuple[str, str],
         context: Any = None,
         zone_id: str | None = None,
+        consistency: str | None = None,
     ) -> bool: ...
 
     async def rebac_check_batch(
         self,
         checks: list[tuple[tuple[str, str], str, tuple[str, str]]],
         zone_id: str | None = None,
+        consistency: str | None = None,
     ) -> list[bool]: ...
 
     async def rebac_create(

--- a/src/nexus/contracts/protocols/rebac.py
+++ b/src/nexus/contracts/protocols/rebac.py
@@ -39,6 +39,7 @@ class ReBACBrickProtocol(Protocol):
         object: tuple[str, str],
         context: dict[str, Any] | None = None,
         zone_id: str | None = None,
+        consistency: Any = None,
     ) -> bool: ...
 
     def rebac_write(
@@ -68,6 +69,7 @@ class ReBACBrickProtocol(Protocol):
         self,
         checks: list[tuple[tuple[str, str], str, tuple[str, str]]],
         zone_id: str,
+        consistency: Any = None,
     ) -> dict[tuple[tuple[str, str], str, tuple[str, str]], bool]: ...
 
     def rebac_list_objects(

--- a/src/nexus/contracts/rebac_types.py
+++ b/src/nexus/contracts/rebac_types.py
@@ -14,11 +14,14 @@ Backward-compat shims:
 """
 
 from dataclasses import dataclass
+from enum import StrEnum
 from typing import Any
 
 __all__ = [
     "WriteResult",
     "CheckResult",
+    "ConsistencyLevel",
+    "is_strong_consistency",
     "TraversalStats",
     "GraphLimits",
     "GraphLimitExceeded",
@@ -88,6 +91,44 @@ class CheckResult:
     traversal_stats: TraversalStats | None = None
     indeterminate: bool = False  # BUGFIX (Issue #5): Track limit-driven denials
     limit_exceeded: "GraphLimitExceeded | None" = None  # BUGFIX (Issue #5): Which limit was hit
+
+
+# ============================================================================
+# Consistency level (Issue #4739)
+# ============================================================================
+
+
+class ConsistencyLevel(StrEnum):
+    """Read consistency a caller may request for a permission decision.
+
+    ``EVENTUAL`` (the default) lets ``check`` / ``list`` / ``search`` answer
+    from the permission caches: the L1 result cache (grants 300 s, denials
+    60 s), the Tiger bitmaps (3600 s) and the boundary / lease caches.
+
+    ``STRONG`` is the SpiceDB ``fully_consistent`` analog: the decision for
+    that one call is resolved from the tuple store, bypassing every cached
+    *allow* or *deny*.  Fresh results are still written back into the caches
+    so a strong read also repairs stale entries.
+    """
+
+    EVENTUAL = "eventual"
+    STRONG = "strong"
+
+
+def is_strong_consistency(value: Any) -> bool:
+    """Return ``True`` when *value* requests :attr:`ConsistencyLevel.STRONG`.
+
+    Accepts the enum, its string value (case-insensitive) or ``None``.  Any
+    other value is treated as eventual so callers that pass ``None`` or an
+    unrelated object keep today's cached behaviour.
+    """
+    if value is None:
+        return False
+    if isinstance(value, ConsistencyLevel):
+        return value is ConsistencyLevel.STRONG
+    if isinstance(value, str):
+        return value.strip().lower() == ConsistencyLevel.STRONG.value
+    return False
 
 
 # ============================================================================

--- a/src/nexus/contracts/types.py
+++ b/src/nexus/contracts/types.py
@@ -105,6 +105,12 @@ class OperationContext:
             Populated by the router when a request is dispatched to a mounted backend.
             Used by the virtual ``.readme/`` overlay to render absolute paths in
             auto-generated skill docs without per-connector instance state.
+        consistency: Permission-cache consistency requested for this operation
+            (Issue #4739). ``None`` / ``"eventual"`` serves permission decisions
+            from the L1 / Tiger / boundary / lease caches; ``"strong"`` resolves
+            ``check``, ``list`` and ``search`` decisions for this call from the
+            tuple store (SpiceDB ``fully_consistent`` analog). Set by the HTTP
+            layer from the ``X-Nexus-Consistency`` header.
 
     Examples:
         >>> ctx = OperationContext(
@@ -141,6 +147,11 @@ class OperationContext:
 
     # TTL for ephemeral content — routes to TTL-bucketed volumes (Issue #3405)
     ttl_seconds: float | None = None
+
+    # Permission-cache consistency for this operation (Issue #4739).
+    # None / "eventual" = cached decisions; "strong" = bypass L1/Tiger/lease
+    # caches for check/list/search on this call.
+    consistency: str | None = None
 
     def __post_init__(self) -> None:
         """Validate context and apply defaults.

--- a/src/nexus/core/config.py
+++ b/src/nexus/core/config.py
@@ -60,6 +60,11 @@ class PermissionConfig:
     enable_tiger_cache: bool = True
     enable_deferred: bool = True
     deferred_flush_interval: float = 0.05
+    # Issue #4739: with enable_deferred, hierarchy (parent) tuples are still
+    # batched, but the creating subject's ``direct_owner`` grant is written
+    # synchronously so the writer's own list/search/check see the new file
+    # immediately. Set False to defer the owner grant as well (pre-#4739).
+    sync_owner_grant: bool = True
 
 
 @dataclass(frozen=True)

--- a/src/nexus/core/nexus_fs_metadata.py
+++ b/src/nexus/core/nexus_fs_metadata.py
@@ -28,6 +28,7 @@ from nexus.contracts.exceptions import (
 from nexus.contracts.metadata import DT_DIR, DT_MOUNT, FileMetadata
 from nexus.contracts.types import OperationContext
 from nexus.core.nexus_fs_content import emit_op_completed
+from nexus.core.readdir_rebac_filter import readdir_visible_paths
 from nexus.kernel_helpers import metastore_list_iter
 from nexus.lib.rpc_decorator import rpc_expose
 from nexus.lib.zone_revision import revision_token
@@ -1895,6 +1896,10 @@ class MetadataMixin:
                     and not self._is_internal_path(child)
                     and _etype not in (DT_DIR, DT_MOUNT)
                 ]
+                # Issue #4739: ReBAC post-filter (non-admin callers only).
+                _visible = readdir_visible_paths(self, [(c, False) for c in _children], context)
+                if _visible is not None:
+                    _children = [c for c in _children if c in _visible]
                 # Issue #3786 / Codex Round 7 finding #1: federation tokens
                 # land here as zone_id="root", so without an explicit zone_perms
                 # filter they would receive every name the kernel returns,
@@ -2026,6 +2031,14 @@ class MetadataMixin:
                 if not self._is_internal_path(e.path) and _zone_allowed(e)
             )
             result = paginate_iter(items_iter, limit=limit, cursor_path=cursor)
+            # Issue #4739: ReBAC post-filter (non-admin callers only). A page
+            # may come back short; the HTTP route already advances the cursor
+            # until a page has visible items.
+            _visible = readdir_visible_paths(
+                self, [(e.path, e.entry_type in (DT_DIR, DT_MOUNT)) for e in result.items], context
+            )
+            if _visible is not None:
+                result.items = [e for e in result.items if e.path in _visible]
             if details:
                 result.items = [self._entry_to_detail_dict(e, recursive) for e in result.items]
             else:
@@ -2058,6 +2071,17 @@ class MetadataMixin:
                 ]
             else:
                 _result = [self._entry_to_detail_dict(e, recursive) for e in entries_iter]
+            # Issue #4739: ReBAC post-filter (non-admin callers only), applied
+            # before recursive expansion — children of expanded directories
+            # are filtered by their own sys_readdir call.
+            _visible = readdir_visible_paths(
+                self,
+                [(d["path"], self._readdir_item_is_dir(d, context=context)) for d in _result],
+                context,
+            )
+            if _visible is not None:
+                _result = [d for d in _result if d["path"] in _visible]
+            if recursive:
                 _result = self._expand_recursive_readdir(
                     _result,
                     details=True,
@@ -2065,7 +2089,14 @@ class MetadataMixin:
                 )
             _emit_list()
             return _result
-        _result = [e.path for e in entries_iter]
+        _entries = list(entries_iter)
+        # Issue #4739: ReBAC post-filter (non-admin callers only).
+        _visible = readdir_visible_paths(
+            self, [(e.path, e.entry_type in (DT_DIR, DT_MOUNT)) for e in _entries], context
+        )
+        if _visible is not None:
+            _entries = [e for e in _entries if e.path in _visible]
+        _result = [e.path for e in _entries]
         if recursive:
             _result = self._expand_recursive_readdir(
                 _result,

--- a/src/nexus/core/readdir_rebac_filter.py
+++ b/src/nexus/core/readdir_rebac_filter.py
@@ -1,0 +1,95 @@
+"""ReBAC post-filter for ``sys_readdir`` results (Issue #4739).
+
+``sys_readdir`` used to apply zone filtering only, so a non-admin key could
+enumerate the names of files it cannot read (the HTTP ``/files/list`` route
+calls the syscall directly).  Files must now pass
+``PermissionEnforcer.filter_list`` — the same chain search ``list`` / ``glob``
+/ ``grep`` use, honouring ``OperationContext.consistency`` — and directories
+stay visible when the caller has an accessible descendant
+(``has_accessible_descendants_batch``), matching ``SearchService``.
+
+Kept out of ``nexus_fs_metadata.py`` so that module stays under the
+repository's file-size limit; ``MetadataMixin.sys_readdir`` calls
+:func:`readdir_visible_paths` with itself as ``fs``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from nexus.contracts.types import OperationContext
+
+logger = logging.getLogger(__name__)
+
+
+def readdir_filter_context(context: Any) -> OperationContext | None:
+    """Return the caller identity the ReBAC listing filter applies to.
+
+    ``None`` means "do not filter": no caller identity (kernel-internal and
+    embedded callers), or an admin / system caller — their listing semantics
+    are unchanged here (admin zone scoping is tracked in #4740).  Dict
+    contexts are promoted to ``OperationContext`` when they carry a subject
+    so RPC callers cannot sidestep the filter.
+    """
+    if context is None:
+        return None
+    if isinstance(context, dict):
+        if context.get("is_admin") or context.get("is_system"):
+            return None
+        user = context.get("user_id") or context.get("subject_id")
+        if not user:
+            return None
+        return OperationContext(
+            user_id=str(user),
+            groups=list(context.get("groups") or []),
+            zone_id=context.get("zone_id"),
+            subject_type=str(context.get("subject_type") or "user"),
+            subject_id=context.get("subject_id"),
+            consistency=context.get("consistency"),
+        )
+    if getattr(context, "is_admin", False) or getattr(context, "is_system", False):
+        return None
+    return context if isinstance(context, OperationContext) else None
+
+
+def readdir_visible_paths(
+    fs: Any,
+    entries: list[tuple[str, bool]],
+    context: Any,
+) -> set[str] | None:
+    """Return the paths of *entries* the caller may see, or ``None`` to skip filtering.
+
+    Args:
+        fs: The ``NexusFS`` (``MetadataMixin``) instance — supplies
+            ``_perm_config`` and the ``permission_enforcer`` service.
+        entries: ``(path, is_directory)`` pairs of the candidate result.
+        context: Caller context (``OperationContext`` or dict).
+
+    Returns:
+        The set of visible paths, or ``None`` when no filtering applies (no
+        identity, admin/system caller, enforcement disabled).  Fails closed
+        (empty set) when enforcement is on but the enforcer is unavailable,
+        like ``PermissionChecker.check`` does for reads.
+    """
+    ctx = readdir_filter_context(context)
+    if ctx is None or not entries:
+        return None
+    perm = getattr(fs, "_perm_config", None)
+    if perm is None or not getattr(perm, "enforce", False):
+        return None
+    service = getattr(fs, "service", None)
+    enforcer = service("permission_enforcer") if callable(service) else None
+    if enforcer is None:
+        logger.warning(
+            "sys_readdir: permission enforcer unavailable; hiding %d entries (fail-closed)",
+            len(entries),
+        )
+        return set()
+    files = [p for p, is_dir in entries if not is_dir]
+    dirs = [p for p, is_dir in entries if is_dir]
+    visible: set[str] = set(enforcer.filter_list(files, ctx)) if files else set()
+    if dirs:
+        dir_visibility = enforcer.has_accessible_descendants_batch(dirs, ctx)
+        visible.update(d for d in dirs if dir_visibility.get(d, True))
+    return visible

--- a/src/nexus/factory/orchestrator.py
+++ b/src/nexus/factory/orchestrator.py
@@ -668,9 +668,15 @@ def _register_vfs_hooks(
     if _dpb is not None:
         from nexus.bricks.rebac.deferred_permission_hook import DeferredPermissionHook
 
+        # Issue #4739: hierarchy tuples stay deferred; the creator's owner
+        # grant is written synchronously unless PermissionConfig opts out.
         _enlist(
             "deferred_permission",
-            DeferredPermissionHook(_dpb, rebac_manager=_rebac_for_perm),
+            DeferredPermissionHook(
+                _dpb,
+                rebac_manager=_rebac_for_perm,
+                sync_owner_grant=getattr(nx._perm_config, "sync_owner_grant", True),
+            ),
         )
     else:
         # Sync fallback — same logic, runs as post-write hook instead of inline kernel code

--- a/src/nexus/lib/context_utils.py
+++ b/src/nexus/lib/context_utils.py
@@ -43,6 +43,26 @@ def get_zone_id(context: Any) -> str:
     return ROOT_ZONE_ID
 
 
+def get_consistency(context: Any, explicit: str | None = None) -> str | None:
+    """Resolve the permission-cache consistency for a call (Issue #4739).
+
+    An explicit ``consistency`` argument wins; otherwise an ``OperationContext``
+    supplies ``context.consistency`` (set from ``X-Nexus-Consistency``). Dict
+    (ABAC) contexts and ``None`` carry no consistency.
+
+    Examples:
+        >>> get_consistency(OperationContext(user_id="a", groups=[], consistency="strong"))
+        'strong'
+        >>> get_consistency({"time": "14:30"}, "strong")
+        'strong'
+    """
+    if explicit is not None:
+        return explicit
+    if isinstance(context, OperationContext):
+        return context.consistency
+    return None
+
+
 def get_user_identity(context: Any) -> tuple[str, str | None]:
     """
     Extract user identity (type, id) from context.

--- a/src/nexus/remote/kernel_client.py
+++ b/src/nexus/remote/kernel_client.py
@@ -1276,7 +1276,14 @@ class _SysWriteResult:
         self.version = 1
         self.gen = gen
         self.size = size
-        self.is_new = False
+        # Issue #4739: the typed Write RPC (vfs.proto WriteResponse) carries
+        # only content_id / size / gen, not the kernel's ``is_new``.  The
+        # kernel computes ``new_gen = old_gen + 1`` with ``old_gen = 0`` when
+        # no entry existed (rust/kernel/src/kernel/io.rs), so ``gen == 1`` is
+        # exactly its ``is_new = old_entry.is_none()``.  Without this the
+        # post-write hooks never saw a new file and the creator's owner grant
+        # was never written over the kernel RPC.
+        self.is_new = gen == 1
         self.old_content_id: str | None = None
         self.old_size: int | None = None
         self.old_version: int | None = None

--- a/src/nexus/server/_rpc_params_generated.py
+++ b/src/nexus/server/_rpc_params_generated.py
@@ -104,14 +104,12 @@ __all__ = [
     "SemanticSearchIndexParams",
     "SemanticSearchParams",
     "ShareWithUserParams",
-    "SnapshotBeginParams",
     "SnapshotCommitParams",
     "SnapshotCreateParams",
     "SnapshotGetParams",
     "SnapshotListEntriesParams",
     "SnapshotListParams",
     "SnapshotRestoreParams",
-    "SnapshotRollbackParams",
     "StatBulkParams",
     "StatParams",
     "SysWatchParams",
@@ -809,6 +807,7 @@ class RebacCheckParams:
     object: tuple[str, str]
     context: Any = None
     zone_id: str | None = None
+    consistency: str | None = None
 
     def __post_init__(self) -> None:
         """Convert lists to tuples (JSON deserializes tuples as lists)."""
@@ -1004,16 +1003,6 @@ class ShareWithUserParams:
 
 
 @dataclass
-class SnapshotBeginParams:
-    """Parameters for snapshot_begin(): Begin a transactional snapshot."""
-
-    agent_id: str | None = None
-    zone_id: str | None = None
-    description: str | None = None
-    ttl_seconds: int = 3600
-
-
-@dataclass
 class SnapshotCommitParams:
     """Parameters for snapshot_commit() method."""
 
@@ -1026,6 +1015,7 @@ class SnapshotCreateParams:
 
     description: str | None = None
     ttl_seconds: int = 3600
+    context: dict | Any | None = None
 
 
 @dataclass
@@ -1039,7 +1029,7 @@ class SnapshotGetParams:
 class SnapshotListParams:
     """Parameters for snapshot_list() method."""
 
-    pass
+    context: dict | Any | None = None
 
 
 @dataclass
@@ -1054,13 +1044,6 @@ class SnapshotRestoreParams:
     """Parameters for snapshot_restore() method."""
 
     txn_id: str
-
-
-@dataclass
-class SnapshotRollbackParams:
-    """Parameters for snapshot_rollback(): Rollback a snapshot — restore paths to pre-snapshot state."""
-
-    snapshot_id: str
 
 
 @dataclass
@@ -1210,14 +1193,12 @@ METHOD_PARAMS: dict[str, type] = {
     "semantic_search": SemanticSearchParams,
     "semantic_search_index": SemanticSearchIndexParams,
     "share_with_user": ShareWithUserParams,
-    "snapshot_begin": SnapshotBeginParams,
     "snapshot_commit": SnapshotCommitParams,
     "snapshot_create": SnapshotCreateParams,
     "snapshot_get": SnapshotGetParams,
     "snapshot_list": SnapshotListParams,
     "snapshot_list_entries": SnapshotListEntriesParams,
     "snapshot_restore": SnapshotRestoreParams,
-    "snapshot_rollback": SnapshotRollbackParams,
     "stat": StatParams,
     "stat_bulk": StatBulkParams,
     "sys_watch": SysWatchParams,

--- a/src/nexus/server/dependencies.py
+++ b/src/nexus/server/dependencies.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING, Any
 from fastapi import Depends, Header, HTTPException, Request
 
 from nexus.contracts.constants import ROOT_ZONE_ID
+from nexus.contracts.rebac_types import ConsistencyLevel
 from nexus.server.token_utils import parse_sk_token
 
 if TYPE_CHECKING:
@@ -320,21 +321,55 @@ async def resolve_auth(
     return None
 
 
+CONSISTENCY_HEADER = "X-Nexus-Consistency"
+_CONSISTENCY_LEVELS = frozenset(level.value for level in ConsistencyLevel)
+
+
+def parse_consistency_header(value: str | None) -> str | None:
+    """Validate the ``X-Nexus-Consistency`` header (Issue #4739).
+
+    Returns the normalised level (``"eventual"`` or ``"strong"``) or ``None``
+    when the header is absent/blank. Raises 400 on any other value so a typo
+    never silently degrades to cached reads.
+    """
+    if value is None:
+        return None
+    normalized = value.strip().lower()
+    if not normalized:
+        return None
+    if normalized not in _CONSISTENCY_LEVELS:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Invalid {CONSISTENCY_HEADER}: {value!r}. "
+                f"Expected one of: {', '.join(sorted(_CONSISTENCY_LEVELS))}"
+            ),
+        )
+    return normalized
+
+
 async def get_auth_result(
     request: Request,
     authorization: str | None = Header(None, alias="Authorization"),
     x_agent_id: str | None = Header(None, alias="X-Agent-ID"),
     x_nexus_subject: str | None = Header(None, alias="X-Nexus-Subject"),
     x_nexus_zone_id: str | None = Header(None, alias="X-Nexus-Zone-ID"),
+    x_nexus_consistency: str | None = Header(None, alias=CONSISTENCY_HEADER),
 ) -> dict[str, Any] | None:
     """FastAPI dependency wrapper for :func:`resolve_auth`.
 
     Extracts headers via FastAPI DI and delegates to the core auth logic.
     For WebSocket endpoints (where ``Depends()`` is unsupported), call
     :func:`resolve_auth` directly with ``websocket.app.state``.
+
+    ``X-Nexus-Consistency: strong`` (Issue #4739) is validated here and
+    carried on the auth result so :func:`get_operation_context` stamps it on
+    the ``OperationContext``; permission ``check`` / ``list`` / ``search`` for
+    that request then bypass the L1 / Tiger / lease caches.
     """
+    consistency = parse_consistency_header(x_nexus_consistency)
     client_host = request.client.host if request.client else None
-    return await resolve_auth(
+    result = await resolve_auth(
         app_state=request.app.state,
         authorization=authorization,
         x_agent_id=x_agent_id,
@@ -342,6 +377,11 @@ async def get_auth_result(
         x_nexus_zone_id=x_nexus_zone_id,
         client_host=client_host,
     )
+    if result is not None and consistency is not None:
+        # Copy: resolve_auth may hand back a cached/shared dict and the
+        # consistency level is per-request, not per-token.
+        result = {**result, "consistency": consistency}
+    return result
 
 
 async def require_auth(
@@ -454,4 +494,6 @@ def get_operation_context(auth_result: dict[str, Any]) -> Any:
         admin_capabilities=admin_capabilities,
         agent_generation=agent_generation,
         zone_perms=zone_perms,
+        # Issue #4739: per-request permission-cache consistency (X-Nexus-Consistency)
+        consistency=auth_result.get("consistency"),
     )

--- a/src/nexus/server/lifespan/permissions.py
+++ b/src/nexus/server/lifespan/permissions.py
@@ -299,8 +299,20 @@ async def _startup_durable_invalidation(app: "FastAPI", svc: "LifespanServices")
             if coordinator is not None:
                 _dlm = distributed_lease_mgr  # capture for closure
 
-                def _distributed_lease_invalidate(affected_zone_id: str) -> None:
+                def _distributed_lease_invalidate(
+                    affected_zone_id: str,
+                    _subject: tuple[str, str],
+                    _relation: str,
+                    _object: tuple[str, str],
+                ) -> None:
                     """Zone-wide distributed lease revocation on permission change.
+
+                    Signature follows ``CacheCoordinator.register_lease_invalidator``:
+                    ``(zone_id, subject, relation, object)``.  Issue #4739: the
+                    callback used to take only ``zone_id``, so every notification
+                    raised ``TypeError`` inside the coordinator (logged, swallowed)
+                    and distributed leases were never revoked; it surfaced once
+                    ``rebac_delete`` started notifying lease invalidators.
 
                     This runs in sync context (from invalidate_for_write).
                     Schedules the async revocation as fire-and-forget on the

--- a/tests/integration/bricks/rebac/test_read_after_write_permissions.py
+++ b/tests/integration/bricks/rebac/test_read_after_write_permissions.py
@@ -1,0 +1,280 @@
+"""Read-after-write and revocation bounds for a non-admin key (Issue #4739).
+
+Acceptance from the issue:
+
+- A non-admin key writes, then reads, lists and searches immediately and sees
+  the file — without waiting for the deferred permission buffer to flush.
+- Revoke a viewer: ``check`` denies, ``list`` and ``search`` exclude the file
+  immediately (well inside 1 s).
+
+The deferred buffer is configured with a one-hour flush interval so nothing
+in these tests can be explained by a background flush.  Tiger is not active
+on SQLite; its bypass/invalidation is covered by the unit suites.
+
+``list`` / ``glob`` / ``grep`` go through the search service, which is where
+ReBAC filtering for listings lives (``PermissionEnforcer.filter_list``); the
+raw ``sys_readdir`` syscall applies zone filtering only and is not asserted on.
+
+Requires the kernel subprocess; set ``NEXUS_BOOTSTRAP_MODE=static`` when the
+local ``nexusd-cluster`` build demands a bootstrap mode.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+pytest.importorskip("pyroaring")
+
+from nexus import CASLocalBackend
+from nexus.contracts.constants import ROOT_ZONE_ID
+from nexus.contracts.types import OperationContext
+from nexus.core.config import ParseConfig, PermissionConfig
+from nexus.factory import create_nexus_fs
+from nexus.storage.record_store import SQLAlchemyRecordStore
+
+TEAM_DIR = "/workspace/team"
+NOTES = f"{TEAM_DIR}/notes.md"
+
+ALICE = OperationContext(user_id="alice", groups=[], zone_id=ROOT_ZONE_ID, is_admin=False)
+BOB = OperationContext(user_id="bob", groups=[], zone_id=ROOT_ZONE_ID, is_admin=False)
+BOB_STRONG = OperationContext(
+    user_id="bob", groups=[], zone_id=ROOT_ZONE_ID, is_admin=False, consistency="strong"
+)
+
+
+def _make_nexus(tmp_path: Path, *, sync_owner_grant: bool) -> Any:
+    return create_nexus_fs(
+        backend=CASLocalBackend(tmp_path / "data"),
+        metadata_store=str(tmp_path / "metastore.redb"),
+        record_store=SQLAlchemyRecordStore(db_path=tmp_path / "metadata.db"),
+        parsing=ParseConfig(auto_parse=False),
+        permissions=PermissionConfig(
+            enforce=True,
+            enable_deferred=True,
+            deferred_flush_interval=3600.0,  # never flushes during a test
+            sync_owner_grant=sync_owner_grant,
+        ),
+    )
+
+
+def _buffer(nx: Any) -> Any:
+    try:
+        return nx.service("deferred_permission_buffer")
+    except Exception:
+        return None
+
+
+def _pending_grants(nx: Any) -> int | None:
+    """Pending deferred owner grants, or None when the buffer is not exposed."""
+    buf = _buffer(nx)
+    if buf is None:
+        return None
+    return int(buf.get_stats().get("pending_grants", 0))
+
+
+def _paths(results: list[Any]) -> set[str]:
+    out: set[str] = set()
+    for r in results:
+        if isinstance(r, str):
+            out.add(r)
+        elif isinstance(r, dict):
+            p = r.get("path") or r.get("file")
+            if p:
+                out.add(str(p))
+    return out
+
+
+@pytest.fixture
+def nx(tmp_path: Path) -> Iterator[Any]:
+    instance = _make_nexus(tmp_path, sync_owner_grant=True)
+    try:
+        yield instance
+    finally:
+        instance.close()
+
+
+@pytest.fixture
+def nx_legacy(tmp_path: Path) -> Iterator[Any]:
+    instance = _make_nexus(tmp_path, sync_owner_grant=False)
+    try:
+        yield instance
+    finally:
+        instance.close()
+
+
+def _grant(nx: Any, ctx: OperationContext, relation: str, path: str) -> Any:
+    return nx.service("rebac_manager").rebac_write(
+        subject=ctx.get_subject(),
+        relation=relation,
+        object=("file", path),
+        zone_id=ROOT_ZONE_ID,
+    )
+
+
+def _file_read_check(nx: Any, ctx: OperationContext, path: str, **kw: Any) -> bool:
+    return bool(
+        nx.service("rebac_manager").rebac_check(
+            ctx.get_subject(), "read", ("file", path), zone_id=ROOT_ZONE_ID, **kw
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_non_admin_writer_sees_file_immediately(nx: Any) -> None:
+    mgr = nx.service("rebac_manager")
+    search = nx.service("search")
+    _grant(nx, ALICE, "direct_editor", TEAM_DIR)
+
+    nx.write(NOTES, b"hello nexus", context=ALICE)
+    started = time.perf_counter()
+
+    # The owner tuple exists now — not after a flush.
+    owner_tuples = mgr.rebac_list_tuples(subject=ALICE.get_subject(), object=("file", NOTES))
+    assert any(t.get("relation") == "direct_owner" for t in owner_tuples), owner_tuples
+    pending = _pending_grants(nx)
+    assert pending in (None, 0), f"owner grant was queued instead of written: {pending}"
+    assert _file_read_check(nx, ALICE, NOTES)
+
+    # read / list / glob / grep as the writer, immediately.
+    assert nx.sys_read(NOTES, context=ALICE) == b"hello nexus"
+    assert NOTES in _paths(search.list(TEAM_DIR, context=ALICE))
+    assert NOTES in _paths(search.glob("*.md", TEAM_DIR, context=ALICE))
+    assert NOTES in _paths(await search.grep("hello", TEAM_DIR, context=ALICE))
+
+    elapsed = time.perf_counter() - started
+    assert elapsed < 5.0, f"read-after-write checks took {elapsed:.3f}s"
+
+
+@pytest.mark.asyncio
+async def test_owner_grant_does_not_depend_on_ancestor_grants(nx: Any) -> None:
+    """The file-level tuple alone must make the writer's file visible.
+
+    Alice's editor grant on the directory is revoked after the write, so any
+    remaining visibility comes from the synchronously written owner tuple.
+    """
+    search = nx.service("search")
+    editor_grant = _grant(nx, ALICE, "direct_editor", TEAM_DIR)
+    nx.write(NOTES, b"hello nexus", context=ALICE)
+
+    assert nx.service("rebac_manager").rebac_delete(editor_grant) is True
+
+    assert _file_read_check(nx, ALICE, NOTES)
+    assert nx.sys_read(NOTES, context=ALICE) == b"hello nexus"
+    assert NOTES in _paths(search.list(TEAM_DIR, context=ALICE))
+    assert NOTES in _paths(search.glob("*.md", TEAM_DIR, context=ALICE))
+
+
+@pytest.mark.asyncio
+async def test_revoked_viewer_is_excluded_within_one_second(nx: Any) -> None:
+    mgr = nx.service("rebac_manager")
+    search = nx.service("search")
+    _grant(nx, ALICE, "direct_editor", TEAM_DIR)
+    nx.write(NOTES, b"hello nexus", context=ALICE)
+
+    grant = _grant(nx, BOB, "direct_viewer", NOTES)
+    # Warm every cache a viewer can populate.
+    assert _file_read_check(nx, BOB, NOTES)
+    assert nx.sys_read(NOTES, context=BOB) == b"hello nexus"
+    assert NOTES in _paths(search.list(TEAM_DIR, context=BOB))
+    assert NOTES in _paths(search.glob("*.md", TEAM_DIR, context=BOB))
+
+    assert mgr.rebac_delete(grant) is True
+    revoked_at = time.perf_counter()
+
+    assert not _file_read_check(nx, BOB, NOTES)
+    assert NOTES not in _paths(search.list(TEAM_DIR, context=BOB))
+    assert NOTES not in _paths(search.glob("*.md", TEAM_DIR, context=BOB))
+    assert NOTES not in _paths(await search.grep("hello", TEAM_DIR, context=BOB))
+    with pytest.raises(PermissionError):
+        nx.sys_read(NOTES, context=BOB)
+
+    elapsed = time.perf_counter() - revoked_at
+    assert elapsed < 1.0, f"revocation took {elapsed:.3f}s to be observed"
+
+
+@pytest.mark.asyncio
+async def test_strong_consistency_context_is_honoured_end_to_end(nx: Any) -> None:
+    """A strong context resolves from tuples even when the L1 holds a stale allow."""
+    mgr = nx.service("rebac_manager")
+    search = nx.service("search")
+    _grant(nx, ALICE, "direct_editor", TEAM_DIR)
+    nx.write(NOTES, b"hello nexus", context=ALICE)
+
+    # Poison the bulk-check L1 with a stale grant for bob on the file.
+    mgr._l1_cache.set("user", "bob", "read", "file", NOTES, True, ROOT_ZONE_ID)
+    eventual = search.list(TEAM_DIR, context=BOB)
+    strong = search.list(TEAM_DIR, context=BOB_STRONG)
+
+    assert NOTES in _paths(eventual)  # cached allow served
+    assert NOTES not in _paths(strong)  # tuple store consulted
+    # The strong pass repaired the cache for later eventual calls.
+    assert NOTES not in _paths(search.list(TEAM_DIR, context=BOB))
+
+    # And for the single-object check API.
+    mgr._l1_cache.set("user", "bob", "read", "file", NOTES, True, ROOT_ZONE_ID)
+    assert not _file_read_check(nx, BOB, NOTES, consistency="strong")
+
+
+def test_legacy_deferred_owner_grant_window(nx_legacy: Any) -> None:
+    """Documents the pre-#4739 window that ``sync_owner_grant=False`` restores."""
+    _grant(nx_legacy, ALICE, "direct_editor", TEAM_DIR)
+
+    nx_legacy.write(NOTES, b"hello nexus", context=ALICE)
+
+    pending = _pending_grants(nx_legacy)
+    if pending is None:
+        pytest.skip("deferred permission buffer not exposed as a service")
+    assert pending == 1
+    owner_tuples = nx_legacy.service("rebac_manager").rebac_list_tuples(
+        subject=ALICE.get_subject(), object=("file", NOTES)
+    )
+    assert not any(t.get("relation") == "direct_owner" for t in owner_tuples)
+
+    _buffer(nx_legacy).flush()
+
+    assert _pending_grants(nx_legacy) == 0
+    owner_tuples = nx_legacy.service("rebac_manager").rebac_list_tuples(
+        subject=ALICE.get_subject(), object=("file", NOTES)
+    )
+    assert any(t.get("relation") == "direct_owner" for t in owner_tuples)
+
+
+def _readdir_paths(nx: Any, ctx: OperationContext, **kw: Any) -> set[str]:
+    result = nx.sys_readdir(TEAM_DIR, context=ctx, **kw)
+    items = getattr(result, "items", result)
+    return _paths(list(items))
+
+
+def test_sys_readdir_is_rebac_filtered_for_non_admin(nx: Any) -> None:
+    """The raw readdir syscall (behind ``/v2/files/list``) honours ReBAC.
+
+    Before #4739 ``sys_readdir`` applied zone filtering only, so a key with no
+    grant could enumerate names of files it cannot read.
+    """
+    mgr = nx.service("rebac_manager")
+    _grant(nx, ALICE, "direct_editor", TEAM_DIR)
+    nx.write(NOTES, b"hello nexus", context=ALICE)
+    admin = OperationContext(user_id="admin", groups=[], zone_id=ROOT_ZONE_ID, is_admin=True)
+
+    # bob has no grant: hidden in every listing shape.
+    assert NOTES not in _readdir_paths(nx, BOB)
+    assert NOTES not in _readdir_paths(nx, BOB, recursive=False)
+    assert NOTES not in _readdir_paths(nx, BOB, recursive=False, details=True)
+    assert NOTES not in _readdir_paths(nx, BOB, recursive=False, details=True, limit=10)
+    # The writer (owner tuple) and admin / system callers still see it.
+    assert NOTES in _readdir_paths(nx, ALICE)
+    assert NOTES in _readdir_paths(nx, ALICE, recursive=False, details=True)
+    assert NOTES in _readdir_paths(nx, admin)
+
+    grant = _grant(nx, BOB, "direct_viewer", NOTES)
+    assert NOTES in _readdir_paths(nx, BOB)
+    assert NOTES in _readdir_paths(nx, BOB, recursive=False, details=True)
+
+    assert mgr.rebac_delete(grant) is True
+    assert NOTES not in _readdir_paths(nx, BOB)
+    assert NOTES not in _readdir_paths(nx, BOB, recursive=False, details=True)

--- a/tests/unit/bricks/rebac/test_consistency_strong.py
+++ b/tests/unit/bricks/rebac/test_consistency_strong.py
@@ -1,0 +1,382 @@
+"""ReBACManager ``consistency="strong"`` and revocation invalidation (Issue #4739).
+
+- ``rebac_check`` / ``rebac_check_bulk`` with ``consistency="strong"`` never
+  serve a cached decision (L1 result cache, Tiger bitmap); the fresh result
+  repairs the cache.
+- ``rebac_delete`` routes through ``CacheCoordinator.invalidate_for_write``
+  (permission leases, Tiger L1/L2 eviction, cross-process hints) and drops the
+  subject's Tiger bitmap when a *directory* grant is revoked, so revocation is
+  bounded by the delete itself rather than the 3600 s Tiger TTL.
+
+All tests use in-memory SQLite; Tiger is a MagicMock because the real bitmap
+store is PostgreSQL-only.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip("pyroaring")
+
+from sqlalchemy import create_engine, text
+from sqlalchemy.pool import StaticPool
+
+from nexus.bricks.rebac.cache.tiger.facade import TigerFacade
+from nexus.bricks.rebac.consistency.metastore_namespace_store import MetastoreNamespaceStore
+from nexus.bricks.rebac.default_namespaces import DEFAULT_FILE_NAMESPACE
+from nexus.bricks.rebac.manager import AsyncReBACManager, ReBACManager
+from nexus.contracts.rebac_types import ConsistencyLevel, is_strong_consistency
+from nexus.storage.models import Base
+from tests.testkit.metadata import InMemoryNexusFS
+
+ALICE = ("user", "alice")
+BOB = ("user", "bob")
+DOC = ("file", "/ws/doc.txt")
+TEAM_DIR = ("file", "/ws/team")
+ZONE = "root"
+
+
+def _make_manager(*, zone_aware: bool) -> ReBACManager:
+    # StaticPool: one shared DBAPI connection so background/cleanup threads and
+    # asyncio.to_thread see the same in-memory database (same recipe as
+    # tests/unit/services/permissions/test_rebac_manager_snapshot.py).
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+        isolation_level="AUTOCOMMIT",
+    )
+    Base.metadata.create_all(engine)
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                """
+                CREATE TABLE IF NOT EXISTS rebac_group_closure (
+                    member_type VARCHAR(50) NOT NULL,
+                    member_id VARCHAR(255) NOT NULL,
+                    group_type VARCHAR(50) NOT NULL,
+                    group_id VARCHAR(255) NOT NULL,
+                    zone_id VARCHAR(255) NOT NULL,
+                    depth INTEGER NOT NULL,
+                    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+                    PRIMARY KEY (member_type, member_id, group_type, group_id, zone_id)
+                )
+                """
+            )
+        )
+    manager = ReBACManager(
+        engine=engine,
+        cache_ttl_seconds=300,
+        max_depth=10,
+        enforce_zone_isolation=zone_aware,
+        enable_tiger_cache=False,  # SQLite: Tiger is mocked where needed
+        namespace_store=MetastoreNamespaceStore(InMemoryNexusFS()),
+    )
+    manager.create_namespace(DEFAULT_FILE_NAMESPACE)
+    return manager
+
+
+@pytest.fixture
+def base_manager():
+    """enforce_zone_isolation=False — single checks consult the L1 result cache."""
+    manager = _make_manager(zone_aware=False)
+    try:
+        yield manager
+    finally:
+        manager.close()
+
+
+@pytest.fixture(params=[False, True], ids=["base-path", "zone-isolated"])
+def any_manager(request):
+    manager = _make_manager(zone_aware=request.param)
+    try:
+        yield manager
+    finally:
+        manager.close()
+
+
+def _poison_l1(manager: ReBACManager, subject, permission, obj, value: bool) -> None:
+    assert manager._l1_cache is not None
+    manager._l1_cache.set(subject[0], subject[1], permission, obj[0], obj[1], value, ZONE)
+
+
+def _attach_tiger_mock(manager: ReBACManager) -> MagicMock:
+    tiger = MagicMock(name="tiger_cache")
+    manager._tiger_cache = tiger
+    manager._tiger_facade = TigerFacade(tiger_cache=tiger)
+    return tiger
+
+
+# ---------------------------------------------------------------------------
+# Vocabulary
+# ---------------------------------------------------------------------------
+
+
+class TestConsistencyVocabulary:
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            (None, False),
+            ("strong", True),
+            (" STRONG ", True),
+            ("eventual", False),
+            ("bounded", False),
+            (ConsistencyLevel.STRONG, True),
+            (ConsistencyLevel.EVENTUAL, False),
+            (object(), False),
+            (True, False),
+        ],
+    )
+    def test_is_strong_consistency(self, value, expected):
+        assert is_strong_consistency(value) is expected
+
+    def test_levels_are_plain_strings(self):
+        assert ConsistencyLevel.STRONG == "strong"
+        assert ConsistencyLevel("eventual") is ConsistencyLevel.EVENTUAL
+
+
+# ---------------------------------------------------------------------------
+# Single check
+# ---------------------------------------------------------------------------
+
+
+class TestSingleCheckStrong:
+    def test_strong_ignores_poisoned_l1_allow(self, base_manager):
+        # No tuple grants alice anything, but the L1 says "allow" (stale grant).
+        _poison_l1(base_manager, ALICE, "read", DOC, True)
+
+        assert base_manager.rebac_check(ALICE, "read", DOC, zone_id=ZONE) is True
+        assert base_manager.rebac_check(ALICE, "read", DOC, zone_id=ZONE, consistency="strong") is (
+            False
+        )
+        # The strong result repaired the cache.
+        assert base_manager.rebac_check(ALICE, "read", DOC, zone_id=ZONE) is False
+
+    def test_strong_repairs_stale_denial(self, base_manager):
+        base_manager.rebac_write(ALICE, "direct_viewer", DOC, zone_id=ZONE)
+        # Simulate a denial cached inside the deferred-grant window (60 s TTL).
+        _poison_l1(base_manager, ALICE, "read", DOC, False)
+
+        assert base_manager.rebac_check(ALICE, "read", DOC, zone_id=ZONE) is False
+        assert (
+            base_manager.rebac_check(
+                ALICE, "read", DOC, zone_id=ZONE, consistency=ConsistencyLevel.STRONG
+            )
+            is True
+        )
+        assert base_manager.rebac_check(ALICE, "read", DOC, zone_id=ZONE) is True
+
+    def test_eventual_is_the_default_and_accepts_explicit_value(self, base_manager):
+        _poison_l1(base_manager, ALICE, "read", DOC, True)
+
+        assert base_manager.rebac_check(ALICE, "read", DOC, zone_id=ZONE, consistency=None) is True
+        assert (
+            base_manager.rebac_check(ALICE, "read", DOC, zone_id=ZONE, consistency="eventual")
+            is True
+        )
+
+    def test_strong_bypasses_tiger_allow(self, any_manager):
+        tiger = _attach_tiger_mock(any_manager)
+        tiger.check_access.return_value = True  # stale bitmap says allow
+
+        assert any_manager.rebac_check(ALICE, "read", DOC, zone_id=ZONE) is True
+        assert (
+            any_manager.rebac_check(ALICE, "read", DOC, zone_id=ZONE, consistency="strong") is False
+        )
+        # The eventual check consulted Tiger; the strong one did not add a call.
+        assert tiger.check_access.call_count == 1
+
+    def test_async_facade_forwards_consistency(self, base_manager):
+        _poison_l1(base_manager, ALICE, "read", DOC, True)
+        facade = AsyncReBACManager(base_manager)
+
+        cached = asyncio.run(facade.rebac_check(ALICE, "read", DOC, None, ZONE))
+        fresh = asyncio.run(facade.rebac_check(ALICE, "read", DOC, None, ZONE, "strong"))
+
+        assert cached is True
+        assert fresh is False
+
+
+# ---------------------------------------------------------------------------
+# Bulk check
+# ---------------------------------------------------------------------------
+
+
+class TestBulkCheckStrong:
+    def test_strong_bulk_ignores_poisoned_l1(self, any_manager):
+        check = (ALICE, "read", DOC)
+        _poison_l1(any_manager, ALICE, "read", DOC, True)
+
+        assert any_manager.rebac_check_bulk([check], zone_id=ZONE)[check] is True
+        assert any_manager.rebac_check_bulk([check], zone_id=ZONE, consistency="strong")[check] is (
+            False
+        )
+
+    def test_strong_bulk_sees_fresh_grant_over_cached_denial(self, any_manager):
+        check = (BOB, "read", DOC)
+        any_manager.rebac_write(BOB, "direct_viewer", DOC, zone_id=ZONE)
+        _poison_l1(any_manager, BOB, "read", DOC, False)
+
+        assert any_manager.rebac_check_bulk([check], zone_id=ZONE)[check] is False
+        assert any_manager.rebac_check_bulk([check], zone_id=ZONE, consistency="strong")[check] is (
+            True
+        )
+
+    def test_strong_bulk_skips_tiger_phase(self, any_manager):
+        tiger = _attach_tiger_mock(any_manager)
+        tiger.check_access_bulk.return_value = {}
+        check = (ALICE, "read", DOC)
+
+        any_manager.rebac_check_bulk([check], zone_id=ZONE, consistency="strong")
+
+        tiger.check_access_bulk.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Revocation
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteInvalidation:
+    def test_revoked_viewer_is_denied_immediately(self, any_manager):
+        grant = any_manager.rebac_write(BOB, "direct_viewer", DOC, zone_id=ZONE)
+        assert any_manager.rebac_check(BOB, "read", DOC, zone_id=ZONE) is True
+        assert any_manager.rebac_check_bulk([(BOB, "read", DOC)], zone_id=ZONE) == {
+            (BOB, "read", DOC): True
+        }
+
+        assert any_manager.rebac_delete(grant) is True
+
+        assert any_manager.rebac_check(BOB, "read", DOC, zone_id=ZONE) is False
+        assert any_manager.rebac_check_bulk([(BOB, "read", DOC)], zone_id=ZONE) == {
+            (BOB, "read", DOC): False
+        }
+
+    def test_delete_notifies_lease_and_tiger_l2_invalidators(self, any_manager):
+        lease_spy = MagicMock(name="lease_invalidator")
+        tiger_l2_spy = MagicMock(name="tiger_l2_invalidator")
+        any_manager._cache_coordinator.register_lease_invalidator("spy", lease_spy)
+        any_manager._cache_coordinator.register_tiger_l2_invalidator("spy", tiger_l2_spy)
+
+        grant = any_manager.rebac_write(BOB, "direct_viewer", DOC, zone_id=ZONE)
+        lease_spy.reset_mock()
+        tiger_l2_spy.reset_mock()
+
+        any_manager.rebac_delete(grant)
+
+        lease_spy.assert_called_once_with(ZONE, BOB, "direct_viewer", DOC)
+        tiger_l2_spy.assert_called_once_with("user", "bob", "read", "file", ZONE)
+
+    def test_grant_does_not_notify_lease_invalidators(self, any_manager):
+        """A new tuple cannot make a cached allow wrong — no lease churn on writes."""
+        lease_spy = MagicMock(name="lease_invalidator")
+        any_manager._cache_coordinator.register_lease_invalidator("spy", lease_spy)
+
+        any_manager.rebac_write(BOB, "direct_viewer", DOC, zone_id=ZONE)
+
+        lease_spy.assert_not_called()
+
+    def test_directory_grant_revoke_drops_subject_bitmap(self, any_manager):
+        tiger = _attach_tiger_mock(any_manager)
+        grant = any_manager.rebac_write(BOB, "direct_viewer", TEAM_DIR, zone_id=ZONE)
+        tiger.reset_mock()
+
+        any_manager.rebac_delete(grant)
+
+        tiger.persist_single_revoke.assert_called_once_with(
+            subject_type="user",
+            subject_id="bob",
+            permission="read",
+            resource_type="file",
+            resource_id="/ws/team",
+            zone_id=ZONE,
+        )
+        tiger.remove_directory_grant.assert_called_once_with(
+            subject_type="user",
+            subject_id="bob",
+            permission="read",
+            directory_path="/ws/team",
+            zone_id=ZONE,
+        )
+        tiger.invalidate.assert_called_once_with(
+            subject_type="user",
+            subject_id="bob",
+            permission="read",
+            resource_type="file",
+            zone_id=ZONE,
+        )
+
+    def test_file_grant_revoke_keeps_rest_of_bitmap(self, any_manager):
+        tiger = _attach_tiger_mock(any_manager)
+        grant = any_manager.rebac_write(BOB, "direct_viewer", DOC, zone_id=ZONE)
+        tiger.reset_mock()
+
+        any_manager.rebac_delete(grant)
+
+        tiger.persist_single_revoke.assert_called_once()
+        tiger.remove_directory_grant.assert_not_called()
+        tiger.invalidate.assert_not_called()
+
+    def test_editor_directory_revoke_covers_every_permission(self, any_manager):
+        tiger = _attach_tiger_mock(any_manager)
+        grant = any_manager.rebac_write(BOB, "direct_editor", TEAM_DIR, zone_id=ZONE)
+        tiger.reset_mock()
+
+        any_manager.rebac_delete(grant)
+
+        revoked = {c.kwargs["permission"] for c in tiger.persist_single_revoke.call_args_list}
+        dropped = {c.kwargs["permission"] for c in tiger.invalidate.call_args_list}
+        assert revoked == {"read", "write"}
+        assert dropped == {"read", "write"}
+
+
+# ---------------------------------------------------------------------------
+# Batch APIs (rebac_check_batch / rebac_check_batch_fast / service wrappers)
+# ---------------------------------------------------------------------------
+
+
+class TestBatchApisStrong:
+    def test_rebac_check_batch_strong_ignores_poisoned_l1(self, base_manager):
+        check = (ALICE, "read", DOC)
+        _poison_l1(base_manager, ALICE, "read", DOC, True)
+
+        assert base_manager.rebac_check_batch([check]) == [True]
+        assert base_manager.rebac_check_batch([check], consistency="strong") == [False]
+        # The strong pass repaired the cache.
+        assert base_manager.rebac_check_batch([check]) == [False]
+
+    def test_rebac_check_batch_fast_strong_ignores_poisoned_l1(self, base_manager):
+        check = (ALICE, "read", DOC)
+        _poison_l1(base_manager, ALICE, "read", DOC, True)
+
+        assert base_manager.rebac_check_batch_fast([check]) == [True]
+        assert base_manager.rebac_check_batch_fast([check], consistency="strong") == [False]
+        assert base_manager.rebac_check_batch_fast([check]) == [False]
+
+    def test_service_batch_sync_forwards_consistency(self):
+        from nexus.bricks.rebac.rebac_service import ReBACService
+
+        mgr = MagicMock()
+        mgr.rebac_check_batch_fast.return_value = [True]
+        svc = ReBACService(rebac_manager=mgr, enable_audit_logging=False)
+
+        assert svc.rebac_check_batch_sync([(ALICE, "read", DOC)], consistency="strong") == [True]
+
+        assert mgr.rebac_check_batch_fast.call_args.kwargs["consistency"] == "strong"
+
+    def test_service_batch_async_forwards_consistency_per_check(self):
+        from nexus.bricks.rebac.rebac_service import ReBACService
+
+        mgr = MagicMock()
+        mgr.rebac_check.return_value = True
+        svc = ReBACService(rebac_manager=mgr, enable_audit_logging=False)
+
+        out = asyncio.run(
+            svc.rebac_check_batch([(ALICE, "read", DOC)], zone_id=ZONE, consistency="strong")
+        )
+
+        assert out == [True]
+        assert mgr.rebac_check.call_args.kwargs["consistency"] == "strong"

--- a/tests/unit/bricks/rebac/test_deferred_permission_hook.py
+++ b/tests/unit/bricks/rebac/test_deferred_permission_hook.py
@@ -1,0 +1,212 @@
+"""DeferredPermissionHook — sync owner grant, deferred hierarchy (Issue #4739).
+
+With ``enable_deferred=True`` the hook used to queue *both* the hierarchy
+tuples and the creator's ``direct_owner`` grant, so a non-admin writer's own
+``list`` / ``search`` / ``check`` could miss the new file until the buffer
+flushed.  The owner grant is now written synchronously through the ReBAC
+manager; only the hierarchy tuples stay deferred.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from nexus.bricks.rebac.deferred_permission_hook import DeferredPermissionHook
+from nexus.contracts.types import OperationContext
+from nexus.contracts.vfs_hooks import (
+    MkdirHookContext,
+    WriteBatchHookContext,
+    WriteHookContext,
+)
+
+
+def _ctx(user_id: str = "alice", *, is_system: bool = False) -> OperationContext:
+    return OperationContext(user_id=user_id, groups=[], zone_id="root", is_system=is_system)
+
+
+@pytest.fixture
+def buf() -> MagicMock:
+    return MagicMock(name="deferred_buffer")
+
+
+@pytest.fixture
+def rebac() -> MagicMock:
+    return MagicMock(name="rebac_manager")
+
+
+class TestWriteHook:
+    def test_new_file_owner_grant_is_written_synchronously(self, buf, rebac):
+        hook = DeferredPermissionHook(buf, rebac_manager=rebac)
+        ctx = WriteHookContext(
+            path="/ws/a.txt", content=b"x", context=_ctx(), zone_id="root", is_new_file=True
+        )
+
+        hook.on_post_write(ctx)
+
+        rebac.rebac_write.assert_called_once_with(
+            subject=("user", "alice"),
+            relation="direct_owner",
+            object=("file", "/ws/a.txt"),
+            zone_id="root",
+        )
+        buf.queue_owner_grant.assert_not_called()
+        # Hierarchy tuples stay deferred.
+        buf.queue_hierarchy.assert_called_once_with("/ws/a.txt", "root")
+        assert ctx.warnings == []
+
+    def test_existing_file_does_not_regrant_ownership(self, buf, rebac):
+        hook = DeferredPermissionHook(buf, rebac_manager=rebac)
+        ctx = WriteHookContext(
+            path="/ws/a.txt", content=b"x", context=_ctx(), zone_id="root", is_new_file=False
+        )
+
+        hook.on_post_write(ctx)
+
+        rebac.rebac_write.assert_not_called()
+        buf.queue_owner_grant.assert_not_called()
+        buf.queue_hierarchy.assert_called_once_with("/ws/a.txt", "root")
+
+    def test_system_context_gets_no_owner_grant(self, buf, rebac):
+        hook = DeferredPermissionHook(buf, rebac_manager=rebac)
+        ctx = WriteHookContext(
+            path="/ws/a.txt",
+            content=b"x",
+            context=_ctx("system", is_system=True),
+            zone_id="root",
+            is_new_file=True,
+        )
+
+        hook.on_post_write(ctx)
+
+        rebac.rebac_write.assert_not_called()
+        buf.queue_owner_grant.assert_not_called()
+
+    def test_sync_failure_falls_back_to_queue_with_degraded_warning(self, buf, rebac):
+        rebac.rebac_write.side_effect = RuntimeError("db down")
+        hook = DeferredPermissionHook(buf, rebac_manager=rebac)
+        ctx = WriteHookContext(
+            path="/ws/a.txt", content=b"x", context=_ctx(), zone_id="root", is_new_file=True
+        )
+
+        hook.on_post_write(ctx)  # must not raise — the write already landed
+
+        buf.queue_owner_grant.assert_called_once_with("alice", "/ws/a.txt", "root")
+        assert len(ctx.warnings) == 1
+        assert ctx.warnings[0].severity == "degraded"
+        assert ctx.warnings[0].component == "deferred_permission"
+        assert "db down" in ctx.warnings[0].message
+
+    def test_opt_out_queues_owner_grant(self, buf, rebac):
+        hook = DeferredPermissionHook(buf, rebac_manager=rebac, sync_owner_grant=False)
+        ctx = WriteHookContext(
+            path="/ws/a.txt", content=b"x", context=_ctx(), zone_id="root", is_new_file=True
+        )
+
+        hook.on_post_write(ctx)
+
+        rebac.rebac_write.assert_not_called()
+        buf.queue_owner_grant.assert_called_once_with("alice", "/ws/a.txt", "root")
+
+    def test_without_rebac_manager_queues_owner_grant(self, buf):
+        hook = DeferredPermissionHook(buf, rebac_manager=None)
+        ctx = WriteHookContext(
+            path="/ws/a.txt", content=b"x", context=_ctx(), zone_id="root", is_new_file=True
+        )
+
+        hook.on_post_write(ctx)
+
+        buf.queue_owner_grant.assert_called_once_with("alice", "/ws/a.txt", "root")
+
+    def test_default_zone_is_root(self, buf, rebac):
+        hook = DeferredPermissionHook(buf, rebac_manager=rebac)
+        ctx = WriteHookContext(
+            path="/ws/a.txt", content=b"x", context=_ctx(), zone_id=None, is_new_file=True
+        )
+
+        hook.on_post_write(ctx)
+
+        assert rebac.rebac_write.call_args.kwargs["zone_id"] == "root"
+        buf.queue_hierarchy.assert_called_once_with("/ws/a.txt", "root")
+
+
+class TestMkdirHook:
+    def test_mkdir_owner_grant_is_written_synchronously(self, buf, rebac):
+        hook = DeferredPermissionHook(buf, rebac_manager=rebac)
+        ctx = MkdirHookContext(path="/ws/dir", context=_ctx(), zone_id="z1")
+
+        hook.on_post_mkdir(ctx)
+
+        rebac.rebac_write.assert_called_once_with(
+            subject=("user", "alice"),
+            relation="direct_owner",
+            object=("file", "/ws/dir"),
+            zone_id="z1",
+        )
+        buf.queue_hierarchy.assert_called_once_with("/ws/dir", "z1")
+        buf.queue_owner_grant.assert_not_called()
+
+
+class TestWriteBatchHook:
+    @staticmethod
+    def _meta(path: str) -> MagicMock:
+        meta = MagicMock()
+        meta.path = path
+        return meta
+
+    def test_batch_uses_rebac_write_batch_for_new_files_only(self, buf, rebac):
+        hook = DeferredPermissionHook(buf, rebac_manager=rebac)
+        ctx = WriteBatchHookContext(
+            items=[(self._meta("/ws/new.txt"), True), (self._meta("/ws/old.txt"), False)],
+            context=_ctx(),
+            zone_id="root",
+        )
+
+        hook.on_post_write_batch(ctx)
+
+        rebac.rebac_write_batch.assert_called_once_with(
+            [
+                {
+                    "subject": ("user", "alice"),
+                    "relation": "direct_owner",
+                    "object": ("file", "/ws/new.txt"),
+                    "zone_id": "root",
+                }
+            ]
+        )
+        rebac.rebac_write.assert_not_called()
+        buf.queue_owner_grant.assert_not_called()
+        assert [c.args for c in buf.queue_hierarchy.call_args_list] == [
+            ("/ws/new.txt", "root"),
+            ("/ws/old.txt", "root"),
+        ]
+
+    def test_batch_failure_falls_back_to_queue(self, buf, rebac):
+        rebac.rebac_write_batch.side_effect = RuntimeError("db down")
+        hook = DeferredPermissionHook(buf, rebac_manager=rebac)
+        ctx = WriteBatchHookContext(
+            items=[(self._meta("/ws/a.txt"), True), (self._meta("/ws/b.txt"), True)],
+            context=_ctx(),
+            zone_id="root",
+        )
+
+        hook.on_post_write_batch(ctx)
+
+        assert [c.args for c in buf.queue_owner_grant.call_args_list] == [
+            ("alice", "/ws/a.txt", "root"),
+            ("alice", "/ws/b.txt", "root"),
+        ]
+        assert len(ctx.warnings) == 1
+        assert ctx.warnings[0].severity == "degraded"
+
+    def test_batch_without_new_files_writes_nothing(self, buf, rebac):
+        hook = DeferredPermissionHook(buf, rebac_manager=rebac)
+        ctx = WriteBatchHookContext(
+            items=[(self._meta("/ws/old.txt"), False)], context=_ctx(), zone_id="root"
+        )
+
+        hook.on_post_write_batch(ctx)
+
+        rebac.rebac_write_batch.assert_not_called()
+        buf.queue_owner_grant.assert_not_called()

--- a/tests/unit/bricks/rebac/test_enforcer_strong_consistency.py
+++ b/tests/unit/bricks/rebac/test_enforcer_strong_consistency.py
@@ -1,0 +1,185 @@
+"""PermissionEnforcer honours ``OperationContext.consistency`` (Issue #4739).
+
+``consistency="strong"`` must (a) reach ``rebac_check`` / ``rebac_check_bulk``
+so the manager skips its L1 / Tiger phases, (b) skip the enforcer-side
+boundary cache, and (c) run ``filter_list`` through the strong chain, which
+never consults the Tiger bitmap or Leopard index.  Cached (default) calls
+must not gain a ``consistency`` kwarg — older managers and test doubles do
+not accept it.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from nexus.bricks.rebac.enforcer import PermissionEnforcer
+from nexus.contracts.types import OperationContext, Permission
+
+
+def _ctx(consistency: str | None) -> OperationContext:
+    return OperationContext(user_id="alice", groups=[], zone_id="root", consistency=consistency)
+
+
+def _rebac(allowed: bool = True) -> MagicMock:
+    rebac = MagicMock()
+    rebac.rebac_check.return_value = allowed
+
+    def _bulk(checks, **_kw):
+        return dict.fromkeys(checks, allowed)
+
+    rebac.rebac_check_bulk.side_effect = _bulk
+    return rebac
+
+
+class TestSinglePathCheck:
+    def test_shallow_path_forwards_strong_to_rebac_check(self):
+        rebac = _rebac()
+        enforcer = PermissionEnforcer(rebac_manager=rebac)
+
+        assert enforcer.check("/doc.txt", Permission.READ, _ctx("strong")) is True
+
+        kwargs = rebac.rebac_check.call_args.kwargs
+        assert kwargs["consistency"] == "strong"
+
+    def test_shallow_path_default_has_no_consistency_kwarg(self):
+        rebac = _rebac()
+        enforcer = PermissionEnforcer(rebac_manager=rebac)
+
+        enforcer.check("/doc.txt", Permission.READ, _ctx(None))
+
+        assert "consistency" not in rebac.rebac_check.call_args.kwargs
+
+    def test_deep_path_forwards_strong_to_bulk(self):
+        rebac = _rebac()
+        enforcer = PermissionEnforcer(rebac_manager=rebac)
+
+        assert enforcer.check("/a/b/c/d/e.txt", Permission.READ, _ctx("strong")) is True
+
+        kwargs = rebac.rebac_check_bulk.call_args.kwargs
+        assert kwargs["zone_id"] == "root"
+        assert kwargs["consistency"] == "strong"
+
+    def test_deep_path_default_has_no_consistency_kwarg(self):
+        rebac = _rebac()
+        enforcer = PermissionEnforcer(rebac_manager=rebac)
+
+        enforcer.check("/a/b/c/d/e.txt", Permission.READ, _ctx(None))
+
+        assert "consistency" not in rebac.rebac_check_bulk.call_args.kwargs
+
+    def test_strong_skips_boundary_cache(self):
+        rebac = _rebac(allowed=False)
+        enforcer = PermissionEnforcer(rebac_manager=rebac)
+        # A cached boundary that would short-circuit an eventual check.
+        enforcer._boundary_cache.set_boundary("root", "user", "alice", "read", "/a/b.txt", "/a")
+        enforcer._boundary_cache.get_boundary = MagicMock(
+            side_effect=AssertionError("boundary cache consulted under strong")
+        )
+
+        assert enforcer.check("/a/b.txt", Permission.READ, _ctx("strong")) is False
+
+
+class TestFilterList:
+    def test_strong_uses_authoritative_chain_only(self):
+        rebac = _rebac()
+        enforcer = PermissionEnforcer(rebac_manager=rebac)
+        enforcer._cache.try_bitmap_filter = MagicMock(
+            side_effect=AssertionError("Tiger consulted under strong")
+        )
+        enforcer._cache.try_leopard_lookup = MagicMock(
+            side_effect=AssertionError("Leopard consulted under strong")
+        )
+
+        allowed = enforcer.filter_list(["/ws/a.txt", "/ws/b.txt"], _ctx("strong"))
+
+        assert allowed == ["/ws/a.txt", "/ws/b.txt"]
+        kwargs = rebac.rebac_check_bulk.call_args.kwargs
+        assert kwargs["consistency"] == "strong"
+
+    def test_default_chain_consults_tiger_first(self):
+        rebac = _rebac()
+        enforcer = PermissionEnforcer(rebac_manager=rebac)
+        enforcer._cache.try_bitmap_filter = MagicMock(return_value=None)
+
+        enforcer.filter_list(["/ws/a.txt"], _ctx(None))
+
+        enforcer._cache.try_bitmap_filter.assert_called_once()
+        assert "consistency" not in rebac.rebac_check_bulk.call_args.kwargs
+
+    def test_strong_denies_when_tuple_store_denies(self):
+        rebac = _rebac(allowed=False)
+        enforcer = PermissionEnforcer(rebac_manager=rebac)
+        enforcer._cache.try_bitmap_filter = MagicMock(
+            return_value=(["/ws/a.txt"], [])  # stale Tiger "allow"
+        )
+
+        assert enforcer.filter_list(["/ws/a.txt"], _ctx("strong")) == []
+
+
+class TestFilterSearchResults:
+    def test_strong_is_forwarded(self):
+        rebac = _rebac()
+        enforcer = PermissionEnforcer(rebac_manager=rebac)
+
+        out = enforcer.filter_search_results(
+            ["/ws/a.txt"], user_id="alice", zone_id="root", consistency="strong"
+        )
+
+        assert out == ["/ws/a.txt"]
+        assert rebac.rebac_check_bulk.call_args.kwargs["consistency"] == "strong"
+
+    def test_default_has_no_consistency_kwarg(self):
+        rebac = _rebac()
+        enforcer = PermissionEnforcer(rebac_manager=rebac)
+
+        enforcer.filter_search_results(["/ws/a.txt"], user_id="alice", zone_id="root")
+
+        assert "consistency" not in rebac.rebac_check_bulk.call_args.kwargs
+
+
+class TestDescendantVisibility:
+    """Tiger misses are confirmed from the tuple store under strong."""
+
+    @pytest.fixture
+    def enforcer_with_empty_bitmap(self):
+        rebac = _rebac(allowed=False)
+        tiger = MagicMock()
+        tiger.get_accessible_paths_with_status.return_value = (None, True)  # no bitmap yet
+        rebac._tiger_cache = tiger
+        return PermissionEnforcer(rebac_manager=rebac), rebac
+
+    def test_eventual_stays_fail_closed(self, enforcer_with_empty_bitmap):
+        enforcer, rebac = enforcer_with_empty_bitmap
+
+        assert enforcer.has_accessible_descendants_batch(["/ws/"], _ctx(None)) == {"/ws/": False}
+        rebac.rebac_check_bulk.assert_not_called()
+
+    def test_strong_confirms_miss_from_tuple_store(self, enforcer_with_empty_bitmap):
+        enforcer, rebac = enforcer_with_empty_bitmap
+
+        def _bulk(checks, **_kw):
+            return {c: c[2][1] == "/ws" for c in checks}
+
+        rebac.rebac_check_bulk.side_effect = _bulk
+
+        result = enforcer.has_accessible_descendants_batch(["/ws/", "/other/"], _ctx("strong"))
+
+        assert result == {"/ws/": True, "/other/": False}
+        assert rebac.rebac_check_bulk.call_args.kwargs["consistency"] == "strong"
+
+    def test_strong_keeps_tiger_hits(self):
+        rebac = _rebac(allowed=False)
+        tiger = MagicMock()
+        tiger.get_accessible_paths_with_status.return_value = (["/ws/deep/file.txt"], True)
+        rebac._tiger_cache = tiger
+        enforcer = PermissionEnforcer(rebac_manager=rebac)
+
+        result = enforcer.has_accessible_descendants_batch(["/ws/", "/other/"], _ctx("strong"))
+
+        # /ws/ visible via the bitmap; /other/ confirmed denied by the tuple store.
+        assert result == {"/ws/": True, "/other/": False}
+        checked_paths = {c[2][1] for c in rebac.rebac_check_bulk.call_args.args[0]}
+        assert "/other" in checked_paths
+        assert "/ws" not in checked_paths

--- a/tests/unit/bricks/rebac/test_permission_filter_chain.py
+++ b/tests/unit/bricks/rebac/test_permission_filter_chain.py
@@ -122,3 +122,97 @@ def test_hierarchy_prefilter_does_not_drop_direct_leaf_grants() -> None:
     )
 
     assert allowed == [paths[0]]
+
+
+# ---------------------------------------------------------------------------
+# Issue #4739: consistency="strong" — authoritative chain, no cache strategies
+# ---------------------------------------------------------------------------
+
+
+class _RecordingBulkReBAC:
+    """Bulk checker that records the kwargs it was called with."""
+
+    def __init__(self, allowed_objects: set[str]) -> None:
+        self.allowed_objects = allowed_objects
+        self.kwargs: list[dict[str, Any]] = []
+
+    def rebac_check_bulk(self, checks: list[Check], **kwargs: Any) -> dict[Check, bool]:
+        self.kwargs.append(dict(kwargs))
+        return {check: check[2][1] in self.allowed_objects for check in checks}
+
+
+class _StaleTigerCache(_FakeCache):
+    """Cache whose Tiger bitmap still allows everything (stale after a revoke)."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.tiger_calls = 0
+        self.leopard_calls = 0
+
+    def try_bitmap_filter(self, paths: list[str], *_args: Any, **_kwargs: Any) -> Any:
+        self.tiger_calls += 1
+        return (list(paths), [])
+
+    def try_leopard_lookup(self, paths: list[str], *_args: Any, **_kwargs: Any) -> Any:
+        self.leopard_calls += 1
+        return ([], list(paths))
+
+    def is_bitmap_complete(self, *_args: Any, **_kwargs: Any) -> bool:
+        return True
+
+
+def _ctx_with(cache: Any, rebac: Any, paths: list[str], consistency: str | None) -> FilterContext:
+    return FilterContext(
+        paths=paths,
+        subject=("user", "alice"),
+        zone_id="root",
+        context=object(),
+        cache=cast(Any, cache),
+        rebac_manager=cast(Any, rebac),
+        consistency=consistency,
+    )
+
+
+def test_strong_chain_skips_tiger_and_leopard_and_forwards_consistency() -> None:
+    paths = ["/workspace/a.md", "/workspace/b.md"]
+    cache = _StaleTigerCache()
+    rebac = _RecordingBulkReBAC(allowed_objects={"/workspace/a.md"})
+
+    allowed = run_filter_chain(_ctx_with(cache, rebac, paths, "strong"))
+
+    # The stale bitmap would have allowed both; the tuple store allows one.
+    assert allowed == ["/workspace/a.md"]
+    assert cache.tiger_calls == 0
+    assert cache.leopard_calls == 0
+    assert rebac.kwargs == [{"zone_id": "root", "consistency": "strong"}]
+
+
+def test_default_chain_still_uses_tiger_and_omits_consistency_kwarg() -> None:
+    paths = ["/workspace/a.md", "/workspace/b.md"]
+    cache = _StaleTigerCache()
+    rebac = _RecordingBulkReBAC(allowed_objects=set())
+
+    allowed = run_filter_chain(_ctx_with(cache, rebac, paths, None))
+
+    assert allowed == paths  # served by the (stale) bitmap
+    assert cache.tiger_calls == 1
+    assert rebac.kwargs == []  # bulk never reached; and if it were, no consistency kwarg
+
+
+def test_strong_chain_keeps_zone_prefilter() -> None:
+    paths = ["/zone/other/secret.md", "/workspace/a.md"]
+    rebac = _RecordingBulkReBAC(allowed_objects={"/zone/other/secret.md", "/workspace/a.md"})
+
+    allowed = run_filter_chain(_ctx_with(_StaleTigerCache(), rebac, paths, "strong"))
+
+    assert allowed == ["/workspace/a.md"]
+
+
+def test_bulk_kwargs_only_forward_strong() -> None:
+    rebac = _RecordingBulkReBAC(allowed_objects=set())
+    assert _ctx_with(_FakeCache(), rebac, [], None).bulk_kwargs() == {"zone_id": "root"}
+    assert _ctx_with(_FakeCache(), rebac, [], "eventual").bulk_kwargs() == {"zone_id": "root"}
+    assert _ctx_with(_FakeCache(), rebac, [], "strong").bulk_kwargs() == {
+        "zone_id": "root",
+        "consistency": "strong",
+    }

--- a/tests/unit/core/test_readdir_rebac_filter.py
+++ b/tests/unit/core/test_readdir_rebac_filter.py
@@ -1,0 +1,144 @@
+"""``sys_readdir`` ReBAC post-filter for non-admin callers (Issue #4739).
+
+``sys_readdir`` applied zone filtering only, so a non-admin key could list the
+names of files it cannot read (the HTTP ``/files/list`` route calls it
+directly).  ``nexus.core.readdir_rebac_filter.readdir_visible_paths`` now runs
+the same enforcer chain the search service uses; admin / system /
+identity-less callers keep the unfiltered view.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from nexus.contracts.types import OperationContext
+from nexus.core.config import PermissionConfig
+from nexus.core.readdir_rebac_filter import readdir_filter_context, readdir_visible_paths
+
+ENTRIES: list[tuple[str, bool]] = [
+    ("/ws/a.txt", False),
+    ("/ws/b.txt", False),
+    ("/ws/sub", True),
+    ("/ws/other", True),
+]
+
+
+def _enforcer(allowed_files: set[str], visible_dirs: set[str]) -> MagicMock:
+    enf = MagicMock(name="permission_enforcer")
+    enf.filter_list.side_effect = lambda paths, ctx: [p for p in paths if p in allowed_files]
+    enf.has_accessible_descendants_batch.side_effect = lambda dirs, ctx: {
+        d: d in visible_dirs for d in dirs
+    }
+    return enf
+
+
+def _fs(enforcer: Any = None, *, enforce: bool = True, perm: Any = "default") -> SimpleNamespace:
+    """Just enough NexusFS surface for the filter: config + service lookup."""
+    if perm == "default":
+        perm = PermissionConfig(enforce=enforce)
+    return SimpleNamespace(
+        _perm_config=perm,
+        service=lambda name: enforcer if name == "permission_enforcer" else None,
+    )
+
+
+BOB = OperationContext(user_id="bob", groups=[], zone_id="root")
+ADMIN = OperationContext(user_id="admin", groups=[], zone_id="root", is_admin=True)
+SYSTEM = OperationContext(user_id="system", groups=[], zone_id="root", is_system=True)
+
+
+class TestNonAdminFiltering:
+    def test_files_through_filter_list_and_dirs_through_descendants(self):
+        enf = _enforcer(allowed_files={"/ws/a.txt"}, visible_dirs={"/ws/sub"})
+
+        visible = readdir_visible_paths(_fs(enf), ENTRIES, BOB)
+
+        assert visible == {"/ws/a.txt", "/ws/sub"}
+        files_arg, ctx_arg = enf.filter_list.call_args.args
+        assert files_arg == ["/ws/a.txt", "/ws/b.txt"]
+        assert ctx_arg is BOB
+        dirs_arg, _ = enf.has_accessible_descendants_batch.call_args.args
+        assert dirs_arg == ["/ws/sub", "/ws/other"]
+
+    def test_directory_without_answer_stays_visible(self):
+        """Matches SearchService: dict.get(prefix, True) for indeterminate dirs."""
+        enf = _enforcer(allowed_files=set(), visible_dirs=set())
+        enf.has_accessible_descendants_batch.side_effect = lambda dirs, ctx: {}
+
+        assert readdir_visible_paths(_fs(enf), ENTRIES, BOB) == {"/ws/sub", "/ws/other"}
+
+    def test_no_files_skips_filter_list(self):
+        enf = _enforcer(allowed_files=set(), visible_dirs={"/ws/sub"})
+
+        assert readdir_visible_paths(_fs(enf), [("/ws/sub", True)], BOB) == {"/ws/sub"}
+        enf.filter_list.assert_not_called()
+
+    def test_strong_consistency_context_reaches_enforcer(self):
+        enf = _enforcer(allowed_files=set(), visible_dirs=set())
+        strong = OperationContext(user_id="bob", groups=[], zone_id="root", consistency="strong")
+
+        readdir_visible_paths(_fs(enf), ENTRIES, strong)
+
+        assert enf.filter_list.call_args.args[1].consistency == "strong"
+
+    def test_empty_entries_do_not_filter(self):
+        enf = _enforcer(allowed_files=set(), visible_dirs=set())
+        assert readdir_visible_paths(_fs(enf), [], BOB) is None
+        enf.filter_list.assert_not_called()
+
+
+class TestUnchangedCallers:
+    @pytest.mark.parametrize("ctx", [None, ADMIN, SYSTEM], ids=["no-identity", "admin", "system"])
+    def test_admin_system_and_identity_less_are_not_filtered(self, ctx):
+        enf = _enforcer(allowed_files=set(), visible_dirs=set())
+
+        assert readdir_visible_paths(_fs(enf), ENTRIES, ctx) is None
+        enf.filter_list.assert_not_called()
+
+    def test_enforcement_disabled_is_not_filtered(self):
+        enf = _enforcer(allowed_files=set(), visible_dirs=set())
+        assert readdir_visible_paths(_fs(enf, enforce=False), ENTRIES, BOB) is None
+
+    def test_missing_permission_config_is_not_filtered(self):
+        enf = _enforcer(allowed_files=set(), visible_dirs=set())
+        assert readdir_visible_paths(_fs(enf, perm=None), ENTRIES, BOB) is None
+
+
+class TestFailClosed:
+    def test_enforcer_unavailable_hides_everything(self):
+        assert readdir_visible_paths(_fs(None), ENTRIES, BOB) == set()
+
+    def test_object_without_service_lookup_hides_everything(self):
+        fs = SimpleNamespace(_perm_config=PermissionConfig(enforce=True))
+        assert readdir_visible_paths(fs, ENTRIES, BOB) == set()
+
+
+class TestDictContexts:
+    def test_dict_with_subject_is_promoted_and_filtered(self):
+        enf = _enforcer(allowed_files={"/ws/a.txt"}, visible_dirs=set())
+        ctx = {"user_id": "bob", "zone_id": "root", "consistency": "strong"}
+
+        visible = readdir_visible_paths(_fs(enf), ENTRIES, ctx)
+
+        assert visible == {"/ws/a.txt"}
+        promoted = enf.filter_list.call_args.args[1]
+        assert isinstance(promoted, OperationContext)
+        assert promoted.user_id == "bob"
+        assert promoted.zone_id == "root"
+        assert promoted.consistency == "strong"
+
+    def test_dict_admin_or_system_is_not_filtered(self):
+        assert readdir_filter_context({"user_id": "a", "is_admin": True}) is None
+        assert readdir_filter_context({"user_id": "s", "is_system": True}) is None
+
+    def test_dict_without_subject_is_not_filtered(self):
+        assert readdir_filter_context({"zone_id": "root"}) is None
+
+    def test_operation_context_passthrough(self):
+        assert readdir_filter_context(BOB) is BOB
+        assert readdir_filter_context(ADMIN) is None
+        assert readdir_filter_context(object()) is None

--- a/tests/unit/remote/test_kernel_client_write_result.py
+++ b/tests/unit/remote/test_kernel_client_write_result.py
@@ -1,0 +1,34 @@
+"""``_SysWriteResult.is_new`` derived from ``gen`` over the typed Write RPC (Issue #4739).
+
+The kernel's ``WriteResponse`` proto exposes only ``content_id``/``size``/``gen``.
+The kernel sets ``gen = old_gen + 1`` and ``old_gen = 0`` when no entry existed,
+so ``gen == 1`` is its own ``is_new`` condition.  The post-write permission
+hooks key the creator's ``direct_owner`` grant on ``is_new_file``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from nexus.remote.kernel_client import _SysWriteResult
+
+
+@pytest.mark.parametrize(
+    ("gen", "expected"),
+    [
+        (0, False),  # error / miss shape
+        (1, True),  # first write to the path
+        (2, False),  # overwrite
+        (7, False),
+    ],
+)
+def test_is_new_follows_generation(gen: int, expected: bool) -> None:
+    result = _SysWriteResult(content_id="cid", size=3, gen=gen)
+    assert result.is_new is expected
+    assert result.gen == gen
+    assert result.hit is True
+    assert result.post_hook_needed is True
+
+
+def test_default_result_is_not_new() -> None:
+    assert _SysWriteResult().is_new is False

--- a/tests/unit/server/test_consistency_header.py
+++ b/tests/unit/server/test_consistency_header.py
@@ -1,0 +1,110 @@
+"""``X-Nexus-Consistency`` header → ``OperationContext.consistency`` (Issue #4739)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from fastapi import Depends, FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+from nexus.server import dependencies
+from nexus.server.dependencies import get_operation_context, parse_consistency_header
+
+
+class TestParseConsistencyHeader:
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            (None, None),
+            ("", None),
+            ("   ", None),
+            ("strong", "strong"),
+            ("STRONG", "strong"),
+            ("  Strong ", "strong"),
+            ("eventual", "eventual"),
+        ],
+    )
+    def test_valid_values(self, raw, expected):
+        assert parse_consistency_header(raw) == expected
+
+    @pytest.mark.parametrize("raw", ["bounded", "fully_consistent", "yes", "1"])
+    def test_invalid_values_are_400(self, raw):
+        with pytest.raises(HTTPException) as exc_info:
+            parse_consistency_header(raw)
+        assert exc_info.value.status_code == 400
+        assert "X-Nexus-Consistency" in str(exc_info.value.detail)
+
+
+class TestOperationContextMapping:
+    def test_consistency_is_carried_from_auth_result(self):
+        ctx = get_operation_context(
+            {
+                "subject_type": "user",
+                "subject_id": "alice",
+                "zone_id": "root",
+                "consistency": "strong",
+            }
+        )
+        assert ctx.consistency == "strong"
+        assert ctx.user_id == "alice"
+
+    def test_default_is_none(self):
+        ctx = get_operation_context({"subject_type": "user", "subject_id": "alice"})
+        assert ctx.consistency is None
+
+
+class TestGetAuthResultHeader:
+    """End-to-end through the FastAPI dependency with a stubbed resolver."""
+
+    @pytest.fixture
+    def shared_auth(self) -> dict[str, Any]:
+        # One dict instance returned for every call — models a cached auth result.
+        return {
+            "authenticated": True,
+            "is_admin": False,
+            "subject_type": "user",
+            "subject_id": "alice",
+            "zone_id": "root",
+        }
+
+    @pytest.fixture
+    def client(self, monkeypatch, shared_auth):
+        async def _fake_resolve_auth(**_kwargs: Any) -> dict[str, Any]:
+            return shared_auth
+
+        monkeypatch.setattr(dependencies, "resolve_auth", _fake_resolve_auth)
+
+        app = FastAPI()
+
+        @app.get("/ctx")
+        async def _ctx(auth: dict[str, Any] = Depends(dependencies.require_auth)) -> dict[str, Any]:
+            return {"consistency": get_operation_context(auth).consistency}
+
+        return TestClient(app)
+
+    def test_strong_header_reaches_operation_context(self, client):
+        resp = client.get("/ctx", headers={"X-Nexus-Consistency": "strong"})
+        assert resp.status_code == 200
+        assert resp.json() == {"consistency": "strong"}
+
+    def test_header_is_case_insensitive(self, client):
+        resp = client.get("/ctx", headers={"x-nexus-consistency": "Strong"})
+        assert resp.status_code == 200
+        assert resp.json() == {"consistency": "strong"}
+
+    def test_absent_header_means_eventual(self, client):
+        resp = client.get("/ctx")
+        assert resp.status_code == 200
+        assert resp.json() == {"consistency": None}
+
+    def test_invalid_header_is_400(self, client):
+        resp = client.get("/ctx", headers={"X-Nexus-Consistency": "bounded"})
+        assert resp.status_code == 400
+        assert "X-Nexus-Consistency" in resp.json()["detail"]
+
+    def test_cached_auth_dict_is_not_mutated(self, client, shared_auth):
+        client.get("/ctx", headers={"X-Nexus-Consistency": "strong"})
+        assert "consistency" not in shared_auth
+        # A following request without the header must not inherit strong.
+        assert client.get("/ctx").json() == {"consistency": None}

--- a/tests/unit/server/test_distributed_lease_invalidator.py
+++ b/tests/unit/server/test_distributed_lease_invalidator.py
@@ -1,0 +1,131 @@
+"""The distributed-lease invalidator honours the coordinator callback contract (Issue #4739).
+
+``CacheCoordinator.register_lease_invalidator`` calls back with
+``(zone_id, subject, relation, object)``.  The lifespan closure used to accept
+only ``zone_id``; every notification raised ``TypeError`` inside the
+coordinator (logged and swallowed), so distributed leases were never revoked.
+It surfaced once ``rebac_delete`` started notifying lease invalidators.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from nexus.server.lifespan import permissions
+
+
+class _FakeRedis:
+    """Stands in for redis.asyncio.Redis: two leases in zone root, delete records."""
+
+    def __init__(self, **_kwargs: Any) -> None:
+        self.deleted: list[str] = []
+        self.scans: list[str] = []
+
+    async def scan_iter(self, match: str, count: int = 100):  # noqa: ARG002
+        self.scans.append(match)
+        for key in ("lease:root:agent-a:/ws", "lease:root:agent-b:/ws"):
+            yield key
+
+    async def delete(self, key: str) -> int:
+        self.deleted.append(key)
+        return 1
+
+
+class _FakeStream:
+    def __init__(self, **_kwargs: Any) -> None:
+        self.handlers: dict[str, Any] = {}
+        self.started = False
+
+    def register_handler(self, name: str, handler: Any) -> None:
+        self.handlers[name] = handler
+
+    async def start(self) -> None:
+        self.started = True
+
+
+class _FakeLeaseManager:
+    def __init__(self, *, redis_client: Any, zone_id: str) -> None:
+        self._client = redis_client
+        self.zone_id = zone_id
+
+
+class _FakeCoordinator:
+    def __init__(self) -> None:
+        self.lease_invalidators: dict[str, Any] = {}
+        self.durable_stream = None
+        self.read_fence = None
+
+    def register_lease_invalidator(self, callback_id: str, callback: Any) -> None:
+        self.lease_invalidators[callback_id] = callback
+
+    def set_durable_stream(self, stream: Any) -> None:
+        self.durable_stream = stream
+
+    def set_read_fence(self, fence: Any) -> None:
+        self.read_fence = fence
+
+
+@pytest.fixture
+def wired(monkeypatch):
+    fake_redis_instances: list[_FakeRedis] = []
+
+    def _make_redis(**kwargs: Any) -> _FakeRedis:
+        inst = _FakeRedis(**kwargs)
+        fake_redis_instances.append(inst)
+        return inst
+
+    monkeypatch.setattr("redis.asyncio.Redis", _make_redis)
+    monkeypatch.setattr(
+        "nexus.bricks.rebac.cache.durable_stream.DurableInvalidationStream", _FakeStream
+    )
+    monkeypatch.setattr("nexus.lib.distributed_lease.DistributedLeaseManager", _FakeLeaseManager)
+
+    coordinator = _FakeCoordinator()
+    rebac = SimpleNamespace(_cache_coordinator=coordinator, _l1_cache=None)
+    cache_store = SimpleNamespace(_client=SimpleNamespace(_pool=object()))
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            cache_brick=SimpleNamespace(has_cache_store=True, cache_store=cache_store)
+        )
+    )
+    svc = SimpleNamespace(rebac_manager=rebac, nexus_fs=None)
+    return app, svc, coordinator, fake_redis_instances
+
+
+@pytest.mark.asyncio
+async def test_distributed_lease_invalidator_accepts_coordinator_contract(wired):
+    app, svc, coordinator, redis_instances = wired
+
+    await permissions._startup_durable_invalidation(app, svc)
+
+    assert "distributed_lease" in coordinator.lease_invalidators
+    callback = coordinator.lease_invalidators["distributed_lease"]
+
+    # Exactly what CacheCoordinator._notify_lease_invalidators passes.
+    callback("root", ("user", "bob"), "direct_viewer", ("file", "/ws/doc.txt"))
+
+    # Fire-and-forget task: let it run to completion.
+    for _ in range(5):
+        await asyncio.sleep(0)
+
+    assert redis_instances, "redis client was never constructed"
+    client = redis_instances[-1]
+    assert client.scans == ["lease:root:*"]
+    assert client.deleted == ["lease:root:agent-a:/ws", "lease:root:agent-b:/ws"]
+
+
+@pytest.mark.asyncio
+async def test_startup_wires_stream_and_fence_into_coordinator(wired):
+    app, svc, coordinator, _ = wired
+
+    await permissions._startup_durable_invalidation(app, svc)
+
+    assert isinstance(coordinator.durable_stream, _FakeStream)
+    assert coordinator.durable_stream.started is True
+    assert "local-cache-invalidate" in coordinator.durable_stream.handlers
+    assert coordinator.read_fence is not None
+    assert getattr(app.state, "distributed_lease_manager", None) is not None


### PR DESCRIPTION
## Summary

Closes #4739.

A non-admin writer could be denied its own file and a revoked viewer could keep seeing files for up to the Tiger TTL. This PR implements the four proposals in the issue and fixes two prerequisites found on the way.

- **Sync owner grant.** `DeferredPermissionHook` writes the creator's `direct_owner` tuple synchronously (`rebac_write`, `rebac_write_batch` for batch writes) and defers only the hierarchy tuples. Failure falls back to the queue with a `degraded` warning. New knob `PermissionConfig.sync_owner_grant` (default on) restores the old behaviour when off.
- **Kernel client `is_new`.** The typed `WriteResponse` carries only `content_id/size/gen`, and the Python client hard-coded `is_new=False`, so no post-write hook ever saw a new file over the kernel RPC and the owner grant (deferred or sync) never fired. `is_new` is now derived as `gen == 1`, which is the kernel's own `old_entry.is_none()` condition.
- **`consistency=strong`.** New `OperationContext.consistency`, set from `X-Nexus-Consistency` (400 on invalid values). `rebac_check`, `rebac_check_bulk`, `rebac_check_batch(_fast)`, the enforcer check and `filter_list`, search's Tiger predicate pushdown, the lease fast path and directory visibility all bypass cached decisions for that call and write the fresh result back. `rebac_check` / `rebac_check_batch` RPCs take an explicit `consistency` parameter. Also fixes `AsyncReBACManager.rebac_check` passing a sixth positional argument the sync method did not accept.
- **Targeted Tiger invalidation on delete.** `rebac_delete` routes through `CacheCoordinator.invalidate_for_write` (leases, Tiger L1/L2 eviction, cross-process hints) and, for directory grants, drops the grant record and the subject's bitmap so Leopard-expanded descendants do not stay visible for 3600 s. Grants keep the cheap write-through path.
- **L1 polarity.** A fresh denial now evicts a stale cached grant for the same key (the grant cache was consulted first, so a stale allow outlived a fresh deny).
- **`sys_readdir` ReBAC filter.** The raw syscall (behind `/v2/files/list`) applied zone filtering only; non-admin, non-system callers now get the same file filter as search list/glob/grep plus descendant-based directory visibility. Admin/system/identity-less callers are unchanged (#4740 covers admin zone scoping). Fails closed if enforcement is on but the enforcer is missing.
- **Distributed lease invalidator.** The lifespan callback took one argument but the coordinator passes four, so it raised on every notification and never revoked distributed leases; fixed with a contract test.
- **RPC params regenerated** (`--check` is clean again; the drift was stale snapshot params).
- **Docs.** `docs/architecture/rebac.md`: cache matrix (layer, TTL, writer, invalidation trigger, strong bypass), sync owner grant, revocation bound, listing surfaces.

## Test plan

- [x] Unit: `tests/unit/bricks/rebac/{test_deferred_permission_hook,test_enforcer_strong_consistency,test_consistency_strong,test_permission_filter_chain}.py`, `tests/unit/core/test_readdir_rebac_filter.py`, `tests/unit/remote/test_kernel_client_write_result.py`, `tests/unit/server/{test_consistency_header,test_distributed_lease_invalidator}.py`; `tests/unit/{core,bricks/rebac,services/permissions,remote,server,lib,bricks/search}` green. ruff / mypy clean on changed files.
- [x] Acceptance (kernel-backed, SQLite): `tests/integration/bricks/rebac/test_read_after_write_permissions.py` — non-admin write then immediate check/read/list/glob/grep with the deferred buffer never flushing; owner tuple stands without ancestor grants; revoked viewer denied and excluded from list/glob/grep and raw `sys_readdir` immediately; strong context honoured end to end; legacy window reproduced with `sync_owner_grant=False`. Run with `NEXUS_BOOTSTRAP_MODE=static` on the local kernel binary.
- [x] Live on `nexus up --build` (Postgres + Dragonfly + Rust search plugin host, Tiger active): 37/37 HTTP checks (write → immediate `rebac_check`, read, list, glob, grep, search as the writer; owner tuple after revoking the directory grant; viewer revoke denied on the first `rebac_check` and excluded from list/glob/grep/search; `X-Nexus-Consistency: strong` on list/glob/search, `bogus` → 400; `rebac_check` RPC with `consistency`); 24/24 for a revoked *directory* viewer grant with Leopard expansion (nested file denied on the first check, list/glob/grep excluded).
- [x] `permissions_demo_enhanced.sh` inside the container: all tests passed.
- [x] `scripts/test_build_perf_e2e.py` inside the container: 30 passed, 0 failed, HERB 8/8, `backend=rust-plugin`.
- [ ] Both scripts re-running on the image rebuilt with the lease-invalidator fix (server log shows zero `Lease invalidator … failed` after revokes); result will be posted as a comment.

## Follow-ups (not in this PR)

- nexus-vfs: `WriteResponse` should carry `is_new` and the `old_*` fields; the kernel does not stamp `FileMetadata.owner_id` on write, so the owner fast-path is inert over the RPC.
- Zone-isolated single-check denials are not served from L1 (`rebac_check_detailed` never consults it) and each fetches tuples per check: 300–900 ms per denial live, one `GraphLimitExceeded` timeout (>1 s) observed on a `/files/read` denial. Pre-existing; not changed here.
- `rebac_check_batch_fast` still ignores `zone_id` (pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
