### PR TITLE
fix: search/index saturation no longer stalls files/write; plugin embeds outside the zone lock (#4777)

### DIFF
--- a/docs/deployment/search-plugin.md
+++ b/docs/deployment/search-plugin.md
@@ -157,6 +157,9 @@ env directly.
 | `NEXUS_SEARCH_EMBED_DIM` | — | Remote embedding dim (required with URL) |
 | `NEXUS_SEARCH_EMBED_API_KEY` | *(unset)* | Bearer token for the endpoint |
 | `NEXUS_SEARCH_EMBED_TIMEOUT_SECONDS` | `30` | Per-request timeout |
+| `NEXUS_SEARCH_EMBED_CONCURRENCY` | `4` | Max concurrent embedding calls across `IndexDocuments` batches (#4777). Embedding runs OUTSIDE the per-zone write lock, so concurrent batches overlap their provider round-trips instead of serialising. `0` = unlimited. |
+| `NEXUS_SEARCH_ANN_FLUSH_SECONDS` | `30` | While sibling `IndexDocuments` batches are in flight for a zone, the full HNSW dump is left to the last one, and while siblings are queued on the zone lock the tantivy commit is coalesced into the last queued batch too; this is the fallback delay after which a deferred dump (and any coalesced commit) is forced to disk if the stream never pauses (#4777). `0` disables both (every batch commits and dumps, pre-#4777 behaviour). Deferred vectors are served from memory immediately and recorded as retry-me until the dump lands, so a crash costs a re-embed, never a hole. |
+| `NEXUS_SEARCH_PHASE_TRACE` | *(unset)* | Set to any value to print a per-batch phase trace for `IndexDocuments` (lock acquired / FTS committed or coalesced / embedded / dump deferred) on the plugin host's stderr. The plugin's `tracing` events do not reach the host log, so this is the way to see where a batch spends its time live. |
 
 And on the **server**:
 
@@ -168,6 +171,14 @@ And on the **server**:
 | `NEXUS_SEARCH_PLUGIN_TLS_CA` | *(system roots)* | CA bundle path for server verification |
 | `NEXUS_SEARCH_PLUGIN_TLS_CERT` / `_KEY` | *(unset)* | Client cert+key pair for mTLS |
 | `NEXUS_SEARCH_PLUGIN_ALLOW_INSECURE` | *(unset)* | Explicit opt-in for **plaintext to a non-loopback** target (trusted network only) — without it the server refuses the channel and boots with search disabled |
+| `NEXUS_SEARCH_INDEX_MAX_INFLIGHT` | `8` | Per-process cap on concurrent `POST /search/index` requests (#4777). The plugin serializes index batches per zone, so requests past the cap are shed with `503` + `Retry-After: 5` instead of parking on the zone mutex for minutes. `0` disables the cap. |
+| `NEXUS_SLOW_REQUEST_MS` | `10000` | Any HTTP request slower than this logs `request_completed` at WARNING with `slow_request=true`, regardless of status. `0` disables. |
+| `NEXUS_AUTH_CACHE_MAX_ENTRIES` | `10000` | Size of the process-local auth-result cache used when no shared cache store (Dragonfly) is configured. Auth results are cached 15 min; key revocation flushes the cache. |
+
+**Backpressure**: a `503` from `/search/index` carries `detail.inflight`,
+`detail.max_inflight` and a `Retry-After` header. Clients should honor the
+header and pace submissions from `/search/stats` (`indexing_in_progress`,
+`pending`) rather than retrying immediately.
 
 **Transport security**: plaintext is only accepted to same-machine
 targets — loopback addresses and Docker's `host.docker.internal`

--- a/docs/surface-coverage/api-rpc-surface-coverage.yaml
+++ b/docs/surface-coverage/api-rpc-surface-coverage.yaml
@@ -256,7 +256,7 @@ operations:
   transports:
     http:
       name: POST /index-directory
-      source: src/nexus/server/api/v2/routers/_search_indexed_dirs.py:68
+      source: src/nexus/server/api/v2/routers/_search_indexed_dirs.py:74
   profiles:
     lite: supported
     sandbox: supported
@@ -273,7 +273,7 @@ operations:
   transports:
     http:
       name: GET /indexed-dirs
-      source: src/nexus/server/api/v2/routers/_search_indexed_dirs.py:137
+      source: src/nexus/server/api/v2/routers/_search_indexed_dirs.py:143
   profiles:
     lite: supported
     sandbox: supported
@@ -290,7 +290,7 @@ operations:
   transports:
     http:
       name: POST /indexing-mode
-      source: src/nexus/server/api/v2/routers/_search_indexed_dirs.py:168
+      source: src/nexus/server/api/v2/routers/_search_indexed_dirs.py:174
   profiles:
     lite: supported
     sandbox: supported
@@ -531,7 +531,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.agent_registry
-      source: src/nexus/remote/kernel_client.py:1140
+      source: src/nexus/remote/kernel_client.py:1164
   profiles:
     lite: supported
     sandbox: supported
@@ -1036,7 +1036,7 @@ operations:
   transports:
     http:
       name: POST /batch/read
-      source: src/nexus/server/api/v2/routers/async_files.py:2229
+      source: src/nexus/server/api/v2/routers/async_files.py:2240
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1055,7 +1055,7 @@ operations:
   transports:
     http:
       name: POST /batch/write
-      source: src/nexus/server/api/v2/routers/async_files.py:2143
+      source: src/nexus/server/api/v2/routers/async_files.py:2154
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1074,7 +1074,7 @@ operations:
   transports:
     http:
       name: POST /copy
-      source: src/nexus/server/api/v2/routers/async_files.py:2424
+      source: src/nexus/server/api/v2/routers/async_files.py:2439
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1093,7 +1093,7 @@ operations:
   transports:
     http:
       name: POST /copy-bulk
-      source: src/nexus/server/api/v2/routers/async_files.py:2532
+      source: src/nexus/server/api/v2/routers/async_files.py:2549
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1112,7 +1112,7 @@ operations:
   transports:
     http:
       name: DELETE /delete
-      source: src/nexus/server/api/v2/routers/async_files.py:1621
+      source: src/nexus/server/api/v2/routers/async_files.py:1629
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1130,7 +1130,7 @@ operations:
   transports:
     http:
       name: GET /exists
-      source: src/nexus/server/api/v2/routers/async_files.py:1707
+      source: src/nexus/server/api/v2/routers/async_files.py:1717
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1148,7 +1148,7 @@ operations:
   transports:
     http:
       name: GET /glob
-      source: src/nexus/server/api/v2/routers/async_files.py:2609
+      source: src/nexus/server/api/v2/routers/async_files.py:2628
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1166,7 +1166,7 @@ operations:
   transports:
     http:
       name: GET /grep
-      source: src/nexus/server/api/v2/routers/async_files.py:2668
+      source: src/nexus/server/api/v2/routers/async_files.py:2687
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1185,7 +1185,7 @@ operations:
   transports:
     http:
       name: GET /list
-      source: src/nexus/server/api/v2/routers/async_files.py:1744
+      source: src/nexus/server/api/v2/routers/async_files.py:1754
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1203,7 +1203,7 @@ operations:
   transports:
     http:
       name: GET /md-structure
-      source: src/nexus/server/api/v2/routers/async_files.py:1523
+      source: src/nexus/server/api/v2/routers/async_files.py:1531
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1221,7 +1221,7 @@ operations:
   transports:
     http:
       name: GET /metadata
-      source: src/nexus/server/api/v2/routers/async_files.py:2039
+      source: src/nexus/server/api/v2/routers/async_files.py:2050
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1239,7 +1239,7 @@ operations:
   transports:
     http:
       name: POST /mkdir
-      source: src/nexus/server/api/v2/routers/async_files.py:1997
+      source: src/nexus/server/api/v2/routers/async_files.py:2006
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1257,7 +1257,7 @@ operations:
   transports:
     http:
       name: GET /read
-      source: src/nexus/server/api/v2/routers/async_files.py:984
+      source: src/nexus/server/api/v2/routers/async_files.py:988
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1275,7 +1275,7 @@ operations:
   transports:
     http:
       name: GET /read-url
-      source: src/nexus/server/api/v2/routers/async_files.py:1359
+      source: src/nexus/server/api/v2/routers/async_files.py:1367
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1294,7 +1294,7 @@ operations:
   transports:
     http:
       name: POST /rename
-      source: src/nexus/server/api/v2/routers/async_files.py:2379
+      source: src/nexus/server/api/v2/routers/async_files.py:2394
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1312,7 +1312,7 @@ operations:
   transports:
     http:
       name: POST /rename-batch
-      source: src/nexus/server/api/v2/routers/async_files.py:2489
+      source: src/nexus/server/api/v2/routers/async_files.py:2506
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1330,7 +1330,7 @@ operations:
   transports:
     http:
       name: GET /stream
-      source: src/nexus/server/api/v2/routers/async_files.py:2308
+      source: src/nexus/server/api/v2/routers/async_files.py:2319
   profiles:
     lite: supported
     sandbox: unavailable
@@ -1570,7 +1570,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/auth/keys
-      source: src/nexus/server/api/v2/routers/auth_keys.py:225
+      source: src/nexus/server/api/v2/routers/auth_keys.py:226
   profiles:
     lite: supported
     sandbox: supported
@@ -1587,7 +1587,7 @@ operations:
   transports:
     http:
       name: GET /api/v2/auth/keys/{key_id}
-      source: src/nexus/server/api/v2/routers/auth_keys.py:358
+      source: src/nexus/server/api/v2/routers/auth_keys.py:367
   profiles:
     lite: supported
     sandbox: supported
@@ -1948,7 +1948,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.close_all_pipes
-      source: src/nexus/remote/kernel_client.py:1018
+      source: src/nexus/remote/kernel_client.py:1042
   profiles:
     lite: supported
     sandbox: supported
@@ -1965,7 +1965,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.close_all_streams
-      source: src/nexus/remote/kernel_client.py:1071
+      source: src/nexus/remote/kernel_client.py:1095
   profiles:
     lite: supported
     sandbox: supported
@@ -1982,7 +1982,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.close_pipe
-      source: src/nexus/remote/kernel_client.py:1008
+      source: src/nexus/remote/kernel_client.py:1032
   profiles:
     lite: supported
     sandbox: supported
@@ -1999,7 +1999,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.close_stream
-      source: src/nexus/remote/kernel_client.py:1062
+      source: src/nexus/remote/kernel_client.py:1086
   profiles:
     lite: supported
     sandbox: supported
@@ -2217,7 +2217,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.count_by_state
-      source: src/nexus/remote/kernel_client.py:1667
+      source: src/nexus/remote/kernel_client.py:1691
   profiles:
     lite: supported
     sandbox: supported
@@ -2251,7 +2251,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.create_pipe
-      source: src/nexus/remote/kernel_client.py:1000
+      source: src/nexus/remote/kernel_client.py:1024
   profiles:
     lite: supported
     sandbox: supported
@@ -2285,7 +2285,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.create_stream
-      source: src/nexus/remote/kernel_client.py:1025
+      source: src/nexus/remote/kernel_client.py:1049
   profiles:
     lite: supported
     sandbox: supported
@@ -2598,7 +2598,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.destroy_pipe
-      source: src/nexus/remote/kernel_client.py:1004
+      source: src/nexus/remote/kernel_client.py:1028
   profiles:
     lite: supported
     sandbox: supported
@@ -2615,7 +2615,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.destroy_stream
-      source: src/nexus/remote/kernel_client.py:1067
+      source: src/nexus/remote/kernel_client.py:1091
   profiles:
     lite: supported
     sandbox: supported
@@ -2721,7 +2721,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.dispatch_post_hooks
-      source: src/nexus/remote/kernel_client.py:754
+      source: src/nexus/remote/kernel_client.py:778
   profiles:
     lite: supported
     sandbox: supported
@@ -2738,7 +2738,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.dispatch_pre_hooks
-      source: src/nexus/remote/kernel_client.py:761
+      source: src/nexus/remote/kernel_client.py:785
   profiles:
     lite: supported
     sandbox: supported
@@ -2755,7 +2755,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.dispatch_pre_hooks_batch_stat
-      source: src/nexus/remote/kernel_client.py:789
+      source: src/nexus/remote/kernel_client.py:813
   profiles:
     lite: supported
     sandbox: supported
@@ -2884,7 +2884,7 @@ operations:
       source: src/nexus/core/nexus_fs_metadata.py:1361
     sdk:
       name: KernelClient.exists_batch
-      source: src/nexus/remote/kernel_client.py:815
+      source: src/nexus/remote/kernel_client.py:839
   profiles:
     lite: supported
     sandbox: supported
@@ -3970,7 +3970,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.get
-      source: src/nexus/remote/kernel_client.py:1614
+      source: src/nexus/remote/kernel_client.py:1638
   profiles:
     lite: supported
     sandbox: supported
@@ -3987,7 +3987,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.heartbeat
-      source: src/nexus/remote/kernel_client.py:1640
+      source: src/nexus/remote/kernel_client.py:1664
   profiles:
     lite: supported
     sandbox: supported
@@ -4038,7 +4038,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.open
-      source: src/nexus/remote/kernel_client.py:307
+      source: src/nexus/remote/kernel_client.py:308
   profiles:
     lite: supported
     sandbox: supported
@@ -4072,7 +4072,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.register
-      source: src/nexus/remote/kernel_client.py:1575
+      source: src/nexus/remote/kernel_client.py:1599
   profiles:
     lite: supported
     sandbox: supported
@@ -4140,7 +4140,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.signal
-      source: src/nexus/remote/kernel_client.py:1617
+      source: src/nexus/remote/kernel_client.py:1641
   profiles:
     lite: supported
     sandbox: supported
@@ -4225,7 +4225,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.unregister
-      source: src/nexus/remote/kernel_client.py:1608
+      source: src/nexus/remote/kernel_client.py:1632
   profiles:
     lite: supported
     sandbox: supported
@@ -4342,7 +4342,7 @@ operations:
       source: src/nexus/core/nexus_fs_metadata.py:630
     sdk:
       name: KernelClient.get_content_id
-      source: src/nexus/remote/kernel_client.py:806
+      source: src/nexus/remote/kernel_client.py:830
   profiles:
     lite: supported
     sandbox: supported
@@ -4410,7 +4410,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.get_mount_points
-      source: src/nexus/remote/kernel_client.py:820
+      source: src/nexus/remote/kernel_client.py:844
   profiles:
     lite: supported
     sandbox: supported
@@ -4532,7 +4532,7 @@ operations:
       source: src/nexus/core/nexus_fs_metadata.py:271
     sdk:
       name: KernelClient.get_top_level_mounts
-      source: src/nexus/remote/kernel_client.py:827
+      source: src/nexus/remote/kernel_client.py:851
   profiles:
     lite: supported
     sandbox: supported
@@ -4567,7 +4567,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.get_xattr
-      source: src/nexus/remote/kernel_client.py:965
+      source: src/nexus/remote/kernel_client.py:989
   profiles:
     lite: supported
     sandbox: supported
@@ -4584,7 +4584,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.get_xattr_bulk
-      source: src/nexus/remote/kernel_client.py:986
+      source: src/nexus/remote/kernel_client.py:1010
   profiles:
     lite: supported
     sandbox: supported
@@ -4789,7 +4789,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.has_pipe
-      source: src/nexus/remote/kernel_client.py:1013
+      source: src/nexus/remote/kernel_client.py:1037
   profiles:
     lite: supported
     sandbox: supported
@@ -4806,7 +4806,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.has_stream
-      source: src/nexus/remote/kernel_client.py:1029
+      source: src/nexus/remote/kernel_client.py:1053
   profiles:
     lite: supported
     sandbox: supported
@@ -4875,7 +4875,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.hook_count
-      source: src/nexus/remote/kernel_client.py:751
+      source: src/nexus/remote/kernel_client.py:775
   profiles:
     lite: supported
     sandbox: supported
@@ -5012,7 +5012,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.is_directory
-      source: src/nexus/remote/kernel_client.py:797
+      source: src/nexus/remote/kernel_client.py:821
   profiles:
     lite: supported
     sandbox: supported
@@ -5151,7 +5151,7 @@ operations:
       source: src/nexus/services/agents/agent_rpc_service.py:584
     sdk:
       name: _AgentRegistryProxy.list_agents
-      source: src/nexus/remote/kernel_client.py:1643
+      source: src/nexus/remote/kernel_client.py:1667
   profiles:
     lite: supported
     sandbox: supported
@@ -5169,7 +5169,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.list_by_priority
-      source: src/nexus/remote/kernel_client.py:1671
+      source: src/nexus/remote/kernel_client.py:1695
   profiles:
     lite: supported
     sandbox: supported
@@ -5314,7 +5314,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.list_processes
-      source: src/nexus/remote/kernel_client.py:1646
+      source: src/nexus/remote/kernel_client.py:1670
   profiles:
     lite: supported
     sandbox: supported
@@ -5745,7 +5745,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.metastore_list_paginated
-      source: src/nexus/remote/kernel_client.py:835
+      source: src/nexus/remote/kernel_client.py:859
   profiles:
     lite: supported
     sandbox: supported
@@ -6934,7 +6934,7 @@ operations:
       source: src/nexus/core/nexus_fs_content.py:1635
     sdk:
       name: KernelClient.read_batch
-      source: src/nexus/remote/kernel_client.py:649
+      source: src/nexus/remote/kernel_client.py:673
   profiles:
     lite: supported
     sandbox: supported
@@ -7230,7 +7230,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/rebac/tuples
-      source: src/nexus/server/api/v2/routers/rebac.py:119
+      source: src/nexus/server/api/v2/routers/rebac.py:120
   profiles:
     lite: supported
     sandbox: supported
@@ -7265,7 +7265,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.register_external
-      source: src/nexus/remote/kernel_client.py:1578
+      source: src/nexus/remote/kernel_client.py:1602
   profiles:
     lite: supported
     sandbox: supported
@@ -7282,7 +7282,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.register_hook
-      source: src/nexus/remote/kernel_client.py:768
+      source: src/nexus/remote/kernel_client.py:792
   profiles:
     lite: supported
     sandbox: supported
@@ -7316,7 +7316,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.register_native_hook
-      source: src/nexus/remote/kernel_client.py:1106
+      source: src/nexus/remote/kernel_client.py:1130
   profiles:
     lite: supported
     sandbox: supported
@@ -7732,7 +7732,7 @@ operations:
       source: src/nexus/bricks/search/search_service.py:1769
     http:
       name: POST /api/v2/search/glob
-      source: src/nexus/server/api/v2/routers/search.py:1713
+      source: src/nexus/server/api/v2/routers/search.py:1717
     mcp:
       name: nexus_glob
       source: src/nexus/config/tool_profiles.yaml:1
@@ -7759,7 +7759,7 @@ operations:
       source: src/nexus/bricks/search/search_service.py:2069
     http:
       name: POST /api/v2/search/grep
-      source: src/nexus/server/api/v2/routers/search.py:1574
+      source: src/nexus/server/api/v2/routers/search.py:1578
     mcp:
       name: nexus_grep
       source: src/nexus/config/tool_profiles.yaml:1
@@ -7795,7 +7795,7 @@ operations:
   transports:
     http:
       name: GET /api/v2/search/health
-      source: src/nexus/server/api/v2/routers/search.py:172
+      source: src/nexus/server/api/v2/routers/search.py:174
   profiles:
     lite: supported
     sandbox: supported
@@ -7812,7 +7812,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/index
-      source: src/nexus/server/api/v2/routers/search.py:1783
+      source: src/nexus/server/api/v2/routers/search.py:1787
   profiles:
     lite: supported
     sandbox: supported
@@ -7829,7 +7829,7 @@ operations:
   transports:
     http:
       name: GET /api/v2/search/query
-      source: src/nexus/server/api/v2/routers/search.py:251
+      source: src/nexus/server/api/v2/routers/search.py:253
   profiles:
     lite: supported
     sandbox: supported
@@ -7846,7 +7846,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/query/batch
-      source: src/nexus/server/api/v2/routers/search.py:911
+      source: src/nexus/server/api/v2/routers/search.py:913
   profiles:
     lite: supported
     sandbox: supported
@@ -7863,7 +7863,7 @@ operations:
   transports:
     http:
       name: POST /api/v2/search/refresh
-      source: src/nexus/server/api/v2/routers/search.py:1898
+      source: src/nexus/server/api/v2/routers/search.py:1972
   profiles:
     lite: supported
     sandbox: supported
@@ -7897,7 +7897,7 @@ operations:
   transports:
     http:
       name: GET /api/v2/search/stats
-      source: src/nexus/server/api/v2/routers/search.py:222
+      source: src/nexus/server/api/v2/routers/search.py:224
   profiles:
     lite: supported
     sandbox: supported
@@ -7986,7 +7986,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.service_close_all
-      source: src/nexus/remote/kernel_client.py:743
+      source: src/nexus/remote/kernel_client.py:767
   profiles:
     lite: supported
     sandbox: supported
@@ -8003,7 +8003,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.service_enlist
-      source: src/nexus/remote/kernel_client.py:730
+      source: src/nexus/remote/kernel_client.py:754
   profiles:
     lite: supported
     sandbox: supported
@@ -8020,7 +8020,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.service_lookup
-      source: src/nexus/remote/kernel_client.py:718
+      source: src/nexus/remote/kernel_client.py:742
   profiles:
     lite: supported
     sandbox: supported
@@ -8037,7 +8037,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.service_mark_bootstrapped
-      source: src/nexus/remote/kernel_client.py:715
+      source: src/nexus/remote/kernel_client.py:739
   profiles:
     lite: supported
     sandbox: supported
@@ -8054,7 +8054,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.service_start_all
-      source: src/nexus/remote/kernel_client.py:712
+      source: src/nexus/remote/kernel_client.py:736
   profiles:
     lite: supported
     sandbox: supported
@@ -8071,7 +8071,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.service_stop_all
-      source: src/nexus/remote/kernel_client.py:740
+      source: src/nexus/remote/kernel_client.py:764
   profiles:
     lite: supported
     sandbox: supported
@@ -8088,7 +8088,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.service_swap
-      source: src/nexus/remote/kernel_client.py:722
+      source: src/nexus/remote/kernel_client.py:746
   profiles:
     lite: supported
     sandbox: supported
@@ -8105,7 +8105,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.service_unregister
-      source: src/nexus/remote/kernel_client.py:946
+      source: src/nexus/remote/kernel_client.py:970
   profiles:
     lite: supported
     sandbox: supported
@@ -8122,7 +8122,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.set_hook_count
-      source: src/nexus/remote/kernel_client.py:785
+      source: src/nexus/remote/kernel_client.py:809
   profiles:
     lite: supported
     sandbox: supported
@@ -8139,7 +8139,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.set_metastore_path
-      source: src/nexus/remote/kernel_client.py:1078
+      source: src/nexus/remote/kernel_client.py:1102
   profiles:
     lite: supported
     sandbox: supported
@@ -8156,7 +8156,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.set_permission_provider
-      source: src/nexus/remote/kernel_client.py:1110
+      source: src/nexus/remote/kernel_client.py:1134
   profiles:
     lite: supported
     sandbox: supported
@@ -8190,7 +8190,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.set_vfs_lock
-      source: src/nexus/remote/kernel_client.py:1102
+      source: src/nexus/remote/kernel_client.py:1126
   profiles:
     lite: supported
     sandbox: supported
@@ -8207,7 +8207,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.set_xattr
-      source: src/nexus/remote/kernel_client.py:978
+      source: src/nexus/remote/kernel_client.py:1002
   profiles:
     lite: supported
     sandbox: supported
@@ -8467,7 +8467,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.stat_batch
-      source: src/nexus/remote/kernel_client.py:683
+      source: src/nexus/remote/kernel_client.py:707
   profiles:
     lite: supported
     sandbox: supported
@@ -8501,7 +8501,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.stream_collect_all
-      source: src/nexus/remote/kernel_client.py:1058
+      source: src/nexus/remote/kernel_client.py:1082
   profiles:
     lite: supported
     sandbox: supported
@@ -8535,7 +8535,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.stream_read_at
-      source: src/nexus/remote/kernel_client.py:1046
+      source: src/nexus/remote/kernel_client.py:1070
   profiles:
     lite: supported
     sandbox: supported
@@ -8552,7 +8552,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.stream_read_at_blocking
-      source: src/nexus/remote/kernel_client.py:1033
+      source: src/nexus/remote/kernel_client.py:1057
   profiles:
     lite: supported
     sandbox: supported
@@ -8569,7 +8569,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.stream_write_nowait
-      source: src/nexus/remote/kernel_client.py:1041
+      source: src/nexus/remote/kernel_client.py:1065
   profiles:
     lite: supported
     sandbox: supported
@@ -8654,7 +8654,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.sys_copy
-      source: src/nexus/remote/kernel_client.py:583
+      source: src/nexus/remote/kernel_client.py:607
   profiles:
     lite: supported
     sandbox: supported
@@ -8671,7 +8671,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.sys_lock
-      source: src/nexus/remote/kernel_client.py:620
+      source: src/nexus/remote/kernel_client.py:644
   profiles:
     lite: supported
     sandbox: supported
@@ -8688,7 +8688,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.sys_mkdir
-      source: src/nexus/remote/kernel_client.py:551
+      source: src/nexus/remote/kernel_client.py:575
   profiles:
     lite: supported
     sandbox: supported
@@ -8705,7 +8705,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.sys_read
-      source: src/nexus/remote/kernel_client.py:445
+      source: src/nexus/remote/kernel_client.py:469
   profiles:
     lite: supported
     sandbox: supported
@@ -8722,7 +8722,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.sys_read_raw
-      source: src/nexus/remote/kernel_client.py:477
+      source: src/nexus/remote/kernel_client.py:501
   profiles:
     lite: supported
     sandbox: supported
@@ -8739,7 +8739,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.sys_readdir
-      source: src/nexus/remote/kernel_client.py:604
+      source: src/nexus/remote/kernel_client.py:628
   profiles:
     lite: supported
     sandbox: supported
@@ -8756,7 +8756,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.sys_rename
-      source: src/nexus/remote/kernel_client.py:559
+      source: src/nexus/remote/kernel_client.py:583
   profiles:
     lite: supported
     sandbox: supported
@@ -8773,7 +8773,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.sys_setattr
-      source: src/nexus/remote/kernel_client.py:517
+      source: src/nexus/remote/kernel_client.py:541
   profiles:
     lite: supported
     sandbox: supported
@@ -8790,7 +8790,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.sys_stat
-      source: src/nexus/remote/kernel_client.py:500
+      source: src/nexus/remote/kernel_client.py:524
   profiles:
     lite: supported
     sandbox: supported
@@ -8807,7 +8807,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.sys_unlink
-      source: src/nexus/remote/kernel_client.py:536
+      source: src/nexus/remote/kernel_client.py:560
   profiles:
     lite: supported
     sandbox: supported
@@ -8824,7 +8824,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.sys_unlock
-      source: src/nexus/remote/kernel_client.py:643
+      source: src/nexus/remote/kernel_client.py:667
   profiles:
     lite: supported
     sandbox: supported
@@ -8844,7 +8844,7 @@ operations:
       source: src/nexus/core/nexus_fs_watch.py:26
     sdk:
       name: KernelClient.sys_watch
-      source: src/nexus/remote/kernel_client.py:698
+      source: src/nexus/remote/kernel_client.py:722
   profiles:
     lite: supported
     sandbox: supported
@@ -8861,7 +8861,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.sys_write
-      source: src/nexus/remote/kernel_client.py:482
+      source: src/nexus/remote/kernel_client.py:506
   profiles:
     lite: supported
     sandbox: supported
@@ -8946,7 +8946,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.trie_lookup
-      source: src/nexus/remote/kernel_client.py:957
+      source: src/nexus/remote/kernel_client.py:981
   profiles:
     lite: supported
     sandbox: supported
@@ -8963,7 +8963,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.trie_register
-      source: src/nexus/remote/kernel_client.py:954
+      source: src/nexus/remote/kernel_client.py:978
   profiles:
     lite: supported
     sandbox: supported
@@ -8980,7 +8980,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.trie_unregister
-      source: src/nexus/remote/kernel_client.py:960
+      source: src/nexus/remote/kernel_client.py:984
   profiles:
     lite: supported
     sandbox: supported
@@ -9356,7 +9356,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.unregister_external
-      source: src/nexus/remote/kernel_client.py:1611
+      source: src/nexus/remote/kernel_client.py:1635
   profiles:
     lite: supported
     sandbox: supported
@@ -9373,7 +9373,7 @@ operations:
   transports:
     sdk:
       name: KernelClient.unregister_hook
-      source: src/nexus/remote/kernel_client.py:773
+      source: src/nexus/remote/kernel_client.py:797
   profiles:
     lite: supported
     sandbox: supported
@@ -9445,7 +9445,7 @@ operations:
   transports:
     sdk:
       name: _AgentRegistryProxy.update_state
-      source: src/nexus/remote/kernel_client.py:1629
+      source: src/nexus/remote/kernel_client.py:1653
   profiles:
     lite: supported
     sandbox: supported
@@ -9685,7 +9685,7 @@ operations:
       source: src/nexus/core/nexus_fs_content.py:1467
     sdk:
       name: KernelClient.write_batch
-      source: src/nexus/remote/kernel_client.py:1114
+      source: src/nexus/remote/kernel_client.py:1138
   profiles:
     lite: supported
     sandbox: supported

--- a/rust/services/search-plugin/src/ann_flush.rs
+++ b/rust/services/search-plugin/src/ann_flush.rs
@@ -1,0 +1,741 @@
+//! Indexing back-pressure primitives (#4777).
+//!
+//! Two problems made a burst of `IndexDocuments` batches stall the whole
+//! node:
+//!
+//! 1. `do_index_documents` held the per-zone write mutex across every
+//!    remote embedding call, so N concurrent batches serialised on the
+//!    mutex and each waited for all the others' network round-trips.
+//!    [`EmbedGate`] replaces that accidental serialisation with an explicit
+//!    concurrency cap that is held ONLY around `embed_batch`, outside the
+//!    zone lock.
+//! 2. Every batch ended with a full `Hnsw::file_dump` — at a few hundred
+//!    thousand chunks that is over a gigabyte of disk writes per batch,
+//!    competing with the kernel's own fsyncs on the same volume.
+//!    [`AnnFlushCoordinator`] lets a batch skip the dump while other
+//!    batches are in flight for the same zone; the last batch of the burst
+//!    dumps once, and a fallback flusher thread lands the dump after
+//!    [`DEFAULT_ANN_FLUSH_SECONDS`] if the stream never pauses.
+//!
+//! Crash safety of the deferral: vectors added since the last dump live
+//! only in memory, so the documents they belong to are recorded in the
+//! zone's `IndexState` with `mtime = None` (the "retry me" verdict) until
+//! the dump lands.  The pairs `(path, real_mtime)` are parked in the
+//! coordinator and upgraded to the real mtime right after the dump.  A
+//! crash in between therefore costs a re-embed of those documents on the
+//! next refresh — never a permanent hole — and the zone's `.write-dirty`
+//! sentinel stays set for the same window so the query cache is bypassed.
+//!
+//! The coordinator also tracks the zone's *epoch* — the window in which at
+//! least one batch is in flight.  The dirty sentinel is cleared only by the
+//! batch that ends the epoch (or by the flusher once the epoch is over),
+//! and only when every batch of the epoch converged and the zone was not
+//! already dirty from a failed write when the epoch began.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use parking_lot::{Condvar, Mutex};
+
+use crate::ann_index::AnnIndex;
+use crate::index_manager::IndexManager;
+use crate::index_state::IndexState;
+use crate::query_cache::SharedQueryCache;
+
+/// Max concurrent `embed_batch` calls across all IndexDocuments batches.
+/// `0` = unlimited.
+pub const EMBED_CONCURRENCY_ENV: &str = "NEXUS_SEARCH_EMBED_CONCURRENCY";
+pub const DEFAULT_EMBED_CONCURRENCY: usize = 4;
+
+/// Fallback delay before a deferred HNSW dump is forced to disk.  `0`
+/// disables deferral entirely (every batch dumps inline, pre-#4777).
+pub const ANN_FLUSH_SECONDS_ENV: &str = "NEXUS_SEARCH_ANN_FLUSH_SECONDS";
+pub const DEFAULT_ANN_FLUSH_SECONDS: u64 = 30;
+
+fn env_usize(name: &str, default: usize) -> usize {
+    match std::env::var(name) {
+        Ok(raw) if !raw.trim().is_empty() => raw.trim().parse().unwrap_or_else(|_| {
+            tracing::warn!(var = name, value = %raw, "not an integer; using default {default}");
+            default
+        }),
+        _ => default,
+    }
+}
+
+// ── EmbedGate ─────────────────────────────────────────────────────
+
+/// Counting semaphore for blocking-pool threads (tokio's `Semaphore` is
+/// async-only and the embed call sites run inside `spawn_blocking`).
+pub struct EmbedGate {
+    capacity: usize,
+    available: Mutex<usize>,
+    released: Condvar,
+}
+
+impl EmbedGate {
+    /// `capacity == 0` means unlimited — `acquire` never blocks.
+    pub fn new(capacity: usize) -> Self {
+        Self {
+            capacity,
+            available: Mutex::new(capacity),
+            released: Condvar::new(),
+        }
+    }
+
+    pub fn from_env() -> Self {
+        Self::new(env_usize(EMBED_CONCURRENCY_ENV, DEFAULT_EMBED_CONCURRENCY))
+    }
+
+    pub fn capacity(&self) -> usize {
+        self.capacity
+    }
+
+    /// Permits currently free (tests / diagnostics).  Meaningless when
+    /// unlimited.
+    pub fn available(&self) -> usize {
+        *self.available.lock()
+    }
+
+    /// Block until a permit is free.
+    pub fn acquire(&self) -> EmbedPermit<'_> {
+        if self.capacity == 0 {
+            return EmbedPermit(None);
+        }
+        let mut free = self.available.lock();
+        while *free == 0 {
+            self.released.wait(&mut free);
+        }
+        *free -= 1;
+        EmbedPermit(Some(self))
+    }
+
+    /// Non-blocking variant — `None` when every permit is taken.
+    pub fn try_acquire(&self) -> Option<EmbedPermit<'_>> {
+        if self.capacity == 0 {
+            return Some(EmbedPermit(None));
+        }
+        let mut free = self.available.lock();
+        if *free == 0 {
+            return None;
+        }
+        *free -= 1;
+        Some(EmbedPermit(Some(self)))
+    }
+}
+
+/// RAII permit from [`EmbedGate::acquire`].
+pub struct EmbedPermit<'a>(Option<&'a EmbedGate>);
+
+impl Drop for EmbedPermit<'_> {
+    fn drop(&mut self) {
+        if let Some(gate) = self.0 {
+            let mut free = gate.available.lock();
+            *free += 1;
+            gate.released.notify_one();
+        }
+    }
+}
+
+// ── AnnFlushCoordinator ───────────────────────────────────────────
+
+/// A zone's ANN mutations that are in memory but not yet dumped.
+pub struct PendingAnnDump {
+    /// The live index whose `commit()` is owed.
+    pub ann: Arc<AnnIndex>,
+    /// `(path, real_mtime)` for documents whose vectors are in memory
+    /// only.  Their `IndexState` entries hold `None` until the dump lands.
+    pub records: Vec<(String, Option<i64>)>,
+    /// Verdict of the epoch that produced this dump, filled in when that
+    /// epoch ended: may the zone's dirty sentinel be cleared once the
+    /// dump lands?  Stays `true` while the epoch is still running (the
+    /// running epoch's `clean` flag carries the verdict instead).
+    pub clearable: bool,
+    /// First deferral in this pending window.
+    pub deferred_at: Instant,
+    flusher_scheduled: bool,
+}
+
+#[derive(Default)]
+struct ZoneState {
+    /// Batches between `begin_batch` and `end_batch`.
+    active: usize,
+    /// Batches currently blocked on the zone write lock.
+    waiting: usize,
+    /// The zone carried dirt from a FAILED write (not from our own
+    /// pending dump) when the current epoch began — never ours to clear.
+    dirty_before: bool,
+    /// Every batch of the current epoch converged and saved its state.
+    clean: bool,
+    pending: Option<PendingAnnDump>,
+    /// A batch added FTS documents but left the tantivy commit to a
+    /// later batch (siblings were queued on the zone lock).  Whoever
+    /// next holds the lock — a sibling's Phase 1, any Phase 3, or the
+    /// flusher — must commit before recording state.
+    fts_uncommitted: bool,
+}
+
+impl ZoneState {
+    fn is_idle(&self) -> bool {
+        self.active == 0 && self.waiting == 0 && self.pending.is_none() && !self.fts_uncommitted
+    }
+}
+
+/// Outcome of [`AnnFlushCoordinator::end_batch`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EpochEnd {
+    /// This batch was the last one in flight for the zone.
+    pub last: bool,
+    /// `last` AND every batch converged AND the zone was clean when the
+    /// epoch began — the caller may clear the dirty sentinel (subject to
+    /// any still-pending dump's own verdict).
+    pub clearable: bool,
+}
+
+/// Ticket held while a batch waits for its zone's write lock — see
+/// [`AnnFlushCoordinator::enter_wait`].
+pub struct WaitTicket<'a> {
+    coordinator: &'a AnnFlushCoordinator,
+    zone_id: String,
+}
+
+impl Drop for WaitTicket<'_> {
+    fn drop(&mut self) {
+        let mut zones = self.coordinator.zones.lock();
+        if let Some(z) = zones.get_mut(&self.zone_id) {
+            z.waiting = z.waiting.saturating_sub(1);
+            if z.is_idle() {
+                zones.remove(&self.zone_id);
+            }
+        }
+    }
+}
+
+pub struct AnnFlushCoordinator {
+    zones: Mutex<HashMap<String, ZoneState>>,
+    /// `None` ⇒ deferral disabled; every batch dumps inline.
+    flush_delay: Option<Duration>,
+}
+
+impl AnnFlushCoordinator {
+    pub fn new(flush_delay: Option<Duration>) -> Self {
+        Self {
+            zones: Mutex::new(HashMap::new()),
+            flush_delay,
+        }
+    }
+
+    pub fn from_env() -> Self {
+        let secs = env_usize(ANN_FLUSH_SECONDS_ENV, DEFAULT_ANN_FLUSH_SECONDS as usize);
+        Self::new((secs > 0).then(|| Duration::from_secs(secs as u64)))
+    }
+
+    pub fn deferral_enabled(&self) -> bool {
+        self.flush_delay.is_some()
+    }
+
+    pub fn flush_delay(&self) -> Option<Duration> {
+        self.flush_delay
+    }
+
+    // ── epoch tracking ──
+
+    /// A batch starts work on `zone_id`.  Call BEFORE the first sink
+    /// mutation (and before `mark_zone_dirty`) so the epoch can record
+    /// whether the zone was already dirty from someone else's failure.
+    pub fn begin_batch(&self, zone_id: &str, manager: &IndexManager) {
+        let mut zones = self.zones.lock();
+        let z = zones.entry(zone_id.to_string()).or_default();
+        if z.active == 0 {
+            z.dirty_before = z.pending.is_none() && manager.zone_is_dirty(zone_id);
+            z.clean = true;
+        }
+        z.active += 1;
+    }
+
+    /// A batch finished `zone_id` (success or failure).  `batch_clean`
+    /// is false when any of its documents did not converge or its state
+    /// save failed.  Caller holds the zone write lock on the success
+    /// path so the returned verdict cannot be raced by a sibling.
+    pub fn end_batch(&self, zone_id: &str, batch_clean: bool) -> EpochEnd {
+        let mut zones = self.zones.lock();
+        let Some(z) = zones.get_mut(zone_id) else {
+            return EpochEnd {
+                last: true,
+                clearable: false,
+            };
+        };
+        z.clean &= batch_clean;
+        z.active = z.active.saturating_sub(1);
+        if z.active > 0 {
+            return EpochEnd {
+                last: false,
+                clearable: false,
+            };
+        }
+        let clearable = z.clean && !z.dirty_before;
+        if let Some(p) = z.pending.as_mut() {
+            p.clearable = clearable;
+        }
+        if z.is_idle() {
+            zones.remove(zone_id);
+        }
+        EpochEnd {
+            last: true,
+            clearable,
+        }
+    }
+
+    /// Batches currently in flight for `zone_id` (including the caller).
+    pub fn active(&self, zone_id: &str) -> usize {
+        self.zones.lock().get(zone_id).map_or(0, |z| z.active)
+    }
+
+    // ── lock queue ──
+
+    /// Register a batch about to block on `zone_id`'s write lock.  Drop
+    /// the ticket right after the lock is acquired so `waiters` counts
+    /// only batches still queued behind the current holder.
+    pub fn enter_wait(&self, zone_id: &str) -> WaitTicket<'_> {
+        self.zones
+            .lock()
+            .entry(zone_id.to_string())
+            .or_default()
+            .waiting += 1;
+        WaitTicket {
+            coordinator: self,
+            zone_id: zone_id.to_string(),
+        }
+    }
+
+    /// Batches currently queued on `zone_id`'s write lock.
+    pub fn waiters(&self, zone_id: &str) -> usize {
+        self.zones.lock().get(zone_id).map_or(0, |z| z.waiting)
+    }
+
+    // ── FTS commit coalescing ──
+
+    /// Phase 1 skipped `fts.commit()` because siblings are queued on the
+    /// zone lock; the documents sit in tantivy's writer until the next
+    /// lock holder commits.  Caller holds the zone write lock.
+    pub fn note_fts_skipped(&self, zone_id: &str) {
+        self.zones
+            .lock()
+            .entry(zone_id.to_string())
+            .or_default()
+            .fts_uncommitted = true;
+    }
+
+    /// Some lock holder committed the FTS writer, covering every skipped
+    /// batch before it.  Caller holds the zone write lock.
+    pub fn note_fts_committed(&self, zone_id: &str) {
+        let mut zones = self.zones.lock();
+        if let Some(z) = zones.get_mut(zone_id) {
+            z.fts_uncommitted = false;
+            if z.is_idle() {
+                zones.remove(zone_id);
+            }
+        }
+    }
+
+    /// Does the zone's FTS writer hold documents no commit has covered?
+    pub fn fts_uncommitted(&self, zone_id: &str) -> bool {
+        self.zones
+            .lock()
+            .get(zone_id)
+            .is_some_and(|z| z.fts_uncommitted)
+    }
+
+    /// Should the lock holder leave the hnsw dump to a later batch?
+    /// True when another batch is queued on the lock or still embedding
+    /// (in flight but not yet waiting) — it will reach the lock soon and
+    /// can dump for both.
+    pub fn others_in_flight(&self, zone_id: &str) -> bool {
+        self.zones
+            .lock()
+            .get(zone_id)
+            .is_some_and(|z| z.waiting > 0 || z.active > 1)
+    }
+
+    // ── pending dump ──
+
+    pub fn has_pending(&self, zone_id: &str) -> bool {
+        self.zones
+            .lock()
+            .get(zone_id)
+            .is_some_and(|z| z.pending.is_some())
+    }
+
+    /// Zones with a dump owed (Stats / diagnostics).
+    pub fn pending_zone_count(&self) -> usize {
+        self.zones
+            .lock()
+            .values()
+            .filter(|z| z.pending.is_some())
+            .count()
+    }
+
+    /// Hand the owed dump to the caller, who MUST hold the zone write
+    /// lock and either commit it or hand it back via [`Self::restore`].
+    pub fn take_pending(&self, zone_id: &str) -> Option<PendingAnnDump> {
+        let mut zones = self.zones.lock();
+        let z = zones.get_mut(zone_id)?;
+        let pending = z.pending.take();
+        if z.is_idle() {
+            zones.remove(zone_id);
+        }
+        pending
+    }
+
+    /// Put a dump back after a failed commit so the next batch or
+    /// flusher retries it.
+    pub fn restore(&self, zone_id: &str, mut pending: PendingAnnDump) {
+        pending.flusher_scheduled = false;
+        let mut zones = self.zones.lock();
+        let z = zones.entry(zone_id.to_string()).or_default();
+        match z.pending.take() {
+            Some(mut newer) => {
+                // A batch deferred in between (cannot happen under the
+                // zone lock, but merge defensively).
+                newer.records.extend(pending.records);
+                newer.clearable &= pending.clearable;
+                newer.deferred_at = newer.deferred_at.min(pending.deferred_at);
+                z.pending = Some(newer);
+            }
+            None => z.pending = Some(pending),
+        }
+    }
+
+    /// A batch that is about to (re)write `paths` owns their state from
+    /// now on: drop any parked upgrade so a later flush cannot clobber
+    /// this batch's verdict.  Caller holds the zone write lock.
+    pub fn forget_paths<'p>(&self, zone_id: &str, paths: impl IntoIterator<Item = &'p str>) {
+        let mut zones = self.zones.lock();
+        let Some(pending) = zones.get_mut(zone_id).and_then(|z| z.pending.as_mut()) else {
+            return;
+        };
+        let owned: HashSet<&str> = paths.into_iter().collect();
+        if owned.is_empty() {
+            return;
+        }
+        pending.records.retain(|(p, _)| !owned.contains(p.as_str()));
+    }
+
+    /// Park `zone_id`'s dump.  Caller holds the zone write lock and has
+    /// already recorded `records`' paths with `mtime = None` in the saved
+    /// state.  Schedules the fallback flusher on the first deferral of a
+    /// pending window.
+    pub fn defer(
+        self: &Arc<Self>,
+        zone_id: &str,
+        ann: Arc<AnnIndex>,
+        records: Vec<(String, Option<i64>)>,
+        manager: Arc<IndexManager>,
+        cache: SharedQueryCache,
+    ) {
+        let Some(delay) = self.flush_delay else {
+            // Deferral disabled — callers check `deferral_enabled` first;
+            // reaching here is a programming error, so dump inline.
+            if let Err(e) = ann.commit() {
+                tracing::warn!(zone = %zone_id, err = %e, "inline ann commit failed");
+            }
+            return;
+        };
+        let schedule = {
+            let mut zones = self.zones.lock();
+            let z = zones.entry(zone_id.to_string()).or_default();
+            let entry = z.pending.get_or_insert_with(|| PendingAnnDump {
+                ann: Arc::clone(&ann),
+                records: Vec::new(),
+                clearable: true,
+                deferred_at: Instant::now(),
+                flusher_scheduled: false,
+            });
+            entry.ann = ann;
+            entry.records.extend(records);
+            let schedule = !entry.flusher_scheduled;
+            entry.flusher_scheduled = true;
+            schedule
+        };
+        tracing::debug!(zone = %zone_id, "hnsw dump deferred — other index batches in flight");
+        if schedule {
+            self.spawn_flusher(zone_id.to_string(), manager, cache, delay);
+        }
+    }
+
+    fn spawn_flusher(
+        self: &Arc<Self>,
+        zone_id: String,
+        manager: Arc<IndexManager>,
+        cache: SharedQueryCache,
+        delay: Duration,
+    ) {
+        let coordinator = Arc::clone(self);
+        let zone_for_thread = zone_id.clone();
+        let spawned = std::thread::Builder::new()
+            .name(format!("nexus-ann-flush-{zone_id}"))
+            .spawn(move || {
+                std::thread::sleep(delay);
+                match coordinator.flush_zone(&zone_for_thread, &manager, &cache) {
+                    Ok(true) => {
+                        tracing::info!(zone = %zone_for_thread, "deferred hnsw dump landed (fallback flusher)")
+                    }
+                    Ok(false) => {
+                        tracing::debug!(zone = %zone_for_thread, "deferred hnsw dump already committed inline")
+                    }
+                    Err(e) => {
+                        tracing::warn!(zone = %zone_for_thread, err = %e, "deferred hnsw dump failed — will retry on next index batch")
+                    }
+                }
+            });
+        if let Err(e) = spawned {
+            tracing::warn!(zone = %zone_id, err = %e, "could not spawn ann flusher thread; next batch will dump inline");
+            if let Some(entry) = self
+                .zones
+                .lock()
+                .get_mut(&zone_id)
+                .and_then(|z| z.pending.as_mut())
+            {
+                entry.flusher_scheduled = false;
+            }
+        }
+    }
+
+    /// Land `zone_id`'s owed dump now: takes the zone write lock, commits
+    /// the ANN index, upgrades the parked `(path, mtime)` records, saves
+    /// the state and clears the dirty sentinel when permitted.
+    ///
+    /// Returns `Ok(false)` when nothing was pending (a batch committed it
+    /// inline first).  On a commit failure the dump is handed back for a
+    /// later retry and the error returned.
+    pub fn flush_zone(
+        &self,
+        zone_id: &str,
+        manager: &IndexManager,
+        cache: &SharedQueryCache,
+    ) -> Result<bool, String> {
+        let zone_lock = manager.zone_write_lock(zone_id);
+        let _guard = zone_lock.lock();
+        // A coalesced FTS commit nobody got to (the burst ended with a
+        // failed batch): land it here so those documents become
+        // searchable and durable.
+        if self.fts_uncommitted(zone_id) {
+            match manager.get_or_open(zone_id) {
+                Ok(fts) => match fts.commit() {
+                    Ok(()) => {
+                        self.note_fts_committed(zone_id);
+                        cache.invalidate_zone(zone_id);
+                    }
+                    Err(e) => {
+                        tracing::warn!(zone = %zone_id, err = %e, "coalesced fts commit failed in flusher")
+                    }
+                },
+                Err(e) => {
+                    tracing::warn!(zone = %zone_id, err = %e, "open fts for coalesced commit failed")
+                }
+            }
+        }
+        let Some(pending) = self.take_pending(zone_id) else {
+            return Ok(false);
+        };
+        if let Err(e) = pending.ann.commit() {
+            let msg = format!("ann commit for zone {zone_id:?}: {e}");
+            self.restore(zone_id, pending);
+            return Err(msg);
+        }
+        let saved = match IndexState::open_or_create(manager.zone_root(zone_id)) {
+            Ok(state) => {
+                upgrade_records(&state, &pending.records);
+                match state.save() {
+                    Ok(()) => true,
+                    Err(e) => {
+                        tracing::warn!(zone = %zone_id, err = %e, "index_state save failed after deferred dump — zone stays cache-bypassed");
+                        false
+                    }
+                }
+            }
+            Err(e) => {
+                tracing::warn!(zone = %zone_id, err = %e, "index_state open failed after deferred dump — zone stays cache-bypassed");
+                false
+            }
+        };
+        cache.invalidate_zone(zone_id);
+        // Dirty-sentinel verdict: clear now if no epoch is running;
+        // otherwise fold this dump's verdict into the running epoch and
+        // let its last batch decide.
+        let clear_now = {
+            let mut zones = self.zones.lock();
+            match zones.get_mut(zone_id) {
+                Some(z) if z.active > 0 => {
+                    z.clean &= saved && pending.clearable;
+                    false
+                }
+                _ => saved && pending.clearable,
+            }
+        };
+        if clear_now {
+            manager.clear_zone_dirty(zone_id);
+        }
+        Ok(true)
+    }
+}
+
+/// Promote parked `(path, mtime)` pairs whose state entry still says
+/// "retry me" (`Some(None)`).  Entries a later batch re-recorded, or
+/// forgot, are left alone — that batch owns the verdict.
+pub fn upgrade_records(state: &IndexState, records: &[(String, Option<i64>)]) {
+    for (path, mtime) in records {
+        if state.cached_mtime(path) == Some(None) {
+            state.record(path, *mtime);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn embed_gate_bounds_concurrency_and_releases_on_drop() {
+        let gate = EmbedGate::new(2);
+        let a = gate.acquire();
+        let b = gate.acquire();
+        assert_eq!(gate.available(), 0);
+        assert!(
+            gate.try_acquire().is_none(),
+            "third permit must not be granted"
+        );
+        drop(a);
+        assert_eq!(gate.available(), 1);
+        let c = gate.try_acquire();
+        assert!(c.is_some());
+        drop(b);
+        drop(c);
+        assert_eq!(gate.available(), 2);
+    }
+
+    #[test]
+    fn embed_gate_blocked_acquire_wakes_when_a_permit_frees() {
+        let gate = Arc::new(EmbedGate::new(1));
+        let held = gate.acquire();
+        let gate2 = Arc::clone(&gate);
+        let waiter = std::thread::spawn(move || {
+            let _permit = gate2.acquire();
+            true
+        });
+        std::thread::sleep(Duration::from_millis(50));
+        assert!(
+            !waiter.is_finished(),
+            "waiter must block while the permit is held"
+        );
+        drop(held);
+        assert!(waiter.join().unwrap());
+    }
+
+    #[test]
+    fn unlimited_gate_never_blocks() {
+        let gate = EmbedGate::new(0);
+        let _a = gate.acquire();
+        let _b = gate.acquire();
+        assert!(gate.try_acquire().is_some());
+    }
+
+    #[test]
+    fn wait_ticket_counts_only_while_held() {
+        let coord = AnnFlushCoordinator::new(Some(Duration::from_secs(60)));
+        assert_eq!(coord.waiters("z"), 0);
+        let t1 = coord.enter_wait("z");
+        let t2 = coord.enter_wait("z");
+        assert_eq!(coord.waiters("z"), 2);
+        assert!(coord.others_in_flight("z"));
+        drop(t1);
+        assert_eq!(coord.waiters("z"), 1);
+        drop(t2);
+        assert_eq!(coord.waiters("z"), 0);
+        assert!(!coord.others_in_flight("z"));
+        assert_eq!(coord.waiters("other"), 0);
+    }
+
+    #[test]
+    fn epoch_tracks_active_batches_and_clearability() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let manager = IndexManager::with_root(tmp.path().to_path_buf());
+        let coord = AnnFlushCoordinator::new(Some(Duration::from_secs(60)));
+
+        coord.begin_batch("z", &manager);
+        coord.begin_batch("z", &manager);
+        assert_eq!(coord.active("z"), 2);
+        assert!(coord.others_in_flight("z"), "a sibling is still embedding");
+
+        // First batch out: not last, no verdict yet.
+        assert_eq!(
+            coord.end_batch("z", true),
+            EpochEnd {
+                last: false,
+                clearable: false
+            }
+        );
+        assert!(!coord.others_in_flight("z"));
+        // Last batch out: epoch verdict.
+        assert_eq!(
+            coord.end_batch("z", true),
+            EpochEnd {
+                last: true,
+                clearable: true
+            }
+        );
+        assert_eq!(coord.active("z"), 0);
+
+        // A non-converged batch poisons the epoch.
+        coord.begin_batch("z", &manager);
+        coord.begin_batch("z", &manager);
+        coord.end_batch("z", false);
+        assert_eq!(
+            coord.end_batch("z", true),
+            EpochEnd {
+                last: true,
+                clearable: false
+            }
+        );
+    }
+
+    #[test]
+    fn epoch_never_clears_dirt_it_did_not_create() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let manager = IndexManager::with_root(tmp.path().to_path_buf());
+        let coord = AnnFlushCoordinator::new(Some(Duration::from_secs(60)));
+
+        // Pre-existing dirt from a failed write.
+        manager.mark_zone_dirty("z").expect("mark");
+        coord.begin_batch("z", &manager);
+        assert_eq!(
+            coord.end_batch("z", true),
+            EpochEnd {
+                last: true,
+                clearable: false
+            }
+        );
+    }
+
+    #[test]
+    fn fts_uncommitted_flag_round_trips_and_keeps_zone_alive() {
+        let coord = AnnFlushCoordinator::new(Some(Duration::from_secs(60)));
+        assert!(!coord.fts_uncommitted("z"));
+        coord.note_fts_skipped("z");
+        assert!(coord.fts_uncommitted("z"));
+        // Idle otherwise, but the owed commit keeps the entry.
+        assert_eq!(coord.active("z"), 0);
+        assert!(coord.fts_uncommitted("z"));
+        coord.note_fts_committed("z");
+        assert!(!coord.fts_uncommitted("z"));
+        // Clearing an unknown zone is a no-op.
+        coord.note_fts_committed("nope");
+    }
+
+    #[test]
+    fn from_env_zero_disables_deferral() {
+        assert!(AnnFlushCoordinator::new(None).flush_delay().is_none());
+        assert!(!AnnFlushCoordinator::new(None).deferral_enabled());
+        assert!(AnnFlushCoordinator::new(Some(Duration::from_secs(5))).deferral_enabled());
+    }
+}

