### PR TITLE
fix(storage): log dropped-event BEFORE bumping total_failed counter (Py3.14 flake)

### DIFF
--- a/src/nexus/storage/piped_record_store_write_observer.py
+++ b/src/nexus/storage/piped_record_store_write_observer.py
@@ -566,9 +566,16 @@ class RecordStoreWriteObserver:
                     self._flush_batch_sync([event])
                     salvaged.append(event)
                 except Exception as event_err:
-                    self._total_failed += 1
-                    io_metrics.record_projection_failed(1)
                     first_error = first_error or event_err
+                    # Emit the ERROR log BEFORE bumping the counter so a
+                    # caller polling ``metrics["total_failed"]`` observes a
+                    # consistent "log-fired AND counter-went-up" state.
+                    # Prior order (counter first, log second) let a poller
+                    # win the race between the two — the counter said "1
+                    # dropped" but ``caplog.records`` was still empty by
+                    # the time the polling loop exited, flaking
+                    # ``test_async_commit_failure_is_logged_and_counted_not_raised``
+                    # on Py3.14 CI + reproducible ~40% locally.
                     logger.error(
                         "RecordStoreWriteObserver dropping audit event: op=%s path=%s error=%s — %s",
                         event.get("op"),
@@ -576,6 +583,8 @@ class RecordStoreWriteObserver:
                         event_err,
                         _RECONCILE_HINT,
                     )
+                    self._total_failed += 1
+                    io_metrics.record_projection_failed(1)
             ticket.finish(first_error)
         if salvaged:
             self._after_commit(salvaged)


### PR DESCRIPTION
## Summary

Fixes the Py3.14 CI flake in \`tests/unit/storage/test_piped_write_observer_async_mode.py::test_async_commit_failure_is_logged_and_counted_not_raised\`.

Observed on:
- nexi-lab/nexus#4754 pre-merge — \`assert False\` on \`any(\"dropping audit event\" in r.getMessage() ...)\`
- nexi-lab/nexus#4731 post-merge — 30-min timeout in Py3.14 unit tests (may be the same test hanging its xdist worker)

Reproducible locally at ~40% (5 stress runs → 2 failed with the same assertion) even though the production code is behaviourally correct.

## Root cause

Race between counter bump and log emission in \`_salvage_tickets\`:

\`\`\`python
except Exception as event_err:
    self._total_failed += 1          # ← counter goes up
    io_metrics.record_projection_failed(1)
    first_error = first_error or event_err
    logger.error(...)                # ← log emitted AFTER
\`\`\`

The test's assertion:
1. Poll \`metrics[\"total_failed\"] >= 1\` (with 2s deadline)
2. Assert an ERROR log containing \"dropping audit event\" is in \`caplog.records\`

The polling loop can exit BETWEEN the counter bump and the \`logger.error\` call — under CI load the observable state at that moment is \"counter says 1, caplog empty\", and the assertion fails.

## Fix

Reorder the fail path so **log fires FIRST, then counter goes up**. Establishes the invariant:

> A caller observing \`metrics[\"total_failed\"] >= N\` has SEEN the logs for the first N drops in \`caplog.records\`.

Behaviour otherwise unchanged — the reorder is observable only to a caller poking at BOTH metrics AND caplog at the same instant (i.e. this test).

## Test plan

- [x] Fix applied to \`src/nexus/storage/piped_record_store_write_observer.py\` (11 line diff, most of it a docstring pinning the invariant)
- [x] Local stress: 5/5 pass after fix (was ~2/5 pre-fix, on Windows Py3.14 with \`-n auto\`)
- [x] Full file: 13/13 pass
- [ ] CI green (especially Test Python 3.14 on ubuntu-latest + macos-latest)

## Not this PR

- The 30-min Py3.14 test-suite timeout observed on nexus#4731 post-merge may be a downstream symptom of the same test hanging its xdist worker when \`time.sleep\` is monkey-patched + a retry loop spins. If that flake persists after this fix, investigate separately (search for other tests that monkey-patch \`mod.time.sleep\`).
- \`_total_retries\` has the same counter-before-log shape but no test polls it — leaving it alone to keep the diff minimal.