### PR TITLE
feat(http-api): /v2/auth/keys POST mint (R10 arc)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "a2a"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=b5b969a060c322835be67ff9b1e6e02f7c97abd1#b5b969a060c322835be67ff9b1e6e02f7c97abd1"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5806c39d471928caabd098c121db85cf8bfa679d#5806c39d471928caabd098c121db85cf8bfa679d"
 dependencies = [
  "contracts",
  "kernel",
@@ -233,8 +233,8 @@ checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "api"
-version = "0.2.0"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=69328d3e081e23801a85d022b292c01fe6f184c5#69328d3e081e23801a85d022b292c01fe6f184c5"
+version = "0.2.2"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=d742e04416121990041d01eda027e90b63d536a3#d742e04416121990041d01eda027e90b63d536a3"
 dependencies = [
  "base64 0.22.1",
  "httpdate",
@@ -327,7 +327,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 [[package]]
 name = "auth"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=b5b969a060c322835be67ff9b1e6e02f7c97abd1#b5b969a060c322835be67ff9b1e6e02f7c97abd1"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5806c39d471928caabd098c121db85cf8bfa679d#5806c39d471928caabd098c121db85cf8bfa679d"
 dependencies = [
  "contracts",
  "dashmap",
@@ -430,7 +430,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=b5b969a060c322835be67ff9b1e6e02f7c97abd1#b5b969a060c322835be67ff9b1e6e02f7c97abd1"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5806c39d471928caabd098c121db85cf8bfa679d#5806c39d471928caabd098c121db85cf8bfa679d"
 dependencies = [
  "ahash",
  "base64 0.22.1",
@@ -847,8 +847,8 @@ dependencies = [
 
 [[package]]
 name = "commands"
-version = "0.2.0"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=69328d3e081e23801a85d022b292c01fe6f184c5#69328d3e081e23801a85d022b292c01fe6f184c5"
+version = "0.2.2"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=d742e04416121990041d01eda027e90b63d536a3#d742e04416121990041d01eda027e90b63d536a3"
 dependencies = [
  "plugins",
  "runtime",
@@ -917,7 +917,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=b5b969a060c322835be67ff9b1e6e02f7c97abd1#b5b969a060c322835be67ff9b1e6e02f7c97abd1"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5806c39d471928caabd098c121db85cf8bfa679d#5806c39d471928caabd098c121db85cf8bfa679d"
 dependencies = [
  "parking_lot",
  "serde",
@@ -2540,7 +2540,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=b5b969a060c322835be67ff9b1e6e02f7c97abd1#b5b969a060c322835be67ff9b1e6e02f7c97abd1"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5806c39d471928caabd098c121db85cf8bfa679d#5806c39d471928caabd098c121db85cf8bfa679d"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -2608,7 +2608,7 @@ checksum = "0c2cdeb66e45e9f36bfad5bbdb4d2384e70936afbee843c6f6543f0c551ebb25"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=b5b969a060c322835be67ff9b1e6e02f7c97abd1#b5b969a060c322835be67ff9b1e6e02f7c97abd1"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5806c39d471928caabd098c121db85cf8bfa679d#5806c39d471928caabd098c121db85cf8bfa679d"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -2813,7 +2813,7 @@ checksum = "fc04a4c58212d57930a24bf47d3fa87485264a3a054e9c10e042eb373573ad3c"
 [[package]]
 name = "managed-agent"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=b5b969a060c322835be67ff9b1e6e02f7c97abd1#b5b969a060c322835be67ff9b1e6e02f7c97abd1"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5806c39d471928caabd098c121db85cf8bfa679d#5806c39d471928caabd098c121db85cf8bfa679d"
 dependencies = [
  "a2a",
  "contracts",
@@ -3008,7 +3008,7 @@ dependencies = [
 [[package]]
 name = "nexus-cluster"
 version = "0.1.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=b5b969a060c322835be67ff9b1e6e02f7c97abd1#b5b969a060c322835be67ff9b1e6e02f7c97abd1"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5806c39d471928caabd098c121db85cf8bfa679d#5806c39d471928caabd098c121db85cf8bfa679d"
 dependencies = [
  "a2a",
  "anyhow",
@@ -3090,7 +3090,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=b5b969a060c322835be67ff9b1e6e02f7c97abd1#b5b969a060c322835be67ff9b1e6e02f7c97abd1"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5806c39d471928caabd098c121db85cf8bfa679d#5806c39d471928caabd098c121db85cf8bfa679d"
 
 [[package]]
 name = "nexus-rebac"
@@ -3162,8 +3162,8 @@ dependencies = [
 
 [[package]]
 name = "nexus-vfs-client"
-version = "0.2.0"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=69328d3e081e23801a85d022b292c01fe6f184c5#69328d3e081e23801a85d022b292c01fe6f184c5"
+version = "0.2.2"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=d742e04416121990041d01eda027e90b63d536a3#d742e04416121990041d01eda027e90b63d536a3"
 dependencies = [
  "prost 0.13.5",
  "protoc-bin-vendored",
@@ -3621,8 +3621,8 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plugins"
-version = "0.2.0"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=69328d3e081e23801a85d022b292c01fe6f184c5#69328d3e081e23801a85d022b292c01fe6f184c5"
+version = "0.2.2"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=d742e04416121990041d01eda027e90b63d536a3#d742e04416121990041d01eda027e90b63d536a3"
 dependencies = [
  "serde",
  "serde_json",
@@ -4036,7 +4036,7 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 [[package]]
 name = "raft"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=b5b969a060c322835be67ff9b1e6e02f7c97abd1#b5b969a060c322835be67ff9b1e6e02f7c97abd1"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5806c39d471928caabd098c121db85cf8bfa679d#5806c39d471928caabd098c121db85cf8bfa679d"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -4465,8 +4465,8 @@ dependencies = [
 
 [[package]]
 name = "runtime"
-version = "0.2.0"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=69328d3e081e23801a85d022b292c01fe6f184c5#69328d3e081e23801a85d022b292c01fe6f184c5"
+version = "0.2.2"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=d742e04416121990041d01eda027e90b63d536a3#d742e04416121990041d01eda027e90b63d536a3"
 dependencies = [
  "a2a",
  "agent-client-protocol",
@@ -5166,7 +5166,7 @@ dependencies = [
 [[package]]
 name = "subprocess"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=b5b969a060c322835be67ff9b1e6e02f7c97abd1#b5b969a060c322835be67ff9b1e6e02f7c97abd1"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5806c39d471928caabd098c121db85cf8bfa679d#5806c39d471928caabd098c121db85cf8bfa679d"
 dependencies = [
  "kernel",
  "libc",
@@ -5384,8 +5384,8 @@ dependencies = [
 
 [[package]]
 name = "telemetry"
-version = "0.2.0"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=69328d3e081e23801a85d022b292c01fe6f184c5#69328d3e081e23801a85d022b292c01fe6f184c5"
+version = "0.2.2"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=d742e04416121990041d01eda027e90b63d536a3#d742e04416121990041d01eda027e90b63d536a3"
 dependencies = [
  "chrono",
  "dirs",
@@ -5776,8 +5776,8 @@ dependencies = [
 
 [[package]]
 name = "tools"
-version = "0.2.0"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=69328d3e081e23801a85d022b292c01fe6f184c5#69328d3e081e23801a85d022b292c01fe6f184c5"
+version = "0.2.2"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=d742e04416121990041d01eda027e90b63d536a3#d742e04416121990041d01eda027e90b63d536a3"
 dependencies = [
  "api",
  "async-trait",
@@ -5922,7 +5922,7 @@ dependencies = [
 [[package]]
 name = "transport"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=b5b969a060c322835be67ff9b1e6e02f7c97abd1#b5b969a060c322835be67ff9b1e6e02f7c97abd1"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5806c39d471928caabd098c121db85cf8bfa679d#5806c39d471928caabd098c121db85cf8bfa679d"
 dependencies = [
  "axum",
  "backends",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -236,30 +236,30 @@ exclude = ["nexus-fuse"]
 #
 # Bump alongside the rest of nexus-vfs updates when a downstream
 # change needs newer kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "b5b969a060c322835be67ff9b1e6e02f7c97abd1" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "b5b969a060c322835be67ff9b1e6e02f7c97abd1" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "b5b969a060c322835be67ff9b1e6e02f7c97abd1" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "b5b969a060c322835be67ff9b1e6e02f7c97abd1", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "b5b969a060c322835be67ff9b1e6e02f7c97abd1", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "b5b969a060c322835be67ff9b1e6e02f7c97abd1", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "b5b969a060c322835be67ff9b1e6e02f7c97abd1" }
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5806c39d471928caabd098c121db85cf8bfa679d" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5806c39d471928caabd098c121db85cf8bfa679d" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5806c39d471928caabd098c121db85cf8bfa679d" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5806c39d471928caabd098c121db85cf8bfa679d", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5806c39d471928caabd098c121db85cf8bfa679d", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5806c39d471928caabd098c121db85cf8bfa679d", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5806c39d471928caabd098c121db85cf8bfa679d" }
 # The cluster daemon library entry (`nexus_cluster::run_with_services`),
 # consumed by the nexus-side assembly binary (`rust/nexusd`) that composes
 # the kernel/federation boot with the nexus service set via the
 # ServiceRegistry bring-up seam.
-nexus-cluster = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "b5b969a060c322835be67ff9b1e6e02f7c97abd1" }
+nexus-cluster = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5806c39d471928caabd098c121db85cf8bfa679d" }
 # a2a messaging substrate. `default-features = false` leaves the
 # `install` feature (which pulls raft to arm the stream-wakeup observer)
 # OFF, so nexus-side consumers link only the stamp hook and stay
 # raft-free — they reach raft through kernel.sys_* (§6.1). The substrate
 # is armed in production at cluster boot in nexus-vfs, not here.
-a2a = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "b5b969a060c322835be67ff9b1e6e02f7c97abd1", default-features = false }
+a2a = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5806c39d471928caabd098c121db85cf8bfa679d", default-features = false }
 # managed-agent control plane + the shared subprocess host — RELOCATED into
 # nexus-vfs (kernel-tier) so the production nexusd-cluster carries the agent
 # control plane. `subprocess-host` enables the raw ACP-subprocess spawner (the
 # nexus-side acp path + managed-agent both use HostedSubprocess).
-managed-agent = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "b5b969a060c322835be67ff9b1e6e02f7c97abd1", default-features = false }
-subprocess = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "b5b969a060c322835be67ff9b1e6e02f7c97abd1" }
+managed-agent = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5806c39d471928caabd098c121db85cf8bfa679d", default-features = false }
+subprocess = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5806c39d471928caabd098c121db85cf8bfa679d" }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir --no-deps --prefix=/install .
 # enforces agreement) — an unpinned install tracks nexus-vfs HEAD and
 # ships an untested kernel (#4343). --locked honors the source tree's
 # Cargo.lock.
-ARG NEXUS_VFS_REV=b5b969a060c322835be67ff9b1e6e02f7c97abd1
+ARG NEXUS_VFS_REV=5806c39d471928caabd098c121db85cf8bfa679d
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-cluster nexus-cluster
 
 # -- Runtime stage --

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -25,7 +25,7 @@ WORKDIR /build
 # (CI preflight enforces agreement) — an unpinned install tracks HEAD
 # and can skew the raft contract against the cluster/witness images.
 # --locked honors the source tree's Cargo.lock.
-ARG NEXUS_VFS_REV=b5b969a060c322835be67ff9b1e6e02f7c97abd1
+ARG NEXUS_VFS_REV=5806c39d471928caabd098c121db85cf8bfa679d
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexus-raft-server raft
 
 # ---------- Production image ----------

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=b5b969a060c322835be67ff9b1e6e02f7c97abd1
+ARG NEXUS_VFS_REV=5806c39d471928caabd098c121db85cf8bfa679d
 RUN cargo install \
     --locked \
     --git https://github.com/nexi-lab/nexus-vfs \

--- a/rust/nexusd/Cargo.toml
+++ b/rust/nexusd/Cargo.toml
@@ -101,7 +101,7 @@ anyhow = "1"
 # nexus-side co-host glue and no runtime enum to map (the adapter reports
 # `kernel::AgentState` directly). Pinned to sudocode main (spawn AgentState
 # collapse).
-sudocode-tools = { package = "tools", git = "https://github.com/sudoprivacy/sudocode", rev = "69328d3e081e23801a85d022b292c01fe6f184c5", optional = true }
+sudocode-tools = { package = "tools", git = "https://github.com/sudoprivacy/sudocode", rev = "d742e04416121990041d01eda027e90b63d536a3", optional = true }
 # Named directly to spell `kernel::kernel::{ServiceDecl, Kernel}` — the
 # managed-agent boot decl's return type (both builds) and the co-host
 # adapter's `SpawnTask<Kernel>` (cohost build). Already present transitively

--- a/rust/nexusd/src/main.rs
+++ b/rust/nexusd/src/main.rs
@@ -211,6 +211,7 @@ fn http_api_decl_from(
         cfg.upstream_grpc.clone(),
         Arc::clone(&ctx.auth),
         ctx.runtime.clone(),
+        ctx.api_key_secret.as_deref().map(Arc::<str>::from),
     ))
 }
 
@@ -236,6 +237,7 @@ fn http_api_decl_from(
         cfg.upstream_grpc.clone(),
         Arc::clone(&ctx.auth),
         ctx.runtime.clone(),
+        ctx.api_key_secret.as_deref().map(Arc::<str>::from),
         rebac_store,
     ))
 }

--- a/rust/services/http-api/Cargo.toml
+++ b/rust/services/http-api/Cargo.toml
@@ -42,7 +42,7 @@ dashmap = "6.1"
 # reads /v2/auth/keys on Rust unchanged).  Pinned to the same
 # nexus-vfs rev the workspace does (no `auth` workspace-dep entry
 # yet — the `kernel` + `transport` neighbors are the precedent).
-auth = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "b5b969a060c322835be67ff9b1e6e02f7c97abd1" }
+auth = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5806c39d471928caabd098c121db85cf8bfa679d" }
 
 # Bearer-token → `OperationContext` SSOT.
 #

--- a/rust/services/http-api/src/handlers/auth.rs
+++ b/rust/services/http-api/src/handlers/auth.rs
@@ -73,6 +73,21 @@ pub enum AuthKeysError {
     /// serving.  Preserves the store's message for the operator log.
     #[error("auth-key store backend error: {0}")]
     Backend(String),
+
+    /// POST-body validation error surfaced by the mint layer (invalid
+    /// zone grant syntax, subject-type not one of user/service,
+    /// zoneless non-admin key, subject already holds a key + no
+    /// `allow_existing`, unknown `subject_type`, etc.).  Maps to 400.
+    /// The mint layer's message names the exact problem.
+    #[error("mint request rejected: {0}")]
+    BadRequest(String),
+
+    /// The daemon was booted `--no-tls` and there is no sk- HMAC
+    /// secret to sign a new key with.  Maps to 503 — a valid request
+    /// against a valid endpoint, but the plane is not up.  Matches
+    /// the gRPC `MintKey` posture ("returns success=false").
+    #[error("mint unavailable: this daemon was booted without API-key auth (--no-tls)")]
+    Unavailable,
 }
 
 impl From<AuthKeyStoreError> for AuthKeysError {
@@ -91,6 +106,8 @@ impl IntoResponse for AuthKeysError {
         let status = match &self {
             Self::Forbidden => StatusCode::FORBIDDEN,
             Self::Backend(_) => StatusCode::BAD_GATEWAY,
+            Self::BadRequest(_) => StatusCode::BAD_REQUEST,
+            Self::Unavailable => StatusCode::SERVICE_UNAVAILABLE,
         };
         (status, self.to_string()).into_response()
     }
@@ -299,11 +316,225 @@ pub async fn revoke(
     Ok(Json(RevokeResponse { existed, key_hash }))
 }
 
+// ── POST /v2/auth/keys (mint) ────────────────────────────────────
+
+/// JSON body for `POST /v2/auth/keys` — mint a fresh sk- key.
+///
+/// Field-shape mirrors Python nexus-server's `CreateKeyRequest`
+/// closely; a few Python-only fields (grants → ReBAC tuples,
+/// expires_days) are trimmed for a first cut and follow up.  In
+/// particular:
+///
+/// * `zones` — list of `"<zone_id>:<perms>"` strings (e.g. `"root:rwx"`).
+///   The mint layer parses them; an empty list is refused UNLESS
+///   `admin: true` (the only kind of principal allowed a zoneless
+///   key).
+/// * `expires_at_ms` — absolute ms-since-epoch cutoff; `0` / absent
+///   ⇒ never expires.  (Python uses `expires_days` relative; the
+///   Rust API takes absolute to avoid clock-drift ambiguity at the
+///   admin edge — an operator computes `now_ms + days*86400_000`.)
+/// * `allow_existing` — rotation escape.  Off by default; on when
+///   the caller is deliberately issuing a second key for an
+///   already-credentialed subject (rotation).
+#[derive(Debug, Clone, Deserialize)]
+pub struct MintBody {
+    /// Human label ("mac-ai laptop", "ci runner").  Optional; empty
+    /// string is preserved as the record's `name`.
+    #[serde(default)]
+    pub name: String,
+    /// `"user"` | `"service"`.  `"agent"` uses a separate mint plane
+    /// (agent identities are cert-anchored, not sk-token-anchored).
+    pub subject_type: String,
+    pub subject_id: String,
+    /// Zone grants as `"<zone_id>:<perms>"` strings.  Empty unless
+    /// `admin=true`.
+    #[serde(default)]
+    pub zones: Vec<String>,
+    /// Global admin flag.  Only zoneless keys are admin.
+    #[serde(default)]
+    pub admin: bool,
+    /// Absolute ms-since-epoch cutoff; `0` / absent ⇒ never expires.
+    #[serde(default)]
+    pub expires_at_ms: u64,
+    /// Rotation escape.
+    #[serde(default)]
+    pub allow_existing: bool,
+}
+
+/// Response body for [`mint`].  `key` is the one-time plaintext
+/// credential the caller MUST persist immediately — the daemon
+/// only stores its HMAC.  Response shape mirrors Python
+/// nexus-server's `create_key` return.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MintResponse {
+    /// One-time plaintext credential.  Present ONLY in the mint
+    /// response; never resurfaceable from the store afterwards.
+    pub key: String,
+    /// HMAC store key — the caller can revoke by this hash later.
+    pub key_hash: String,
+    /// Stable id for logs + audit tooling.
+    pub key_id: String,
+    /// Echo of the record (same shape as `list` entries; convenient
+    /// for a client that wants a single round-trip mint→display).
+    pub record: AuthKeyView,
+}
+
+/// Handler for `POST /v2/auth/keys` — mint a fresh sk- key.
+pub async fn mint(
+    State(state): State<AppState>,
+    Extension(ctx): Extension<OperationContext>,
+    Json(body): Json<MintBody>,
+) -> Result<Json<MintResponse>, AuthKeysError> {
+    require_admin(&ctx)?;
+
+    // Fail-loud when the daemon has no HMAC secret — matches the
+    // gRPC `MintKey` posture (returns success=false under NoAuth).
+    let secret = state
+        .api_key_secret
+        .as_ref()
+        .ok_or(AuthKeysError::Unavailable)?
+        .clone();
+    let store = Arc::clone(&state.auth_key_store);
+
+    // Parse + validate + mint on a blocking thread — `auth::mint_key`
+    // does a full `store.list()` scan for the uniqueness check + a
+    // `store.put` (both blocking on the raft layer).  Errors from
+    // parse (bad zone-grant syntax, unknown subject_type, empty
+    // zone list on a non-admin key) come back as `BadRequest`;
+    // storage failures come back as `Backend`.  The subject-already-
+    // holds-a-key case surfaces from `mint_key` as `Backend(msg)` —
+    // we peek the message to reclassify it to `BadRequest`, matching
+    // Python's 400 shape.
+    let minted = tokio::task::spawn_blocking(move || {
+        let record = build_record(&body).map_err(AuthKeysError::BadRequest)?;
+        auth::mint::mint_key(&store, &secret, record, body.allow_existing).map_err(|e| {
+            let msg = e.to_string();
+            // The mint layer's uniqueness rejection is a `Backend`
+            // variant carrying a message that starts with "subject
+            // ... already has an active key" — reclassify to 400
+            // (client input error, not a backend fault).
+            if msg.contains("already has an active key") {
+                AuthKeysError::BadRequest(msg)
+            } else {
+                AuthKeysError::from(e)
+            }
+        })
+    })
+    .await
+    .map_err(|e| AuthKeysError::Backend(format!("mint task panicked: {e}")))??;
+
+    let view = AuthKeyView::from_row(
+        minted.key_hash.clone(),
+        &minted.record.encode().map_err(|e| {
+            AuthKeysError::Backend(format!("encode fresh record for response: {e}"))
+        })?,
+    )
+    .ok_or_else(|| {
+        AuthKeysError::Backend(
+            "decoded-just-encoded record failed — schema roundtrip broken".to_string(),
+        )
+    })?;
+    Ok(Json(MintResponse {
+        key: minted.key,
+        key_hash: minted.key_hash,
+        key_id: minted.record.key_id,
+        record: view,
+    }))
+}
+
+/// Compose an `AuthKeyRecord` from the request body.  Owns:
+///
+///   * subject-type parsing (rejects `agent` — separate plane)
+///   * zone-grant syntax parsing (`"zone_id:perms"`)
+///   * zoneless-admin-only invariant
+///   * `key_id` synthesis (uuid v4-ish; delegated to `auth`'s helper
+///     if any, else a random hex string)
+///
+/// Errors are `String`s — the caller wraps them in
+/// `AuthKeysError::BadRequest`.
+fn build_record(body: &MintBody) -> Result<AuthKeyRecord, String> {
+    let subject_type = match body.subject_type.as_str() {
+        "user" => SubjectType::User,
+        "service" => SubjectType::Service,
+        "agent" => {
+            return Err(
+                "subject_type='agent' uses the cert-anchored mint plane, not sk-".to_string(),
+            )
+        }
+        other => {
+            return Err(format!(
+                "unknown subject_type={other:?} (allowed: user, service)"
+            ))
+        }
+    };
+    let zone_perms: Vec<(String, String)> = body
+        .zones
+        .iter()
+        .map(|z| {
+            z.split_once(':')
+                .map(|(zone, perms)| (zone.to_string(), perms.to_string()))
+                .ok_or_else(|| {
+                    format!(
+                        "zone grant {z:?} malformed — expected \"<zone_id>:<perms>\" \
+                         (e.g. \"root:rwx\")"
+                    )
+                })
+        })
+        .collect::<Result<_, _>>()?;
+    if zone_perms.is_empty() && !body.admin {
+        return Err(
+            "a key with no zone grants reaches nothing and is refused at authentication \
+             time.  Pass zones=[\"<zone>:<perms>\"], or admin=true for a global admin \
+             (the only principal allowed a zoneless key)."
+                .to_string(),
+        );
+    }
+    let expires_at_ms = if body.expires_at_ms == 0 {
+        None
+    } else {
+        Some(body.expires_at_ms)
+    };
+    Ok(AuthKeyRecord {
+        // Composed inline here — the `auth` crate's helper
+        // (`build_sk_record`) lives in `nexus-vfs/rust/profiles/
+        // cluster/src/lib.rs` alongside `DaemonKeyMinter` and is
+        // not `pub`; keep the record synthesis local to this
+        // handler until upstream ships a shared helper.
+        key_id: generate_key_id(),
+        name: body.name.clone(),
+        subject_type,
+        subject_id: body.subject_id.clone(),
+        is_admin: body.admin,
+        revoked: false,
+        expires_at_ms,
+        zone_perms,
+    })
+}
+
+/// Stable audit-log id for a fresh sk- record.  Not a secret; the
+/// mint layer's HMAC is what carries entropy — this id is a log
+/// handle only.  Uses `SystemTime::now()` nanoseconds + a process-
+/// local monotonically-increasing counter to avoid a `uuid` or
+/// `rand`/`getrandom` dep just for this one call site.  Collisions
+/// are effectively impossible: two calls in the same nanosecond
+/// still differ on the counter.
+fn generate_key_id() -> String {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::time::{SystemTime, UNIX_EPOCH};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos() as u64)
+        .unwrap_or(0);
+    let counter = COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("kid-{nanos:x}{counter:x}")
+}
+
 // ── Router ────────────────────────────────────────────────────────
 
 pub fn router() -> Router<AppState> {
     Router::new()
-        .route("/v2/auth/keys", get(list))
+        .route("/v2/auth/keys", get(list).post(mint))
         .route("/v2/auth/keys/{key_hash}", delete(revoke))
 }
 

--- a/rust/services/http-api/src/lib.rs
+++ b/rust/services/http-api/src/lib.rs
@@ -91,6 +91,15 @@ pub struct AppState {
     /// (via `kernel.auth_key_store()` at install time).  One SSOT,
     /// two surfaces (gRPC + HTTP).
     pub auth_key_store: Arc<dyn kernel::hal::auth_key_store::AuthKeyStore>,
+    /// The daemon's HMAC secret for sk- key material — `Some(_)`
+    /// under API-key auth, `None` under `--no-tls` (mint returns
+    /// 503).  Threaded from `ServiceBootCtx.api_key_secret` (the
+    /// same secret `DaemonKeyMinter` uses on the gRPC side) so the
+    /// HTTP mint plane hashes with the identical secret.  Never
+    /// exposed in logs / Debug output — the mint layer's own
+    /// `auth::mint::mint_key` takes it as `&str` and consumes it
+    /// only for HMAC.
+    pub api_key_secret: Option<Arc<str>>,
     /// The kernel-adjacent ReBAC tuple store — grant / list / revoke
     /// backend for `/v2/rebac/tuples`.  Present iff this crate was
     /// built `--features rebac`; the composition root in `nexusd`
@@ -126,6 +135,8 @@ impl AppState {
             // real composition root pulls the raft-backed store from
             // `kernel.auth_key_store()` at install time.
             auth_key_store: Arc::new(middleware::auth::empty_auth_key_store_for_tests()),
+            // No secret by default — mint tests set it explicitly.
+            api_key_secret: None,
             #[cfg(feature = "rebac")]
             rebac_store: Arc::new(nexus_rebac::InMemoryReBACTupleStore::new()),
         }
@@ -273,12 +284,20 @@ pub fn service_decl(
     upstream_grpc: String,
     auth: Arc<dyn AuthProvider>,
     runtime: tokio::runtime::Handle,
+    api_key_secret: Option<Arc<str>>,
 ) -> kernel::kernel::ServiceDecl {
     kernel::kernel::ServiceDecl {
         name: "http_api".to_string(),
         install: Box::new(move |kernel| {
             let auth_key_store = kernel.auth_key_store();
-            install_impl(addr, upstream_grpc, auth, runtime, auth_key_store)
+            install_impl(
+                addr,
+                upstream_grpc,
+                auth,
+                runtime,
+                auth_key_store,
+                api_key_secret,
+            )
         }),
     }
 }
@@ -295,6 +314,7 @@ pub fn service_decl(
     upstream_grpc: String,
     auth: Arc<dyn AuthProvider>,
     runtime: tokio::runtime::Handle,
+    api_key_secret: Option<Arc<str>>,
     rebac_store: Arc<dyn nexus_rebac::ReBACTupleStore>,
 ) -> kernel::kernel::ServiceDecl {
     kernel::kernel::ServiceDecl {
@@ -307,6 +327,7 @@ pub fn service_decl(
                 auth,
                 runtime,
                 auth_key_store,
+                api_key_secret,
                 rebac_store,
             )
         }),
@@ -330,12 +351,14 @@ pub fn install_impl(
     auth: Arc<dyn AuthProvider>,
     runtime: tokio::runtime::Handle,
     auth_key_store: Arc<dyn kernel::hal::auth_key_store::AuthKeyStore>,
+    api_key_secret: Option<Arc<str>>,
     #[cfg(feature = "rebac")] rebac_store: Arc<dyn nexus_rebac::ReBACTupleStore>,
 ) -> Result<(), String> {
     let state = AppState {
         search: SearchBackend::new(upstream_grpc),
         auth,
         auth_key_store,
+        api_key_secret,
         #[cfg(feature = "rebac")]
         rebac_store,
     };

--- a/rust/services/http-api/tests/auth_keys_e2e.rs
+++ b/rust/services/http-api/tests/auth_keys_e2e.rs
@@ -99,6 +99,15 @@ fn sample_record(name: &str, subject_id: &str, admin: bool, revoked: bool) -> Au
 async fn spawn_test_server(
     seed: Vec<(String, AuthKeyRecord)>,
 ) -> (String, Arc<MemStore>, tokio::task::JoinHandle<()>) {
+    spawn_test_server_with_secret(seed, None).await
+}
+
+/// Variant with an explicit HMAC secret — mint tests need one.  A
+/// server built with `None` returns 503 from POST /v2/auth/keys.
+async fn spawn_test_server_with_secret(
+    seed: Vec<(String, AuthKeyRecord)>,
+    secret: Option<&str>,
+) -> (String, Arc<MemStore>, tokio::task::JoinHandle<()>) {
     let store = Arc::new(MemStore::default());
     for (hash, record) in seed {
         let bytes = record.encode().expect("encode seed record");
@@ -107,6 +116,7 @@ async fn spawn_test_server(
     let mut state = AppState::for_tests("http://127.0.0.1:1");
     state.auth_key_store = Arc::clone(&store) as Arc<dyn AuthKeyStore>;
     state.auth = Arc::new(FixtureAuth);
+    state.api_key_secret = secret.map(Arc::<str>::from);
     let addr: std::net::SocketAddr = "127.0.0.1:0".parse().expect("parse addr");
     let (bound, fut) = bind_and_serve(addr, state).await.expect("bind + serve");
     let handle = tokio::spawn(async move {
@@ -427,4 +437,280 @@ async fn revoke_without_bearer_returns_401() {
         .await
         .expect("send");
     assert_eq!(resp.status().as_u16(), 401);
+}
+
+// ── POST /v2/auth/keys (mint) tests ──────────────────────────────
+
+/// Happy path: mint a `user` key with a zone grant.  Response
+/// includes the plaintext key + hash + key_id + record echo.  The
+/// store row is really present after mint.
+#[tokio::test]
+async fn mint_user_key_with_zone_grant_returns_key_and_persists_row() {
+    let (base, store, _h) = spawn_test_server_with_secret(vec![], Some("test-hmac-secret")).await;
+
+    let body = json!({
+        "name": "alice-laptop",
+        "subject_type": "user",
+        "subject_id": "alice",
+        "zones": ["root:rwx"],
+        "admin": false,
+    });
+    let resp: serde_json::Value = reqwest::Client::new()
+        .post(format!("{base}/v2/auth/keys"))
+        .bearer_auth("admin-token")
+        .json(&body)
+        .send()
+        .await
+        .expect("send")
+        .json()
+        .await
+        .expect("json");
+
+    let key = resp["key"].as_str().expect("key present");
+    let key_hash = resp["key_hash"].as_str().expect("key_hash present");
+    assert!(key.starts_with("sk-"), "plaintext key must be sk-prefixed");
+    assert!(
+        !key_hash.is_empty(),
+        "key_hash must be present for later revoke",
+    );
+    assert_eq!(resp["record"]["name"], "alice-laptop");
+    assert_eq!(resp["record"]["subject_type"], "user");
+    assert_eq!(resp["record"]["subject_id"], "alice");
+    assert_eq!(resp["record"]["is_admin"], false);
+    assert!(
+        store.get(key_hash).unwrap().is_some(),
+        "mint must persist the row at the returned hash",
+    );
+}
+
+/// Admin key with no zone grants — the zoneless-admin-only rule.
+#[tokio::test]
+async fn mint_admin_key_without_zones_is_allowed() {
+    let (base, _store, _h) = spawn_test_server_with_secret(vec![], Some("test-hmac-secret")).await;
+    let body = json!({
+        "name": "root-admin",
+        "subject_type": "user",
+        "subject_id": "root",
+        "admin": true,
+    });
+    let resp = reqwest::Client::new()
+        .post(format!("{base}/v2/auth/keys"))
+        .bearer_auth("admin-token")
+        .json(&body)
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(resp.status().as_u16(), 200);
+}
+
+/// Non-admin key with NO zone grants → 400 (a key with no grants
+/// reaches nothing; the mint layer refuses it).  Pin against a
+/// regression that silently mints an unreachable key.
+#[tokio::test]
+async fn mint_non_admin_without_zones_returns_400() {
+    let (base, _store, _h) = spawn_test_server_with_secret(vec![], Some("test-hmac-secret")).await;
+    let body = json!({
+        "name": "unreachable",
+        "subject_type": "user",
+        "subject_id": "alice",
+        "admin": false,
+    });
+    let resp = reqwest::Client::new()
+        .post(format!("{base}/v2/auth/keys"))
+        .bearer_auth("admin-token")
+        .json(&body)
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(
+        resp.status().as_u16(),
+        400,
+        "no-grants-no-admin must be 400 (client input error)",
+    );
+}
+
+/// A malformed zone grant → 400.  Message names the segment.
+#[tokio::test]
+async fn mint_malformed_zone_grant_returns_400() {
+    let (base, _store, _h) = spawn_test_server_with_secret(vec![], Some("test-hmac-secret")).await;
+    let body = json!({
+        "subject_type": "user",
+        "subject_id": "alice",
+        "zones": ["missing-colon-here"],
+    });
+    let resp = reqwest::Client::new()
+        .post(format!("{base}/v2/auth/keys"))
+        .bearer_auth("admin-token")
+        .json(&body)
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(resp.status().as_u16(), 400);
+}
+
+/// `subject_type=agent` is rejected — agents use the cert-anchored
+/// plane, not sk-.
+#[tokio::test]
+async fn mint_agent_subject_type_returns_400() {
+    let (base, _store, _h) = spawn_test_server_with_secret(vec![], Some("test-hmac-secret")).await;
+    let body = json!({
+        "subject_type": "agent",
+        "subject_id": "some-agent",
+        "zones": ["root:rwx"],
+    });
+    let resp = reqwest::Client::new()
+        .post(format!("{base}/v2/auth/keys"))
+        .bearer_auth("admin-token")
+        .json(&body)
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(resp.status().as_u16(), 400);
+}
+
+/// Repeat mint for the same `(subject_type, subject_id)` without
+/// `allow_existing` → 400 (uniqueness rejection reclassified from
+/// the mint layer's Backend error).
+#[tokio::test]
+async fn mint_repeat_same_subject_returns_400_without_allow_existing() {
+    let (base, _store, _h) = spawn_test_server_with_secret(vec![], Some("test-hmac-secret")).await;
+    let body = json!({
+        "subject_type": "user",
+        "subject_id": "alice",
+        "zones": ["root:rwx"],
+    });
+    // First mint succeeds.
+    let r1 = reqwest::Client::new()
+        .post(format!("{base}/v2/auth/keys"))
+        .bearer_auth("admin-token")
+        .json(&body)
+        .send()
+        .await
+        .expect("send1");
+    assert_eq!(r1.status().as_u16(), 200);
+    // Second without allow_existing → 400.
+    let r2 = reqwest::Client::new()
+        .post(format!("{base}/v2/auth/keys"))
+        .bearer_auth("admin-token")
+        .json(&body)
+        .send()
+        .await
+        .expect("send2");
+    assert_eq!(
+        r2.status().as_u16(),
+        400,
+        "duplicate subject without allow_existing must be 400 (input error), not 502",
+    );
+}
+
+/// `allow_existing=true` lets a rotation land — two keys for the
+/// same subject coexist (the audit path).
+#[tokio::test]
+async fn mint_allow_existing_true_allows_rotation() {
+    let (base, store, _h) = spawn_test_server_with_secret(vec![], Some("test-hmac-secret")).await;
+    let body = json!({
+        "subject_type": "user",
+        "subject_id": "alice",
+        "zones": ["root:rwx"],
+        "allow_existing": true,
+    });
+    reqwest::Client::new()
+        .post(format!("{base}/v2/auth/keys"))
+        .bearer_auth("admin-token")
+        .json(&body)
+        .send()
+        .await
+        .expect("mint1");
+    reqwest::Client::new()
+        .post(format!("{base}/v2/auth/keys"))
+        .bearer_auth("admin-token")
+        .json(&body)
+        .send()
+        .await
+        .expect("mint2");
+    assert_eq!(
+        store.list().unwrap().len(),
+        2,
+        "allow_existing=true must let two rows coexist for the same subject",
+    );
+}
+
+/// No HMAC secret configured → 503 (auth-off daemon; sk- plane
+/// unavailable).
+#[tokio::test]
+async fn mint_without_secret_returns_503() {
+    let (base, _store, _h) = spawn_test_server(vec![]).await; // secret=None
+    let body = json!({
+        "subject_type": "user",
+        "subject_id": "alice",
+        "zones": ["root:rwx"],
+    });
+    let resp = reqwest::Client::new()
+        .post(format!("{base}/v2/auth/keys"))
+        .bearer_auth("admin-token")
+        .json(&body)
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(
+        resp.status().as_u16(),
+        503,
+        "no secret → 503 (service unavailable), matches gRPC MintKey posture under NoAuth",
+    );
+}
+
+/// Non-admin bearer → 403 even with a valid secret + body.
+#[tokio::test]
+async fn mint_rejects_non_admin_with_403() {
+    let (base, _store, _h) = spawn_test_server_with_secret(vec![], Some("test-hmac-secret")).await;
+    let body = json!({
+        "subject_type": "user",
+        "subject_id": "alice",
+        "zones": ["root:rwx"],
+    });
+    let resp = reqwest::Client::new()
+        .post(format!("{base}/v2/auth/keys"))
+        .bearer_auth("user-token")
+        .json(&body)
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(resp.status().as_u16(), 403);
+}
+
+/// End-to-end mint → revoke: the minted key's hash from the
+/// response body is a valid revoke target.
+#[tokio::test]
+async fn minted_key_can_be_revoked_by_returned_hash() {
+    let (base, store, _h) = spawn_test_server_with_secret(vec![], Some("test-hmac-secret")).await;
+    let mint_body = json!({
+        "subject_type": "user",
+        "subject_id": "alice",
+        "zones": ["root:rwx"],
+    });
+    let mint_resp: serde_json::Value = reqwest::Client::new()
+        .post(format!("{base}/v2/auth/keys"))
+        .bearer_auth("admin-token")
+        .json(&mint_body)
+        .send()
+        .await
+        .expect("mint")
+        .json()
+        .await
+        .expect("mint json");
+    let hash = mint_resp["key_hash"].as_str().unwrap();
+    let revoke: serde_json::Value = reqwest::Client::new()
+        .delete(format!("{base}/v2/auth/keys/{hash}"))
+        .bearer_auth("admin-token")
+        .send()
+        .await
+        .expect("revoke")
+        .json()
+        .await
+        .expect("revoke json");
+    assert_eq!(revoke["existed"], true);
+    assert!(
+        store.get(hash).unwrap().is_none(),
+        "revoke of just-minted hash must actually remove the row",
+    );
 }

--- a/rust/services/http-api/tests/auth_middleware_e2e.rs
+++ b/rust/services/http-api/tests/auth_middleware_e2e.rs
@@ -197,6 +197,7 @@ impl Harness {
             auth_key_store: std::sync::Arc::new(
                 nexus_http_api::middleware::auth::empty_auth_key_store_for_tests(),
             ),
+            api_key_secret: None,
             // Under `--features rebac` (nexusd's `full` build path
             // exercises this harness transitively via CI), AppState
             // gains a `rebac_store` field.  Use the same in-memory

--- a/rust/services/http-api/tests/serve_e2e.rs
+++ b/rust/services/http-api/tests/serve_e2e.rs
@@ -113,6 +113,8 @@ async fn service_decl_install_body_runs_under_a_tokio_runtime() {
         // Empty in-memory `AuthKeyStore` — this test hits only
         // `/v2/status`, so any store is fine.
         std::sync::Arc::new(nexus_http_api::middleware::auth::empty_auth_key_store_for_tests()),
+        // No api_key_secret needed — this test only hits /v2/status.
+        None,
         // The `--features rebac` build widens `install_impl` with a
         // tuple-store arg — use the same in-memory default the
         // `AppState::for_tests` helper wires (this test never hits
@@ -156,6 +158,8 @@ async fn service_decl_install_body_returns_err_on_bind_failure() {
         default_no_auth_provider(),
         handle.clone(),
         std::sync::Arc::new(nexus_http_api::middleware::auth::empty_auth_key_store_for_tests()),
+        // No api_key_secret needed — this test only hits /v2/status.
+        None,
         #[cfg(feature = "rebac")]
         std::sync::Arc::new(nexus_rebac::InMemoryReBACTupleStore::new()),
     );
@@ -169,6 +173,8 @@ async fn service_decl_install_body_returns_err_on_bind_failure() {
         default_no_auth_provider(),
         handle,
         std::sync::Arc::new(nexus_http_api::middleware::auth::empty_auth_key_store_for_tests()),
+        // No api_key_secret needed — this test only hits /v2/status.
+        None,
         #[cfg(feature = "rebac")]
         std::sync::Arc::new(nexus_rebac::InMemoryReBACTupleStore::new()),
     );


### PR DESCRIPTION
## Summary

**Closes the HTTP surface of the R10 arc**: \`POST /v2/auth/keys\` mints a fresh sk- credential. Handler calls \`auth::mint::mint_key(store, secret, record, allow_existing)\` with the HMAC secret plumbed via \`ServiceBootCtx.api_key_secret\` (see nexi-lab/nexus-vfs#261).

## Endpoint

- \`POST /v2/auth/keys\` — mint (admin-only)
- Body: \`{subject_type, subject_id, name?, zones: [\"zone:perms\"...], admin?, expires_at_ms?, allow_existing?}\`
- Returns: \`{key, key_hash, key_id, record}\` — one-time plaintext key + hash (revoke target) + audit id + persisted view

Body shape mirrors Python \`CreateKeyRequest\` closely — one difference: \`expires_at_ms\` is absolute (matches gRPC \`MintKey\`) rather than Python's relative \`expires_days\`.

## Cross-repo bumps

- nexus-vfs: \`b5b969a0\` → \`5806c39d\` (#261 — ServiceBootCtx api_key_secret widen)
- sudocode-tools: \`69328d3e\` → \`d742e044\` (sudoprivacy/sudocode#552 matching bump)
- All 3 dockerfiles + workspace Cargo.toml consistent

## Design decisions

- **Reclassify mint-layer \"already has key\" → 400.** \`auth::mint_key\`'s uniqueness reject arrives as \`AuthKeyStoreError::Backend(msg)\` with a stable \"already has an active key\" substring. Peek + reclassify to \`BadRequest\` so callers see 400 (input violates uniqueness), not 502 (backend fault).
- **503 for no-secret path.** Endpoint exists but the plane doesn't (\`--no-tls\` daemon). Matches gRPC \`MintKey\`'s \"returns success=false under NoAuth\".
- **Local \`build_record\` + \`generate_key_id\`.** Upstream helpers (\`build_sk_record\`, \`uuid_v4\`) are not \`pub\`; local variants keep the handler self-contained. Follow-up can factor to the auth crate once shared.

## Test plan

- [x] \`cargo test -p nexus-http-api\` → 65 existing + 10 new mint tests (22 total in auth_keys_e2e.rs) all pass
- [x] Build sweep clean: default / http-api / rebac / http-api,rebac / full
- [x] \`cargo clippy\` clean on all combos
- [x] \`cargo fmt --check\` clean
- [ ] CI green

10 new mint tests:
* happy path (user key + zone grant, plaintext + hash returned, row persisted)
* admin key without zones (zoneless-admin-only rule)
* non-admin without zones → 400
* malformed zone grant → 400
* subject_type=agent → 400 (agents use cert plane)
* duplicate subject without allow_existing → 400
* allow_existing=true rotation
* no secret → 503
* non-admin bearer → 403
* mint→revoke chain (returned hash is a valid revoke target)

## R10 arc — HTTP surface COMPLETE

All /v2 endpoints Python nexus-server exposed now live on the Rust side: \`/v2/status\`, \`/v2/search/{glob,grep,query}\`, \`/v2/documents/{index,refresh,batch,stats}\`, \`/v2/rebac/tuples\` (grant/list/revoke), \`/v2/auth/keys\` (POST/GET/DELETE). Enforcement (kernel PermissionProvider via nexus-rebac) also wired. Remaining: SANDBOX Python delete (~4400 LoC) + Python \`bricks/rebac/\` delete (~37k LoC) once callers verified retired.