### PR TITLE
feat(http-api): /v2/auth/keys list + revoke (R10 arc)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3050,6 +3050,7 @@ dependencies = [
 name = "nexus-http-api"
 version = "0.1.0"
 dependencies = [
+ "auth",
  "axum",
  "contracts",
  "dashmap",
@@ -3057,6 +3058,7 @@ dependencies = [
  "kernel",
  "lib",
  "nexus-rebac",
+ "parking_lot",
  "prost 0.14.4",
  "protoc-bin-vendored",
  "reqwest 0.12.28",

--- a/rust/services/http-api/Cargo.toml
+++ b/rust/services/http-api/Cargo.toml
@@ -34,6 +34,16 @@ tonic-prost = { workspace = true }
 # sibling search-plugin peer-fanout uses (search-plugin/Cargo.toml).
 dashmap = "6.1"
 
+# `auth::record::AuthKeyRecord` + `SubjectType` decode for the
+# `/v2/auth/keys` list handler.  The store's value bytes are the
+# authoritative serialised record shape; this crate owns the
+# decode so the wire body mirrors the Python nexus-server response
+# 1:1 (an ops script that scrapes /api/v2/auth/keys on Python
+# reads /v2/auth/keys on Rust unchanged).  Pinned to the same
+# nexus-vfs rev the workspace does (no `auth` workspace-dep entry
+# yet — the `kernel` + `transport` neighbors are the precedent).
+auth = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "b5b969a060c322835be67ff9b1e6e02f7c97abd1" }
+
 # Bearer-token → `OperationContext` SSOT.
 #
 # The `AuthProvider` trait + `AuthCredentials` + kernel-default
@@ -97,6 +107,11 @@ protoc-bin-vendored = "3"
 # `tower::ServiceExt::oneshot`).
 tower = { version = "0.5", features = ["util"] }
 http-body-util = "0.1"
+# Auth-keys E2E hand-rolls an in-memory `AuthKeyStore` behind a
+# `parking_lot::Mutex<BTreeMap>` (same shape auth's own mint tests
+# use).  parking_lot is already a normal dep of `nexus-rebac`; the
+# dev-dep entry here keeps the auth_keys_e2e test self-contained.
+parking_lot = "0.12"
 # Real-TCP integration cover — `tests/serve_e2e.rs` binds an
 # ephemeral port with `axum::serve` and hits it via `reqwest` so the
 # hyper listener + tower service composition is exercised end-to-end

--- a/rust/services/http-api/src/handlers/auth.rs
+++ b/rust/services/http-api/src/handlers/auth.rs
@@ -1,0 +1,316 @@
+//! `/v2/auth/keys` — HTTP list + revoke over the kernel-adjacent
+//! `AuthKeyStore` (raft-backed, cluster-wide replicated).
+//!
+//! Port of Python nexus-server's `/api/v2/auth/keys` router
+//! (`src/nexus/server/api/v2/routers/auth_keys.py`), R10 arc.
+//! Python-side ships the full CRUD (create + get + list + delete);
+//! this Rust port ships **list + revoke** in this PR — mint (POST)
+//! lands in a follow-up PR that requires plumbing the API-key
+//! secret through `ServiceBootCtx` (needed to HMAC the returned
+//! plaintext key at mint time).
+//!
+//! # Endpoints
+//!
+//! * `GET    /v2/auth/keys` — list every credential record on the
+//!   local raft-applied replica.  Optional query filters
+//!   (`?subject_type=`, `?include_revoked=`, `?is_admin=`) narrow
+//!   client-side; the store returns every record and this handler
+//!   applies the predicates before shaping the response.
+//! * `DELETE /v2/auth/keys/:key_hash` — revoke by key hash (the
+//!   caller has the hash but not the plaintext key — the audit
+//!   view under `/__sys__/auth/keys/` exposes hashes only).  The
+//!   response reports whether a record was actually removed
+//!   (advisory — the raft log is authoritative).
+//!
+//! # Auth
+//!
+//! **Admin-only** — the mint / revoke plane on the gRPC side is
+//! gated by a mTLS **node** cert (a peer, not any authenticated
+//! caller).  HTTP has no mTLS cert, so this router substitutes an
+//! `is_admin`-required check at the middleware boundary: a bearer
+//! that resolves to `ctx.is_admin = true` passes, everything else
+//! gets `403`.  Matches Python nexus-server's `dependencies=
+//! [Depends(require_admin)]` posture.
+//!
+//! # Wire shape
+//!
+//! JSON response body deliberately mirrors the Python auth_keys.py
+//! shape 1:1 (`key_id`, `subject_type`, `subject_id`, `is_admin`,
+//! `revoked`, `expires_at_ms`, `zone_perms`, `name`) so an ops
+//! script that scrapes `/api/v2/auth/keys` on Python side keeps
+//! working when it flips to `/v2/auth/keys` on the Rust side.
+
+use std::sync::Arc;
+
+use auth::record::{AuthKeyRecord, SubjectType};
+use axum::extract::{Path, Query, State};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::routing::{delete, get};
+use axum::{Extension, Json, Router};
+use contracts::operation_context::OperationContext;
+use kernel::hal::auth_key_store::AuthKeyStoreError;
+use serde::{Deserialize, Serialize};
+
+use crate::AppState;
+
+// ── error surface ────────────────────────────────────────────────
+
+/// Errors surfaced by the /v2/auth/keys handlers.  Same shape as
+/// [`crate::handlers::search::SearchError`] +
+/// [`crate::handlers::rebac::RebacError`] — a typed enum with an
+/// [`IntoResponse`] impl mapping variants to HTTP status.
+#[derive(Debug, thiserror::Error)]
+pub enum AuthKeysError {
+    /// Bearer resolved but the caller is not an admin.  Maps to
+    /// 403 — matches Python nexus-server's `require_admin`
+    /// rejection.
+    #[error("admin privilege required to manage auth keys")]
+    Forbidden,
+
+    /// The `AuthKeyStore` backend refused a read / write.  Maps to
+    /// 502 — caller is well-formed, backend is not currently
+    /// serving.  Preserves the store's message for the operator log.
+    #[error("auth-key store backend error: {0}")]
+    Backend(String),
+}
+
+impl From<AuthKeyStoreError> for AuthKeysError {
+    fn from(e: AuthKeyStoreError) -> Self {
+        // The trait's `Backend(String)` is the only variant today;
+        // matching exhaustively guards against a silent widen where
+        // a new variant would fall through the wrong status.
+        match e {
+            AuthKeyStoreError::Backend(msg) => Self::Backend(msg),
+        }
+    }
+}
+
+impl IntoResponse for AuthKeysError {
+    fn into_response(self) -> Response {
+        let status = match &self {
+            Self::Forbidden => StatusCode::FORBIDDEN,
+            Self::Backend(_) => StatusCode::BAD_GATEWAY,
+        };
+        (status, self.to_string()).into_response()
+    }
+}
+
+/// Enforce the "admin-only" gate at the handler boundary.  A bearer
+/// that did not resolve to `is_admin == true` gets 403.
+///
+/// Kept as a plain fn instead of a middleware so the check runs
+/// AFTER the `require_bearer` middleware has stamped
+/// `Extension<OperationContext>` — the middleware's job is authN,
+/// the handler's job is authZ.  Same split Python nexus-server uses
+/// (`Depends(require_admin)` runs after the bearer resolver).
+fn require_admin(ctx: &OperationContext) -> Result<(), AuthKeysError> {
+    if ctx.is_admin {
+        Ok(())
+    } else {
+        Err(AuthKeysError::Forbidden)
+    }
+}
+
+// ── wire shape ───────────────────────────────────────────────────
+
+/// One credential's public record on the wire — no key material.
+///
+/// The store's raw value is an opaque `Vec<u8>` (serde-json bytes
+/// of an `AuthKeyRecord`); this shape is the client-facing view
+/// after decode.  `key_hash` is added on top of the decoded record
+/// because it lives in the store KEY, not the value — a caller
+/// listing records needs the hash to target a subsequent
+/// `DELETE /v2/auth/keys/:key_hash`.
+///
+/// Field names + JSON shape match Python nexus-server's
+/// `list_keys` response 1:1 (see `auth_keys.py::list_keys` —
+/// wraps `handle_admin_list_keys`).  A polling ops script that
+/// scrapes the Python endpoint reads the Rust endpoint unchanged.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AuthKeyView {
+    /// HMAC-of-key store key.  Used by `DELETE /v2/auth/keys/:key_hash`.
+    pub key_hash: String,
+    /// Stable id for logs + audit tooling (not derived from key
+    /// material — safe to log).
+    pub key_id: String,
+    /// Human label ("mac-ai laptop", "ci runner").
+    pub name: String,
+    /// `"user"` | `"agent"` | `"service"` — matches Python side's
+    /// lowercase spelling.  A caller filtering by subject type
+    /// compares against this string, not an int enum.
+    pub subject_type: String,
+    /// The principal id ((agent) name or user id).
+    pub subject_id: String,
+    /// Global admin flag.
+    pub is_admin: bool,
+    /// Tombstone flag — a revoked record is normally deleted
+    /// outright, but the flag lets a soft-revoke survive for audit.
+    pub revoked: bool,
+    /// Expiry (ms since epoch); absent ⇒ never expires.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expires_at_ms: Option<u64>,
+    /// Zone grants as `(zone_id, perms)` pairs.  Empty ⇒ admin-only
+    /// key (a non-admin key with no zone grants is refused at mint).
+    pub zone_perms: Vec<(String, String)>,
+}
+
+impl AuthKeyView {
+    /// Compose from a store row `(key_hash, opaque_bytes)`.  Returns
+    /// `Ok(None)` for a row that fails to decode as an
+    /// `AuthKeyRecord` — the same soft-skip posture the mint layer
+    /// takes (`find_active_subject` continues past unreadable rows).
+    /// A row from a newer schema this build cannot parse is invisible
+    /// to `list`, but does not wedge the whole listing.
+    fn from_row(key_hash: String, bytes: &[u8]) -> Option<Self> {
+        let record = AuthKeyRecord::decode(bytes).ok()?;
+        Some(Self {
+            key_hash,
+            key_id: record.key_id,
+            name: record.name,
+            subject_type: record.subject_type.as_str().to_string(),
+            subject_id: record.subject_id,
+            is_admin: record.is_admin,
+            revoked: record.revoked,
+            expires_at_ms: record.expires_at_ms,
+            zone_perms: record.zone_perms,
+        })
+    }
+}
+
+// ── GET /v2/auth/keys ────────────────────────────────────────────
+
+/// Query params for [`list`].  All optional; absent ⇒ no filter.
+///
+/// Client-side filtering — the store's `list()` returns every
+/// record on the local raft-applied replica; this handler applies
+/// the predicates before shaping the response.  Matches Python
+/// nexus-server's `ListKeysParams` shape (see `auth_keys.py`).
+///
+/// `include_revoked` defaults to `false` (audit tooling asking
+/// "what's active?"); flip it to `true` to see soft-revoked rows.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ListQuery {
+    /// `"user"` | `"agent"` | `"service"`.  Anything else silently
+    /// filters to nothing (parse-then-match — an unknown value can
+    /// only be a client typo).
+    #[serde(default)]
+    pub subject_type: Option<String>,
+    /// Filter by subject id (`user_id` on the Python side).
+    #[serde(default)]
+    pub subject_id: Option<String>,
+    /// Filter by admin flag.
+    #[serde(default)]
+    pub is_admin: Option<bool>,
+    /// Include soft-revoked rows in the response.
+    #[serde(default)]
+    pub include_revoked: bool,
+}
+
+/// Response body for [`list`].
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct ListResponse {
+    pub keys: Vec<AuthKeyView>,
+}
+
+/// Handler for `GET /v2/auth/keys` — list every credential.  Reads
+/// the local raft-applied replica; no leader round-trip, works on a
+/// learner.  Matches the `KeyMinter::list_keys` semantic (see
+/// `raft::key_minter`).
+pub async fn list(
+    State(state): State<AppState>,
+    Extension(ctx): Extension<OperationContext>,
+    Query(params): Query<ListQuery>,
+) -> Result<Json<ListResponse>, AuthKeysError> {
+    require_admin(&ctx)?;
+    let store = Arc::clone(&state.auth_key_store);
+    // `store.list()` bridges through raft's blocking read; run
+    // under `spawn_blocking` so the axum worker stays responsive.
+    let rows = tokio::task::spawn_blocking(move || store.list())
+        .await
+        .map_err(|e| AuthKeysError::Backend(format!("list task panicked: {e}")))??;
+
+    let keys: Vec<AuthKeyView> = rows
+        .into_iter()
+        .filter_map(|(hash, bytes)| AuthKeyView::from_row(hash, &bytes))
+        .filter(|k| {
+            // include_revoked=false ⇒ only active records
+            if !params.include_revoked && k.revoked {
+                return false;
+            }
+            if let Some(subj_type) = &params.subject_type {
+                if k.subject_type != *subj_type {
+                    return false;
+                }
+            }
+            if let Some(subj_id) = &params.subject_id {
+                if k.subject_id != *subj_id {
+                    return false;
+                }
+            }
+            if let Some(is_admin) = params.is_admin {
+                if k.is_admin != is_admin {
+                    return false;
+                }
+            }
+            true
+        })
+        .collect();
+    Ok(Json(ListResponse { keys }))
+}
+
+// ── DELETE /v2/auth/keys/:key_hash ───────────────────────────────
+
+/// Response body for [`revoke`].  `existed` is advisory — a delete
+/// on a missing key returns `Ok(false)` (idempotent); the flag lets
+/// a caller distinguish "removed something" from "nothing there".
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct RevokeResponse {
+    pub existed: bool,
+    /// Echo of the hash the caller passed — lets a caller confirm
+    /// they hit the row they meant to hit (defense-in-depth against
+    /// a copy-paste error hitting the wrong row).
+    pub key_hash: String,
+}
+
+/// Handler for `DELETE /v2/auth/keys/:key_hash` — revoke by hash.
+///
+/// Path shape matches Python nexus-server's
+/// `/api/v2/auth/keys/{key_id}` DELETE — one path segment carries
+/// the identifier.  We use HASH here (not `key_id`) because the
+/// audit view (`/__sys__/auth/keys/`) exposes hashes; a caller
+/// who knows a `key_id` but not its hash uses the /v2/auth/keys
+/// GET response to look up the hash first.
+///
+/// Matches the `KeyMinter::revoke_key` semantic (see
+/// `raft::key_minter`), one gate over: node-cert gate replaced
+/// with HTTP admin gate at [`require_admin`].
+pub async fn revoke(
+    State(state): State<AppState>,
+    Extension(ctx): Extension<OperationContext>,
+    Path(key_hash): Path<String>,
+) -> Result<Json<RevokeResponse>, AuthKeysError> {
+    require_admin(&ctx)?;
+    let store = Arc::clone(&state.auth_key_store);
+    let hash_for_call = key_hash.clone();
+    let existed = tokio::task::spawn_blocking(move || store.delete(&hash_for_call))
+        .await
+        .map_err(|e| AuthKeysError::Backend(format!("revoke task panicked: {e}")))??;
+    Ok(Json(RevokeResponse { existed, key_hash }))
+}
+
+// ── Router ────────────────────────────────────────────────────────
+
+pub fn router() -> Router<AppState> {
+    Router::new()
+        .route("/v2/auth/keys", get(list))
+        .route("/v2/auth/keys/{key_hash}", delete(revoke))
+}
+
+// `SubjectType` is unused directly here — record decode uses its
+// `.as_str()` impl inside `AuthKeyView::from_row`.  Silence the
+// unused-import warning by asserting the type exists.
+#[allow(dead_code)]
+fn _assert_subject_type_is_reachable() -> Option<SubjectType> {
+    None
+}

