### PR TITLE
fix(zones): fail closed on list/search zone defaults (#4740)

### DIFF
--- a/docs/architecture/zone-visibility.md
+++ b/docs/architecture/zone-visibility.md
@@ -18,6 +18,7 @@ may enumerate — or refuses.
 | Caller | View |
 |--------|------|
 | `context is None` (kernel / internal caller) | unrestricted |
+| the kernel's own init credential (`NexusFS._init_cred`) passed explicitly — the embedded operator, e.g. the MCP tools in sandbox mode; matched by identity, a copy is an ordinary caller | unrestricted, same as `context is None` |
 | `is_system` without a zone claim (internal service scans) | unrestricted |
 | `is_system` with a zone (ReBAC expansion, zone export) | that zone's namespace, plus root-namespace rows (see §1.1) |
 | credential with `zone_perms` | zones granting `r` or `x`; write-only grants see nothing |

--- a/docs/architecture/zone-visibility.md
+++ b/docs/architecture/zone-visibility.md
@@ -1,0 +1,120 @@
+# Zone visibility on enumeration surfaces
+
+Issue: nexi-lab/nexus#4740 (zone defaults fell open on list/search).
+Companions: `consistency-contract.md` (#4737), `rebac.md` (per-file ReBAC).
+
+Reads and writes are path-addressed: the caller has to know a path, and the
+RPC layer prefixes it with the caller's `/zone/<id>/` namespace
+(`nexus.lib.zone_scoping`). **List and search enumerate**, so the zone
+predicate applied to the candidate set *is* the tenant boundary. This document
+records what that predicate guarantees.
+
+## 1. The rule
+
+`nexus.lib.zone_visibility.resolve_zone_view(context, all_zones=…)` is the
+single source of truth. It returns a `ZoneView` — the set of zones the caller
+may enumerate — or refuses.
+
+| Caller | View |
+|--------|------|
+| `context is None` (kernel / internal caller) | unrestricted |
+| `is_system` without a zone claim (internal service scans) | unrestricted |
+| `is_system` with a zone (ReBAC expansion, zone export) | that zone's namespace, plus root-namespace rows (see §1.1) |
+| credential with `zone_perms` | zones granting `r` or `x`; write-only grants see nothing |
+| credential with `zone_set` only (legacy) | those zones |
+| credential with `zone_id` only | that zone |
+| admin without a zone claim | the **root zone**, not every zone |
+| admin with `all_zones=true` | unrestricted, **audited** |
+| non-admin with `all_zones=true` | refused (403) |
+| **non-admin, non-system, no zone claim** | **refused (403)** |
+
+The `zone_id=root` placeholder a multi-zone token carries does not make it a
+root-zone caller: only an explicit root grant or claim does.
+
+An entry is visible when the zone embedded in its internal path
+(`/zone/<id>/…`, or the legacy `/zones/<id>/…` the ReBAC filter chain also
+treats as zone-scoped) is in the view; entries outside a zone namespace fall
+back to their `zone_id` column, `None` meaning root. Consequences:
+
+* **Root-tagged entries are visible only to root-zone callers.** Anything
+  written without zone scoping (embedded mode, an admin key without a zone
+  header, root-zone traffic) is no longer listable by every tenant.
+* A root-tagged row written *inside* a tenant namespace (`/zone/ta/x`, zone
+  column root) belongs to that tenant's view and is hidden from root.
+* Explicit ReBAC cross-zone shares (`shared-viewer` etc.) are re-added by the
+  search list pipeline after the zone predicate, as before.
+
+### 1.1 What the kernel stamps
+
+In standalone mode the kernel stamps every metadata row with the **route's**
+zone, which is `root` — including rows under `/zone/<id>/…` written by a
+zone-scoped context (verified against the pinned kernel: `sys_stat` reports
+`zone_id=root` for `/zone/acme/y.txt`). The column therefore carries no
+tenant information in standalone deployments; the `/zone/<id>/` prefix that
+`scope_params_for_zone` adds to every remote caller's path **is** the tenant
+boundary, and the predicate above treats the path zone as authoritative.
+
+Two consequences:
+
+* An embedded (in-process) context with a zone can enumerate only its
+  `/zone/<id>/…` namespace. Rows it writes under legacy layouts such as
+  `/workspace/<zone>/…` are root-attributed by the kernel and visible only to
+  root-zone callers. `tests/integration/core/test_embedded_namespaces_rebac.py`
+  documents this.
+* Internal service scans that carry a zone (`is_system=True`, e.g. the ReBAC
+  directory expander, the Tiger resource-map sync, zone export) keep the
+  root-namespace rows they always saw — `ZoneView.system` — while remaining
+  scoped to their zone's namespace. Without this, ReBAC inheritance on legacy
+  layouts would silently break in standalone deployments.
+
+Making the kernel stamp the caller's zone (`context_zone_id` is already
+passed) would let the column carry tenant information everywhere; that is a
+nexus-vfs change and the natural follow-up to "require a zone tag on every
+write".
+
+## 2. Where it is enforced
+
+| Surface | Enforcement |
+|---------|-------------|
+| `NexusFS.sys_readdir` (RPC `list`/`sys_readdir`, gRPC `Call`, REST `/api/v2/files/list`) | view resolved first; recursive/detail/paginated branches post-filter the metastore scan; the non-recursive kernel fast path fetches each child's zone with one `stat_batch` and filters |
+| `SearchService.list` (and `glob`, `grep`, `glob_batch`, which build on it) | view resolved first; the scan uses the caller's `/zone/<id>/…` path as scoped (the former "flat standalone rows" prefix strip is gone; it made every enforced tenant list/glob/grep scan the root namespace); candidate rows filtered before permission filtering; paginated pages filtered per page |
+| REST `/api/v2/search/query`, `/query/batch` | `token_zone_filter_from_auth` fails closed (empty set → 403) for a non-admin credential with no zone claim |
+| REST `/api/v2/files/*`, `/api/v2/batch`, `/api/v2/search/glob|grep` | Zone-scoped callers get a `ZoneScopedFS` view (`server/api/v2/_zone_scoped_fs.py`): every request path is prefixed with `/zone/<id>/` (a path naming another zone is 403), every result path is unscoped. Same contract as the RPC/gRPC `scope_params_for_zone` |
+| Rust `http-api` `/v2/search/*`, `/v2/documents/*` | `rust/services/http-api/src/zone.rs`: zone derived from the authenticated `OperationContext`, not the request body; zone-less non-admin → 403; `root_path` scoped and results unscoped; admins may name a zone explicitly |
+| Server boundary (`get_operation_context`) | a missing zone claim is no longer coerced to root for non-admins; the context stays zone-less and the surfaces above refuse it. Admins keep root as their default zone |
+| `context_for_target_zone` | returns a copy; the caller's context is never mutated when an admin is retargeted to `/zone/<id>/` |
+
+Providers that legitimately mean "the default zone" now claim root
+explicitly instead of relying on the server's coercion: open-access
+(loopback, no auth configured), `DatabaseLocalAuth` users without an assigned
+zone, and OIDC when a zone claim is not required. `StaticAPIKeyAuth` and
+`LocalAuth` keys configured without a `zone_id` are zone-less on purpose and
+are refused on list/search — add `zone_id: root` to the key's config if the
+root view is intended. `DatabaseAPIKeyAuth` already refuses zone-less
+non-admin keys at authentication time (#3871).
+
+## 3. Admin cross-zone listing
+
+`all_zones=true` is available on `sys_readdir` (RPC `list` param, REST
+`?all_zones=true`) and `SearchService.list`. Each request emits one
+`zone.all_zones_enumeration` audit event (`nexus.lib.events.emit_audit_event`)
+carrying the operation, path, subject, zone and `request_id`, plus an INFO log
+line. Nested calls within the same request (pagination, explicit child routes)
+are recorded once.
+
+## 4. Known gaps (unchanged by #4740)
+
+* **Migration note for zone-scoped REST clients.** Before #4740 the REST
+  routes never prefixed paths, so a zone-scoped key's REST writes landed in
+  the root namespace (`/x.txt`, stamped root). Those rows are now outside
+  the key's namespace: they stay readable by root-zone callers and can be
+  moved into place by an admin (`rename /x.txt → /zone/<id>/x.txt`).
+* The recursive / detail / paginated `sys_readdir` branch is a Python walk
+  over the kernel's per-directory `readdir` plus `stat_batch`
+  (`kernel_client.metastore_list_paginated`); whether it reaches
+  federation-zone entries behind their own mounted metastore was not
+  verified here.
+* The Rust `http-api` handlers have no file-level ReBAC post-filter yet;
+  that is the R10 epic's step (#4674). Zone scoping there is done.
+* Search-index routing: `/search/query` scopes to the credential's zone. A
+  zone-less credential is refused; it is not redirected to the root index.

--- a/docs/surface-coverage/api-rpc-surface-coverage.yaml
+++ b/docs/surface-coverage/api-rpc-surface-coverage.yaml
@@ -1775,7 +1775,7 @@ operations:
   transports:
     grpc_expose:
       name: backfill_directory_index
-      source: src/nexus/core/nexus_fs_metadata.py:2089
+      source: src/nexus/core/nexus_fs_metadata.py:2096
     sdk:
       name: MCPClient.backfill_directory_index
       source: src/nexus/remote/domain/mcp.py:91
@@ -3868,7 +3868,7 @@ operations:
   transports:
     grpc_expose:
       name: flush_write_observer
-      source: src/nexus/core/nexus_fs_metadata.py:2119
+      source: src/nexus/core/nexus_fs_metadata.py:2126
   profiles:
     lite: supported
     sandbox: supported
@@ -4601,7 +4601,7 @@ operations:
   transports:
     grpc_expose:
       name: glob_batch
-      source: src/nexus/bricks/search/search_service.py:2059
+      source: src/nexus/bricks/search/search_service.py:2068
   profiles:
     lite: supported
     sandbox: supported
@@ -5012,7 +5012,7 @@ operations:
   transports:
     grpc_expose:
       name: initialize_semantic_search
-      source: src/nexus/bricks/search/search_service.py:4940
+      source: src/nexus/bricks/search/search_service.py:4949
   profiles:
     lite: supported
     sandbox: supported
@@ -7747,7 +7747,7 @@ operations:
       source: src/nexus/cli/commands/search.py:1
     grpc_expose:
       name: glob
-      source: src/nexus/bricks/search/search_service.py:1816
+      source: src/nexus/bricks/search/search_service.py:1825
     http:
       name: POST /api/v2/search/glob
       source: src/nexus/server/api/v2/routers/search.py:1713
@@ -7774,7 +7774,7 @@ operations:
       source: src/nexus/cli/commands/search.py:1
     grpc_expose:
       name: grep
-      source: src/nexus/bricks/search/search_service.py:2116
+      source: src/nexus/bricks/search/search_service.py:2125
     http:
       name: POST /api/v2/search/grep
       source: src/nexus/server/api/v2/routers/search.py:1574
@@ -7968,7 +7968,7 @@ operations:
   transports:
     grpc_expose:
       name: semantic_search
-      source: src/nexus/bricks/search/search_service.py:4447
+      source: src/nexus/bricks/search/search_service.py:4456
     mcp:
       name: nexus_semantic_search
       source: src/nexus/config/tool_profiles.yaml:1
@@ -7989,7 +7989,7 @@ operations:
   transports:
     grpc_expose:
       name: semantic_search_index
-      source: src/nexus/bricks/search/search_service.py:4798
+      source: src/nexus/bricks/search/search_service.py:4807
   profiles:
     lite: supported
     sandbox: supported
@@ -8006,7 +8006,7 @@ operations:
   transports:
     grpc_expose:
       name: semantic_search_stats
-      source: src/nexus/bricks/search/search_service.py:4892
+      source: src/nexus/bricks/search/search_service.py:4901
   profiles:
     lite: supported
     sandbox: supported

--- a/docs/surface-coverage/api-rpc-surface-coverage.yaml
+++ b/docs/surface-coverage/api-rpc-surface-coverage.yaml
@@ -1036,7 +1036,7 @@ operations:
   transports:
     http:
       name: POST /batch/read
-      source: src/nexus/server/api/v2/routers/async_files.py:2206
+      source: src/nexus/server/api/v2/routers/async_files.py:2229
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1055,7 +1055,7 @@ operations:
   transports:
     http:
       name: POST /batch/write
-      source: src/nexus/server/api/v2/routers/async_files.py:2120
+      source: src/nexus/server/api/v2/routers/async_files.py:2143
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1074,7 +1074,7 @@ operations:
   transports:
     http:
       name: POST /copy
-      source: src/nexus/server/api/v2/routers/async_files.py:2401
+      source: src/nexus/server/api/v2/routers/async_files.py:2424
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1093,7 +1093,7 @@ operations:
   transports:
     http:
       name: POST /copy-bulk
-      source: src/nexus/server/api/v2/routers/async_files.py:2509
+      source: src/nexus/server/api/v2/routers/async_files.py:2532
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1112,7 +1112,7 @@ operations:
   transports:
     http:
       name: DELETE /delete
-      source: src/nexus/server/api/v2/routers/async_files.py:1606
+      source: src/nexus/server/api/v2/routers/async_files.py:1621
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1130,7 +1130,7 @@ operations:
   transports:
     http:
       name: GET /exists
-      source: src/nexus/server/api/v2/routers/async_files.py:1692
+      source: src/nexus/server/api/v2/routers/async_files.py:1707
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1148,7 +1148,7 @@ operations:
   transports:
     http:
       name: GET /glob
-      source: src/nexus/server/api/v2/routers/async_files.py:2586
+      source: src/nexus/server/api/v2/routers/async_files.py:2609
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1166,7 +1166,7 @@ operations:
   transports:
     http:
       name: GET /grep
-      source: src/nexus/server/api/v2/routers/async_files.py:2645
+      source: src/nexus/server/api/v2/routers/async_files.py:2668
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1185,7 +1185,7 @@ operations:
   transports:
     http:
       name: GET /list
-      source: src/nexus/server/api/v2/routers/async_files.py:1729
+      source: src/nexus/server/api/v2/routers/async_files.py:1744
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1203,7 +1203,7 @@ operations:
   transports:
     http:
       name: GET /md-structure
-      source: src/nexus/server/api/v2/routers/async_files.py:1508
+      source: src/nexus/server/api/v2/routers/async_files.py:1523
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1221,7 +1221,7 @@ operations:
   transports:
     http:
       name: GET /metadata
-      source: src/nexus/server/api/v2/routers/async_files.py:2016
+      source: src/nexus/server/api/v2/routers/async_files.py:2039
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1239,7 +1239,7 @@ operations:
   transports:
     http:
       name: POST /mkdir
-      source: src/nexus/server/api/v2/routers/async_files.py:1974
+      source: src/nexus/server/api/v2/routers/async_files.py:1997
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1257,7 +1257,7 @@ operations:
   transports:
     http:
       name: GET /read
-      source: src/nexus/server/api/v2/routers/async_files.py:969
+      source: src/nexus/server/api/v2/routers/async_files.py:984
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1275,7 +1275,7 @@ operations:
   transports:
     http:
       name: GET /read-url
-      source: src/nexus/server/api/v2/routers/async_files.py:1344
+      source: src/nexus/server/api/v2/routers/async_files.py:1359
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1294,7 +1294,7 @@ operations:
   transports:
     http:
       name: POST /rename
-      source: src/nexus/server/api/v2/routers/async_files.py:2356
+      source: src/nexus/server/api/v2/routers/async_files.py:2379
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1312,7 +1312,7 @@ operations:
   transports:
     http:
       name: POST /rename-batch
-      source: src/nexus/server/api/v2/routers/async_files.py:2466
+      source: src/nexus/server/api/v2/routers/async_files.py:2489
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1330,7 +1330,7 @@ operations:
   transports:
     http:
       name: GET /stream
-      source: src/nexus/server/api/v2/routers/async_files.py:2285
+      source: src/nexus/server/api/v2/routers/async_files.py:2308
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1348,7 +1348,7 @@ operations:
   transports:
     http:
       name: POST /write
-      source: src/nexus/server/api/v2/routers/async_files.py:739
+      source: src/nexus/server/api/v2/routers/async_files.py:754
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1775,7 +1775,7 @@ operations:
   transports:
     grpc_expose:
       name: backfill_directory_index
-      source: src/nexus/core/nexus_fs_metadata.py:2109
+      source: src/nexus/core/nexus_fs_metadata.py:2089
     sdk:
       name: MCPClient.backfill_directory_index
       source: src/nexus/remote/domain/mcp.py:91
@@ -1795,7 +1795,7 @@ operations:
   transports:
     http:
       name: POST /batch
-      source: src/nexus/server/api/v2/routers/batch.py:89
+      source: src/nexus/server/api/v2/routers/batch.py:90
   profiles:
     lite: supported
     sandbox: supported
@@ -2525,7 +2525,7 @@ operations:
   transports:
     grpc_expose:
       name: delete_batch
-      source: src/nexus/core/nexus_fs_metadata.py:1465
+      source: src/nexus/core/nexus_fs_metadata.py:1466
   profiles:
     lite: supported
     sandbox: supported
@@ -2881,7 +2881,7 @@ operations:
   transports:
     grpc_expose:
       name: exists_batch
-      source: src/nexus/core/nexus_fs_metadata.py:1360
+      source: src/nexus/core/nexus_fs_metadata.py:1361
     sdk:
       name: KernelClient.exists_batch
       source: src/nexus/remote/kernel_client.py:815
@@ -3412,7 +3412,7 @@ operations:
       source: src/nexus/server/_kernel_syscall_dispatch.py:52
     grpc_expose:
       name: list
-      source: src/nexus/bricks/search/search_service.py:481
+      source: src/nexus/bricks/search/search_service.py:482
   profiles:
     lite: supported
     sandbox: supported
@@ -3741,7 +3741,7 @@ operations:
       source: src/nexus/cli/commands/file_ops.py:1
     grpc_expose:
       name: stat
-      source: src/nexus/core/nexus_fs_metadata.py:1140
+      source: src/nexus/core/nexus_fs_metadata.py:1141
   profiles:
     lite: supported
     sandbox: supported
@@ -3868,7 +3868,7 @@ operations:
   transports:
     grpc_expose:
       name: flush_write_observer
-      source: src/nexus/core/nexus_fs_metadata.py:2139
+      source: src/nexus/core/nexus_fs_metadata.py:2119
   profiles:
     lite: supported
     sandbox: supported
@@ -4339,7 +4339,7 @@ operations:
   transports:
     grpc_expose:
       name: get_content_id
-      source: src/nexus/core/nexus_fs_metadata.py:629
+      source: src/nexus/core/nexus_fs_metadata.py:630
     sdk:
       name: KernelClient.get_content_id
       source: src/nexus/remote/kernel_client.py:806
@@ -4529,7 +4529,7 @@ operations:
   transports:
     grpc_expose:
       name: get_top_level_mounts
-      source: src/nexus/core/nexus_fs_metadata.py:270
+      source: src/nexus/core/nexus_fs_metadata.py:271
     sdk:
       name: KernelClient.get_top_level_mounts
       source: src/nexus/remote/kernel_client.py:827
@@ -4601,7 +4601,7 @@ operations:
   transports:
     grpc_expose:
       name: glob_batch
-      source: src/nexus/bricks/search/search_service.py:2076
+      source: src/nexus/bricks/search/search_service.py:2059
   profiles:
     lite: supported
     sandbox: supported
@@ -5012,7 +5012,7 @@ operations:
   transports:
     grpc_expose:
       name: initialize_semantic_search
-      source: src/nexus/bricks/search/search_service.py:4957
+      source: src/nexus/bricks/search/search_service.py:4940
   profiles:
     lite: supported
     sandbox: supported
@@ -5746,7 +5746,7 @@ operations:
   transports:
     grpc_expose:
       name: metadata_batch
-      source: src/nexus/core/nexus_fs_metadata.py:1370
+      source: src/nexus/core/nexus_fs_metadata.py:1371
   profiles:
     lite: supported
     sandbox: supported
@@ -7371,7 +7371,7 @@ operations:
   transports:
     grpc_expose:
       name: rename_batch
-      source: src/nexus/core/nexus_fs_metadata.py:1604
+      source: src/nexus/core/nexus_fs_metadata.py:1605
   profiles:
     lite: supported
     sandbox: supported
@@ -7747,10 +7747,10 @@ operations:
       source: src/nexus/cli/commands/search.py:1
     grpc_expose:
       name: glob
-      source: src/nexus/bricks/search/search_service.py:1823
+      source: src/nexus/bricks/search/search_service.py:1816
     http:
       name: POST /api/v2/search/glob
-      source: src/nexus/server/api/v2/routers/search.py:1694
+      source: src/nexus/server/api/v2/routers/search.py:1713
     mcp:
       name: nexus_glob
       source: src/nexus/config/tool_profiles.yaml:1
@@ -7774,10 +7774,10 @@ operations:
       source: src/nexus/cli/commands/search.py:1
     grpc_expose:
       name: grep
-      source: src/nexus/bricks/search/search_service.py:2133
+      source: src/nexus/bricks/search/search_service.py:2116
     http:
       name: POST /api/v2/search/grep
-      source: src/nexus/server/api/v2/routers/search.py:1555
+      source: src/nexus/server/api/v2/routers/search.py:1574
     mcp:
       name: nexus_grep
       source: src/nexus/config/tool_profiles.yaml:1
@@ -7813,7 +7813,7 @@ operations:
   transports:
     http:
       name: GET /api/v2/search/health
-      source: src/nexus/server/api/v2/routers/search.py:171
+      source: src/nexus/server/api/v2/routers/search.py:172
   profiles:
     lite: supported
     sandbox: supported
@@ -7830,7 +7830,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/index
-      source: src/nexus/server/api/v2/routers/search.py:1764
+      source: src/nexus/server/api/v2/routers/search.py:1783
   profiles:
     lite: supported
     sandbox: supported
@@ -7847,7 +7847,7 @@ operations:
   transports:
     http:
       name: GET /api/v2/search/query
-      source: src/nexus/server/api/v2/routers/search.py:250
+      source: src/nexus/server/api/v2/routers/search.py:251
   profiles:
     lite: supported
     sandbox: supported
@@ -7865,7 +7865,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/query/batch
-      source: src/nexus/server/api/v2/routers/search.py:910
+      source: src/nexus/server/api/v2/routers/search.py:911
   profiles:
     lite: supported
     sandbox: supported
@@ -7882,7 +7882,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/refresh
-      source: src/nexus/server/api/v2/routers/search.py:1879
+      source: src/nexus/server/api/v2/routers/search.py:1898
   profiles:
     lite: supported
     sandbox: supported
@@ -7916,7 +7916,7 @@ operations:
   transports:
     http:
       name: GET /api/v2/search/stats
-      source: src/nexus/server/api/v2/routers/search.py:221
+      source: src/nexus/server/api/v2/routers/search.py:222
   profiles:
     lite: supported
     sandbox: supported
@@ -7968,7 +7968,7 @@ operations:
   transports:
     grpc_expose:
       name: semantic_search
-      source: src/nexus/bricks/search/search_service.py:4464
+      source: src/nexus/bricks/search/search_service.py:4447
     mcp:
       name: nexus_semantic_search
       source: src/nexus/config/tool_profiles.yaml:1
@@ -7989,7 +7989,7 @@ operations:
   transports:
     grpc_expose:
       name: semantic_search_index
-      source: src/nexus/bricks/search/search_service.py:4815
+      source: src/nexus/bricks/search/search_service.py:4798
   profiles:
     lite: supported
     sandbox: supported
@@ -8006,7 +8006,7 @@ operations:
   transports:
     grpc_expose:
       name: semantic_search_stats
-      source: src/nexus/bricks/search/search_service.py:4909
+      source: src/nexus/bricks/search/search_service.py:4892
   profiles:
     lite: supported
     sandbox: supported
@@ -8521,7 +8521,7 @@ operations:
   transports:
     grpc_expose:
       name: stat_bulk
-      source: src/nexus/core/nexus_fs_metadata.py:1228
+      source: src/nexus/core/nexus_fs_metadata.py:1229
   profiles:
     lite: supported
     sandbox: supported

--- a/rust/services/http-api/src/handlers/documents.rs
+++ b/rust/services/http-api/src/handlers/documents.rs
@@ -30,7 +30,8 @@
 
 use axum::extract::{Query, State};
 use axum::routing::{get, post};
-use axum::{Json, Router};
+use axum::{Extension, Json, Router};
+use contracts::operation_context::OperationContext;
 use serde::{Deserialize, Serialize};
 
 use crate::handlers::search::SearchError;
@@ -38,15 +39,16 @@ use crate::search_proto::{
     DocumentInput as ProtoDocumentInput, IndexDocumentsRequest, IndexRequest, RefreshRequest,
     StatsRequest,
 };
+use crate::zone::{effective_zone, is_privileged, scope_request_path, ZoneError};
 use crate::AppState;
 
 // ── shared field-shape helpers ───────────────────────────────────
 
 fn default_zone() -> String {
-    // Empty ⇒ server-side default (ROOT_ZONE_ID); matches the
-    // sibling search routes.  Kept as an explicit helper so a
-    // future zone-required route can flip the shape without
-    // touching every field.
+    // Empty ⇒ the caller's zone (#4740): resolved from the
+    // authenticated context by `crate::zone::effective_zone`, never
+    // from the wire alone.  Admin / system callers may still name a
+    // zone explicitly; everyone else is refused on a mismatch.
     String::new()
 }
 
@@ -88,12 +90,15 @@ pub struct IndexResponseBody {
 /// Handler for `POST /v2/documents/index`.
 pub async fn index(
     State(state): State<AppState>,
+    Extension(ctx): Extension<OperationContext>,
     Json(body): Json<IndexBody>,
 ) -> Result<Json<IndexResponseBody>, SearchError> {
+    let zone_id = effective_zone(&ctx, &body.zone_id)?;
+    let root_path = scope_request_path(&ctx, &zone_id, &body.root_path)?;
     let mut client = state.search.client().await?;
     let req = IndexRequest {
-        root_path: body.root_path,
-        zone_id: body.zone_id,
+        root_path,
+        zone_id,
         recursive: body.recursive,
         max_docs: body.max_docs,
         auth_token: body.auth_token,
@@ -147,12 +152,15 @@ pub struct RefreshResponseBody {
 /// Handler for `POST /v2/documents/refresh`.
 pub async fn refresh(
     State(state): State<AppState>,
+    Extension(ctx): Extension<OperationContext>,
     Json(body): Json<RefreshBody>,
 ) -> Result<Json<RefreshResponseBody>, SearchError> {
+    let zone_id = effective_zone(&ctx, &body.zone_id)?;
+    let root_path = scope_request_path(&ctx, &zone_id, &body.root_path)?;
     let mut client = state.search.client().await?;
     let req = RefreshRequest {
-        root_path: body.root_path,
-        zone_id: body.zone_id,
+        root_path,
+        zone_id,
         recursive: body.recursive,
         max_docs: body.max_docs,
         auth_token: body.auth_token,
@@ -229,21 +237,40 @@ pub struct BatchResponseBody {
 /// Handler for `POST /v2/documents/batch`.
 pub async fn batch(
     State(state): State<AppState>,
+    Extension(ctx): Extension<OperationContext>,
     Json(body): Json<BatchBody>,
 ) -> Result<Json<BatchResponseBody>, SearchError> {
+    let zone_id = effective_zone(&ctx, &body.zone_id)?;
+    // #4740: a non-privileged caller indexes into its own zone only —
+    // a per-document override naming another zone is refused, never
+    // silently honoured.  Privileged callers' documents pass through
+    // verbatim (an empty per-doc zone keeps falling back at the plugin).
+    let privileged = is_privileged(&ctx);
+    let mut documents = Vec::with_capacity(body.documents.len());
+    for d in body.documents {
+        let doc_zone = if privileged {
+            d.zone_id
+        } else if d.zone_id.is_empty() {
+            zone_id.clone()
+        } else if d.zone_id == zone_id {
+            d.zone_id
+        } else {
+            return Err(SearchError::Forbidden(ZoneError::Mismatch {
+                requested: d.zone_id,
+                caller: zone_id,
+            }));
+        };
+        documents.push(ProtoDocumentInput {
+            path: d.path,
+            text: d.text,
+            mtime_ms: d.mtime_ms,
+            zone_id: doc_zone,
+        });
+    }
     let mut client = state.search.client().await?;
     let req = IndexDocumentsRequest {
-        documents: body
-            .documents
-            .into_iter()
-            .map(|d| ProtoDocumentInput {
-                path: d.path,
-                text: d.text,
-                mtime_ms: d.mtime_ms,
-                zone_id: d.zone_id,
-            })
-            .collect(),
-        zone_id: body.zone_id,
+        documents,
+        zone_id,
         auth_token: body.auth_token,
     };
     let resp = client

--- a/rust/services/http-api/src/handlers/search.rs
+++ b/rust/services/http-api/src/handlers/search.rs
@@ -4,13 +4,17 @@
 //! through the cached [`SearchBackend`] client, and serialises the
 //! response as JSON.
 //!
-//! # Auth / ReBAC
+//! # Auth / zone / ReBAC
 //!
-//! Deliberately absent from this crate — sits in the middleware
-//! layer above once the auth port lands (see the epic issue for
-//! the sequence).  Handlers here operate on the callable
-//! contract only; a caller with tokenised access is presumed
-//! already granted.
+//! Authentication happens in [`crate::middleware::auth`], which stamps
+//! the resolved `OperationContext` into request extensions.  Handlers
+//! derive the **zone** from that context via [`crate::zone`]
+//! (nexi-lab/nexus#4740): a non-admin caller searches its own zone
+//! only, an explicit `zone_id` that differs is refused, a credential
+//! with no zone claim is refused rather than routed to ROOT, and
+//! `root_path` is scoped into the zone namespace like the Python RPC
+//! layer does.  File-level ReBAC post-filtering is still the R10 epic's
+//! separate step (#4674).
 //!
 //! # Error shape (shared)
 //!
@@ -25,12 +29,17 @@ use axum::extract::{Query, State};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};
-use axum::{Json, Router};
+use axum::{Extension, Json, Router};
+use contracts::operation_context::OperationContext;
 use serde::{Deserialize, Serialize};
 
 use crate::search_proto::{
     FusionMethod, GlobRequest, GrepRequest, QueryRequest, QueryResult as ProtoQueryResult,
     QueryType,
+};
+use crate::zone::{
+    effective_zone, is_privileged, present_paths, scope_request_path, unscope_path,
+    visible_in_zone, ZoneError,
 };
 use crate::{AppState, BackendError};
 
@@ -61,6 +70,11 @@ pub struct GlobQuery {
     /// Sort results by most-recent-mtime first when `true`.
     #[serde(default)]
     pub sort_recency: bool,
+    /// Zone to search.  Admin / system callers may name any zone;
+    /// everyone else gets their own zone and a differing value is a
+    /// 403 (#4740).  Empty ⇒ the caller's zone.
+    #[serde(default)]
+    pub zone_id: String,
 }
 
 fn default_root() -> String {
@@ -85,11 +99,14 @@ pub struct GlobResponse {
 /// Handler for `GET /v2/search/glob`.
 pub async fn glob(
     State(state): State<AppState>,
+    Extension(ctx): Extension<OperationContext>,
     Query(params): Query<GlobQuery>,
 ) -> Result<Json<GlobResponse>, SearchError> {
+    let zone = effective_zone(&ctx, &params.zone_id)?;
+    let root_path = scope_request_path(&ctx, &zone, &params.root_path)?;
     let mut client = state.search.client().await?;
     let req = GlobRequest {
-        root_path: params.root_path,
+        root_path,
         pattern: params.pattern,
         max_results: params.max_results,
         auth_token: params.auth_token,
@@ -101,7 +118,7 @@ pub async fn glob(
         .map_err(SearchError::Rpc)?
         .into_inner();
     Ok(Json(GlobResponse {
-        paths: resp.paths,
+        paths: present_paths(&ctx, &zone, resp.paths),
         truncated: resp.truncated,
         error: resp.error,
     }))
@@ -147,6 +164,9 @@ pub struct GrepQuery {
     /// Sort matches by containing-file mtime descending.
     #[serde(default)]
     pub sort_recency: bool,
+    /// Zone to search — same contract as [`GlobQuery::zone_id`] (#4740).
+    #[serde(default)]
+    pub zone_id: String,
 }
 
 /// One match row in [`GrepResponse::matches`].  Same field names as
@@ -175,11 +195,15 @@ pub struct GrepResponse {
 /// Handler for `GET /v2/search/grep`.
 pub async fn grep(
     State(state): State<AppState>,
+    Extension(ctx): Extension<OperationContext>,
     Query(params): Query<GrepQuery>,
 ) -> Result<Json<GrepResponse>, SearchError> {
+    let zone = effective_zone(&ctx, &params.zone_id)?;
+    let root_path = scope_request_path(&ctx, &zone, &params.root_path)?;
+    let privileged = is_privileged(&ctx);
     let mut client = state.search.client().await?;
     let req = GrepRequest {
-        root_path: params.root_path,
+        root_path,
         pattern: params.pattern,
         file_pattern: params.file_pattern,
         ignore_case: params.ignore_case,
@@ -199,8 +223,9 @@ pub async fn grep(
         matches: resp
             .matches
             .into_iter()
+            .filter(|m| privileged || visible_in_zone(&zone, &m.path))
             .map(|m| GrepMatch {
-                path: m.path,
+                path: unscope_path(&zone, &m.path),
                 line_number: m.line_number,
                 line: m.line,
                 before: m.before,
@@ -401,15 +426,19 @@ fn hit_from_proto(r: ProtoQueryResult) -> QueryHit {
 /// so a POST body keeps the wire honest.
 pub async fn query(
     State(state): State<AppState>,
+    Extension(ctx): Extension<OperationContext>,
     Json(body): Json<QueryBody>,
 ) -> Result<Json<QueryResponseBody>, SearchError> {
     let query_type = parse_query_type(&body.query_type).map_err(SearchError::BadRequest)?;
     let fusion_method =
         parse_fusion_method(&body.fusion_method).map_err(SearchError::BadRequest)?;
+    // #4740: the index zone is the caller's zone, never a wire-supplied
+    // one (admins may still name a zone explicitly).
+    let zone_id = effective_zone(&ctx, &body.zone_id)?;
     let mut client = state.search.client().await?;
     let req = QueryRequest {
         q: body.q,
-        zone_id: body.zone_id,
+        zone_id,
         limit: body.limit,
         path_filter: body.path_filter,
         query_type: query_type as i32,
@@ -467,6 +496,11 @@ pub enum SearchError {
     BackendUnavailable(#[from] BackendError),
     #[error("bad request: {0}")]
     BadRequest(String),
+    /// #4740: zone refusal — zone-less non-admin caller, an explicit
+    /// `zone_id` that is not the caller's, or a path naming another
+    /// zone.  403, matching the Python surface.
+    #[error("forbidden: {0}")]
+    Forbidden(#[from] ZoneError),
     #[error("rpc failed: {0}")]
     Rpc(tonic::Status),
 }
@@ -476,6 +510,7 @@ impl IntoResponse for SearchError {
         let (status, message) = match self {
             SearchError::BackendUnavailable(e) => (StatusCode::SERVICE_UNAVAILABLE, e.to_string()),
             SearchError::BadRequest(m) => (StatusCode::BAD_REQUEST, m),
+            SearchError::Forbidden(e) => (StatusCode::FORBIDDEN, e.to_string()),
             SearchError::Rpc(s) => (grpc_status_to_http(s.code()), s.message().to_string()),
         };
         (status, Json(serde_json::json!({ "error": message }))).into_response()

--- a/rust/services/http-api/src/lib.rs
+++ b/rust/services/http-api/src/lib.rs
@@ -54,6 +54,7 @@ use transport::auth::AuthProvider;
 pub mod handlers;
 pub mod middleware;
 pub mod search_backend;
+pub mod zone;
 
 /// Client stubs for the workspace's `nexus.search.v1` proto SSOT
 /// — generated at build time by `build.rs` from

--- a/rust/services/http-api/src/zone.rs
+++ b/rust/services/http-api/src/zone.rs
@@ -1,0 +1,359 @@
+//! Caller-zone derivation for the protected `/v2/search/*` and
+//! `/v2/documents/*` handlers (nexi-lab/nexus#4740).
+//!
+//! Before this module the handlers took `zone_id` straight from the
+//! request body / query string ("empty ⇒ ROOT") and forwarded
+//! `root_path` untouched, so an authenticated caller could search or
+//! index any zone by naming it, and a caller with no zone at all landed
+//! in the root index.  The Python `nexus-server` closed the same gap in
+//! `nexus.lib.zone_visibility` + `nexus.lib.zone_scoping`; this is the
+//! Rust mirror of those two rules:
+//!
+//! 1. **The zone comes from the authenticated context**, not the wire.
+//!    Admin / system callers may still name a zone explicitly (that is
+//!    how an operator inspects a tenant); everyone else gets their own
+//!    zone, a mismatching explicit zone is refused, and a credential
+//!    with no zone claim is refused rather than routed to ROOT.
+//! 2. **Paths are scoped into the zone namespace** (`/zone/<id>/…`) the
+//!    way `scope_params_for_zone` does for every RPC syscall, and
+//!    results are unscoped back.  A path that names another zone is a
+//!    403, never silently re-rooted.  Non-privileged root-zone callers
+//!    see the root namespace only.
+//!
+//! Pure functions — no I/O — so the rules are unit-tested here and the
+//! handlers stay thin.
+
+use contracts::operation_context::OperationContext;
+
+/// The root zone id (mirrors `nexus.contracts.constants.ROOT_ZONE_ID`).
+pub const ROOT_ZONE_ID: &str = "root";
+
+const ZONE_PREFIX: &str = "/zone/";
+
+/// Why a request could not be attributed to a zone.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ZoneError {
+    /// Non-admin credential with no zone claim at all.
+    NoZoneClaim,
+    /// Non-admin credential asked for a zone other than its own.
+    Mismatch { requested: String, caller: String },
+    /// A path names a zone the caller may not address.
+    CrossZonePath { path: String, zone: String },
+}
+
+impl std::fmt::Display for ZoneError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ZoneError::NoZoneClaim => write!(
+                f,
+                "refused: caller has no zone claim; zone-less callers no longer receive the \
+                 root view (nexi-lab/nexus#4740)"
+            ),
+            ZoneError::Mismatch { requested, caller } => write!(
+                f,
+                "refused: zone_id {requested:?} does not match the caller's zone {caller:?}"
+            ),
+            ZoneError::CrossZonePath { path, zone } => write!(
+                f,
+                "refused: path {path:?} is outside the caller's zone {zone:?}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ZoneError {}
+
+/// Admin and system contexts may address any zone.
+pub fn is_privileged(ctx: &OperationContext) -> bool {
+    ctx.is_admin || ctx.is_system
+}
+
+/// The zone the credential is scoped to: the explicit caller zone when
+/// the auth provider set one, else the routing zone.  `None` = no claim.
+pub fn caller_zone(ctx: &OperationContext) -> Option<&str> {
+    match ctx.context_zone_id.as_deref() {
+        Some(z) if !z.is_empty() => Some(z),
+        _ if !ctx.zone_id.is_empty() => Some(ctx.zone_id.as_str()),
+        _ => None,
+    }
+}
+
+/// `true` for the root zone in either spelling the wire uses: the explicit
+/// id, or the empty string the search proto documents as "server default".
+pub fn is_root(zone: &str) -> bool {
+    zone.is_empty() || zone == ROOT_ZONE_ID
+}
+
+/// Resolve the zone a request operates on.
+///
+/// * privileged: the request passes through verbatim — an explicit zone
+///   is honoured, and an empty one keeps meaning "the backend default
+///   (ROOT)" so the admin wire contract is unchanged;
+/// * everyone else: the caller's zone — an explicit `requested` must
+///   match it, and a missing claim is an error.
+pub fn effective_zone(ctx: &OperationContext, requested: &str) -> Result<String, ZoneError> {
+    let requested = requested.trim();
+    if is_privileged(ctx) {
+        return Ok(requested.to_string());
+    }
+    let caller = caller_zone(ctx).ok_or(ZoneError::NoZoneClaim)?;
+    if !requested.is_empty() && requested != caller {
+        return Err(ZoneError::Mismatch {
+            requested: requested.to_string(),
+            caller: caller.to_string(),
+        });
+    }
+    Ok(caller.to_string())
+}
+
+/// Zone embedded in an internal `/zone/<id>/…` path.
+pub fn embedded_zone(path: &str) -> Option<&str> {
+    let rest = path.strip_prefix(ZONE_PREFIX)?;
+    let zone = rest.split('/').next().unwrap_or("");
+    if zone.is_empty() {
+        None
+    } else {
+        Some(zone)
+    }
+}
+
+fn collapse_slashes(path: &str) -> String {
+    let mut out = path.to_string();
+    while out.contains("//") {
+        out = out.replace("//", "/");
+    }
+    out
+}
+
+/// Scope a caller-supplied VFS path into `zone`'s namespace.
+///
+/// Mirrors `nexus.lib.zone_scoping.scope_single_path`: the root zone sees
+/// the whole tree unchanged; any other zone gets `/zone/<id>` prefixed,
+/// and a path already carrying a *different* zone prefix is refused.
+pub fn scope_path(zone: &str, path: &str) -> Result<String, ZoneError> {
+    let canonical = collapse_slashes(path);
+    if is_root(zone) {
+        return Ok(canonical);
+    }
+    if canonical.starts_with(ZONE_PREFIX) {
+        return match embedded_zone(&canonical) {
+            Some(embedded) if embedded == zone => Ok(canonical),
+            _ => Err(ZoneError::CrossZonePath {
+                path: path.to_string(),
+                zone: zone.to_string(),
+            }),
+        };
+    }
+    let prefix = format!("{ZONE_PREFIX}{zone}");
+    if canonical == "/" {
+        return Ok(prefix);
+    }
+    if canonical.starts_with('/') {
+        Ok(format!("{prefix}{canonical}"))
+    } else {
+        Ok(format!("{prefix}/{canonical}"))
+    }
+}
+
+/// [`scope_path`] plus the root-namespace rule: a non-privileged caller in
+/// the root zone may not address another zone's namespace either.
+pub fn scope_request_path(
+    ctx: &OperationContext,
+    zone: &str,
+    path: &str,
+) -> Result<String, ZoneError> {
+    let scoped = scope_path(zone, path)?;
+    if !is_privileged(ctx) && is_root(zone) && embedded_zone(&scoped).is_some() {
+        return Err(ZoneError::CrossZonePath {
+            path: path.to_string(),
+            zone: zone.to_string(),
+        });
+    }
+    Ok(scoped)
+}
+
+/// Whether an internal result path belongs to `zone`'s view: paths inside
+/// a zone namespace belong to that zone; paths outside any namespace are
+/// the root zone's.
+pub fn visible_in_zone(zone: &str, path: &str) -> bool {
+    match embedded_zone(path) {
+        Some(embedded) => embedded == zone,
+        None => is_root(zone),
+    }
+}
+
+/// Strip `zone`'s own prefix from an internal path; other paths pass
+/// through unchanged (so a privileged cross-zone listing stays
+/// zone-qualified, as the Python RPC adapter does for `all_zones`).
+pub fn unscope_path(zone: &str, path: &str) -> String {
+    if is_root(zone) {
+        return path.to_string();
+    }
+    let prefix = format!("{ZONE_PREFIX}{zone}");
+    if path == prefix {
+        return "/".to_string();
+    }
+    match path.strip_prefix(&format!("{prefix}/")) {
+        Some(rest) => format!("/{rest}"),
+        None => path.to_string(),
+    }
+}
+
+/// Filter + unscope result paths for the caller: privileged callers keep
+/// everything (zone-qualified), everyone else sees only their zone.
+pub fn present_paths<I>(ctx: &OperationContext, zone: &str, paths: I) -> Vec<String>
+where
+    I: IntoIterator<Item = String>,
+{
+    let privileged = is_privileged(ctx);
+    paths
+        .into_iter()
+        .filter(|p| privileged || visible_in_zone(zone, p))
+        .map(|p| unscope_path(zone, &p))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tenant(zone: &str) -> OperationContext {
+        let mut ctx = OperationContext::new("alice", ROOT_ZONE_ID, false, None, false);
+        ctx.context_zone_id = Some(zone.to_string());
+        ctx
+    }
+
+    fn admin() -> OperationContext {
+        OperationContext::new("root-op", ROOT_ZONE_ID, true, None, false)
+    }
+
+    fn zoneless() -> OperationContext {
+        let mut ctx = OperationContext::new("nozone", "", false, None, false);
+        ctx.context_zone_id = None;
+        ctx
+    }
+
+    #[test]
+    fn caller_zone_prefers_context_zone_then_routing_zone() {
+        assert_eq!(caller_zone(&tenant("ta")), Some("ta"));
+        let routing_only = OperationContext::new("bob", "tb", false, None, false);
+        assert_eq!(caller_zone(&routing_only), Some("tb"));
+        assert_eq!(caller_zone(&zoneless()), None);
+    }
+
+    #[test]
+    fn tenant_gets_its_own_zone_and_cannot_pick_another() {
+        assert_eq!(effective_zone(&tenant("ta"), "").unwrap(), "ta");
+        assert_eq!(effective_zone(&tenant("ta"), "ta").unwrap(), "ta");
+        assert_eq!(
+            effective_zone(&tenant("ta"), "tb"),
+            Err(ZoneError::Mismatch {
+                requested: "tb".into(),
+                caller: "ta".into()
+            })
+        );
+    }
+
+    #[test]
+    fn zone_less_non_admin_is_refused_not_rooted() {
+        assert_eq!(effective_zone(&zoneless(), ""), Err(ZoneError::NoZoneClaim));
+        assert_eq!(
+            effective_zone(&zoneless(), "ta"),
+            Err(ZoneError::NoZoneClaim)
+        );
+    }
+
+    #[test]
+    fn admin_requests_pass_through_verbatim() {
+        // empty keeps meaning "backend default" so the admin wire contract
+        // (`index_defaults_reach_backend_intact`) is unchanged
+        assert_eq!(effective_zone(&admin(), "").unwrap(), "");
+        assert_eq!(effective_zone(&admin(), "tb").unwrap(), "tb");
+        assert!(is_root("") && is_root(ROOT_ZONE_ID) && !is_root("ta"));
+        assert_eq!(scope_path("", "/docs").unwrap(), "/docs");
+        assert_eq!(unscope_path("", "/zone/ta/a.txt"), "/zone/ta/a.txt");
+    }
+
+    #[test]
+    fn scope_path_mirrors_python_scoping() {
+        assert_eq!(scope_path("ta", "/").unwrap(), "/zone/ta");
+        assert_eq!(
+            scope_path("ta", "/docs/a.txt").unwrap(),
+            "/zone/ta/docs/a.txt"
+        );
+        assert_eq!(
+            scope_path("ta", "docs//a.txt").unwrap(),
+            "/zone/ta/docs/a.txt"
+        );
+        assert_eq!(
+            scope_path("ta", "/zone/ta/a.txt").unwrap(),
+            "/zone/ta/a.txt"
+        );
+        assert!(matches!(
+            scope_path("ta", "/zone/tb/a.txt"),
+            Err(ZoneError::CrossZonePath { .. })
+        ));
+        // //zone//tb slips past a naive prefix check; canonicalise first.
+        assert!(matches!(
+            scope_path("ta", "//zone//tb/x"),
+            Err(ZoneError::CrossZonePath { .. })
+        ));
+        assert_eq!(
+            scope_path(ROOT_ZONE_ID, "/zone/tb/a.txt").unwrap(),
+            "/zone/tb/a.txt"
+        );
+    }
+
+    #[test]
+    fn root_zone_non_admin_cannot_address_tenant_namespaces() {
+        let root_user = OperationContext::new("carol", ROOT_ZONE_ID, false, None, false);
+        assert_eq!(
+            scope_request_path(&root_user, ROOT_ZONE_ID, "/docs").unwrap(),
+            "/docs"
+        );
+        assert!(matches!(
+            scope_request_path(&root_user, ROOT_ZONE_ID, "/zone/tb/x"),
+            Err(ZoneError::CrossZonePath { .. })
+        ));
+        assert_eq!(
+            scope_request_path(&admin(), ROOT_ZONE_ID, "/zone/tb/x").unwrap(),
+            "/zone/tb/x"
+        );
+    }
+
+    #[test]
+    fn present_paths_filters_and_unscopes_for_tenants_only() {
+        let hits = vec![
+            "/zone/ta/a.txt".to_string(),
+            "/zone/tb/b.txt".to_string(),
+            "/root.txt".to_string(),
+        ];
+        assert_eq!(
+            present_paths(&tenant("ta"), "ta", hits.clone()),
+            vec!["/a.txt"]
+        );
+        let root_user = OperationContext::new("carol", ROOT_ZONE_ID, false, None, false);
+        assert_eq!(
+            present_paths(&root_user, ROOT_ZONE_ID, hits.clone()),
+            vec!["/root.txt"]
+        );
+        // privileged callers keep everything, zone-qualified
+        assert_eq!(present_paths(&admin(), ROOT_ZONE_ID, hits.clone()), hits);
+        // an admin inspecting one zone gets that zone's view unscoped
+        assert_eq!(
+            present_paths(&admin(), "ta", hits),
+            vec!["/a.txt", "/zone/tb/b.txt", "/root.txt"]
+        );
+    }
+
+    #[test]
+    fn unscope_only_strips_own_prefix() {
+        assert_eq!(unscope_path("ta", "/zone/ta"), "/");
+        assert_eq!(unscope_path("ta", "/zone/ta/a.txt"), "/a.txt");
+        assert_eq!(unscope_path("ta", "/zone/tb/b.txt"), "/zone/tb/b.txt");
+        assert_eq!(
+            unscope_path(ROOT_ZONE_ID, "/zone/ta/a.txt"),
+            "/zone/ta/a.txt"
+        );
+    }
+}

--- a/src/nexus/bricks/auth/providers/database_local.py
+++ b/src/nexus/bricks/auth/providers/database_local.py
@@ -19,6 +19,7 @@ from nexus.bricks.auth.user_queries import (
     get_user_by_username,
     validate_user_uniqueness,
 )
+from nexus.contracts.constants import ROOT_ZONE_ID
 from nexus.storage.models import UserModel
 
 logger = logging.getLogger(__name__)
@@ -116,7 +117,11 @@ class DatabaseLocalAuth(LocalAuth):
         user_info = {
             "subject_type": "user",
             "subject_id": user.user_id,
-            "zone_id": None,
+            # Issue #4740: local users without an assigned zone live in the
+            # root zone explicitly — the server no longer coerces a missing
+            # zone to ROOT, and zone-less non-admins are refused on list /
+            # search.
+            "zone_id": getattr(user, "zone_id", None) or ROOT_ZONE_ID,
             "is_admin": user.is_global_admin == 1,
             "name": user.display_name or user.username or user.email,
         }
@@ -155,7 +160,8 @@ class DatabaseLocalAuth(LocalAuth):
             user_info = {
                 "subject_type": "user",
                 "subject_id": user.user_id,
-                "zone_id": None,
+                # Issue #4740: see register_user_and_login — explicit ROOT.
+                "zone_id": getattr(user, "zone_id", None) or ROOT_ZONE_ID,
                 "is_admin": user.is_global_admin == 1,
                 "name": user.display_name or user.username or user.email,
             }
@@ -279,7 +285,8 @@ class DatabaseLocalAuth(LocalAuth):
             return {
                 "subject_type": "user",
                 "subject_id": user.user_id,
-                "zone_id": user.zone_id,
+                # Issue #4740: explicit ROOT for zone-less local users.
+                "zone_id": user.zone_id or ROOT_ZONE_ID,
                 "is_admin": user.is_global_admin == 1,
                 "name": user.display_name or user.username or user.email,
                 "api_key": user.api_key,

--- a/src/nexus/bricks/auth/providers/oidc.py
+++ b/src/nexus/bricks/auth/providers/oidc.py
@@ -231,6 +231,17 @@ class OIDCAuth(AuthProvider):
                 )
                 return AuthResult(authenticated=False)
 
+            if not zone_id:
+                # Issue #4740: the server no longer coerces a missing zone to
+                # ROOT — zone-less non-admin contexts are refused on list /
+                # search.  When this provider is configured to tolerate a
+                # missing claim (``require_zone=False`` or
+                # ``allow_default_zone=True``), "the default zone" IS the
+                # root zone, so claim it explicitly here.
+                from nexus.contracts.constants import ROOT_ZONE_ID
+
+                zone_id = ROOT_ZONE_ID
+
             email = claims.get("email")
             is_admin = email in self.admin_emails if email else False
 

--- a/src/nexus/bricks/search/search_auth.py
+++ b/src/nexus/bricks/search/search_auth.py
@@ -89,7 +89,13 @@ def token_zone_filter_from_auth(
         return None
     raw_zone_set = tuple(auth_result.get("zone_set") or ())
     if not raw_zone_set:
-        return None
+        # Issue #4740: an empty scope is "unbounded" only for a credential
+        # that at least carries a zone claim (a root-zone operator key).  A
+        # non-admin credential with NO zone claim at all used to fall through
+        # to the root index here; it now fails closed (empty set → the
+        # router's existing 403), matching sys_readdir's refusal of
+        # zone-less callers.
+        return None if auth_result.get("zone_id") else frozenset()
     if set(raw_zone_set) == {root_zone_id}:
         root_letters = "".join(
             zp[1]

--- a/src/nexus/bricks/search/search_service.py
+++ b/src/nexus/bricks/search/search_service.py
@@ -511,8 +511,15 @@ class SearchService:
         # Issue #4740: resolve the caller's zone view first and fail closed —
         # a zone-less non-admin caller is refused instead of receiving the
         # root/global view, and admins only cross zones with an explicit,
-        # audited ``all_zones=True``.
-        _zone_view = resolve_zone_view(context, all_zones=all_zones, operation="search.list")
+        # audited ``all_zones=True``.  The service's default context is the
+        # kernel's own init credential (embedded operator): passed explicitly
+        # it keeps the unrestricted view ``context=None`` would get.
+        _zone_view = resolve_zone_view(
+            context,
+            all_zones=all_zones,
+            operation="search.list",
+            init_cred=self._default_context,
+        )
         if _zone_view.all_zones:
             audit_all_zones(context, operation="search.list", path=path)
 
@@ -1654,7 +1661,9 @@ class SearchService:
         from nexus.lib.pagination import encode_cursor
 
         if zone_view is None:
-            zone_view = resolve_zone_view(context, operation="search.list")
+            zone_view = resolve_zone_view(
+                context, operation="search.list", init_cred=self._default_context
+            )
         context = context or self._default_context
         import time as _time
 

--- a/src/nexus/bricks/search/search_service.py
+++ b/src/nexus/bricks/search/search_service.py
@@ -44,6 +44,7 @@ from nexus.contracts.search_types import (
 from nexus.contracts.types import Permission
 from nexus.kernel_helpers import metastore_get_searchable_text_bulk
 from nexus.lib.rpc_decorator import rpc_expose
+from nexus.lib.zone_visibility import audit_all_zones, resolve_zone_view
 
 # List directory traversal thresholds (Issue #901)
 # Issue #2071: LIST_PARALLEL_WORKERS now sourced from ProfileTuning.search.list_parallel_workers
@@ -488,6 +489,7 @@ class SearchService:
         context: Any = None,
         limit: int | None = None,
         cursor: str | None = None,
+        all_zones: bool = False,
     ) -> builtins.list[str] | builtins.list[dict[str, Any]] | Any:
         """List files in a directory.
 
@@ -502,7 +504,18 @@ class SearchService:
             context: Operation context for permission filtering
             limit: Max items per page (enables pagination mode)
             cursor: Continuation token from previous page
+            all_zones: Admin only — enumerate across every zone instead of
+                the caller's zone; audited (#4740). Non-admins get
+                PermissionDeniedError.
         """
+        # Issue #4740: resolve the caller's zone view first and fail closed —
+        # a zone-less non-admin caller is refused instead of receiving the
+        # root/global view, and admins only cross zones with an explicit,
+        # audited ``all_zones=True``.
+        _zone_view = resolve_zone_view(context, all_zones=all_zones, operation="search.list")
+        if _zone_view.all_zones:
+            audit_all_zones(context, operation="search.list", path=path)
+
         # Issue #937: Pagination mode
         if limit is not None:
             return self._list_paginated(
@@ -512,6 +525,7 @@ class SearchService:
                 limit=limit,
                 cursor=cursor,
                 context=context,
+                zone_view=_zone_view,
             )
         # Check if path routes to a dynamic API-backed connector.
         # Detect via mount root metadata is_external_storage flag (§12d).
@@ -571,25 +585,13 @@ class SearchService:
             path = path + "/"
         list_prefix = path if path != "/" else ""
 
-        # Issue #3779 follow-up: in standalone mode, files are stored flat
-        # (``/marker.txt``) with zone_id as a metadata column — NOT under
-        # ``/zone/<id>/`` in the key. The RPC layer's
-        # ``scope_params_for_zone`` prefixes incoming paths with
-        # ``/zone/<id>/`` anyway (for federation mode). Strip that prefix
-        # here when the backing store is not zone-partitioned so the
-        # metastore query finds the flat-stored entries; the zone-column
-        # post-filter below enforces isolation.
-        # list_prefix is either "" or ends with "/" (set above), so only the
-        # trailing-slash case can match.
-        _engine_zone_id: str | None = getattr(self.metadata, "_zone_id", None)
-        _standalone_flat_paths = _engine_zone_id is None
-        if (
-            _standalone_flat_paths
-            and list_zone_id
-            and list_zone_id != ROOT_ZONE_ID
-            and list_prefix.startswith(f"/zone/{list_zone_id}/")
-        ):
-            list_prefix = list_prefix[len(f"/zone/{list_zone_id}") :]
+        # #4740: the scan runs on the path exactly as scoped by the caller's
+        # layer.  An earlier "#3779 follow-up" stripped the caller's
+        # ``/zone/<id>`` prefix here on the assumption that standalone rows
+        # were stored flat with a zone column; the kernel stores them under
+        # ``/zone/<id>/…`` (verified against the pinned kernel), so that
+        # strip made every zone-scoped list/glob/grep scan the ROOT namespace
+        # and return nothing for tenants whenever permissions were enforced.
 
         # OPTIMIZATION: For non-recursive, try sparse directory index + Tiger bitmap
         _use_fast_path = False
@@ -630,16 +632,15 @@ class SearchService:
             sample_paths = [m["path"] for m in all_files[:5]]
             logger.info(f"[LIST-DEBUG] FALLBACK all_files sample: {sample_paths}")
 
-        # Issue #3779 follow-up: when the caller is in a specific zone, drop
-        # rows whose zone_id column doesn't match. The metastore is shared
-        # across zones (each row carries a zone_id) and filtering here is
-        # the cheapest place to enforce isolation without changing the
-        # engine-level list API. Admins and root-zone callers see everything;
-        # cross-zone shared files are re-added below via
-        # _get_cross_zone_shared_paths.
-        _is_admin_caller = bool(getattr(context, "is_admin", False)) if context else False
-        if list_zone_id and list_zone_id != ROOT_ZONE_ID and not _is_admin_caller:
-            all_files = [m for m in all_files if (m.get("zone_id") or ROOT_ZONE_ID) == list_zone_id]
+        # Issue #3779 follow-up / #4740: the metastore is shared across zones
+        # (each row carries a zone_id), so the zone predicate is applied to
+        # the candidate set here.  The predicate is the caller's ZoneView:
+        # root-tagged rows are visible only to callers that can read the
+        # root zone, and admins no longer skip the filter unless they asked
+        # for ``all_zones``.  Cross-zone shared files (explicit ReBAC shares)
+        # are re-added below via _get_cross_zone_shared_paths.
+        if not _zone_view.unrestricted:
+            all_files = [m for m in all_files if _zone_view.allows(m.get("zone_id"), m.get("path"))]
 
         # Issue #904: Fetch cross-zone shared files
         if list_zone_id and subject_type and subject_id:
@@ -1396,30 +1397,12 @@ class SearchService:
         # Single permission filter call
         filter_start = time.time()
         if _accessible_int_ids is not None:
+            # ``all_files`` reached us already narrowed to the caller's
+            # ZoneView in ``list()`` (#4740), which subsumes the former
+            # #3786 federation-token allow-list intersection: predicate-
+            # pushdown paths outside the token's readable zones were
+            # dropped upstream, root-tagged rows included.
             allowed_set = {meta["path"] for meta in all_files}
-            # Issue #3786 / Codex Round 9 finding #3: predicate-pushdown
-            # via _accessible_int_ids reflects ReBAC visibility for the
-            # subject — but multi-zone federation tokens can scope to a
-            # subset of those zones.  Intersect with the token's
-            # zone_perms allow-list so list/glob/grep cannot leak paths
-            # outside the active token scope.
-            try:
-                _eff_zp = self._permission_enforcer._effective_zone_perms(ctx)
-            except Exception:
-                _eff_zp = getattr(ctx, "zone_perms", ()) or ()
-            _real_zp = tuple((z, p) for z, p in (_eff_zp or ()) if z != ROOT_ZONE_ID)
-            if (
-                getattr(ctx, "zone_id", ROOT_ZONE_ID) == ROOT_ZONE_ID
-                and _real_zp
-                and not getattr(ctx, "is_admin", False)
-            ):
-                _allowed_zones = {z for z, p in _real_zp if "r" in p or "x" in p}
-                allowed_set = {
-                    p
-                    for p in allowed_set
-                    if not p.startswith("/zone/")
-                    or (len(p[6:].split("/", 1)) > 0 and p[6:].split("/", 1)[0] in _allowed_zones)
-                }
             logger.info(
                 f"[PREDICATE-PUSHDOWN] Skipped filter_list() - "
                 f"using {len(allowed_set)} pre-filtered paths"
@@ -1657,14 +1640,21 @@ class SearchService:
         limit: int,
         cursor: str | None,
         context: Any,
+        zone_view: Any = None,
     ) -> Any:
-        """Paginated list with over-fetch strategy for permission filtering (Issue #937)."""
+        """Paginated list with over-fetch strategy for permission filtering (Issue #937).
+
+        ``zone_view`` is the caller's resolved ZoneView (#4740); when omitted
+        it is resolved from *context* here so direct callers stay fail-closed.
+        """
         from nexus.contracts.constants import SYSTEM_PATH_PREFIX
         from nexus.contracts.metadata import DT_DIR
         from nexus.contracts.types import OperationContext
         from nexus.core.pagination import PaginatedResult
         from nexus.lib.pagination import encode_cursor
 
+        if zone_view is None:
+            zone_view = resolve_zone_view(context, operation="search.list")
         context = context or self._default_context
         import time as _time
 
@@ -1719,6 +1709,9 @@ class SearchService:
                 # (e.g. ns:rebac:*) whose paths are not valid virtual paths.
                 if str(item.get("path", "")).startswith("/")
                 and not str(item.get("path", "")).startswith(SYSTEM_PATH_PREFIX)
+                # Issue #4740: the scan runs under is_system (unrestricted), so
+                # the caller's zone predicate has to be applied to each page.
+                and zone_view.allows(item.get("zone_id"), item.get("path"))
             ]
 
             if self._enforce_permissions and context:
@@ -1848,21 +1841,11 @@ class SearchService:
         if path and path != "/":
             path = self._validate_path(path)
 
-        # Issue #3779 follow-up: when the caller's zone has been applied by
-        # the RPC layer's scope_params_for_zone, the incoming path is
-        # ``/zone/<id>/...`` even though files are stored flat in standalone
-        # mode. Strip that prefix here so pattern assembly and list() see
-        # the flat path universe; the zone-column post-filter in list()
-        # enforces isolation.
+        # #4740: keep the caller's ``/zone/<id>/…`` path as scoped — rows live
+        # under that prefix in the kernel (see the matching note in ``list``).
+        # ``_engine_zone_id`` still gates the scoped/unscoped candidate
+        # fallbacks further down for stores that expose a zone id.
         _engine_zone_id: str | None = getattr(self.metadata, "_zone_id", None)
-        if _engine_zone_id is None and context is not None:
-            _caller_zone = getattr(context, "zone_id", None)
-            if _caller_zone and _caller_zone != ROOT_ZONE_ID and isinstance(path, str):
-                _zone_prefix = f"/zone/{_caller_zone}"
-                if path == _zone_prefix or path == f"{_zone_prefix}/":
-                    path = "/"
-                elif path.startswith(f"{_zone_prefix}/"):
-                    path = path[len(_zone_prefix) :]
 
         import time
 

--- a/src/nexus/core/nexus_fs_metadata.py
+++ b/src/nexus/core/nexus_fs_metadata.py
@@ -1843,9 +1843,16 @@ class MetadataMixin:
         # 403) instead of receiving the root/global view; root-tagged entries
         # are visible only to callers that can read the root zone; admins
         # see across zones only with an explicit ``all_zones=True``, which is
-        # audited.  ``context=None`` (kernel / internal callers) and
-        # zone-less ``is_system`` contexts keep the unrestricted view.
-        _view = resolve_zone_view(context, all_zones=all_zones, operation="list")
+        # audited.  ``context=None`` (kernel / internal callers), zone-less
+        # ``is_system`` contexts and the kernel's own init credential passed
+        # explicitly (embedded operator, e.g. the MCP tools in sandbox mode)
+        # keep the unrestricted view.
+        _view = resolve_zone_view(
+            context,
+            all_zones=all_zones,
+            operation="list",
+            init_cred=getattr(self, "_init_cred", None),
+        )
         if _view.all_zones:
             # Deduplicated per request_id, so the nested calls made by the
             # paginated branch and _expand_recursive_readdir log once.

--- a/src/nexus/core/nexus_fs_metadata.py
+++ b/src/nexus/core/nexus_fs_metadata.py
@@ -32,6 +32,7 @@ from nexus.core.readdir_rebac_filter import readdir_visible_paths
 from nexus.kernel_helpers import metastore_list_iter
 from nexus.lib.rpc_decorator import rpc_expose
 from nexus.lib.zone_revision import revision_token
+from nexus.lib.zone_visibility import audit_all_zones, resolve_zone_view
 
 if TYPE_CHECKING:
     pass
@@ -1762,8 +1763,14 @@ class MetadataMixin:
         *,
         details: bool,
         context: OperationContext | None,
+        all_zones: bool = False,
     ) -> builtins.list[Any]:
-        """Expand explicit child directories that live behind their own metastore route."""
+        """Expand explicit child directories that live behind their own metastore route.
+
+        ``all_zones`` is forwarded to the nested ``sys_readdir`` calls so an
+        admin's explicit cross-zone listing (#4740) keeps the same view while
+        descending into child routes.
+        """
         from collections import deque
 
         by_path: dict[str, Any] = {}
@@ -1789,6 +1796,7 @@ class MetadataMixin:
                     recursive=True,
                     details=details,
                     context=context,
+                    all_zones=all_zones,
                 )
             except Exception as exc:
                 logger.debug("recursive sys_readdir expansion skipped for %s: %s", directory, exc)
@@ -1825,9 +1833,23 @@ class MetadataMixin:
         context: OperationContext | None = None,
         limit: int | None = None,
         cursor: str | None = None,
+        all_zones: bool = False,
     ) -> builtins.list[str] | builtins.list[dict[str, Any]] | Any:
         _list_start = time.perf_counter()
         _, _list_agent_id, _ = self._get_context_identity(context)
+
+        # Issue #4740: resolve the caller's zone view FIRST and fail closed.
+        # A zone-less non-admin caller is refused (PermissionDeniedError →
+        # 403) instead of receiving the root/global view; root-tagged entries
+        # are visible only to callers that can read the root zone; admins
+        # see across zones only with an explicit ``all_zones=True``, which is
+        # audited.  ``context=None`` (kernel / internal callers) and
+        # zone-less ``is_system`` contexts keep the unrestricted view.
+        _view = resolve_zone_view(context, all_zones=all_zones, operation="list")
+        if _view.all_zones:
+            # Deduplicated per request_id, so the nested calls made by the
+            # paginated branch and _expand_recursive_readdir log once.
+            audit_all_zones(context, operation="list", path=path)
 
         def _emit_list() -> None:
             emit_op_completed(
@@ -1896,39 +1918,38 @@ class MetadataMixin:
                     and not self._is_internal_path(child)
                     and _etype not in (DT_DIR, DT_MOUNT)
                 ]
-                # Issue #4739: ReBAC post-filter (non-admin callers only).
+                # Issue #4740 (supersedes the #3786 federation tripwire): the
+                # kernel readdir is called with the ENGINE zone, so it does
+                # not apply the caller's zone predicate, and it returns
+                # (path, entry_type) only.  For a restricted view, fetch the
+                # zone column of each child in one batched stat and drop
+                # everything outside the caller's readable zones — including
+                # root-tagged entries, which are no longer visible from
+                # other zones.  A child with no stat row fails closed unless
+                # its path carries a readable zone.
+                if not _view.unrestricted and _children:
+                    try:
+                        _child_stats = self._kernel.stat_batch(_children, ROOT_ZONE_ID)
+                    except (OSError, ValueError) as exc:
+                        logger.debug("kernel.stat_batch failed for %s: %s", path, exc)
+                        _child_stats = []
+                    _stats_by_path = dict(zip(_children, _child_stats, strict=False))
+                    _children = [
+                        _child
+                        for _child in _children
+                        if _view.allows(
+                            _stats_by_path[_child].get("zone_id")
+                            if isinstance(_stats_by_path.get(_child), dict)
+                            else None,
+                            _child,
+                        )
+                    ]
+                # Issue #4739: ReBAC post-filter (non-admin callers only),
+                # applied after the zone predicate so only in-zone names
+                # reach the permission enforcer.
                 _visible = readdir_visible_paths(self, [(c, False) for c in _children], context)
                 if _visible is not None:
                     _children = [c for c in _children if c in _visible]
-                # Issue #3786 / Codex Round 7 finding #1: federation tokens
-                # land here as zone_id="root", so without an explicit zone_perms
-                # filter they would receive every name the kernel returns,
-                # including paths under zones outside their allow-list.
-                _ctx_zp = (
-                    getattr(context, "zone_perms", ())
-                    if context is not None and not isinstance(context, dict)
-                    else (
-                        tuple(tuple(zp) for zp in (context.get("zone_perms") or ()) if len(zp) == 2)
-                        if isinstance(context, dict)
-                        else ()
-                    )
-                )
-                _real_zp = tuple((z, p) for z, p in (_ctx_zp or ()) if z != ROOT_ZONE_ID)
-                if not _is_admin and _real_zp:
-                    _allowed_zones = {z for z, p in _real_zp if "r" in p or "x" in p}
-                    _filtered: builtins.list[str] = []
-                    for _child in _children:
-                        if _child.startswith("/zone/"):
-                            _parts = _child[6:].split("/", 1)
-                            if _parts and _parts[0] in _allowed_zones:
-                                _filtered.append(_child)
-                            # else: drop — outside token's allow-list
-                        else:
-                            # Non-zone paths (root namespace) — keep; they
-                            # are not the federation tenant data.
-                            _filtered.append(_child)
-                    _emit_list()
-                    return _filtered
                 _emit_list()
                 return _children
 
@@ -1936,61 +1957,17 @@ class MetadataMixin:
         if prefix and not prefix.endswith("/"):
             prefix = prefix + "/"
 
-        # Issue #3779 follow-up: filter list results by the caller's zone_id.
-        # The metastore is a single store shared across zones (each row carries
-        # a zone_id column). Without this filter, V2 API callers see every
-        # zone's files. Admins and root-zone callers keep the global view.
-        # Handle OperationContext, dict, and None uniformly — missing zone
-        # falls open to ROOT (admin-equivalent view) by design: a caller
-        # without a zone claim is either the kernel or an unauthenticated
-        # path, neither of which should be zone-restricted here.
-        if isinstance(context, dict):
-            caller_zone = context.get("zone_id") or ROOT_ZONE_ID
-            caller_is_admin = bool(context.get("is_admin", False))
-            _ctx_zp = tuple(tuple(zp) for zp in (context.get("zone_perms") or ()) if len(zp) == 2)
-        elif context is not None:
-            caller_zone = getattr(context, "zone_id", None) or ROOT_ZONE_ID
-            caller_is_admin = bool(getattr(context, "is_admin", False))
-            _ctx_zp = tuple(getattr(context, "zone_perms", ()) or ())
-        else:
-            caller_zone = ROOT_ZONE_ID
-            caller_is_admin = False
-            _ctx_zp = ()
-
-        # Issue #3786 / Codex Round 8 finding #2: federation token allow-list
-        # for the recursive / detail / paginated path.  Multi-zone tokens land
-        # here as caller_zone==root (so the original _zone_allowed shortcut
-        # would let them enumerate every zone).  Build the allow-list once.
-        _real_zp = tuple((z, p) for z, p in _ctx_zp if z != ROOT_ZONE_ID)
-        _fed_allowed_zones = {z for z, p in _real_zp if "r" in p or "x" in p}
-
+        # Issue #3779 follow-up / #4740: the metastore is a single store
+        # shared across zones (each row carries a zone_id column), so the
+        # recursive / detail / paginated path is a Python post-filter over
+        # the prefix scan.  The predicate is the caller's ZoneView resolved
+        # above: an entry is visible when the zone embedded in its internal
+        # path (``/zone/<id>/…``) is readable, else when its zone column is
+        # (``None`` == root).  Root-tagged entries are no longer visible from
+        # every zone, and admins no longer bypass the predicate unless they
+        # asked for ``all_zones``.
         def _zone_allowed(entry: Any) -> bool:
-            if caller_is_admin:
-                return True
-            # Federation token tripwire — restrict /zone/<id>/ entries to
-            # the allow-list even when caller_zone==root.  Root-namespace
-            # entries (no /zone/ prefix) stay visible.
-            if _real_zp:
-                _ep = getattr(entry, "path", "") or ""
-                if _ep.startswith("/zone/"):
-                    _parts = _ep[6:].split("/", 1)
-                    return bool(_parts) and _parts[0] in _fed_allowed_zones
-                return True
-            if caller_zone == ROOT_ZONE_ID:
-                return True
-            entry_zone = getattr(entry, "zone_id", None) or ROOT_ZONE_ID
-            # Root zone is the global namespace, not any user's private zone:
-            # standalone NexusFS tags every file as zone_id=root, and
-            # federation-root-mounted files are visible from every zone by
-            # design. Filtering them out would break sys_readdir in
-            # standalone mode entirely (surface-level cost: the
-            # test_embedded_namespaces_rebac tests that write under
-            # /workspace/acme/ and fail to readdir them). Per-zone isolation
-            # continues to work because non-root entry_zone still has to
-            # match caller_zone below.
-            if entry_zone == ROOT_ZONE_ID:
-                return True
-            return entry_zone == caller_zone
+            return _view.allows(getattr(entry, "zone_id", None), getattr(entry, "path", None))
 
         if limit is not None:
             if recursive:
@@ -2001,6 +1978,7 @@ class MetadataMixin:
                     recursive=True,
                     details=details,
                     context=context,
+                    all_zones=all_zones,
                 )
                 expanded_items = sorted(
                     expanded_items,
@@ -2086,6 +2064,7 @@ class MetadataMixin:
                     _result,
                     details=True,
                     context=context,
+                    all_zones=all_zones,
                 )
             _emit_list()
             return _result
@@ -2102,6 +2081,7 @@ class MetadataMixin:
                 _result,
                 details=False,
                 context=context,
+                all_zones=all_zones,
             )
         _emit_list()
         return _result

--- a/src/nexus/lib/zone_scoping.py
+++ b/src/nexus/lib/zone_scoping.py
@@ -76,24 +76,27 @@ def scope_single_path(path: str, prefix: str, caller_zone_id: str) -> str:
     return f"{prefix}/{canonical}"
 
 
-def scope_params_for_zone(params: Any, zone_id: str) -> None:
+def scope_params_for_zone(params: Any, zone_id: str | None) -> None:
     """Prefix path attributes with ``/zone/{zone_id}/`` for zone isolation.
 
-    Mutates the params object in place.  Only applies when *zone_id*
-    differs from ROOT_ZONE_ID — the root zone sees the full tree.
+    Mutates the params object in place.  Only applies when *zone_id* is a
+    concrete zone other than ROOT_ZONE_ID — the root zone sees the full
+    tree, and a zone-less context (``None``, #4740) has no namespace to
+    prefix; its enumeration calls are refused downstream instead.
 
     Works with both dataclass-style params (RPC) and protobuf request
     objects (gRPC).
 
     Args:
         params: The params/request object with path attributes.
-        zone_id: The caller's authenticated zone ID.
+        zone_id: The caller's authenticated zone ID (``None`` when the
+            credential carries no zone claim).
 
     Raises:
         ZoneScopingError: If any path has a zone prefix that doesn't match
             the caller's zone.
     """
-    if zone_id == ROOT_ZONE_ID:
+    if not zone_id or zone_id == ROOT_ZONE_ID:
         return
 
     prefix = f"/zone/{zone_id}"

--- a/src/nexus/lib/zone_visibility.py
+++ b/src/nexus/lib/zone_visibility.py
@@ -1,0 +1,264 @@
+"""Zone visibility for enumeration surfaces — list, glob, grep, search (#4740).
+
+Reads and writes are path-addressed: a caller has to know a path, and the
+RPC layer prefixes it with the caller's ``/zone/<id>/`` namespace.  List and
+search are different — they *enumerate*, so the zone predicate applied to
+the candidate set is the tenant boundary.  Before #4740 that predicate
+failed open in three places:
+
+* a context with no zone claim was resolved to the ROOT zone and received
+  the global view;
+* entries tagged with the ROOT zone were visible from every zone;
+* admins skipped the zone predicate entirely.
+
+This module is the single source of truth for what a caller may enumerate.
+The rules, in order:
+
+1. ``context is None`` — the kernel or an internal caller.  Unrestricted.
+2. ``all_zones=True`` — only admins may ask; the caller gets the global
+   view and the request is audited by the caller (``audit_all_zones``).
+   A non-admin asking for ``all_zones`` is refused, not silently narrowed.
+3. Readable zones come from ``zone_perms`` (entries granting ``r`` or
+   ``x``), else ``zone_set`` (legacy tokens: read implied), else
+   ``zone_id``.  ROOT counts only when explicitly granted or claimed; the
+   ``zone_id=root`` placeholder a multi-zone token carries does not make
+   root-tagged entries visible to it.
+4. No zone claim at all:
+   * ``is_system`` — internal service caller.  Unrestricted.
+   * ``is_admin`` — the operator's default view is the ROOT zone itself,
+     not every zone; cross-zone needs ``all_zones=True``.
+   * otherwise — **refused** (``PermissionDeniedError`` → 403).
+
+An entry is visible when the zone embedded in its internal path
+(``/zone/<id>/…``, or the legacy ``/zones/<id>/…`` the ReBAC filter chain
+also recognises) is readable; entries outside a zone namespace fall back to
+their ``zone_id`` column, ``None`` meaning ROOT.  Root-tagged entries are
+therefore visible only to callers that can read the ROOT zone.
+
+Two facts about the kernel shape this predicate.  In standalone mode the
+kernel stamps every row with the *route's* zone, which is ROOT — so the
+column carries no tenant information and the ``/zone/<id>/`` prefix the RPC
+layer adds to every remote caller's path IS the tenant boundary.  Internal
+service scans (``is_system`` with a zone, e.g. ReBAC directory expansion or a
+zone export) still need the root-namespace rows they always saw, so a system
+view keeps them while remaining scoped to its zone's namespace.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from collections import OrderedDict
+from dataclasses import dataclass
+from typing import Any
+
+from nexus.contracts.constants import ROOT_ZONE_ID
+from nexus.contracts.exceptions import PermissionDeniedError
+
+logger = logging.getLogger(__name__)
+
+# ``/zone/<id>/`` is what ``nexus.lib.zone_scoping`` produces; ``/zones/<id>/``
+# is the legacy layout ``ZonePreFilterStrategy`` in the ReBAC chain treats as
+# zone-scoped, kept in sync so list and ReBAC agree on what a zone path is.
+_ZONE_PATH_PREFIXES = ("/zone/", "/zones/")
+
+#: Audit event emitted (via ``nexus.lib.events.emit_audit_event``) whenever an
+#: admin enumerates across zones with ``all_zones=True``.
+ALL_ZONES_AUDIT_EVENT = "zone.all_zones_enumeration"
+
+
+def zone_from_path(path: Any) -> str | None:
+    """Return the zone embedded in an internal ``/zone/<id>/…`` path, else None."""
+    if not isinstance(path, str):
+        return None
+    for prefix in _ZONE_PATH_PREFIXES:
+        if path.startswith(prefix):
+            zone = path[len(prefix) :].split("/", 1)[0]
+            return zone or None
+    return None
+
+
+def _attr(context: Any, name: str, default: Any = None) -> Any:
+    if isinstance(context, dict):
+        return context.get(name, default)
+    return getattr(context, name, default)
+
+
+def readable_zones_from_perms(zone_perms: Any) -> frozenset[str] | None:
+    """Zones granted ``r`` or ``x`` by well-formed ``(zone, perms)`` entries.
+
+    Returns ``None`` when there is no well-formed entry at all (no perms
+    information), and an empty set when perms exist but grant no read —
+    the latter fails closed, matching ``search_auth.readable_zone_filter``.
+    """
+    if not zone_perms:
+        return None
+    well_formed = [
+        zp
+        for zp in zone_perms
+        if isinstance(zp, (list, tuple))
+        and len(zp) == 2
+        and isinstance(zp[0], str)
+        and zp[0]
+        and isinstance(zp[1], str)
+    ]
+    if not well_formed:
+        return None
+    return frozenset(z for z, p in well_formed if "r" in p or "x" in p)
+
+
+@dataclass(frozen=True, slots=True)
+class ZoneView:
+    """The set of zones a caller may enumerate.
+
+    ``zones is None`` means unrestricted (global view).  ``all_zones`` records
+    that the global view was granted through the explicit admin flag so the
+    caller can audit it.  ``system`` marks an internal service scan: it stays
+    scoped to its zone's namespace but keeps the root-namespace rows (column
+    ROOT, no ``/zone/<id>/`` prefix) that standalone kernels stamp on every
+    write.
+    """
+
+    zones: frozenset[str] | None
+    all_zones: bool = False
+    system: bool = False
+
+    @property
+    def unrestricted(self) -> bool:
+        return self.zones is None
+
+    def allows(self, entry_zone: Any, path: Any = None) -> bool:
+        """Whether an entry with this zone column and internal path is visible."""
+        if self.zones is None:
+            return True
+        path_zone = zone_from_path(path)
+        if path_zone is not None:
+            return path_zone in self.zones
+        zone = entry_zone if isinstance(entry_zone, str) and entry_zone else ROOT_ZONE_ID
+        if zone == ROOT_ZONE_ID and self.system:
+            return True
+        return zone in self.zones
+
+
+UNRESTRICTED_VIEW = ZoneView(zones=None)
+
+
+def resolve_zone_view(
+    context: Any,
+    *,
+    all_zones: bool = False,
+    operation: str = "list",
+) -> ZoneView:
+    """Resolve the zones *context* may enumerate; fail closed.
+
+    Accepts an ``OperationContext``, a plain dict with the same keys, or
+    ``None`` (kernel / internal caller → unrestricted).
+
+    Raises:
+        PermissionDeniedError: for a non-admin ``all_zones`` request, or for
+            an authenticated non-admin, non-system caller with no zone claim.
+    """
+    if context is None:
+        return UNRESTRICTED_VIEW
+
+    is_admin = bool(_attr(context, "is_admin", False))
+    is_system = bool(_attr(context, "is_system", False))
+
+    if all_zones:
+        if not is_admin:
+            raise PermissionDeniedError(
+                f"{operation}: all_zones=true requires admin privileges (#4740)"
+            )
+        return ZoneView(zones=None, all_zones=True)
+
+    zone_id = _attr(context, "zone_id")
+    if not isinstance(zone_id, str) or not zone_id:
+        zone_id = None
+
+    readable = readable_zones_from_perms(_attr(context, "zone_perms"))
+    if readable is None:
+        zone_set = frozenset(
+            z for z in (_attr(context, "zone_set") or ()) if isinstance(z, str) and z
+        )
+        if zone_set:
+            readable = zone_set
+        elif zone_id is not None:
+            readable = frozenset({zone_id})
+
+    if readable is not None:
+        return ZoneView(zones=readable, system=is_system)
+
+    # No zone claim of any kind.
+    if is_system:
+        return UNRESTRICTED_VIEW
+    if is_admin:
+        return ZoneView(zones=frozenset({ROOT_ZONE_ID}))
+    raise PermissionDeniedError(
+        f"{operation} refused: caller has no zone claim. Zone-less callers no longer "
+        "receive the root view; send X-Nexus-Zone-ID or use a zone-scoped credential (#4740)"
+    )
+
+
+#: ``(request_id, operation)`` keys already audited — one row per request even
+#: when the enumeration recurses (pagination, explicit child routes).  Bounded
+#: so a long-lived server never grows it without limit.
+_RECENT_AUDITS: OrderedDict[tuple[str, str], None] = OrderedDict()
+_RECENT_AUDITS_MAX = 4096
+_RECENT_AUDITS_LOCK = threading.Lock()
+
+
+def _already_audited(request_id: Any, operation: str) -> bool:
+    if not isinstance(request_id, str) or not request_id:
+        return False
+    key = (request_id, operation)
+    with _RECENT_AUDITS_LOCK:
+        if key in _RECENT_AUDITS:
+            return True
+        _RECENT_AUDITS[key] = None
+        while len(_RECENT_AUDITS) > _RECENT_AUDITS_MAX:
+            _RECENT_AUDITS.popitem(last=False)
+    return False
+
+
+def audit_all_zones(context: Any, *, operation: str, path: str | None = None) -> None:
+    """Record an admin's explicit cross-zone enumeration.
+
+    Emits :data:`ALL_ZONES_AUDIT_EVENT` to the registered audit sinks and an
+    INFO log line so the access is attributable even without a sink.  Nested
+    calls within one request (same ``request_id``) are recorded once.
+    """
+    from nexus.lib.events import emit_audit_event
+
+    if _already_audited(_attr(context, "request_id"), operation):
+        return
+
+    payload: dict[str, Any] = {
+        "operation": operation,
+        "path": path,
+        "subject_type": _attr(context, "subject_type"),
+        "subject_id": _attr(context, "subject_id") or _attr(context, "user_id"),
+        "agent_id": _attr(context, "agent_id"),
+        "zone_id": _attr(context, "zone_id"),
+        "request_id": _attr(context, "request_id"),
+    }
+    logger.info(
+        "[ZONE-AUDIT] all_zones enumeration op=%s path=%s subject=%s:%s zone=%s request_id=%s",
+        operation,
+        path,
+        payload["subject_type"],
+        payload["subject_id"],
+        payload["zone_id"],
+        payload["request_id"],
+    )
+    emit_audit_event(ALL_ZONES_AUDIT_EVENT, payload)
+
+
+__all__ = [
+    "ALL_ZONES_AUDIT_EVENT",
+    "UNRESTRICTED_VIEW",
+    "ZoneView",
+    "audit_all_zones",
+    "readable_zones_from_perms",
+    "resolve_zone_view",
+    "zone_from_path",
+]

--- a/src/nexus/lib/zone_visibility.py
+++ b/src/nexus/lib/zone_visibility.py
@@ -15,6 +15,11 @@ This module is the single source of truth for what a caller may enumerate.
 The rules, in order:
 
 1. ``context is None`` — the kernel or an internal caller.  Unrestricted.
+   The kernel's own init credential (``NexusFS._init_cred``, the embedded
+   operator that ``context=None`` resolves to) gets the same view when a
+   caller passes it explicitly — the MCP tools do in sandbox mode.  It is
+   matched by identity, so a copy with the same fields is an ordinary
+   zone-less caller.
 2. ``all_zones=True`` — only admins may ask; the caller gets the global
    view and the request is audited by the caller (``audit_all_zones``).
    A non-admin asking for ``all_zones`` is refused, not silently narrowed.
@@ -148,17 +153,26 @@ def resolve_zone_view(
     *,
     all_zones: bool = False,
     operation: str = "list",
+    init_cred: Any = None,
 ) -> ZoneView:
     """Resolve the zones *context* may enumerate; fail closed.
 
     Accepts an ``OperationContext``, a plain dict with the same keys, or
     ``None`` (kernel / internal caller → unrestricted).
 
+    ``init_cred`` is the kernel's own credential (``NexusFS._init_cred``).
+    When *context* **is** that object (identity, not equality) the caller is
+    the embedded operator — the same principal ``context=None`` resolves to
+    — and gets the unrestricted view instead of being refused as a
+    zone-less tenant.  The MCP tools pass it explicitly in sandbox mode.
+
     Raises:
         PermissionDeniedError: for a non-admin ``all_zones`` request, or for
             an authenticated non-admin, non-system caller with no zone claim.
     """
     if context is None:
+        return UNRESTRICTED_VIEW
+    if init_cred is not None and context is init_cred:
         return UNRESTRICTED_VIEW
 
     is_admin = bool(_attr(context, "is_admin", False))

--- a/src/nexus/server/_kernel_syscall_dispatch.py
+++ b/src/nexus/server/_kernel_syscall_dispatch.py
@@ -230,30 +230,37 @@ def _apply_result_adapter(
     if method == "lock_acquire":
         return {"acquired": raw_result is not None, "lock_id": raw_result}
     if method in ("sys_readdir", "list"):
+        # Issue #4740: an admin's explicit cross-zone listing
+        # (``all_zones=true``) spans several tenants' namespaces, so the
+        # internal ``/zone/<id>/...`` prefix IS the information — stripping
+        # it would collapse ``/zone/ta/a.txt`` and ``/zone/tb/a.txt`` into
+        # one ambiguous ``/a.txt``.  Keep the zone-qualified form there;
+        # single-zone callers still get user-facing paths.
+        _keep_zone_prefix = bool(params.get("all_zones"))
+
+        def _wire_entry(f: Any) -> Any:
+            if _keep_zone_prefix:
+                return f
+            if isinstance(f, dict):
+                return unscope_internal_dict(f, ["path", "virtual_path"])
+            return unscope_internal_path(f)
+
         # PaginatedResult (from limit kwarg) → wire dict; bare list →
         # wire dict with has_more=False / next_cursor=None.
         if hasattr(raw_result, "to_dict"):
             paginated = raw_result.to_dict()
-            items = [
-                unscope_internal_dict(f, ["path", "virtual_path"])
-                if isinstance(f, dict)
-                else unscope_internal_path(f)
-                for f in paginated["items"]
-            ]
             return {
-                "files": items,
+                "files": [_wire_entry(f) for f in paginated["items"]],
                 "next_cursor": paginated["next_cursor"],
                 "has_more": paginated["has_more"],
                 "total_count": paginated.get("total_count"),
             }
         raw_entries = raw_result if isinstance(raw_result, list) else []
-        entries = [
-            unscope_internal_dict(f, ["path", "virtual_path"])
-            if isinstance(f, dict)
-            else unscope_internal_path(f)
-            for f in raw_entries
-        ]
-        return {"files": entries, "has_more": False, "next_cursor": None}
+        return {
+            "files": [_wire_entry(f) for f in raw_entries],
+            "has_more": False,
+            "next_cursor": None,
+        }
     return raw_result
 
 

--- a/src/nexus/server/_rpc_params_generated.py
+++ b/src/nexus/server/_rpc_params_generated.py
@@ -533,6 +533,7 @@ class ListParams:
     context: Any = None
     limit: int | None = None
     cursor: str | None = None
+    all_zones: bool = False
 
 
 @dataclass

--- a/src/nexus/server/api/v2/_zone_scoped_fs.py
+++ b/src/nexus/server/api/v2/_zone_scoped_fs.py
@@ -1,0 +1,350 @@
+"""Per-request zone view of NexusFS for the REST v2 routes (#4740).
+
+The RPC (``/api/nfs/*``) and gRPC paths prefix every caller path with the
+caller's ``/zone/<id>/`` namespace (``nexus.lib.zone_scoping``) and strip it
+again on the way out (``_kernel_syscall_dispatch._apply_result_adapter``).
+The REST routes never did.  A zone-scoped REST caller therefore read and
+wrote the ROOT namespace: two tenants shared ``/x.txt`` (ReBAC permitting),
+and under the #4740 visibility predicate a tenant's own REST writes were
+root-attributed and invisible to its own listing.
+
+:class:`ZoneScopedFS` gives the REST layer the RPC contract:
+
+* every path in a request is scoped with ``scope_single_path`` — a path that
+  names another zone is refused with HTTP 403, never silently re-rooted;
+* every path in a result (list entries, stat dicts, batch results, revision
+  tokens) is unscoped back to the caller's view;
+* root-zone callers and multi-zone tokens (``zone_id == root`` placeholder)
+  get the underlying filesystem unchanged, exactly as the RPC layer does.
+
+Unknown attributes are forwarded to the wrapped filesystem unchanged; every
+path-taking method the REST routers and the batch executor call is proxied
+explicitly below.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from collections.abc import Iterable
+from typing import Any
+
+from fastapi import HTTPException
+
+from nexus.contracts.constants import ROOT_ZONE_ID
+from nexus.lib.zone_scoping import ZoneScopingError, scope_single_path
+
+#: Dict keys whose string values are VFS paths in NexusFS results.
+_PATH_KEYS = (
+    "path",
+    "virtual_path",
+    "file",
+    "file_path",
+    "old_path",
+    "new_path",
+    "source",
+    "destination",
+)
+
+
+def zone_prefix_for(context: Any) -> str | None:
+    """``/zone/<id>`` for a context scoped to a concrete non-root zone, else None."""
+    zone = getattr(context, "zone_id", None)
+    if not isinstance(zone, str) or not zone or zone == ROOT_ZONE_ID:
+        return None
+    return f"/zone/{zone}"
+
+
+def scope_rest_path(path: Any, context: Any) -> Any:
+    """Scope one caller-supplied path for *context*; 403 when it names another zone."""
+    prefix = zone_prefix_for(context)
+    if prefix is None or not isinstance(path, str):
+        return path
+    try:
+        return scope_single_path(path, prefix, context.zone_id)
+    except ZoneScopingError as exc:
+        raise HTTPException(status_code=403, detail=str(exc)) from exc
+
+
+def zone_scoped_fs(fs: Any, context: Any) -> Any:
+    """Return *fs* wrapped in a :class:`ZoneScopedFS` when *context* has a zone."""
+    if fs is None or zone_prefix_for(context) is None:
+        return fs
+    if isinstance(fs, ZoneScopedFS):
+        return fs
+    return ZoneScopedFS(fs, context.zone_id)
+
+
+class ZoneScopedFS:
+    """Zone-namespaced view over a NexusFS instance (see module docstring)."""
+
+    __slots__ = ("_fs", "_prefix", "_zone")
+
+    def __init__(self, fs: Any, zone_id: str) -> None:
+        self._fs = fs
+        self._zone = zone_id
+        self._prefix = f"/zone/{zone_id}"
+
+    # ── identity ───────────────────────────────────────────────────────
+
+    @property
+    def wrapped_fs(self) -> Any:
+        return self._fs
+
+    @property
+    def zone_id(self) -> str:
+        return self._zone
+
+    # ── path translation ────────────────────────────────────────────────
+
+    def scope(self, path: Any) -> Any:
+        """Caller path → internal path; 403 when the path names another zone."""
+        if not isinstance(path, str):
+            return path
+        try:
+            return scope_single_path(path, self._prefix, self._zone)
+        except ZoneScopingError as exc:
+            raise HTTPException(status_code=403, detail=str(exc)) from exc
+
+    def unscope(self, path: Any) -> Any:
+        """Internal path → caller path (only this caller's own prefix is stripped)."""
+        if not isinstance(path, str):
+            return path
+        if path == self._prefix:
+            return "/"
+        if path.startswith(self._prefix + "/"):
+            return path[len(self._prefix) :]
+        return path
+
+    def _unscope_revision(self, token: Any) -> Any:
+        if not isinstance(token, str) or "@" not in token:
+            return token
+        anchor, _, index = token.rpartition("@")
+        return f"{self.unscope(anchor)}@{index}"
+
+    def _unscope_dict(self, value: Any) -> Any:
+        if not isinstance(value, dict):
+            return self._unscope_object(value)
+        out = dict(value)
+        for key in _PATH_KEYS:
+            if isinstance(out.get(key), str):
+                out[key] = self.unscope(out[key])
+        if "revision" in out:
+            out["revision"] = self._unscope_revision(out["revision"])
+        return out
+
+    def _unscope_object(self, value: Any) -> Any:
+        """Dataclass results (FileMetadata) carry ``.path``; rebuild with it unscoped."""
+        if dataclasses.is_dataclass(value) and not isinstance(value, type):
+            path = getattr(value, "path", None)
+            if isinstance(path, str):
+                try:
+                    return dataclasses.replace(value, path=self.unscope(path))
+                except (TypeError, ValueError):
+                    return value
+        return value
+
+    def _unscope_entries(self, entries: Any) -> Any:
+        if isinstance(entries, list):
+            return [
+                self.unscope(e) if isinstance(e, str) else self._unscope_dict(e) for e in entries
+            ]
+        return entries
+
+    def _unscope_readdir(self, result: Any) -> Any:
+        """``sys_readdir`` returns a list or a PaginatedResult (items + path cursor)."""
+        if isinstance(result, list):
+            return self._unscope_entries(result)
+        if (
+            dataclasses.is_dataclass(result)
+            and not isinstance(result, type)
+            and hasattr(result, "items")
+        ):
+            updates: dict[str, Any] = {"items": self._unscope_entries(list(result.items))}
+            cursor = getattr(result, "next_cursor", None)
+            if isinstance(cursor, str):
+                updates["next_cursor"] = self.unscope(cursor)
+            return dataclasses.replace(result, **updates)
+        return result
+
+    def _unscope_keyed(self, result: Any) -> Any:
+        """Results keyed by path (``read_bulk``, ``rename_batch``)."""
+        if not isinstance(result, dict):
+            return result
+        return {self.unscope(k): self._unscope_dict(v) for k, v in result.items()}
+
+    def _scope_paths(self, paths: Iterable[Any]) -> list[Any]:
+        return [self.scope(p) for p in paths]
+
+    # ── single-path operations ──────────────────────────────────────────
+
+    def sys_stat(self, path: str, *args: Any, **kwargs: Any) -> Any:
+        return self._unscope_dict(self._fs.sys_stat(self.scope(path), *args, **kwargs))
+
+    def sys_read(self, path: str, *args: Any, **kwargs: Any) -> Any:
+        return self._fs.sys_read(self.scope(path), *args, **kwargs)
+
+    def read(self, path: str, *args: Any, **kwargs: Any) -> Any:
+        return self._unscope_dict(self._fs.read(self.scope(path), *args, **kwargs))
+
+    def read_range(self, path: str, *args: Any, **kwargs: Any) -> Any:
+        return self._fs.read_range(self.scope(path), *args, **kwargs)
+
+    def stream(self, path: str, *args: Any, **kwargs: Any) -> Any:
+        return self._fs.stream(self.scope(path), *args, **kwargs)
+
+    def access(self, path: str, *args: Any, **kwargs: Any) -> Any:
+        return self._fs.access(self.scope(path), *args, **kwargs)
+
+    def exists(self, path: str, *args: Any, **kwargs: Any) -> Any:
+        return self._fs.exists(self.scope(path), *args, **kwargs)
+
+    def get_metadata(self, path: str, *args: Any, **kwargs: Any) -> Any:
+        return self._unscope_object(self._fs.get_metadata(self.scope(path), *args, **kwargs))
+
+    def get_content_id(self, path: str, *args: Any, **kwargs: Any) -> Any:
+        return self._fs.get_content_id(self.scope(path), *args, **kwargs)
+
+    def write(self, *args: Any, **kwargs: Any) -> Any:
+        # Callers pass ``path`` both positionally (copy) and by keyword (the
+        # write route, the batch executor); forward it the way it came so
+        # keyword-only implementations keep working.
+        if "path" in kwargs:
+            kwargs["path"] = self.scope(kwargs["path"])
+        elif args:
+            args = (self.scope(args[0]), *args[1:])
+        return self._unscope_dict(self._fs.write(*args, **kwargs))
+
+    def sys_write(self, path: str, *args: Any, **kwargs: Any) -> Any:
+        return self._unscope_dict(self._fs.sys_write(self.scope(path), *args, **kwargs))
+
+    def write_stream(self, path: str, *args: Any, **kwargs: Any) -> Any:
+        return self._unscope_dict(self._fs.write_stream(self.scope(path), *args, **kwargs))
+
+    def sys_unlink(self, path: str, *args: Any, **kwargs: Any) -> Any:
+        return self._unscope_dict(self._fs.sys_unlink(self.scope(path), *args, **kwargs))
+
+    def delete(self, path: str, *args: Any, **kwargs: Any) -> Any:
+        return self._unscope_dict(self._fs.delete(self.scope(path), *args, **kwargs))
+
+    def sys_rename(self, old_path: str, new_path: str, *args: Any, **kwargs: Any) -> Any:
+        return self._unscope_dict(
+            self._fs.sys_rename(self.scope(old_path), self.scope(new_path), *args, **kwargs)
+        )
+
+    def mkdir(self, path: str, *args: Any, **kwargs: Any) -> Any:
+        return self._unscope_dict(self._fs.mkdir(self.scope(path), *args, **kwargs))
+
+    def rmdir(self, path: str, *args: Any, **kwargs: Any) -> Any:
+        return self._unscope_dict(self._fs.rmdir(self.scope(path), *args, **kwargs))
+
+    def is_directory(self, path: str, *args: Any, **kwargs: Any) -> Any:
+        return self._fs.is_directory(self.scope(path), *args, **kwargs)
+
+    # ── listing ────────────────────────────────────────────────────────
+
+    def sys_readdir(self, path: str = "/", *args: Any, **kwargs: Any) -> Any:
+        if isinstance(kwargs.get("cursor"), str):
+            kwargs["cursor"] = self.scope(kwargs["cursor"])
+        return self._unscope_readdir(self._fs.sys_readdir(self.scope(path), *args, **kwargs))
+
+    def list(self, path: str = "/", *args: Any, **kwargs: Any) -> Any:
+        if isinstance(kwargs.get("cursor"), str):
+            kwargs["cursor"] = self.scope(kwargs["cursor"])
+        return self._unscope_readdir(self._fs.list(self.scope(path), *args, **kwargs))
+
+    # ── batch operations ───────────────────────────────────────────────
+
+    def write_batch(self, files: Iterable[Any], *args: Any, **kwargs: Any) -> Any:
+        scoped = [
+            (self.scope(item[0]), *item[1:]) if isinstance(item, (list, tuple)) and item else item
+            for item in files
+        ]
+        return self._unscope_entries(self._fs.write_batch(scoped, *args, **kwargs))
+
+    def read_batch(self, paths: Iterable[Any], *args: Any, **kwargs: Any) -> Any:
+        return self._unscope_entries(self._fs.read_batch(self._scope_paths(paths), *args, **kwargs))
+
+    def read_bulk(self, paths: Iterable[Any], *args: Any, **kwargs: Any) -> Any:
+        return self._unscope_keyed(self._fs.read_bulk(self._scope_paths(paths), *args, **kwargs))
+
+    def rename_batch(self, renames: Iterable[Any], *args: Any, **kwargs: Any) -> Any:
+        scoped = [
+            (self.scope(item[0]), self.scope(item[1]), *item[2:])
+            if isinstance(item, (list, tuple)) and len(item) >= 2
+            else item
+            for item in renames
+        ]
+        return self._unscope_keyed(self._fs.rename_batch(scoped, *args, **kwargs))
+
+    # ── services ───────────────────────────────────────────────────────
+
+    @property
+    def service(self) -> Any:
+        # A property so ``hasattr(fs, "service")`` stays faithful to the
+        # wrapped filesystem (test fakes and minimal backends may lack it).
+        inner = getattr(self._fs, "service", None)
+        if inner is None:
+            raise AttributeError("service")
+
+        def _service(name: str) -> Any:
+            svc = inner(name)
+            if name == "search" and svc is not None:
+                return _ZoneScopedSearch(svc, self)
+            return svc
+
+        return _service
+
+    def __getattr__(self, name: str) -> Any:
+        # Everything not proxied above (kernel handle, service accessors,
+        # capability probes) is forwarded unchanged.
+        return getattr(self._fs, name)
+
+
+class _ZoneScopedSearch:
+    """Path-scoping proxy for the search service handed out by :meth:`ZoneScopedFS.service`."""
+
+    __slots__ = ("_svc", "_view")
+
+    def __init__(self, svc: Any, view: ZoneScopedFS) -> None:
+        self._svc = svc
+        self._view = view
+
+    def _scoped_files(self, files: Any) -> Any:
+        if files is None:
+            return None
+        return [self._view.scope(f) for f in files]
+
+    def list(self, path: str = "/", *args: Any, **kwargs: Any) -> Any:
+        if isinstance(kwargs.get("cursor"), str):
+            kwargs["cursor"] = self._view.scope(kwargs["cursor"])
+        return self._view._unscope_readdir(self._svc.list(self._view.scope(path), *args, **kwargs))
+
+    def glob(
+        self, pattern: str, path: str = "/", *args: Any, files: Any = None, **kwargs: Any
+    ) -> Any:
+        result = self._svc.glob(
+            pattern, self._view.scope(path), *args, files=self._scoped_files(files), **kwargs
+        )
+        return self._view._unscope_entries(result)
+
+    async def grep(
+        self, pattern: str, path: str = "/", *args: Any, files: Any = None, **kwargs: Any
+    ) -> Any:
+        result = await self._svc.grep(
+            pattern, self._view.scope(path), *args, files=self._scoped_files(files), **kwargs
+        )
+        return self._view._unscope_entries(list(result)) if result is not None else result
+
+    def resolve_physical_path(self, path: str, *args: Any, **kwargs: Any) -> Any:
+        return self._svc.resolve_physical_path(self._view.scope(path), *args, **kwargs)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._svc, name)
+
+
+__all__ = [
+    "ZoneScopedFS",
+    "scope_rest_path",
+    "zone_prefix_for",
+    "zone_scoped_fs",
+]

--- a/src/nexus/server/api/v2/routers/async_files.py
+++ b/src/nexus/server/api/v2/routers/async_files.py
@@ -40,6 +40,7 @@ from nexus.server.api.v2._revision_fence import (
     get_revision_fence,
     stamp_revision,
 )
+from nexus.server.api.v2._zone_scoped_fs import zone_scoped_fs
 from nexus.server.api.v2.routers._index_on_write import (
     IndexOnWrite,
     WriteIndexResult,
@@ -50,7 +51,7 @@ from nexus.server.api.v2.routers._index_on_write import (
     index_zone_for,
     require_search_daemon,
 )
-from nexus.server.zone_execution import run_zone_scoped
+from nexus.server.zone_execution import context_for_target_zone, run_zone_scoped
 
 logger = logging.getLogger(__name__)
 T = TypeVar("T")
@@ -121,6 +122,12 @@ def _apply_zone_override(
         _gate_zone(auth_result, target, required_perm=required_perm)
     if zone is None:
         return context
+    if getattr(context, "is_admin", False):
+        # #4740: an admin's zone_perms name the root zone; retarget them along
+        # with zone_id (as the RPC path does via context_for_target_zone) or
+        # the zone visibility predicate keeps following the stale root grant
+        # and the override lists nothing.
+        return context_for_target_zone(context, zone)
     return _dc.replace(context, zone_id=zone)
 
 
@@ -696,18 +703,26 @@ def create_async_files_router(
         require_auth,
     )
 
-    async def _get_fs() -> Any:
-        """Get NexusFS, supporting both direct and lazy modes."""
+    async def _get_fs(context: Any = None) -> Any:
+        """Get NexusFS, supporting both direct and lazy modes.
+
+        #4740: when *context* is scoped to a concrete non-root zone the
+        caller receives a :class:`ZoneScopedFS` view, so every path in the
+        request is prefixed with ``/zone/<id>/`` and every path in the
+        result is unscoped again — the same contract the RPC and gRPC
+        paths already apply.  Root-zone callers get the raw filesystem.
+        """
+        fs: Any = None
         if nexus_fs is not None:
-            return nexus_fs
-        if get_fs is not None:
+            fs = nexus_fs
+        elif get_fs is not None:
             fs = get_fs()
-            if fs is not None:
-                return cast(Any, fs)
-        raise HTTPException(
-            status_code=503,
-            detail="NexusFS not initialized. Server may still be starting up.",
-        )
+        if fs is None:
+            raise HTTPException(
+                status_code=503,
+                detail="NexusFS not initialized. Server may still be starting up.",
+            )
+        return zone_scoped_fs(cast(Any, fs), context)
 
     def _get_zone_registry() -> Any | None:
         return get_zone_registry() if get_zone_registry is not None else None
@@ -771,7 +786,7 @@ def create_async_files_router(
         try:
 
             async def _work() -> Any:
-                fs = await _get_fs()
+                fs = await _get_fs(context)
                 # #4736 write+index: resolve the daemon BEFORE writing so a
                 # request that asked for indexing never half-succeeds.
                 index_daemon = (
@@ -1027,7 +1042,7 @@ def create_async_files_router(
         try:
 
             async def _work() -> Any:
-                fs = await _get_fs()
+                fs = await _get_fs(context)
                 await revision_fence.enforce(fs, context=context)
 
                 # Fast path: content-hash (content_id) lookup — used by the diff viewer
@@ -1383,7 +1398,7 @@ def create_async_files_router(
         context = _apply_zone_override(context, zone, auth_result, required_perm="r")
 
         async def _work() -> Response:
-            fs = await _get_fs()
+            fs = await _get_fs(context)
             meta = await _call_sync_or_async(
                 fs.sys_stat, path, context=context
             )  # raises -> 403 if denied
@@ -1518,7 +1533,7 @@ def create_async_files_router(
         try:
 
             async def _work() -> Response:
-                fs = await _get_fs()
+                fs = await _get_fs(context)
                 accessible = await fs.access(path, context=context)
                 if not accessible:
                     raise NexusFileNotFoundError(path)
@@ -1623,7 +1638,7 @@ def create_async_files_router(
         try:
 
             async def _work() -> DeleteResponse:
-                fs = await _get_fs()
+                fs = await _get_fs(context)
 
                 _ss = None
                 _norm_path: str | None = None
@@ -1706,7 +1721,7 @@ def create_async_files_router(
         try:
 
             async def _work() -> ExistsResponse:
-                fs = await _get_fs()
+                fs = await _get_fs(context)
                 await revision_fence.enforce(fs, context=context)
                 exists = fs.access(path, context=context)
                 return ExistsResponse(exists=exists)
@@ -1740,6 +1755,13 @@ def create_async_files_router(
             None,
             description="Override zone (must be in token's zone_set).",
         ),
+        all_zones: bool = Query(
+            False,
+            description=(
+                "Admin only: enumerate across every zone instead of the caller's "
+                "zone. Audited (#4740). Non-admin callers get 403."
+            ),
+        ),
         context: Any = Depends(get_context),
         auth_result: dict[str, Any] = Depends(require_auth),
         revision_fence: RevisionFence = Depends(get_revision_fence),
@@ -1757,7 +1779,7 @@ def create_async_files_router(
         try:
 
             async def _work() -> Any:
-                fs = await _get_fs()
+                fs = await _get_fs(context)
                 await revision_fence.enforce(fs, context=context)
 
                 # Decode opaque cursor (base64-encoded path)
@@ -1782,6 +1804,7 @@ def create_async_files_router(
                         context=context,
                         limit=limit,
                         cursor=cursor_path,
+                        all_zones=all_zones,
                     )
                 )
 
@@ -1986,7 +2009,7 @@ def create_async_files_router(
         try:
 
             async def _work() -> dict[str, Any]:
-                fs = await _get_fs()
+                fs = await _get_fs(context)
                 _made = fs.mkdir(request.path, parents=request.parents, context=context)
                 return {
                     "created": True,
@@ -2030,7 +2053,7 @@ def create_async_files_router(
         try:
 
             async def _work() -> MetadataResponse:
-                fs = await _get_fs()
+                fs = await _get_fs(context)
                 await revision_fence.enforce(fs, context=context)
                 meta = fs.sys_stat(path, context=context)
                 if meta is None:
@@ -2080,7 +2103,7 @@ def create_async_files_router(
         try:
 
             async def _work() -> dict[str, Any]:
-                fs = await _get_fs()
+                fs = await _get_fs(context)
                 await revision_fence.enforce(fs, context=context)
                 results = await asyncio.to_thread(fs.read_bulk, request.paths, context=context)
 
@@ -2147,7 +2170,7 @@ def create_async_files_router(
         try:
 
             async def _work() -> BatchWriteResponse:
-                fs = await _get_fs()
+                fs = await _get_fs(context)
                 index_daemon = (
                     require_search_daemon(http_request.app.state)
                     if any(
@@ -2223,7 +2246,7 @@ def create_async_files_router(
         try:
 
             async def _work() -> BatchReadResponse:
-                fs = await _get_fs()
+                fs = await _get_fs(context)
                 await revision_fence.enforce(fs, context=context)
                 raw_results = await _maybe_await(
                     fs.read_batch(request.paths, partial=request.partial, context=context)
@@ -2302,7 +2325,7 @@ def create_async_files_router(
         try:
 
             async def _work() -> Response | StreamingResponse:
-                fs = await _get_fs()
+                fs = await _get_fs(context)
                 await revision_fence.enforce(fs, context=context)
                 meta = fs.sys_stat(path, context=context)
                 if meta is None:
@@ -2368,7 +2391,7 @@ def create_async_files_router(
         try:
 
             async def _work() -> RenameResponse:
-                fs = await _get_fs()
+                fs = await _get_fs(context)
                 rename_result = await _maybe_await(
                     fs.sys_rename(request.source, request.destination, context=context)
                 )
@@ -2413,7 +2436,7 @@ def create_async_files_router(
         try:
 
             async def _work() -> CopyResponse:
-                fs = await _get_fs()
+                fs = await _get_fs(context)
 
                 # Check source exists and get size
                 meta = await _maybe_await(fs.sys_stat(request.source, context=context))
@@ -2477,7 +2500,7 @@ def create_async_files_router(
         try:
 
             async def _work() -> RenameBatchResponse:
-                fs = await _get_fs()
+                fs = await _get_fs(context)
                 renames = [(op.source, op.destination) for op in request.operations]
                 raw_results = await _maybe_await(fs.rename_batch(renames, context=context))
 
@@ -2521,7 +2544,7 @@ def create_async_files_router(
         try:
 
             async def _work() -> CopyBulkResponse:
-                fs = await _get_fs()
+                fs = await _get_fs(context)
                 results: list[BulkCopyResult] = []
 
                 for op in request.operations:
@@ -2601,7 +2624,7 @@ def create_async_files_router(
         try:
 
             async def _work() -> GlobResponse:
-                fs = await _get_fs()
+                fs = await _get_fs(context)
                 await revision_fence.enforce(fs, context=context)
 
                 # List all files without blocking the zone runner when a
@@ -2663,7 +2686,7 @@ def create_async_files_router(
         try:
 
             async def _work() -> GrepResponse:
-                fs = await _get_fs()
+                fs = await _get_fs(context)
                 await revision_fence.enforce(fs, context=context)
 
                 flags = re.IGNORECASE if ignore_case else 0

--- a/src/nexus/server/api/v2/routers/batch.py
+++ b/src/nexus/server/api/v2/routers/batch.py
@@ -21,6 +21,7 @@ from typing import Any, cast
 from fastapi import APIRouter, Depends, HTTPException
 
 from nexus.contracts.types import OperationContext
+from nexus.server.api.v2._zone_scoped_fs import zone_scoped_fs
 from nexus.server.batch_executor import BatchExecutor, BatchRequest, BatchResponse
 
 logger = logging.getLogger(__name__)
@@ -109,7 +110,9 @@ def create_batch_router(
         - 30-second timeout per operation
         """
         fs = await _get_fs()
-        executor = BatchExecutor(fs=fs, zone_registry=_get_zone_registry())
+        # #4740: zone-scoped callers operate on their /zone/<id>/ namespace,
+        # exactly like the RPC path; root-zone callers get the raw filesystem.
+        executor = BatchExecutor(fs=zone_scoped_fs(fs, context), zone_registry=_get_zone_registry())
 
         logger.info(
             "Batch request: %d operations, stop_on_error=%s",

--- a/src/nexus/server/api/v2/routers/search.py
+++ b/src/nexus/server/api/v2/routers/search.py
@@ -45,6 +45,7 @@ from nexus.lib.rebac_filter import compute_rebac_fetch_limit as _compute_rebac_f
 from nexus.lib.rebac_filter import rebac_denial_stats as _rebac_denial_stats
 from nexus.runtime.zone_resolution import target_zone_for_context
 from nexus.server.api.v2._revision_fence import RevisionFence, get_revision_fence
+from nexus.server.api.v2._zone_scoped_fs import scope_rest_path
 from nexus.server.api.v2.routers._index_on_write import (
     REASON_EMPTY,
     REASON_NON_TEXT,
@@ -1153,7 +1154,7 @@ async def _do_grep_operation(
     response envelope.
     """
     from nexus.contracts.constants import ROOT_ZONE_ID
-    from nexus.contracts.exceptions import InvalidPathError
+    from nexus.contracts.exceptions import InvalidPathError, NexusPermissionError
     from nexus.server.dependencies import get_operation_context
 
     start_time = time.perf_counter()
@@ -1182,6 +1183,11 @@ async def _do_grep_operation(
         sentinel_window, has_enforcer=permission_enforcer is not None
     )
 
+    # #4740: scope the caller's path and files into its zone namespace, as the
+    # RPC layer does for every syscall; a path naming another zone is a 403.
+    path = scope_rest_path(path, op_context)
+    if files:
+        files = [scope_rest_path(f, op_context) for f in files]
     target_zone = target_zone_for_context(op_context, {"path": path, "files": files})
 
     async def _work() -> dict[str, Any]:
@@ -1208,6 +1214,10 @@ async def _do_grep_operation(
             #  * ValueError — invalid regex, size cap exceeded, cross-zone entry
             #  * InvalidPathError — path traversal segment in ``path`` or ``files``
             raise HTTPException(status_code=400, detail=str(exc)) from exc
+        except NexusPermissionError as exc:
+            # #4740: zone-less non-admin callers are refused by the zone
+            # visibility predicate — surface it as 403, not a 500.
+            raise HTTPException(status_code=403, detail=str(exc)) from exc
         except Exception as exc:
             logger.error("grep failed: %s", exc, exc_info=True)
             raise HTTPException(
@@ -1316,7 +1326,7 @@ async def _do_glob_operation(
     Shared by ``GET /glob`` (query params) and ``POST /glob`` (JSON body).
     """
     from nexus.contracts.constants import ROOT_ZONE_ID
-    from nexus.contracts.exceptions import InvalidPathError
+    from nexus.contracts.exceptions import InvalidPathError, NexusPermissionError
     from nexus.server.dependencies import get_operation_context
 
     start_time = time.perf_counter()
@@ -1330,6 +1340,11 @@ async def _do_glob_operation(
     op_context = get_operation_context(auth_result)
     permission_enforcer = getattr(request.app.state, "permission_enforcer", None)
 
+    # #4740: scope the caller's path and files into its zone namespace, as the
+    # RPC layer does for every syscall; a path naming another zone is a 403.
+    path = scope_rest_path(path, op_context)
+    if files:
+        files = [scope_rest_path(f, op_context) for f in files]
     target_zone = target_zone_for_context(op_context, {"path": path, "files": files})
 
     async def _work() -> dict[str, Any]:
@@ -1339,6 +1354,10 @@ async def _do_glob_operation(
             )
         except (ValueError, InvalidPathError) as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
+        except NexusPermissionError as exc:
+            # #4740: zone-less non-admin callers are refused by the zone
+            # visibility predicate — surface it as 403, not a 500.
+            raise HTTPException(status_code=403, detail=str(exc)) from exc
         except Exception as exc:
             logger.error("glob failed: %s", exc, exc_info=True)
             raise HTTPException(

--- a/src/nexus/server/dependencies.py
+++ b/src/nexus/server/dependencies.py
@@ -199,12 +199,17 @@ async def resolve_auth(
 
         is_admin = subject_id in _STATIC_ADMINS if subject_id else False
 
+        # Issue #4740: open-access mode has no tenant model — the loopback
+        # caller IS the operator — so the absence of a zone header means the
+        # ROOT zone explicitly, not "zone-less" (which list/search now
+        # refuse for non-admins).  This is still tighter than before: a root
+        # caller sees root-tagged entries, not every ``/zone/<id>/`` tree.
         return {
             "authenticated": True,
             "is_admin": is_admin,
             "subject_type": subject_type,
             "subject_id": subject_id,
-            "zone_id": zone_id,
+            "zone_id": zone_id or ROOT_ZONE_ID,
             "inherit_permissions": True,  # Open access mode always inherits
             "metadata": {"open_access": True},
             "x_agent_id": x_agent_id,
@@ -426,8 +431,16 @@ def get_operation_context(auth_result: dict[str, Any]) -> Any:
 
     subject_type = auth_result.get("subject_type") or "user"
     subject_id = auth_result.get("subject_id") or "anonymous"
-    zone_id = auth_result.get("zone_id") or ROOT_ZONE_ID
     is_admin = auth_result.get("is_admin", False)
+    # Issue #4740: a missing zone claim is no longer coerced to ROOT for
+    # non-admin callers.  The context keeps ``zone_id=None`` and the
+    # enumeration surfaces (sys_readdir, search list/glob/grep) refuse it
+    # (403) instead of handing out the global view.  Admins keep ROOT as
+    # their default zone — that is the operator's own namespace, and cross-
+    # zone listing still needs an explicit ``all_zones=true``.  Providers
+    # that legitimately mean "the default zone" (open-access mode, local
+    # users, OIDC without a zone claim) now say ROOT explicitly upstream.
+    zone_id = auth_result.get("zone_id") or (ROOT_ZONE_ID if is_admin else None)
     agent_id = auth_result.get("x_agent_id")
     user_id = subject_id
 

--- a/src/nexus/server/zone_execution.py
+++ b/src/nexus/server/zone_execution.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import copy
+import dataclasses
 from collections.abc import Awaitable, Callable
 from typing import Any, TypeVar, cast
 
@@ -34,9 +36,28 @@ def context_for_target_zone(context: Any, target_zone: str | None) -> Any:
     if getattr(context, "is_admin", False):
         updates["zone_set"] = (target_zone,)
         updates["zone_perms"] = ((target_zone, "rw"),)
+    return _with_updates(context, updates)
+
+
+def _with_updates(context: Any, updates: dict[str, Any]) -> Any:
+    """Return a copy of *context* with *updates* applied — never mutate the caller's.
+
+    Issue #4740: the request-scoped context can be shared (batch executors,
+    retries, cached auth results), so retargeting it in place leaked the
+    admin ``zone_perms=((target, "rw"),)`` grant into later operations.
+    ``dataclasses.replace`` re-runs ``OperationContext.__post_init__`` so
+    ``zone_set`` / ``zone_perms`` stay consistent; non-dataclass contexts
+    (tests use ``SimpleNamespace``) fall back to a shallow copy.
+    """
+    if dataclasses.is_dataclass(context) and not isinstance(context, type):
+        try:
+            return dataclasses.replace(context, **updates)
+        except (TypeError, ValueError):
+            pass
+    clone = copy.copy(context)
     for key, value in updates.items():
-        setattr(context, key, value)
-    return context
+        setattr(clone, key, value)
+    return clone
 
 
 async def run_zone_scoped(

--- a/tests/e2e/self_contained/test_zone_visibility_matrix_e2e.py
+++ b/tests/e2e/self_contained/test_zone_visibility_matrix_e2e.py
@@ -1,0 +1,551 @@
+"""Zone visibility matrix — acceptance test for nexi-lab/nexus#4740.
+
+Real kernel-backed NexusFS + the real FastAPI app + real API-key auth
+(``DatabaseAPIKeyAuth`` for the tenant/admin keys, chained with a
+``StaticAPIKeyAuth`` key that deliberately carries no zone).  No mocks on
+the request path, so a regression in the RPC zone scoping, the REST zone
+gate, ``sys_readdir`` or the search list pipeline shows up as a real HTTP
+result.
+
+Matrix (each cell over ``/api/nfs/list``, ``/api/v2/files/list``,
+``/api/v2/search/glob`` and ``/api/v2/search/grep``):
+
+* tenant A, with and without ``X-Nexus-Zone-ID`` — sees its own file, never
+  tenant B's or the root-tagged file;
+* tenant B — symmetric;
+* tenant A asking for tenant B's zone via the header — rejected;
+* a non-admin asking for ``all_zones`` — 403, not silently narrowed;
+* a key with **no zone claim** (the issue's headline case) — 403 on list
+  and search instead of the root/global view;
+* admin without a zone header — the root zone only (root-tagged file, no
+  tenant trees);
+* admin with ``all_zones=true`` — the anti-vacuity control: sees tenant A,
+  tenant B and the root-tagged file, and the access is audited exactly once.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from dataclasses import dataclass
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from starlette.testclient import TestClient
+
+from nexus.backends.storage.cas_local import CASLocalBackend
+from nexus.bricks.auth.providers.database_key import DatabaseAPIKeyAuth
+from nexus.bricks.auth.providers.static_key import StaticAPIKeyAuth
+from nexus.contracts.constants import ROOT_ZONE_ID
+from nexus.core.config import PermissionConfig
+from nexus.factory import create_nexus_fs
+from nexus.lib.events import register_audit_sink
+from nexus.lib.zone_visibility import ALL_ZONES_AUDIT_EVENT
+from nexus.server.auth.factory import _ChainedAPIKeyAuth
+from nexus.storage.models import Base, ZoneModel
+from nexus.storage.record_store import SQLAlchemyRecordStore
+
+pytestmark = pytest.mark.e2e
+
+RPC_PERMISSION_ERROR = -32003
+
+ZONE_A = "ta"
+ZONE_B = "tb"
+FILE_A = "/a.txt"
+FILE_B = "/b.txt"
+FILE_ROOT = "/root.txt"
+WORD_A = "alpha-tenant-a-secret"
+WORD_B = "bravo-tenant-b-secret"
+WORD_ROOT = "rootword-operator-only"
+ZONELESS_KEY = "sk-zoneless-nonadmin-e2e-4740"
+
+
+@dataclass
+class Stack:
+    client: TestClient
+    nx: Any
+    key_a: str
+    key_b: str
+    key_admin: str
+    key_zoneless: str
+    audit_events: list[tuple[str, dict[str, Any]]]
+
+
+@pytest.fixture(scope="module")
+def stack(tmp_path_factory: pytest.TempPathFactory) -> Iterator[Stack]:
+    tmp: Path = tmp_path_factory.mktemp("zone_visibility_matrix")
+    mp = pytest.MonkeyPatch()
+    mp.setenv("NEXUS_ENFORCE_PERMISSIONS", "false")
+    mp.setenv("NEXUS_SEARCH_DAEMON", "false")
+    mp.setenv("NEXUS_ENABLE_WRITE_BUFFER", "false")
+    mp.setenv("NEXUS_ACTIVITY_ENABLED", "0")
+    # The locally installed nexusd-cluster demands a bootstrap mode; the
+    # pinned CI kernel ignores the variable.
+    if "NEXUS_BOOTSTRAP_MODE" not in __import__("os").environ:
+        mp.setenv("NEXUS_BOOTSTRAP_MODE", "static")
+
+    storage = tmp / "storage"
+    storage.mkdir()
+    record_store = SQLAlchemyRecordStore(db_url=f"sqlite:///{tmp / 'records.db'}")
+    try:
+        nx = create_nexus_fs(
+            backend=CASLocalBackend(root_path=storage),
+            metadata_store=str(tmp / "meta"),
+            record_store=record_store,
+            permissions=PermissionConfig(enforce=False),
+            is_admin=False,
+        )
+    except Exception as exc:  # kernel spawn failure surfaces as AttributeError/RuntimeError
+        mp.undo()
+        pytest.skip(f"kernel binary unavailable in this environment: {exc}")
+    if getattr(nx, "_kernel", None) is None:
+        nx.close()
+        mp.undo()
+        pytest.skip("kernel binary unavailable in this environment")
+
+    # --- real DB-backed API keys: two tenants + one zone-less global admin ---
+    engine = create_engine(f"sqlite:///{tmp / 'auth.db'}")
+    Base.metadata.create_all(engine)
+    session_factory = sessionmaker(bind=engine)
+    with session_factory() as session:
+        session.add(ZoneModel(zone_id=ZONE_A, name="Tenant A"))
+        session.add(ZoneModel(zone_id=ZONE_B, name="Tenant B"))
+        session.commit()
+        _, key_a = DatabaseAPIKeyAuth.create_key(
+            session, user_id="alice", name="alice-key", zone_id=ZONE_A
+        )
+        _, key_b = DatabaseAPIKeyAuth.create_key(
+            session, user_id="bob", name="bob-key", zone_id=ZONE_B
+        )
+        _, key_admin = DatabaseAPIKeyAuth.create_key(
+            session, user_id="root-op", name="admin-key", zone_id=None, is_admin=True
+        )
+        session.commit()
+
+    # A static non-admin key with NO zone claim.  DatabaseAPIKeyAuth already
+    # refuses such keys at authentication time (#3871), so the static
+    # provider is the only way to reach the server with one — exactly the
+    # "authenticated but zone-less" shape #4740 is about.
+    static_provider = StaticAPIKeyAuth(
+        {ZONELESS_KEY: {"subject_type": "user", "subject_id": "nozone", "is_admin": False}}
+    )
+    db_provider = DatabaseAPIKeyAuth(SimpleNamespace(session_factory=session_factory))
+    provider = _ChainedAPIKeyAuth(static_provider, db_provider)
+
+    from nexus.server.fastapi_server import create_app
+
+    app = create_app(
+        nexus_fs=nx,
+        auth_provider=provider,
+        database_url=f"sqlite:///{tmp / 'records.db'}",
+    )
+
+    audit_events: list[tuple[str, dict[str, Any]]] = []
+    handle = register_audit_sink(lambda name, payload: audit_events.append((name, payload)))
+    try:
+        with TestClient(app, raise_server_exceptions=False) as client:
+            s = Stack(
+                client=client,
+                nx=nx,
+                key_a=key_a,
+                key_b=key_b,
+                key_admin=key_admin,
+                key_zoneless=ZONELESS_KEY,
+                audit_events=audit_events,
+            )
+            _seed(s)
+            yield s
+    finally:
+        handle.remove()
+        nx.close()
+        mp.undo()
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _headers(key: str, zone: str | None = None) -> dict[str, str]:
+    h = {"Authorization": f"Bearer {key}"}
+    if zone is not None:
+        h["X-Nexus-Zone-ID"] = zone
+    return h
+
+
+def _rpc(s: Stack, key: str, method: str, params: dict[str, Any], zone: str | None = None):
+    return s.client.post(
+        f"/api/nfs/{method}",
+        json={"jsonrpc": "2.0", "id": str(uuid.uuid4()), "method": method, "params": params},
+        headers=_headers(key, zone),
+    )
+
+
+def _rpc_result(resp) -> Any:
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert "error" not in body, body
+    return body["result"]
+
+
+def _rpc_error_code(resp) -> int | None:
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    return body.get("error", {}).get("code") if "error" in body else None
+
+
+def _collect_paths(payload: Any) -> set[str]:
+    """Every path-like string in a list/glob/grep response, whatever the envelope."""
+    out: set[str] = set()
+
+    def walk(node: Any) -> None:
+        if isinstance(node, str):
+            if node.startswith("/"):
+                out.add(node)
+        elif isinstance(node, dict):
+            for k in ("path", "file", "file_path", "virtual_path"):
+                v = node.get(k)
+                if isinstance(v, str):
+                    out.add(v)
+            for k in ("files", "items", "results", "matches", "data"):
+                if k in node:
+                    walk(node[k])
+        elif isinstance(node, list):
+            for item in node:
+                walk(item)
+
+    walk(payload)
+    return out
+
+
+def _rpc_list(s: Stack, key: str, zone: str | None = None, **extra: Any) -> set[str]:
+    return _collect_paths(_rpc_result(_rpc(s, key, "list", {"path": "/", **extra}, zone)))
+
+
+def _rest_list(s: Stack, key: str, zone: str | None = None, **params: Any):
+    return s.client.get(
+        "/api/v2/files/list", params={"path": "/", **params}, headers=_headers(key, zone)
+    )
+
+
+def _glob(s: Stack, key: str, zone: str | None = None):
+    return s.client.get(
+        "/api/v2/search/glob",
+        params={"pattern": "**/*.txt", "path": "/"},
+        headers=_headers(key, zone),
+    )
+
+
+def _grep(s: Stack, key: str, zone: str | None = None):
+    return s.client.get(
+        "/api/v2/search/grep",
+        params={"pattern": "secret|rootword", "path": "/"},
+        headers=_headers(key, zone),
+    )
+
+
+def _seed(s: Stack) -> None:
+    _rpc_result(_rpc(s, s.key_a, "write", {"path": FILE_A, "content": WORD_A}))
+    _rpc_result(_rpc(s, s.key_b, "write", {"path": FILE_B, "content": WORD_B}))
+    _rpc_result(_rpc(s, s.key_admin, "write", {"path": FILE_ROOT, "content": WORD_ROOT}))
+
+    # The search router applies a file-level ReBAC filter to glob/grep hits
+    # on top of the zone predicate (Decision #17), so give each principal a
+    # read grant on the files it legitimately owns.  Without these the
+    # tenant cells would be vacuous ("sees nothing" for the wrong reason);
+    # the zone predicate is what must hide the OTHER tenants' files.
+    # ReBAC objects are keyed by the user-facing path within the zone (the
+    # enforcer unscopes ``/zone/<id>/`` before checking), hence ``/a.txt``
+    # in zone ``ta``, not ``/zone/ta/a.txt``.
+    rebac = s.nx.service("rebac")
+    assert rebac is not None, "ReBAC service must be wired for the search cells"
+    grants = [
+        ("alice", FILE_A, ZONE_A),
+        ("bob", FILE_B, ZONE_B),
+        ("root-op", FILE_ROOT, ROOT_ZONE_ID),
+        ("root-op", FILE_A, ZONE_A),
+        ("root-op", FILE_B, ZONE_B),
+    ]
+    for user, path, zone in grants:
+        rebac.rebac_create_sync(
+            subject=("user", user),
+            relation="direct_viewer",
+            object=("file", path),
+            zone_id=zone,
+        )
+
+
+def _assert_only_tenant(paths: set[str], *, own: str, others: tuple[str, ...]) -> None:
+    assert any(p.endswith(own) for p in paths), f"own file {own} missing from {sorted(paths)}"
+    leaked = [p for p in paths if any(p.endswith(o) for o in others)]
+    assert not leaked, f"cross-tenant leak: {leaked}"
+
+
+# ---------------------------------------------------------------------------
+# tenant rows of the matrix
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("zone_header", [None, ZONE_A], ids=["no-header", "own-zone-header"])
+def test_tenant_a_list_sees_only_its_zone(stack: Stack, zone_header: str | None) -> None:
+    others = (FILE_B, FILE_ROOT)
+    _assert_only_tenant(_rpc_list(stack, stack.key_a, zone_header), own=FILE_A, others=others)
+
+    rest = _rest_list(stack, stack.key_a, zone_header)
+    assert rest.status_code == 200, rest.text
+    rest_paths = _collect_paths(rest.json())
+    leaked = [p for p in rest_paths if p.endswith(FILE_B) or p.endswith(FILE_ROOT)]
+    assert not leaked, f"REST list leaked {leaked}"
+
+
+@pytest.mark.parametrize("zone_header", [None, ZONE_A], ids=["no-header", "own-zone-header"])
+def test_tenant_a_search_sees_only_its_zone(stack: Stack, zone_header: str | None) -> None:
+    glob = _glob(stack, stack.key_a, zone_header)
+    assert glob.status_code == 200, glob.text
+    _assert_only_tenant(_collect_paths(glob.json()), own=FILE_A, others=(FILE_B, FILE_ROOT))
+
+    grep = _grep(stack, stack.key_a, zone_header)
+    assert grep.status_code == 200, grep.text
+    body = grep.text
+    assert WORD_A in body
+    assert WORD_B not in body
+    assert WORD_ROOT not in body
+
+
+def test_tenant_b_is_symmetric(stack: Stack) -> None:
+    _assert_only_tenant(_rpc_list(stack, stack.key_b), own=FILE_B, others=(FILE_A, FILE_ROOT))
+    glob = _glob(stack, stack.key_b, ZONE_B)
+    assert glob.status_code == 200, glob.text
+    _assert_only_tenant(_collect_paths(glob.json()), own=FILE_B, others=(FILE_A, FILE_ROOT))
+
+
+def test_tenant_cannot_borrow_another_zone_via_header(stack: Stack) -> None:
+    resp = _rpc(stack, stack.key_a, "list", {"path": "/"}, zone=ZONE_B)
+    # The zone override is rejected at authentication (401); if a deployment
+    # ever lets it through, the visibility predicate must still hide B.
+    if resp.status_code == 200 and "error" not in resp.json():
+        paths = _collect_paths(resp.json()["result"])
+        assert not any(p.endswith(FILE_B) for p in paths)
+    else:
+        assert resp.status_code in (401, 403), resp.text
+
+
+def test_non_admin_all_zones_is_refused(stack: Stack) -> None:
+    assert _rpc_error_code(_rpc(stack, stack.key_a, "list", {"path": "/", "all_zones": True})) == (
+        RPC_PERMISSION_ERROR
+    )
+    rest = _rest_list(stack, stack.key_a, all_zones="true")
+    assert rest.status_code == 403, rest.text
+
+
+# ---------------------------------------------------------------------------
+# the headline case: authenticated, non-admin, no zone claim → refused
+# ---------------------------------------------------------------------------
+
+
+def test_zone_less_non_admin_list_returns_403(stack: Stack) -> None:
+    rest = _rest_list(stack, stack.key_zoneless)
+    assert rest.status_code == 403, rest.text
+    assert "zone" in rest.text.lower()
+
+    code = _rpc_error_code(_rpc(stack, stack.key_zoneless, "list", {"path": "/"}))
+    assert code == RPC_PERMISSION_ERROR
+
+    code = _rpc_error_code(_rpc(stack, stack.key_zoneless, "sys_readdir", {"path": "/"}))
+    assert code == RPC_PERMISSION_ERROR
+
+
+def test_zone_less_non_admin_search_returns_403(stack: Stack) -> None:
+    assert _glob(stack, stack.key_zoneless).status_code == 403
+    assert _grep(stack, stack.key_zoneless).status_code == 403
+
+
+def test_zone_less_non_admin_with_zone_header_is_scoped_not_global(stack: Stack) -> None:
+    """Sending a zone header turns the zone-less key into a zone-scoped caller."""
+    resp = _rpc(stack, stack.key_zoneless, "list", {"path": "/"}, zone=ZONE_A)
+    if resp.status_code == 200 and "error" not in resp.json():
+        paths = _collect_paths(resp.json()["result"])
+        assert not any(p.endswith(FILE_B) or p.endswith(FILE_ROOT) for p in paths)
+    else:
+        # A deployment that refuses the override outright is also fail-closed.
+        assert resp.status_code in (401, 403) or _rpc_error_code(resp) == RPC_PERMISSION_ERROR
+
+
+# ---------------------------------------------------------------------------
+# admin rows: root zone by default, everything only with all_zones (audited)
+# ---------------------------------------------------------------------------
+
+
+def test_admin_without_all_zones_sees_root_zone_only(stack: Stack) -> None:
+    paths = _rpc_list(stack, stack.key_admin)
+    assert FILE_ROOT in paths, sorted(paths)
+    leaked = [p for p in paths if p.endswith(FILE_A) or p.endswith(FILE_B)]
+    assert not leaked, f"admin default view leaked tenant data: {leaked}"
+
+    rest = _rest_list(stack, stack.key_admin)
+    assert rest.status_code == 200, rest.text
+    rest_paths = _collect_paths(rest.json())
+    assert FILE_ROOT in rest_paths, sorted(rest_paths)
+    assert not any(p.endswith(FILE_A) or p.endswith(FILE_B) for p in rest_paths)
+
+
+def test_admin_search_is_scoped_per_zone_header(stack: Stack) -> None:
+    """Search has no ``all_zones``; the admin control is one zone per request."""
+    glob_root = _glob(stack, stack.key_admin)
+    assert glob_root.status_code == 200, glob_root.text
+    _assert_only_tenant(_collect_paths(glob_root.json()), own=FILE_ROOT, others=(FILE_A, FILE_B))
+
+    glob_a = _glob(stack, stack.key_admin, ZONE_A)
+    assert glob_a.status_code == 200, glob_a.text
+    _assert_only_tenant(_collect_paths(glob_a.json()), own=FILE_A, others=(FILE_B, FILE_ROOT))
+
+    glob_b = _glob(stack, stack.key_admin, ZONE_B)
+    assert glob_b.status_code == 200, glob_b.text
+    _assert_only_tenant(_collect_paths(glob_b.json()), own=FILE_B, others=(FILE_A, FILE_ROOT))
+
+    grep_b = _grep(stack, stack.key_admin, ZONE_B)
+    assert grep_b.status_code == 200, grep_b.text
+    assert WORD_B in grep_b.text
+    assert WORD_A not in grep_b.text
+    assert WORD_ROOT not in grep_b.text
+
+
+# ---------------------------------------------------------------------------
+# REST file routes: tenants operate on their own /zone/<id>/ namespace, like RPC
+# ---------------------------------------------------------------------------
+
+
+def _rest(s: Stack, key: str, method: str, url: str, zone: str | None = None, **kw: Any):
+    return getattr(s.client, method)(url, headers=_headers(key, zone), **kw)
+
+
+def test_rest_files_are_namespaced_per_tenant(stack: Stack) -> None:
+    """REST write/read/exists/metadata/list/rename/delete all live in the tenant namespace."""
+    w = _rest(
+        stack,
+        stack.key_a,
+        "post",
+        "/api/v2/files/write",
+        json={"path": "/rest-a.txt", "content": "rest tenant a"},
+    )
+    assert w.status_code == 200, w.text
+    revision = w.json().get("revision")
+    assert revision and revision.startswith("/rest-a.txt@"), w.json()
+
+    # stored under tenant A's namespace, not in the root namespace
+    assert stack.nx.sys_stat(f"/zone/{ZONE_A}/rest-a.txt") is not None
+    assert stack.nx.sys_stat("/rest-a.txt") is None
+
+    # A reads it back (also through the revision fence); B cannot address it
+    r = _rest(stack, stack.key_a, "get", "/api/v2/files/read", params={"path": "/rest-a.txt"})
+    assert r.status_code == 200 and r.json()["content"] == "rest tenant a", r.text
+    fenced = stack.client.get(
+        "/api/v2/files/read",
+        params={"path": "/rest-a.txt"},
+        headers={**_headers(stack.key_a), "X-Nexus-Min-Revision": revision},
+    )
+    assert fenced.status_code == 200, fenced.text
+    rb = _rest(stack, stack.key_b, "get", "/api/v2/files/read", params={"path": "/rest-a.txt"})
+    assert rb.status_code == 404, rb.text
+    ex_b = _rest(stack, stack.key_b, "get", "/api/v2/files/exists", params={"path": "/rest-a.txt"})
+    assert ex_b.status_code == 200 and ex_b.json()["exists"] is False, ex_b.text
+
+    ex_a = _rest(stack, stack.key_a, "get", "/api/v2/files/exists", params={"path": "/rest-a.txt"})
+    assert ex_a.status_code == 200 and ex_a.json()["exists"] is True, ex_a.text
+    meta = _rest(
+        stack, stack.key_a, "get", "/api/v2/files/metadata", params={"path": "/rest-a.txt"}
+    )
+    assert meta.status_code == 200, meta.text
+    assert not any("/zone/" in p for p in _collect_paths(meta.json()))
+
+    # listing shows A's files under caller-facing paths and nothing else
+    lst = _rest_list(stack, stack.key_a)
+    assert lst.status_code == 200, lst.text
+    paths = _collect_paths(lst.json())
+    assert "/rest-a.txt" in paths and "/a.txt" in paths, sorted(paths)
+    assert not any(p.endswith(FILE_B) or p.endswith(FILE_ROOT) or "/zone/" in p for p in paths)
+
+    # explicit cross-zone paths are refused, never silently re-rooted
+    for method, url, kw in (
+        ("get", "/api/v2/files/read", {"params": {"path": f"/zone/{ZONE_B}{FILE_B}"}}),
+        (
+            "post",
+            "/api/v2/files/write",
+            {"json": {"path": f"/zone/{ZONE_B}/x.txt", "content": "x"}},
+        ),
+        ("get", "/api/v2/files/list", {"params": {"path": f"/zone/{ZONE_B}"}}),
+    ):
+        resp = _rest(stack, stack.key_a, method, url, **kw)
+        assert resp.status_code == 403, (url, resp.status_code, resp.text)
+
+    # rename and delete stay inside the namespace
+    rn = _rest(
+        stack,
+        stack.key_a,
+        "post",
+        "/api/v2/files/rename",
+        json={"source": "/rest-a.txt", "destination": "/rest-a2.txt"},
+    )
+    assert rn.status_code == 200, rn.text
+    assert stack.nx.sys_stat(f"/zone/{ZONE_A}/rest-a2.txt") is not None
+    d = _rest(stack, stack.key_a, "delete", "/api/v2/files/delete", params={"path": "/rest-a2.txt"})
+    assert d.status_code == 200, d.text
+    assert stack.nx.sys_stat(f"/zone/{ZONE_A}/rest-a2.txt") is None
+
+
+def test_rest_files_glob_and_grep_are_namespaced(stack: Stack) -> None:
+    glob = _rest(
+        stack, stack.key_a, "get", "/api/v2/files/glob", params={"pattern": "**/*.txt", "path": "/"}
+    )
+    assert glob.status_code == 200, glob.text
+    _assert_only_tenant(_collect_paths(glob.json()), own=FILE_A, others=(FILE_B, FILE_ROOT))
+    assert not any("/zone/" in p for p in _collect_paths(glob.json()))
+
+    grep = _rest(
+        stack,
+        stack.key_a,
+        "get",
+        "/api/v2/files/grep",
+        params={"pattern": "secret|rootword", "path": "/"},
+    )
+    assert grep.status_code == 200, grep.text
+    assert WORD_A in grep.text and WORD_B not in grep.text and WORD_ROOT not in grep.text
+
+
+def test_rest_admin_root_view_and_zone_override(stack: Stack) -> None:
+    root_list = _rest_list(stack, stack.key_admin)
+    assert root_list.status_code == 200, root_list.text
+    root_paths = _collect_paths(root_list.json())
+    assert FILE_ROOT in root_paths and not any(
+        p.endswith(FILE_A) or p.endswith(FILE_B) for p in root_paths
+    )
+
+    # ?zone=<id> gives the admin that tenant's namespaced view
+    zone_list = _rest_list(stack, stack.key_admin, zone=ZONE_A)
+    assert zone_list.status_code == 200, zone_list.text
+    zone_paths = _collect_paths(zone_list.json())
+    assert FILE_A in zone_paths, sorted(zone_paths)
+    assert not any(p.endswith(FILE_B) or p.endswith(FILE_ROOT) or "/zone/" in p for p in zone_paths)
+
+
+def test_admin_all_zones_is_the_anti_vacuity_control_and_is_audited(stack: Stack) -> None:
+    before = len(stack.audit_events)
+    paths = _rpc_list(stack, stack.key_admin, all_zones=True)
+    assert FILE_ROOT in paths, sorted(paths)
+    assert f"/zone/{ZONE_A}{FILE_A}" in paths, sorted(paths)
+    assert f"/zone/{ZONE_B}{FILE_B}" in paths, sorted(paths)
+
+    new_events = [e for e in stack.audit_events[before:] if e[0] == ALL_ZONES_AUDIT_EVENT]
+    assert len(new_events) == 1, new_events
+    payload = new_events[0][1]
+    assert payload["operation"] == "list"
+    assert payload["subject_id"] == "root-op"
+    assert payload["zone_id"] == ROOT_ZONE_ID
+
+    rest = _rest_list(stack, stack.key_admin, all_zones="true")
+    assert rest.status_code == 200, rest.text
+    assert FILE_ROOT in _collect_paths(rest.json())

--- a/tests/integration/core/test_embedded_namespaces_rebac.py
+++ b/tests/integration/core/test_embedded_namespaces_rebac.py
@@ -14,6 +14,7 @@ from pathlib import Path
 import pytest
 
 from nexus import CASLocalBackend
+from nexus.contracts.constants import ROOT_ZONE_ID
 from nexus.contracts.types import OperationContext
 from nexus.core.config import ParseConfig, PermissionConfig
 from nexus.factory import create_nexus_fs
@@ -61,9 +62,15 @@ def test_workspace_namespace_operations():
         # Check existence
         assert nx.access("/workspace/acme/agent1/code.py", context=ctx)
 
-        # List files
-        files = nx.sys_readdir("/workspace/acme/agent1", context=ctx)
+        # List files. #4740: a standalone kernel stamps every row with the
+        # route zone (root), and root-namespace rows are visible only to
+        # root-zone callers — a zone-scoped context enumerates its own
+        # ``/zone/acme/…`` namespace, not the legacy ``/workspace/acme/``
+        # layout. The row is there for a root-zone caller.
+        root_ctx = OperationContext(user_id="operator", groups=[], zone_id=ROOT_ZONE_ID)
+        files = nx.sys_readdir("/workspace/acme/agent1", context=root_ctx)
         assert "/workspace/acme/agent1/code.py" in files
+        assert nx.sys_readdir("/workspace/acme/agent1", context=ctx) == []
 
         # Delete
         nx.sys_unlink("/workspace/acme/agent1/code.py", context=ctx)
@@ -101,8 +108,10 @@ def test_shared_namespace_operations():
         content = nx.sys_read("/shared/acme/models/model.pkl", context=ctx)
         assert content == b"model data"
 
-        # List files
-        files = nx.sys_readdir("/shared/acme/models", context=ctx)
+        # List files — see test_workspace_namespace_operations for why a
+        # root-zone context is needed to enumerate this legacy layout (#4740).
+        root_ctx = OperationContext(user_id="operator", groups=[], zone_id=ROOT_ZONE_ID)
+        files = nx.sys_readdir("/shared/acme/models", context=root_ctx)
         assert "/shared/acme/models/model.pkl" in files
 
         # Delete
@@ -130,8 +139,11 @@ def test_external_namespace_operations():
             subject_type="user",
             subject_id="anonymous",
             groups=[],
+            # #4740: a zone-less non-admin context is refused on list; the
+            # external namespace lives in the root zone, so claim it.
+            zone_id=ROOT_ZONE_ID,
             is_admin=False,
-        )  # External namespace doesn't require zone_id
+        )
 
         # Write to external namespace
         nx.write("/external/s3/bucket/file.txt", b"external data", context=ctx)

--- a/tests/unit/bricks/search/test_list_process_credential.py
+++ b/tests/unit/bricks/search/test_list_process_credential.py
@@ -1,0 +1,94 @@
+"""``SearchService.list``: the wired default context is the embedded operator (#4740).
+
+The factory wires ``SearchService(default_context=nx._init_cred)`` and the MCP
+tools in sandbox mode pass that same credential explicitly.  It is zone-less
+and non-admin, so the #4740 fail-closed rule refused the embedded operator —
+the CI ``test_issue_4129_sandbox_search_e2e`` failure.  Identity with the
+default context keeps the unrestricted view ``context=None`` gets; a copy
+with the same fields is an ordinary zone-less caller and is refused.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+
+from nexus.bricks.search.search_service import SearchService
+from nexus.contracts.exceptions import PermissionDeniedError
+from nexus.contracts.types import OperationContext
+from nexus.core.pagination import PaginatedResult
+
+TENANT_FILE = "/zone/za/ws/f.txt"
+ROOT_FILE = "/ws/root.txt"
+
+
+class _FakeFS:
+    def __init__(self) -> None:
+        self.rows = [
+            {"path": TENANT_FILE, "size": 3, "entry_type": 0, "zone_id": "root"},
+            {"path": ROOT_FILE, "size": 3, "entry_type": 0, "zone_id": "root"},
+        ]
+
+    def _get_context_identity(self, context: Any) -> tuple[str | None, str | None, bool]:
+        if context is None:
+            return ("root", None, True)
+        return (context.zone_id, context.agent_id, context.is_admin)
+
+    def sys_stat(self, path: str, **_: Any) -> dict[str, Any] | None:
+        return None
+
+    def sys_readdir(self, path: str = "/", **kwargs: Any) -> Any:
+        base = path.rstrip("/")
+        rows = [dict(r) for r in self.rows if r["path"].startswith(base + "/")]
+        if kwargs.get("limit") is not None:  # the real syscall pages when asked to
+            return PaginatedResult(items=rows, next_cursor=None, has_more=False)
+        return rows
+
+
+def _service(default_context: OperationContext) -> SearchService:
+    enforcer = SimpleNamespace(filter_list=lambda paths, _ctx: list(paths), rebac_manager=None)
+    return SearchService(
+        metadata_store=SimpleNamespace(),  # no ``_zone_id`` → standalone shape
+        permission_enforcer=cast(Any, enforcer),
+        enforce_permissions=True,
+        default_context=default_context,
+        nexus_fs=cast(Any, _FakeFS()),
+    )
+
+
+def _process_cred() -> OperationContext:
+    # What ``create_nexus_fs`` installs when no init_cred is given.
+    return OperationContext(user_id="system", groups=[])
+
+
+def _paths(items: Any) -> set[str]:
+    return {i["path"] if isinstance(i, dict) else i for i in items}
+
+
+def test_default_context_passed_explicitly_sees_everything() -> None:
+    cred = _process_cred()
+    svc = _service(cred)
+
+    result = svc.list("/", recursive=True, context=cred)
+
+    assert _paths(result) == {TENANT_FILE, ROOT_FILE}
+
+
+def test_default_context_paginated_sees_everything() -> None:
+    cred = _process_cred()
+    svc = _service(cred)
+
+    page = svc.list("/", recursive=True, context=cred, limit=10)
+
+    assert _paths(page.items) == {TENANT_FILE, ROOT_FILE}
+
+
+def test_copy_of_default_context_is_refused() -> None:
+    cred = _process_cred()
+    svc = _service(cred)
+
+    with pytest.raises(PermissionDeniedError):
+        svc.list("/", recursive=True, context=dataclasses.replace(cred))

--- a/tests/unit/bricks/search/test_list_scans_scoped_zone_prefix.py
+++ b/tests/unit/bricks/search/test_list_scans_scoped_zone_prefix.py
@@ -1,0 +1,83 @@
+"""SearchService.list / glob must scan the caller's scoped prefix (#4740).
+
+Regression for the "files are stored flat in standalone mode" strip: with
+permissions enforced, a zone-scoped caller's ``/zone/<id>/…`` prefix was cut
+back to ``/…`` before the metastore scan, so tenants' list/glob/grep looked at
+the ROOT namespace and returned nothing.  The kernel stores rows under
+``/zone/<id>/…``; the scan has to use that path.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, cast
+
+from nexus.bricks.search.search_service import SearchService
+from nexus.contracts.types import OperationContext
+
+ZONE = "za"
+TENANT_FILE = f"/zone/{ZONE}/ws/f.txt"
+ROOT_FILE = "/ws/root.txt"
+
+
+class _FakeFS:
+    """Records the readdir roots SearchService asks for; serves two rows."""
+
+    def __init__(self) -> None:
+        self.readdir_roots: list[str] = []
+        self.rows = [
+            {"path": TENANT_FILE, "size": 3, "entry_type": 0, "zone_id": "root"},
+            {"path": ROOT_FILE, "size": 3, "entry_type": 0, "zone_id": "root"},
+        ]
+
+    def _get_context_identity(self, context: Any) -> tuple[str | None, str | None, bool]:
+        if context is None:
+            return ("root", None, True)
+        return (context.zone_id, context.agent_id, context.is_admin)
+
+    def sys_stat(self, path: str, **_: Any) -> dict[str, Any] | None:
+        return None
+
+    def sys_readdir(self, path: str = "/", **kwargs: Any) -> list[dict[str, Any]]:
+        self.readdir_roots.append(path)
+        base = path.rstrip("/")
+        return [dict(r) for r in self.rows if r["path"].startswith(base + "/")]
+
+
+def _service(fs: _FakeFS) -> SearchService:
+    enforcer = SimpleNamespace(
+        filter_list=lambda paths, _ctx: list(paths),
+        rebac_manager=None,
+    )
+    return SearchService(
+        metadata_store=SimpleNamespace(),  # no ``_zone_id`` → standalone shape
+        permission_enforcer=cast(Any, enforcer),
+        enforce_permissions=True,
+        nexus_fs=cast(Any, fs),
+    )
+
+
+def _tenant() -> OperationContext:
+    return OperationContext(user_id="alice", groups=[], zone_id=ZONE)
+
+
+def test_list_scans_the_scoped_prefix_not_the_root_namespace() -> None:
+    fs = _FakeFS()
+    svc = _service(fs)
+
+    result = svc.list(f"/zone/{ZONE}/ws", recursive=True, context=_tenant())
+
+    assert fs.readdir_roots, "list() never reached the syscall surface"
+    assert all(root.startswith(f"/zone/{ZONE}/ws") for root in fs.readdir_roots), fs.readdir_roots
+    assert TENANT_FILE in result
+    assert ROOT_FILE not in result
+
+
+def test_glob_matches_under_the_scoped_prefix() -> None:
+    fs = _FakeFS()
+    svc = _service(fs)
+
+    matches = svc.glob("**/*.txt", f"/zone/{ZONE}/ws", context=_tenant())
+
+    assert matches == [TENANT_FILE], matches
+    assert all(root.startswith(f"/zone/{ZONE}") for root in fs.readdir_roots), fs.readdir_roots

--- a/tests/unit/bricks/search/test_readable_zone_filter.py
+++ b/tests/unit/bricks/search/test_readable_zone_filter.py
@@ -109,8 +109,22 @@ class TestTokenZoneFilterFromAuthRootGrant:
         auth = {"zone_set": ["root"], "zone_perms": [None, ["root"], [1, "w"]]}
         assert token_zone_filter_from_auth(auth, root_zone_id=ROOT) is None
 
-    def test_unconstrained_credential_stays_unbounded(self) -> None:
-        assert token_zone_filter_from_auth({"zone_set": []}, root_zone_id=ROOT) is None
+    def test_zone_less_non_admin_fails_closed(self) -> None:
+        """#4740: an empty scope with NO zone claim is a zone-less non-admin
+        credential — it used to be treated as unbounded and searched the root
+        index.  It now fails closed (empty set → router 403)."""
+        assert token_zone_filter_from_auth({"zone_set": []}, root_zone_id=ROOT) == frozenset()
+        assert token_zone_filter_from_auth({}, root_zone_id=ROOT) == frozenset()
+
+    def test_root_zone_claim_with_empty_scope_stays_unbounded(self) -> None:
+        """A credential that carries an explicit zone claim but no allow-list
+        (open-access root callers, static keys with ``zone_id``) keeps the
+        pre-#4740 unbounded semantics."""
+        auth = {"zone_set": [], "zone_id": ROOT}
+        assert token_zone_filter_from_auth(auth, root_zone_id=ROOT) is None
+
+    def test_zone_less_admin_stays_unbounded(self) -> None:
+        assert token_zone_filter_from_auth({"is_admin": True}, root_zone_id=ROOT) is None
 
     def test_non_root_zone_set_uses_readable_zone_filter(self) -> None:
         auth = {"zone_set": ["eng"], "zone_perms": [["eng", "w"]]}

--- a/tests/unit/core/test_readdir_zone_visibility.py
+++ b/tests/unit/core/test_readdir_zone_visibility.py
@@ -1,0 +1,258 @@
+"""sys_readdir zone-visibility matrix (#4740) against a fake kernel.
+
+Runs without the kernel binary: ``MetadataMixin.sys_readdir`` is exercised
+on a stub NexusFS whose kernel serves a fixed metastore.  Covers the three
+fail-open paths the issue names — zone-less contexts resolving to ROOT,
+root-tagged entries visible from every zone, admins skipping the zone
+predicate — across the recursive (metastore scan), non-recursive fast path
+(kernel readdir + stat_batch) and paginated branches.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from nexus.contracts.constants import ROOT_ZONE_ID
+from nexus.contracts.exceptions import PermissionDeniedError
+from nexus.contracts.metadata import FileMetadata
+from nexus.contracts.types import OperationContext
+from nexus.core.nexus_fs_metadata import MetadataMixin
+from nexus.lib.events import register_audit_sink
+from nexus.lib.zone_visibility import ALL_ZONES_AUDIT_EVENT
+
+ROOT_FILE = "/root.txt"  # root-tagged, root namespace
+FLAT_TA = "/flat-ta.txt"  # tenant row stored flat (standalone mode)
+TA_FILE = "/zone/ta/a.txt"
+TA_ROOTY = "/zone/ta/rooty.txt"  # root-tagged row written inside tenant A's namespace
+TB_FILE = "/zone/tb/b.txt"
+
+ALL_PATHS = {ROOT_FILE, FLAT_TA, TA_FILE, TA_ROOTY, TB_FILE}
+
+
+def _entries() -> list[FileMetadata]:
+    return [
+        FileMetadata(path=ROOT_FILE, size=1, zone_id=ROOT_ZONE_ID),
+        FileMetadata(path=FLAT_TA, size=1, zone_id="ta"),
+        FileMetadata(path=TA_FILE, size=1, zone_id="ta"),
+        FileMetadata(path=TA_ROOTY, size=1, zone_id=None),
+        FileMetadata(path=TB_FILE, size=1, zone_id="tb"),
+    ]
+
+
+class _FakeKernel:
+    def __init__(self, entries: list[FileMetadata]) -> None:
+        self.entries = entries
+        self.stat_batch_calls = 0
+
+    def metastore_list_paginated(
+        self, prefix: str, recursive: bool, limit: int, cursor: Any
+    ) -> dict[str, Any]:
+        items = [e for e in self.entries if e.path.startswith(prefix)]
+        if not recursive:
+            items = [e for e in items if "/" not in e.path[len(prefix) :].lstrip("/")]
+        if cursor:
+            items = [e for e in items if e.path > cursor]
+        page = items[:limit]
+        return {
+            "items": page,
+            "next_cursor": page[-1].path if len(items) > limit else None,
+            "has_more": len(items) > limit,
+            "total_count": len(items),
+        }
+
+    def sys_readdir(self, path: str, zone_id: str, is_admin: bool) -> list[tuple[str, int]]:
+        base = "" if path == "/" else path.rstrip("/")
+        out: list[tuple[str, int]] = []
+        for e in self.entries:
+            if e.path.startswith(base + "/") and "/" not in e.path[len(base) + 1 :]:
+                out.append((e.path, e.entry_type))
+        return out
+
+    def stat_batch(self, paths: list[str], zone_id: str) -> list[dict[str, Any] | None]:
+        self.stat_batch_calls += 1
+        by_path = {e.path: e for e in self.entries}
+        return [
+            {"path": p, "zone_id": by_path[p].zone_id, "is_directory": False}
+            if p in by_path
+            else None
+            for p in paths
+        ]
+
+    def sys_stat(self, path: str, zone_id: str) -> dict[str, Any] | None:
+        for e in self.entries:
+            if e.path == path:
+                return {"path": path, "zone_id": e.zone_id, "is_directory": False}
+        return None
+
+
+class _FakeFS(MetadataMixin):
+    """Just enough NexusFS surface for MetadataMixin.sys_readdir."""
+
+    def __init__(self, entries: list[FileMetadata]) -> None:
+        self._kernel = _FakeKernel(entries)
+        self._zone_id = ROOT_ZONE_ID
+        self._hook_specs = {}
+        self.metadata = None
+        self._driver_coordinator = None
+
+    def _get_context_identity(self, context: Any = None) -> tuple[str | None, str | None, bool]:
+        if context is None:
+            return (ROOT_ZONE_ID, None, True)
+        if isinstance(context, dict):
+            return (context.get("zone_id"), context.get("agent_id"), context.get("is_admin", False))
+        return (context.zone_id, context.agent_id, getattr(context, "is_admin", False))
+
+    def sys_stat(self, path: str, *, context: Any = None) -> dict[str, Any] | None:
+        return self._kernel.sys_stat(path, ROOT_ZONE_ID)
+
+
+@pytest.fixture
+def fs() -> _FakeFS:
+    return _FakeFS(_entries())
+
+
+def _ctx(**kwargs: Any) -> OperationContext:
+    kwargs.setdefault("user_id", "alice")
+    kwargs.setdefault("groups", [])
+    return OperationContext(**kwargs)
+
+
+def _paths(result: Any) -> set[str]:
+    items = result.items if hasattr(result, "items") and not isinstance(result, list) else result
+    return {i["path"] if isinstance(i, dict) else i for i in items}
+
+
+TENANT_A_VISIBLE = {FLAT_TA, TA_FILE, TA_ROOTY}
+TENANT_B_VISIBLE = {TB_FILE}
+ROOT_VISIBLE = {ROOT_FILE}
+
+
+class TestRecursiveScan:
+    """recursive=True → metastore prefix scan + Python post-filter."""
+
+    def test_kernel_caller_sees_everything(self, fs: _FakeFS) -> None:
+        assert _paths(fs.sys_readdir("/", context=None)) == ALL_PATHS
+
+    def test_tenant_a_sees_only_its_zone_including_flat_and_rooty(self, fs: _FakeFS) -> None:
+        assert _paths(fs.sys_readdir("/", context=_ctx(zone_id="ta"))) == TENANT_A_VISIBLE
+
+    def test_tenant_b_never_sees_tenant_a_or_root(self, fs: _FakeFS) -> None:
+        assert _paths(fs.sys_readdir("/", context=_ctx(user_id="bob", zone_id="tb"))) == (
+            TENANT_B_VISIBLE
+        )
+
+    def test_root_zone_caller_sees_root_tagged_only(self, fs: _FakeFS) -> None:
+        assert _paths(fs.sys_readdir("/", context=_ctx(zone_id=ROOT_ZONE_ID))) == ROOT_VISIBLE
+
+    def test_zone_less_non_admin_is_refused(self, fs: _FakeFS) -> None:
+        with pytest.raises(PermissionDeniedError):
+            fs.sys_readdir("/", context=_ctx())
+
+    def test_zone_less_dict_context_is_refused(self, fs: _FakeFS) -> None:
+        with pytest.raises(PermissionDeniedError):
+            fs.sys_readdir("/", context={"user_id": "alice", "is_admin": False})
+
+    def test_admin_without_all_zones_sees_root_zone_only(self, fs: _FakeFS) -> None:
+        assert _paths(fs.sys_readdir("/", context=_ctx(is_admin=True))) == ROOT_VISIBLE
+
+    def test_admin_in_tenant_zone_sees_that_zone_only(self, fs: _FakeFS) -> None:
+        assert _paths(fs.sys_readdir("/", context=_ctx(is_admin=True, zone_id="ta"))) == (
+            TENANT_A_VISIBLE
+        )
+
+    def test_admin_all_zones_sees_everything_and_is_audited_once(self, fs: _FakeFS) -> None:
+        seen: list[tuple[str, dict]] = []
+        handle = register_audit_sink(lambda n, p: seen.append((n, p)))
+        try:
+            ctx = _ctx(user_id="root-op", is_admin=True)
+            assert _paths(fs.sys_readdir("/", context=ctx, all_zones=True)) == ALL_PATHS
+        finally:
+            handle.remove()
+        assert [n for n, _ in seen] == [ALL_ZONES_AUDIT_EVENT]
+        assert seen[0][1]["operation"] == "list"
+        assert seen[0][1]["subject_id"] == "root-op"
+
+    def test_non_admin_all_zones_is_refused_not_narrowed(self, fs: _FakeFS) -> None:
+        with pytest.raises(PermissionDeniedError, match="all_zones"):
+            fs.sys_readdir("/", context=_ctx(zone_id="ta"), all_zones=True)
+
+    def test_multi_zone_token_sees_readable_zones_not_root(self, fs: _FakeFS) -> None:
+        ctx = _ctx(zone_id=ROOT_ZONE_ID, zone_perms=(("ta", "r"), ("tb", "w")))
+        assert _paths(fs.sys_readdir("/", context=ctx)) == TENANT_A_VISIBLE
+
+    def test_system_context_with_zone_keeps_root_namespace_rows(self, fs: _FakeFS) -> None:
+        ctx = _ctx(user_id="system", is_system=True, zone_id="ta")
+        assert _paths(fs.sys_readdir("/", context=ctx)) == TENANT_A_VISIBLE | ROOT_VISIBLE
+
+    def test_system_context_without_zone_is_unrestricted(self, fs: _FakeFS) -> None:
+        ctx = _ctx(user_id="system", is_system=True)
+        assert _paths(fs.sys_readdir("/", context=ctx)) == ALL_PATHS
+
+    def test_details_projection_is_filtered_too(self, fs: _FakeFS) -> None:
+        rows = fs.sys_readdir("/", details=True, context=_ctx(zone_id="tb"))
+        assert {r["path"] for r in rows} == TENANT_B_VISIBLE
+        assert all(r["zone_id"] == "tb" for r in rows)
+
+
+class TestNonRecursiveKernelFastPath:
+    """recursive=False, details=False, no limit → kernel readdir + stat_batch."""
+
+    def test_tenant_a_at_root_sees_flat_row_not_root_file(self, fs: _FakeFS) -> None:
+        assert _paths(fs.sys_readdir("/", recursive=False, context=_ctx(zone_id="ta"))) == {FLAT_TA}
+        assert fs._kernel.stat_batch_calls == 1
+
+    def test_tenant_a_inside_its_namespace(self, fs: _FakeFS) -> None:
+        got = fs.sys_readdir("/zone/ta", recursive=False, context=_ctx(zone_id="ta"))
+        assert _paths(got) == {TA_FILE, TA_ROOTY}
+
+    def test_root_caller_cannot_enumerate_tenant_namespace(self, fs: _FakeFS) -> None:
+        got = fs.sys_readdir("/zone/ta", recursive=False, context=_ctx(zone_id=ROOT_ZONE_ID))
+        assert _paths(got) == set()
+
+    def test_root_caller_at_root(self, fs: _FakeFS) -> None:
+        got = fs.sys_readdir("/", recursive=False, context=_ctx(zone_id=ROOT_ZONE_ID))
+        assert _paths(got) == ROOT_VISIBLE
+
+    def test_unrestricted_callers_skip_stat_batch(self, fs: _FakeFS) -> None:
+        got = fs.sys_readdir("/", recursive=False, context=None)
+        assert _paths(got) == {ROOT_FILE, FLAT_TA}
+        assert fs._kernel.stat_batch_calls == 0
+
+    def test_admin_all_zones_fast_path(self, fs: _FakeFS) -> None:
+        got = fs.sys_readdir(
+            "/zone/tb", recursive=False, context=_ctx(is_admin=True), all_zones=True
+        )
+        assert _paths(got) == {TB_FILE}
+
+    def test_zone_less_non_admin_is_refused_before_kernel(self, fs: _FakeFS) -> None:
+        with pytest.raises(PermissionDeniedError):
+            fs.sys_readdir("/", recursive=False, context=_ctx())
+
+
+class TestPaginated:
+    def test_paginated_recursive_is_filtered(self, fs: _FakeFS) -> None:
+        page = fs.sys_readdir("/", recursive=True, limit=10, context=_ctx(zone_id="ta"))
+        assert _paths(page) == TENANT_A_VISIBLE
+        assert page.has_more is False
+
+    def test_paginated_non_recursive_is_filtered(self, fs: _FakeFS) -> None:
+        page = fs.sys_readdir("/", recursive=False, limit=10, context=_ctx(zone_id=ROOT_ZONE_ID))
+        assert _paths(page) == ROOT_VISIBLE
+
+    def test_paginated_admin_all_zones_audits_once(self, fs: _FakeFS) -> None:
+        seen: list[str] = []
+        handle = register_audit_sink(lambda n, _p: seen.append(n))
+        try:
+            page = fs.sys_readdir(
+                "/", recursive=True, limit=10, context=_ctx(is_admin=True), all_zones=True
+            )
+        finally:
+            handle.remove()
+        assert _paths(page) == ALL_PATHS
+        assert seen == [ALL_ZONES_AUDIT_EVENT]
+
+    def test_paginated_zone_less_non_admin_is_refused(self, fs: _FakeFS) -> None:
+        with pytest.raises(PermissionDeniedError):
+            fs.sys_readdir("/", recursive=True, limit=10, context=_ctx())

--- a/tests/unit/core/test_readdir_zone_visibility.py
+++ b/tests/unit/core/test_readdir_zone_visibility.py
@@ -96,6 +96,7 @@ class _FakeFS(MetadataMixin):
         self._hook_specs = {}
         self.metadata = None
         self._driver_coordinator = None
+        self._init_cred: Any = None
 
     def _get_context_identity(self, context: Any = None) -> tuple[str | None, str | None, bool]:
         if context is None:
@@ -256,3 +257,29 @@ class TestPaginated:
     def test_paginated_zone_less_non_admin_is_refused(self, fs: _FakeFS) -> None:
         with pytest.raises(PermissionDeniedError):
             fs.sys_readdir("/", recursive=True, limit=10, context=_ctx())
+
+
+class TestProcessCredential:
+    """``fs._init_cred`` passed explicitly (MCP tools in sandbox mode) is the embedded operator."""
+
+    def test_init_cred_sees_everything_like_context_none(self, fs: _FakeFS) -> None:
+        fs._init_cred = _ctx(user_id="system")  # factory default: zone-less, non-admin
+        assert _paths(fs.sys_readdir("/", context=fs._init_cred)) == ALL_PATHS
+
+    def test_init_cred_fast_path_skips_stat_batch(self, fs: _FakeFS) -> None:
+        fs._init_cred = _ctx(user_id="system")
+        got = fs.sys_readdir("/", recursive=False, context=fs._init_cred)
+        assert _paths(got) == {ROOT_FILE, FLAT_TA}
+        assert fs._kernel.stat_batch_calls == 0
+
+    def test_init_cred_paginated_sees_everything(self, fs: _FakeFS) -> None:
+        fs._init_cred = _ctx(user_id="system")
+        page = fs.sys_readdir("/", recursive=True, context=fs._init_cred, limit=10)
+        assert _paths(page) == ALL_PATHS
+
+    def test_equal_copy_of_init_cred_is_an_ordinary_zone_less_caller(self, fs: _FakeFS) -> None:
+        import dataclasses
+
+        fs._init_cred = _ctx(user_id="system")
+        with pytest.raises(PermissionDeniedError):
+            fs.sys_readdir("/", context=dataclasses.replace(fs._init_cred))

--- a/tests/unit/lib/test_zone_visibility.py
+++ b/tests/unit/lib/test_zone_visibility.py
@@ -1,0 +1,217 @@
+"""Unit tests for ``nexus.lib.zone_visibility`` (#4740).
+
+The ZoneView is the single predicate behind ``sys_readdir`` and the search
+list/glob/grep pipeline.  These tests pin the fail-closed rules:
+
+* zone-less non-admin callers are refused, not resolved to ROOT;
+* root-tagged entries are visible only to callers that can read ROOT;
+* admins cross zones only via an explicit ``all_zones=True`` (audited);
+* ``context=None`` (kernel / internal) and zone-less ``is_system`` stay
+  unrestricted.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from nexus.contracts.constants import ROOT_ZONE_ID
+from nexus.contracts.exceptions import PermissionDeniedError
+from nexus.contracts.types import OperationContext
+from nexus.lib import zone_visibility as zv
+from nexus.lib.events import register_audit_sink
+from nexus.lib.zone_visibility import (
+    ALL_ZONES_AUDIT_EVENT,
+    ZoneView,
+    audit_all_zones,
+    readable_zones_from_perms,
+    resolve_zone_view,
+    zone_from_path,
+)
+
+
+def _ctx(**kwargs) -> OperationContext:
+    kwargs.setdefault("user_id", "alice")
+    kwargs.setdefault("groups", [])
+    return OperationContext(**kwargs)
+
+
+class TestZoneFromPath:
+    def test_extracts_embedded_zone(self) -> None:
+        assert zone_from_path("/zone/acme/docs/a.txt") == "acme"
+
+    def test_zone_dir_itself(self) -> None:
+        assert zone_from_path("/zone/acme") == "acme"
+
+    def test_legacy_zones_prefix_matches_rebac_chain(self) -> None:
+        assert zone_from_path("/zones/acme/docs/a.txt") == "acme"
+
+    def test_non_zone_paths_and_junk(self) -> None:
+        assert zone_from_path("/docs/a.txt") is None
+        assert zone_from_path("/workspace/acme/a.txt") is None  # legacy layout, not a zone ns
+        assert zone_from_path("/zone/") is None
+        assert zone_from_path(None) is None
+        assert zone_from_path(42) is None
+
+
+class TestReadableZonesFromPerms:
+    def test_read_or_execute_grants_pass(self) -> None:
+        assert readable_zones_from_perms((("a", "r"), ("b", "x"), ("c", "w"))) == {"a", "b"}
+
+    def test_root_grant_counts_when_readable(self) -> None:
+        assert readable_zones_from_perms(((ROOT_ZONE_ID, "rw"),)) == {ROOT_ZONE_ID}
+
+    def test_no_perms_is_none(self) -> None:
+        assert readable_zones_from_perms(()) is None
+        assert readable_zones_from_perms(None) is None
+
+    def test_all_malformed_is_none_but_write_only_is_empty(self) -> None:
+        assert readable_zones_from_perms([None, "junk", ("a",), (1, "r")]) is None
+        assert readable_zones_from_perms((("a", "w"),)) == frozenset()
+
+
+class TestZoneViewAllows:
+    def test_unrestricted_allows_everything(self) -> None:
+        view = ZoneView(zones=None)
+        assert view.unrestricted
+        assert view.allows(None, "/anything")
+        assert view.allows("other", "/zone/other/x")
+
+    def test_path_zone_is_authoritative(self) -> None:
+        view = ZoneView(zones=frozenset({"ta"}))
+        # root-tagged entry written inside the tenant namespace is the tenant's
+        assert view.allows(None, "/zone/ta/rooty.txt")
+        assert view.allows("ta", "/zone/ta/a.txt")
+        assert not view.allows("ta", "/zone/tb/leak.txt")
+
+    def test_column_zone_used_outside_zone_namespace(self) -> None:
+        view = ZoneView(zones=frozenset({"ta"}))
+        assert view.allows("ta", "/flat.txt")  # standalone flat-stored tenant row
+        assert not view.allows(None, "/root.txt")  # root-tagged: hidden from tenants
+        assert not view.allows(ROOT_ZONE_ID, "/root.txt")
+
+    def test_root_view_sees_root_tagged_only(self) -> None:
+        view = ZoneView(zones=frozenset({ROOT_ZONE_ID}))
+        assert view.allows(None, "/root.txt")
+        assert view.allows("", "/root.txt")
+        assert not view.allows("ta", "/flat.txt")
+        assert not view.allows(None, "/zone/ta/rooty.txt")
+
+
+class TestResolveZoneView:
+    def test_none_context_is_kernel_unrestricted(self) -> None:
+        assert resolve_zone_view(None).unrestricted
+
+    def test_zone_less_non_admin_is_refused(self) -> None:
+        with pytest.raises(PermissionDeniedError, match="no zone claim"):
+            resolve_zone_view(_ctx())
+
+    def test_zone_less_non_admin_dict_is_refused(self) -> None:
+        with pytest.raises(PermissionDeniedError):
+            resolve_zone_view({"is_admin": False, "user_id": "alice"})
+
+    def test_zone_less_admin_gets_root_zone_not_global(self) -> None:
+        view = resolve_zone_view(_ctx(is_admin=True))
+        assert view.zones == {ROOT_ZONE_ID}
+        assert not view.unrestricted
+
+    def test_zone_less_system_is_unrestricted(self) -> None:
+        assert resolve_zone_view(_ctx(user_id="system", is_system=True)).unrestricted
+
+    def test_system_with_zone_is_scoped_to_it_but_keeps_root_namespace(self) -> None:
+        view = resolve_zone_view(_ctx(user_id="system", is_system=True, zone_id="ta"))
+        assert view.zones == {"ta"}
+        assert view.system
+        # internal scans (ReBAC expansion, zone export) still see the
+        # root-namespace rows a standalone kernel stamps on every write …
+        assert view.allows(None, "/workspace/ta/x.txt")
+        assert view.allows(ROOT_ZONE_ID, "/root.txt")
+        # … but not another zone's namespace or another zone's flat rows.
+        assert not view.allows(None, "/zone/tb/x.txt")
+        assert not view.allows("tb", "/flat-tb.txt")
+
+    def test_user_with_zone_does_not_get_root_namespace(self) -> None:
+        view = resolve_zone_view(_ctx(zone_id="ta"))
+        assert not view.system
+        assert not view.allows(None, "/workspace/ta/x.txt")
+
+    def test_single_zone_context(self) -> None:
+        assert resolve_zone_view(_ctx(zone_id="ta")).zones == {"ta"}
+
+    def test_explicit_root_zone_context(self) -> None:
+        assert resolve_zone_view(_ctx(zone_id=ROOT_ZONE_ID)).zones == {ROOT_ZONE_ID}
+
+    def test_admin_in_a_zone_sees_that_zone_only(self) -> None:
+        assert resolve_zone_view(_ctx(zone_id="ta", is_admin=True)).zones == {"ta"}
+
+    def test_multi_zone_token_root_placeholder_does_not_grant_root(self) -> None:
+        ctx = _ctx(zone_id=ROOT_ZONE_ID, zone_perms=(("ta", "r"), ("tb", "rw")))
+        assert resolve_zone_view(ctx).zones == {"ta", "tb"}
+
+    def test_multi_zone_token_with_root_read_grant_sees_root(self) -> None:
+        ctx = _ctx(zone_id=ROOT_ZONE_ID, zone_perms=(("ta", "r"), (ROOT_ZONE_ID, "r")))
+        assert resolve_zone_view(ctx).zones == {"ta", ROOT_ZONE_ID}
+
+    def test_write_only_grants_see_nothing(self) -> None:
+        ctx = _ctx(zone_id="ta", zone_perms=(("ta", "w"),))
+        view = resolve_zone_view(ctx)
+        assert view.zones == frozenset()
+        assert not view.allows("ta", "/zone/ta/a.txt")
+
+    def test_legacy_zone_set_only_dict_context(self) -> None:
+        view = resolve_zone_view({"zone_set": ["ta", "tb"], "is_admin": False})
+        assert view.zones == {"ta", "tb"}
+
+    def test_all_zones_requires_admin(self) -> None:
+        with pytest.raises(PermissionDeniedError, match="all_zones"):
+            resolve_zone_view(_ctx(zone_id="ta"), all_zones=True)
+
+    def test_all_zones_admin_is_unrestricted_and_flagged(self) -> None:
+        view = resolve_zone_view(_ctx(is_admin=True), all_zones=True)
+        assert view.unrestricted
+        assert view.all_zones
+
+    def test_simple_namespace_context(self) -> None:
+        ctx = SimpleNamespace(zone_id="ta", is_admin=False, zone_perms=(), zone_set=())
+        assert resolve_zone_view(ctx).zones == {"ta"}
+
+
+class TestAuditAllZones:
+    def test_emits_once_per_request(self) -> None:
+        seen: list[tuple[str, dict]] = []
+        handle = register_audit_sink(lambda name, payload: seen.append((name, payload)))
+        try:
+            ctx = _ctx(user_id="root-op", is_admin=True, zone_id=ROOT_ZONE_ID)
+            audit_all_zones(ctx, operation="list", path="/")
+            audit_all_zones(ctx, operation="list", path="/zone/ta")  # nested call, same request
+            audit_all_zones(ctx, operation="search.list", path="/")  # different operation
+        finally:
+            handle.remove()
+        names = [n for n, _ in seen]
+        assert names == [ALL_ZONES_AUDIT_EVENT, ALL_ZONES_AUDIT_EVENT]
+        ops = sorted(p["operation"] for _, p in seen)
+        assert ops == ["list", "search.list"]
+        payload = seen[0][1]
+        assert payload["subject_id"] == "root-op"
+        assert payload["zone_id"] == ROOT_ZONE_ID
+        assert payload["request_id"] == ctx.request_id
+
+    def test_contexts_without_request_id_always_emit(self) -> None:
+        seen: list[str] = []
+        handle = register_audit_sink(lambda name, _payload: seen.append(name))
+        try:
+            audit_all_zones({"is_admin": True}, operation="list", path="/")
+            audit_all_zones({"is_admin": True}, operation="list", path="/")
+        finally:
+            handle.remove()
+        assert seen == [ALL_ZONES_AUDIT_EVENT, ALL_ZONES_AUDIT_EVENT]
+
+    def test_recent_audit_cache_is_bounded(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(zv, "_RECENT_AUDITS_MAX", 3)
+        zv._RECENT_AUDITS.clear()
+        for i in range(10):
+            assert zv._already_audited(f"req-{i}", "list") is False
+        assert len(zv._RECENT_AUDITS) == 3
+        # evicted keys are treated as new again
+        assert zv._already_audited("req-0", "list") is False

--- a/tests/unit/lib/test_zone_visibility.py
+++ b/tests/unit/lib/test_zone_visibility.py
@@ -215,3 +215,41 @@ class TestAuditAllZones:
         assert len(zv._RECENT_AUDITS) == 3
         # evicted keys are treated as new again
         assert zv._already_audited("req-0", "list") is False
+
+
+class TestProcessCredential:
+    """The kernel's own init credential is the embedded operator, not a zone-less tenant.
+
+    ``create_nexus_fs`` installs ``OperationContext(user_id="system")`` — no
+    zone, not admin — as ``NexusFS._init_cred``; the MCP tools pass it
+    explicitly in sandbox mode.  Refusing it broke
+    ``test_issue_4129_sandbox_search_e2e`` in CI.
+    """
+
+    def test_init_cred_passed_explicitly_is_unrestricted(self) -> None:
+        cred = _ctx(user_id="system")
+        assert resolve_zone_view(cred, init_cred=cred).unrestricted is True
+
+    def test_identity_not_equality(self) -> None:
+        import dataclasses
+
+        cred = _ctx(user_id="system")
+        twin = dataclasses.replace(cred)
+        assert twin is not cred
+        with pytest.raises(PermissionDeniedError):
+            resolve_zone_view(twin, init_cred=cred)
+
+    def test_same_context_without_init_cred_is_refused(self) -> None:
+        cred = _ctx(user_id="system")
+        with pytest.raises(PermissionDeniedError):
+            resolve_zone_view(cred)
+
+    def test_init_cred_matches_context_none_even_with_a_zone(self) -> None:
+        # ``context=None`` resolves to the init credential and is unrestricted;
+        # passing the credential explicitly must not narrow that.
+        cred = _ctx(user_id="system", zone_id="acme")
+        assert resolve_zone_view(cred, init_cred=cred).unrestricted is True
+
+    def test_all_zones_from_init_cred_is_not_refused(self) -> None:
+        cred = _ctx(user_id="system")
+        assert resolve_zone_view(cred, all_zones=True, init_cred=cred).unrestricted is True

--- a/tests/unit/server/api/v2/routers/test_files_write_index_on_write.py
+++ b/tests/unit/server/api/v2/routers/test_files_write_index_on_write.py
@@ -109,7 +109,10 @@ def test_plain_write_does_not_index() -> None:
     assert resp.status_code == 200
     assert resp.json()["index"] is None
     daemon.index_documents.assert_not_awaited()
-    assert fs.writes == [("/docs/a.md", b"hello")]
+    # #4740: the REST route writes into the caller's zone namespace
+    # (auth zone "eng"), exactly like the RPC path; the index leg keeps the
+    # caller-facing path (see the indexing tests below).
+    assert fs.writes == [("/zone/eng/docs/a.md", b"hello")]
 
 
 def test_index_true_indexes_the_written_text_in_the_same_call() -> None:
@@ -143,7 +146,7 @@ def test_index_text_override_replaces_the_written_bytes() -> None:
     assert resp.json()["index"]["status"] == "indexed"
     docs, _ = _sent_docs(daemon)
     assert docs[0]["text"] == "extracted words"
-    assert fs.writes == [("/docs/report.pdf", b"\x00\x01\x02")]
+    assert fs.writes == [("/zone/eng/docs/report.pdf", b"\x00\x01\x02")]
 
 
 def test_binary_content_without_text_is_skipped_locally() -> None:

--- a/tests/unit/server/test_kernel_syscall_dispatch_all_zones.py
+++ b/tests/unit/server/test_kernel_syscall_dispatch_all_zones.py
@@ -1,0 +1,44 @@
+"""RPC list result adapter keeps zone-qualified paths for ``all_zones`` (#4740).
+
+Single-zone callers get user-facing paths (``/zone/<id>/`` stripped) as
+before; an admin's explicit cross-zone listing keeps the prefix, otherwise
+``/zone/ta/a.txt`` and ``/zone/tb/a.txt`` would collapse into one ``/a.txt``.
+"""
+
+from __future__ import annotations
+
+from nexus.core.pagination import PaginatedResult
+from nexus.server._kernel_syscall_dispatch import _apply_result_adapter
+
+_ENTRIES = ["/zone/ta/a.txt", "/zone/tb/a.txt", "/root.txt"]
+_DETAIL_ENTRIES = [{"path": p, "size": 1} for p in _ENTRIES]
+
+
+def test_single_zone_list_unscopes_paths() -> None:
+    wire = _apply_result_adapter("list", list(_ENTRIES), {"path": "/"})
+    assert wire["files"] == ["/a.txt", "/a.txt", "/root.txt"]
+    assert wire["has_more"] is False
+
+
+def test_all_zones_list_keeps_zone_prefix() -> None:
+    wire = _apply_result_adapter("sys_readdir", list(_ENTRIES), {"path": "/", "all_zones": True})
+    assert wire["files"] == _ENTRIES
+
+
+def test_all_zones_detail_dicts_keep_zone_prefix() -> None:
+    wire = _apply_result_adapter("list", list(_DETAIL_ENTRIES), {"all_zones": True})
+    assert [f["path"] for f in wire["files"]] == _ENTRIES
+
+    wire_scoped = _apply_result_adapter("list", list(_DETAIL_ENTRIES), {"all_zones": False})
+    assert [f["path"] for f in wire_scoped["files"]] == ["/a.txt", "/a.txt", "/root.txt"]
+
+
+def test_all_zones_paginated_result_keeps_zone_prefix() -> None:
+    page = PaginatedResult(items=list(_ENTRIES), next_cursor="/root.txt", has_more=True)
+    wire = _apply_result_adapter("list", page, {"all_zones": True, "limit": 3})
+    assert wire["files"] == _ENTRIES
+    assert wire["has_more"] is True
+    assert wire["next_cursor"] == "/root.txt"
+
+    wire_scoped = _apply_result_adapter("list", page, {"limit": 3})
+    assert wire_scoped["files"] == ["/a.txt", "/a.txt", "/root.txt"]

--- a/tests/unit/server/test_operation_context_zone_default.py
+++ b/tests/unit/server/test_operation_context_zone_default.py
@@ -1,0 +1,141 @@
+"""Server-boundary zone defaults (#4740).
+
+``get_operation_context`` used to coerce a missing zone claim to ROOT for
+every caller, which is how a zone-less tenant key reached ``sys_readdir``
+looking like a root-zone operator.  Now only admins default to ROOT; a
+non-admin without a zone stays zone-less (and is refused by list/search).
+Open-access mode, which has no tenant model, claims ROOT explicitly.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from nexus.contracts.constants import ROOT_ZONE_ID
+from nexus.lib.zone_scoping import scope_params_for_zone
+from nexus.server.dependencies import get_operation_context, resolve_auth
+
+
+def _auth(**overrides):
+    base = {
+        "authenticated": True,
+        "subject_type": "user",
+        "subject_id": "alice",
+        "is_admin": False,
+    }
+    base.update(overrides)
+    return base
+
+
+class TestGetOperationContextZone:
+    def test_non_admin_without_zone_stays_zone_less(self) -> None:
+        ctx = get_operation_context(_auth())
+        assert ctx.zone_id is None
+        assert ctx.zone_set == ()
+        assert ctx.zone_perms == ()
+
+    def test_non_admin_with_empty_zone_string_stays_zone_less(self) -> None:
+        assert get_operation_context(_auth(zone_id="")).zone_id is None
+
+    def test_admin_without_zone_defaults_to_root(self) -> None:
+        ctx = get_operation_context(_auth(subject_id="admin", is_admin=True))
+        assert ctx.zone_id == ROOT_ZONE_ID
+        assert ctx.zone_set == (ROOT_ZONE_ID,)
+
+    def test_provider_zone_is_kept(self) -> None:
+        ctx = get_operation_context(_auth(zone_id="acme", zone_perms=[["acme", "rw"]]))
+        assert ctx.zone_id == "acme"
+        assert ctx.zone_perms == (("acme", "rw"),)
+
+    def test_multi_zone_token_keeps_root_routing_placeholder(self) -> None:
+        ctx = get_operation_context(
+            _auth(zone_id="eng", zone_perms=[["eng", "r"], ["ops", "rw"]]),
+        )
+        assert ctx.zone_id == ROOT_ZONE_ID
+        assert ctx.zone_perms == (("eng", "r"), ("ops", "rw"))
+
+
+class TestRestZoneOverride:
+    """REST ``?zone=`` override must retarget an admin's grants, not just zone_id (#4740)."""
+
+    def test_admin_override_retargets_perms_so_the_zone_view_follows(self) -> None:
+        from nexus.lib.zone_visibility import resolve_zone_view
+        from nexus.server.api.v2.routers.async_files import _apply_zone_override
+
+        auth = _auth(subject_id="admin", is_admin=True)
+        ctx = get_operation_context(auth)
+        assert ctx.zone_perms == ((ROOT_ZONE_ID, "rw"),)
+
+        out = _apply_zone_override(ctx, "ta", auth)
+
+        assert out is not ctx
+        assert out.zone_id == "ta"
+        assert out.zone_perms == (("ta", "rw"),)
+        assert resolve_zone_view(out).zones == {"ta"}
+        # the caller's own context is untouched
+        assert ctx.zone_id == ROOT_ZONE_ID
+
+    def test_non_admin_override_keeps_own_grants(self) -> None:
+        from nexus.lib.zone_visibility import resolve_zone_view
+        from nexus.server.api.v2.routers.async_files import _apply_zone_override
+
+        auth = _auth(zone_id="eng", zone_perms=[["eng", "r"], ["ops", "r"]])
+        ctx = get_operation_context(auth)
+        out = _apply_zone_override(ctx, "ops", auth)
+        assert out.zone_id == "ops"
+        assert resolve_zone_view(out).zones == {"eng", "ops"}
+
+    def test_no_override_returns_same_context(self) -> None:
+        from nexus.server.api.v2.routers.async_files import _apply_zone_override
+
+        auth = _auth(zone_id="eng", zone_perms=[["eng", "rw"]])
+        ctx = get_operation_context(auth)
+        assert _apply_zone_override(ctx, None, auth) is ctx
+
+
+class TestScopeParamsForZoneLessContext:
+    def test_none_zone_leaves_paths_untouched(self) -> None:
+        params = SimpleNamespace(path="/a.txt", paths=["/b.txt"])
+        scope_params_for_zone(params, None)
+        assert params.path == "/a.txt"
+        assert params.paths == ["/b.txt"]
+
+    def test_root_zone_leaves_paths_untouched(self) -> None:
+        params = SimpleNamespace(path="/a.txt")
+        scope_params_for_zone(params, ROOT_ZONE_ID)
+        assert params.path == "/a.txt"
+
+    def test_concrete_zone_still_prefixes(self) -> None:
+        params = SimpleNamespace(path="/a.txt")
+        scope_params_for_zone(params, "acme")
+        assert params.path == "/zone/acme/a.txt"
+
+
+class TestOpenAccessResolvesRootExplicitly:
+    @pytest.mark.asyncio
+    async def test_no_header_means_root_zone(self) -> None:
+        state = SimpleNamespace(api_key=None, auth_provider=None)
+        result = await resolve_auth(
+            state,
+            x_nexus_subject="user:alice",
+            client_host="127.0.0.1",
+        )
+        assert result is not None
+        assert result["authenticated"] is True
+        assert result["is_admin"] is False
+        assert result["zone_id"] == ROOT_ZONE_ID
+        assert get_operation_context(result).zone_id == ROOT_ZONE_ID
+
+    @pytest.mark.asyncio
+    async def test_zone_header_wins(self) -> None:
+        state = SimpleNamespace(api_key=None, auth_provider=None)
+        result = await resolve_auth(
+            state,
+            x_nexus_subject="user:alice",
+            x_nexus_zone_id="acme",
+            client_host="127.0.0.1",
+        )
+        assert result is not None
+        assert result["zone_id"] == "acme"

--- a/tests/unit/server/test_zone_execution.py
+++ b/tests/unit/server/test_zone_execution.py
@@ -74,3 +74,45 @@ def test_context_for_target_zone_preserves_root_for_multizone_token() -> None:
     assert result is context
     assert context.zone_id == "root"
     assert context.zone_perms == (("company", "r"), ("shared", "rw"))
+
+
+def test_context_for_target_zone_does_not_mutate_admin_context() -> None:
+    """#4740: retargeting returns a copy; the caller's context keeps its zone/perms."""
+    from nexus.contracts.types import OperationContext
+
+    context = OperationContext(user_id="admin", groups=[], zone_id="root", is_admin=True)
+
+    result = context_for_target_zone(context, "eng")
+
+    assert result is not context
+    assert context.zone_id == "root"
+    assert context.zone_perms == (("root", "rw"),)
+    assert result.zone_id == "eng"
+    assert result.zone_perms == (("eng", "rw"),)
+    assert result.zone_set == ("eng",)
+    assert result.is_admin is True
+    assert result.request_id == context.request_id
+
+
+def test_context_for_target_zone_copies_non_dataclass_contexts() -> None:
+    context = SimpleNamespace(
+        zone_id="eng",
+        zone_set=("eng", "ops"),
+        zone_perms=(("eng", "r"), ("ops", "r")),
+        is_admin=False,
+    )
+
+    result = context_for_target_zone(context, "ops")
+
+    assert result is not context
+    assert context.zone_id == "eng"
+    assert result.zone_id == "ops"
+    assert result.zone_perms == (("eng", "r"), ("ops", "r"))
+
+
+def test_context_for_target_zone_returns_same_object_when_not_allowed() -> None:
+    context = SimpleNamespace(zone_id="eng", zone_set=("eng",), zone_perms=(("eng", "rw"),))
+
+    assert context_for_target_zone(context, "ops") is context
+    assert context_for_target_zone(context, None) is context
+    assert context_for_target_zone(context, "eng") is context

--- a/tests/unit/server/test_zone_scoped_fs.py
+++ b/tests/unit/server/test_zone_scoped_fs.py
@@ -1,0 +1,294 @@
+"""ZoneScopedFS — the REST layer's per-request zone view (#4740).
+
+Pure tests against a recording fake filesystem: every path-taking method the
+REST routers and the batch executor call must scope its inputs into the
+caller's ``/zone/<id>/`` namespace, refuse paths naming another zone with
+403, and unscope paths in results.  Root-zone callers get the raw filesystem.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+from fastapi import HTTPException
+
+from nexus.contracts.constants import ROOT_ZONE_ID
+from nexus.contracts.metadata import FileMetadata
+from nexus.contracts.types import OperationContext
+from nexus.core.pagination import PaginatedResult
+from nexus.server.api.v2._zone_scoped_fs import (
+    ZoneScopedFS,
+    scope_rest_path,
+    zone_prefix_for,
+    zone_scoped_fs,
+)
+
+
+class _FakeSearch:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, Any]] = []
+
+    def list(self, path: str = "/", **kw: Any) -> list[str]:
+        self.calls.append(("list", path))
+        return [f"{path.rstrip('/')}/x.txt", "/root.txt"]
+
+    def glob(self, pattern: str, path: str = "/", context: Any = None, files: Any = None) -> list:
+        self.calls.append(("glob", (pattern, path, files)))
+        return [f"{path.rstrip('/')}/{pattern}"]
+
+    async def grep(self, pattern: str, path: str = "/", **kw: Any) -> list[dict[str, Any]]:
+        self.calls.append(("grep", (pattern, path, kw.get("files"))))
+        return [{"file": f"{path.rstrip('/')}/hit.txt", "line": 1, "content": pattern}]
+
+
+@dataclass
+class _FakeFS:
+    """Records every call and echoes paths back the way NexusFS does."""
+
+    calls: list[tuple[str, tuple[Any, ...], dict[str, Any]]]
+    search: _FakeSearch
+
+    def _rec(self, name: str, *args: Any, **kwargs: Any) -> None:
+        self.calls.append((name, args, kwargs))
+
+    def sys_stat(self, path: str, **kw: Any) -> dict[str, Any] | None:
+        self._rec("sys_stat", path, **kw)
+        return {"path": path, "size": 1}
+
+    def sys_read(self, path: str, **kw: Any) -> bytes:
+        self._rec("sys_read", path, **kw)
+        return b"data"
+
+    def read(self, path: str, **kw: Any) -> Any:
+        self._rec("read", path, **kw)
+        if kw.get("return_metadata"):
+            return {"content": b"data", "path": path}
+        return b"data"
+
+    def read_range(self, path: str, start: int, end: int, **kw: Any) -> bytes:
+        self._rec("read_range", path, start, end, **kw)
+        return b"da"
+
+    def access(self, path: str, **kw: Any) -> bool:
+        self._rec("access", path, **kw)
+        return True
+
+    def exists(self, path: str, **kw: Any) -> bool:
+        self._rec("exists", path, **kw)
+        return True
+
+    def get_metadata(self, path: str, **kw: Any) -> FileMetadata:
+        self._rec("get_metadata", path, **kw)
+        return FileMetadata(path=path, size=3)
+
+    def write(self, path: str, *args: Any, **kw: Any) -> dict[str, Any]:
+        self._rec("write", path, *args, **kw)
+        return {"path": path, "content_id": "c", "revision": f"{path}@1"}
+
+    def sys_unlink(self, path: str, **kw: Any) -> dict[str, Any]:
+        self._rec("sys_unlink", path, **kw)
+        return {"deleted": True, "path": path}
+
+    def delete(self, path: str, **kw: Any) -> bool:
+        self._rec("delete", path, **kw)
+        return True
+
+    def sys_rename(self, old: str, new: str, **kw: Any) -> dict[str, Any]:
+        self._rec("sys_rename", old, new, **kw)
+        return {"old_path": old, "new_path": new, "revision": f"{new}@2"}
+
+    def mkdir(self, path: str, **kw: Any) -> None:
+        self._rec("mkdir", path, **kw)
+
+    def sys_readdir(self, path: str = "/", **kw: Any) -> Any:
+        self._rec("sys_readdir", path, **kw)
+        base = path.rstrip("/")
+        entries: list[Any] = [f"{base}/a.txt", {"path": f"{base}/b.txt", "size": 2}]
+        if kw.get("limit") is not None:
+            return PaginatedResult(items=entries, next_cursor=f"{base}/b.txt", has_more=True)
+        return entries
+
+    def list(self, path: str = "/", **kw: Any) -> list[str]:
+        self._rec("list", path, **kw)
+        return [f"{path.rstrip('/')}/a.txt"]
+
+    def write_batch(self, files: list[Any], **kw: Any) -> list[dict[str, Any]]:
+        self._rec("write_batch", files, **kw)
+        return [{"path": p, "revision": f"{p}@1"} for p, _ in files]
+
+    def read_batch(self, paths: list[str], **kw: Any) -> list[dict[str, Any]]:
+        self._rec("read_batch", paths, **kw)
+        return [{"path": p, "content": b"x"} for p in paths]
+
+    def read_bulk(self, paths: list[str], **kw: Any) -> dict[str, Any]:
+        self._rec("read_bulk", paths, **kw)
+        return {p: {"content": b"x", "path": p} for p in paths}
+
+    def rename_batch(self, renames: list[Any], **kw: Any) -> dict[str, Any]:
+        self._rec("rename_batch", renames, **kw)
+        return {src: {"success": True, "new_path": dst} for src, dst in renames}
+
+    def service(self, name: str) -> Any:
+        return self.search if name == "search" else object()
+
+    @property
+    def _kernel(self) -> str:
+        return "kernel-handle"
+
+
+@pytest.fixture
+def raw() -> _FakeFS:
+    return _FakeFS(calls=[], search=_FakeSearch())
+
+
+@pytest.fixture
+def view(raw: _FakeFS) -> ZoneScopedFS:
+    return ZoneScopedFS(raw, "ta")
+
+
+def _ctx(zone: str | None) -> OperationContext:
+    return OperationContext(user_id="alice", groups=[], zone_id=zone)
+
+
+class TestFactory:
+    def test_root_and_zone_less_callers_get_raw_fs(self, raw: _FakeFS) -> None:
+        assert zone_scoped_fs(raw, _ctx(ROOT_ZONE_ID)) is raw
+        assert zone_scoped_fs(raw, _ctx(None)) is raw
+        assert zone_scoped_fs(raw, None) is raw
+        assert zone_prefix_for(_ctx(ROOT_ZONE_ID)) is None
+
+    def test_zone_caller_gets_view_and_is_not_double_wrapped(self, raw: _FakeFS) -> None:
+        v = zone_scoped_fs(raw, _ctx("ta"))
+        assert isinstance(v, ZoneScopedFS)
+        assert v.zone_id == "ta"
+        assert zone_scoped_fs(v, _ctx("ta")) is v
+        assert zone_prefix_for(_ctx("ta")) == "/zone/ta"
+
+    def test_scope_rest_path_helper(self) -> None:
+        assert scope_rest_path("/docs/a.txt", _ctx("ta")) == "/zone/ta/docs/a.txt"
+        assert scope_rest_path("/docs/a.txt", _ctx(ROOT_ZONE_ID)) == "/docs/a.txt"
+        with pytest.raises(HTTPException) as exc:
+            scope_rest_path("/zone/tb/a.txt", _ctx("ta"))
+        assert exc.value.status_code == 403
+
+
+class TestScoping:
+    def test_paths_are_prefixed_and_results_unscoped(
+        self, view: ZoneScopedFS, raw: _FakeFS
+    ) -> None:
+        assert view.sys_stat("/docs/a.txt", context="c") == {"path": "/docs/a.txt", "size": 1}
+        assert raw.calls[-1] == ("sys_stat", ("/zone/ta/docs/a.txt",), {"context": "c"})
+        assert view.sys_read("/a.txt") == b"data"
+        assert view.read("/a.txt", return_metadata=True) == {"content": b"data", "path": "/a.txt"}
+        assert view.access("/a.txt") is True
+        assert raw.calls[-1][1] == ("/zone/ta/a.txt",)
+
+    def test_cross_zone_path_is_403_not_rerooted(self, view: ZoneScopedFS) -> None:
+        with pytest.raises(HTTPException) as exc:
+            view.sys_read("/zone/tb/secret.txt")
+        assert exc.value.status_code == 403
+        with pytest.raises(HTTPException):
+            view.write("/zone//tb/secret.txt", buf=b"x")
+
+    def test_own_prefix_is_accepted_without_doubling(
+        self, view: ZoneScopedFS, raw: _FakeFS
+    ) -> None:
+        view.sys_stat("/zone/ta/a.txt")
+        assert raw.calls[-1][1] == ("/zone/ta/a.txt",)
+
+    def test_write_by_keyword_and_positional(self, view: ZoneScopedFS, raw: _FakeFS) -> None:
+        out = view.write(path="/a.txt", buf=b"x", context="c")
+        # the fake binds the keyword ``path`` to its positional parameter
+        assert raw.calls[-1] == ("write", ("/zone/ta/a.txt",), {"buf": b"x", "context": "c"})
+        assert out["path"] == "/a.txt"
+        assert out["revision"] == "/a.txt@1"
+        out = view.write("/b.txt", buf=b"y")
+        assert raw.calls[-1][1] == ("/zone/ta/b.txt",)
+        assert out["revision"] == "/b.txt@1"
+
+    def test_rename_delete_mkdir(self, view: ZoneScopedFS, raw: _FakeFS) -> None:
+        out = view.sys_rename("/a.txt", "/b.txt", context="c")
+        assert raw.calls[-1][1] == ("/zone/ta/a.txt", "/zone/ta/b.txt")
+        assert out == {"old_path": "/a.txt", "new_path": "/b.txt", "revision": "/b.txt@2"}
+        assert view.sys_unlink("/b.txt") == {"deleted": True, "path": "/b.txt"}
+        assert view.delete("/b.txt") is True
+        view.mkdir("/dir", parents=True)
+        assert raw.calls[-1] == ("mkdir", ("/zone/ta/dir",), {"parents": True})
+
+    def test_get_metadata_dataclass_is_unscoped(self, view: ZoneScopedFS) -> None:
+        meta = view.get_metadata("/a.txt")
+        assert isinstance(meta, FileMetadata)
+        assert meta.path == "/a.txt"
+
+
+class TestListing:
+    def test_readdir_entries_and_dicts_are_unscoped(self, view: ZoneScopedFS, raw: _FakeFS) -> None:
+        out = view.sys_readdir("/", recursive=False, details=True)
+        # "/" scopes to the namespace root with a trailing slash, exactly as
+        # scope_params_for_zone does for the RPC ``list`` path
+        assert raw.calls[-1][1] == ("/zone/ta/",)
+        assert out == ["/a.txt", {"path": "/b.txt", "size": 2}]
+
+    def test_paginated_result_and_cursor(self, view: ZoneScopedFS, raw: _FakeFS) -> None:
+        page = view.sys_readdir("/docs", limit=2, cursor="/docs/a.txt")
+        assert raw.calls[-1][2]["cursor"] == "/zone/ta/docs/a.txt"
+        assert isinstance(page, PaginatedResult)
+        assert page.items == ["/docs/a.txt", {"path": "/docs/b.txt", "size": 2}]
+        assert page.next_cursor == "/docs/b.txt"
+        assert page.has_more is True
+
+    def test_legacy_list(self, view: ZoneScopedFS) -> None:
+        assert view.list("/docs", recursive=False) == ["/docs/a.txt"]
+
+    def test_other_zones_paths_pass_through_unchanged(self, view: ZoneScopedFS) -> None:
+        # only the caller's own prefix is stripped — a privileged cross-zone
+        # result must stay zone-qualified
+        assert view.unscope("/zone/tb/b.txt") == "/zone/tb/b.txt"
+        assert view.unscope("/zone/ta") == "/"
+
+
+class TestBatchOperations:
+    def test_write_batch(self, view: ZoneScopedFS, raw: _FakeFS) -> None:
+        out = view.write_batch([("/a.txt", b"1"), ("/b.txt", b"2")], context="c")
+        assert raw.calls[-1][1] == ([("/zone/ta/a.txt", b"1"), ("/zone/ta/b.txt", b"2")],)
+        assert out == [
+            {"path": "/a.txt", "revision": "/a.txt@1"},
+            {"path": "/b.txt", "revision": "/b.txt@1"},
+        ]
+
+    def test_read_batch_and_read_bulk(self, view: ZoneScopedFS, raw: _FakeFS) -> None:
+        assert view.read_batch(["/a.txt"]) == [{"path": "/a.txt", "content": b"x"}]
+        assert raw.calls[-1][1] == (["/zone/ta/a.txt"],)
+        assert view.read_bulk(["/a.txt"]) == {"/a.txt": {"content": b"x", "path": "/a.txt"}}
+
+    def test_rename_batch(self, view: ZoneScopedFS, raw: _FakeFS) -> None:
+        out = view.rename_batch([("/a.txt", "/b.txt")])
+        assert raw.calls[-1][1] == ([("/zone/ta/a.txt", "/zone/ta/b.txt")],)
+        assert out == {"/a.txt": {"success": True, "new_path": "/b.txt"}}
+
+    def test_cross_zone_in_batch_is_403(self, view: ZoneScopedFS) -> None:
+        with pytest.raises(HTTPException):
+            view.read_batch(["/a.txt", "/zone/tb/b.txt"])
+
+
+class TestServicesAndPassthrough:
+    def test_search_service_is_scoped(self, view: ZoneScopedFS, raw: _FakeFS) -> None:
+        search = view.service("search")
+        assert search.list("/") == ["/x.txt", "/root.txt"]
+        assert raw.search.calls[-1] == ("list", "/zone/ta/")
+        assert search.glob("*.txt", "/docs", files=["/docs/a.txt"]) == ["/docs/*.txt"]
+        assert raw.search.calls[-1] == ("glob", ("*.txt", "/zone/ta/docs", ["/zone/ta/docs/a.txt"]))
+        hits = asyncio.run(search.grep("needle", path="/", files=["/a.txt"]))
+        assert hits == [{"file": "/hit.txt", "line": 1, "content": "needle"}]
+        assert raw.search.calls[-1] == ("grep", ("needle", "/zone/ta/", ["/zone/ta/a.txt"]))
+
+    def test_other_services_and_attributes_pass_through(
+        self, view: ZoneScopedFS, raw: _FakeFS
+    ) -> None:
+        assert view.service("mount") is not raw.search
+        assert view._kernel == "kernel-handle"
+        assert view.wrapped_fs is raw
+        assert hasattr(view, "service")


### PR DESCRIPTION
Closes #4740

## What was wrong

Enumeration surfaces fell open on zone. `sys_readdir` resolved a missing zone claim to the ROOT view "by design", root-tagged entries passed the zone filter from every zone, the search `list` post-filter was skipped for admins, and `context_for_target_zone` mutated the request context in place. Reads and writes are path-addressed, so the zone predicate on the candidate set *is* the tenant boundary — and it had three holes.

## The model (`nexus/lib/zone_visibility.py`)

One predicate, `resolve_zone_view(context, all_zones=…) → ZoneView`, used by every enumeration surface:

| Caller | View |
|---|---|
| `context is None` (kernel / internal) | unrestricted |
| `is_system` without a zone | unrestricted; with a zone: that zone plus root-namespace rows |
| credential with `zone_perms` / `zone_set` / `zone_id` | its readable zones; the `zone_id=root` placeholder of a multi-zone token does not grant root |
| admin without a zone claim | the **root zone**, not every zone |
| admin with `all_zones=true` | unrestricted, **audited** (`zone.all_zones_enumeration`, once per request) |
| non-admin with `all_zones=true` | 403 |
| **non-admin, no zone claim** | **403** (REST) / JSON-RPC `-32003` |

An entry is visible when the zone embedded in its internal path (`/zone/<id>/…`, legacy `/zones/<id>/…`) is readable; entries outside a zone namespace fall back to their `zone_id` column, `None` meaning root. Root-tagged entries are therefore visible only to root-zone callers.

## Where it is enforced

- `NexusFS.sys_readdir` — view resolved first, every branch; the non-recursive kernel fast path post-filters via one `stat_batch`. New `all_zones` kwarg (RPC `list` param, REST `?all_zones=true`).
- `SearchService.list` / `_list_paginated` (glob, grep, glob_batch inherit). The "standalone rows are stored flat" prefix strip is gone: the kernel stores rows under `/zone/<id>/…`, so that strip made every enforced tenant list/glob/grep scan the root namespace and return nothing.
- `token_zone_filter_from_auth` fails closed for a non-admin credential with no zone claim (`/search/query`, `/query/batch`).
- `get_operation_context` no longer coerces a missing zone to ROOT for non-admins. Providers that legitimately mean "the default zone" now say root explicitly: open-access mode, `DatabaseLocalAuth` users without a zone, OIDC when a zone claim is not required. `StaticAPIKeyAuth`/`LocalAuth` keys configured without `zone_id` are zone-less on purpose and are refused on list/search.
- `context_for_target_zone` returns a copy; the REST `?zone=` override for admins goes through it too (it used to replace only `zone_id`, so the view followed the stale root grant).
- **REST path scoping** — `/api/v2/files/*`, `/api/v2/batch` and the search router's glob/grep never zone-prefixed paths the way RPC/gRPC do (`scope_params_for_zone`); a tenant's REST write landed in the root namespace. `ZoneScopedFS` (`server/api/v2/_zone_scoped_fs.py`) gives the REST layer the RPC contract: paths scoped in, unscoped out (list entries, cursors, batch results, revision tokens), a path naming another zone is 403.
- RPC list adapter keeps `/zone/<id>/` prefixes when `all_zones` is set so tenants' files don't collapse into one ambiguous path.
- **Rust http-api** (`rust/services/http-api/src/zone.rs`): search and documents handlers derive the zone from the authenticated `OperationContext`, not the request body; zone-less non-admins 403; `root_path` scoped and results unscoped; privileged callers pass through verbatim (empty zone keeps meaning the backend default). File-level ReBAC post-filter stays with the R10 epic (#4674).

Doc: `docs/architecture/zone-visibility.md`.

## Behaviour changes to know about

- An admin key without a zone header listing `/` recursively no longer sees `/zone/*` trees without `all_zones=true`.
- Zone-scoped REST clients now operate in `/zone/<id>/…`. Rows they wrote before this change sit in the root namespace; an admin can move them (`rename /x.txt → /zone/<id>/x.txt`).
- Embedded (in-process) zone contexts enumerate their `/zone/<id>/…` namespace; legacy layouts such as `/workspace/<zone>/` are root-attributed by the kernel (it stamps the route zone, verified against the pinned kernel), so two tests in `tests/integration/core/test_embedded_namespaces_rebac.py` were updated to the new contract.
- `_rpc_params_generated.py` was hand-edited (one line) because `scripts/generate_rpc_params.py` currently drops two unrelated snapshot classes.

## Verification

- Unit: `tests/unit/lib/test_zone_visibility.py`, `tests/unit/core/test_readdir_zone_visibility.py` (kernel-free `sys_readdir` matrix), `tests/unit/server/test_zone_scoped_fs.py`, `test_operation_context_zone_default.py`, `test_kernel_syscall_dispatch_all_zones.py`, `tests/unit/bricks/search/test_list_scans_scoped_zone_prefix.py`; full `tests/unit` green (5735 passed).
- E2E in `test.yml`: `tests/e2e/self_contained/test_zone_visibility_matrix_e2e.py` — real kernel, real FastAPI app, real DB API keys for tenants A/B plus admin, a static zone-less key; 16 cells over RPC list, REST list/read/write/rename/delete, REST glob/grep, admin `?zone=`, `all_zones` audit.
- Rust: `cargo test` for `nexus-http-api` (unit + e2e), clippy clean, fmt clean (needs `PROTOC` from `protobuf@21` locally).
- Live stack (`nexus up --build` from this branch, ReBAC enforced, plugin host on 2128): `permissions_demo_enhanced.sh` exit 0, `scripts/test_build_perf_e2e.py` 30/30 (HERB 7/8, gate passes), live tenant matrix 30/30 inside the container.

- Rebased onto develop after #4745 (#4738 `projection_seq`) and #4746 (#4739 ReBAC-filtered `sys_readdir`) merged. Both compose with this change: in `sys_readdir` the zone predicate runs first and the new `readdir_visible_paths` ReBAC post-filter runs on the in-zone names; the REST `mkdir` handler keeps the zone-scoped fs and returns `projection_seq`. The surface coverage matrix was regenerated (line references only). Re-verified on the rebased tree: zone unit tests plus `tests/unit/{core,server,lib,bricks/search,bricks/rebac}` green, e2e matrix 16/16, `tests/integration/bricks/rebac/test_read_after_write_permissions.py` green, surface coverage tests green, and the live stack rebuilt from the rebased branch: `permissions_demo_enhanced.sh` exit 0, `test_build_perf_e2e.py` 30/30, live tenant matrix 30/30.

- CI follow-up: `E2E Tests (Self-Contained)` caught the MCP tools in sandbox mode passing the kernel's own init credential (`NexusFS._init_cred`, the factory default `OperationContext(user_id="system")`: no zone, not admin) explicitly to `SearchService.glob`, which the fail-closed rule refused. That credential is what `context=None` already resolves to, so `resolve_zone_view(..., init_cred=)` now gives it the same unrestricted view when the context *is* that object (identity, not equality; a copy is still refused). Server request contexts are always fresh objects built from auth, so the tenant boundary is unchanged. Unit tests in `tests/unit/lib`, `tests/unit/core`, `tests/unit/bricks/search`; `test_issue_4129_sandbox_search_e2e` passes locally again.

## Follow-ups (not in this PR)

- `/api/v2/batch` executor calls `write(content=…)`, `exists`, `get_metadata`, `list`, which NexusFS lacks — every op 500s on develop.
- `tests/unit/cli/test_profile_contract.py::…test_auth_mode_from_project_config` and `tests/unit/remote/test_grpc_target.py::test_default_port_no_tls` read the worktree's `nexus.yaml` / `nexus-data/.state.json` and fail while a locally managed stack is up in the checkout.
- Kernel: stamping `context_zone_id` on rows would let the zone column carry tenant information in standalone mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


