### PR TITLE
chore(deps): bump nexus-vfs to v0.7.3 — idle zones free, restart tracks active zones

### DIFF
--- a/.github/workflows/cc-tasks-share-e2e.yml
+++ b/.github/workflows/cc-tasks-share-e2e.yml
@@ -176,12 +176,24 @@ jobs:
 
       - name: Wait for founder + joiner healthy
         if: steps.changes.outputs.run == 'true'
+        # Readiness is "the shared zone can COMMIT", not "the port answers".
+        # The joiner rejoins `sharedzone` as a second voter and then restarts,
+        # so there is a window where the zone has two voters and one of them is
+        # down: writes correctly fail with `proposal dropped` until the group
+        # re-forms. A TCP probe cannot see that window — it passed while the
+        # first test's write took an I/O error — so gate on a real write
+        # through the federated mount instead, which is exactly the property
+        # every test below depends on.
         run: |
+          probe=/mnt/cc-tasks/founder/.e2e-readiness-probe
           deadline=$((SECONDS + 180))
           while [ $SECONDS -lt $deadline ]; do
             if docker exec nexus-cc-tasks-founder bash -c 'timeout 1 bash -c "</dev/tcp/localhost/2126" 2>/dev/null' && \
-               docker exec nexus-cc-tasks-joiner bash -c 'timeout 1 bash -c "</dev/tcp/localhost/2126" 2>/dev/null'; then
-              echo "Founder + joiner healthy (gRPC 2126 reachable on both) after ${SECONDS}s"
+               docker exec nexus-cc-tasks-joiner bash -c 'timeout 1 bash -c "</dev/tcp/localhost/2126" 2>/dev/null' && \
+               docker exec nexus-cc-tasks-founder bash -c "echo ready > $probe" 2>/dev/null; then
+              # Leave nothing behind: the tests list this directory.
+              docker exec nexus-cc-tasks-founder bash -c "rm -f $probe" 2>/dev/null || true
+              echo "Founder + joiner healthy and the shared zone commits, after ${SECONDS}s"
               exit 0
             fi
             sleep 2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "a2a"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5806c39d471928caabd098c121db85cf8bfa679d#5806c39d471928caabd098c121db85cf8bfa679d"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5f7e0a925ce1e8e796bcd004a61d7fbd23a5a712#5f7e0a925ce1e8e796bcd004a61d7fbd23a5a712"
 dependencies = [
  "contracts",
  "kernel",
@@ -233,8 +233,8 @@ checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "api"
-version = "0.2.2"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=d742e04416121990041d01eda027e90b63d536a3#d742e04416121990041d01eda027e90b63d536a3"
+version = "0.2.7"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=59549a4ed40989f7cc5ed25b7fe84f8a75b016c8#59549a4ed40989f7cc5ed25b7fe84f8a75b016c8"
 dependencies = [
  "base64 0.22.1",
  "httpdate",
@@ -327,7 +327,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 [[package]]
 name = "auth"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5806c39d471928caabd098c121db85cf8bfa679d#5806c39d471928caabd098c121db85cf8bfa679d"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5f7e0a925ce1e8e796bcd004a61d7fbd23a5a712#5f7e0a925ce1e8e796bcd004a61d7fbd23a5a712"
 dependencies = [
  "contracts",
  "dashmap",
@@ -430,7 +430,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5806c39d471928caabd098c121db85cf8bfa679d#5806c39d471928caabd098c121db85cf8bfa679d"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5f7e0a925ce1e8e796bcd004a61d7fbd23a5a712#5f7e0a925ce1e8e796bcd004a61d7fbd23a5a712"
 dependencies = [
  "ahash",
  "base64 0.22.1",
@@ -847,9 +847,10 @@ dependencies = [
 
 [[package]]
 name = "commands"
-version = "0.2.2"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=d742e04416121990041d01eda027e90b63d536a3#d742e04416121990041d01eda027e90b63d536a3"
+version = "0.2.7"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=59549a4ed40989f7cc5ed25b7fe84f8a75b016c8#59549a4ed40989f7cc5ed25b7fe84f8a75b016c8"
 dependencies = [
+ "api",
  "plugins",
  "runtime",
  "serde_json",
@@ -917,7 +918,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5806c39d471928caabd098c121db85cf8bfa679d#5806c39d471928caabd098c121db85cf8bfa679d"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5f7e0a925ce1e8e796bcd004a61d7fbd23a5a712#5f7e0a925ce1e8e796bcd004a61d7fbd23a5a712"
 dependencies = [
  "parking_lot",
  "serde",
@@ -2540,7 +2541,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5806c39d471928caabd098c121db85cf8bfa679d#5806c39d471928caabd098c121db85cf8bfa679d"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5f7e0a925ce1e8e796bcd004a61d7fbd23a5a712#5f7e0a925ce1e8e796bcd004a61d7fbd23a5a712"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -2608,7 +2609,7 @@ checksum = "0c2cdeb66e45e9f36bfad5bbdb4d2384e70936afbee843c6f6543f0c551ebb25"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5806c39d471928caabd098c121db85cf8bfa679d#5806c39d471928caabd098c121db85cf8bfa679d"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5f7e0a925ce1e8e796bcd004a61d7fbd23a5a712#5f7e0a925ce1e8e796bcd004a61d7fbd23a5a712"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -2813,7 +2814,7 @@ checksum = "fc04a4c58212d57930a24bf47d3fa87485264a3a054e9c10e042eb373573ad3c"
 [[package]]
 name = "managed-agent"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5806c39d471928caabd098c121db85cf8bfa679d#5806c39d471928caabd098c121db85cf8bfa679d"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5f7e0a925ce1e8e796bcd004a61d7fbd23a5a712#5f7e0a925ce1e8e796bcd004a61d7fbd23a5a712"
 dependencies = [
  "a2a",
  "contracts",
@@ -3008,7 +3009,7 @@ dependencies = [
 [[package]]
 name = "nexus-cluster"
 version = "0.1.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5806c39d471928caabd098c121db85cf8bfa679d#5806c39d471928caabd098c121db85cf8bfa679d"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5f7e0a925ce1e8e796bcd004a61d7fbd23a5a712#5f7e0a925ce1e8e796bcd004a61d7fbd23a5a712"
 dependencies = [
  "a2a",
  "anyhow",
@@ -3090,7 +3091,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5806c39d471928caabd098c121db85cf8bfa679d#5806c39d471928caabd098c121db85cf8bfa679d"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5f7e0a925ce1e8e796bcd004a61d7fbd23a5a712#5f7e0a925ce1e8e796bcd004a61d7fbd23a5a712"
 
 [[package]]
 name = "nexus-rebac"
@@ -3162,8 +3163,8 @@ dependencies = [
 
 [[package]]
 name = "nexus-vfs-client"
-version = "0.2.2"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=d742e04416121990041d01eda027e90b63d536a3#d742e04416121990041d01eda027e90b63d536a3"
+version = "0.2.7"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=59549a4ed40989f7cc5ed25b7fe84f8a75b016c8#59549a4ed40989f7cc5ed25b7fe84f8a75b016c8"
 dependencies = [
  "prost 0.13.5",
  "protoc-bin-vendored",
@@ -3621,8 +3622,8 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plugins"
-version = "0.2.2"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=d742e04416121990041d01eda027e90b63d536a3#d742e04416121990041d01eda027e90b63d536a3"
+version = "0.2.7"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=59549a4ed40989f7cc5ed25b7fe84f8a75b016c8#59549a4ed40989f7cc5ed25b7fe84f8a75b016c8"
 dependencies = [
  "serde",
  "serde_json",
@@ -3747,7 +3748,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -3767,7 +3768,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph 0.8.3",
@@ -3788,7 +3789,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -3801,7 +3802,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -4036,7 +4037,7 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 [[package]]
 name = "raft"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5806c39d471928caabd098c121db85cf8bfa679d#5806c39d471928caabd098c121db85cf8bfa679d"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5f7e0a925ce1e8e796bcd004a61d7fbd23a5a712#5f7e0a925ce1e8e796bcd004a61d7fbd23a5a712"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -4465,8 +4466,8 @@ dependencies = [
 
 [[package]]
 name = "runtime"
-version = "0.2.2"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=d742e04416121990041d01eda027e90b63d536a3#d742e04416121990041d01eda027e90b63d536a3"
+version = "0.2.7"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=59549a4ed40989f7cc5ed25b7fe84f8a75b016c8#59549a4ed40989f7cc5ed25b7fe84f8a75b016c8"
 dependencies = [
  "a2a",
  "agent-client-protocol",
@@ -5166,7 +5167,7 @@ dependencies = [
 [[package]]
 name = "subprocess"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5806c39d471928caabd098c121db85cf8bfa679d#5806c39d471928caabd098c121db85cf8bfa679d"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5f7e0a925ce1e8e796bcd004a61d7fbd23a5a712#5f7e0a925ce1e8e796bcd004a61d7fbd23a5a712"
 dependencies = [
  "kernel",
  "libc",
@@ -5384,8 +5385,8 @@ dependencies = [
 
 [[package]]
 name = "telemetry"
-version = "0.2.2"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=d742e04416121990041d01eda027e90b63d536a3#d742e04416121990041d01eda027e90b63d536a3"
+version = "0.2.7"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=59549a4ed40989f7cc5ed25b7fe84f8a75b016c8#59549a4ed40989f7cc5ed25b7fe84f8a75b016c8"
 dependencies = [
  "chrono",
  "dirs",
@@ -5776,8 +5777,8 @@ dependencies = [
 
 [[package]]
 name = "tools"
-version = "0.2.2"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=d742e04416121990041d01eda027e90b63d536a3#d742e04416121990041d01eda027e90b63d536a3"
+version = "0.2.7"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=59549a4ed40989f7cc5ed25b7fe84f8a75b016c8#59549a4ed40989f7cc5ed25b7fe84f8a75b016c8"
 dependencies = [
  "api",
  "async-trait",
@@ -5922,7 +5923,7 @@ dependencies = [
 [[package]]
 name = "transport"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5806c39d471928caabd098c121db85cf8bfa679d#5806c39d471928caabd098c121db85cf8bfa679d"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5f7e0a925ce1e8e796bcd004a61d7fbd23a5a712#5f7e0a925ce1e8e796bcd004a61d7fbd23a5a712"
 dependencies = [
  "axum",
  "backends",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -236,30 +236,30 @@ exclude = ["nexus-fuse"]
 #
 # Bump alongside the rest of nexus-vfs updates when a downstream
 # change needs newer kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5806c39d471928caabd098c121db85cf8bfa679d" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5806c39d471928caabd098c121db85cf8bfa679d" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5806c39d471928caabd098c121db85cf8bfa679d" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5806c39d471928caabd098c121db85cf8bfa679d", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5806c39d471928caabd098c121db85cf8bfa679d", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5806c39d471928caabd098c121db85cf8bfa679d", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5806c39d471928caabd098c121db85cf8bfa679d" }
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5f7e0a925ce1e8e796bcd004a61d7fbd23a5a712" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5f7e0a925ce1e8e796bcd004a61d7fbd23a5a712" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5f7e0a925ce1e8e796bcd004a61d7fbd23a5a712" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5f7e0a925ce1e8e796bcd004a61d7fbd23a5a712", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5f7e0a925ce1e8e796bcd004a61d7fbd23a5a712", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5f7e0a925ce1e8e796bcd004a61d7fbd23a5a712", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5f7e0a925ce1e8e796bcd004a61d7fbd23a5a712" }
 # The cluster daemon library entry (`nexus_cluster::run_with_services`),
 # consumed by the nexus-side assembly binary (`rust/nexusd`) that composes
 # the kernel/federation boot with the nexus service set via the
 # ServiceRegistry bring-up seam.
-nexus-cluster = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5806c39d471928caabd098c121db85cf8bfa679d" }
+nexus-cluster = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5f7e0a925ce1e8e796bcd004a61d7fbd23a5a712" }
 # a2a messaging substrate. `default-features = false` leaves the
 # `install` feature (which pulls raft to arm the stream-wakeup observer)
 # OFF, so nexus-side consumers link only the stamp hook and stay
 # raft-free — they reach raft through kernel.sys_* (§6.1). The substrate
 # is armed in production at cluster boot in nexus-vfs, not here.
-a2a = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5806c39d471928caabd098c121db85cf8bfa679d", default-features = false }
+a2a = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5f7e0a925ce1e8e796bcd004a61d7fbd23a5a712", default-features = false }
 # managed-agent control plane + the shared subprocess host — RELOCATED into
 # nexus-vfs (kernel-tier) so the production nexusd-cluster carries the agent
 # control plane. `subprocess-host` enables the raw ACP-subprocess spawner (the
 # nexus-side acp path + managed-agent both use HostedSubprocess).
-managed-agent = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5806c39d471928caabd098c121db85cf8bfa679d", default-features = false }
-subprocess = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5806c39d471928caabd098c121db85cf8bfa679d" }
+managed-agent = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5f7e0a925ce1e8e796bcd004a61d7fbd23a5a712", default-features = false }
+subprocess = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5f7e0a925ce1e8e796bcd004a61d7fbd23a5a712" }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir --no-deps --prefix=/install .
 # enforces agreement) — an unpinned install tracks nexus-vfs HEAD and
 # ships an untested kernel (#4343). --locked honors the source tree's
 # Cargo.lock.
-ARG NEXUS_VFS_REV=5806c39d471928caabd098c121db85cf8bfa679d
+ARG NEXUS_VFS_REV=5f7e0a925ce1e8e796bcd004a61d7fbd23a5a712
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-cluster nexus-cluster
 
 # -- Runtime stage --

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -25,7 +25,7 @@ WORKDIR /build
 # (CI preflight enforces agreement) — an unpinned install tracks HEAD
 # and can skew the raft contract against the cluster/witness images.
 # --locked honors the source tree's Cargo.lock.
-ARG NEXUS_VFS_REV=5806c39d471928caabd098c121db85cf8bfa679d
+ARG NEXUS_VFS_REV=5f7e0a925ce1e8e796bcd004a61d7fbd23a5a712
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexus-raft-server raft
 
 # ---------- Production image ----------

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=5806c39d471928caabd098c121db85cf8bfa679d
+ARG NEXUS_VFS_REV=5f7e0a925ce1e8e796bcd004a61d7fbd23a5a712
 RUN cargo install \
     --locked \
     --git https://github.com/nexi-lab/nexus-vfs \

--- a/rust/nexusd/Cargo.toml
+++ b/rust/nexusd/Cargo.toml
@@ -33,7 +33,7 @@ http-api = ["dep:nexus-http-api", "dep:tracing"]
 # carries `SudoCodeSpawnAdapter` next to the loop it wraps) and injects it
 # via `install_managed_agent_with_spawn`, so a minted agent runs a real LLM
 # loop doing in-process `KernelSyscall` calls (no gRPC on its fs path).
-# The kernel rev MUST match the workspace pin (both at nexus-vfs `601c2af`)
+# The kernel rev MUST match the workspace pin (both at nexus-vfs `5f7e0a9`)
 # so `SpawnTask<Kernel>` is one type across the seam.
 cohost-sudocode = ["dep:sudocode-tools"]
 # Opt-in ReBAC enforcer — Rust replacement for the Python
@@ -94,14 +94,14 @@ anyhow = "1"
 # ── Co-host (opt-in `cohost-sudocode`) ──────────────────────────────────
 # The real sudocode agent runtime, linked ONLY when co-hosting. `sudocode-
 # tools` reaches `kernel` at the SAME nexus-vfs rev the workspace pins
-# (`601c2af`), so `Kernel` / `AgentDescriptor` / `KernelSyscall` / `AgentState`
+# (`5f7e0a9`), so `Kernel` / `AgentDescriptor` / `KernelSyscall` / `AgentState`
 # unify across the seam and `SpawnTask<Kernel>` is a single monomorphised
 # type. `sudocode-tools` carries BOTH the `spawn_managed_agent` factory and
 # the `SudoCodeSpawnAdapter` this binary injects at boot — there is no
 # nexus-side co-host glue and no runtime enum to map (the adapter reports
-# `kernel::AgentState` directly). Pinned to sudocode main (spawn AgentState
-# collapse).
-sudocode-tools = { package = "tools", git = "https://github.com/sudoprivacy/sudocode", rev = "d742e04416121990041d01eda027e90b63d536a3", optional = true }
+# `kernel::AgentState` directly). Pinned to the sudocode main merge that carries the same nexus-vfs
+# rev (zone-cost release v0.7.3).
+sudocode-tools = { package = "tools", git = "https://github.com/sudoprivacy/sudocode", rev = "59549a4ed40989f7cc5ed25b7fe84f8a75b016c8", optional = true }
 # Named directly to spell `kernel::kernel::{ServiceDecl, Kernel}` — the
 # managed-agent boot decl's return type (both builds) and the co-host
 # adapter's `SpawnTask<Kernel>` (cohost build). Already present transitively

--- a/rust/services/http-api/Cargo.toml
+++ b/rust/services/http-api/Cargo.toml
@@ -42,7 +42,7 @@ dashmap = "6.1"
 # reads /v2/auth/keys on Rust unchanged).  Pinned to the same
 # nexus-vfs rev the workspace does (no `auth` workspace-dep entry
 # yet — the `kernel` + `transport` neighbors are the precedent).
-auth = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5806c39d471928caabd098c121db85cf8bfa679d" }
+auth = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5f7e0a925ce1e8e796bcd004a61d7fbd23a5a712" }
 
 # Bearer-token → `OperationContext` SSOT.
 #


### PR DESCRIPTION
Last link of the release chain for nexi-lab/nexus-vfs#269 + #270, cut as **v0.7.3**.

## What this picks up

* **An idle federation zone costs nothing.** The per-zone transport loop was a 100 Hz poller regardless of activity (~0.1% of a core each, so zone count was a capacity variable). It now waits on work with a computed raft deadline, and a lone-leader zone with no peers parks with no timer at all.
* **Restart tracks ACTIVE zones, not persisted ones.** Boot opened every persisted zone before serving, then swept them again for per-zone wiring (with the mount replay inside that sweep re-walking every zone — quadratic). A zone is now a catalog entry read by one readdir, materialized on first access.
* **Every write lost up to 10 ms of latency** — a proposal no longer waits out a tick to be noticed.
* **A real bug that cost us here:** a single-voter zone with no peers re-scanned its ENTIRE EC replication WAL on every tick, and such a zone never compacts. The A2A mailbox plane writes EC, so this was live cost in this repo's workloads.

## Measured on the released Windows binary (v0.7.2 → v0.7.3, 40 zones)

| | before | after |
|---|---|---|
| idle CPU | 5.16% of one core | **0.00%** |
| per zone | 0.129% | **~0** |
| restart to serving | 1364 ms | **332 ms** |
| zones opened on restart | 41 | **1** |
| fresh create to serving | 349 ms | 355 ms (unchanged) |

Creation stays eager on purpose — founding a zone writes it durably; that is durability, not boot cost.

## The chain

`nexus-vfs v0.7.3` → `sudoprivacy/sudocode#611` → this PR. sudocode pins nexus-vfs too, and the pin-consistency preflight requires a single unique nexus-vfs rev across the whole lock, so its bump had to land first. Verified here: the lock resolves exactly one nexus-vfs rev (`5f7e0a92`) and one sudocode rev (`59549a4e`).

## Drift

None across the 30 nexus-vfs commits. `cargo check --workspace --all-targets` and `cargo clippy --workspace --all-targets` are clean. `cargo check -p nexusd --features cohost-sudocode` is clean as well — CI does not build the co-host feature, so that one was verified locally rather than left for whoever builds it next (that bump crosses 187 sudocode commits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