--- a/rust/services/search-plugin/src/lib.rs
+++ b/rust/services/search-plugin/src/lib.rs
@@ -52,6 +52,7 @@ pub mod search_proto {
     tonic::include_proto!("nexus.search.v1");
 }
 
+pub mod ann_flush;
 pub mod ann_index;
 pub mod chunker;
 pub mod contextual_chunker;

--- a/rust/services/search-plugin/src/service.rs
+++ b/rust/services/search-plugin/src/service.rs
@@ -81,11 +81,9 @@ fn batch_query_concurrency() -> usize {
         .unwrap_or(DEFAULT_BATCH_QUERY_CONCURRENCY)
 }
 
-/// #4623: explicit-index incremental FTS commit cadence.  Every N
-/// successfully indexed documents the FTS layer commits (and the
-/// zone's result cache drops) so keyword hits become visible while
-/// the embed-heavy remainder of the batch is still building.
-const INDEX_INCREMENTAL_COMMIT_EVERY: usize = 8;
+// #4623's incremental FTS commit cadence is gone (#4777): the FTS pass
+// now commits in full BEFORE the embed phase starts, so keyword hits are
+// visible for the whole time a batch is embedding.
 
 /// #4617: backend identity string on Stats — distinguishes this
 /// generation from the deleted Python daemon's BM25S/pgvector stack.
