### PR TITLE
chore(deps): pin nexus-vfs v0.7.4 (and the matching sudocode merge)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "a2a"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5f7e0a925ce1e8e796bcd004a61d7fbd23a5a712#5f7e0a925ce1e8e796bcd004a61d7fbd23a5a712"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=35df753583d15aa26c14b5ac4885ec1a210eb2d4#35df753583d15aa26c14b5ac4885ec1a210eb2d4"
 dependencies = [
  "contracts",
  "kernel",
@@ -234,7 +234,7 @@ checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 [[package]]
 name = "api"
 version = "0.2.7"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=59549a4ed40989f7cc5ed25b7fe84f8a75b016c8#59549a4ed40989f7cc5ed25b7fe84f8a75b016c8"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=66abb4af508a1be96af64b082a691a5085c9cbb4#66abb4af508a1be96af64b082a691a5085c9cbb4"
 dependencies = [
  "base64 0.22.1",
  "httpdate",
@@ -327,7 +327,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 [[package]]
 name = "auth"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5f7e0a925ce1e8e796bcd004a61d7fbd23a5a712#5f7e0a925ce1e8e796bcd004a61d7fbd23a5a712"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=35df753583d15aa26c14b5ac4885ec1a210eb2d4#35df753583d15aa26c14b5ac4885ec1a210eb2d4"
 dependencies = [
  "contracts",
  "dashmap",
@@ -430,7 +430,7 @@ dependencies = [
 [[package]]
 name = "backends"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5f7e0a925ce1e8e796bcd004a61d7fbd23a5a712#5f7e0a925ce1e8e796bcd004a61d7fbd23a5a712"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=35df753583d15aa26c14b5ac4885ec1a210eb2d4#35df753583d15aa26c14b5ac4885ec1a210eb2d4"
 dependencies = [
  "ahash",
  "base64 0.22.1",
@@ -848,7 +848,7 @@ dependencies = [
 [[package]]
 name = "commands"
 version = "0.2.7"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=59549a4ed40989f7cc5ed25b7fe84f8a75b016c8#59549a4ed40989f7cc5ed25b7fe84f8a75b016c8"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=66abb4af508a1be96af64b082a691a5085c9cbb4#66abb4af508a1be96af64b082a691a5085c9cbb4"
 dependencies = [
  "api",
  "plugins",
@@ -918,7 +918,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5f7e0a925ce1e8e796bcd004a61d7fbd23a5a712#5f7e0a925ce1e8e796bcd004a61d7fbd23a5a712"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=35df753583d15aa26c14b5ac4885ec1a210eb2d4#35df753583d15aa26c14b5ac4885ec1a210eb2d4"
 dependencies = [
  "parking_lot",
  "serde",
@@ -2541,7 +2541,7 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.10.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5f7e0a925ce1e8e796bcd004a61d7fbd23a5a712#5f7e0a925ce1e8e796bcd004a61d7fbd23a5a712"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=35df753583d15aa26c14b5ac4885ec1a210eb2d4#35df753583d15aa26c14b5ac4885ec1a210eb2d4"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -2609,7 +2609,7 @@ checksum = "0c2cdeb66e45e9f36bfad5bbdb4d2384e70936afbee843c6f6543f0c551ebb25"
 [[package]]
 name = "lib"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5f7e0a925ce1e8e796bcd004a61d7fbd23a5a712#5f7e0a925ce1e8e796bcd004a61d7fbd23a5a712"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=35df753583d15aa26c14b5ac4885ec1a210eb2d4#35df753583d15aa26c14b5ac4885ec1a210eb2d4"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -2814,7 +2814,7 @@ checksum = "fc04a4c58212d57930a24bf47d3fa87485264a3a054e9c10e042eb373573ad3c"
 [[package]]
 name = "managed-agent"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5f7e0a925ce1e8e796bcd004a61d7fbd23a5a712#5f7e0a925ce1e8e796bcd004a61d7fbd23a5a712"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=35df753583d15aa26c14b5ac4885ec1a210eb2d4#35df753583d15aa26c14b5ac4885ec1a210eb2d4"
 dependencies = [
  "a2a",
  "contracts",
@@ -3009,7 +3009,7 @@ dependencies = [
 [[package]]
 name = "nexus-cluster"
 version = "0.1.1"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5f7e0a925ce1e8e796bcd004a61d7fbd23a5a712#5f7e0a925ce1e8e796bcd004a61d7fbd23a5a712"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=35df753583d15aa26c14b5ac4885ec1a210eb2d4#35df753583d15aa26c14b5ac4885ec1a210eb2d4"
 dependencies = [
  "a2a",
  "anyhow",
@@ -3091,7 +3091,7 @@ dependencies = [
 [[package]]
 name = "nexus-plugin-abi"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5f7e0a925ce1e8e796bcd004a61d7fbd23a5a712#5f7e0a925ce1e8e796bcd004a61d7fbd23a5a712"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=35df753583d15aa26c14b5ac4885ec1a210eb2d4#35df753583d15aa26c14b5ac4885ec1a210eb2d4"
 
 [[package]]
 name = "nexus-rebac"
@@ -3164,7 +3164,7 @@ dependencies = [
 [[package]]
 name = "nexus-vfs-client"
 version = "0.2.7"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=59549a4ed40989f7cc5ed25b7fe84f8a75b016c8#59549a4ed40989f7cc5ed25b7fe84f8a75b016c8"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=66abb4af508a1be96af64b082a691a5085c9cbb4#66abb4af508a1be96af64b082a691a5085c9cbb4"
 dependencies = [
  "prost 0.13.5",
  "protoc-bin-vendored",
@@ -3623,7 +3623,7 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 [[package]]
 name = "plugins"
 version = "0.2.7"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=59549a4ed40989f7cc5ed25b7fe84f8a75b016c8#59549a4ed40989f7cc5ed25b7fe84f8a75b016c8"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=66abb4af508a1be96af64b082a691a5085c9cbb4#66abb4af508a1be96af64b082a691a5085c9cbb4"
 dependencies = [
  "serde",
  "serde_json",
@@ -4037,7 +4037,7 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 [[package]]
 name = "raft"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5f7e0a925ce1e8e796bcd004a61d7fbd23a5a712#5f7e0a925ce1e8e796bcd004a61d7fbd23a5a712"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=35df753583d15aa26c14b5ac4885ec1a210eb2d4#35df753583d15aa26c14b5ac4885ec1a210eb2d4"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -4467,7 +4467,7 @@ dependencies = [
 [[package]]
 name = "runtime"
 version = "0.2.7"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=59549a4ed40989f7cc5ed25b7fe84f8a75b016c8#59549a4ed40989f7cc5ed25b7fe84f8a75b016c8"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=66abb4af508a1be96af64b082a691a5085c9cbb4#66abb4af508a1be96af64b082a691a5085c9cbb4"
 dependencies = [
  "a2a",
  "agent-client-protocol",
@@ -5167,7 +5167,7 @@ dependencies = [
 [[package]]
 name = "subprocess"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5f7e0a925ce1e8e796bcd004a61d7fbd23a5a712#5f7e0a925ce1e8e796bcd004a61d7fbd23a5a712"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=35df753583d15aa26c14b5ac4885ec1a210eb2d4#35df753583d15aa26c14b5ac4885ec1a210eb2d4"
 dependencies = [
  "kernel",
  "libc",
@@ -5386,7 +5386,7 @@ dependencies = [
 [[package]]
 name = "telemetry"
 version = "0.2.7"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=59549a4ed40989f7cc5ed25b7fe84f8a75b016c8#59549a4ed40989f7cc5ed25b7fe84f8a75b016c8"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=66abb4af508a1be96af64b082a691a5085c9cbb4#66abb4af508a1be96af64b082a691a5085c9cbb4"
 dependencies = [
  "chrono",
  "dirs",
@@ -5778,7 +5778,7 @@ dependencies = [
 [[package]]
 name = "tools"
 version = "0.2.7"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=59549a4ed40989f7cc5ed25b7fe84f8a75b016c8#59549a4ed40989f7cc5ed25b7fe84f8a75b016c8"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=66abb4af508a1be96af64b082a691a5085c9cbb4#66abb4af508a1be96af64b082a691a5085c9cbb4"
 dependencies = [
  "api",
  "async-trait",
@@ -5923,7 +5923,7 @@ dependencies = [
 [[package]]
 name = "transport"
 version = "0.1.0"
-source = "git+https://github.com/nexi-lab/nexus-vfs?rev=5f7e0a925ce1e8e796bcd004a61d7fbd23a5a712#5f7e0a925ce1e8e796bcd004a61d7fbd23a5a712"
+source = "git+https://github.com/nexi-lab/nexus-vfs?rev=35df753583d15aa26c14b5ac4885ec1a210eb2d4#35df753583d15aa26c14b5ac4885ec1a210eb2d4"
 dependencies = [
  "axum",
  "backends",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -236,30 +236,30 @@ exclude = ["nexus-fuse"]
 #
 # Bump alongside the rest of nexus-vfs updates when a downstream
 # change needs newer kernel bits.
-contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5f7e0a925ce1e8e796bcd004a61d7fbd23a5a712" }
-lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5f7e0a925ce1e8e796bcd004a61d7fbd23a5a712" }
-transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5f7e0a925ce1e8e796bcd004a61d7fbd23a5a712" }
-backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5f7e0a925ce1e8e796bcd004a61d7fbd23a5a712", default-features = false }
-kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5f7e0a925ce1e8e796bcd004a61d7fbd23a5a712", default-features = false }
-raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5f7e0a925ce1e8e796bcd004a61d7fbd23a5a712", default-features = false, features = ["grpc"] }
-nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5f7e0a925ce1e8e796bcd004a61d7fbd23a5a712" }
+contracts = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "35df753583d15aa26c14b5ac4885ec1a210eb2d4" }
+lib = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "35df753583d15aa26c14b5ac4885ec1a210eb2d4" }
+transport = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "35df753583d15aa26c14b5ac4885ec1a210eb2d4" }
+backends = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "35df753583d15aa26c14b5ac4885ec1a210eb2d4", default-features = false }
+kernel = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "35df753583d15aa26c14b5ac4885ec1a210eb2d4", default-features = false }
+raft = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "35df753583d15aa26c14b5ac4885ec1a210eb2d4", default-features = false, features = ["grpc"] }
+nexus-plugin-abi = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "35df753583d15aa26c14b5ac4885ec1a210eb2d4" }
 # The cluster daemon library entry (`nexus_cluster::run_with_services`),
 # consumed by the nexus-side assembly binary (`rust/nexusd`) that composes
 # the kernel/federation boot with the nexus service set via the
 # ServiceRegistry bring-up seam.
-nexus-cluster = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5f7e0a925ce1e8e796bcd004a61d7fbd23a5a712" }
+nexus-cluster = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "35df753583d15aa26c14b5ac4885ec1a210eb2d4" }
 # a2a messaging substrate. `default-features = false` leaves the
 # `install` feature (which pulls raft to arm the stream-wakeup observer)
 # OFF, so nexus-side consumers link only the stamp hook and stay
 # raft-free — they reach raft through kernel.sys_* (§6.1). The substrate
 # is armed in production at cluster boot in nexus-vfs, not here.
-a2a = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5f7e0a925ce1e8e796bcd004a61d7fbd23a5a712", default-features = false }
+a2a = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "35df753583d15aa26c14b5ac4885ec1a210eb2d4", default-features = false }
 # managed-agent control plane + the shared subprocess host — RELOCATED into
 # nexus-vfs (kernel-tier) so the production nexusd-cluster carries the agent
 # control plane. `subprocess-host` enables the raw ACP-subprocess spawner (the
 # nexus-side acp path + managed-agent both use HostedSubprocess).
-managed-agent = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5f7e0a925ce1e8e796bcd004a61d7fbd23a5a712", default-features = false }
-subprocess = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5f7e0a925ce1e8e796bcd004a61d7fbd23a5a712" }
+managed-agent = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "35df753583d15aa26c14b5ac4885ec1a210eb2d4", default-features = false }
+subprocess = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "35df753583d15aa26c14b5ac4885ec1a210eb2d4" }
 # Local service crate (nexus-owned).
 services = { path = "rust/services" }
 serde = { version = "1.0", features = ["derive"] }

--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir --no-deps --prefix=/install .
 # enforces agreement) — an unpinned install tracks nexus-vfs HEAD and
 # ships an untested kernel (#4343). --locked honors the source tree's
 # Cargo.lock.
-ARG NEXUS_VFS_REV=5f7e0a925ce1e8e796bcd004a61d7fbd23a5a712
+ARG NEXUS_VFS_REV=35df753583d15aa26c14b5ac4885ec1a210eb2d4
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexusd-cluster nexus-cluster
 
 # -- Runtime stage --

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -25,7 +25,7 @@ WORKDIR /build
 # (CI preflight enforces agreement) — an unpinned install tracks HEAD
 # and can skew the raft contract against the cluster/witness images.
 # --locked honors the source tree's Cargo.lock.
-ARG NEXUS_VFS_REV=5f7e0a925ce1e8e796bcd004a61d7fbd23a5a712
+ARG NEXUS_VFS_REV=35df753583d15aa26c14b5ac4885ec1a210eb2d4
 RUN cargo install --locked --git https://github.com/nexi-lab/nexus-vfs --rev "${NEXUS_VFS_REV}" --bin nexus-raft-server raft
 
 # ---------- Production image ----------

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -27,7 +27,7 @@ WORKDIR /build
 # See Dockerfile.nexusd-cluster for rationale on the SHA pin.  Both
 # images must build off the same nexus-vfs revision so the witness and
 # cluster nodes negotiate over the same raft contract.
-ARG NEXUS_VFS_REV=5f7e0a925ce1e8e796bcd004a61d7fbd23a5a712
+ARG NEXUS_VFS_REV=35df753583d15aa26c14b5ac4885ec1a210eb2d4
 RUN cargo install \
     --locked \
     --git https://github.com/nexi-lab/nexus-vfs \

--- a/rust/nexusd/Cargo.toml
+++ b/rust/nexusd/Cargo.toml
@@ -33,8 +33,8 @@ http-api = ["dep:nexus-http-api", "dep:tracing"]
 # carries `SudoCodeSpawnAdapter` next to the loop it wraps) and injects it
 # via `install_managed_agent_with_spawn`, so a minted agent runs a real LLM
 # loop doing in-process `KernelSyscall` calls (no gRPC on its fs path).
-# The kernel rev MUST match the workspace pin (both at nexus-vfs `5f7e0a9`)
-# so `SpawnTask<Kernel>` is one type across the seam.
+# `sudocode-tools` MUST reach the kernel at the same nexus-vfs rev this
+# workspace pins, so `SpawnTask<Kernel>` is one type across the seam.
 cohost-sudocode = ["dep:sudocode-tools"]
 # Opt-in ReBAC enforcer — Rust replacement for the Python
 # `bricks/rebac/` (part of the R10 pure-Rust `nexus-server`
@@ -93,15 +93,16 @@ anyhow = "1"
 
 # ── Co-host (opt-in `cohost-sudocode`) ──────────────────────────────────
 # The real sudocode agent runtime, linked ONLY when co-hosting. `sudocode-
-# tools` reaches `kernel` at the SAME nexus-vfs rev the workspace pins
-# (`5f7e0a9`), so `Kernel` / `AgentDescriptor` / `KernelSyscall` / `AgentState`
-# unify across the seam and `SpawnTask<Kernel>` is a single monomorphised
-# type. `sudocode-tools` carries BOTH the `spawn_managed_agent` factory and
-# the `SudoCodeSpawnAdapter` this binary injects at boot — there is no
+# tools` reaches `kernel` at the SAME nexus-vfs rev the workspace pins, so
+# `Kernel` / `AgentDescriptor` / `KernelSyscall` / `AgentState` unify across
+# the seam and `SpawnTask<Kernel>` is a single monomorphised type.
+# `sudocode-tools` carries BOTH the `spawn_managed_agent` factory and the
+# `SudoCodeSpawnAdapter` this binary injects at boot — there is no
 # nexus-side co-host glue and no runtime enum to map (the adapter reports
-# `kernel::AgentState` directly). Pinned to the sudocode main merge that carries the same nexus-vfs
-# rev (zone-cost release v0.7.3).
-sudocode-tools = { package = "tools", git = "https://github.com/sudoprivacy/sudocode", rev = "59549a4ed40989f7cc5ed25b7fe84f8a75b016c8", optional = true }
+# `kernel::AgentState` directly). Pinned to the sudocode main merge that
+# carries that same rev: bumping the workspace pin means bumping this one
+# in the same commit, or the co-host build fails to compile.
+sudocode-tools = { package = "tools", git = "https://github.com/sudoprivacy/sudocode", rev = "66abb4af508a1be96af64b082a691a5085c9cbb4", optional = true }
 # Named directly to spell `kernel::kernel::{ServiceDecl, Kernel}` — the
 # managed-agent boot decl's return type (both builds) and the co-host
 # adapter's `SpawnTask<Kernel>` (cohost build). Already present transitively

--- a/rust/services/http-api/Cargo.toml
+++ b/rust/services/http-api/Cargo.toml
@@ -42,7 +42,7 @@ dashmap = "6.1"
 # reads /v2/auth/keys on Rust unchanged).  Pinned to the same
 # nexus-vfs rev the workspace does (no `auth` workspace-dep entry
 # yet — the `kernel` + `transport` neighbors are the precedent).
-auth = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "5f7e0a925ce1e8e796bcd004a61d7fbd23a5a712" }
+auth = { git = "https://github.com/nexi-lab/nexus-vfs", rev = "35df753583d15aa26c14b5ac4885ec1a210eb2d4" }
 
 # Bearer-token → `OperationContext` SSOT.
 #


### PR DESCRIPTION
## Why

nexus-vfs cut **v0.7.4** (`35df7535`). What it carries for this repo and for
the desktop consumer downstream:

- **One stamped build identity.** `--version` and the typed `Ping` RPC both
  answer `<tag> (nexus-cluster <crate>, plugin-abi <N>)`. The consumer can
  assert the plugin ABI on the wire rather than inferring it from the
  artifact they downloaded — the gap that made the v5→v6 ABI move hard to
  verify from outside, since a mismatched dylib set fails boot rather than
  degrading.
- **An unknown generic `Call` method now names the typed RPCs** that carry
  filesystem operations. `call('mkdir', ...)` used to answer with a bare
  method name and no hint that `Mkdir` exists as its own RPC.
- **Node client 0.3.0** — typed `stat` / `exists` / `readdir` / `mkdir`, and
  `ping` routed to the typed `Ping` RPC instead of a `Call` method that does
  not exist. Published to the COS mirror at
  `nexus-vfs/clients/node/0.3.0/`.

## What

The rev, in every file that carries it: `Cargo.toml`, `Cargo.lock`,
`rust/services/http-api/Cargo.toml`, and the three `dockerfiles/*` build
ARGs.

`sudocode-tools` moves in the same commit, to sudoprivacy/sudocode#619
(`66abb4af`), which pins the same nexus-vfs rev. It has to: `sudocode-tools`
reaches `kernel` through its own pin, and a mismatch makes `SpawnTask<Kernel>`
two distinct types across the co-host seam. The comments that spelled the rev
in prose now point at the pin itself, so the next bump has one place to
change and cannot leave a stale sha behind.

## Test

- `cargo check --workspace --all-targets` — clean.
- `cargo check -p nexusd --features cohost-sudocode` — clean. This is the
  seam the two pins exist to keep unified, and it is not in `full`, so
  nothing else in CI compiles it.
- `cargo metadata --locked` resolves with exactly one nexus-vfs rev in the
  lock — no second copy of the kernel graph.
- The released v0.7.4 Windows binary from the COS mirror reports
  `nexusd-cluster v0.7.4 (nexus-cluster 0.1.1, plugin-abi 6)`, and its
  SHA256 matches `SHA256SUMS.txt`.
- The Docker E2E suites gated on `Cargo.toml` / `Cargo.lock` run on this PR.

Merging this triggers `auto-plugin-release`, which cuts vault / fuse /
local-connector / search tags rebuilt against the new rev — the four-artifact
set the desktop consumer loads together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)