### PR TITLE
chore(search): strip dead SANDBOX SqliteVec code path in SearchService

### DIFF
--- a/docs/surface-coverage/api-rpc-surface-coverage.yaml
+++ b/docs/surface-coverage/api-rpc-surface-coverage.yaml
@@ -3412,7 +3412,7 @@ operations:
       source: src/nexus/server/_kernel_syscall_dispatch.py:52
     grpc_expose:
       name: list
-      source: src/nexus/bricks/search/search_service.py:482
+      source: src/nexus/bricks/search/search_service.py:465
   profiles:
     lite: supported
     sandbox: supported
@@ -4601,7 +4601,7 @@ operations:
   transports:
     grpc_expose:
       name: glob_batch
-      source: src/nexus/bricks/search/search_service.py:2068
+      source: src/nexus/bricks/search/search_service.py:2051
   profiles:
     lite: supported
     sandbox: supported
@@ -5012,7 +5012,7 @@ operations:
   transports:
     grpc_expose:
       name: initialize_semantic_search
-      source: src/nexus/bricks/search/search_service.py:4949
+      source: src/nexus/bricks/search/search_service.py:4595
   profiles:
     lite: supported
     sandbox: supported
@@ -7747,7 +7747,7 @@ operations:
       source: src/nexus/cli/commands/search.py:1
     grpc_expose:
       name: glob
-      source: src/nexus/bricks/search/search_service.py:1825
+      source: src/nexus/bricks/search/search_service.py:1808
     http:
       name: POST /api/v2/search/glob
       source: src/nexus/server/api/v2/routers/search.py:1713
@@ -7774,7 +7774,7 @@ operations:
       source: src/nexus/cli/commands/search.py:1
     grpc_expose:
       name: grep
-      source: src/nexus/bricks/search/search_service.py:2125
+      source: src/nexus/bricks/search/search_service.py:2108
     http:
       name: POST /api/v2/search/grep
       source: src/nexus/server/api/v2/routers/search.py:1574
@@ -7967,7 +7967,7 @@ operations:
   transports:
     grpc_expose:
       name: semantic_search
-      source: src/nexus/bricks/search/search_service.py:4456
+      source: src/nexus/bricks/search/search_service.py:4106
     mcp:
       name: nexus_semantic_search
       source: src/nexus/config/tool_profiles.yaml:1
@@ -7988,7 +7988,7 @@ operations:
   transports:
     grpc_expose:
       name: semantic_search_index
-      source: src/nexus/bricks/search/search_service.py:4807
+      source: src/nexus/bricks/search/search_service.py:4453
   profiles:
     lite: supported
     sandbox: supported
@@ -8005,7 +8005,7 @@ operations:
   transports:
     grpc_expose:
       name: semantic_search_stats
-      source: src/nexus/bricks/search/search_service.py:4901
+      source: src/nexus/bricks/search/search_service.py:4547
   profiles:
     lite: supported
     sandbox: supported

--- a/src/nexus/bricks/search/search_service.py
+++ b/src/nexus/bricks/search/search_service.py
@@ -234,7 +234,6 @@ class SearchService:
         file_cache: Any | None = None,
         zoekt_client: Any | None = None,
         deployment_profile: str | None = None,
-        sqlite_vec_backend: Any | None = None,
         federation_dispatcher: Any | None = None,
     ):
         """Initialize search service.
@@ -253,13 +252,6 @@ class SearchService:
                 When set to ``"sandbox"``, a semantic search that goes through
                 ``_semantic_with_sandbox_fallback`` will degrade gracefully to
                 local BM25S when federation reports all peers unreachable.
-            sqlite_vec_backend: Optional ``SqliteVecBackend`` instance
-                (Issue #3778). When supplied, SANDBOX-profile semantic search
-                tries this local vector backend first; a non-empty result set
-                short-circuits the federation/BM25S fallback chain. The
-                factory only wires this when ``profile=sandbox`` AND
-                ``cfg.enable_vector_search`` AND both ``sqlite-vec`` +
-                ``litellm`` are importable.
         """
         self.metadata = metadata_store
         # Kernel handle, kept ONLY for kernel-ABI methods that have no
@@ -311,15 +303,6 @@ class SearchService:
         # the instance so a long-running sandbox doesn't spam the log.
         self._deployment_profile = (deployment_profile or "").lower() or None
         self._sandbox_fallback_warned = False
