### PR TITLE
fix(ci): give the search plugin a size budget it can actually meet

### DIFF
--- a/.github/workflows/release-search-plugin.yml
+++ b/.github/workflows/release-search-plugin.yml
@@ -41,6 +41,15 @@ jobs:
       signing_key_name: kernel-dogfood-v1
       platforms: '["linux-x86_64", "macos-arm64", "macos-x86_64", "windows-x86_64"]'
       override_ref: ${{ inputs.tag && format('refs/tags/{0}', inputs.tag) || '' }}
+      # 24 MiB. The reusable's 8 MiB default is vault's shape — a thin
+      # service over the kernel. This plugin links tantivy's index engine,
+      # the ONNX Runtime bindings and an HNSW index, and measures 14.8 MiB
+      # (macos-arm64) to 18.9 MiB (linux-x86_64), so it never once passed
+      # that gate: every `search-v*` tag from 0.1.2 on failed here, which is
+      # why the newest published search release is 0.1.1. A budget that
+      # nothing can meet is not a regression detector. This one is set from
+      # the measured sizes with ~27% headroom over the largest.
+      max_size_bytes: 25165824
       release_description: |
         Nexus search service plugin for nexusd-cluster.
 


### PR DESCRIPTION
## Why

`search-v0.1.28` failed on all four platforms:

```
##[error]nexus-search-plugin linux-x86_64 exceeds size budget (18880616 > 8388608 bytes)
```

The reusable workflow's 8 MiB default is vault's shape — a thin service over
the kernel. The search plugin links tantivy's index engine, the ONNX Runtime
bindings and an HNSW index. Measured this run:

| platform | size |
| --- | --- |
| macos-arm64 | 14.8 MiB |
| macos-x86_64 | 17.0 MiB |
| windows-x86_64 | 18.3 MiB |
| linux-x86_64 | 18.9 MiB |

So it has never fit. The newest published search release is **0.1.1** —
every tag from 0.1.2 to 0.1.28 produced nothing, behind this gate and behind
the tag-push trigger that a `GITHUB_TOKEN`-raised event cannot fire (fixed in
#4769). A budget nothing can meet is not a regression detector.

## What

`max_size_bytes: 25165824` (24 MiB) on the search wrapper — from the measured
sizes, ~27% headroom over the largest, so a real jump still trips it.

## Test

Re-dispatching `search-v0.1.28` after merge; the gate runs per platform in
that build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)