### PR TITLE
fix(ci): auto plugin release cut tags but never released them

### DIFF
--- a/.github/workflows/auto-plugin-release.yml
+++ b/.github/workflows/auto-plugin-release.yml
@@ -105,14 +105,17 @@ jobs:
 
           # Fuse + local-connector + search can go together (all use dogfood
           # signing which fetches the latest vault-v* release — vault must
-          # be released first, but the tag push triggers are async so there
-          # is a race.  The release-plugin-reusable workflow retries vault
-          # fetch, so in practice this works. If it doesn't, workflow_dispatch
-          # retry is available.)
+          # be released first, which the dispatch step below orders).
           git tag -a "$FUSE_TAG" HEAD -m "fuse-plugin ${FUSE_TAG#fuse-v} — $MSG"
           git tag -a "$LC_TAG" HEAD -m "local-connector ${LC_TAG#local-connector-v} — $MSG"
           git tag -a "$SEARCH_TAG" HEAD -m "search-plugin ${SEARCH_TAG#search-v} — $MSG"
           git push origin "$FUSE_TAG" "$LC_TAG" "$SEARCH_TAG"
+
+          {
+            echo "fuse_tag=$FUSE_TAG"
+            echo "lc_tag=$LC_TAG"
+            echo "search_tag=$SEARCH_TAG"
+          } >> "$GITHUB_ENV"
 
           echo "### Auto Plugin Release" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
@@ -124,3 +127,53 @@ jobs:
           echo "| fuse | $FUSE_TAG |" >> "$GITHUB_STEP_SUMMARY"
           echo "| local-connector | $LC_TAG |" >> "$GITHUB_STEP_SUMMARY"
           echo "| search-plugin | $SEARCH_TAG |" >> "$GITHUB_STEP_SUMMARY"
+
+      # Cutting the tag is NOT what releases the plugin — this step is.
+      #
+      # GitHub does not start a workflow from an event raised with the
+      # default `GITHUB_TOKEN`, so the `on: push: tags:` trigger in each
+      # release wrapper never fired for a tag pushed above. The tags landed,
+      # the releases did not, and every downstream that pins a plugin version
+      # (sudowork pins nexus-vault by version + SHA256) was stuck on the last
+      # hand-released build while the daemon's ABI moved underneath it —
+      # ten rev bumps' worth, silently.
+      #
+      # `workflow_dispatch` is the documented exception: it may be triggered
+      # with `GITHUB_TOKEN`. Each wrapper already accepts the tag as an input
+      # for exactly this kind of retry, so dispatch them explicitly rather
+      # than hoping for a trigger that cannot fire.
+      #
+      # Vault goes first and we WAIT for it: every other plugin dogfoods its
+      # signing key out of the newest vault-v* release, so releasing them
+      # against a stale vault is how a signature ends up covering the wrong
+      # key. Ordering it here also retires the race the old comment described.
+      - name: Dispatch the release workflows
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          dispatch() { # workflow-file tag
+            echo "dispatching $1 for $2"
+            gh workflow run "$1" --ref "${{ github.ref_name }}" -f "tag=$2"
+          }
+
+          dispatch release-vault-plugin.yml "$vault_tag"
+
+          # Wait for the vault release to exist before the dogfooding
+          # plugins go, rather than letting them race it.
+          deadline=$((SECONDS + 1500))
+          until gh release view "$vault_tag" --json tagName >/dev/null 2>&1; do
+            if [ $SECONDS -ge $deadline ]; then
+              echo "::error::vault release $vault_tag did not appear within 25m; \
+          the dogfooding plugins were NOT dispatched. Re-run them by hand once \
+          vault is published."
+              exit 1
+            fi
+            sleep 20
+          done
+          echo "vault release $vault_tag is published"
+
+          dispatch release-fuse-plugin.yml "$fuse_tag"
+          dispatch release-local-connector-plugin.yml "$lc_tag"
+          dispatch release-search-plugin.yml "$search_tag"

--- a/.github/workflows/release-plugin-reusable.yml
+++ b/.github/workflows/release-plugin-reusable.yml
@@ -372,6 +372,12 @@ jobs:
             exit 1
           fi
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          # The release step needs the tag NAME, not just the version: on a
+          # workflow_dispatch run `github.ref` is the branch, so the release
+          # action has no tag to attach to and fails with "GitHub Releases
+          # requires a tag". Emit it from the same effective ref the version
+          # came from, so both paths agree by construction.
+          echo "tag=${{ inputs.version_tag_prefix }}${VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Download all build artifacts
         uses: actions/download-artifact@v4