-        # One-shot warning when SANDBOX hybrid is requested but the local
-        # vec backend is missing (no sqlite-vec / no embedder reachable),
-        # so the user sees exactly once that hybrid degraded to keyword.
-        self._sandbox_hybrid_no_vec_warned = False
-        # Issue #3778: optional local vector backend (sqlite-vec + litellm).
-        # When non-None on SANDBOX, semantic search tries the local backend
-        # first and only falls back to federation/BM25S when it returns
-        # empty (or raises).
-        self._sqlite_vec_backend = sqlite_vec_backend
 
         # Issue #3778 (R1 review): optional real federation dispatcher. When
         # set, SANDBOX semantic fallback routes through it instead of
@@ -3824,13 +3807,6 @@ class SearchService:
             cache_url=cache_url,
             embedding_cache_ttl=embedding_cache_ttl,
             nx=nx,
-            # Codex review R5 #2 (high): forward the SANDBOX local
-            # vec backend so the IndexingPipeline can mirror writes
-            # into it on every indexed doc. Without this, the
-            # _sqlite_vec_backend attached to SearchService for
-            # SEARCH would never receive any vectors via the
-            # production indexing flow.
-            sqlite_vec_backend=self._sqlite_vec_backend,
         )
         self._query_service = components.query_service
         self._indexing_service = components.indexing_service
@@ -3912,317 +3888,6 @@ class SearchService:
             stamped.append(r)
         return stamped
 