--- a/rust/services/http-api/src/handlers/mod.rs
+++ b/rust/services/http-api/src/handlers/mod.rs
@@ -7,6 +7,7 @@
 //! keeps `AppState` growth O(1) per new domain — a fresh domain
 //! adds a field, no handler rewire.
 
+pub mod auth;
 pub mod documents;
 #[cfg(feature = "rebac")]
 pub mod rebac;

--- a/rust/services/http-api/src/lib.rs
+++ b/rust/services/http-api/src/lib.rs
@@ -85,6 +85,12 @@ pub use search_backend::{BackendError, SearchBackend};
 pub struct AppState {
     pub search: SearchBackend,
     pub auth: Arc<dyn AuthProvider>,
+    /// The kernel-adjacent `AuthKeyStore` — list / revoke backend
+    /// for `/v2/auth/keys`.  Threaded from the same
+    /// `RaftAuthKeyStore` the kernel's gRPC bearer-auth path reads
+    /// (via `kernel.auth_key_store()` at install time).  One SSOT,
+    /// two surfaces (gRPC + HTTP).
+    pub auth_key_store: Arc<dyn kernel::hal::auth_key_store::AuthKeyStore>,
     /// The kernel-adjacent ReBAC tuple store — grant / list / revoke
     /// backend for `/v2/rebac/tuples`.  Present iff this crate was
     /// built `--features rebac`; the composition root in `nexusd`
@@ -116,6 +122,10 @@ impl AppState {
         Self {
             search: SearchBackend::new(grpc_target),
             auth: middleware::auth::default_no_auth_provider(),
+            // Empty in-memory store for `/v2/auth/keys` tests.  The
+            // real composition root pulls the raft-backed store from
+            // `kernel.auth_key_store()` at install time.
+            auth_key_store: Arc::new(middleware::auth::empty_auth_key_store_for_tests()),
             #[cfg(feature = "rebac")]
             rebac_store: Arc::new(nexus_rebac::InMemoryReBACTupleStore::new()),
         }
@@ -150,7 +160,8 @@ pub fn router(state: AppState) -> Router {
     let protected_router = {
         let r = Router::new()
             .merge(handlers::search::router())
-            .merge(handlers::documents::router());
+            .merge(handlers::documents::router())
+            .merge(handlers::auth::router());
         #[cfg(feature = "rebac")]
         let r = r.merge(handlers::rebac::router());
         r.layer(from_fn_with_state(
@@ -252,6 +263,10 @@ pub async fn bind_and_serve(
 /// half-served request), but the "listener is up" invariant is
 /// established synchronously — matches `a2a::install_a2a_stamp_hook`
 /// which also fails install synchronously if setup errors.
+/// `AuthKeyStore` for the `/v2/auth/keys` handlers comes from the
+/// live kernel — [`kernel::Kernel::auth_key_store`] surfaces the
+/// same `RaftAuthKeyStore` the gRPC bearer-auth path already
+/// reads.  One SSOT, two surfaces (gRPC + HTTP).
 #[cfg(not(feature = "rebac"))]
 pub fn service_decl(
     addr: SocketAddr,
@@ -261,7 +276,10 @@ pub fn service_decl(
 ) -> kernel::kernel::ServiceDecl {
     kernel::kernel::ServiceDecl {
         name: "http_api".to_string(),
-        install: Box::new(move |_kernel| install_impl(addr, upstream_grpc, auth, runtime)),
+        install: Box::new(move |kernel| {
+            let auth_key_store = kernel.auth_key_store();
+            install_impl(addr, upstream_grpc, auth, runtime, auth_key_store)
+        }),
     }
 }
 
@@ -281,8 +299,16 @@ pub fn service_decl(
 ) -> kernel::kernel::ServiceDecl {
     kernel::kernel::ServiceDecl {
         name: "http_api".to_string(),
-        install: Box::new(move |_kernel| {
-            install_impl(addr, upstream_grpc, auth, runtime, rebac_store)
+        install: Box::new(move |kernel| {
+            let auth_key_store = kernel.auth_key_store();
+            install_impl(
+                addr,
+                upstream_grpc,
+                auth,
+                runtime,
+                auth_key_store,
+                rebac_store,
+            )
         }),
     }
 }
@@ -303,11 +329,13 @@ pub fn install_impl(
     upstream_grpc: String,
     auth: Arc<dyn AuthProvider>,
     runtime: tokio::runtime::Handle,
+    auth_key_store: Arc<dyn kernel::hal::auth_key_store::AuthKeyStore>,
     #[cfg(feature = "rebac")] rebac_store: Arc<dyn nexus_rebac::ReBACTupleStore>,
 ) -> Result<(), String> {
     let state = AppState {
         search: SearchBackend::new(upstream_grpc),
         auth,
+        auth_key_store,
         #[cfg(feature = "rebac")]
         rebac_store,
     };

--- a/rust/services/http-api/src/middleware/auth.rs
+++ b/rust/services/http-api/src/middleware/auth.rs
@@ -197,6 +197,35 @@ pub fn default_no_auth_provider() -> Arc<dyn AuthProvider> {
     Arc::new(transport::auth::NoAuth)
 }
 
+/// A `Send + Sync` empty `AuthKeyStore` for tests + probes that
+/// wire an `AppState` without a real raft-backed store — the
+/// `/v2/auth/keys` list handler returns an empty array, revoke
+/// returns `existed=false`.  Never a real deployment (the mint
+/// plane wouldn't work; the composition root in `nexusd` binds
+/// the raft-backed store via `kernel.auth_key_store()`).
+pub fn empty_auth_key_store_for_tests() -> impl kernel::hal::auth_key_store::AuthKeyStore + 'static
+{
+    use kernel::hal::auth_key_store::{AuthKeyStore, AuthKeyStoreError};
+
+    #[derive(Default)]
+    struct EmptyStore;
+    impl AuthKeyStore for EmptyStore {
+        fn get(&self, _key_hash: &str) -> Result<Option<Vec<u8>>, AuthKeyStoreError> {
+            Ok(None)
+        }
+        fn put(&self, _key_hash: &str, _record: &[u8]) -> Result<(), AuthKeyStoreError> {
+            Ok(())
+        }
+        fn delete(&self, _key_hash: &str) -> Result<bool, AuthKeyStoreError> {
+            Ok(false)
+        }
+        fn list(&self) -> Result<Vec<(String, Vec<u8>)>, AuthKeyStoreError> {
+            Ok(Vec::new())
+        }
+    }
+    EmptyStore
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/rust/services/http-api/tests/auth_keys_e2e.rs
+++ b/rust/services/http-api/tests/auth_keys_e2e.rs
@@ -1,0 +1,430 @@
+//! Integration coverage for the `/v2/auth/keys` router.
+//!
+//! Real-chain shape: bind an ephemeral axum listener over an
+//! `AppState` whose `auth_key_store` is a hand-rolled in-memory
+//! double (populated with pre-encoded `AuthKeyRecord` bytes).
+//! The list handler reads the store, decodes each row, filters by
+//! query params, and shapes the response.  Revoke calls
+//! `store.delete(hash)`.  Same wire shape the raft-backed store
+//! serves in production.
+
+use std::sync::Arc;
+
+use auth::record::{AuthKeyRecord, SubjectType};
+use contracts::operation_context::OperationContext;
+use kernel::hal::auth_key_store::{AuthKeyStore, AuthKeyStoreError};
+use nexus_http_api::{bind_and_serve, AppState};
+use parking_lot::Mutex;
+use serde_json::json;
+use std::collections::BTreeMap;
+use transport::auth::{AuthCredentials, AuthProvider};
+
+// ── shared test doubles ──────────────────────────────────────────
+
+/// Store double — records get + put + delete + list against a
+/// `BTreeMap<String, Vec<u8>>`.  Matches the shape the mint layer's
+/// own test double (`auth::mint::tests::MemStore`) uses.
+#[derive(Default)]
+struct MemStore {
+    records: Mutex<BTreeMap<String, Vec<u8>>>,
+}
+
+impl AuthKeyStore for MemStore {
+    fn get(&self, key_hash: &str) -> Result<Option<Vec<u8>>, AuthKeyStoreError> {
+        Ok(self.records.lock().get(key_hash).cloned())
+    }
+    fn put(&self, key_hash: &str, record: &[u8]) -> Result<(), AuthKeyStoreError> {
+        self.records
+            .lock()
+            .insert(key_hash.to_string(), record.to_vec());
+        Ok(())
+    }
+    fn delete(&self, key_hash: &str) -> Result<bool, AuthKeyStoreError> {
+        Ok(self.records.lock().remove(key_hash).is_some())
+    }
+    fn list(&self) -> Result<Vec<(String, Vec<u8>)>, AuthKeyStoreError> {
+        Ok(self
+            .records
+            .lock()
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect())
+    }
+}
+
+/// AuthProvider that returns an admin OperationContext for the
+/// bearer `"admin-token"`, a non-admin ctx for `"user-token"`, and
+/// 401 for anything else.  Lets a single test file exercise both
+/// the require_bearer middleware AND the /v2/auth/keys admin gate.
+struct FixtureAuth;
+
+impl AuthProvider for FixtureAuth {
+    fn resolve(&self, creds: &AuthCredentials<'_>) -> Result<OperationContext, tonic::Status> {
+        match creds.token {
+            "admin-token" => Ok(OperationContext::new(
+                "admin-user",
+                "root",
+                /* is_admin */ true,
+                None,
+                false,
+            )),
+            "user-token" => Ok(OperationContext::new(
+                "normal-user",
+                "root",
+                /* is_admin */ false,
+                None,
+                false,
+            )),
+            _ => Err(tonic::Status::unauthenticated("bad token")),
+        }
+    }
+}
+
+fn sample_record(name: &str, subject_id: &str, admin: bool, revoked: bool) -> AuthKeyRecord {
+    AuthKeyRecord {
+        key_id: format!("kid-{name}"),
+        name: name.to_string(),
+        subject_type: SubjectType::User,
+        subject_id: subject_id.to_string(),
+        is_admin: admin,
+        revoked,
+        expires_at_ms: None,
+        zone_perms: vec![("root".to_string(), "rwx".to_string())],
+    }
+}
+
+/// Bring up an axum listener on an ephemeral port with pre-seeded
+/// store rows.  Returns the base URL + a handle keeping the serve
+/// task alive.
+async fn spawn_test_server(
+    seed: Vec<(String, AuthKeyRecord)>,
+) -> (String, Arc<MemStore>, tokio::task::JoinHandle<()>) {
+    let store = Arc::new(MemStore::default());
+    for (hash, record) in seed {
+        let bytes = record.encode().expect("encode seed record");
+        store.put(&hash, &bytes).expect("seed put");
+    }
+    let mut state = AppState::for_tests("http://127.0.0.1:1");
+    state.auth_key_store = Arc::clone(&store) as Arc<dyn AuthKeyStore>;
+    state.auth = Arc::new(FixtureAuth);
+    let addr: std::net::SocketAddr = "127.0.0.1:0".parse().expect("parse addr");
+    let (bound, fut) = bind_and_serve(addr, state).await.expect("bind + serve");
+    let handle = tokio::spawn(async move {
+        let _ = fut.await;
+    });
+    (format!("http://{bound}"), store, handle)
+}
+
+// ── GET /v2/auth/keys tests ──────────────────────────────────────
+
+/// Happy path: seed 2 records, admin-token GET returns both.
+#[tokio::test]
+async fn list_returns_seeded_records_for_admin() {
+    let (base, _store, _h) = spawn_test_server(vec![
+        (
+            "hash-alice".to_string(),
+            sample_record("alice-key", "alice", false, false),
+        ),
+        (
+            "hash-bob".to_string(),
+            sample_record("bob-key", "bob", false, false),
+        ),
+    ])
+    .await;
+
+    let resp: serde_json::Value = reqwest::Client::new()
+        .get(format!("{base}/v2/auth/keys"))
+        .bearer_auth("admin-token")
+        .send()
+        .await
+        .expect("send")
+        .json()
+        .await
+        .expect("json");
+    let keys = resp["keys"].as_array().expect("keys array");
+    assert_eq!(keys.len(), 2, "must list both seeded records");
+    let names: Vec<_> = keys.iter().map(|k| k["name"].as_str().unwrap()).collect();
+    assert!(names.contains(&"alice-key"));
+    assert!(names.contains(&"bob-key"));
+}
+
+/// A non-admin bearer is rejected with 403 — the router's admin
+/// gate MUST override the bearer middleware's "you're authenticated"
+/// pass.  Regression pin against a refactor that drops the
+/// require_admin call.
+#[tokio::test]
+async fn list_rejects_non_admin_with_403() {
+    let (base, _store, _h) = spawn_test_server(vec![(
+        "hash-alice".to_string(),
+        sample_record("alice-key", "alice", false, false),
+    )])
+    .await;
+
+    let resp = reqwest::Client::new()
+        .get(format!("{base}/v2/auth/keys"))
+        .bearer_auth("user-token")
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(
+        resp.status().as_u16(),
+        403,
+        "authenticated non-admin must be 403 (Forbidden), not 200 or 401",
+    );
+}
+
+/// No bearer → 401 (bearer middleware catches this before the
+/// admin gate).  Pins the layering: middleware first, handler gate
+/// second.
+#[tokio::test]
+async fn list_without_bearer_returns_401() {
+    let (base, _store, _h) = spawn_test_server(vec![]).await;
+    let resp = reqwest::get(format!("{base}/v2/auth/keys"))
+        .await
+        .expect("send");
+    assert_eq!(resp.status().as_u16(), 401);
+}
+
+/// `include_revoked=false` (default) filters revoked rows out.
+#[tokio::test]
+async fn list_hides_revoked_by_default() {
+    let (base, _store, _h) = spawn_test_server(vec![
+        (
+            "hash-alive".to_string(),
+            sample_record("alive-key", "alice", false, false),
+        ),
+        (
+            "hash-dead".to_string(),
+            sample_record("dead-key", "bob", false, /* revoked */ true),
+        ),
+    ])
+    .await;
+
+    let resp: serde_json::Value = reqwest::Client::new()
+        .get(format!("{base}/v2/auth/keys"))
+        .bearer_auth("admin-token")
+        .send()
+        .await
+        .expect("send")
+        .json()
+        .await
+        .expect("json");
+    let keys = resp["keys"].as_array().unwrap();
+    assert_eq!(keys.len(), 1, "revoked row must be filtered by default");
+    assert_eq!(keys[0]["name"], "alive-key");
+}
+
+/// `include_revoked=true` surfaces revoked rows for audit.
+#[tokio::test]
+async fn list_include_revoked_true_shows_revoked() {
+    let (base, _store, _h) = spawn_test_server(vec![
+        (
+            "hash-alive".to_string(),
+            sample_record("alive-key", "alice", false, false),
+        ),
+        (
+            "hash-dead".to_string(),
+            sample_record("dead-key", "bob", false, true),
+        ),
+    ])
+    .await;
+
+    let resp: serde_json::Value = reqwest::Client::new()
+        .get(format!("{base}/v2/auth/keys?include_revoked=true"))
+        .bearer_auth("admin-token")
+        .send()
+        .await
+        .expect("send")
+        .json()
+        .await
+        .expect("json");
+    let keys = resp["keys"].as_array().unwrap();
+    assert_eq!(keys.len(), 2, "include_revoked=true must show all rows");
+}
+
+/// `is_admin=true` filter narrows to admin keys only.
+#[tokio::test]
+async fn list_filters_by_is_admin() {
+    let (base, _store, _h) = spawn_test_server(vec![
+        (
+            "hash-admin".to_string(),
+            sample_record("admin-key", "root", true, false),
+        ),
+        (
+            "hash-user".to_string(),
+            sample_record("user-key", "alice", false, false),
+        ),
+    ])
+    .await;
+
+    let resp: serde_json::Value = reqwest::Client::new()
+        .get(format!("{base}/v2/auth/keys?is_admin=true"))
+        .bearer_auth("admin-token")
+        .send()
+        .await
+        .expect("send")
+        .json()
+        .await
+        .expect("json");
+    let keys = resp["keys"].as_array().unwrap();
+    assert_eq!(keys.len(), 1);
+    assert_eq!(keys[0]["name"], "admin-key");
+}
+
+/// `subject_id=alice` narrows to that principal's keys.
+#[tokio::test]
+async fn list_filters_by_subject_id() {
+    let (base, _store, _h) = spawn_test_server(vec![
+        (
+            "hash-a1".to_string(),
+            sample_record("a1", "alice", false, false),
+        ),
+        (
+            "hash-a2".to_string(),
+            sample_record("a2", "alice", false, false),
+        ),
+        (
+            "hash-b".to_string(),
+            sample_record("b", "bob", false, false),
+        ),
+    ])
+    .await;
+
+    let resp: serde_json::Value = reqwest::Client::new()
+        .get(format!("{base}/v2/auth/keys?subject_id=alice"))
+        .bearer_auth("admin-token")
+        .send()
+        .await
+        .expect("send")
+        .json()
+        .await
+        .expect("json");
+    let keys = resp["keys"].as_array().unwrap();
+    assert_eq!(keys.len(), 2, "must include both of alice's keys");
+    for k in keys {
+        assert_eq!(k["subject_id"], "alice");
+    }
+}
+
+/// A row this build cannot decode (schema drift / corrupt bytes)
+/// is soft-skipped — the listing carries the other rows through.
+/// Regression pin against a bug where a single bad row wedges the
+/// whole listing.
+#[tokio::test]
+async fn list_soft_skips_undecodable_row() {
+    let store = Arc::new(MemStore::default());
+    // Well-formed row.
+    let good = sample_record("good", "alice", false, false)
+        .encode()
+        .unwrap();
+    store.put("hash-good", &good).unwrap();
+    // Corrupt row (not JSON).
+    store.put("hash-bad", b"\xff\xfe not-json").unwrap();
+
+    let mut state = AppState::for_tests("http://127.0.0.1:1");
+    state.auth_key_store = Arc::clone(&store) as Arc<dyn AuthKeyStore>;
+    state.auth = Arc::new(FixtureAuth);
+    let addr: std::net::SocketAddr = "127.0.0.1:0".parse().unwrap();
+    let (bound, fut) = bind_and_serve(addr, state).await.unwrap();
+    let _h = tokio::spawn(async move {
+        let _ = fut.await;
+    });
+
+    let resp: serde_json::Value = reqwest::Client::new()
+        .get(format!("http://{bound}/v2/auth/keys"))
+        .bearer_auth("admin-token")
+        .send()
+        .await
+        .expect("send")
+        .json()
+        .await
+        .expect("json");
+    let keys = resp["keys"].as_array().unwrap();
+    assert_eq!(
+        keys.len(),
+        1,
+        "one bad row must NOT wedge the listing — the good row stays visible",
+    );
+    assert_eq!(keys[0]["name"], "good");
+}
+
+// ── DELETE /v2/auth/keys/:key_hash tests ─────────────────────────
+
+/// Happy path: revoke an existing key returns 200 with existed=true;
+/// the store row is really gone.
+#[tokio::test]
+async fn revoke_existing_removes_row_and_reports_existed_true() {
+    let (base, store, _h) = spawn_test_server(vec![(
+        "hash-a".to_string(),
+        sample_record("a", "alice", false, false),
+    )])
+    .await;
+
+    let resp: serde_json::Value = reqwest::Client::new()
+        .delete(format!("{base}/v2/auth/keys/hash-a"))
+        .bearer_auth("admin-token")
+        .send()
+        .await
+        .expect("send")
+        .json()
+        .await
+        .expect("json");
+    assert_eq!(resp["existed"], true);
+    assert_eq!(resp["key_hash"], "hash-a");
+    assert!(
+        store.get("hash-a").unwrap().is_none(),
+        "store row must be really gone, not just reported as removed",
+    );
+}
+
+/// Revoke on missing hash → 200 with existed=false (idempotent).
+#[tokio::test]
+async fn revoke_missing_reports_existed_false() {
+    let (base, _store, _h) = spawn_test_server(vec![]).await;
+    let resp: serde_json::Value = reqwest::Client::new()
+        .delete(format!("{base}/v2/auth/keys/hash-nope"))
+        .bearer_auth("admin-token")
+        .send()
+        .await
+        .expect("send")
+        .json()
+        .await
+        .expect("json");
+    assert_eq!(resp["existed"], false);
+    assert_eq!(resp["key_hash"], "hash-nope");
+}
+
+/// Non-admin bearer → 403 (revoke is admin-only).
+#[tokio::test]
+async fn revoke_rejects_non_admin_with_403() {
+    let (base, store, _h) = spawn_test_server(vec![(
+        "hash-a".to_string(),
+        sample_record("a", "alice", false, false),
+    )])
+    .await;
+    let resp = reqwest::Client::new()
+        .delete(format!("{base}/v2/auth/keys/hash-a"))
+        .bearer_auth("user-token")
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(resp.status().as_u16(), 403);
+    assert!(
+        store.get("hash-a").unwrap().is_some(),
+        "denied revoke must NOT touch the store — the row must survive",
+    );
+}
+
+/// No bearer → 401 (bearer middleware). Pins the layer order:
+/// authN first (middleware), authZ second (handler admin gate).
+#[tokio::test]
+async fn revoke_without_bearer_returns_401() {
+    let (base, _store, _h) = spawn_test_server(vec![]).await;
+    let resp = reqwest::Client::new()
+        .delete(format!("{base}/v2/auth/keys/hash-x"))
+        .body(json!({}).to_string())
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(resp.status().as_u16(), 401);
+}

--- a/rust/services/http-api/tests/auth_middleware_e2e.rs
+++ b/rust/services/http-api/tests/auth_middleware_e2e.rs
@@ -192,6 +192,11 @@ impl Harness {
         let state = AppState {
             search: SearchBackend::new(grpc_target),
             auth,
+            // Empty in-memory `AuthKeyStore` — this middleware
+            // suite never hits `/v2/auth/keys`, so any store is fine.
+            auth_key_store: std::sync::Arc::new(
+                nexus_http_api::middleware::auth::empty_auth_key_store_for_tests(),
+            ),
             // Under `--features rebac` (nexusd's `full` build path
             // exercises this harness transitively via CI), AppState
             // gains a `rebac_store` field.  Use the same in-memory

--- a/rust/services/http-api/tests/serve_e2e.rs
+++ b/rust/services/http-api/tests/serve_e2e.rs
@@ -110,6 +110,9 @@ async fn service_decl_install_body_runs_under_a_tokio_runtime() {
         "http://127.0.0.1:1".to_string(),
         default_no_auth_provider(),
         handle,
+        // Empty in-memory `AuthKeyStore` — this test hits only
+        // `/v2/status`, so any store is fine.
+        std::sync::Arc::new(nexus_http_api::middleware::auth::empty_auth_key_store_for_tests()),
         // The `--features rebac` build widens `install_impl` with a
         // tuple-store arg — use the same in-memory default the
         // `AppState::for_tests` helper wires (this test never hits
@@ -152,6 +155,7 @@ async fn service_decl_install_body_returns_err_on_bind_failure() {
         "http://127.0.0.1:1".to_string(),
         default_no_auth_provider(),
         handle.clone(),
+        std::sync::Arc::new(nexus_http_api::middleware::auth::empty_auth_key_store_for_tests()),
         #[cfg(feature = "rebac")]
         std::sync::Arc::new(nexus_rebac::InMemoryReBACTupleStore::new()),
     );
@@ -164,6 +168,7 @@ async fn service_decl_install_body_returns_err_on_bind_failure() {
         "http://127.0.0.1:1".to_string(),
         default_no_auth_provider(),
         handle,
+        std::sync::Arc::new(nexus_http_api::middleware::auth::empty_auth_key_store_for_tests()),
         #[cfg(feature = "rebac")]
         std::sync::Arc::new(nexus_rebac::InMemoryReBACTupleStore::new()),
     );


### PR DESCRIPTION
## Summary

Ports the read+revoke half of Python nexus-server's \`/api/v2/auth/keys\` router (\`src/nexus/server/api/v2/routers/auth_keys.py\`) to Rust. Handlers read the same \`RaftAuthKeyStore\` the kernel's gRPC bearer-auth path already resolves against (**one SSOT, two surfaces**), via \`kernel.auth_key_store()\` at http-api install time.

## Endpoints

- \`GET  /v2/auth/keys\` — list every credential record; optional filters (\`subject_type=\`, \`subject_id=\`, \`is_admin=\`, \`include_revoked=\`). Wire shape mirrors Python's \`list_keys\` 1:1 so ops scripts scraping \`/api/v2/auth/keys\` work unchanged on the Rust endpoint.
- \`DELETE /v2/auth/keys/:key_hash\` — revoke by hash (audit view exposes hashes; caller who knows a \`key_id\` looks up the hash via GET first). Idempotent; returns \`existed\` flag.

## What this PR does NOT do

**No mint (POST).** Mint requires the API-key HMAC secret, which isn't yet on \`ServiceBootCtx\`. Follow-up: upstream widen \`ServiceBootCtx\` with \`api_key_secret: Option<Arc<str>>\` (same pattern as \`credential_consensus\` in #259), then land POST in a second PR calling \`auth::mint_key(store, secret, record, allow_existing)\`.

## Auth posture

- **Bearer required** — routes slot under the same \`require_bearer\` middleware as \`/v2/search/*\`.
- **Admin-only** — the handler additionally calls \`require_admin(ctx)\` and returns \`403\` for a non-admin bearer. Matches Python's \`Depends(require_admin)\`.

The gRPC \`KeyMinter\` path uses an mTLS node-cert gate (\`gate_node_caller\`); HTTP has no mTLS cert, so admin-bearer substitutes.

## Design decisions

- **\`AppState\` widening via \`for_tests\` struct-update.** The new \`auth_key_store\` field lands in \`AppState\`; existing tests use \`..AppState::for_tests(target)\` so future additive fields flow through without touching every test.
- **\`empty_auth_key_store_for_tests\` helper.** Named + doc'd so a reviewer sees why it's public (bind-only regression tests + the \`for_tests\` seed). Never used in production.
- **\`install_impl\` signature widened uniformly.** The auth-key store is REQUIRED (kernel always has one, even under \`--no-tls\` where it's bound over \`root\`). No cfg-gate on this field.
- **Soft-skip undecodable rows.** One bad row does not wedge the whole listing — matches the mint layer's own \`find_active_subject\` posture. Regression pin included.

## Test plan

- [x] \`cargo test -p nexus-http-api\` → 65 tests pass (12 new + 53 prior)
- [x] \`cargo test -p nexus-http-api --features rebac\` → clean
- [x] Build sweep: default / http-api / rebac / http-api,rebac / full — all clean
- [x] \`cargo clippy\` clean on all combos
- [x] \`cargo fmt --check\` clean
- [ ] CI green

12 new \`auth_keys_e2e.rs\` tests:

* list happy path (admin sees seeded rows)
* list rejects non-admin (403), no bearer (401)
* \`include_revoked\` default hides / opt-in shows
* \`is_admin=true\` and \`subject_id=X\` filters narrow correctly
* list soft-skips undecodable rows
* revoke removes row + reports \`existed=true\`
* revoke missing → \`existed=false\` (idempotent)
* revoke rejects non-admin (403) + no bearer (401)