### PR TITLE
fix(search-plugin): natural-language queries fall back to tantivy's lenient parser

### DIFF
--- a/rust/services/search-plugin/src/fts_index.rs
+++ b/rust/services/search-plugin/src/fts_index.rs
@@ -576,9 +576,29 @@ impl FtsIndex {
         let searcher = self.reader.searcher();
 
         let parser = QueryParser::for_index(&self.index, vec![self.fields.chunk_text]);
-        let parsed = parser
-            .parse_query(query)
-            .map_err(|e| IndexError::ParseQuery(query.to_string(), e.to_string()))?;
+        // Natural-language queries routinely contain tantivy syntax by
+        // accident ("confirm - what did ...", an unbalanced quote, a
+        // stray ':' or '[').  The strict parser rejects the whole query,
+        // and because the hybrid path joins this leg with the semantic
+        // leg, one dash used to fail the entire hybrid RPC with
+        // "parse query ...: Syntax Error" even though the ANN leg had
+        // the answer (LongMemEval 58470ed2).  Try strict first so
+        // deliberate operator syntax keeps its exact semantics; on a
+        // syntax error fall back to tantivy's lenient parser, which
+        // drops the offending tokens and keeps the rest of the terms.
+        let parsed = match parser.parse_query(query) {
+            Ok(parsed) => parsed,
+            Err(strict_err) => {
+                let (lenient, lenient_errors) = parser.parse_query_lenient(query);
+                tracing::debug!(
+                    query,
+                    strict_error = %strict_err,
+                    lenient_errors = lenient_errors.len(),
+                    "fts query did not parse strictly; using lenient parse"
+                );
+                lenient
+            }
+        };
 
         // Over-fetch when a path prefix is set: the prefix filter is
         // applied post-scoring in P1, so we grab a wider window to
@@ -815,6 +835,52 @@ mod tests {
         assert_eq!(hits[0].chunk_index, 0);
         assert_eq!(hits[0].mtime_ms, Some(1_700_000_000_000));
         assert!(hits[0].score > 0.0);
+    }
+
+    #[test]
+    fn natural_language_syntax_falls_back_to_lenient_parse() {
+        // A dash surrounded by spaces, an unbalanced quote, a stray
+        // colon: all strict-parser syntax errors that a user question
+        // carries by accident.  They must not fail the query (and, via
+        // the hybrid join, the whole hybrid RPC) — the remaining terms
+        // still search.  Deliberate, well-formed syntax keeps working.
+        let dir = tempdir().join("fts");
+        let idx = FtsIndex::open_or_create(dir).expect("open");
+        idx.add_document(
+            "/lme/borges.md",
+            0,
+            "Borges wrote that the Library is a sphere whose exact center is any hexagon",
+            Some(1),
+        )
+        .expect("add");
+        idx.add_document(
+            "/lme/other.md",
+            0,
+            "an unrelated note about gardening",
+            Some(2),
+        )
+        .expect("add");
+        idx.commit().expect("commit");
+
+        for query in [
+            "I wanted to confirm - what did Borges say about the center of the Library?",
+            "what did Borges say about the \"center of the Library",
+            "Borges: center of the Library [sphere]",
+        ] {
+            let hits = idx
+                .search(query, 10, None)
+                .expect("lenient search must not fail");
+            assert!(
+                hits.iter().any(|h| h.path == "/lme/borges.md"),
+                "query {query:?}: expected the Borges doc, got {hits:?}"
+            );
+        }
+        // Well-formed operator syntax is still honoured strictly.
+        let hits = idx
+            .search("Borges -gardening", 10, None)
+            .expect("strict search");
+        assert_eq!(hits.len(), 1, "{hits:?}");
+        assert_eq!(hits[0].path, "/lme/borges.md");
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Running the LongMemEval retrieval benchmark (`longmemeval_s`, cleaned Sept-2025, the protocol from garrytan/gbrain-evals) against a Nexus server built from develop `327dfd1`, question `58470ed2` ("… and I wanted to confirm - what did Borges say about the center and circumference of the Library?") failed on **every** keyword and hybrid fusion mode with

```
search: parse query "…": Syntax Error
```

while the semantic lane had the gold session at rank 1. `FtsIndex::search` parses the query strictly with tantivy's `QueryParser::parse_query`; a dash surrounded by spaces, an unbalanced quote, a stray `:` or `[` — all things a natural-language question carries by accident — reject the whole query, and because the hybrid path joins the keyword leg with the semantic leg, the whole hybrid RPC fails. Koodle works around this today with a client-side sanitizer in its SDK; any other client (CLI, MCP, the Python SDK) gets the 500.

## Change

Try the strict parser first so deliberate operator syntax keeps its exact semantics; on a syntax error fall back to `QueryParser::parse_query_lenient`, which drops the offending tokens and searches the remaining terms. Strict error + lenient error count are logged at debug.

## Verification

| Check | Result |
|---|---|
| `natural_language_syntax_falls_back_to_lenient_parse` (new): three accidental-syntax questions hit the right doc; `Borges -gardening` still excludes the negated term | pass |
| `cargo test -p nexus-search-plugin` (267 unit + integration binaries), `cargo clippy --all-targets -D warnings`, `cargo fmt --check` | pass |
| Live: plugin rebuilt, dev-signed and hot-swapped into a `nexusd-cluster --plugin-dir` host behind a `nexus up --build` stack; the 50-session haystack of `58470ed2` indexed, raw question queried | keyword hits=15 gold rank 1, hybrid hits=15 gold rank 1, semantic gold rank 1 (before: keyword + every hybrid mode → Syntax Error) |

Independent of #4748 (write path); both apply cleanly on develop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