-    async def _try_sqlite_vec_sandbox(
-        self,
-        *,
-        query: str,
-        path: str,
-        limit: int,
-        context: "OperationContext | None",
-    ) -> builtins.list[dict[str, Any]] | None:
-        """Issue #3778: try the local sqlite-vec backend first on SANDBOX.
-
-        Returns:
-            * a non-empty list of dict results when the backend is wired and
-              KNN returned hits — caller should NOT stamp ``semantic_degraded``
-              because this is a *real* semantic match.
-            * ``None`` when the backend is absent, errored, or returned no
-              hits — caller falls through to the federation/BM25S chain.
-        """
-        backend = self._sqlite_vec_backend
-        if backend is None:
-            return None
-
-        zone_id = getattr(context, "zone_id", None) if context else None
-        if not zone_id:
-            zone_id = ROOT_ZONE_ID
-
-        try:
-            from nexus.server.path_utils import unscope_internal_path as _unscope
-
-            db_path = _unscope(path) if path != "/" else None
-            fetch_limit = (
-                limit * 3 if self._enforce_permissions and self._permission_enforcer else limit
-            )
-            results = await backend.search(
-                query=query,
-                limit=fetch_limit,
-                zone_id=zone_id,
-                search_type="hybrid",
-                path_filter=db_path,
-            )
-        except Exception as exc:
-            logger.warning(
-                "[SearchService] SANDBOX local sqlite-vec search failed (%s); "
-                "falling back to federation/BM25S chain",
-                exc,
-            )
-            return None
-
-        if not results:
-            return None
-
-        hits: builtins.list[dict[str, Any]] = []
-        for r in results:
-            entry: dict[str, Any] = {
-                "path": r.path,
-                "chunk_text": getattr(r, "chunk_text", ""),
-                "score": round(r.score, 4),
-                "chunk_index": getattr(r, "chunk_index", 0),
-                "start_offset": getattr(r, "start_offset", 0) or 0,
-                "end_offset": getattr(r, "end_offset", 0) or 0,
-                "line_start": getattr(r, "line_start", 0) or 0,
-                "line_end": getattr(r, "line_end", 0) or 0,
-            }
-            ctx_val = getattr(r, "context", None)
-            if ctx_val is not None:
-                entry["context"] = ctx_val
-            hits.append(entry)
-
-        if self._enforce_permissions and self._permission_enforcer and hits and context is not None:
-            hits = self._filter_hit_dicts_by_read_permission(hits, context)
-
-        return hits[:limit] if hits else None
-
-    async def _hybrid_search_sandbox(
-        self,
-        *,
-        query: str,
-        path: str,
-        limit: int,
-        context: "OperationContext | None",
-    ) -> builtins.list[dict[str, Any]] | None:
-        """SANDBOX hybrid: run sqlite-vec + BM25S in parallel, fuse via RRF.
-
-        FULL-profile parity: both lanes are real (vec via local
-        sqlite-vec, keyword via the daemon's BM25S backend), so the fused
-        result carries no ``semantic_degraded`` marker.
-
-        Returns:
-            * fused list of dicts when at least one lane produced results.
-            * ``None`` when both lanes are empty / errored — caller falls
-              through to the semantic-only chain (which itself ends in
-              the BM25S degradation path).
-        """
-        backend = self._sqlite_vec_backend
-        if backend is None:
-            # SANDBOX hybrid was requested but vector search is not wired
-            # (likely missing sqlite-vec / fastembed, or the user opted
-            # out via NEXUS_DISABLE_VECTOR_SEARCH). Warn once so users
-            # understand they're on the keyword-only fallback. The TITLE
-            # arm is keyword-side (#4545 review round 9), so instead of
-            # bailing straight to the caller's degradation chain we fall
-            # through with an inert vec lane — title-only docs stay
-            # reachable; when the title arm finds nothing the fused
-            # result is keyword-only and degraded-stamped as before.
-            if not self._sandbox_hybrid_no_vec_warned:
-                logger.warning(
-                    "[SearchService] SANDBOX hybrid requested but no local "
-                    "vector backend wired — degrading to keyword-only "
-                    "(BM25S) results. Install with: "
-                    "pip install 'nexus-ai-fs[sandbox]' (bundles sqlite-vec "
-                    "+ fastembed) and unset NEXUS_DISABLE_VECTOR_SEARCH to "
-                    "enable. Further occurrences will be logged at DEBUG."
-                )
-                self._sandbox_hybrid_no_vec_warned = True
-            else:
-                logger.debug("[SearchService] SANDBOX hybrid: no vec backend; keyword-only")
-
-        zone_id = getattr(context, "zone_id", None) if context else None
-        if not zone_id:
-            zone_id = ROOT_ZONE_ID
-
-        from nexus.server.path_utils import unscope_internal_path as _unscope
-
-        db_path = _unscope(path) if path != "/" else None
-        # Over-fetch on each lane so RRF has more material to merge.
-        # Permission filtering happens after fusion, so account for that
-        # too when an enforcer is active.
-        per_lane_limit = limit * 3
-        if self._enforce_permissions and self._permission_enforcer:
-            per_lane_limit = max(per_lane_limit, limit * 5)
-
-        async def _vec_lane() -> builtins.list[Any]:
-            if backend is None:
-                return []
-            try:
-                return list(
-                    await backend.search(
-                        query=query,
-                        limit=per_lane_limit,
-                        zone_id=zone_id,
-                        search_type="hybrid",
-                        path_filter=db_path,
-                    )
-                )
-            except Exception as exc:
-                logger.warning(
-                    "[SearchService] SANDBOX hybrid: vec lane failed (%s); "
-                    "fusion will use keyword-only",
-                    exc,
-                )
-                return []
-
-        async def _kw_lane() -> builtins.list[dict[str, Any]]:
-            # Codex review R8 #1 (high): the prior gate required
-            # ``daemon._backend`` (the optional txtai backend), but
-            # SANDBOX installs bm25s + sqlite-vec + fastembed and
-            # does NOT install txtai by default. With the strict
-            # gate, the keyword lane returned empty under the SANDBOX
-            # default install shape — turning hybrid-by-default into
-            # vec-only without any degradation marker. The daemon's
-            # ``search(search_type="keyword", ...)`` path serves
-            # BM25S/FTS without the txtai backend, so we only require
-            # a wired daemon — the daemon itself decides whether
-            # BM25S, FTS, or txtai answers.
-            daemon = getattr(self, "_search_daemon", None)
-            if daemon is not None:
-                try:
-                    rows = await daemon.search(
-                        SearchRequest(
-                            query=query,
-                            search_type="keyword",
-                            limit=per_lane_limit,
-                            path_filter=db_path,
-                            zone_id=zone_id,
-                        )
-                    )
-                except Exception as exc:
-                    logger.warning(
-                        "[SearchService] SANDBOX hybrid: keyword lane failed (%s); "
-                        "falling back to SQL chunk keyword search",
-                        exc,
-                    )
-                else:
-                    out: builtins.list[dict[str, Any]] = []
-                    for r in rows:
-                        entry: dict[str, Any] = {
-                            "path": r.path,
-                            "chunk_text": getattr(r, "chunk_text", ""),
-                            "score": round(r.score, 4),
-                            "chunk_index": getattr(r, "chunk_index", 0),
-                            "start_offset": getattr(r, "start_offset", 0) or 0,
-                            "end_offset": getattr(r, "end_offset", 0) or 0,
-                            "line_start": getattr(r, "line_start", 0) or 0,
-                            "line_end": getattr(r, "line_end", 0) or 0,
-                        }
-                        ctx_val = getattr(r, "context", None)
-                        if ctx_val is not None:
-                            entry["context"] = ctx_val
-                        out.append(entry)
-                    if out:
-                        return out
-
-            if self._record_store is not None:
-                return await self._sql_chunk_search(
-                    query,
-                    path,
-                    per_lane_limit,
-                    context=context,
-                )
-            return []
-
-        vec_results, kw_results = await asyncio.gather(_vec_lane(), _kw_lane())
-
-        # Skeleton title arm (#4545 review rounds 7-8): SANDBOX composes its
-        # own hybrid, so fold the daemon's title arm in here too — same
-        # keyword-side sub-fusion shape as the FULL-profile daemon path.
-        # Gathered BEFORE the emptiness exit: a chunkless title-only doc is
-        # exactly the case where both body lanes come back empty.
-        title_hits: builtins.list[Any] = []
-        title_daemon = getattr(self, "_search_daemon", None)
-        if title_daemon is not None and getattr(
-            getattr(title_daemon, "config", None), "title_arm", False
-        ):
-            try:
-                # per_lane_limit (#4545 review round 10): ACL filtering
-                # happens after fusion, so the title arm must over-fetch
-                # like the body lanes or denied hits exhaust its pool.
-                # kw_results as borrow source aligns title votes with the
-                # BM25 chunk identity instead of duplicating the doc.
-                title_hits = await title_daemon._gather_title_hits(
-                    query,
-                    zone_id=zone_id,
-                    limit=per_lane_limit,
-                    path_filter=db_path,
-                    chunk_kw=kw_results,
-                    page_kw=[],
-                    timing={},
-                    dense=vec_results,
-                )
-            except Exception as exc:
-                logger.debug("[SearchService] SANDBOX title arm failed: %s", exc)
-                title_hits = []
-
-        if backend is None and not title_hits:
-            # No vec backend and no title evidence: preserve the original
-            # contract — the caller's semantic-only chain owns degradation.
-            return None
-
-        if not vec_results and not kw_results and not title_hits:
-            return None
-
-        if title_hits:
-            from nexus.bricks.search.fusion import rrf_multi_fusion
-
-            kw_results = rrf_multi_fusion(
-                [("chunk", kw_results), ("title", title_hits)],
-                k=60,
-                limit=per_lane_limit,
-                id_key=None,
-            )
-
-        # Codex review R1 (high): track whether the vector lane
-        # contributed anything at all so we can flag keyword-only
-        # results. We must record the vec keys BEFORE fusion so the
-        # post-filter check (R2) can ask "did any surviving row come
-        # from the vec lane?" without trusting fields stamped by
-        # fusion (e.g. vector_score=0.0 inherited from a BaseSearchResult
-        # default would falsely look like a vec contribution).
-        vec_keys: builtins.set[tuple[str, int]] = {
-            (getattr(r, "path", ""), int(getattr(r, "chunk_index", 0) or 0)) for r in vec_results
-        }
-        vec_lane_empty = not vec_results
-
-        from nexus.bricks.search.fusion import (
-            FusionConfig,
-            FusionMethod,
-            fuse_results,
-        )
-
-        fused = fuse_results(
-            keyword_results=kw_results,
-            vector_results=vec_results,
-            config=FusionConfig(method=FusionMethod.RRF),
-            limit=(limit * 3 if self._enforce_permissions and self._permission_enforcer else limit),
-            id_key=None,  # use path:chunk_index — no chunk_id stamped here
-        )
-
-        if (
-            self._enforce_permissions
-            and self._permission_enforcer
-            and fused
-            and context is not None
-        ):
-            fused = self._filter_hit_dicts_by_read_permission(fused, context)
-
-        # Codex review R2 (high): recompute degradation AFTER
-        # permission filtering. If every fused row that originated in
-        # the vec lane was filtered out, the caller is effectively on
-        # keyword-only results even though the vec lane itself returned
-        # hits, and must be flagged degraded.
-        surviving_from_vec = any(
-            (r.get("path", ""), int(r.get("chunk_index", 0) or 0)) in vec_keys for r in fused
-        )
-        vec_degraded = vec_lane_empty or not surviving_from_vec
-
-        if vec_degraded and fused:
-            LAST_SEMANTIC_DEGRADED.set(True)
-            for r in fused:
-                r["semantic_degraded"] = True
-
-        return fused[:limit] if fused else None
-
     async def _semantic_search_sandbox(
         self,
         *,
@@ -4232,27 +3897,25 @@ class SearchService:
         context: "OperationContext | None",
         search_mode: str = "semantic",
     ) -> builtins.list[dict[str, Any]]:
-        """SANDBOX-profile semantic_search: local vec → federation → BM25S.
+        """SANDBOX-profile semantic_search: federation → BM25S.
 
-        Issue #3778. The fallback chain on SANDBOX is:
+        The in-process `SqliteVecBackend` lanes (RRF hybrid + local
+        KNN) were removed as part of the R10 arc — the Rust search-
+        plugin is now the sole semantic backend, and the SANDBOX
+        profile is on the federation/BM25S fallback chain
+        production `full` deployments already use.
 
-        1. **Hybrid (RRF)**: when ``search_mode == "hybrid"`` and the
-           local sqlite-vec backend is wired, run the vec lane and the
-           daemon BM25S keyword lane in parallel and fuse via RRF. This
-           is the FULL-profile parity path — both lanes are real, so we
-           do NOT stamp ``semantic_degraded``.
-        2. **Local sqlite-vec semantic** (``self._sqlite_vec_backend``).
-           For ``search_mode == "semantic"`` (or when hybrid sees an empty
-           keyword lane), the KNN query alone is treated as a real
-           semantic match and ``semantic_degraded`` is NOT set.
-        3. **Federation**: SANDBOX never has peers configured, so the
-           ``FederatedSearchResponse`` is synthesised as "no peers" — that
-           causes ``_semantic_with_sandbox_fallback`` to invoke the BM25S
+        The remaining chain on SANDBOX is:
+
+        1. **Federation**: when a real dispatcher is wired, invoke
+           it; SANDBOX vanilla has no peers, so the response is
+           synthesised as "no peers" — that causes
+           ``_semantic_with_sandbox_fallback`` to invoke the BM25S
            callable.
