### PR TITLE
fix(ci): read the embedder model from the COS mirror, with checksums

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -405,6 +405,8 @@ jobs:
           key: nexus-embedder-ort-1.28.0-me5small-onnx-v1
 
       - name: Provision embedder assets for the search-plugin sidecar
+        env:
+          COS_BUCKET: ${{ secrets.COS_BUCKET }}
         run: |
           set -euo pipefail
           ORT_VERSION=1.28.0   # ort 2.0.0-rc.13 (Cargo.lock) is built for ONNX Runtime 1.28
@@ -421,14 +423,32 @@ jobs:
               "$ASSETS/ort/libonnxruntime.so"
           fi
 
+          # The model comes from our own COS mirror, never from
+          # huggingface.co.  HF rate-limits GitHub's runner IP ranges and
+          # answers 429 to every retry while it does; that failed this step,
+          # which meant the cache above never got written, which meant the
+          # next run missed the cache and hit the same 429 — a loop with no
+          # exit once the cache expired.  `mirror-embedder-assets.yml` puts
+          # the bytes somewhere we control; refresh it when the model moves.
+          if [ -z "$COS_BUCKET" ]; then
+            echo "::error::COS_BUCKET is not configured; the embedder mirror is unreachable."
+            exit 1
+          fi
+          MIRROR="https://${COS_BUCKET}.cos.accelerate.myqcloud.com/nexus/embedder/intfloat-multilingual-e5-small/onnx"
+
           # Layout contract from FastEmbedder::load (embedder.rs): the
           # five files of the HF onnx/ export, flat in the model dir.
-          HF=https://huggingface.co/intfloat/multilingual-e5-small/resolve/main/onnx
           for f in model.onnx tokenizer.json config.json special_tokens_map.json tokenizer_config.json; do
             if [ ! -s "$ASSETS/model/$f" ]; then
-              curl -fL --retry 5 --retry-delay 2 -o "$ASSETS/model/$f" "$HF/$f"
+              curl -fL --retry 5 --retry-delay 2 -o "$ASSETS/model/$f" "$MIRROR/$f"
             fi
           done
+
+          # Verify the bytes, cached or freshly pulled: a truncated model
+          # fails at inference time as a scoring regression, which reads as
+          # a product bug rather than a bad download.
+          curl -fsSL --retry 5 -o /tmp/embedder-SHA256SUMS.txt "$MIRROR/SHA256SUMS.txt"
+          (cd "$ASSETS/model" && sha256sum -c /tmp/embedder-SHA256SUMS.txt)
 
           # Sidecar runs as nexus (UID 1000) — must be able to read.
           chmod -R a+rX "$ASSETS"


### PR DESCRIPTION
## Why

Second half of the fix for develop's red `Docker Publish` →
`E2E edge smoke tests`:

```
curl: (22) The requested URL returned error: 429
##[error]Process completed with exit code 22
```

huggingface.co rate-limits GitHub's runner IP ranges. The step failing means
the `actions/cache` entry above it is never written, so the next run misses
the cache and hits the same 429 — and once the cached copy expires the loop
has no exit, `promote-tags` never runs, and `edge` freezes while SHA tags
advance.

#4770 put the bytes in the COS bucket that already carries every other
binary artifact. This switches the consumer over.

## What

- Pull the five files from the mirror; fail loudly if `COS_BUCKET` is not
  configured rather than silently falling back to a source that 429s.
- `sha256sum -c` against the mirror's manifest on every run, cached or not.

## Test

The mirror is populated and serving — dispatched
`mirror-embedder-assets.yml` on develop, which uploads and then re-downloads
and verifies. Independently confirmed from outside CI:

```
$ curl -fsSL .../nexus/embedder/intfloat-multilingual-e5-small/onnx/SHA256SUMS.txt
ca456c06...  model.onnx
0b44a9d7...  tokenizer.json
bbb7c133...  config.json
d05497f1...  special_tokens_map.json
a1d6bc87...  tokenizer_config.json
$ curl -sI .../onnx/model.onnx | grep -i content-length
Content-Length: 470268510
```

The edge smoke on this PR's merge to develop exercises the step itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)