### PR TITLE
fix(ci): upload plugin release artifacts through COS acceleration, chunked

### DIFF
--- a/scripts/upload_cos.py
+++ b/scripts/upload_cos.py
@@ -1,5 +1,16 @@
 #!/usr/bin/env python3
-"""Upload a build artifact to Tencent COS using the official Python SDK."""
+"""Upload a build artifact to Tencent COS using the official Python SDK.
+
+Every upload goes through the global acceleration endpoint as a chunked,
+retrying transfer. A GitHub runner talking straight to the regional endpoint
+(ap-beijing) is slow enough that COS aborts the request itself:
+
+    CosServiceError: {'code': 'UserNetworkTooSlow', ...}
+
+which killed a plugin release mid-upload. `release-nexusd-cluster.yml` hit the
+same wall and answered it the same way; this is that answer for every caller
+of this script.
+"""
 
 from __future__ import annotations
 
@@ -10,7 +21,14 @@ from pathlib import Path
 
 from qcloud_cos import CosConfig, CosS3Client
 
-LARGE_FILE_THRESHOLD = 128 * 1024 * 1024
+# Global acceleration: routes the runner to the nearest COS edge instead of
+# across the public internet to the bucket's region.
+ACCELERATE_ENDPOINT = "cos.accelerate.myqcloud.com"
+# Small enough that a stalled part is retried rather than restarting the file.
+PART_SIZE_MB = 10
+UPLOAD_THREADS = 5
+# Per-request retries inside the SDK, on top of the per-part retry above.
+REQUEST_RETRIES = 5
 
 
 def _required_env(name: str) -> str:
@@ -31,11 +49,18 @@ class COSClient:
         region: str,
         base_url: str | None = None,
     ) -> None:
-        config = CosConfig(Region=region, SecretId=secret_id, SecretKey=secret_key)
-        self.client = CosS3Client(config)
+        config = CosConfig(
+            Region=region,
+            SecretId=secret_id,
+            SecretKey=secret_key,
+            Endpoint=ACCELERATE_ENDPOINT,
+        )
+        self.client = CosS3Client(config, retry=REQUEST_RETRIES)
         self.bucket = bucket
         self.region = region
-        self.base_url = base_url or f"https://{bucket}.cos.{region}.myqcloud.com"
+        # Report the object at the host we uploaded through — the same
+        # acceleration domain the published download URLs use.
+        self.base_url = base_url or f"https://{bucket}.{ACCELERATE_ENDPOINT}"
 
     def upload_file(
         self,
@@ -43,26 +68,24 @@ class COSClient:
         remote_path: str,
         content_type: str | None = None,
     ) -> str:
+        """Upload one artifact, chunked, whatever its size.
+
+        `upload_file` picks simple-vs-multipart itself from `PartSize`, and
+        retries a part rather than the whole transfer. A plain `put_object`
+        streams the file in one request, which is what COS was rejecting as
+        too slow — so there is no size below which the simple path is worth
+        keeping.
+        """
         if content_type is None:
             content_type, _ = mimetypes.guess_type(str(local_path))
 
-        with local_path.open("rb") as fh:
-            self.client.put_object(
-                Bucket=self.bucket,
-                Key=remote_path,
-                Body=fh,
-                ContentType=content_type,
-            )
-
-        return f"{self.base_url.rstrip('/')}/{remote_path}"
-
-    def upload_large_file(self, local_path: Path, remote_path: str) -> str:
         self.client.upload_file(
             Bucket=self.bucket,
             Key=remote_path,
             LocalFilePath=str(local_path),
-            PartSize=10,
-            MAXThread=5,
+            PartSize=PART_SIZE_MB,
+            MAXThread=UPLOAD_THREADS,
+            ContentType=content_type,
         )
         return f"{self.base_url.rstrip('/')}/{remote_path}"
 
@@ -93,10 +116,7 @@ def main() -> int:
     )
 
     remote_path = _normalize_remote_path(args.remote_path)
-    if local_path.stat().st_size >= LARGE_FILE_THRESHOLD:
-        url = client.upload_large_file(local_path, remote_path)
-    else:
-        url = client.upload_file(local_path, remote_path)
+    url = client.upload_file(local_path, remote_path)
 
     print(f"Uploaded {local_path} -> {remote_path}")
     print(f"URL: {url}")


### PR DESCRIPTION
## Why

`vault-v0.5.55` (cut by `auto-plugin-release` for the v0.7.4 pin bump) failed
in `Package and upload`:

```
qcloud_cos.cos_exception.CosServiceError: {'code': 'UserNetworkTooSlow',
  'message': 'User network is too slow.',
  'resource': '/nexus-vault/release/v0.5.55/nexusd-vault-macos-x86_64.tar.gz'}
```

The tag exists with no release behind it — and fuse / local-connector /
search all dogfood their signing key out of the newest `vault-v*` release, so
one stalled upload holds up the whole four-plugin set.

`release-nexusd-cluster.yml` hit this exact wall before and answered it by
going through the global acceleration endpoint with chunked upload. This
script — the one every plugin release uses — never got that treatment.

## What

- Route uploads through `cos.accelerate.myqcloud.com` instead of the bucket's
  regional endpoint.
- Drop the 128 MiB threshold and always use `upload_file`: it chunks at 10 MiB
  and retries a part, where `put_object` streams the whole file in one request
  that either completes or starts over. Nothing about a small file made the
  simple path worth keeping — the failing artifact was well under the old
  threshold.
- Five SDK-level retries on top of the per-part retry.
- The reported URL now names the host the bytes actually went through, which
  is also the host the published download URLs use.

## Test

Checked against the installed `cos-python-sdk-v5`:

- `CosConfig(Endpoint='cos.accelerate.myqcloud.com').uri(...)` →
  `https://<bucket>.cos.accelerate.myqcloud.com/<key>`.
- `Retry` is a `CosS3Client(conf, retry=N)` argument, not a `CosConfig` one —
  passing it to `CosConfig` raises `TypeError`, so this is wired the way the
  SDK actually accepts it.
- End-to-end proof is the vault release re-run, which is what this unblocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)