### PR TITLE
fix(ci): stamp the assembly tag into the binary it releases

### DIFF
--- a/.github/workflows/release-nexusd-cluster.yml
+++ b/.github/workflows/release-nexusd-cluster.yml
@@ -135,6 +135,15 @@ jobs:
       # Default features -> managed_agent ON, cohost-sudocode OFF (the slim
       # production profile). Do NOT add --features cohost-sudocode here.
       - name: Build release binary (assembly, managed_agent on / cohost off)
+        env:
+          # Stamp the assembly tag into `--version` and the `Ping` RPC
+          # (nexus-vfs reads NEXUSD_BUILD_VERSION; see its cluster profile).
+          # Without it the binary reports the version of the crate that owns
+          # the clap derive — nexus-vfs's `nexus-cluster` — which is the SAME
+          # number the pure nexus-vfs daemon prints and does not move when
+          # this assembly is re-tagged. Downstream confirming an upgrade read
+          # 0.1.1 before and after v0.1.2.
+          NEXUSD_BUILD_VERSION: ${{ inputs.tag || github.ref_name }}
         run: cargo build --locked --release -p nexusd --bin nexusd-cluster ${{ matrix.target && format('--target {0}', matrix.target) || '' }}
 
       - name: Stage release payload


### PR DESCRIPTION
## What

The assembly binary self-reported `nexusd-cluster 0.1.1` after being released as `nexusd-cluster-v0.1.2`. The tag moved, the bytes moved, `--version` did not.

## Why

clap takes its version from the crate that owns the derive — nexus-vfs's `nexus-cluster` (0.1.1) — not this repo's `nexusd`. Two consequences, both bad for a consumer:

* the number does not move when this assembly is re-tagged, so confirming an upgrade landed gives a **false negative**;
* the pure nexus-vfs daemon prints the *same* number, so it cannot distinguish the two binaries that share the filename `nexusd-cluster` either — precisely the pair an operator is trying to tell apart when diagnosing a mismatch.

## The fix

Pass the released tag as `NEXUSD_BUILD_VERSION`. nexus-vfs's cluster profile reads it for **both** `--version` and the `Ping` RPC (nexi-lab/nexus-vfs#271), so the CLI and the wire cannot disagree, and an unstamped local build falls back to the crate version rather than claiming a tag it is not:

```
$ nexusd-cluster --version
nexusd-cluster v0.1.2 (nexus-cluster 0.1.1, plugin-abi 6)
```

The `plugin-abi` component is deliberate: it is the number that decides whether a pinned plugin set is loadable by this daemon, which is what a deployment pairing pinned dylibs with a pinned daemon actually needs to read.

## Order

nexus-vfs#271 must land (and this repo's pin move to include it) before the stamp has an effect here; until then this env var is simply unread. Harmless in either order.

Found by sudowork while verifying the v0.1.2 upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)