### PR TITLE
fix(ci): grant auto-plugin-release the permission to dispatch releases

### DIFF
--- a/.github/workflows/auto-plugin-release.yml
+++ b/.github/workflows/auto-plugin-release.yml
@@ -21,7 +21,14 @@ on:
       - "Cargo.toml"
 
 permissions:
+  # Push the tags.
   contents: write
+  # Dispatch the release workflows. `workflow_dispatch` via the API is an
+  # `actions` write, not a `contents` one — without this the dispatch step
+  # gets HTTP 403 "Resource not accessible by integration" and the tags land
+  # with no releases behind them, which is the exact failure this workflow's
+  # dispatch step exists to prevent.
+  actions: write
 
 jobs:
   check-rev-change:


### PR DESCRIPTION
## Why

The `Dispatch the release workflows` step exists because GitHub does not
start a workflow from a tag pushed with the default `GITHUB_TOKEN`, so
`on: push: tags:` never fires for the tags this workflow cuts. The first
rev bump after that step landed (#4768) hit:

```
dispatching release-vault-plugin.yml for vault-v0.5.55
could not create workflow dispatch event: HTTP 403: Resource not accessible by integration
```

`workflow_dispatch` through the API is an **`actions`** write; the workflow
only asked for `contents: write`. So the tags landed — `vault-v0.5.55`,
`fuse-v0.6.55`, `local-connector-v0.4.55`, `search-v0.1.28` — with no
releases behind them: exactly the failure mode the dispatch step was added
to prevent.

## What

`actions: write` alongside `contents: write`, with the reason recorded next
to it so it is not dropped as noise later.

## Test

The four releases for this bump were dispatched by hand to unblock the
consumer waiting on them. The next rev bump exercises this path
automatically; this PR is what makes that path work rather than 403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)