### PR TITLE
fix(ci): build plugin dylibs on the daemon's glibc floor

### DIFF
--- a/.github/workflows/release-plugin-reusable.yml
+++ b/.github/workflows/release-plugin-reusable.yml
@@ -129,7 +129,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
+          # 22.04, not `ubuntu-latest`. A dylib's glibc floor is whatever the
+          # runner it was linked on provides, and `nexusd-cluster` is released
+          # from ubuntu-22.04 (glibc 2.34). On `ubuntu-latest` (24.04) the
+          # plugins came out needing 2.38-2.39 — so on Debian 12 or Ubuntu
+          # 22.04 the daemon starts fine on its own and then refuses to boot
+          # the moment one of these is in `--plugin-dir`, because a dylib that
+          # fails to load fails BOOT rather than being skipped. Matching the
+          # daemon's runner keeps the whole set loadable wherever the daemon
+          # runs.
+          - os: ubuntu-22.04
             artifact_name_suffix: linux-x86_64
             dylib_ext: .so
             strip_lib_prefix: false


### PR DESCRIPTION
## Why

Found while verifying the four-artifact chain for the v0.7.4 bump on local
Docker. Booting the **released** `nexusd-cluster` with the four **released**
dylibs in `debian:bookworm-slim`:

```
Error: --plugin-dir /plugins load failed: plugin 'libnexus_fuse_plugin.so'
failed to load: dlopen(...): /lib/x86_64-linux-gnu/libc.so.6:
version `GLIBC_2.39' not found
```

Measured floors (`objdump -T`, highest versioned symbol):

| artifact | glibc |
| --- | --- |
| `nexusd-cluster` | 2.34 |
| `libnexus_vault.so` | 2.34 |
| `libnexus_local_connector.so` | 2.34 |
| `libnexus_search_plugin.so` | **2.38** |
| `libnexus_fuse_plugin.so` | **2.39** |

The daemon is released from `ubuntu-22.04`; this workflow builds on
`ubuntu-latest`, which is now 24.04. Every host in between — Debian 12
(2.36), Ubuntu 22.04 (2.35), RHEL 9 — can run the daemon and cannot load two
of its plugins. Because `load_plugin_dir` fails **boot** rather than skipping
a bad dylib (the property we just documented for downstream in #4766), such
a host does not get degraded search or no FUSE mount: it gets a daemon that
will not start.

## What

Pin the linux plugin build to `ubuntu-22.04`, matching the daemon's release
runner, with the reason recorded next to it.

## Test

- The failure above is the reproduction: released daemon + released dylibs,
  `debian:bookworm-slim`.
- The same set on `ubuntu:24.04` loads all four and serves — so the ABI
  pairing is right and glibc is the only thing separating them.
- After merge, the next plugin release's artifacts should measure 2.34, same
  as the daemon. Worth re-running the `objdump` check on them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)