@@ -709,9 +715,13 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
+          # Explicit, for the dispatch path: `github.ref` is a branch there.
+          tag_name: ${{ steps.version.outputs.tag }}
           body_path: release-body/release_body.md
           files: release-assets/*
           draft: false
-          prerelease: ${{ contains(github.ref, 'alpha') || contains(github.ref, 'beta') || contains(github.ref, 'rc') }}
+          # Read the pre-release marker off the resolved version for the same
+          # reason — `github.ref` does not carry it on a dispatch.
+          prerelease: ${{ contains(steps.version.outputs.version, 'alpha') || contains(steps.version.outputs.version, 'beta') || contains(steps.version.outputs.version, 'rc') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-plugin-reusable.yml
+++ b/.github/workflows/release-plugin-reusable.yml
@@ -353,6 +353,11 @@ jobs:
     name: Package and upload
     needs: [build]
     runs-on: ubuntu-latest
+    # Surfaced for `create-release`, which runs in its own job and so cannot
+    # read this one's step outputs.
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      tag: ${{ steps.version.outputs.tag }}
 
     steps:
       - name: Checkout code
@@ -716,12 +721,12 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           # Explicit, for the dispatch path: `github.ref` is a branch there.
-          tag_name: ${{ steps.version.outputs.tag }}
+          tag_name: ${{ needs.package-and-upload.outputs.tag }}
           body_path: release-body/release_body.md
           files: release-assets/*
           draft: false
           # Read the pre-release marker off the resolved version for the same
           # reason — `github.ref` does not carry it on a dispatch.
-          prerelease: ${{ contains(steps.version.outputs.version, 'alpha') || contains(steps.version.outputs.version, 'beta') || contains(steps.version.outputs.version, 'rc') }}
+          prerelease: ${{ contains(needs.package-and-upload.outputs.version, 'alpha') || contains(needs.package-and-upload.outputs.version, 'beta') || contains(needs.package-and-upload.outputs.version, 'rc') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What

`Auto Plugin Release` has been cutting plugin tags on every nexus-vfs rev bump and producing **no releases** since `vault-v0.5.44` (2026-08-22). Ten bumps, four plugins, forty tags with nothing behind them:

| latest tag | release |
|---|---|
| `vault-v0.5.54` | none |
| `fuse-v0.6.54` | none |
| `local-connector-v0.4.54` | none |
| `search-v0.1.27` | none |

## Why

GitHub does not start a workflow from an event raised with the default `GITHUB_TOKEN`. The tags are pushed by this workflow, so the `on: push: tags:` trigger in each release wrapper cannot fire — by design, to prevent recursion. The tags landed; the pipeline behind them never ran.

## Why it matters now

Downstream pins the published artifact, not the tag. sudowork pins `nexus-vault` by version + SHA256 and verifies the detached `.sig` — it does not build the dylib. So it has had no vault build matching the daemon's ABI for three weeks, across a `PLUGIN_API_VERSION` 5 → 6 change that makes a mismatched daemon/plugin pair **refuse to boot** (loader hard-fails, and `load_plugin_dir` fails boot rather than skipping). Their upgrade to v0.7.3 was blocked on an artifact that silently never got built.

## The fix

Dispatch the wrappers explicitly. `workflow_dispatch` is the documented exception that `GITHUB_TOKEN` may trigger, and every wrapper already accepts the tag as an input for hand-retries — so this uses the seam that was already there rather than adding a PAT.

Vault is dispatched first and **waited on** before the other three: they dogfood their signing key out of the newest `vault-v*` release, so releasing them against a stale vault is how a signature ends up covering the wrong key. That ordering also retires the race the previous comment shrugged at ("the tag push triggers are async so there is a race … in practice this works").

If vault does not publish within 25 minutes the step fails loud and says which plugins were not dispatched, instead of leaving three half-released plugins to be discovered downstream.

## Verification

`vault-v0.5.54` (the tag auto-cut on the v0.7.3 pin bump) was released by hand-dispatching the same wrapper this change now calls — that is the path being automated, exercised end to end before automating it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)