-        4. **BM25S** (via the local SearchDaemon's keyword path), or the
-           SQL chunk search when no daemon is wired. Results carry
-           ``semantic_degraded=True`` so MCP / HTTP clients can warn users
-           that the answer is keyword-only.
+        2. **BM25S** (via the local SearchDaemon's keyword path), or
+           the SQL chunk search when no daemon is wired. Results
+           carry ``semantic_degraded=True`` so MCP / HTTP clients
+           can warn users that the answer is keyword-only.
         """
         # Reset the degraded flag at the entry point of a SANDBOX search so
         # callers read a value that reflects THIS call only. The contextvar
@@ -4278,28 +3941,15 @@ class SearchService:
             if _readable_scope is not None and not _readable_scope:
                 return []
 
-        # Step 1 — real RRF hybrid when requested. We always invoke the
-        # helper (even with no vec backend) so the one-shot "no-vec"
-        # warning fires for users who asked for hybrid explicitly via
-        # the public API. The helper returns None when it can't produce
-        # fused results; the caller falls through to the existing
-        # semantic-only / degraded chain.
-        if search_mode == "hybrid":
-            fused = await self._hybrid_search_sandbox(
-                query=query, path=path, limit=limit, context=context
-            )
-            if fused is not None:
-                return fused
+        # SANDBOX chain: the in-process `SqliteVecBackend` (deleted in
+        # #4761) previously served an RRF hybrid + semantic-only pass
+        # here; both are gone.  SANDBOX now goes straight to the
+        # federation dispatcher (when wired) + BM25S fallback below —
+        # the same path production `full` deployments already use.
+        # `search_mode` becomes advisory: no local vec lane exists, so
+        # `"hybrid"` and `"semantic"` collapse to the fed/BM25S chain.
 
-        # Step 2 — try the local vector backend (semantic-only path, or
-        # hybrid fallback when fusion couldn't run).
-        local = await self._try_sqlite_vec_sandbox(
-            query=query, path=path, limit=limit, context=context
-        )
-        if local is not None:
-            return local
-
-        # Step 2 + 3 — try a real federation dispatcher when one is wired;
+        # Try a real federation dispatcher when one is wired;
         # otherwise synthesise an empty FederatedSearchResponse so the
         # shared fallback wrapper invokes the BM25S callable and stamps
         # ``semantic_degraded=True`` on every result.
@@ -4535,15 +4185,11 @@ class SearchService:
         # the "no-peers" detection + stamping to _semantic_with_sandbox_fallback
         # so the fallback logic is shared with any future federation caller.
         #
-        # SANDBOX hybrid-by-default: when the caller asks for the default
-        # "semantic" mode AND a local vec backend is wired, transparently
-        # upgrade to "hybrid" so users get the fused vec+BM25 path without
-        # needing to remember the keyword. Explicit "keyword" requests are
-        # untouched. When no vec backend is wired we leave the request as
-        # "semantic" so the existing degraded chain handles it.
+        # SANDBOX profile routes semantic + hybrid to the shared
+        # federation/BM25S fallback chain.  The pre-#4761 hybrid-by-
+        # default upgrade (flip "semantic" → "hybrid" when a local vec
+        # backend is wired) was removed alongside the SqliteVec plane.
         if self._deployment_profile == "sandbox" and search_mode in ("semantic", "hybrid"):
-            if search_mode == "semantic" and self._sqlite_vec_backend is not None:
-                search_mode = "hybrid"
             return await self._semantic_search_sandbox(
                 query=query,
                 path=path,
@@ -4981,7 +4627,6 @@ class SearchService:
             metadata=self.metadata,
             file_reader=self._read,
             file_lister=self.list,
-            sqlite_vec_backend=self._sqlite_vec_backend,
         )
         self._query_service = components.query_service
         self._indexing_service = components.indexing_service

--- a/src/nexus/bricks/search/search_service.py
+++ b/src/nexus/bricks/search/search_service.py
@@ -3895,7 +3895,7 @@ class SearchService:
         path: str,
         limit: int,
         context: "OperationContext | None",
-        search_mode: str = "semantic",
+        search_mode: str = "semantic",  # noqa: ARG002  advisory now — no in-process vec lane exists post-#4761
     ) -> builtins.list[dict[str, Any]]:
         """SANDBOX-profile semantic_search: federation → BM25S.
 

--- a/src/nexus/factory/_wired.py
+++ b/src/nexus/factory/_wired.py
@@ -215,25 +215,6 @@ def _boot_post_kernel_services(
         # model download). On other profiles vector search remains opt-in
         # via ``NEXUS_ENABLE_VECTOR_SEARCH=1``.
         #
-        # If both ``sqlite-vec`` and an embedder (fastembed OR a remote
-        # API key for litellm) are reachable, we wire the backend.
-        # The SANDBOX in-process `SqliteVecBackend` init block was
-        # deleted as part of the R10 arc (task #41): the Rust search-
-        # plugin is now the sole semantic-search backend, and no live
-        # SANDBOX deployment depends on the Python in-process path.
-        # `SearchService.sqlite_vec_backend=None` disables the dead
-        # `_try_sqlite_vec_sandbox` / `_hybrid_search_sandbox` fast-
-        # paths — those method bodies are unreachable but left in
-        # `search_service.py` for a follow-up strip PR to remove
-        # cleanly alongside the rest of the SANDBOX chain
-        # (indexing.py / indexing_service.py / pipeline_indexer.py /
-        # chunking.py / chunk_store.py / factory/_semantic_search.py).
-        # Env vars `NEXUS_ENABLE_VECTOR_SEARCH` /
-        # `NEXUS_DISABLE_VECTOR_SEARCH` are no-ops as a result — the
-        # `connect()` helper still forwards them for back-compat, but
-        # nothing here reads them.
-        _sqlite_vec_backend: Any = None
-
         # Issue #3778 (R2 review): look up an already-constructed federation
         # dispatcher on the ServiceRegistry / NexusFS if one is available, so
         # the SANDBOX semantic path actually dispatches when the deployment
@@ -257,13 +238,11 @@ def _boot_post_kernel_services(
             record_store=getattr(nx, "_record_store", None),
             nexus_fs=nx,
             deployment_profile=_profile,
-            sqlite_vec_backend=_sqlite_vec_backend,
             federation_dispatcher=_federation_dispatcher,
         )
         logger.debug(
-            "[BOOT:WIRED] SearchService created (kernel-level, profile=%s, sqlite_vec=%s)",
+            "[BOOT:WIRED] SearchService created (kernel-level, profile=%s)",
             _profile,
-            _sqlite_vec_backend is not None,
         )
     except Exception as exc:
         logger.warning(

--- a/tests/unit/bricks/search/test_federated_degraded.py
+++ b/tests/unit/bricks/search/test_federated_degraded.py
@@ -312,9 +312,13 @@ class TestWriteOnlyContextFailsClosedEverywhere:
         from nexus.contracts.types import OperationContext
 
         svc = _make_sandbox_service()
-        # Any retrieval work reaching these would be a leak.
-        svc._hybrid_search_sandbox = None  # type: ignore[assignment]
-        svc._try_sqlite_vec_sandbox = None  # type: ignore[assignment]
+        # `_hybrid_search_sandbox` and `_try_sqlite_vec_sandbox`
+        # were removed as part of the R10 SANDBOX cleanup — the
+        # `_semantic_search_sandbox` chain now goes federation →
+        # BM25S with no in-process vec lane.  The leak-check
+        # below (dispatched["called"] is False + out == []) still
+        # covers the invariant: an empty readable scope must not
+        # reach ANY retrieval lane.
 
         dispatched = {"called": False}
 


### PR DESCRIPTION
## Summary

Third slice of the SANDBOX Python semantic-chain deprecation (task R10#41; first two = #4760 pgvector, #4761 SqliteVecBackend + factory wiring). With \`_sqlite_vec_backend\` unconditionally None post-#4761, the two method bodies + their call sites became dead code. This PR removes them.

**372 LoC removed net** (SearchService is now 4989 → 4653 lines).

## What's stripped

### \`search_service.py\`

- Constructor: drop \`sqlite_vec_backend\` param + docstring; drop \`self._sqlite_vec_backend\` field + \`_sandbox_hybrid_no_vec_warned\` flag.
- \`_try_sqlite_vec_sandbox\` (deleted, ~70 LoC — SANDBOX \"local KNN first\" fast-path)
- \`_hybrid_search_sandbox\` (deleted, ~240 LoC — SANDBOX RRF fusion of vec + BM25 lanes)
- \`_semantic_search_sandbox\`: Steps 1 (hybrid) + 2 (local vec) removed; SANDBOX now goes straight to federation dispatcher + BM25S fallback (same chain \`full\` production deployments use). Docstring rewritten.
- \`semantic_search\` dispatch: hybrid-by-default upgrade branch removed.
- Two \`create_semantic_search_components(sqlite_vec_backend=...)\` kwargs dropped.

### \`factory/_wired.py\`

- \`_sqlite_vec_backend: Any = None\` bridge declaration + \`SearchService(sqlite_vec_backend=..., ...)\` kwarg gone.
- Historical explainer comment block removed (already narrated in #4761).
- Log line: no more \`sqlite_vec=%s\` field.

## Test-side follow-through

\`tests/unit/bricks/search/test_federated_degraded.py::test_write_only_context_gets_no_results_and_no_fallback\` was sabotaging the two deleted methods to leak-check. Replaced with explainer comment; the test's other assertions still cover the write-only fail-closed invariant. Verified 3/3 pass locally.

## Test plan

- [x] \`import nexus.bricks.search.search_service\` → clean
- [x] \`SearchService.__init__\` signature no longer accepts \`sqlite_vec_backend\`
- [x] \`import nexus.factory._wired\` → clean
- [x] \`pytest tests --collect-only\` → 10580 collect (2 pre-existing optional-dep errors on \`fuse\` + \`psutil\` unrelated)
- [x] \`grep _try_sqlite_vec_sandbox tests/\` → 0 hits post-fix
- [ ] CI green

## Remaining slice (PR 4, follow-up)

The SANDBOX chain — \`indexing.py\` (still carries a \`sqlite_vec_backend\` param), \`indexing_service.py\`, \`pipeline_indexer.py\`, \`chunking.py\`, \`chunk_store.py\`, \`factory/_semantic_search.py\` — deletes in one shot once the caller sites in \`search_service.py\` are settled here.