@@ -198,6 +196,12 @@ pub struct SearchServiceImpl {
     /// Handler panics caught at the plugin's dispatch boundary
     /// (#4725) — surfaced on Health.  Recorded from `lib.rs`.
     dispatch_panics: DispatchPanicLog,
+    /// #4777: bounds concurrent `embed_batch` calls across
+    /// IndexDocuments batches (held OUTSIDE the zone write lock).
+    embed_gate: Arc<crate::ann_flush::EmbedGate>,
+    /// #4777: defers the per-batch hnsw dump while more batches are
+    /// queued on a zone, with a fallback flusher for durability.
+    ann_flush: Arc<crate::ann_flush::AnnFlushCoordinator>,
 }
 
 /// Bundle used by the query wrapper — the live expander plus its
@@ -317,6 +321,8 @@ impl SearchServiceImpl {
             expander_pin: None,
             peer_fanout_pin: None,
             context_generator_pin: None,
+            embed_gate: None,
+            ann_flush: None,
         }
     }
 
@@ -695,9 +701,26 @@ pub struct SearchServiceBuilder {
     expander_pin: Option<Option<Arc<ExpanderHandle>>>,
     peer_fanout_pin: Option<Option<SharedPeerFanoutDispatcher>>,
     context_generator_pin: Option<Option<SharedContextGenerator>>,
+    embed_gate: Option<Arc<crate::ann_flush::EmbedGate>>,
+    ann_flush: Option<Arc<crate::ann_flush::AnnFlushCoordinator>>,
 }
 
 impl SearchServiceBuilder {
+    /// Pin the embedding concurrency gate (#4777) — tests use it to
+    /// avoid reading `NEXUS_SEARCH_EMBED_CONCURRENCY` from the host env.
+    pub fn embed_gate(mut self, gate: Arc<crate::ann_flush::EmbedGate>) -> Self {
+        self.embed_gate = Some(gate);
+        self
+    }
+
+    /// Pin the deferred-dump coordinator (#4777) — tests pass a
+    /// coordinator with deferral disabled or a long fallback delay so
+    /// assertions never race the flusher thread.
+    pub fn ann_flush(mut self, coordinator: Arc<crate::ann_flush::AnnFlushCoordinator>) -> Self {
+        self.ann_flush = Some(coordinator);
+        self
+    }
+
     /// Inject a pre-configured `IndexManager` (typically rooted at
     /// a tempdir for tests, or at an explicit data volume for
     /// operators overriding the default storage location).
@@ -810,6 +833,12 @@ impl SearchServiceBuilder {
             peer_fanout_slot: Arc::new(pin_to_once_lock(self.peer_fanout_pin)),
             context_generator_slot: Arc::new(pin_to_once_lock(self.context_generator_pin)),
             dispatch_panics: DispatchPanicLog::default(),
+            embed_gate: self
+                .embed_gate
+                .unwrap_or_else(|| Arc::new(crate::ann_flush::EmbedGate::from_env())),
+            ann_flush: self
+                .ann_flush
+                .unwrap_or_else(|| Arc::new(crate::ann_flush::AnnFlushCoordinator::from_env())),
         }
     }
 }
@@ -2870,14 +2899,129 @@ struct IndexDocumentsOutcome {
     skipped_paths: Vec<String>,
 }
 
+/// One document of an `IndexDocuments` batch as it moves through the
+/// three phases of [`do_index_documents`] (#4777).
+struct BatchDoc {
+    path: String,
+    mtime_ms: Option<i64>,
+    /// Original text — the contextual chunker needs the whole document.
+    text: String,
+    /// Empty for content skips (empty / whitespace-only / chunkless).
+    chunks: Vec<crate::chunker::Chunk>,
+    /// Phase 1 could not add this doc's chunks to the FTS index.
+    fts_failed: bool,
+    /// Phase 2 result: `None` when no embedder is configured (or the
+    /// doc is a skip / FTS failure); otherwise the vectors — one per
+    /// chunk — or the reason embedding failed.
+    vectors: Option<Result<Vec<Vec<f32>>, String>>,
+}
+
+impl BatchDoc {
+    fn is_content_skip(&self) -> bool {
+        self.chunks.is_empty()
+    }
+}
+
+/// Phase 0 (no lock, CPU only): split every document into chunks.
+fn chunk_documents(docs: Vec<crate::search_proto::DocumentInput>) -> Vec<BatchDoc> {
+    docs.into_iter()
+        .map(|doc| {
+            let chunks = if doc.text.trim().is_empty() {
+                Vec::new()
+            } else {
+                crate::chunker::chunk_document(&doc.text)
+            };
+            BatchDoc {
+                path: doc.path,
+                mtime_ms: doc.mtime_ms,
+                text: doc.text,
+                chunks,
+                fts_failed: false,
+                vectors: None,
+            }
+        })
+        .collect()
+}
+
+/// Phase 2 (no lock): contextualise + embed every doc whose FTS add
+/// landed.  Everything that talks to the network happens here, so the
+/// zone write lock is never held across a provider round-trip; `gate`
+/// bounds how many batches hit the provider at once.
+fn embed_documents(
+    docs: &mut [BatchDoc],
+    embedder: &Arc<dyn Embedder>,
+    context_generator: Option<&dyn ContextGenerator>,
+    gate: &crate::ann_flush::EmbedGate,
+) {
+    for doc in docs.iter_mut() {
+        if doc.is_content_skip() || doc.fts_failed {
+            continue;
+        }
+        // Feature 3 — contextual chunking (see index_one's twin
+        // insertion point).  Per-chunk LLM failure = None ⇒ that
+        // chunk keeps its plain embed_input.  Only `embed_input` is
+        // touched, so the FTS text committed in Phase 1 is unaffected.
+        if let Some(gen) = context_generator {
+            crate::contextual_chunker::apply_contexts(
+                gen,
+                &doc.text,
+                &mut doc.chunks,
+                gen.max_chunks_per_doc(),
+            );
+        }
+        let _permit = gate.acquire();
+        let inputs: Vec<&str> = doc.chunks.iter().map(|c| c.embed_input.as_str()).collect();
+        doc.vectors = Some(match embedder.embed_batch(&inputs) {
+            Ok(vecs) if vecs.len() == doc.chunks.len() => Ok(vecs),
+            Ok(vecs) => Err(format!(
+                "embed count mismatch: got {} vectors for {} chunks",
+                vecs.len(),
+                doc.chunks.len()
+            )),
+            Err(e) => Err(format!("embed failed: {e}")),
+        });
+    }
+}
+
+/// Per-zone counters accumulated by [`index_zone_documents`].
+/// Per-process counter naming batches in the phase trace.
+static INDEX_BATCH_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+static PHASE_TRACE: OnceLock<bool> = OnceLock::new();
+
+/// Stderr phase trace for `IndexDocuments`, enabled by
+/// `NEXUS_SEARCH_PHASE_TRACE=1`.  The plugin is a cdylib with no tracing
+/// subscriber of its own (its `tracing` events never reach the host's
+/// log), so this is the one way to see where a batch spends its time in
+/// a live host without attaching a profiler.
+fn phase_trace(zone_id: &str, batch_no: u64, what: &str, t0: Instant) {
+    let enabled =
+        *PHASE_TRACE.get_or_init(|| std::env::var_os("NEXUS_SEARCH_PHASE_TRACE").is_some());
+    if enabled {
+        eprintln!(
+            "[nexus-search-plugin] zone={zone_id} batch={batch_no} {what} t={:.3}s",
+            t0.elapsed().as_secs_f64()
+        );
+    }
+}
+
+#[derive(Default)]
+struct ZoneIndexOutcome {
+    indexed: u32,
+    skipped: u32,
+    skipped_paths: Vec<String>,
+}
+
+#[allow(clippy::too_many_arguments)]
 fn do_index_documents(
-    manager: &IndexManager,
+    manager: &Arc<IndexManager>,
     embedder: Option<&Arc<dyn Embedder>>,
     embed_broken: bool,
     context_generator: Option<&dyn ContextGenerator>,
     default_zone: &str,
     documents: Vec<crate::search_proto::DocumentInput>,
     cache: &crate::query_cache::SharedQueryCache,
+    gate: &crate::ann_flush::EmbedGate,
+    flush: &Arc<crate::ann_flush::AnnFlushCoordinator>,
 ) -> Result<IndexDocumentsOutcome, String> {
     // Bucket by zone so per-zone open + commit happens once.
     let mut by_zone: std::collections::HashMap<String, Vec<crate::search_proto::DocumentInput>> =
@@ -2896,226 +3040,34 @@ fn do_index_documents(
     let mut skipped_paths: Vec<String> = Vec::new();
 
     for (zone_id, docs) in by_zone {
-        // Serialize writers per zone — same rationale as do_index.
-        let zone_lock = manager.zone_write_lock(&zone_id);
-        let _zone_guard = zone_lock.lock();
-        // Dirty window — same rationale as do_index (reviews R5/R7).
-        let zone_was_dirty = manager.mark_zone_dirty(&zone_id)?;
-
-        let fts = manager
-            .get_or_open(&zone_id)
-            .map_err(|e| format!("open fts for zone {zone_id:?}: {e}"))?;
-        let ann = if let Some(e) = embedder {
-            Some(
-                manager
-                    .get_or_open_ann(&zone_id, e.tag(), e.dim())
-                    .map_err(|err| format!("open ann for zone {zone_id:?}: {err}"))?,
-            )
-        } else {
-            None
-        };
-        let state = crate::index_state::IndexState::open_or_create(manager.zone_root(&zone_id))
-            .map_err(|e| format!("open state for zone {zone_id:?}: {e}"))?;
-
-        // Embedder-generation alignment — same rationale as do_index.
-        if let Some(e) = embedder {
-            if state.ensure_embedder_generation(e.tag()) {
-                tracing::warn!(
-                    zone = %zone_id,
-                    tag = %e.tag(),
-                    "embedder generation changed — invalidated mtime cache; full re-embed",
-                );
-            }
-        }
-
-        // #4623: incremental FTS visibility.  Embedding dominates a
-        // large explicit batch (tens of seconds of CPU), and a single
-        // end-of-batch commit left keyword queries answering
-        // healthy-empty the whole time — indistinguishable from the
-        // silent-degradation modes health sentinels exist to catch.
-        // Commit (and drop the zone's cached results) every few docs
-        // so keyword hits appear progressively; commits are a couple
-        // of ms, noise next to the embed cost.  ANN stays end-commit:
-        // the dense leg is what's being built, and hnsw dumps are not
-        // cheap per-doc.
-        let mut docs_since_commit: usize = 0;
-
-        let zone_has_ann = zone_has_ann_dir(manager, &zone_id);
-        // Content transition on explicit indexing (review R6): a doc
-        // re-posted with empty/whitespace text must PURGE its prior
-        // chunks, not leave stale text searchable behind a skip.
-        // Returns true when the purge stayed TRANSIENT (unreachable
-        // ANN → retry tombstone kept) — the zone did not converge
-        // this pass (review R8).
-        let content_skip = |path: &str| -> bool {
-            fts.delete_all_chunks(path);
-            match ann.as_ref() {
-                Some(a) => {
-                    a.delete_all_chunks(path);
-                    state.forget(path);
-                    false
-                }
-                None if zone_has_ann => {
-                    // Vectors may exist but are unreachable — retry
-                    // tombstone so a later pass finishes the purge.
-                    // `tombstone()` dispatches to the correct map
-                    // (matches the `remove_one` posture).
-                    state.tombstone(path);
-                    true
-                }
-                None => {
-                    state.forget(path);
-                    false
-                }
-            }
-        };
-        // Docs whose sinks did NOT verifiably converge this pass
-        // (review R8) — blocks the zone's dirty-mark clear below.
-        let mut zone_transient: u32 = 0;
-        for doc in docs {
-            if doc.text.trim().is_empty() {
-                if content_skip(&doc.path) {
-                    zone_transient += 1;
-                }
-                total_skipped += 1;
-                skipped_paths.push(doc.path.clone());
-                continue;
-            }
-            let mut chunks = crate::chunker::chunk_document(&doc.text);
-            if chunks.is_empty() {
-                if content_skip(&doc.path) {
-                    zone_transient += 1;
-                }
-                total_skipped += 1;
-                skipped_paths.push(doc.path.clone());
-                continue;
-            }
-            // Feature 3 — contextual chunking (see index_one's twin
-            // insertion point).  Per-chunk LLM failure = None ⇒ that
-            // chunk keeps its plain embed_input.
-            if let Some(gen) = context_generator {
-                crate::contextual_chunker::apply_contexts(
-                    gen,
-                    &doc.text,
-                    &mut chunks,
-                    gen.max_chunks_per_doc(),
-                );
-            }
-            // FTS: drop-old-then-add-new (mirrors do_index).
-            fts.delete_all_chunks(&doc.path);
-            let mut fts_ok = true;
-            for chunk in &chunks {
-                if let Err(e) =
-                    fts.add_document(&doc.path, chunk.chunk_index, &chunk.text, doc.mtime_ms)
-                {
-                    tracing::warn!(path = %doc.path, err = %e, "index_documents: fts add failed");
-                    fts_ok = false;
-                    break;
-                }
-            }
-            if !fts_ok {
-                total_skipped += 1;
-                skipped_paths.push(doc.path.clone());
-                zone_transient += 1;
-                continue;
-            }
-
-            // ANN: keyword-degradation is fine per query, but a
-            // transient embed failure must stay RETRYABLE.  Recording
-            // the mtime below despite a failed embed would make the
-            // hole permanent — the next Refresh sees the matching
-            // mtime and never retries the missing vectors (a remote
-            // provider 429/timeout would silently produce a
-            // forever-keyword-only doc; review R1).
-            // Same completion invariant as index_one (review R7):
-            // embedder absent + existing ann-* dirs ⇒ stay retryable.
-            let mut ann_complete = !(embed_broken || embedder.is_none() && zone_has_ann);
-            if let (Some(ann), Some(emb)) = (ann.as_ref(), embedder) {
-                let inputs: Vec<&str> = chunks.iter().map(|c| c.embed_input.as_str()).collect();
-                match emb.embed_batch(&inputs) {
-                    Ok(vecs) if vecs.len() == chunks.len() => {
-                        ann.delete_all_chunks(&doc.path);
-                        for (chunk, vec) in chunks.iter().zip(vecs.iter()) {
-                            if let Err(e) = ann.add_vector(&doc.path, chunk.chunk_index, vec) {
-                                ann_complete = false;
-                                tracing::warn!(
-                                    path = %doc.path,
-                                    err = %e,
-                                    "index_documents: ann add failed — will retry on next index/refresh",
-                                );
-                            }
-                        }
-                    }
-                    Ok(vecs) => {
-                        ann_complete = false;
-                        tracing::warn!(
-                            path = %doc.path,
-                            got = vecs.len(),
-                            want = chunks.len(),
-                            "index_documents: embed count mismatch — will retry on next index/refresh",
-                        );
-                    }
-                    Err(e) => {
-                        ann_complete = false;
-                        tracing::warn!(
-                            path = %doc.path,
-                            err = %e,
-                            "index_documents: embed failed — will retry on next index/refresh",
-                        );
-                    }
-                }
-            }
-
-            // Only a FULLY indexed doc (FTS + ANN when an embedder is
-            // configured) gets its real mtime recorded.  An incomplete
-            // doc records mtime None EXPLICITLY — merely skipping the
-            // record would leave a PRIOR same-mtime entry in place and
-            // Refresh would read Unchanged forever (review R2).  A
-            // None mtime always verdicts Changed, so the next
-            // Refresh / IndexDocuments retries the missing vectors;
-            // FTS re-adds are idempotent (delete-then-add).
-            if ann_complete {
-                state.record(&doc.path, doc.mtime_ms);
-            } else {
-                state.record(&doc.path, None);
-                zone_transient += 1;
-            }
-            total_indexed += 1;
-            docs_since_commit += 1;
-            if docs_since_commit >= INDEX_INCREMENTAL_COMMIT_EVERY {
-                if let Err(e) = fts.commit() {
-                    return Err(format!("fts incremental commit for zone {zone_id:?}: {e}"));
-                }
-                // Cached results captured before this commit would
-                // mask the fresh docs for the cache TTL — drop them
-                // with every visibility step, not just at the end.
-                cache.invalidate_zone(&zone_id);
-                docs_since_commit = 0;
-            }
-        }
-
-        if let Err(e) = fts.commit() {
-            return Err(format!("fts commit for zone {zone_id:?}: {e}"));
-        }
-        if let Some(a) = ann.as_ref() {
-            if let Err(e) = a.commit() {
-                return Err(format!("ann commit for zone {zone_id:?}: {e}"));
-            }
-        }
-        let state_saved = match state.save() {
-            Ok(()) => true,
+        let batch = chunk_documents(docs);
+        // Epoch bookkeeping brackets the whole zone pass so the dirty
+        // sentinel is only ever cleared by the last batch in flight.
+        flush.begin_batch(&zone_id, manager);
+        let outcome = index_zone_documents(
+            manager,
+            embedder,
+            embed_broken,
+            context_generator,
+            &zone_id,
+            batch,
+            cache,
+            gate,
+            flush,
+        );
+        let outcome = match outcome {
+            Ok(outcome) => outcome,
             Err(e) => {
-                tracing::warn!(err = %e, zone = %zone_id, "index_state save failed — zone stays cache-bypassed");
-                false
+                // The success path ends the epoch itself (under the zone
+                // lock); a failure must still release its slot, and it
+                // never clears dirt.
+                flush.end_batch(&zone_id, false);
+                return Err(e);
             }
         };
-        cache.invalidate_zone(&zone_id);
-        // Clear only dirt this write created, only when the state
-        // file persisted, and only when every doc it touched
-        // verifiably converged (reviews R7/R8).
-        if state_saved && !zone_was_dirty && zone_transient == 0 {
-            manager.clear_zone_dirty(&zone_id);
-        }
+        total_indexed += outcome.indexed;
+        total_skipped += outcome.skipped;
+        skipped_paths.extend(outcome.skipped_paths);
     }
 
     Ok(IndexDocumentsOutcome {
@@ -3123,6 +3075,337 @@ fn do_index_documents(
         skipped: total_skipped,
         skipped_paths,
     })
+}
+
+/// One zone's share of an `IndexDocuments` batch, in three phases
+/// (#4777):
+///
+/// 1. **FTS (zone lock, short)** — delete-then-add every doc's chunks
+///    and commit, so keyword hits are visible BEFORE any embedding
+///    starts (#4623's progressive-visibility guarantee, now met up
+///    front instead of every eight docs).
+/// 2. **Embed (no lock)** — contextualise + embed behind [`EmbedGate`];
+///    concurrent batches overlap their provider round-trips instead of
+///    serialising on the zone mutex.
+/// 3. **ANN + state (zone lock, short)** — add vectors, record mtimes,
+///    then dump the hnsw graph — or defer the dump while sibling batches
+///    are in flight (see [`crate::ann_flush::AnnFlushCoordinator`]).
+///
+/// Ends the zone's epoch on success (caller ends it on failure).
+#[allow(clippy::too_many_arguments)]
+fn index_zone_documents(
+    manager: &Arc<IndexManager>,
+    embedder: Option<&Arc<dyn Embedder>>,
+    embed_broken: bool,
+    context_generator: Option<&dyn ContextGenerator>,
+    zone_id: &str,
+    mut batch: Vec<BatchDoc>,
+    cache: &crate::query_cache::SharedQueryCache,
+    gate: &crate::ann_flush::EmbedGate,
+    flush: &Arc<crate::ann_flush::AnnFlushCoordinator>,
+) -> Result<ZoneIndexOutcome, String> {
+    let zone_lock = manager.zone_write_lock(zone_id);
+    let mut out = ZoneIndexOutcome::default();
+    let t0 = Instant::now();
+    let batch_no = INDEX_BATCH_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let docs_n = batch.len();
+    phase_trace(zone_id, batch_no, &format!("start docs={docs_n}"), t0);
+
+    // ── Phase 1: FTS under the lock ──
+    {
+        let wait_ticket = flush.enter_wait(zone_id);
+        let _zone_guard = zone_lock.lock();
+        drop(wait_ticket);
+        phase_trace(zone_id, batch_no, "phase1 lock acquired", t0);
+        // Dirty window — same rationale as do_index (reviews R5/R7).
+        // Stays set across the unlocked embed phase; cleared (if ever)
+        // at the end of Phase 3 by the epoch's last batch.  Marking is
+        // three durable fsyncs, so skip it when the sentinel is already
+        // there (a sibling in the same burst set it).
+        if !manager.zone_is_dirty(zone_id) {
+            manager.mark_zone_dirty(zone_id)?;
+        }
+        let fts = manager
+            .get_or_open(zone_id)
+            .map_err(|e| format!("open fts for zone {zone_id:?}: {e}"))?;
+        for doc in batch.iter_mut() {
+            // Drop-old-then-add-new (mirrors do_index).  A content skip
+            // purges prior chunks here; its ANN/state side lands in
+            // Phase 3 (review R6).
+            fts.delete_all_chunks(&doc.path);
+            for chunk in &doc.chunks {
+                if let Err(e) =
+                    fts.add_document(&doc.path, chunk.chunk_index, &chunk.text, doc.mtime_ms)
+                {
+                    tracing::warn!(path = %doc.path, err = %e, "index_documents: fts add failed");
+                    doc.fts_failed = true;
+                    break;
+                }
+            }
+        }
+        // The tantivy commit (segment flush + fsync + reader reload +
+        // liveness probe) is the expensive part of this phase and it is
+        // serialised by the zone lock.  While siblings are queued behind
+        // us, leave it to the last of them — one commit then covers the
+        // whole burst, and keyword hits still appear before any of the
+        // batches finishes embedding.  Phase 3 (and the flusher) commit
+        // whatever is still uncommitted before recording state, so no
+        // document is ever recorded as indexed over an uncommitted add.
+        let coalesce = flush.deferral_enabled() && flush.waiters(zone_id) > 0;
+        if coalesce {
+            flush.note_fts_skipped(zone_id);
+            phase_trace(
+                zone_id,
+                batch_no,
+                "phase1 fts commit coalesced, lock released",
+                t0,
+            );
+        } else {
+            if let Err(e) = fts.commit() {
+                return Err(format!("fts commit for zone {zone_id:?}: {e}"));
+            }
+            flush.note_fts_committed(zone_id);
+            // Cached results captured before this commit would mask the
+            // fresh docs for the cache TTL.
+            cache.invalidate_zone(zone_id);
+            phase_trace(zone_id, batch_no, "phase1 fts committed, lock released", t0);
+        }
+    }
+
+    // ── Phase 2: embed with NO lock held ──
+    if let Some(emb) = embedder {
+        embed_documents(&mut batch, emb, context_generator, gate);
+    }
+    phase_trace(zone_id, batch_no, "phase2 embedded", t0);
+
+    // ── Phase 3: ANN + state under the lock ──
+    let wait_ticket = flush.enter_wait(zone_id);
+    let _zone_guard = zone_lock.lock();
+    drop(wait_ticket);
+    phase_trace(zone_id, batch_no, "phase3 lock acquired", t0);
+    // Re-assert the dirty window: a sibling that ended the previous
+    // epoch (or the flusher) may have cleared it while we embedded.
+    if !manager.zone_is_dirty(zone_id) {
+        manager.mark_zone_dirty(zone_id)?;
+    }
+    // A coalesced Phase 1 commit that no sibling has landed yet must go
+    // in BEFORE this batch records any document as indexed (a recorded
+    // mtime over an uncommitted FTS add would be a keyword hole after a
+    // crash).  In a burst the last queued Phase 1 normally commits for
+    // everyone, so this is rarely taken.
+    if flush.fts_uncommitted(zone_id) {
+        let fts = manager
+            .get_or_open(zone_id)
+            .map_err(|e| format!("open fts for zone {zone_id:?}: {e}"))?;
+        if let Err(e) = fts.commit() {
+            return Err(format!("fts commit for zone {zone_id:?}: {e}"));
+        }
+        flush.note_fts_committed(zone_id);
+        cache.invalidate_zone(zone_id);
+        phase_trace(zone_id, batch_no, "phase3 committed coalesced fts", t0);
+    }
+    // This batch now owns the verdict for its paths: drop any parked
+    // upgrade so a later flush cannot overwrite what we record.
+    flush.forget_paths(zone_id, batch.iter().map(|d| d.path.as_str()));
+
+    let ann = if let Some(e) = embedder {
+        Some(
+            manager
+                .get_or_open_ann(zone_id, e.tag(), e.dim())
+                .map_err(|err| format!("open ann for zone {zone_id:?}: {err}"))?,
+        )
+    } else {
+        None
+    };
+    let state = crate::index_state::IndexState::open_or_create(manager.zone_root(zone_id))
+        .map_err(|e| format!("open state for zone {zone_id:?}: {e}"))?;
+
+    // Embedder-generation alignment — same rationale as do_index.
+    if let Some(e) = embedder {
+        if state.ensure_embedder_generation(e.tag()) {
+            tracing::warn!(
+                zone = %zone_id,
+                tag = %e.tag(),
+                "embedder generation changed — invalidated mtime cache; full re-embed",
+            );
+        }
+    }
+
+    let zone_has_ann = zone_has_ann_dir(manager, zone_id);
+    // Content transition on explicit indexing (review R6): a doc
+    // re-posted with empty/whitespace text must PURGE its prior
+    // chunks, not leave stale text searchable behind a skip.  FTS
+    // chunks went in Phase 1; this is the ANN + state side.  Returns
+    // true when the purge stayed TRANSIENT (unreachable ANN → retry
+    // tombstone kept) — the zone did not converge this pass (review R8).
+    let content_skip = |path: &str| -> bool {
+        match ann.as_ref() {
+            Some(a) => {
+                a.delete_all_chunks(path);
+                state.forget(path);
+                false
+            }
+            None if zone_has_ann => {
+                // Vectors may exist but are unreachable — retry
+                // tombstone so a later pass finishes the purge.
+                // `tombstone()` dispatches to the correct map
+                // (matches the `remove_one` posture).
+                state.tombstone(path);
+                true
+            }
+            None => {
+                state.forget(path);
+                false
+            }
+        }
+    };
+    // Docs whose sinks did NOT verifiably converge this pass
+    // (review R8) — blocks the zone's dirty-mark clear below.
+    let mut zone_transient: u32 = 0;
+    // Docs whose FTS + ANN adds fully landed in memory.  Their real
+    // mtime is recorded only once the ANN dump is durable (below).
+    let mut completed: Vec<(String, Option<i64>)> = Vec::new();
+    for doc in batch {
+        if doc.is_content_skip() {
+            if content_skip(&doc.path) {
+                zone_transient += 1;
+            }
+            out.skipped += 1;
+            out.skipped_paths.push(doc.path);
+            continue;
+        }
+        if doc.fts_failed {
+            out.skipped += 1;
+            out.skipped_paths.push(doc.path);
+            zone_transient += 1;
+            continue;
+        }
+
+        // ANN: keyword-degradation is fine per query, but a
+        // transient embed failure must stay RETRYABLE.  Recording
+        // the mtime below despite a failed embed would make the
+        // hole permanent — the next Refresh sees the matching
+        // mtime and never retries the missing vectors (a remote
+        // provider 429/timeout would silently produce a
+        // forever-keyword-only doc; review R1).
+        // Same completion invariant as index_one (review R7):
+        // embedder absent + existing ann-* dirs ⇒ stay retryable.
+        let mut ann_complete = !(embed_broken || embedder.is_none() && zone_has_ann);
+        if let Some(ann) = ann.as_ref() {
+            match &doc.vectors {
+                Some(Ok(vecs)) => {
+                    ann.delete_all_chunks(&doc.path);
+                    for (chunk, vec) in doc.chunks.iter().zip(vecs.iter()) {
+                        if let Err(e) = ann.add_vector(&doc.path, chunk.chunk_index, vec) {
+                            ann_complete = false;
+                            tracing::warn!(
+                                path = %doc.path,
+                                err = %e,
+                                "index_documents: ann add failed — will retry on next index/refresh",
+                            );
+                        }
+                    }
+                }
+                Some(Err(reason)) => {
+                    ann_complete = false;
+                    tracing::warn!(
+                        path = %doc.path,
+                        err = %reason,
+                        "index_documents: embedding unavailable — will retry on next index/refresh",
+                    );
+                }
+                // `ann` is Some iff an embedder is configured, and
+                // Phase 2 embeds every surviving doc whenever one is —
+                // unreachable in practice; keep the computed verdict.
+                None => {}
+            }
+        }
+
+        // Only a FULLY indexed doc (FTS + ANN when an embedder is
+        // configured) gets its real mtime recorded.  An incomplete
+        // doc records mtime None EXPLICITLY — merely skipping the
+        // record would leave a PRIOR same-mtime entry in place and
+        // Refresh would read Unchanged forever (review R2).  A
+        // None mtime always verdicts Changed, so the next
+        // Refresh / IndexDocuments retries the missing vectors;
+        // FTS re-adds are idempotent (delete-then-add).
+        if ann_complete {
+            completed.push((doc.path, doc.mtime_ms));
+        } else {
+            state.record(&doc.path, None);
+            zone_transient += 1;
+        }
+        out.indexed += 1;
+    }
+
+    // #4777: the hnsw dump is a full rewrite of the graph (over a
+    // gigabyte at a few hundred thousand chunks).  While sibling
+    // batches are in flight for this zone, leave the dump to the last
+    // one — the vectors are already served from memory.  Until it
+    // lands, completed docs are recorded as `None` (retry-me) so a
+    // crash costs a re-embed, never a permanent hole; the coordinator
+    // upgrades them afterwards.
+    let defer_dump = ann.is_some() && flush.deferral_enabled() && flush.others_in_flight(zone_id);
+    let mut taken_pending_clearable = true;
+    if defer_dump {
+        for (path, _) in &completed {
+            state.record(path, None);
+        }
+    } else {
+        for (path, mtime) in &completed {
+            state.record(path, *mtime);
+        }
+        if let Some(a) = ann.as_ref() {
+            if let Err(e) = a.commit() {
+                return Err(format!("ann commit for zone {zone_id:?}: {e}"));
+            }
+            // This dump also covers vectors earlier batches deferred:
+            // promote their parked records now that they are durable.
+            if let Some(pending) = flush.take_pending(zone_id) {
+                crate::ann_flush::upgrade_records(&state, &pending.records);
+                taken_pending_clearable = pending.clearable;
+            }
+        }
+    }
+    let state_saved = match state.save() {
+        Ok(()) => true,
+        Err(e) => {
+            tracing::warn!(err = %e, zone = %zone_id, "index_state save failed — zone stays cache-bypassed");
+            false
+        }
+    };
+    cache.invalidate_zone(zone_id);
+
+    if defer_dump {
+        if let Some(a) = ann.clone() {
+            flush.defer(
+                zone_id,
+                a,
+                completed,
+                Arc::clone(manager),
+                Arc::clone(cache),
+            );
+        }
+    }
+    // Clear only dirt this epoch created, only when every batch of the
+    // epoch persisted its state and every doc it touched verifiably
+    // converged (reviews R7/R8), and never while a dump is still owed
+    // (the flusher or the committing batch clears it then).
+    let end = flush.end_batch(zone_id, state_saved && zone_transient == 0);
+    phase_trace(
+        zone_id,
+        batch_no,
+        &format!(
+            "phase3 done defer_dump={defer_dump} last={} indexed={}",
+            end.last, out.indexed
+        ),
+        t0,
+    );
+    if !defer_dump && end.last && end.clearable && taken_pending_clearable {
+        manager.clear_zone_dirty(zone_id);
+    }
+
+    Ok(out)
 }
 
 /// Per-file change event.  "delete" drops the file from every
@@ -4120,6 +4403,8 @@ impl SearchService for SearchServiceImpl {
         let context_generator = self.get_or_init_context_generator();
         let cache = Arc::clone(&self.query_cache);
         let index_seq = Arc::clone(&self.index_seq);
+        let embed_gate = Arc::clone(&self.embed_gate);
+        let ann_flush = Arc::clone(&self.ann_flush);
         let outcome = tokio::task::spawn_blocking(move || {
             let _indexing = indexing; // held until the WORK ends, not the RPC
             let _pending = pending;
@@ -4131,6 +4416,8 @@ impl SearchService for SearchServiceImpl {
                 &default_zone,
                 req.documents,
                 &cache,
+                &embed_gate,
+                &ann_flush,
             )
             // Sequence assigned AFTER the per-zone commits above —
             // `last_index_seq >= this` on Stats means the batch is
@@ -4733,6 +5020,221 @@ mod tests {
         assert_eq!(strip_root("/", "/foo/bar"), "foo/bar");
         assert_eq!(strip_root("/root", "/root/a/b"), "a/b");
         assert_eq!(strip_root("/root/", "/root/a/b"), "a/b");
+    }
+
+    // ── #4777: deferred hnsw dump + lock-free embedding ──────────
+
+    fn deferral_fixture(
+        flush_delay: Option<std::time::Duration>,
+    ) -> (
+        tempfile::TempDir,
+        Arc<IndexManager>,
+        Arc<dyn Embedder>,
+        crate::query_cache::SharedQueryCache,
+        crate::ann_flush::EmbedGate,
+        Arc<crate::ann_flush::AnnFlushCoordinator>,
+    ) {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let manager = Arc::new(IndexManager::with_root(tmp.path().to_path_buf()));
+        let embedder: Arc<dyn Embedder> = Arc::new(crate::embedder::MockEmbedder::with_dim(8));
+        let cache: crate::query_cache::SharedQueryCache =
+            Arc::new(crate::query_cache::QueryCache::new());
+        let gate = crate::ann_flush::EmbedGate::new(0);
+        let flush = Arc::new(crate::ann_flush::AnnFlushCoordinator::new(flush_delay));
+        (tmp, manager, embedder, cache, gate, flush)
+    }
+
+    fn doc(path: &str, text: &str, mtime: i64) -> crate::search_proto::DocumentInput {
+        crate::search_proto::DocumentInput {
+            path: path.to_string(),
+            text: text.to_string(),
+            mtime_ms: Some(mtime),
+            zone_id: String::new(),
+        }
+    }
+
+    fn has_hnsw_dump(ann_dir: &std::path::Path) -> bool {
+        match std::fs::read_dir(ann_dir) {
+            Ok(rd) => rd
+                .flatten()
+                .any(|e| e.file_name().to_string_lossy().starts_with("hnsw")),
+            Err(_) => false,
+        }
+    }
+
+    fn cached(manager: &IndexManager, path: &str) -> Option<Option<i64>> {
+        crate::index_state::IndexState::open_or_create(manager.zone_root("root"))
+            .expect("state")
+            .cached_mtime(path)
+    }
+
+    #[test]
+    fn index_documents_defers_hnsw_dump_while_writers_are_queued() {
+        let (_tmp, manager, embedder, cache, gate, flush) =
+            deferral_fixture(Some(std::time::Duration::from_secs(3600)));
+        let ann_dir = manager.ann_dir("root", embedder.tag());
+
+        // A second batch is queued on the zone lock.
+        let queued = flush.enter_wait("root");
+        do_index_documents(
+            &manager,
+            Some(&embedder),
+            false,
+            None,
+            "root",
+            vec![doc("/a.md", "alpha bravo charlie", 1_000)],
+            &cache,
+            &gate,
+            &flush,
+        )
+        .expect("first batch");
+
+        assert!(
+            !has_hnsw_dump(&ann_dir),
+            "dump must be deferred while a batch is queued"
+        );
+        assert_eq!(
+            cached(&manager, "/a.md"),
+            Some(None),
+            "deferred doc stays retry-me"
+        );
+        assert!(flush.has_pending("root"));
+        assert!(
+            manager.zone_is_dirty("root"),
+            "zone stays dirty until the dump lands"
+        );
+        // The vectors are already served from memory.
+        let ann = manager
+            .get_or_open_ann("root", embedder.tag(), embedder.dim())
+            .unwrap();
+        assert_eq!(ann.live_paths(), 1);
+
+        // Last batch in the burst: nobody queued behind it ⇒ dumps
+        // inline and promotes the earlier batch's records.
+        drop(queued);
+        do_index_documents(
+            &manager,
+            Some(&embedder),
+            false,
+            None,
+            "root",
+            vec![doc("/b.md", "delta echo foxtrot", 2_000)],
+            &cache,
+            &gate,
+            &flush,
+        )
+        .expect("second batch");
+
+        assert!(has_hnsw_dump(&ann_dir), "final batch must dump");
+        assert_eq!(cached(&manager, "/a.md"), Some(Some(1_000)));
+        assert_eq!(cached(&manager, "/b.md"), Some(Some(2_000)));
+        assert!(!flush.has_pending("root"));
+        assert!(!manager.zone_is_dirty("root"));
+    }
+
+    #[test]
+    fn flush_zone_lands_deferred_dump_and_promotes_records() {
+        let (_tmp, manager, embedder, cache, gate, flush) =
+            deferral_fixture(Some(std::time::Duration::from_secs(3600)));
+        let ann_dir = manager.ann_dir("root", embedder.tag());
+
+        let queued = flush.enter_wait("root");
+        do_index_documents(
+            &manager,
+            Some(&embedder),
+            false,
+            None,
+            "root",
+            vec![doc("/a.md", "alpha bravo", 1_000)],
+            &cache,
+            &gate,
+            &flush,
+        )
+        .expect("batch");
+        drop(queued);
+        assert!(!has_hnsw_dump(&ann_dir));
+
+        assert_eq!(flush.flush_zone("root", &manager, &cache), Ok(true));
+        assert!(has_hnsw_dump(&ann_dir));
+        assert_eq!(cached(&manager, "/a.md"), Some(Some(1_000)));
+        assert!(!manager.zone_is_dirty("root"));
+        // Nothing left to flush.
+        assert_eq!(flush.flush_zone("root", &manager, &cache), Ok(false));
+    }
+
+    #[test]
+    fn later_batch_owns_its_paths_over_a_parked_upgrade() {
+        // Batch 1 defers /a.md@1000.  Batch 2 (also deferring) re-indexes
+        // /a.md@1500.  The flush must land 1500, not the stale 1000.
+        let (_tmp, manager, embedder, cache, gate, flush) =
+            deferral_fixture(Some(std::time::Duration::from_secs(3600)));
+
+        let queued = flush.enter_wait("root");
+        for (text, mtime) in [("alpha", 1_000), ("alpha revised", 1_500)] {
+            do_index_documents(
+                &manager,
+                Some(&embedder),
+                false,
+                None,
+                "root",
+                vec![doc("/a.md", text, mtime)],
+                &cache,
+                &gate,
+                &flush,
+            )
+            .expect("batch");
+        }
+        drop(queued);
+        assert_eq!(flush.flush_zone("root", &manager, &cache), Ok(true));
+        assert_eq!(cached(&manager, "/a.md"), Some(Some(1_500)));
+    }
+
+    #[test]
+    fn deferral_disabled_dumps_inline_even_with_queued_writers() {
+        let (_tmp, manager, embedder, cache, gate, flush) = deferral_fixture(None);
+        let ann_dir = manager.ann_dir("root", embedder.tag());
+
+        let _queued = flush.enter_wait("root");
+        do_index_documents(
+            &manager,
+            Some(&embedder),
+            false,
+            None,
+            "root",
+            vec![doc("/a.md", "alpha bravo", 1_000)],
+            &cache,
+            &gate,
+            &flush,
+        )
+        .expect("batch");
+
+        assert!(has_hnsw_dump(&ann_dir));
+        assert_eq!(cached(&manager, "/a.md"), Some(Some(1_000)));
+        assert!(!flush.has_pending("root"));
+        assert!(!manager.zone_is_dirty("root"));
+    }
+
+    #[test]
+    fn keyword_only_zone_never_defers() {
+        // No embedder ⇒ no ANN sink ⇒ nothing to defer, queued or not.
+        let (_tmp, manager, _embedder, cache, gate, flush) =
+            deferral_fixture(Some(std::time::Duration::from_secs(3600)));
+        let _queued = flush.enter_wait("root");
+        do_index_documents(
+            &manager,
+            None,
+            false,
+            None,
+            "root",
+            vec![doc("/a.md", "alpha bravo", 1_000)],
+            &cache,
+            &gate,
+            &flush,
+        )
+        .expect("batch");
+        assert!(!flush.has_pending("root"));
+        assert_eq!(cached(&manager, "/a.md"), Some(Some(1_000)));
+        assert!(!manager.zone_is_dirty("root"));
     }
 
     #[test]

--- a/src/nexus/remote/kernel_client.py
+++ b/src/nexus/remote/kernel_client.py
@@ -15,6 +15,7 @@ Call RPC for metadata/service operations.
 
 from __future__ import annotations
 
+import atexit
 import contextlib
 import logging
 import os
@@ -319,34 +320,13 @@ class KernelClient:
     def close(self) -> None:
         """Shutdown kernel subprocess and close gRPC channel."""
         if self._transport:
-            import contextlib
-
             with contextlib.suppress(Exception):
                 self._transport.close()
             self._transport = None
-        if self._process:
-            self._process.send_signal(signal.SIGTERM)
-            try:
-                self._process.wait(timeout=5)
-            except subprocess.TimeoutExpired:
-                self._process.kill()
-            self._process = None
-        if self._stderr_file is not None:
-            import contextlib
-
-            with contextlib.suppress(OSError):
-                self._stderr_file.close()
-            stderr_path = getattr(self, "_stderr_path", None)
-            if stderr_path:
-                with contextlib.suppress(OSError):
-                    os.unlink(stderr_path)
-            self._stderr_file = None
-        if self._ephemeral_dir is not None:
-            import contextlib
-
-            with contextlib.suppress(OSError):
-                shutil.rmtree(self._ephemeral_dir, ignore_errors=True)
-            self._ephemeral_dir = None
+        # Also removes the stderr log and any ephemeral data dir.
+        self._terminate_spawned_kernel()
+        with contextlib.suppress(Exception):
+            atexit.unregister(self._terminate_spawned_kernel)
 
     def _is_remote(self) -> bool:
         return self._process is None and self._transport is not None
@@ -388,6 +368,14 @@ class KernelClient:
             stdout=subprocess.DEVNULL,
             stderr=self._stderr_file,
         )
+        # Reap the kernel when this interpreter exits (#4777 follow-up).
+        # Every `nexus` CLI invocation — including the REMOTE profile,
+        # whose routing kernel is a local ephemeral spawn — creates one of
+        # these, and callers rarely reach ``close()``.  Without this hook
+        # each CLI run left a ~30-thread ``nexus-cluster`` orphan behind
+        # (128 of them after two CI scripts in one container), which walks
+        # straight into a container's PID cgroup limit.
+        atexit.register(self._terminate_spawned_kernel)
         logger.info(
             "Spawned %s (pid=%d) at %s, log=%s",
             kernel_binary,
@@ -395,6 +383,42 @@ class KernelClient:
             self._server_address,
             self._stderr_path,
         )
+
+    def _terminate_spawned_kernel(self) -> None:
+        """SIGTERM (then SIGKILL) the kernel subprocess we spawned, if any.
+
+        Idempotent and exception-free so it is safe as an ``atexit`` hook.
+        """
+        proc = self._process
+        if proc is None:
+            return
+        self._process = None
+        if proc.poll() is None:
+            with contextlib.suppress(Exception):
+                proc.send_signal(signal.SIGTERM)
+                try:
+                    proc.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+                    with contextlib.suppress(Exception):
+                        proc.wait(timeout=5)
+        # The spawn's scratch files go with it: the stderr log and, for
+        # ``:memory:`` kernels, the throwaway data dir — otherwise every
+        # CLI run also leaves a tempdir behind.
+        stderr_file = getattr(self, "_stderr_file", None)
+        if stderr_file is not None:
+            with contextlib.suppress(OSError):
+                stderr_file.close()
+            self._stderr_file = None
+        stderr_path = getattr(self, "_stderr_path", None)
+        if stderr_path:
+            with contextlib.suppress(OSError):
+                os.unlink(stderr_path)
+            self._stderr_path = None
+        ephemeral_dir = getattr(self, "_ephemeral_dir", None)
+        if ephemeral_dir is not None:
+            shutil.rmtree(ephemeral_dir, ignore_errors=True)
+            self._ephemeral_dir = None
 
     def _wait_ready(self, timeout: float = 30.0) -> None:
         """Poll kernel health until ready."""

--- a/src/nexus/server/api/v2/routers/_index_on_write.py
+++ b/src/nexus/server/api/v2/routers/_index_on_write.py
@@ -14,6 +14,7 @@ Underscore-prefixed sibling of the router modules (same convention as
 
 from __future__ import annotations
 
+import asyncio
 import inspect
 import logging
 import time
@@ -291,7 +292,8 @@ async def read_written_bytes(fs: Any, path: str, context: Any) -> tuple[bytes, i
     use: 404 missing, 403 denied, 400 for a directory.
     """
     try:
-        raw = fs.read(path, context=context)
+        # Blocking kernel round-trip — off the event loop (#4777).
+        raw = await asyncio.to_thread(fs.read, path, context=context)
         if inspect.isawaitable(raw):
             raw = await raw
     except NexusFileNotFoundError as exc:
@@ -310,7 +312,7 @@ async def read_written_bytes(fs: Any, path: str, context: Any) -> tuple[bytes, i
 
     mtime_ms: int | None = None
     try:
-        meta = fs.sys_stat(path, context=context)
+        meta = await asyncio.to_thread(fs.sys_stat, path, context=context)
         if inspect.isawaitable(meta):
             meta = await meta
         if isinstance(meta, dict):

--- a/src/nexus/server/api/v2/routers/_search_indexed_dirs.py
+++ b/src/nexus/server/api/v2/routers/_search_indexed_dirs.py
@@ -8,6 +8,7 @@ because ``search.py`` includes this module's ``router`` via
 Shared helpers (``_get_search_daemon``) come from the parent module.
 """
 
+import asyncio
 import logging
 from typing import Any
 
@@ -53,7 +54,12 @@ async def _require_admin_or_path_write(
         subject_id=auth_result.get("subject_id"),
     )
     try:
-        allowed = bool(enforcer.check(directory_path, Permission.WRITE, ctx))
+        # The enforcer is synchronous and may hit the database on a cache
+        # miss; keep it off the event loop (#4777) — ``/search/index`` runs
+        # this once per document.
+        allowed = bool(
+            await asyncio.to_thread(enforcer.check, directory_path, Permission.WRITE, ctx)
+        )
     except Exception as exc:
         logger.warning("ReBAC write check failed for %s: %s", directory_path, exc)
         raise HTTPException(status_code=500, detail="permission check failed") from exc

--- a/src/nexus/server/api/v2/routers/async_files.py
+++ b/src/nexus/server/api/v2/routers/async_files.py
@@ -151,7 +151,7 @@ async def _read_connector_by_physical_path(
     longer needs it handed in.
     """
     try:
-        content = fs.sys_read(display_path, context=context)
+        content = await _call_sync_or_async(fs.sys_read, display_path, context=context)
     except Exception:
         return None
     if isinstance(content, bytes):
@@ -807,7 +807,9 @@ def create_async_files_router(
                         _ss.validate_path_available(transaction_id, _norm_path)
                         # Capture original state for rollback
                         try:
-                            _orig_meta = fs.sys_stat(_norm_path, context=context)
+                            _orig_meta = await _call_sync_or_async(
+                                fs.sys_stat, _norm_path, context=context
+                            )
                             if _orig_meta:
                                 _original_hash = _orig_meta.get("content_id")
                                 _original_metadata = {
@@ -902,8 +904,10 @@ def create_async_files_router(
                     except FileExistsError as exc:
                         raise HTTPException(status_code=409, detail=str(exc)) from exc
                 else:
-                    # fs.write is async — call directly
-                    result = fs.write(**write_kwargs)
+                    # #4777: fs.write is a blocking kernel gRPC round-trip
+                    # (plus post-write hooks); run it off the event loop so a
+                    # slow write cannot stall every other request.
+                    result = await _call_sync_or_async(fs.write, **write_kwargs)
 
                 # Track write in transaction AFTER successful write.
                 # Skip if _write_internal already tracked it (path already in registry).
@@ -1105,7 +1109,9 @@ def create_async_files_router(
                     _skip_access = _entry_op == "delete" and _is_admin
                     if not _skip_access:
                         try:
-                            _accessible = fs.access(path, context=context)
+                            _accessible = await _call_sync_or_async(
+                                fs.access, path, context=context
+                            )
                         except _PERMISSION_ERRORS as e:
                             raise HTTPException(status_code=403, detail=str(e)) from e
                         if not _accessible:
@@ -1208,7 +1214,7 @@ def create_async_files_router(
                 if_none_match = request.headers.get("If-None-Match")
                 if if_none_match:
                     try:
-                        meta = fs.sys_stat(path, context=context)
+                        meta = await _call_sync_or_async(fs.sys_stat, path, context=context)
                     except Exception:
                         meta = None
                     meta_cid = None
@@ -1273,8 +1279,10 @@ def create_async_files_router(
                         media_type="application/json",
                     )
 
-                # Standard VFS read
-                result = fs.read(path, return_metadata=include_metadata, context=context)
+                # Standard VFS read — off the event loop (#4777).
+                result = await _call_sync_or_async(
+                    fs.read, path, return_metadata=include_metadata, context=context
+                )
 
                 # --- Markdown partial read (Issue #3718) ---
                 if section and path.endswith(".md"):
@@ -1534,10 +1542,10 @@ def create_async_files_router(
 
             async def _work() -> Response:
                 fs = await _get_fs(context)
-                accessible = await fs.access(path, context=context)
+                accessible = await _call_sync_or_async(fs.access, path, context=context)
                 if not accessible:
                     raise NexusFileNotFoundError(path)
-                raw = await fs.read(path, context=context)
+                raw = await _call_sync_or_async(fs.read, path, context=context)
                 content = (
                     raw
                     if isinstance(raw, bytes)
@@ -1650,7 +1658,9 @@ def create_async_files_router(
                         _norm_path = _normalize_path(path)
                         _ss.validate_path_available(transaction_id, _norm_path)
                         try:
-                            _orig_meta = fs.sys_stat(_norm_path, context=context)
+                            _orig_meta = await _call_sync_or_async(
+                                fs.sys_stat, _norm_path, context=context
+                            )
                             if _orig_meta:
                                 _original_hash = _orig_meta.get("content_id")
                                 _original_metadata = {
@@ -1662,7 +1672,7 @@ def create_async_files_router(
                         except Exception:
                             _original_hash = None
 
-                unlink_result = fs.sys_unlink(path, context=context)
+                unlink_result = await _call_sync_or_async(fs.sys_unlink, path, context=context)
 
                 if (
                     _ss is not None
@@ -1723,7 +1733,7 @@ def create_async_files_router(
             async def _work() -> ExistsResponse:
                 fs = await _get_fs(context)
                 await revision_fence.enforce(fs, context=context)
-                exists = fs.access(path, context=context)
+                exists = await _call_sync_or_async(fs.access, path, context=context)
                 return ExistsResponse(exists=exists)
 
             exists_response = await _run_for_context(context, {"path": path, "zone": zone}, _work)
@@ -1796,16 +1806,15 @@ def create_async_files_router(
                 # while sys_readdir(details=True) returns detail dicts. We use
                 # sys_readdir as the primary path and only fall back to search
                 # for connector mounts where metastore-first listing is needed.
-                result = await _maybe_await(
-                    fs.sys_readdir(
-                        path,
-                        recursive=False,
-                        details=True,
-                        context=context,
-                        limit=limit,
-                        cursor=cursor_path,
-                        all_zones=all_zones,
-                    )
+                result = await _call_sync_or_async(
+                    fs.sys_readdir,
+                    path,
+                    recursive=False,
+                    details=True,
+                    context=context,
+                    limit=limit,
+                    cursor=cursor_path,
+                    all_zones=all_zones,
                 )
 
                 # Issue #3266: If sys_readdir returned nothing for a connector
@@ -1814,7 +1823,8 @@ def create_async_files_router(
                 if not result_items and path.startswith("/mnt/"):
                     search = fs.service("search")
                     if search is not None:
-                        search_result = search.list(
+                        search_result = await _call_sync_or_async(
+                            search.list,
                             path=path,
                             recursive=False,
                             context=context,
@@ -1930,15 +1940,14 @@ def create_async_files_router(
 
                     # If filtering emptied the page but more data exists, keep fetching
                     while not file_items and has_more and next_cursor_raw:
-                        result = await _maybe_await(
-                            fs.sys_readdir(
-                                path,
-                                recursive=False,
-                                details=True,
-                                context=context,
-                                limit=limit,
-                                cursor=next_cursor_raw,
-                            )
+                        result = await _call_sync_or_async(
+                            fs.sys_readdir,
+                            path,
+                            recursive=False,
+                            details=True,
+                            context=context,
+                            limit=limit,
+                            cursor=next_cursor_raw,
                         )
                         if isinstance(result, list):
                             _page_items = result
@@ -2010,7 +2019,9 @@ def create_async_files_router(
 
             async def _work() -> dict[str, Any]:
                 fs = await _get_fs(context)
-                _made = fs.mkdir(request.path, parents=request.parents, context=context)
+                _made = await _call_sync_or_async(
+                    fs.mkdir, request.path, parents=request.parents, context=context
+                )
                 return {
                     "created": True,
                     "path": request.path,
@@ -2055,7 +2066,7 @@ def create_async_files_router(
             async def _work() -> MetadataResponse:
                 fs = await _get_fs(context)
                 await revision_fence.enforce(fs, context=context)
-                meta = fs.sys_stat(path, context=context)
+                meta = await _call_sync_or_async(fs.sys_stat, path, context=context)
                 if meta is None:
                     raise NexusFileNotFoundError(path=path)
 
@@ -2182,7 +2193,7 @@ def create_async_files_router(
                 files = [
                     (item.path, base64.b64decode(item.content_base64)) for item in request.files
                 ]
-                raw_results = await _maybe_await(fs.write_batch(files, context=context))
+                raw_results = await _call_sync_or_async(fs.write_batch, files, context=context)
                 results = [
                     BatchWriteResult(
                         path=r["path"] if "path" in r else files[i][0],
@@ -2248,8 +2259,8 @@ def create_async_files_router(
             async def _work() -> BatchReadResponse:
                 fs = await _get_fs(context)
                 await revision_fence.enforce(fs, context=context)
-                raw_results = await _maybe_await(
-                    fs.read_batch(request.paths, partial=request.partial, context=context)
+                raw_results = await _call_sync_or_async(
+                    fs.read_batch, request.paths, partial=request.partial, context=context
                 )
                 # Belt-and-suspenders aggregate size guard (Finding #3).
                 # NexusFS.read_batch() already pre-checks via metadata sizes; this
@@ -2327,24 +2338,28 @@ def create_async_files_router(
             async def _work() -> Response | StreamingResponse:
                 fs = await _get_fs(context)
                 await revision_fence.enforce(fs, context=context)
-                meta = fs.sys_stat(path, context=context)
+                meta = await _call_sync_or_async(fs.sys_stat, path, context=context)
                 if meta is None:
                     raise NexusFileNotFoundError(path=path)
 
                 def _chunks(data: bytes, cs: int) -> Iterator[bytes]:
                     return (data[i : i + cs] for i in range(0, len(data), cs))
 
+                # Lazy generators (#4777): the kernel read runs on first
+                # ``next()``, which StreamingResponse drives from a worker
+                # thread — not eagerly on the event loop when the factory
+                # is called inside ``build_range_response``.
                 def _range_generator(start: int, end: int, cs: int) -> Iterator[bytes]:
                     data = fs.read_range(path, start, end, context=context)
                     if isinstance(data, bytes):
-                        return _chunks(data, cs)
-                    return iter(())
+                        yield from _chunks(data, cs)
 
                 def _full_generator() -> Iterator[bytes]:
                     data = fs.sys_read(path, context=context)
                     if isinstance(data, bytes):
-                        return _chunks(data, chunk_size)
-                    return _chunks(str(data).encode("utf-8"), chunk_size)
+                        yield from _chunks(data, chunk_size)
+                    else:
+                        yield from _chunks(str(data).encode("utf-8"), chunk_size)
 
                 return build_range_response(
                     request_headers=request.headers,
@@ -2392,8 +2407,8 @@ def create_async_files_router(
 
             async def _work() -> RenameResponse:
                 fs = await _get_fs(context)
-                rename_result = await _maybe_await(
-                    fs.sys_rename(request.source, request.destination, context=context)
+                rename_result = await _call_sync_or_async(
+                    fs.sys_rename, request.source, request.destination, context=context
                 )
                 return RenameResponse(
                     success=True,
@@ -2439,7 +2454,7 @@ def create_async_files_router(
                 fs = await _get_fs(context)
 
                 # Check source exists and get size
-                meta = await _maybe_await(fs.sys_stat(request.source, context=context))
+                meta = await _call_sync_or_async(fs.sys_stat, request.source, context=context)
                 if meta is None:
                     raise NexusFileNotFoundError(path=request.source)
 
@@ -2447,9 +2462,11 @@ def create_async_files_router(
 
                 if file_size < STREAMING_COPY_THRESHOLD:
                     # Small file: read all then write all
-                    content = await _maybe_await(fs.sys_read(request.source, context=context))
-                    write_result = await _maybe_await(
-                        fs.write(request.destination, buf=content, context=context)
+                    content = await _call_sync_or_async(
+                        fs.sys_read, request.source, context=context
+                    )
+                    write_result = await _call_sync_or_async(
+                        fs.write, request.destination, buf=content, context=context
                     )
                     bytes_copied = len(content)
                 else:
@@ -2502,7 +2519,7 @@ def create_async_files_router(
             async def _work() -> RenameBatchResponse:
                 fs = await _get_fs(context)
                 renames = [(op.source, op.destination) for op in request.operations]
-                raw_results = await _maybe_await(fs.rename_batch(renames, context=context))
+                raw_results = await _call_sync_or_async(fs.rename_batch, renames, context=context)
 
                 results: list[BulkRenameResult] = []
                 for op in request.operations:
@@ -2549,7 +2566,7 @@ def create_async_files_router(
 
                 for op in request.operations:
                     try:
-                        meta = await _maybe_await(fs.sys_stat(op.source, context=context))
+                        meta = await _call_sync_or_async(fs.sys_stat, op.source, context=context)
                         if meta is None:
                             results.append(
                                 BulkCopyResult(
@@ -2564,9 +2581,11 @@ def create_async_files_router(
                         file_size = _metadata_field(meta, "size", 0) or 0
 
                         if file_size < STREAMING_COPY_THRESHOLD:
-                            content = await _maybe_await(fs.sys_read(op.source, context=context))
-                            await _maybe_await(
-                                fs.write(op.destination, buf=content, context=context)
+                            content = await _call_sync_or_async(
+                                fs.sys_read, op.source, context=context
+                            )
+                            await _call_sync_or_async(
+                                fs.write, op.destination, buf=content, context=context
                             )
                             bytes_copied = len(content)
                         else:

--- a/src/nexus/server/api/v2/routers/auth_keys.py
+++ b/src/nexus/server/api/v2/routers/auth_keys.py
@@ -10,6 +10,7 @@ Wraps the existing RPC admin handlers with proper REST semantics.
 Admin auth required for all operations.
 """
 
+import asyncio
 import json
 import logging
 from datetime import UTC, datetime, timedelta
@@ -227,16 +228,25 @@ async def create_key(
     request: Request,
     body: CreateKeyRequest,
 ) -> dict[str, Any]:
-    """Create a new API key."""
-    from types import SimpleNamespace
+    """Create a new API key.
 
-    from nexus.server.rpc.handlers.admin import handle_admin_create_key
-
+    The key/grant writes are synchronous SQLAlchemy + ReBAC calls, so the
+    whole body runs on a worker thread (#4777) — never on the event loop.
+    """
     db_provider = _resolve_db_auth(request)
 
     # Fail-fast: verify rebac_manager is available before creating the key
-    if body.grants:
-        _resolve_rebac_manager(request)
+    rebac_manager = _resolve_rebac_manager(request) if body.grants else None
+
+    return await asyncio.to_thread(_create_key_sync, db_provider, rebac_manager, body)
+
+
+def _create_key_sync(
+    db_provider: Any, rebac_manager: Any, body: CreateKeyRequest
+) -> dict[str, Any]:
+    from types import SimpleNamespace
+
+    from nexus.server.rpc.handlers.admin import handle_admin_create_key
 
     key_name = body.label or body.name or "unnamed"
 
@@ -285,8 +295,7 @@ async def create_key(
     }
 
     # Create ReBAC grants if requested — rollback key on failure
-    if body.grants:
-        rebac_manager = _resolve_rebac_manager(request)
+    if body.grants and rebac_manager is not None:
         subject_id = result.get("subject_id") or result["user_id"]
         subject_type = body.subject_type or "user"
 
@@ -352,7 +361,7 @@ async def list_keys(
         offset=offset,
     )
     context = SimpleNamespace(is_admin=True)
-    return handle_admin_list_keys(db_provider, params, context)
+    return await asyncio.to_thread(handle_admin_list_keys, db_provider, params, context)
 
 
 @router.get("/{key_id}")
@@ -369,7 +378,7 @@ async def get_key(
     db_provider = _resolve_db_auth(request)
     params = SimpleNamespace(key_id=key_id, zone_id=zone_id)
     context = SimpleNamespace(is_admin=True)
-    return handle_admin_get_key(db_provider, params, context)
+    return await asyncio.to_thread(handle_admin_get_key, db_provider, params, context)
 
 
 @router.delete("/{key_id}")
@@ -379,15 +388,30 @@ async def revoke_key(
     zone_id: str | None = None,
 ) -> dict[str, Any]:
     """Revoke an API key and clean up only the ReBAC grants created for it."""
+    from nexus.server.dependencies import _reset_auth_cache
+
+    db_provider = _resolve_db_auth(request)
+    rebac_manager = getattr(request.app.state, "rebac_manager", None)
+
+    # Synchronous SQLAlchemy + ReBAC work — off the event loop (#4777).
+    result = await asyncio.to_thread(_revoke_key_sync, db_provider, rebac_manager, key_id, zone_id)
+
+    # Flush auth cache so revoked key is immediately rejected (Issue #2195)
+    auth_cache = getattr(request.app.state, "auth_cache_store", None)
+    await _reset_auth_cache(auth_cache)
+
+    return result
+
+
+def _revoke_key_sync(
+    db_provider: Any, rebac_manager: Any, key_id: str, zone_id: str | None
+) -> dict[str, Any]:
     from types import SimpleNamespace
 
     from sqlalchemy import select
 
-    from nexus.server.dependencies import _reset_auth_cache
     from nexus.server.rpc.handlers.admin import handle_admin_revoke_key
     from nexus.storage.models import APIKeyModel
-
-    db_provider = _resolve_db_auth(request)
 
     # Read grant_tuple_ids before revocation so we can do targeted cleanup
     grant_tuple_ids: list[str] = []
@@ -411,23 +435,17 @@ async def revoke_key(
     result = handle_admin_revoke_key(db_provider, params, context)
 
     # Delete only the ReBAC tuples that were created for this specific key
-    if grant_tuple_ids:
-        rebac_manager = getattr(request.app.state, "rebac_manager", None)
-        if rebac_manager is not None:
-            deleted = 0
-            for tid in grant_tuple_ids:
-                if rebac_manager.rebac_delete(tid):
-                    deleted += 1
-            if deleted:
-                logger.info(
-                    "Cleaned up %d/%d ReBAC grant tuple(s) for key %s",
-                    deleted,
-                    len(grant_tuple_ids),
-                    key_id,
-                )
-
-    # Flush auth cache so revoked key is immediately rejected (Issue #2195)
-    auth_cache = getattr(request.app.state, "auth_cache_store", None)
-    await _reset_auth_cache(auth_cache)
+    if grant_tuple_ids and rebac_manager is not None:
+        deleted = 0
+        for tid in grant_tuple_ids:
+            if rebac_manager.rebac_delete(tid):
+                deleted += 1
+        if deleted:
+            logger.info(
+                "Cleaned up %d/%d ReBAC grant tuple(s) for key %s",
+                deleted,
+                len(grant_tuple_ids),
+                key_id,
+            )
 
     return result

--- a/src/nexus/server/api/v2/routers/rebac.py
+++ b/src/nexus/server/api/v2/routers/rebac.py
@@ -27,6 +27,7 @@ boundary — file-grant semantics stay in ``auth_keys.py``.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import Any
 
@@ -146,7 +147,10 @@ async def write_tuple(
     obj = (body.object_namespace, normalized_object_id)
 
     try:
-        result = rebac_manager.rebac_write(
+        # ReBACManager is synchronous (database round-trips); keep it off
+        # the event loop (#4777).
+        result = await asyncio.to_thread(
+            rebac_manager.rebac_write,
             subject=subject,
             relation=body.relation,
             object=obj,
@@ -197,7 +201,8 @@ async def list_tuples(
     if object_id is not None and object_namespace is not None:
         object_id = _normalize_file_object_id(object_namespace, object_id)
 
-    tuples: list[dict[str, Any]] = rebac_manager.rebac_list_tuples(
+    tuples: list[dict[str, Any]] = await asyncio.to_thread(
+        rebac_manager.rebac_list_tuples,
         relation=relation,
         subject_type=subject_namespace,
         subject_id=subject_id,
@@ -234,19 +239,22 @@ async def delete_tuple(
     # zone) would also be deleted. ``body.subject_relation`` is None
     # for direct tuples (POST's default) and a string for usersets.
     # Either value routes through the manager's _UNSET-aware filter.
-    matches: list[dict[str, Any]] = rebac_manager.rebac_list_tuples(
-        subject=(body.subject_namespace, body.subject_id),
-        relation=body.relation,
-        object=obj,
-        subject_relation=body.subject_relation,
-        zone_id=body.zone_id,
-    )
+    def _delete_matching() -> int:
+        matches: list[dict[str, Any]] = rebac_manager.rebac_list_tuples(
+            subject=(body.subject_namespace, body.subject_id),
+            relation=body.relation,
+            object=obj,
+            subject_relation=body.subject_relation,
+            zone_id=body.zone_id,
+        )
+        removed = 0
+        for t in matches:
+            tid = t.get("tuple_id")
+            if tid and rebac_manager.rebac_delete(tid):
+                removed += 1
+        return removed
 
-    deleted = 0
-    for t in matches:
-        tid = t.get("tuple_id")
-        if tid and rebac_manager.rebac_delete(tid):
-            deleted += 1
+    deleted = await asyncio.to_thread(_delete_matching)
 
     return {
         "deleted": deleted,

--- a/src/nexus/server/api/v2/routers/search.py
+++ b/src/nexus/server/api/v2/routers/search.py
@@ -29,8 +29,10 @@ Rewritten for txtai backend (#2663):
   instrumentation so callers can detect silent-undercount scenarios.
 """
 
+import asyncio
 import inspect
 import logging
+import os
 import time
 from typing import Any
 
@@ -1349,8 +1351,10 @@ async def _do_glob_operation(
 
     async def _work() -> dict[str, Any]:
         try:
-            all_matches: list[str] = search_service.glob(
-                pattern=pattern, path=path, context=op_context, files=files
+            # SearchService.glob is synchronous (metastore walk); keep it
+            # off the event loop like the grep sibling (#4777).
+            all_matches: list[str] = await asyncio.to_thread(
+                search_service.glob, pattern=pattern, path=path, context=op_context, files=files
             )
         except (ValueError, InvalidPathError) as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
@@ -1823,76 +1827,146 @@ async def search_index_documents(
                 ),
             )
 
-    # WRITE authorization (review R3): explicit indexing REPLACES the
-    # searchable content other readers see at these paths — a read-only
-    # principal must not be able to poison results.  Same
-    # admin-bypass / per-path ReBAC WRITE / fail-closed-without-enforcer
-    # gate the sibling index-directory mutation routes use.
-    from nexus.server.api.v2.routers._search_indexed_dirs import _require_admin_or_path_write
+    # Admission control (#4777): the plugin serializes index batches per
+    # zone, so every request past the first waits its turn while holding an
+    # HTTP connection for minutes.  Shed above the cap with 503 +
+    # Retry-After so clients back off instead of deepening the queue.
+    _admit_index_request(request.app.state)
+    try:
+        # WRITE authorization (review R3): explicit indexing REPLACES the
+        # searchable content other readers see at these paths — a read-only
+        # principal must not be able to poison results.  Same
+        # admin-bypass / per-path ReBAC WRITE / fail-closed-without-enforcer
+        # gate the sibling index-directory mutation routes use.
+        from nexus.server.api.v2.routers._search_indexed_dirs import (
+            _require_admin_or_path_write,
+        )
 
-    for doc in documents:
-        doc_path = doc.get("path", "") if isinstance(doc, dict) else ""
-        await _require_admin_or_path_write(request, auth_result, zone_id, doc_path or "/")
+        for doc in documents:
+            doc_path = doc.get("path", "") if isinstance(doc, dict) else ""
+            await _require_admin_or_path_write(request, auth_result, zone_id, doc_path or "/")
 
-    async def _work() -> dict[str, Any]:
-        try:
-            result = await search_daemon.index_documents(documents, zone_id=zone_id)
-        except Exception as exc:
-            logger.error("index_documents failed: %s", exc, exc_info=True)
-            raise HTTPException(
-                status_code=500,
-                detail=f"Index persistence failed: {type(exc).__name__}: {exc}",
-            ) from exc
-        # #4617: the P12 proxy returns a dict, the pre-P12 daemon
-        # returned an ExplicitIndexResult, and int-returning test
-        # doubles exist — normalize ALL of them so ``count`` stays the
-        # plain int the pre-pivot wire contract promised (the dict
-        # previously leaked whole into ``count`` because ``getattr``
-        # doesn't read dict keys).
-        if isinstance(result, dict):
-            count = result.get("indexed", 0)
-            skipped = list(result.get("skipped") or [])
-            skipped_count = int(result.get("skipped_count") or 0)
-            skipped_paths = list(result.get("skipped_paths") or [])
-            index_seq = result.get("index_seq")
-        else:
-            count = getattr(result, "indexed", result)
-            skipped = list(getattr(result, "skipped", []) or [])
-            skipped_count = int(getattr(result, "skipped_count", 0) or 0)
-            skipped_paths = list(getattr(result, "skipped_paths", []) or [])
-            index_seq = getattr(result, "index_seq", None)
-        if skipped:
-            raise HTTPException(
-                status_code=409,
-                detail={
-                    "error": (
-                        "documents skipped: no live file_paths row after the bounded "
-                        "projection wait — retry once the write is visible"
-                    ),
-                    "count": count,
-                    "skipped": skipped,
-                    "zone_id": zone_id,
-                },
-            )
-        # ``zoneId`` casing is the pre-P12 public contract (#4617);
-        # ``skippedCount`` is additive (review R2) — content-level
-        # skips (empty/whitespace/chunkless docs) were previously
-        # invisible behind a bare 200, so a caller couldn't tell
-        # "all indexed" from "half the batch was empty".
-        # #4736: ``skippedPaths`` names the content-skipped documents
-        # behind ``skippedCount``; ``indexSeq`` is the plugin sequence
-        # stamped after this batch's commit — ``/search/stats``
-        # ``last_index_seq >= indexSeq`` means the batch is served.
-        return {
-            "status": "indexed",
-            "count": int(count),
-            "skippedCount": skipped_count,
-            "skippedPaths": skipped_paths,
-            "indexSeq": int(index_seq) if index_seq is not None else None,
-            "zoneId": zone_id,
-        }
+        return await run_zone_scoped(
+            _get_zone_registry(request),
+            _auth_target_zone(auth_result),
+            lambda: _index_documents_work(search_daemon, documents, zone_id),
+        )
+    finally:
+        _release_index_request(request.app.state)
 
-    return await run_zone_scoped(_get_zone_registry(request), _auth_target_zone(auth_result), _work)
+
+INDEX_MAX_INFLIGHT_ENV = "NEXUS_SEARCH_INDEX_MAX_INFLIGHT"
+DEFAULT_INDEX_MAX_INFLIGHT = 8
+INDEX_RETRY_AFTER_SECONDS = 5
+
+
+def index_max_inflight() -> int:
+    """Per-process cap on concurrent ``POST /search/index`` requests.
+
+    ``0`` disables admission control.  Read per request so operators can
+    tune it without a restart-time config object and tests can patch env.
+    """
+    raw = os.environ.get(INDEX_MAX_INFLIGHT_ENV, "").strip()
+    if not raw:
+        return DEFAULT_INDEX_MAX_INFLIGHT
+    try:
+        return max(0, int(raw))
+    except ValueError:
+        logger.warning(
+            "%s=%r is not an int; using %d", INDEX_MAX_INFLIGHT_ENV, raw, DEFAULT_INDEX_MAX_INFLIGHT
+        )
+        return DEFAULT_INDEX_MAX_INFLIGHT
+
+
+def _admit_index_request(state: Any) -> None:
+    """Reserve an in-flight slot or raise 503 (no await between check and
+    increment, so the counter is race-free on the single event loop)."""
+    cap = index_max_inflight()
+    inflight = int(getattr(state, "search_index_inflight", 0) or 0)
+    if cap > 0 and inflight >= cap:
+        logger.warning("search/index shed: %d requests already in flight (cap %d)", inflight, cap)
+        raise HTTPException(
+            status_code=503,
+            detail={
+                "error": "search indexing backlog: too many index requests in flight",
+                "inflight": inflight,
+                "max_inflight": cap,
+                "retry_after_seconds": INDEX_RETRY_AFTER_SECONDS,
+                "hint": (
+                    "back off and retry; poll /api/v2/search/stats "
+                    "(indexing_in_progress / pending) to pace submissions"
+                ),
+            },
+            headers={"Retry-After": str(INDEX_RETRY_AFTER_SECONDS)},
+        )
+    state.search_index_inflight = inflight + 1
+
+
+def _release_index_request(state: Any) -> None:
+    inflight = int(getattr(state, "search_index_inflight", 0) or 0)
+    state.search_index_inflight = max(0, inflight - 1)
+
+
+async def _index_documents_work(
+    search_daemon: Any, documents: list[dict[str, Any]], zone_id: str
+) -> dict[str, Any]:
+    """Body of ``POST /search/index`` once admitted and authorized."""
+    try:
+        result = await search_daemon.index_documents(documents, zone_id=zone_id)
+    except Exception as exc:
+        logger.error("index_documents failed: %s", exc, exc_info=True)
+        raise HTTPException(
+            status_code=500,
+            detail=f"Index persistence failed: {type(exc).__name__}: {exc}",
+        ) from exc
+    # #4617: the P12 proxy returns a dict, the pre-P12 daemon
+    # returned an ExplicitIndexResult, and int-returning test
+    # doubles exist — normalize ALL of them so ``count`` stays the
+    # plain int the pre-pivot wire contract promised (the dict
+    # previously leaked whole into ``count`` because ``getattr``
+    # doesn't read dict keys).
+    if isinstance(result, dict):
+        count = result.get("indexed", 0)
+        skipped = list(result.get("skipped") or [])
+        skipped_count = int(result.get("skipped_count") or 0)
+        skipped_paths = list(result.get("skipped_paths") or [])
+        index_seq = result.get("index_seq")
+    else:
+        count = getattr(result, "indexed", result)
+        skipped = list(getattr(result, "skipped", []) or [])
+        skipped_count = int(getattr(result, "skipped_count", 0) or 0)
+        skipped_paths = list(getattr(result, "skipped_paths", []) or [])
+        index_seq = getattr(result, "index_seq", None)
+    if skipped:
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "error": (
+                    "documents skipped: no live file_paths row after the bounded "
+                    "projection wait — retry once the write is visible"
+                ),
+                "count": count,
+                "skipped": skipped,
+                "zone_id": zone_id,
+            },
+        )
+    # ``zoneId`` casing is the pre-P12 public contract (#4617);
+    # ``skippedCount`` is additive (review R2) — content-level
+    # skips (empty/whitespace/chunkless docs) were previously
+    # invisible behind a bare 200, so a caller couldn't tell
+    # "all indexed" from "half the batch was empty".
+    # #4736: ``skippedPaths`` names the content-skipped documents
+    # behind ``skippedCount``; ``indexSeq`` is the plugin sequence
+    # stamped after this batch's commit — ``/search/stats``
+    # ``last_index_seq >= indexSeq`` means the batch is served.
+    return {
+        "status": "indexed",
+        "count": int(count),
+        "skippedCount": skipped_count,
+        "skippedPaths": skipped_paths,
+        "indexSeq": int(index_seq) if index_seq is not None else None,
+        "zoneId": zone_id,
+    }
 
 
 @router.post("/refresh")

--- a/src/nexus/server/app_state.py
+++ b/src/nexus/server/app_state.py
@@ -35,6 +35,10 @@ class NexusAppState:
     database_url: str | None = None
     api_key: str | None = None
     auth_provider: Any = None
+    # #4777: CacheStoreABC behind ``dependencies.get_auth_result``; wired by
+    # the lifespan once the cache brick is up (shared store when configured,
+    # process-local otherwise).  ``None`` = every request re-authenticates.
+    auth_cache_store: Any = None
     data_dir: str | None = None
     brick_container: Any = None
     zone_registry: Any = None
@@ -86,6 +90,10 @@ class NexusAppState:
     subscription_manager: Any = None
     search_daemon: Any = None
     search_daemon_enabled: bool = False
+    # #4777: ``POST /search/index`` requests currently in flight in this
+    # process — admission control sheds with 503 + Retry-After above
+    # ``NEXUS_SEARCH_INDEX_MAX_INFLIGHT``.
+    search_index_inflight: int = 0
     directory_grant_expander: Any = None
     cache_brick: Any = None
     websocket_manager: Any = None

--- a/src/nexus/server/lifespan/__init__.py
+++ b/src/nexus/server/lifespan/__init__.py
@@ -13,10 +13,11 @@ import asyncio
 import ctypes
 import gc
 import logging
+import os
 import threading
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager, suppress
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from nexus.server.lifespan._async_engines import adispose_async_engines
 from nexus.server.lifespan.services_container import LifespanServices
@@ -127,6 +128,72 @@ def _wire_query_observer(_app: "FastAPI", svc: LifespanServices) -> None:
         logger.info("QueryObserverComponent registered in observability registry")
     except Exception as exc:
         logger.info("QueryObserverComponent registration skipped: %s", exc)
+
+
+def _size_default_executor(max_workers: int) -> None:
+    """Size the loop's default executor to the configured thread pool (#4777).
+
+    ``asyncio.to_thread`` — which the REST routers use to keep blocking
+    kernel gRPC calls off the event loop — runs on the loop's default
+    ``ThreadPoolExecutor``, whose stock size is ``min(32, cpus + 4)``: six
+    threads on a 2-vCPU container.  The AnyIO limiter above only governs
+    ``anyio.to_thread`` / sync route handlers, so without this the two pools
+    disagree and offloaded syscalls queue behind each other.
+    """
+    if max_workers <= 0:
+        return
+    import concurrent.futures
+
+    try:
+        loop = asyncio.get_running_loop()
+        loop.set_default_executor(
+            concurrent.futures.ThreadPoolExecutor(
+                max_workers=max_workers, thread_name_prefix="nexus-to-thread"
+            )
+        )
+        logger.info("asyncio default executor sized to %d threads", max_workers)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning("Could not resize the asyncio default executor: %s", exc)
+
+
+def _wire_auth_cache(app: "FastAPI") -> None:
+    """Attach the auth-result cache ``dependencies.get_auth_result`` reads (#4777).
+
+    The dependency has always looked up ``app.state.auth_cache_store`` but
+    nothing ever assigned it, so every request paid the provider round-trip
+    (100 % ``(cache miss)`` in ``[AUTH-TIMING]``).  Reuse the CacheBrick's
+    shared store when one is configured — a key revocation's flush then
+    reaches every replica — else fall back to a process-local store.
+    ``/auth/keys`` revocation flushes ``auth:cache:*`` either way.
+    """
+    if getattr(app.state, "auth_provider", None) is None:
+        return
+    if getattr(app.state, "auth_cache_store", None) is not None:
+        return
+
+    store: Any = None
+    cache_brick = getattr(app.state, "cache_brick", None)
+    if cache_brick is not None and getattr(cache_brick, "has_cache_store", False):
+        store = getattr(cache_brick, "cache_store", None)
+    backend = "shared"
+    if store is None:
+        from nexus.contracts.cache_store import InMemoryCacheStore
+
+        max_entries = _env_int("NEXUS_AUTH_CACHE_MAX_ENTRIES", 10_000)
+        store = InMemoryCacheStore(max_size=max_entries)
+        backend = f"in-memory (max {max_entries} entries)"
+    app.state.auth_cache_store = store
+    logger.info("Auth result cache enabled: %s", backend)
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        return max(0, int(raw))
+    except ValueError:
+        return default
 
 
 def _apply_boot_tweaks() -> None:
@@ -286,6 +353,7 @@ async def lifespan(app: "FastAPI") -> AsyncIterator[None]:
     limiter = to_thread.current_default_thread_limiter()
     limiter.total_tokens = svc.thread_pool_size
     logger.info("Thread pool size set to %d", limiter.total_tokens)
+    _size_default_executor(svc.thread_pool_size)
 
     _done(StartupPhase.OBSERVABILITY)
 
@@ -293,6 +361,7 @@ async def lifespan(app: "FastAPI") -> AsyncIterator[None]:
     _done(StartupPhase.FEATURES)
 
     bg_tasks.extend(await startup_permissions(app, svc))
+    _wire_auth_cache(app)
     _done(StartupPhase.PERMISSIONS)
 
     bg_tasks.extend(await startup_realtime(app, svc))

--- a/src/nexus/server/middleware/correlation.py
+++ b/src/nexus/server/middleware/correlation.py
@@ -15,6 +15,7 @@ It is then:
 - Set as the ``X-Request-ID`` response header
 """
 
+import os
 import re
 import time
 import uuid
@@ -23,6 +24,24 @@ from contextvars import ContextVar
 from typing import Any
 
 import structlog
+
+# #4777: requests slower than this log at WARNING with ``slow_request=True``
+# even when they succeed, so a 300 s ``200 OK`` is not indistinguishable from
+# a 20 ms one except by reading ``duration_ms``.  ``0`` disables the check.
+SLOW_REQUEST_MS_ENV = "NEXUS_SLOW_REQUEST_MS"
+DEFAULT_SLOW_REQUEST_MS = 10_000.0
+
+
+def slow_request_threshold_ms() -> float:
+    """Resolve the slow-request threshold from the environment (ms)."""
+    raw = os.environ.get(SLOW_REQUEST_MS_ENV, "").strip()
+    if not raw:
+        return DEFAULT_SLOW_REQUEST_MS
+    try:
+        return max(0.0, float(raw))
+    except ValueError:
+        return DEFAULT_SLOW_REQUEST_MS
+
 
 # ASGI type aliases for mypy compatibility with Starlette's _MiddlewareFactory
 ASGIApp = Callable[
@@ -55,8 +74,11 @@ class CorrelationMiddleware:
     Non-HTTP scopes (websocket, lifespan) are passed through without modification.
     """
 
-    def __init__(self, app: ASGIApp) -> None:
+    def __init__(self, app: ASGIApp, slow_request_ms: float | None = None) -> None:
         self._app = app
+        self._slow_request_ms = (
+            slow_request_ms if slow_request_ms is not None else slow_request_threshold_ms()
+        )
 
     async def __call__(self, scope: dict, receive: Any, send: Any) -> None:
         if scope["type"] != "http":
@@ -100,12 +122,16 @@ class CorrelationMiddleware:
         finally:
             duration_ms = round((time.perf_counter() - start_time) * 1000, 1)
 
-            log_kw = {
+            log_kw: dict[str, Any] = {
                 "status_code": status_code,
                 "duration_ms": duration_ms,
             }
+            is_slow = self._slow_request_ms > 0 and duration_ms >= self._slow_request_ms
+            if is_slow:
+                log_kw["slow_request"] = True
+                log_kw["slow_threshold_ms"] = self._slow_request_ms
 
-            if status_code >= 500:
+            if status_code >= 500 or is_slow:
                 _log.warning("request_completed", **log_kw)
             else:
                 _log.info("request_completed", **log_kw)

--- a/tests/unit/remote/test_kernel_client_exit_cleanup.py
+++ b/tests/unit/remote/test_kernel_client_exit_cleanup.py
@@ -1,0 +1,82 @@
+"""KernelClient reaps its spawned kernel at interpreter exit (#4777 follow-up).
+
+Every ``nexus`` CLI invocation (including the remote profile's ephemeral
+routing kernel) spawns a ``nexus-cluster`` subprocess; nothing terminated it
+when the CLI exited, so each run leaked a ~30-thread orphan.
+"""
+
+from __future__ import annotations
+
+import atexit
+import subprocess
+import sys
+from typing import Any
+
+import pytest
+
+from nexus.remote import kernel_client as kc
+
+
+def _sleeper() -> subprocess.Popen[bytes]:
+    return subprocess.Popen([sys.executable, "-c", "import time; time.sleep(60)"])
+
+
+def test_terminate_spawned_kernel_kills_child_and_is_idempotent() -> None:
+    client = kc.KernelClient.__new__(kc.KernelClient)
+    client._process = _sleeper()
+    pid_proc = client._process
+    assert pid_proc.poll() is None
+
+    client._terminate_spawned_kernel()
+    assert pid_proc.poll() is not None, "child must be reaped"
+    assert client._process is None
+    # Second call is a no-op.
+    client._terminate_spawned_kernel()
+
+
+def test_terminate_is_noop_without_process() -> None:
+    client = kc.KernelClient.__new__(kc.KernelClient)
+    client._process = None
+    client._terminate_spawned_kernel()
+    assert client._process is None
+
+
+def test_spawn_registers_atexit_hook(monkeypatch: pytest.MonkeyPatch, tmp_path: Any) -> None:
+    registered: list[Any] = []
+    monkeypatch.setattr(kc.atexit, "register", lambda fn, *a, **k: registered.append(fn))
+    monkeypatch.setattr(kc, "_resolve_kernel_binary", lambda: sys.executable)
+
+    class _FakePopen:
+        pid = 4242
+
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            self.args = args
+
+        def poll(self) -> int:
+            return 0
+
+    monkeypatch.setattr(kc.subprocess, "Popen", _FakePopen)
+
+    client = kc.KernelClient(metadata_path=str(tmp_path))
+    client._spawn_kernel()
+
+    assert registered == [client._terminate_spawned_kernel]
+    # close() must unregister the hook so the object can be collected.
+    unregistered: list[Any] = []
+    monkeypatch.setattr(kc.atexit, "unregister", lambda fn: unregistered.append(fn))
+    client.close()
+    assert unregistered == [client._terminate_spawned_kernel]
+
+
+def test_close_reaps_child_via_same_path() -> None:
+    client = kc.KernelClient.__new__(kc.KernelClient)
+    client._process = _sleeper()
+    client._transport = None
+    client._stderr_file = None
+    client._stderr_path = None
+    client._ephemeral_dir = None
+    proc = client._process
+    atexit.register(client._terminate_spawned_kernel)  # mirror _spawn_kernel
+    client.close()
+    assert proc.poll() is not None
+    assert client._process is None

--- a/tests/unit/server/api/v2/routers/test_files_off_loop.py
+++ b/tests/unit/server/api/v2/routers/test_files_off_loop.py
@@ -1,0 +1,205 @@
+"""Blocking VFS calls in the files router run off the event loop (#4777).
+
+``fs.write`` and friends are synchronous kernel gRPC round-trips.  Running
+them on the request event loop meant one slow write (e.g. while the search
+plugin saturates the volume) stalled every other request in the process.
+Every route must dispatch the call to a worker thread.
+"""
+
+from __future__ import annotations
+
+import base64
+import threading
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+
+try:
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    _HAS_FASTAPI = True
+except ImportError:
+    _HAS_FASTAPI = False
+
+pytestmark = pytest.mark.skipif(not _HAS_FASTAPI, reason="fastapi test client unavailable")
+
+_AUTH = {
+    "authenticated": True,
+    "subject_type": "user",
+    "subject_id": "alice",
+    "zone_id": "eng",
+    "zone_perms": [["eng", "rw"]],
+    "is_admin": True,
+}
+_MODIFIED = datetime(2026, 9, 12, 12, 0, tzinfo=UTC)
+
+
+class _ThreadRecordingFS:
+    """Records the thread every VFS call ran on."""
+
+    def __init__(self) -> None:
+        self.calls: dict[str, list[str]] = {}
+
+    def _note(self, op: str) -> None:
+        self.calls.setdefault(op, []).append(threading.current_thread().name)
+
+    def _meta(self, path: str) -> dict[str, Any]:
+        return {
+            "path": path,
+            "content_id": "cid-1",
+            "version": 1,
+            "size": 5,
+            "modified_at": _MODIFIED.isoformat(),
+            "mime_type": "text/plain",
+            "entry_type": 0,
+        }
+
+    def write(self, path: str, buf: bytes = b"", **_: Any) -> dict[str, Any]:
+        self._note("write")
+        return {**self._meta(path), "size": len(buf)}
+
+    def read(self, path: str, *, return_metadata: bool = False, **_: Any) -> Any:
+        self._note("read")
+        return {"content": b"hello", **self._meta(path)} if return_metadata else b"hello"
+
+    def sys_read(self, path: str, **_: Any) -> bytes:
+        self._note("sys_read")
+        return b"hello"
+
+    def sys_stat(self, path: str, **_: Any) -> dict[str, Any]:
+        self._note("sys_stat")
+        return self._meta(path)
+
+    def sys_unlink(self, path: str, **_: Any) -> dict[str, Any]:
+        self._note("sys_unlink")
+        return {"projection_seq": 1}
+
+    def access(self, path: str, **_: Any) -> bool:
+        self._note("access")
+        return True
+
+    def sys_readdir(self, path: str, **_: Any) -> list[dict[str, Any]]:
+        self._note("sys_readdir")
+        return [self._meta(f"{path.rstrip('/')}/a.md")]
+
+    def mkdir(self, path: str, **_: Any) -> dict[str, Any]:
+        self._note("mkdir")
+        return {"path": path}
+
+    def sys_rename(self, source: str, destination: str, **_: Any) -> dict[str, Any]:
+        self._note("sys_rename")
+        return {"projection_seq": 1}
+
+    def write_batch(self, files: list[tuple[str, bytes]], **_: Any) -> list[dict[str, Any]]:
+        self._note("write_batch")
+        return [{**self._meta(p), "size": len(b)} for p, b in files]
+
+    def read_batch(self, paths: list[str], **_: Any) -> list[dict[str, Any]]:
+        self._note("read_batch")
+        return [{"path": p, "content": b"hello", "success": True} for p in paths]
+
+    def rename_batch(self, renames: list[tuple[str, str]], **_: Any) -> dict[str, Any]:
+        self._note("rename_batch")
+        return {src: {"success": True, "new_path": dst} for src, dst in renames}
+
+
+def _client(fs: _ThreadRecordingFS) -> TestClient:
+    from nexus.server.api.v2.routers.async_files import create_async_files_router
+    from nexus.server.dependencies import get_auth_result, require_auth
+
+    app = FastAPI()
+    app.state.search_daemon = None
+    app.dependency_overrides[get_auth_result] = lambda: _AUTH
+    app.dependency_overrides[require_auth] = lambda: _AUTH
+    app.include_router(create_async_files_router(nexus_fs=fs), prefix="/api/v2/files")
+
+    # TestClient runs the app on a portal thread; this probe records the
+    # event-loop thread's name so tests can assert VFS calls ran elsewhere.
+    @app.get("/__probe_loop_thread")
+    async def _probe() -> dict[str, str]:
+        return {"thread": threading.current_thread().name}
+
+    return TestClient(app)
+
+
+def _loop_thread_name(client: TestClient) -> str:
+    response = client.get("/__probe_loop_thread")
+    assert response.status_code == 200
+    return str(response.json()["thread"])
+
+
+@pytest.mark.parametrize(
+    ("op", "request_fn"),
+    [
+        (
+            "write",
+            lambda c: c.post("/api/v2/files/write", json={"path": "/d/a.md", "content": "hi"}),
+        ),
+        ("read", lambda c: c.get("/api/v2/files/read", params={"path": "/d/a.md"})),
+        ("sys_unlink", lambda c: c.delete("/api/v2/files/delete", params={"path": "/d/a.md"})),
+        ("access", lambda c: c.get("/api/v2/files/exists", params={"path": "/d/a.md"})),
+        ("sys_readdir", lambda c: c.get("/api/v2/files/list", params={"path": "/d"})),
+        ("mkdir", lambda c: c.post("/api/v2/files/mkdir", json={"path": "/d/new"})),
+        ("sys_stat", lambda c: c.get("/api/v2/files/metadata", params={"path": "/d/a.md"})),
+        (
+            "sys_rename",
+            lambda c: c.post(
+                "/api/v2/files/rename", json={"source": "/d/a.md", "destination": "/d/b.md"}
+            ),
+        ),
+        (
+            "write_batch",
+            lambda c: c.post(
+                "/api/v2/files/batch/write",
+                json={
+                    "files": [
+                        {"path": "/d/a.md", "content_base64": base64.b64encode(b"a").decode()}
+                    ]
+                },
+            ),
+        ),
+        (
+            "read_batch",
+            lambda c: c.post("/api/v2/files/batch/read", json={"paths": ["/d/a.md"]}),
+        ),
+        (
+            "rename_batch",
+            lambda c: c.post(
+                "/api/v2/files/rename-batch",
+                json={"operations": [{"source": "/d/a.md", "destination": "/d/b.md"}]},
+            ),
+        ),
+        (
+            "write",
+            lambda c: c.post(
+                "/api/v2/files/copy", json={"source": "/d/a.md", "destination": "/d/b.md"}
+            ),
+        ),
+    ],
+)
+def test_vfs_call_runs_off_the_event_loop(op: str, request_fn: Any) -> None:
+    fs = _ThreadRecordingFS()
+    with _client(fs) as client:
+        loop_thread = _loop_thread_name(client)
+        response = request_fn(client)
+        assert response.status_code == 200, response.text
+
+    assert fs.calls.get(op), f"{op} was never invoked; calls={fs.calls}"
+    for thread_name in fs.calls[op]:
+        assert thread_name != loop_thread, f"{op} ran on the event loop thread {loop_thread}"
+
+
+def test_stream_read_runs_off_the_event_loop() -> None:
+    fs = _ThreadRecordingFS()
+    with _client(fs) as client:
+        loop_thread = _loop_thread_name(client)
+        response = client.get("/api/v2/files/stream", params={"path": "/d/a.md"})
+        assert response.status_code == 200, response.text
+        assert response.content == b"hello"
+
+    for op in ("sys_stat", "sys_read"):
+        assert fs.calls.get(op), f"{op} was never invoked; calls={fs.calls}"
+        for thread_name in fs.calls[op]:
+            assert thread_name != loop_thread, f"{op} ran on the event loop thread"

--- a/tests/unit/server/api/v2/test_search_index_admission.py
+++ b/tests/unit/server/api/v2/test_search_index_admission.py
@@ -1,0 +1,169 @@
+"""POST /api/v2/search/index admission control (#4777).
+
+The plugin serializes index batches per zone, so every request past the
+first waits on a mutex while holding an HTTP connection for minutes.  The
+route now sheds above ``NEXUS_SEARCH_INDEX_MAX_INFLIGHT`` with 503 +
+``Retry-After`` so clients back off instead of deepening the queue.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+try:
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    _HAS_FASTAPI = True
+except ImportError:
+    _HAS_FASTAPI = False
+
+pytestmark = pytest.mark.skipif(not _HAS_FASTAPI, reason="fastapi test client unavailable")
+
+_AUTH = {
+    "authenticated": True,
+    "subject_type": "user",
+    "subject_id": "alice",
+    "zone_id": "eng",
+    "zone_perms": [["eng", "rw"]],
+    "is_admin": True,
+}
+
+_DOCS = {"documents": [{"id": "1", "text": "alpha", "path": "/a.md"}]}
+
+
+class _Runner:
+    async def call(self, work: Any) -> Any:
+        return await work()
+
+
+class _Registry:
+    def runner_for(self, zone_id: str) -> _Runner:
+        return _Runner()
+
+
+def _build_app(daemon: Any) -> FastAPI:
+    from nexus.server.api.v2.routers.search import router
+    from nexus.server.dependencies import require_auth
+
+    app = FastAPI()
+    app.state.search_daemon = daemon
+    app.state.zone_registry = _Registry()
+    app.dependency_overrides[require_auth] = lambda: _AUTH
+    app.include_router(router)
+    return app
+
+
+def _make_daemon() -> MagicMock:
+    daemon = MagicMock()
+    daemon.index_documents = AsyncMock(return_value=SimpleNamespace(indexed=1, skipped=[]))
+    return daemon
+
+
+def test_default_cap_is_positive_and_env_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
+    from nexus.server.api.v2.routers import search as search_mod
+
+    monkeypatch.delenv(search_mod.INDEX_MAX_INFLIGHT_ENV, raising=False)
+    assert search_mod.index_max_inflight() == search_mod.DEFAULT_INDEX_MAX_INFLIGHT
+    monkeypatch.setenv(search_mod.INDEX_MAX_INFLIGHT_ENV, "3")
+    assert search_mod.index_max_inflight() == 3
+    monkeypatch.setenv(search_mod.INDEX_MAX_INFLIGHT_ENV, "not-an-int")
+    assert search_mod.index_max_inflight() == search_mod.DEFAULT_INDEX_MAX_INFLIGHT
+    monkeypatch.setenv(search_mod.INDEX_MAX_INFLIGHT_ENV, "-4")
+    assert search_mod.index_max_inflight() == 0
+
+
+def test_sheds_with_503_and_retry_after_when_at_cap(monkeypatch: pytest.MonkeyPatch) -> None:
+    from nexus.server.api.v2.routers import search as search_mod
+
+    monkeypatch.setenv(search_mod.INDEX_MAX_INFLIGHT_ENV, "2")
+    daemon = _make_daemon()
+    app = _build_app(daemon)
+    # Two requests already parked on the plugin's zone mutex.
+    app.state.search_index_inflight = 2
+
+    with TestClient(app) as client:
+        response = client.post("/api/v2/search/index", json=_DOCS)
+
+    assert response.status_code == 503
+    assert response.headers["Retry-After"] == str(search_mod.INDEX_RETRY_AFTER_SECONDS)
+    detail = response.json()["detail"]
+    assert detail["inflight"] == 2
+    assert detail["max_inflight"] == 2
+    assert "search/stats" in detail["hint"]
+    # Shed requests must not touch the plugin or the counter.
+    daemon.index_documents.assert_not_awaited()
+    assert app.state.search_index_inflight == 2
+
+
+def test_admitted_request_releases_its_slot(monkeypatch: pytest.MonkeyPatch) -> None:
+    from nexus.server.api.v2.routers import search as search_mod
+
+    monkeypatch.setenv(search_mod.INDEX_MAX_INFLIGHT_ENV, "2")
+    daemon = _make_daemon()
+    app = _build_app(daemon)
+    app.state.search_index_inflight = 1
+
+    with TestClient(app) as client:
+        response = client.post("/api/v2/search/index", json=_DOCS)
+
+    assert response.status_code == 200
+    assert response.json()["count"] == 1
+    assert app.state.search_index_inflight == 1
+
+
+def test_slot_is_released_when_the_plugin_fails() -> None:
+    daemon = MagicMock()
+    daemon.index_documents = AsyncMock(side_effect=RuntimeError("plugin down"))
+    app = _build_app(daemon)
+
+    with TestClient(app) as client:
+        response = client.post("/api/v2/search/index", json=_DOCS)
+
+    assert response.status_code == 500
+    assert app.state.search_index_inflight == 0
+
+
+def test_counter_tracks_concurrent_inflight_requests(monkeypatch: pytest.MonkeyPatch) -> None:
+    """While a request is awaiting the plugin the slot stays reserved."""
+    from nexus.server.api.v2.routers import search as search_mod
+
+    monkeypatch.setenv(search_mod.INDEX_MAX_INFLIGHT_ENV, "1")
+    observed: list[int] = []
+    app_holder: dict[str, FastAPI] = {}
+
+    async def _slow_index(documents: Any, *, zone_id: str) -> Any:
+        observed.append(app_holder["app"].state.search_index_inflight)
+        await asyncio.sleep(0)
+        return SimpleNamespace(indexed=len(documents), skipped=[])
+
+    daemon = MagicMock()
+    daemon.index_documents = _slow_index
+    app = _build_app(daemon)
+    app_holder["app"] = app
+
+    with TestClient(app) as client:
+        response = client.post("/api/v2/search/index", json=_DOCS)
+
+    assert response.status_code == 200
+    assert observed == [1]
+    assert app.state.search_index_inflight == 0
+
+
+def test_zero_cap_disables_admission_control(monkeypatch: pytest.MonkeyPatch) -> None:
+    from nexus.server.api.v2.routers import search as search_mod
+
+    monkeypatch.setenv(search_mod.INDEX_MAX_INFLIGHT_ENV, "0")
+    app = _build_app(_make_daemon())
+    app.state.search_index_inflight = 10_000
+
+    with TestClient(app) as client:
+        response = client.post("/api/v2/search/index", json=_DOCS)
+
+    assert response.status_code == 200
+    assert app.state.search_index_inflight == 10_000

--- a/tests/unit/server/lifespan/test_wire_auth_cache.py
+++ b/tests/unit/server/lifespan/test_wire_auth_cache.py
@@ -1,0 +1,84 @@
+"""Lifespan wiring of ``app.state.auth_cache_store`` (#4777).
+
+``dependencies.get_auth_result`` has always consulted this attribute, but no
+startup code assigned it — every request re-authenticated against the
+provider (100 % ``(cache miss)`` in ``[AUTH-TIMING]``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from nexus.contracts.cache_store import InMemoryCacheStore, NullCacheStore
+from nexus.server.lifespan import _size_default_executor, _wire_auth_cache
+
+
+def _app(**state: Any) -> Any:
+    """A stand-in for FastAPI: only ``app.state`` is consulted."""
+    return SimpleNamespace(state=SimpleNamespace(**state))
+
+
+def test_no_auth_provider_leaves_cache_unset() -> None:
+    app = _app(auth_provider=None, auth_cache_store=None, cache_brick=None)
+    _wire_auth_cache(app)
+    assert app.state.auth_cache_store is None
+
+
+def test_falls_back_to_process_local_store(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("NEXUS_AUTH_CACHE_MAX_ENTRIES", "7")
+    app = _app(auth_provider=object(), auth_cache_store=None, cache_brick=None)
+    _wire_auth_cache(app)
+    store = app.state.auth_cache_store
+    assert isinstance(store, InMemoryCacheStore)
+    assert store._max_size == 7
+
+
+def test_null_cache_brick_store_is_not_reused() -> None:
+    brick = SimpleNamespace(has_cache_store=False, cache_store=NullCacheStore())
+    app = _app(auth_provider=object(), auth_cache_store=None, cache_brick=brick)
+    _wire_auth_cache(app)
+    assert isinstance(app.state.auth_cache_store, InMemoryCacheStore)
+
+
+def test_shared_cache_brick_store_is_reused() -> None:
+    shared = InMemoryCacheStore()
+    brick = SimpleNamespace(has_cache_store=True, cache_store=shared)
+    app = _app(auth_provider=object(), auth_cache_store=None, cache_brick=brick)
+    _wire_auth_cache(app)
+    assert app.state.auth_cache_store is shared
+
+
+def test_preconfigured_store_is_kept() -> None:
+    preset = InMemoryCacheStore()
+    app = _app(auth_provider=object(), auth_cache_store=preset, cache_brick=None)
+    _wire_auth_cache(app)
+    assert app.state.auth_cache_store is preset
+
+
+def test_wired_store_round_trips_through_dependencies_helpers() -> None:
+    from nexus.server.dependencies import _get_cached_auth, _set_cached_auth
+
+    app = _app(auth_provider=object(), auth_cache_store=None, cache_brick=None)
+    _wire_auth_cache(app)
+    store = app.state.auth_cache_store
+
+    async def _roundtrip() -> dict[str, Any] | None:
+        await _set_cached_auth(store, "sk-token", {"authenticated": True, "subject_id": "a"})
+        return await _get_cached_auth(store, "sk-token")
+
+    assert asyncio.run(_roundtrip()) == {"authenticated": True, "subject_id": "a"}
+
+
+def test_default_executor_is_resized_to_thread_pool() -> None:
+    async def _probe() -> int:
+        _size_default_executor(17)
+        loop = asyncio.get_running_loop()
+        executor = getattr(loop, "_default_executor", None)
+        assert executor is not None
+        return int(executor._max_workers)
+
+    assert asyncio.run(_probe()) == 17

--- a/tests/unit/server/test_correlation_slow_request.py
+++ b/tests/unit/server/test_correlation_slow_request.py
@@ -1,0 +1,103 @@
+"""CorrelationMiddleware slow-request warning (#4777).
+
+A 300 s ``200 OK`` used to log at ``info`` exactly like a 20 ms one; slow
+requests now log at ``warning`` with ``slow_request=True``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from nexus.server.middleware import correlation as mod
+
+
+def _scope() -> dict[str, Any]:
+    return {"type": "http", "method": "POST", "path": "/api/v2/files/write", "headers": []}
+
+
+def _app_factory(delay: float, status: int = 200) -> Any:
+    async def app(scope: Any, receive: Any, send: Any) -> None:
+        if delay:
+            await asyncio.sleep(delay)
+        await send({"type": "http.response.start", "status": status, "headers": []})
+        await send({"type": "http.response.body", "body": b""})
+
+    return app
+
+
+async def _receive() -> dict[str, Any]:
+    return {"type": "http.request"}
+
+
+async def _send(_: Any) -> None:
+    return None
+
+
+def test_threshold_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(mod.SLOW_REQUEST_MS_ENV, raising=False)
+    assert mod.slow_request_threshold_ms() == mod.DEFAULT_SLOW_REQUEST_MS
+    monkeypatch.setenv(mod.SLOW_REQUEST_MS_ENV, "2500")
+    assert mod.slow_request_threshold_ms() == 2500.0
+    monkeypatch.setenv(mod.SLOW_REQUEST_MS_ENV, "garbage")
+    assert mod.slow_request_threshold_ms() == mod.DEFAULT_SLOW_REQUEST_MS
+    monkeypatch.setenv(mod.SLOW_REQUEST_MS_ENV, "-1")
+    assert mod.slow_request_threshold_ms() == 0.0
+
+
+def test_slow_request_logs_warning(monkeypatch: pytest.MonkeyPatch) -> None:
+    log = MagicMock()
+    monkeypatch.setattr(mod, "_log", log)
+    middleware = mod.CorrelationMiddleware(_app_factory(delay=0.02), slow_request_ms=5.0)
+
+    asyncio.run(middleware(_scope(), _receive, _send))
+
+    log.warning.assert_called_once()
+    _, kwargs = log.warning.call_args
+    assert kwargs["status_code"] == 200
+    assert kwargs["slow_request"] is True
+    assert kwargs["slow_threshold_ms"] == 5.0
+    assert kwargs["duration_ms"] >= 5.0
+    log.info.assert_not_called()
+
+
+def test_fast_request_logs_info(monkeypatch: pytest.MonkeyPatch) -> None:
+    log = MagicMock()
+    monkeypatch.setattr(mod, "_log", log)
+    middleware = mod.CorrelationMiddleware(_app_factory(delay=0), slow_request_ms=10_000.0)
+
+    asyncio.run(middleware(_scope(), _receive, _send))
+
+    log.info.assert_called_once()
+    _, kwargs = log.info.call_args
+    assert "slow_request" not in kwargs
+    log.warning.assert_not_called()
+
+
+def test_zero_threshold_disables_slow_warning(monkeypatch: pytest.MonkeyPatch) -> None:
+    log = MagicMock()
+    monkeypatch.setattr(mod, "_log", log)
+    middleware = mod.CorrelationMiddleware(_app_factory(delay=0.01), slow_request_ms=0.0)
+
+    asyncio.run(middleware(_scope(), _receive, _send))
+
+    log.info.assert_called_once()
+    log.warning.assert_not_called()
+
+
+def test_server_error_still_warns_without_slow_flag(monkeypatch: pytest.MonkeyPatch) -> None:
+    log = MagicMock()
+    monkeypatch.setattr(mod, "_log", log)
+    middleware = mod.CorrelationMiddleware(
+        _app_factory(delay=0, status=500), slow_request_ms=10_000.0
+    )
+
+    asyncio.run(middleware(_scope(), _receive, _send))
+
+    log.warning.assert_called_once()
+    _, kwargs = log.warning.call_args
+    assert kwargs["status_code"] == 500
+    assert "slow_request" not in kwargs


### PR DESCRIPTION
Closes #4777

## Problem

On a saturated `POST /api/v2/search/index` queue, unrelated `POST /api/v2/files/write` calls hung for seconds to minutes (write p50 94 ms → 35 s, 44 index batches in flight at 200–320 s each), plus a 100 % auth-cache miss rate.

## Root causes (all verified in code and reproduced on a local stack)

1. **Server ran blocking kernel calls on the event loop.** The files router called the kernel's synchronous gRPC write (and the main read path, delete, exists, list, mkdir, rename, copy, batch ops) directly in `async` handlers. One slow kernel write froze every request in the process. ReBAC tuples, auth keys, search glob and the refresh helper did the same with synchronous DB calls.
2. **Plugin serialised whole batches.** `do_index_documents` held the per-zone write mutex across every remote embedding call, and ended every batch with a full `Hnsw::file_dump` (≈1.3 GB at the reporter's 219 k chunks). Concurrent batches waited for each other's network time and each rewrote the graph on the same volume the kernel fsyncs to.
3. **No admission control** on indexing: unbounded in-flight requests, each holding a connection for minutes.
4. **`app.state.auth_cache_store` was never assigned**, so `get_auth_result` always paid the provider round-trip.
5. Slow successful requests logged at `info`, indistinguishable from fast ones.

## Changes

**Server (Python)**
- Every blocking VFS call in the files router goes through the existing `_call_sync_or_async` offload; stream generators made lazy. Same offload for ReBAC tuples, auth keys, search glob, refresh helper and the per-document ReBAC check on `/search/index`.
- `/search/index` admission control: `NEXUS_SEARCH_INDEX_MAX_INFLIGHT` (default 8) sheds with `503` + `Retry-After: 5`. `0` disables.
- asyncio default executor sized to the configured thread pool (stock is `min(32, cpus+4)`).
- Auth-result cache wired: shared CacheBrick store when configured, else process-local (`NEXUS_AUTH_CACHE_MAX_ENTRIES`).
- `NEXUS_SLOW_REQUEST_MS` (default 10 s) → `request_completed` at WARNING with `slow_request=true`.

**Search plugin (Rust)**
- `IndexDocuments` is now three phases per zone: FTS adds under a short lock → embedding with **no lock held** behind `NEXUS_SEARCH_EMBED_CONCURRENCY` (default 4) → ANN adds + state under a short lock. Keyword hits are visible before a batch starts embedding.
- While sibling batches are queued, the tantivy commit is **coalesced** into the last one and the HNSW dump is **deferred** to the last batch in flight; a fallback flusher lands both after `NEXUS_SEARCH_ANN_FLUSH_SECONDS` (default 30, `0` = pre-PR behaviour).
- Crash safety: deferred vectors are served from memory but recorded as retry-me until the dump lands, then upgraded; a coalesced commit is always landed before any batch records state; the dirty sentinel is cleared only by the last batch of an epoch.
- `NEXUS_SEARCH_PHASE_TRACE=1` prints a per-batch phase trace on the host's stderr (the cdylib has no tracing subscriber).

**Kernel client (pre-existing leak found during validation)**
- Every `nexus` CLI run spawned a routing kernel that was never terminated (128 orphans / ~3,800 threads after two CI scripts in one container). An `atexit` reaper now terminates it and its scratch files.

## Verification

- Unit: `tests/unit/server` (626), plugin `cargo test --tests` (280 unit + all e2e suites), new tests for admission, off-loop routing (14 routes), auth cache, slow-request log, coalescing/deferral/epoch, kernel reaper. ruff, mypy, clippy `-D warnings`, rustfmt clean.
- Full stack from this branch (`nexus up --build` + release plugin host): `scripts/test_build_perf_e2e.py` 30/30 (HERB 8/8), `permissions_demo_enhanced.sh` exit 0, three times across builds.
- Koodle's own `scripts/nexus-crud-perf.ts` 23/23 (p50 39–43 ms vs their Railway baseline ~200 ms) and `nexus-client` integration test 2/2.
- Saturation benchmark (12 index workers, cap 8, 32 docs queued): 1,200 file-API requests, 0 errors; sequential write p50/p99 28/86 ms idle → 62/484 ms saturated. The reported 30 s hangs do not reproduce.
- 16-way index burst: 8 admitted, 8 shed with `Retry-After`, retries all landed, 16/16 searchable; 7 of 8 dumps and 7 of 8 commits coalesced in a burst; 8-way direct plugin burst 10.5 s → 4.4 s per call.
- Crash test: SIGKILL of the plugin host with 3 batches in the deferred window → after restart no document claims lost vectors, deferred docs read retry-me, re-index converges.
- Process leak: container stays at 4 processes / 66 threads across a CLI-heavy script run (was 132 / 3,800).

## Rollout notes for Koodle

- Clients see `503` + `Retry-After` under bursts instead of minutes-long waits; `@koodle/nexus-client` already honours it.
- Kill switches without a code change: `NEXUS_SEARCH_ANN_FLUSH_SECONDS=0`, `NEXUS_SEARCH_INDEX_MAX_INFLIGHT=0`.
- Server image and `nexusd-cluster` plugin image must come from the same commit (plugin changed).

## Not addressed here

- The kernel process caps small-op throughput (~200 % CPU for ~30 writes/s at 8-way concurrency); that lives in nexus-vfs.
- Pre-existing: dirt from an interrupted write is never cleared by later batches, so a zone stays cache-bypassed after a plugin crash until repaired.
- The remote-embedder path is exercised structurally (same `embed_batch` trait); live validation used the local ONNX embedder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
